### PR TITLE
ci: fix mergify matrix integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,7 @@ on:
       - converted_to_draft
       - ready_for_review
       - labeled
+      - unlabeled
       - auto_merge_enabled
       - auto_merge_disabled
   merge_group:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -311,3 +311,22 @@ jobs:
         timeout-minutes: 4
         with:
           datadog-token: ${{ secrets.DATADOG_API_KEY }}
+
+  integration-test-result:
+    needs:
+      - pre_check
+      - getting-started
+      - deployment-test
+      - test-docker-build
+    if: needs.pre_check.outputs.should_run == 'true' && (success() || failure() || cancelled())
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        shell: bash
+        run: |
+          cat <<EOF
+            needs ${{ toJSON(needs) }}
+          EOF
+          [ "${{ needs.getting-started.result }}" = "success" ] || exit 1
+          [ "${{ needs.deployment-test.result }}" = "success" ] || exit 1
+          [ "${{ needs.test-docker-build.result }}" = "success" ] || exit 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,6 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         cli: [link-cli, local-npm]
+    # Mark a failure of `local-npm` as a successful result
+    # TODO: remove when `local-npm` job is fixed
+    continue-on-error: ${{ matrix.cli == 'local-npm' }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
@@ -270,6 +273,8 @@ jobs:
     strategy:
       matrix:
         bootstrap-version: ['test', 'main']
+    # Uncomment to mark a failure of the `test` bootstrap job as a successful result
+    # continue-on-error: ${{ matrix.bootstrap-version == 'test' }}
     steps:
       - name: free up disk space
         run: |

--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -9,6 +9,7 @@ on:
       - converted_to_draft
       - ready_for_review
       - labeled
+      - unlabeled
       - auto_merge_enabled
       - auto_merge_disabled
   merge_group:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,38 +5,9 @@ queue_rules:
       - base=master
       # Require integration tests before merging only
       - or:
-          - label=bypass:integration
-          - check-failure!=Integration tests
-      - or:
-          - label=bypass:integration
-          - check-success=deployment-test
-          - check-neutral=deployment-test
-          - check-skipped=deployment-test
-      - or:
-          - label=bypass:integration
-          - check-failure!=test-docker-build (main)
-      - or:
-          - label=bypass:integration
-          - check-skipped=test-docker-build
-          - check-success=test-docker-build (main)
-          - check-neutral=test-docker-build (main)
-          - check-skipped=test-docker-build (main)
-      - or:
-          - label=bypass:integration
-          - check-failure!=getting-started (link-cli)
-      - or:
-          - label=bypass:integration
-          - check-skipped=getting-started
-          - check-success=getting-started (link-cli)
-          - check-neutral=getting-started (link-cli)
-          - check-skipped=getting-started (link-cli)
-      # FIXME: Enable this section to validate NPM deploys...
-      #- or:
-      #    - label=bypass:integration
-      #    - check-skipped=getting-started
-      #    - check-success=getting-started (local-npm)
-      #    - check-neutral=getting-started (local-npm)
-      #    - check-skipped=getting-started (local-npm)
+          - check-success=integration-test-result
+          - check-neutral=integration-test-result
+          - check-skipped=integration-test-result
 
 pull_request_rules:
   - name: merge to master
@@ -44,7 +15,7 @@ pull_request_rules:
       - base=master
       - label=automerge:no-update
       - or:
-          - "#commits-behind=0"
+          - '#commits-behind=0'
           - label=bypass:linear-history
       - or:
           - check-success=wait-integration-pre-checks


### PR DESCRIPTION
## Description

Mergify can get stuck when matrix tests fail, not realizing that the PR cannot make forward progress anymore.

This change reports a matrix job result as normal job, and switches mergify to using that job's result instead

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Will manually test variations on this PR

### Upgrade Considerations

None