### PR TITLE
ci: merge endo integration branch

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -76,6 +76,18 @@ runs:
           echo "sha=NOPE" >> $GITHUB_OUTPUT
         fi
       shell: bash
+    - name: merge endo integration branch
+      id: endo-integration-merge
+      run: |-
+        set -e
+        git ls-remote --exit-code --heads origin "refs/heads/integration-endo-${{ steps.endo-branch.outputs.result }}" || exit 0
+        git fetch --unshallow origin integration-endo-${{ steps.endo-branch.outputs.result }}
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git merge --commit --no-edit origin/integration-endo-${{ steps.endo-branch.outputs.result }}
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      if: steps.endo-branch.outputs.result != 'NOPE'
     - name: Reconfigure git to use HTTP authentication
       run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
       shell: bash


### PR DESCRIPTION
## Description

For CI runs which run using an endo branch instead of NPM packages, merge in a branch named `integration-endo-${endoBranchName}` if it exists. This allows staging changes to support the upcoming endo release, including any known breaking changes.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

TBD (integration branch name should be added to any place that document this endo integration feature)

### Testing Considerations

The `integration-endo-master` branch is being used by this PR which uses the `master` branch of endo for its checks.

```
#endo-branch: master
```

### Upgrade Considerations

None