### PR TITLE
chore: clean up UPGRADE_INFO_11 copy-pasta

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -95,8 +95,8 @@ ARG DEST_IMAGE
 FROM ghcr.io/agoric/agoric-sdk:35 as propose-agoric-upgrade-11
 # This default UPGRADE_INFO_11 is to test core proposals like the network vat.
 # TODO: Maybe replace with a Zoe core proposal, or remove when other paths test it.
-ARG BOOTSTRAP_MODE UPGRADE_INFO_11='{"coreProposals":["@agoric/builders/scripts/vats/init-network.js"]}'
-ENV THIS_NAME=propose-agoric-upgrade-11 UPGRADE_TO=agoric-upgrade-11 UPGRADE_INFO=${UPGRADE_INFO_11} BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ARG BOOTSTRAP_MODE
+ENV THIS_NAME=propose-agoric-upgrade-11 UPGRADE_TO=agoric-upgrade-11
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/


### PR DESCRIPTION
refs: #8166

## Description

`UPGRADE_INFO_11` should be empty, as noted in [a comment](https://github.com/Agoric/agoric-sdk/pull/8254#discussion_r1312176781) from @mhofman

