### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,6 +44,9 @@ pull_request_rules:
       - base=master
       - label=automerge:no-update
       - or:
+          - "#commits-behind=0"
+          - label=bypass:linear-history
+      - or:
           - check-success=wait-integration-pre-checks
           - label=bypass:integration
       - or:


### PR DESCRIPTION
This change has been made by @mhofman from Mergify config editor.

Avoid churn through Mergify's `update_method` if the PR with `automerge:no-update` would not merge because of linear history checks.