### PR TITLE
ci: fix integration test skip

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -277,7 +277,7 @@ jobs:
       - getting-started
       - deployment-test
       - test-docker-build
-    if: needs.pre_check.outputs.should_run == 'true' && (success() || failure() || cancelled())
+    if: (needs.pre_check.outputs.should_run == 'true' && (success() || failure() || cancelled())) || needs.pre_check.outputs.previous_success == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
@@ -286,6 +286,7 @@ jobs:
           cat <<EOF
             needs ${{ toJSON(needs) }}
           EOF
+          [ "${{ needs.pre_check.outputs.previous_success }}" = "true" ] && exit 0
           [ "${{ needs.getting-started.result }}" = "success" ] || exit 1
           [ "${{ needs.deployment-test.result }}" = "success" ] || exit 1
           [ "${{ needs.test-docker-build.result }}" = "success" ] || exit 1

--- a/.github/workflows/pre-check-integration.yml
+++ b/.github/workflows/pre-check-integration.yml
@@ -6,6 +6,9 @@ on:
       should_run:
         description: "'true' if the test should run"
         value: "${{ jobs.check_and_cancel.outcome != 'skipped' && jobs.check_and_cancel.outputs.should_skip != 'true' }}"
+      previous_success:
+        description: "'true' if should not run because of a previous successful run"
+        value: "${{ jobs.check_and_cancel.outcome != 'skipped' && jobs.check_and_cancel.outputs.previous_success == 'true' }}"
       merge_requested:
         description: "'true' if pull_request was requested for merge"
         value: >-
@@ -49,6 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ (steps.step2.outcome == 'skipped' || steps.step2.outputs.concurrent_conclusion == 'success') && steps.step1.outputs.should_skip || 'false' }}
+      previous_success: >-
+        ${{
+          (steps.step2.outcome == 'skipped' && steps.step1.outputs.reason == 'skip_after_successful_duplicate' && 'true') || 
+          (steps.step2.outputs.concurrent_conclusion == 'success' && 'true') ||
+          'false'
+        }}
     steps:
       - id: step1
         uses: fkirc/skip-duplicate-actions@v5

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,9 +5,8 @@ queue_rules:
       - base=master
       # Require integration tests before merging only
       - or:
+          - label=bypass:integration
           - check-success=integration-test-result
-          - check-neutral=integration-test-result
-          - check-skipped=integration-test-result
 
 pull_request_rules:
   - name: merge to master


### PR DESCRIPTION
## Description

#8267 and #8275 attempted to fix the reporting of integration test results, but apparently #8220 still made it through with a skipped integration test.

This changes the mergify rule to always require a successful run of the integration test or a bypass. To accommodate the case of  an integration test having successfully run before (e.g. `force:integration` label, then `automerge:` label applied on up to date PR after all checks have already passed), this PR also updates the result reporting of the integration test to carry forward this previous success instead of marking it as skipped.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Will manually test the carry forward on this PR

### Upgrade Considerations

None
