### PR TITLE
feat(swingset): add controller.resetAllMeters()

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -323,6 +323,10 @@ export async function makeSwingsetController(
       kernel.changeKernelOptions(options);
     },
 
+    resetAllMeters(remaining) {
+      kernel.resetAllMeters(remaining);
+    },
+
     getStats() {
       return defensiveCopy(kernel.getStats());
     },

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1871,6 +1871,10 @@ export default function buildKernel(
     }
   }
 
+  function resetAllMeters(remaining) {
+    kernelKeeper.resetAllMeters(remaining);
+  }
+
   function kpRegisterInterest(kpid) {
     kernelKeeper.incrementRefCount(kpid, 'external');
   }
@@ -1934,6 +1938,7 @@ export default function buildKernel(
     run,
     shutdown,
     changeKernelOptions,
+    resetAllMeters,
 
     // the rest are for testing and debugging
 

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1063,6 +1063,21 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     kvStore.delete(`${meterID}.threshold`);
   }
 
+  function resetAllMeters(remaining) {
+    remaining = Nat(BigInt(remaining));
+    const keyRE = /^m\d+\.remaining$/;
+    for (const key of enumeratePrefixedKeys(kvStore, 'm')) {
+      // meter data is stored in m$NN keys, however there are other keys
+      // that start with 'm' too
+      if (keyRE.test(key)) {
+        // UnlimitedMeters remain unchanged
+        if (getRequired(key) !== 'unlimited') {
+          kvStore.set(key, `${remaining}`);
+        }
+      }
+    }
+  }
+
   function hasVatWithName(name) {
     return kvStore.has(`vat.name.${name}`);
   }
@@ -1604,6 +1619,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     checkMeter,
     deductMeter,
     deleteMeter,
+    resetAllMeters,
 
     hasVatWithName,
     getVatIDForName,

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -10,6 +10,8 @@ import { restartVatAdminVat } from '../util.js';
 import { kunser, krefOf } from '../../src/lib/kmarshal.js';
 import { enumeratePrefixedKeys } from '../../src/kernel/state/storageHelper.js';
 
+const LOTS = 100_000_000n; // 100Mc
+
 async function prepare() {
   const kernelBundles = await buildKernelBundles();
   // we'll give this bundle to the loader vat, which will use it to create a
@@ -80,6 +82,10 @@ async function meterObjectsTest(t, doVatAdminRestarts) {
   await doMeter('setMeterThreshold', 7n);
   await vaRestart();
   t.deepEqual(await getMeter(), { remaining: 18n, threshold: 7n });
+
+  // resetAllMeters() will update it
+  c.resetAllMeters(99n);
+  t.deepEqual(await getMeter(), { remaining: 99n, threshold: 7n });
 }
 
 test('meter objects', async t => {
@@ -293,12 +299,11 @@ test('meter decrements', async t => {
   // times, but this is sensitive to SES and other libraries, so we
   // try to be tolerant of variation over time.
 
-  const lots = 100_000_000n; // TODO 100m
-  const t0 = await createMeteredVat(c, t, dynamicVatBundle, lots, 0n);
+  const t0 = await createMeteredVat(c, t, dynamicVatBundle, LOTS, 0n);
   let remaining0 = await t0.getMeter();
-  const consumedByStartVat = lots - remaining0;
+  const consumedByStartVat = LOTS - remaining0;
   console.log(`-- consumedByStartVat`, consumedByStartVat);
-  t.not(remaining0, lots);
+  t.not(remaining0, LOTS);
   await t0.consume(true);
   const remaining1 = await t0.getMeter();
   const firstConsume = remaining0 - remaining1;
@@ -439,6 +444,11 @@ async function unlimitedMeterTest(t, doVatAdminRestarts) {
   remaining = await getMeter();
   t.is(remaining, 'unlimited');
   await vaRestart();
+
+  // resetAllMeters() will not change an UnlimitedMeter
+  c.resetAllMeters(LOTS);
+  remaining = await getMeter();
+  t.is(remaining, 'unlimited');
 
   // but each crank is still limited, so an infinite loop will kill the vat
   const kp4 = c.queueToVatRoot('bootstrap', 'explode', ['compute']);


### PR DESCRIPTION
Add a feature which allows the host application to reset all non-unlimited Meters to a new absolute value.

refs #7938
