### PR TITLE
ci: only satisfy pre-checks once merge requested

### DIFF
--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -20,6 +20,7 @@ jobs:
 
   wait-integration-pre-checks:
     needs: pre_check
+    if: needs.pre_check.outputs.merge_requested == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: wait
@@ -28,7 +29,7 @@ jobs:
           cat <<EOF
             needs ${{ toJSON(needs.pre_check.outputs) }}
           EOF
-          sleep 5
+          sleep 15
 
   merge-strategy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-check-integration.yml
+++ b/.github/workflows/pre-check-integration.yml
@@ -6,6 +6,25 @@ on:
       should_run:
         description: "'true' if the test should run"
         value: "${{ jobs.check_and_cancel.outcome != 'skipped' && jobs.check_and_cancel.outputs.should_skip != 'true' }}"
+      merge_requested:
+        description: "'true' if pull_request was requested for merge"
+        value: >-
+          ${{
+            github.event_name != 'pull_request' || (
+              (
+                github.event.pull_request.base.ref == 'master' ||
+                github.event.pull_request.base.ref == 'release-pismo' ||
+                github.event.pull_request.base.ref == 'beta'
+              ) &&
+              github.event.pull_request.draft == false &&
+              (
+                contains(github.event.pull_request.labels.*.name, 'automerge:squash') || 
+                contains(github.event.pull_request.labels.*.name, 'automerge:no-update') ||
+                contains(github.event.pull_request.labels.*.name, 'automerge:rebase') ||
+                github.event.pull_request.auto_merge != null
+              )
+            )
+          }}
 
 jobs:
   check_and_cancel:


### PR DESCRIPTION
## Description

#8253 left in place the cancellation of any concurrent pull request integration test, because of #6466

Unfortunately that resulted in [mergify offboarding a PR](https://github.com/Agoric/agoric-sdk/pull/8250) that had been labelled `force:integration` right when adding an `automerge:` label because:
- all required checks had already succeeded (except for merge strategy chosen)
- adding the `automerge:` label immediately satisfied the merge strategy chosen checks, and thus onboarded the PR onto the queue
  - the `wait-integration-pre-checks` check was already marked as success because of the `force:integration` label
  - the merge was pending on getting a `integration-test-result` check status
- Actions triggered a new run of `Integration tests`
  - The concurrent rules caused the cancellation of the [existing run](https://github.com/Agoric/agoric-sdk/actions/runs/6014646219) (known limitation due to #6466)
  - `integration-test-result` reported a failure because of the run cancellation (we need that behavior to solve #6014 and #7126)
  - Problem: mergify offboarded the PR because "The queue conditions cannot be satisfied due to failing checks."

This PR tweaks the `wait-integration-pre-checks` check to only report a success once the PR is labelled with an `automerge:` label, instead of also allowing `force:integration`. This is not foolproof as cancellations may still happen if changing labels after adding the `automerge:` label, however that should be much less common an occurrence.

The right solution would be remove the GH managed concurrent check and restore the one based on source tree, aka solve #6466 

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Add this known limitation to the wiki

### Testing Considerations

Manually on this PR

### Upgrade Considerations

None
