### PR TITLE
fix(inter): remove excess authority in price-feed-proposal.js

### DIFF
--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -253,7 +253,6 @@ export const getManifestForPriceFeed = async (
         chainTimerService: t,
         client: t,
         econCharterKit: t,
-        economicCommitteeCreatorFacet: t,
         highPrioritySendersManager: t,
         namesByAddressAdmin: t,
         priceAuthority: t,


### PR DESCRIPTION
refs: #8176, https://github.com/0xpatrickdev/agoric-vault-collateral-proposal/issues/5

## Description

Prune permit for `economicCommitteeCreatorFacet`, `contractGovernor` in `price-feed-proposal.js`, since they are subsumed by `startGovernedUpgradable`.

### Security Considerations

proposal is slightly less confusing to read

### Scaling Considerations

n/a

### Documentation Considerations

Do we document contributors anywhere in particular?

ack: @0xpatrickdev

### Testing Considerations

existing tests should suffice

### Upgrade Considerations

This should slightly simplify future proposals to add collaterals.
