### PR TITLE
build: publish to NPM

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@agoric/builders",
   "version": "0.1.0",
-  "private": true,
   "description": "Build scripts for proposals to an Agoric chain",
   "type": "module",
   "main": "./index.js",


### PR DESCRIPTION
## Description
https://github.com/Agoric/agoric-sdk/pull/8204 made `cosmic-swingset` depend on `builders`, but runtime [couldn't install it](https://github.com/Agoric/agoric-sdk/actions/runs/5871855329/job/15922184952) because it wasn't being published. (`private: true` overrides the `publishConfig`)