### PR TITLE
doc: fix wrong quote in import example code

### DIFF
--- a/packages/SwingSet/docs/timer.md
+++ b/packages/SwingSet/docs/timer.md
@@ -10,7 +10,7 @@ a timer object in order to create the timer's endowments, source code, and
 The timer service consists of a device (`device-timer`) and a helper vat (`vat-timer`). The host application must configure the device as it builds the swingset kernel, and then the bootstrap vat must finish the job by wiring the device and vat together.
 
 ```js
-import { buildTimer } from `@agoric/swingset-vat`;
+import { buildTimer } from '@agoric/swingset-vat';
 const timer = buildTimer();
 ```
 


### PR DESCRIPTION
Saw https://github.com/endojs/endo/pull/1740/files?short_path=12f0146#diff-12f0146121857891eaea02008892eb51e98883364bc9ed4dfc544b7676e96c43 and wondered if it was a common mistake. Not too common, but not unique either.

See also https://github.com/endojs/endo/pull/1743