### PR TITLE
lint-with-types cleanup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,7 +32,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    // this is not yet compatible with eslint lsp so it's conditioned on AGORIC_ESLINT_TYPES
+    // Works for us!
     EXPERIMENTAL_useProjectService: true,
     sourceType: 'module',
     project: [

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -57,7 +57,7 @@ jobs:
   # We split the package tests into two jobs because type linting
   # is inefficient and slow https://github.com/typescript-eslint/typescript-eslint/issues/2094
   lint-primary:
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
         run: ./scripts/lint-with-types.sh primary
 
   lint-rest:
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/scripts/lint-with-types.sh
+++ b/scripts/lint-with-types.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 
-# we don't collect type info by default because the EXPERIMENTAL_useProjectService that provides viable perf
-# is not yet compatible with running eslint in IDE
-export AGORIC_ESLINT_TYPES='keypresent'
-
-# CI and some VMs OOM without this
-export NODE_OPTIONS='--max-old-space-size=8192'
+# TODO consolidate back into one job https://github.com/Agoric/agoric-sdk/pull/8061
 
 # argument used by CI to split this across two jobs
 SCOPE=$1
@@ -21,7 +16,7 @@ rest)
     yarn lerna run --ignore=$PRIMARY_PACKAGES --no-bail lint
     ;;
 *)
-    # all scopes
-    yarn lint
+    echo "The regular lint command now lints with types. Just use that."
+    exit 0
     ;;
 esac


### PR DESCRIPTION

## Description

The 10min timeout for the lint job is exceed sometimes since https://github.com/Agoric/agoric-sdk/pull/8198

([example](https://github.com/Agoric/agoric-sdk/actions/runs/5930289830/job/16081901654))

This raises it to 15min and cleans up the config options.

