### PR TITLE
refactor: consistent interface naming

### DIFF
--- a/packages/base-zone/tools/greeter.js
+++ b/packages/base-zone/tools/greeter.js
@@ -5,7 +5,7 @@ export const bindAllMethodsTo = (obj, that = obj) =>
     Object.entries(obj).map(([name, fn]) => [name, fn.bind(that)]),
   );
 
-export const greetGuard = M.interface('Greeter', {
+export const GreeterI = M.interface('Greeter', {
   greet: M.call().optional(M.string()).returns(M.string()),
 });
 export const greetFacet = {
@@ -14,7 +14,7 @@ export const greetFacet = {
   },
 };
 
-export const adminGuard = M.interface('GreeterAdmin', {
+export const GreeterAdminI = M.interface('GreeterAdmin', {
   setNick: M.call(M.string()).returns(),
 });
 export const adminFacet = {
@@ -23,21 +23,21 @@ export const adminFacet = {
   },
 };
 
-export const combinedGuard = M.interface('GreeterWithAdmin', {
-  ...greetGuard.methodGuards,
-  ...adminGuard.methodGuards,
+export const GreeterWithAdminI = M.interface('GreeterWithAdmin', {
+  ...GreeterI.methodGuards,
+  ...GreeterAdminI.methodGuards,
 });
 
 export const prepareGreeterSingleton = (zone, label, nick) => {
   const myThis = Object.freeze({ state: { nick } });
-  return zone.exo(label, combinedGuard, {
+  return zone.exo(label, GreeterWithAdminI, {
     ...bindAllMethodsTo(greetFacet, myThis),
     ...bindAllMethodsTo(adminFacet, myThis),
   });
 };
 
 export const prepareGreeter = zone =>
-  zone.exoClass('Greeter', combinedGuard, nick => ({ nick }), {
+  zone.exoClass('Greeter', GreeterWithAdminI, nick => ({ nick }), {
     ...greetFacet,
     ...adminFacet,
   });
@@ -45,7 +45,7 @@ export const prepareGreeter = zone =>
 export const prepareGreeterKit = zone =>
   zone.exoClassKit(
     'GreeterKit',
-    { greeter: greetGuard, admin: adminGuard },
+    { greeter: GreeterI, admin: GreeterAdminI },
     nick => ({ nick }),
     {
       greeter: greetFacet,

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -156,7 +156,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     return harden({ invitationMakers });
   };
 
-  const charterCreatorI = M.interface('Charter creatorFacet', {
+  const CharterCreatorI = M.interface('Charter creatorFacet', {
     addInstance: M.call(InstanceHandleShape, M.any())
       .optional(M.string())
       .returns(),
@@ -166,7 +166,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const creatorFacet = prepareExo(
     baggage,
     'Charter creatorFacet',
-    charterCreatorI,
+    CharterCreatorI,
     {
       /**
        * @param {Instance} governedInstance

--- a/packages/zoe/README.md
+++ b/packages/zoe/README.md
@@ -4,7 +4,7 @@
 
 Zoe is a framework for building smart contracts like auctions, swaps,
 decentralized exchanges, and more. Zoe itself is a smart contract
-written in JavaScript and running on the Agoric platform. 
+written in JavaScript and running on the Agoric platform.
 
 _For users_: Zoe guarantees that as a user of a smart contract, you will
 either get what you wanted or get a full refund, even if the smart
@@ -17,7 +17,7 @@ losing their assets due to a bug in the code that you wrote. Writing a
 smart contract on Zoe is easy: all of the Zoe smart contracts are
 written in the familiar language of JavaScript.
 
-To learn more, please see the [Zoe guide](https://agoric.com/documentation/zoe/guide/). 
+To learn more, please see the [Zoe guide](https://agoric.com/documentation/zoe/guide/).
 
 ## Reading data off-chain
 
@@ -63,7 +63,7 @@ The upgrade process is triggered through the "adminFacet" of the instance, and r
 const results = E(instanceAdminFacet).upgradeContract(newBundleID);
 ```
 
-This will replace the behavior of the existing instance with that defined in the new bundle. The new behavior is an additional _incarnation_ of the instance. Most state from the old incarnation is discarded, however "durable" collections are retained for use by its replacement. 
+This will replace the behavior of the existing instance with that defined in the new bundle. The new behavior is an additional _incarnation_ of the instance. Most state from the old incarnation is discarded, however "durable" collections are retained for use by its replacement.
 
 There are a few requirements for the contract that differ from non-upgradable contracts:
 1. Export
@@ -117,13 +117,13 @@ export const start = async (zcf, _privateArgs, instanceBaggage) => {
     },
   );
 
-  const creatorI = M.interface('CounterExample', {
+  const CreatorI = M.interface('CounterExample', {
     makeCounter: M.call().returns(M.remotable('Counter')),
   });
   const creatorFacet = prepareExo(
     instanceBaggage,
     'creatorFacet',
-    creatorI,
+    CreatorI,
     { makeCounter },
   );
   return harden({ creatorFacet });

--- a/packages/zone/test/test-exos.js
+++ b/packages/zone/test/test-exos.js
@@ -29,7 +29,7 @@ const testFirstVatDataIncarnation = (t, baggage) => {
   const subBaggage = vatData.provideDurableMapStore(baggage, 'sub');
 
   const myThis = Object.freeze({ state: { nick: 'Singly' } });
-  const singly = vatData.prepareExo(subBaggage, 'a', g.combinedGuard, {
+  const singly = vatData.prepareExo(subBaggage, 'a', g.GreeterWithAdminI, {
     ...g.bindAllMethodsTo(g.greetFacet, myThis),
     ...g.bindAllMethodsTo(g.adminFacet, myThis),
   });
@@ -38,7 +38,7 @@ const testFirstVatDataIncarnation = (t, baggage) => {
   const makeGreeter = vatData.prepareExoClass(
     subBaggage,
     'Greeter',
-    g.combinedGuard,
+    g.GreeterWithAdminI,
     nick => ({ nick }),
     {
       ...g.greetFacet,
@@ -51,7 +51,7 @@ const testFirstVatDataIncarnation = (t, baggage) => {
   const makeGreeterKit = vatData.prepareExoClassKit(
     subBaggage,
     'GreeterKit',
-    { greeter: g.greetGuard, admin: g.adminGuard },
+    { greeter: g.GreeterI, admin: g.GreeterAdminI },
     nick => ({ nick }),
     {
       greeter: g.greetFacet,


### PR DESCRIPTION
We have a convention for interface variable names of an identifier beginning with an upper case letter and ending with an uppercase `I`, such as `FooI`. Whether this convention is great or not, it is pervasive in our code, but with a small number of exceptions, which this PR fixes.

See https://github.com/endojs/endo/pull/1746