### PR TITLE
fix(addAssetToVault): support issuerName separate from keyword

### DIFF
--- a/packages/builders/scripts/inter-protocol/add-collateral-core.js
+++ b/packages/builders/scripts/inter-protocol/add-collateral-core.js
@@ -19,10 +19,11 @@ export const defaultProposalBuilder = async (
   const {
     issuerBoardId = env.INTERCHAIN_ISSUER_BOARD_ID,
     denom = env.INTERCHAIN_DENOM,
-    oracleBrand = 'ATOM',
-    decimalPlaces = 6,
     keyword = 'ATOM',
-    proposedName = oracleBrand,
+    issuerName = keyword,
+    oracleBrand = issuerName,
+    decimalPlaces = 6,
+    proposedName = issuerName,
     initialPrice = undefined,
   } = interchainAssetOptions;
 
@@ -45,6 +46,7 @@ export const defaultProposalBuilder = async (
           decimalPlaces,
           initialPrice,
           keyword,
+          issuerName,
           proposedName,
           oracleBrand,
         },

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -180,6 +180,7 @@ type WellKnownName = {
     | 'Pegasus'
     | 'reserve'
     | 'psm'
+    | 'scaledPriceAuthority'
     | 'econCommitteeCharter'
     | 'priceAggregator';
   instance:

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -54,6 +54,7 @@ export const agoricNamesReserved = harden({
     psm: 'Parity Stability Module',
     econCommitteeCharter: 'Charter for Econ Governance questions',
     priceAggregator: 'simple price aggregator',
+    scaledPriceAuthority: 'scaled price authority',
   },
   instance: {
     economicCommittee: 'Economic Committee',

--- a/packages/vats/src/mintHolder.js
+++ b/packages/vats/src/mintHolder.js
@@ -10,6 +10,8 @@ import {
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
 /**
+ * NOTE: "keyword" connotes initial caps constraint, which doesn't apply here.
+ *
  * @template {AssetKind} K
  * @typedef {{
  *   keyword: string;


### PR DESCRIPTION
fixes: #8235
refs: #8176, #8177

## Description

In `addAssetToVault`, we conflated `keyword` (needed for registration with the reserve and auction) with `issuerName` (for use in `agoricNames`). This adds to `InterchainAssetOptions` an `issuerName` property that defaults to the value of `keyword`.

### Security, Documentation Considerations

Allows higher fidelity between `agoricNames` and well-known names of assets.

### Scaling Considerations

n/a/

### Testing Considerations

Manual testing with `issuerName: 'atom'` and `issuerName: 'stars'` succeeded. We could keep the `issuerName: 'stars'` tweak. But first, I'd like to see what ci thinks of this.

### Upgrade Considerations

doesn't affect existing vats.
