### PR TITLE
chore: patch @lerna/conventional-commits to avoid version bump for prereleases

### DIFF
--- a/patches/@lerna+conventional-commits+5.6.2.patch
+++ b/patches/@lerna+conventional-commits+5.6.2.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@lerna/conventional-commits/lib/recommend-version.js b/node_modules/@lerna/conventional-commits/lib/recommend-version.js
+index a982adf..453ef14 100644
+--- a/node_modules/@lerna/conventional-commits/lib/recommend-version.js
++++ b/node_modules/@lerna/conventional-commits/lib/recommend-version.js
+@@ -58,6 +58,15 @@ function recommendVersion(pkg, type, { changelogPreset, rootPath, tagPrefix, pre
+         // we still need to bump _something_ because lerna saw a change here
+         let releaseType = data.releaseType || "patch";
+ 
++        // Don't gratuitously break compatibility with clients using `^0.x.y`.
++        if (semver.major(pkg.version) === 0) {
++          if (releaseType === "major") {
++            releaseType = "minor";
++          } else if (releaseType === "minor") {
++            releaseType = "patch";
++          }
++        }
++
+         if (prereleaseId) {
+           const shouldBump = shouldBumpPrerelease(releaseType, pkg.version);
+           const prereleaseType = shouldBump ? `pre${releaseType}` : "prerelease";


### PR DESCRIPTION
We used to patch this library to reduce the `releaseType` level for our packages that had not yet reached 1.0 . We then switched to an upstream version which performed this reduction itself, except not when doing a "prerelease". Now that we need to do a prerelease, we'd like this reduction behavior in both arms of the conditional, so this commit re-introduces our original patch.

closes #8242
