### PR TITLE
ci(lint): error importing E() in bootstrapTests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -122,6 +122,17 @@ module.exports = {
       },
     },
     {
+      // These tests use EV() instead of E(), which are easy to confuse.
+      // Help by erroring when E() packages are imported.
+      files: ['packages/boot/test/**/test-*'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          { paths: ['@endo/eventual-send', '@endo/far'] },
+        ],
+      },
+    },
+    {
       // Allow "loan" contracts to mention the word "loan".
       files: ['packages/zoe/src/contracts/loan/*.js'],
       rules: {


### PR DESCRIPTION
## Description

Help prevent accidental usage of `E()` in a "bootstrapTest". 

Note the glob should apply to anything using the EV-style test but right now it's only used in this particular set of tests.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
