### PR TITLE
build: drop swingset from vat-data runtime deps

### DIFF
--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -20,12 +20,12 @@
   "dependencies": {
     "@agoric/base-zone": "workspace:*",
     "@agoric/store": "workspace:*",
-    "@agoric/swingset-liveslots": "workspace:*",
     "@endo/errors": "^1.2.13",
     "@endo/exo": "^1.5.12",
     "@endo/patterns": "^1.7.0"
   },
   "devDependencies": {
+    "@agoric/swingset-liveslots": "workspace:*",
     "@endo/far": "^1.1.14",
     "@endo/init": "^1.1.12",
     "@endo/ses-ava": "^1.3.2",


### PR DESCRIPTION
hygiene

## Description

'vat-data' does not depend on swingset-liveslots for its runtime functionality.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
