### PR TITLE
fix(zoe,pegasus): some zoe and pegasus invitations use proposal patterns

### DIFF
--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -42,6 +42,7 @@
     "@endo/far": "^1.0.1",
     "@endo/init": "^1.0.1",
     "@endo/nat": "^5.0.1",
+    "@endo/patterns": "^1.0.1",
     "@endo/promise-kit": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -1,13 +1,11 @@
 // @ts-check
 
 import { assert, details as X, Fail } from '@agoric/assert';
-import { makeLegacyWeakMap, makeLegacyMap } from '@agoric/store';
+import { makeLegacyWeakMap, makeLegacyMap, M } from '@agoric/store';
 import { E, Far } from '@endo/far';
-import {
-  assertProposalShape,
-  atomicTransfer,
-} from '@agoric/zoe/src/contractSupport/index.js';
+import { atomicTransfer } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeSubscriptionKit } from '@agoric/notifier';
+import { AmountShape } from '@agoric/ertp';
 
 import '@agoric/network/exported.js';
 import '@agoric/zoe/exported.js';
@@ -20,11 +18,11 @@ import { makeCourierMaker, getCourierPK } from './courier.js';
 const DEFAULT_DENOM_TRANSFORMER = IBCSourceTraceDenomTransformer;
 const DEFAULT_TRANSFER_PROTOCOL = ICS20TransferProtocol;
 
-const TRANSFER_PROPOSAL_SHAPE = {
+const TransferProposalShape = M.splitRecord({
   give: {
-    Transfer: null,
+    Transfer: AmountShape, // TODO get amount shape from brand
   },
-};
+});
 
 /**
  * Make a Pegasus public API.
@@ -481,11 +479,15 @@ const makePegasus = (zcf, board, namesByAddress) => {
        * @type {OfferHandler}
        */
       const offerHandler = zcfSeat => {
-        assertProposalShape(zcfSeat, TRANSFER_PROPOSAL_SHAPE);
         send(zcfSeat, depositAddress, memo, opts);
       };
 
-      return zcf.makeInvitation(offerHandler, `pegasus ${sendDenom} transfer`);
+      return zcf.makeInvitation(
+        offerHandler,
+        `pegasus ${sendDenom} transfer`,
+        undefined,
+        TransferProposalShape,
+      );
     },
   });
 };

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -1,7 +1,8 @@
 // @ts-check
 
 import { assert, details as X, Fail } from '@agoric/assert';
-import { makeLegacyWeakMap, makeLegacyMap, M } from '@agoric/store';
+import { M } from '@endo/patterns';
+import { makeLegacyWeakMap, makeLegacyMap } from '@agoric/store';
 import { E, Far } from '@endo/far';
 import { atomicTransfer } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeSubscriptionKit } from '@agoric/notifier';

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -6,6 +6,7 @@ import { AssetKind } from '@agoric/ertp';
 import { fromUniqueEntries } from '@agoric/internal';
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
 import { atomicTransfer, fromOnly, toOnly } from './atomicTransfer.js';
+import { AmountKeywordRecordShape } from '../typeGuards.js';
 
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
@@ -199,6 +200,12 @@ export const depositToSeat = async (zcf, recipientSeat, amounts, payments) => {
   const invitation = zcf.makeInvitation(
     reallocateAfterDeposit,
     'temporary seat for deposit',
+    undefined,
+    harden({
+      give: AmountKeywordRecordShape,
+      want: {},
+      exit: { onDemand: null },
+    }),
   );
   const proposal = harden({ give: amounts });
   harden(payments);

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -1,5 +1,5 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
-import { mustMatch, keyEQ } from '@agoric/store';
+import { mustMatch, keyEQ, M } from '@endo/patterns';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { AssetKind } from '@agoric/ertp';
@@ -201,7 +201,7 @@ export const depositToSeat = async (zcf, recipientSeat, amounts, payments) => {
     reallocateAfterDeposit,
     'temporary seat for deposit',
     undefined,
-    harden({
+    M.splitRecord({
       give: AmountKeywordRecordShape,
       want: {},
       exit: { onDemand: null },

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -1,9 +1,8 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { E } from '@endo/eventual-send';
-import { mustMatch } from '@endo/patterns';
+import { mustMatch, M } from '@endo/patterns';
 import { Far } from '@endo/marshal';
 import { TimeMath, RelativeTimeShape } from '@agoric/time';
-import { M } from '@agoric/store';
 import { AmountShape } from '@agoric/ertp';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'


### PR DESCRIPTION
First commit was extracted from #7041 . Likely some of the review comments there are relevant here.

Replaces some uses of the deprecated `assertProposalShape` with `makeInvitation`s direct support for proposalShape patterns. This provides better protection for contracts against malformed offers. When an offer's proposal violates the contract's required proposalShape pattern, it is rejected in Zoe and the contract never even sees the malformed offer.

This PR is somewhat empirical, revising the provided proposal patterns so that they were tighter than the `assertProposalPattern` call it replaced, while still passing all tests. For each modified contract, it would be good for someone who knows the meaning of the contract to do a sanity check on the proposalShape pattern.

One particular way these patterns could be tighter, to protect the contract from seeing more malformed offers, is to use the amountShape specific to the brand the contract is willing to accept in that position. I skipped that additional work, leaving a TODO there instead. Reviewers, if you know what brand-specific amountShape I should use in any such case, please let me know.

# Upgrade considerations

This PR was extracted from #7041 to omit packages/governance, so that we can worry separately about its upgrade sensitivity.