### PR TITLE
always init Endo in tests

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -74,6 +74,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "5m"
   },
   "publishConfig": {

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -88,6 +88,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   },

--- a/packages/SwingSet/test/test-bundle-handler.js
+++ b/packages/SwingSet/test/test-bundle-handler.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 
 import {

--- a/packages/SwingSet/test/test-xsnap-store.js
+++ b/packages/SwingSet/test/test-xsnap-store.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 /* global globalThis */
-import '@endo/init/debug.js';
 
 import { spawn } from 'child_process';
 import fs from 'fs';

--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import test from 'ava';
-import '@endo/init/debug.js';
 import tmp from 'tmp';
 import {
   initSwingStore,

--- a/packages/SwingSet/test/transcript/test-transcript-entries.js
+++ b/packages/SwingSet/test/transcript/test-transcript-entries.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import test from 'ava';
-import '@endo/init/debug.js';
 import { initSwingStore } from '@agoric/swing-store';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 import { buildKernelBundle } from '../../src/controller/initializeSwingset.js';

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -1,9 +1,7 @@
 // @ts-check
 
-import '@endo/init/pre-bundle-source.js';
-
-// eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava.js';
+
 import { buildVatController } from '../../src/index.js';
 import { makeLRU } from '../../src/kernel/vat-warehouse.js';
 

--- a/packages/SwingSet/test/virtualObjects/test-facet-retention.js
+++ b/packages/SwingSet/test/virtualObjects/test-facet-retention.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import '@endo/init/debug.js';
 import test from 'ava';
 import { initSwingStore } from '@agoric/swing-store';
 import { buildVatController } from '../../src/index.js';

--- a/packages/SwingSet/test/xsnap-stable-bundles/test-stable-bundles.js
+++ b/packages/SwingSet/test/xsnap-stable-bundles/test-stable-bundles.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import '@endo/init/debug.js';
 import test from 'ava';
 import { createHash } from 'crypto';
 

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -13,9 +13,6 @@ import '@endo/ses-ava/exported.js';
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 
-/** @type {typeof rawTest} */
-// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-// @ts-ignore XXX https://github.com/endojs/endo/issues/1235
 export const test = wrapTest(rawTest);
 
 // Does not import from a module because we're testing the global env

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -31,6 +31,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   }
 }

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -21,6 +21,11 @@
     "@endo/init": "^0.5.57",
     "ava": "^5.3.0"
   },
+  "ava": {
+    "require": [
+      "@endo/init/debug.js"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Agoric/agoric-sdk.git"

--- a/packages/assert/test/test-assert.js
+++ b/packages/assert/test/test-assert.js
@@ -1,5 +1,3 @@
-import '@endo/init';
-// eslint-disable-next-line import/no-unresolved -- lint error not worth solving; test passes
 import test from 'ava';
 
 import { NonNullish, Fail } from '../src/assert.js';

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -46,6 +46,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/base-zone/test/prepare-test-env-ava.js
+++ b/packages/base-zone/test/prepare-test-env-ava.js
@@ -1,5 +1,4 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@endo/init/debug.js';
 
 import test from 'ava';
 

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -66,6 +66,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -72,6 +72,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -42,6 +42,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m"
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -61,6 +61,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m"
   }
 }

--- a/packages/cosmic-swingset/test/test-clean-core-eval.js
+++ b/packages/cosmic-swingset/test/test-clean-core-eval.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 import {
   defangEvaluableCode,

--- a/packages/cosmic-swingset/test/test-export-storage.js
+++ b/packages/cosmic-swingset/test/test-export-storage.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@endo/init';
 import test from 'ava';
 import { exportStorage } from '../src/export-storage.js';
 

--- a/packages/cosmic-swingset/test/test-provision-smartwallet.js
+++ b/packages/cosmic-swingset/test/test-provision-smartwallet.js
@@ -1,5 +1,4 @@
 /* global setTimeout */
-import '@endo/init/debug.js';
 import test from 'ava';
 
 // Use ambient authority only in test.before()

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -64,6 +64,9 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
+    ],
+    "require": [
+      "@endo/init/debug.js"
     ]
   },
   "publishConfig": {

--- a/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
+++ b/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
@@ -1,6 +1,5 @@
 // @ts-check
 import test from 'ava';
-import '@endo/init';
 
 import { assertOfferResult } from '../../src/assertOfferResult.js';
 

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -67,6 +67,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "10m"
   },
   "publishConfig": {

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -1,6 +1,5 @@
 /* eslint-disable ava/assertion-arguments -- the standard diff is unreadable */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@endo/init/debug.js';
 import test from 'ava';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import path from 'path';
 

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -73,6 +73,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "workerThreads": false,
     "timeout": "10m"
   },

--- a/packages/inter-protocol/test/vaultFactory/test-storeUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storeUtils.js
@@ -1,5 +1,3 @@
-// Must be first to set up globals
-import '@endo/init/debug.js';
 // Consider ses-ava once https://github.com/endojs/endo/issues/1235 is resolved
 import test from 'ava';
 

--- a/packages/inter-protocol/test/vaultFactory/test-storeUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storeUtils.js
@@ -1,4 +1,3 @@
-// Consider ses-ava once https://github.com/endojs/endo/issues/1235 is resolved
 import test from 'ava';
 
 import { AmountMath } from '@agoric/ertp';

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -36,6 +36,11 @@
     "ava": "^5.3.0",
     "tsd": "^0.28.1"
   },
+  "ava": {
+    "require": [
+      "@endo/init/debug.js"
+    ]
+  },
   "author": "Agoric",
   "license": "Apache-2.0",
   "files": [

--- a/packages/internal/src/install-ses-debug.js
+++ b/packages/internal/src/install-ses-debug.js
@@ -3,4 +3,4 @@
 // The setting below are *unsafe* and should not be used in contact with
 // genuinely malicious code.
 
-export * from '@endo/init/debug.js';
+import '@endo/init/debug.js';

--- a/packages/internal/test/test-callback.js
+++ b/packages/internal/test/test-callback.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@endo/init';
 import test from 'ava';
 
 import { Far } from '@endo/far';

--- a/packages/internal/test/test-netstring.js
+++ b/packages/internal/test/test-netstring.js
@@ -1,5 +1,4 @@
 /* global Buffer */
-import '@endo/init/debug.js';
 import test from 'ava';
 
 import {

--- a/packages/internal/test/test-priority-senders.js
+++ b/packages/internal/test/test-priority-senders.js
@@ -1,6 +1,5 @@
 // @ts-check
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { makeFakeStorageKit } from '../src/storage-test-utils.js';
 import { HIGH_PRIORITY_SENDERS } from '../src/chain-storage-paths.js';

--- a/packages/internal/test/test-storage-test-utils.js
+++ b/packages/internal/test/test-storage-test-utils.js
@@ -1,6 +1,5 @@
 // @ts-check
 import test from 'ava';
-import '@endo/init/debug.js';
 import { Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 

--- a/packages/internal/test/test-upgrade-api.js
+++ b/packages/internal/test/test-upgrade-api.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@endo/init';
 import test from 'ava';
 import {
   makeUpgradeDisconnection,

--- a/packages/internal/test/test-utils.js
+++ b/packages/internal/test/test-utils.js
@@ -1,6 +1,5 @@
 // @ts-check
 import test from 'ava';
-import '@endo/init';
 
 import { Far } from '@endo/far';
 import {

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -57,6 +57,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -69,6 +69,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   }
 }

--- a/packages/notifier/test/prepare-test-env-ava.js
+++ b/packages/notifier/test/prepare-test-env-ava.js
@@ -1,6 +1,4 @@
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 
-// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-// @ts-ignore -- https://github.com/endojs/endo/issues/1235
 export const test = wrapTest(rawTest);

--- a/packages/notifier/test/prepare-test-env-ava.js
+++ b/packages/notifier/test/prepare-test-env-ava.js
@@ -1,5 +1,3 @@
-import '@endo/init';
-
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -59,6 +59,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "10m"
   },
   "publishConfig": {

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -58,6 +58,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   },
   "publishConfig": {

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -71,6 +71,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -55,6 +55,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -54,6 +54,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   }
 }

--- a/packages/store/test/perf-patterns.js
+++ b/packages/store/test/perf-patterns.js
@@ -1,5 +1,3 @@
-import '@endo/init/debug.js';
-
 import { Far, makeTagged } from '@endo/marshal';
 import {
   makeCopyBag,

--- a/packages/store/test/prepare-test-env-ava.js
+++ b/packages/store/test/prepare-test-env-ava.js
@@ -1,5 +1,3 @@
-import '@endo/init/debug.js';
-
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 

--- a/packages/store/test/test-AtomicProvider.js
+++ b/packages/store/test/test-AtomicProvider.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-use-before-define */
-import '@endo/init/debug.js';
 
 import test from 'ava';
 import { Far } from '@endo/marshal';

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-use-before-define */
-import '@endo/init/debug.js';
 
 import test from 'ava';
 

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -43,6 +43,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   }
 }

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@endo/init/debug.js';
 import test from 'ava';
 import tmp from 'tmp';
 import { Buffer } from 'buffer';

--- a/packages/swing-store/test/test-deletion.js
+++ b/packages/swing-store/test/test-deletion.js
@@ -1,6 +1,5 @@
 // @ts-check
 import test from 'ava';
-import '@endo/init/debug.js';
 import { Buffer } from 'node:buffer';
 import { initSwingStore } from '../src/swingStore.js';
 

--- a/packages/swing-store/test/test-export.js
+++ b/packages/swing-store/test/test-export.js
@@ -1,5 +1,3 @@
-import '@endo/init/debug.js';
-
 import test from 'ava';
 
 import { buffer } from '../src/util.js';

--- a/packages/swing-store/test/test-exportImport.js
+++ b/packages/swing-store/test/test-exportImport.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import '@endo/init/debug.js';
 import { Buffer } from 'node:buffer';
 
 import test from 'ava';

--- a/packages/swing-store/test/test-hasher.js
+++ b/packages/swing-store/test/test-hasher.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 
 // eslint-disable-next-line import/order

--- a/packages/swing-store/test/test-import.js
+++ b/packages/swing-store/test/test-import.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-import '@endo/init/debug.js';
-
 import path from 'path';
 import { createGunzip } from 'zlib';
 import { Readable } from 'stream';

--- a/packages/swing-store/test/test-repair-metadata.js
+++ b/packages/swing-store/test/test-repair-metadata.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-import '@endo/init/debug.js';
-
 import path from 'path';
 import test from 'ava';
 import sqlite3 from 'better-sqlite3';

--- a/packages/swing-store/test/test-snapstore.js
+++ b/packages/swing-store/test/test-snapstore.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import '@endo/init/debug.js';
 import { Buffer } from 'node:buffer';
 import zlib from 'zlib';
 import sqlite3 from 'better-sqlite3';

--- a/packages/swing-store/test/test-state.js
+++ b/packages/swing-store/test/test-state.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-import '@endo/init/debug.js';
-
 import tmp from 'tmp';
 import test from 'ava';
 

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -54,6 +54,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   },

--- a/packages/swingset-liveslots/test/storeGC/test-lifecycle.js
+++ b/packages/swingset-liveslots/test/storeGC/test-lifecycle.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import {
   setupTestLiveslots,

--- a/packages/swingset-liveslots/test/storeGC/test-refcount-management.js
+++ b/packages/swingset-liveslots/test/storeGC/test-refcount-management.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import {
   findSyscallsByType,

--- a/packages/swingset-liveslots/test/storeGC/test-scalar-store-kind.js
+++ b/packages/swingset-liveslots/test/storeGC/test-scalar-store-kind.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { setupTestLiveslots } from '../liveslots-helpers.js';
 import { buildRootObject, mapRef } from '../gc-helpers.js';

--- a/packages/swingset-liveslots/test/storeGC/test-weak-key.js
+++ b/packages/swingset-liveslots/test/storeGC/test-weak-key.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { setupTestLiveslots } from '../liveslots-helpers.js';
 import {

--- a/packages/swingset-liveslots/test/test-baggage.js
+++ b/packages/swingset-liveslots/test/test-baggage.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { setupTestLiveslots } from './liveslots-helpers.js';

--- a/packages/swingset-liveslots/test/test-cache.js
+++ b/packages/swingset-liveslots/test/test-cache.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { makeCache } from '../src/cache.js';
 

--- a/packages/swingset-liveslots/test/test-collection-schema-refcount.js
+++ b/packages/swingset-liveslots/test/test-collection-schema-refcount.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { makeLiveSlots } from '../src/liveslots.js';

--- a/packages/swingset-liveslots/test/test-collection-upgrade.js
+++ b/packages/swingset-liveslots/test/test-collection-upgrade.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';

--- a/packages/swingset-liveslots/test/test-dropped-collection-weakrefs.js
+++ b/packages/swingset-liveslots/test/test-dropped-collection-weakrefs.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 import { Far } from '@endo/marshal';
 import { makeLiveSlots } from '../src/liveslots.js';
 import { kser } from './kmarshal.js';

--- a/packages/swingset-liveslots/test/test-durabilityChecks.js
+++ b/packages/swingset-liveslots/test/test-durabilityChecks.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { makeFakeVirtualStuff } from '../tools/fakeVirtualSupport.js';

--- a/packages/swingset-liveslots/test/test-facetiousness.js
+++ b/packages/swingset-liveslots/test/test-facetiousness.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 import {
   assessFacetiousness,

--- a/packages/swingset-liveslots/test/test-gc-sensitivity.js
+++ b/packages/swingset-liveslots/test/test-gc-sensitivity.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 import { Far } from '@endo/marshal';
 import { buildSyscall } from './liveslots-helpers.js';
 import { makeLiveSlots } from '../src/liveslots.js';

--- a/packages/swingset-liveslots/test/test-handled-promises.js
+++ b/packages/swingset-liveslots/test/test-handled-promises.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { Fail } from '@agoric/assert';

--- a/packages/swingset-liveslots/test/test-initial-vrefs.js
+++ b/packages/swingset-liveslots/test/test-initial-vrefs.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/far';
 import { M } from '@agoric/store';

--- a/packages/swingset-liveslots/test/test-liveslots-mock-gc.js
+++ b/packages/swingset-liveslots/test/test-liveslots-mock-gc.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { makeLiveSlots } from '../src/liveslots.js';

--- a/packages/swingset-liveslots/test/test-liveslots-real-gc.js
+++ b/packages/swingset-liveslots/test/test-liveslots-real-gc.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* global WeakRef */
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/swingset-liveslots/test/test-liveslots.js
+++ b/packages/swingset-liveslots/test/test-liveslots.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/swingset-liveslots/test/test-vo-test-harness.js
+++ b/packages/swingset-liveslots/test/test-vo-test-harness.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 import { runVOTest } from '../tools/vo-test-harness.js';
 
 async function voTestTest(t, mode) {

--- a/packages/swingset-liveslots/test/test-vpid-liveslots.js
+++ b/packages/swingset-liveslots/test/test-vpid-liveslots.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/swingset-liveslots/test/virtual-objects/test-cease-recognition.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-cease-recognition.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* global FinalizationRegistry WeakRef */
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { buildSyscall } from '../liveslots-helpers.js';
 import { makeVirtualReferenceManager } from '../../src/virtualReferences.js';

--- a/packages/swingset-liveslots/test/virtual-objects/test-cross-facet.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-cross-facet.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 

--- a/packages/swingset-liveslots/test/virtual-objects/test-empty-data.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-empty-data.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 

--- a/packages/swingset-liveslots/test/virtual-objects/test-facets.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-facets.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 

--- a/packages/swingset-liveslots/test/virtual-objects/test-kind-changes.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-kind-changes.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 import { Far } from '@endo/marshal';
 import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
 import { makeLiveSlots } from '../../src/liveslots.js';

--- a/packages/swingset-liveslots/test/virtual-objects/test-reachable-vrefs.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-reachable-vrefs.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Remotable } from '@endo/marshal';
 import { initEmpty } from '@agoric/store';

--- a/packages/swingset-liveslots/test/virtual-objects/test-rep-tostring.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-rep-tostring.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 // this sets process.env.DEBUG = 'label-instances'
 import './set-debug-label-instances.js';
 

--- a/packages/swingset-liveslots/test/virtual-objects/test-retain-remotable.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-retain-remotable.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* global WeakRef */
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { initEmpty } from '@agoric/store';

--- a/packages/swingset-liveslots/test/virtual-objects/test-state-shape.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-state-shape.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';

--- a/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectGC.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectGC.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import {

--- a/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectManager.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectManager.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import {
   makeFakeVirtualObjectManager,

--- a/packages/swingset-liveslots/test/virtual-objects/test-vo-real-gc.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-vo-real-gc.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* global WeakRef */
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { kser, kunser } from '../kmarshal.js';

--- a/packages/swingset-liveslots/test/virtual-objects/test-weakcollections-vref-handling.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-weakcollections-vref-handling.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 

--- a/packages/swingset-liveslots/tools/prepare-test-env.js
+++ b/packages/swingset-liveslots/tools/prepare-test-env.js
@@ -5,9 +5,8 @@
  * and stores.
  */
 
-import '@endo/init/pre.js';
-
 import '@agoric/internal/src/install-ses-debug.js';
+
 import { reincarnate } from './setup-vat-data.js';
 
 // Install the VatData globals.

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -50,6 +50,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m"
   }
 }

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -45,6 +45,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m",
     "workerThreads": false
   }

--- a/packages/swingset-xsnap-supervisor/test/test-bundle.js
+++ b/packages/swingset-xsnap-supervisor/test/test-bundle.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 import fs from 'fs';
 import crypto from 'crypto';

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -57,6 +57,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/telemetry/test/prepare-test-env-ava.js
+++ b/packages/telemetry/test/prepare-test-env-ava.js
@@ -1,5 +1,3 @@
-import '@endo/init';
-
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -39,6 +39,11 @@
     "@endo/init": "^0.5.57",
     "ava": "^5.3.0"
   },
+  "ava": {
+    "require": [
+      "@endo/init/debug.js"
+    ]
+  },
   "files": [
     "*.js",
     "NEWS.md",

--- a/packages/time/test/test-timeMath.js
+++ b/packages/time/test/test-timeMath.js
@@ -1,6 +1,3 @@
-import '@endo/init';
-
-// eslint-disable-next-line import/order
 import test from 'ava';
 import { Far } from '@endo/far';
 import { TimeMath } from '../src/timeMath.js';

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -29,6 +29,11 @@
     "ava": "^5.3.0",
     "tsd": "^0.28.1"
   },
+  "ava": {
+    "require": [
+      "@endo/init/debug.js"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vat-data/test/absent.test.js
+++ b/packages/vat-data/test/absent.test.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 
 /* global globalThis */

--- a/packages/vat-data/test/present.test.js
+++ b/packages/vat-data/test/present.test.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 
 const mockDefineKind = /** @type {any} */ (harden({}));

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -68,6 +68,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/vats/test/test-dump.js
+++ b/packages/vats/test/test-dump.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@endo/init/debug.js';
 import test from 'ava';
 
 import { dump } from '../src/repl.js';

--- a/packages/vats/test/test-repl.js
+++ b/packages/vats/test/test-repl.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 import { getReplHandler } from '../src/repl.js';
 

--- a/packages/vats/test/test-tokens.js
+++ b/packages/vats/test/test-tokens.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@endo/init';
 import test from 'ava';
 
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';

--- a/packages/vm-config/package.json
+++ b/packages/vm-config/package.json
@@ -42,6 +42,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -53,6 +53,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m",
     "workerThreads": false
   },

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -40,6 +40,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m",
     "workerThreads": false
   }

--- a/packages/xsnap-lockdown/test/test-bundle.js
+++ b/packages/xsnap-lockdown/test/test-bundle.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import test from 'ava';
 import fs from 'fs';
 import crypto from 'crypto';

--- a/packages/xsnap-lockdown/test/test-inspect.js
+++ b/packages/xsnap-lockdown/test/test-inspect.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 import unconfinedInspect from '../lib/object-inspect.js';
 
 const testCases = [

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -59,6 +59,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "2m",
     "workerThreads": false
   }

--- a/packages/xsnap/test/test-boot-lockdown.js
+++ b/packages/xsnap/test/test-boot-lockdown.js
@@ -1,7 +1,5 @@
 import test from 'ava';
 
-import '@endo/init/debug.js';
-
 import * as proc from 'child_process';
 import * as os from 'os';
 import * as fs from 'fs';

--- a/packages/xsnap/test/test-err-stack.js
+++ b/packages/xsnap/test/test-err-stack.js
@@ -1,7 +1,5 @@
 // JavaScript correctness tests
 
-import '@endo/init/debug.js';
-
 import test from 'ava';
 import * as proc from 'child_process';
 import fs from 'fs';

--- a/packages/xsnap/test/test-gc.js
+++ b/packages/xsnap/test/test-gc.js
@@ -1,5 +1,4 @@
 /* global FinalizationRegistry WeakRef */
-import '@endo/init/debug.js';
 
 import test from 'ava';
 

--- a/packages/xsnap/test/test-inspect.js
+++ b/packages/xsnap/test/test-inspect.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import '@endo/init/debug.js';
 
 import * as proc from 'child_process';
 import fs from 'fs';

--- a/packages/xsnap/test/test-replay.js
+++ b/packages/xsnap/test/test-replay.js
@@ -1,7 +1,5 @@
 /* global Buffer */
 
-import '@endo/init/debug.js';
-
 import test from 'ava';
 
 import * as proc from 'child_process';

--- a/packages/xsnap/test/test-xs-js.js
+++ b/packages/xsnap/test/test-xs-js.js
@@ -1,7 +1,5 @@
 // JavaScript correctness tests
 
-import '@endo/init/debug.js';
-
 import test from 'ava';
 import * as proc from 'child_process';
 import fs from 'fs';

--- a/packages/xsnap/test/test-xs-limits.js
+++ b/packages/xsnap/test/test-xs-limits.js
@@ -1,7 +1,5 @@
 // XS resource exhaustion tests
 
-import '@endo/init/debug.js';
-
 import test from 'ava';
 
 import * as proc from 'child_process';

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -1,5 +1,4 @@
 /* global performance */
-import '@endo/init/debug.js';
 
 import test from 'ava';
 

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -1,5 +1,4 @@
 /* global setTimeout, FinalizationRegistry, setImmediate, process */
-import '@endo/init/debug.js';
 
 import test from 'ava';
 

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -125,6 +125,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m"
   },
   "publishConfig": {

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-import '@endo/init/debug.js';
 import test from 'ava';
 import path from 'path';
 

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import anyTest from 'ava';
 import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';

--- a/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import anyTest from 'ava';
 import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';

--- a/packages/zoe/test/swingsetTests/privateArgs/test-privateArgs.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/test-privateArgs.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import anyTest from 'ava';
 import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';

--- a/packages/zoe/test/swingsetTests/runMint/test-runMint.js
+++ b/packages/zoe/test/swingsetTests/runMint/test-runMint.js
@@ -1,4 +1,3 @@
-import '@endo/init/debug.js';
 import anyTest from 'ava';
 import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import '@endo/init/debug.js';
 import test from 'ava';
 import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -47,6 +47,9 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
     "timeout": "20m",
     "workerThreads": false
   }


### PR DESCRIPTION
refs: #2663

## Description

Our test env setup has someproblems:
1. The setup import has both side-effects and exports (the latter implying to tools that it doesn't have side-effects, resulting in moves and test breakage) (https://github.com/Agoric/agoric-sdk/issues/2663, https://github.com/endojs/endo/issues/1467)
2. The side-effects are needed for all the tests in the package, but require each test to include them
3. the ses-ava wrapper breaks features of Ava (https://github.com/endojs/endo/issues/647)

This PR tackles #2, and progress towards the others. It configures some aspects of test env preparation to be package-scoped instead of file scoped. It does this by configuring the Ava runner to import the modules that have the desired side-effects. In this case, `@endo/init/debug.js`.

Many tests were using only that and then `import ava from 'ava'` instead of `prepare-test-env-ava`. This frees those tests of any side-effect imports.

With this pattern maybe we could also make a `@endo/ses-ava/monkeypatch` that modifies the the Ava module instead of wrapping. If we can do that in a way that's fully compatible with Ava then we could always run that patch and remove another test-level concern. Most tests at that point could just begin with `import test from 'ava'`.

The other setup tasks are adding `reincarnate` and/or `VatData`. I expect those are needed on a package basis and could have the same package-level config.
 
### Security Considerations

--

### Scaling Considerations

--

### Documentation Considerations

Will require notifying developers when this lands that the old imports are redundant.

### Testing Considerations

CI

### Upgrade Considerations

--