### PR TITLE
fix(publish-kit): workaround endo bug #1728

### DIFF
--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -40,24 +40,42 @@ export const ForkableAsyncIterableIteratorShape = M.interface(
   'ForkableAsyncIterableIterator',
   {
     fork: M.call().returns(M.any()),
-    [Symbol.asyncIterator]: M.call().returns(M.any()), // oops: recursive type
+    // See https://github.com/Agoric/agoric-sdk/issues/8231
+    // [Symbol.asyncIterator]: M.call().returns(M.any()), // oops: recursive type
     next: M.callWhen().returns(M.any()),
+  },
+  {
+    sloppy: true,
   },
 );
 
-export const IterableEachTopicI = M.interface('IterableEachTopic', {
-  subscribeAfter: SubscriberI.methodGuards.subscribeAfter,
-  [Symbol.asyncIterator]: M.call().returns(
-    M.remotable('ForkableAsyncIterableIterator'),
-  ),
-});
+export const IterableEachTopicI = M.interface(
+  'IterableEachTopic',
+  {
+    subscribeAfter: SubscriberI.methodGuards.subscribeAfter,
+    // See https://github.com/Agoric/agoric-sdk/issues/8231
+    // [Symbol.asyncIterator]: M.call().returns(
+    //   M.remotable('ForkableAsyncIterableIterator'),
+    // ),
+  },
+  {
+    sloppy: true,
+  },
+);
 
-export const IterableLatestTopicI = M.interface('IterableLatestTopic', {
-  getUpdateSince: SubscriberI.methodGuards.getUpdateSince,
-  [Symbol.asyncIterator]: M.call().returns(
-    M.remotable('ForkableAsyncIterableIterator'),
-  ),
-});
+export const IterableLatestTopicI = M.interface(
+  'IterableLatestTopic',
+  {
+    getUpdateSince: SubscriberI.methodGuards.getUpdateSince,
+    // See https://github.com/Agoric/agoric-sdk/issues/8231
+    // [Symbol.asyncIterator]: M.call().returns(
+    //   M.remotable('ForkableAsyncIterableIterator'),
+    // ),
+  },
+  {
+    sloppy: true,
+  },
+);
 
 /**
  * @template {object} Arg


### PR DESCRIPTION
Works around bug https://github.com/endojs/endo/issues/1728 by omitting method guards for symbol-named methods.

Detected by https://github.com/Agoric/agoric-sdk/pull/7937 as a consequence of the stricter checking just merged from https://github.com/endojs/endo/pull/1715 . The InterfaceGuards created by this code were always incorrect in this manner. But previous error checking was too lax to catch it.

CI on this PR checks it against the endo normally used by agoric-sdk. https://github.com/Agoric/agoric-sdk/pull/8233 checks this same change against "current" endo master, to see if this PR fixes the https://github.com/endojs/endo/issues/1728 problem detected by #7937
