### PR TITLE
8288 prune deps

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -42,7 +42,6 @@
     "@agoric/assert": "^0.6.0",
     "@agoric/notifier": "^0.6.2",
     "@agoric/store": "^0.9.2",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vat-data": "^0.5.2",
     "@endo/eventual-send": "^0.17.3",
     "@endo/far": "^0.2.19",
@@ -51,6 +50,7 @@
     "@endo/promise-kit": "^0.2.57"
   },
   "devDependencies": {
+    "@agoric/swingset-vat": "^0.32.2",
     "@endo/bundle-source": "^2.5.2",
     "@fast-check/ava": "^1.1.5",
     "ava": "^5.3.0",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -22,7 +22,6 @@
     "@agoric/ertp": "^0.16.2",
     "@agoric/internal": "^0.3.2",
     "@agoric/builders": "^0.1.0",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
     "@agoric/vm-config": "^0.1.0",
@@ -46,6 +45,7 @@
     "@agoric/store": "^0.9.2",
     "@agoric/swing-store": "^0.9.1",
     "@agoric/swingset-liveslots": "^0.10.2",
+    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/time": "^0.3.2",
     "ava": "^5.3.0",
     "c8": "^7.13.0"

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -28,7 +28,6 @@
     "@agoric/network": "^0.1.0",
     "@agoric/notifier": "^0.6.2",
     "@agoric/smart-wallet": "^0.5.3",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
     "@agoric/zoe": "^0.26.2",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -22,7 +22,6 @@
     "@agoric/internal": "^0.3.2",
     "@agoric/notifier": "^0.6.2",
     "@agoric/store": "^0.9.2",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vat-data": "^0.5.2",
     "@endo/far": "^0.2.19",
     "@endo/marshal": "^0.8.6"

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -37,7 +37,6 @@
     "@agoric/network": "^0.1.0",
     "@agoric/notifier": "^0.6.2",
     "@agoric/store": "^0.9.2",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/time": "^0.3.2",
     "@agoric/vat-data": "^0.5.2",
     "@agoric/zoe": "^0.26.2",
@@ -51,6 +50,7 @@
     "import-meta-resolve": "^2.2.1"
   },
   "devDependencies": {
+    "@agoric/swingset-vat": "^0.32.2",
     "@endo/bundle-source": "^2.5.2",
     "@endo/init": "^0.5.57",
     "ava": "^5.3.0",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -24,12 +24,12 @@
     "@agoric/assert": "^0.6.0",
     "@agoric/internal": "^0.3.2",
     "@agoric/store": "^0.9.2",
-    "@agoric/swingset-vat": "^0.32.2",
     "@endo/base64": "^0.2.32",
     "@endo/far": "^0.2.19",
     "@endo/promise-kit": "^0.2.57"
   },
   "devDependencies": {
+    "@agoric/swingset-vat": "^0.32.2",
     "@endo/bundle-source": "^2.5.2",
     "ava": "^5.3.0",
     "c8": "^7.13.0"

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.3.0",
+    "@agoric/swingset-vat": "^0.32.2",
     "@endo/bundle-source": "^2.5.2",
     "@endo/captp": "^3.1.2",
     "@endo/init": "^0.5.57",
@@ -30,7 +31,6 @@
     "@agoric/internal": "^0.3.2",
     "@agoric/notifier": "^0.6.2",
     "@agoric/store": "^0.9.2",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
     "@agoric/zoe": "^0.26.2",


### PR DESCRIPTION
refs: #8288 

## Description

There were some deps declared on `@agoric/swingset-vat` that were just devDependencies or not dependencies at all. This downgrades or removes as possible.

The upshot is that depending on `@agoric/ertp` no longer requires all of `@agoric/swingset-vat`.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

CI

### Upgrade Considerations

Decouples