### PR TITLE
fix(upgrade-test): run tests and actions in agoric-upgrade-12

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -147,5 +147,6 @@ COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 RUN apt install -y tmux
 SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./upgrade-test-scripts/*.sh
+RUN . ./upgrade-test-scripts/start_to_to.sh
 # enter image in interactive shell
 ENTRYPOINT /usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -144,9 +144,8 @@ COPY --from=propose-agoric-upgrade-12 /root/.agoric /root/.agoric
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./package.json ./*.mjs ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
-RUN apt install -y tmux
-SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./upgrade-test-scripts/*.sh
+SHELL ["/bin/bash", "-c"]
 RUN . ./upgrade-test-scripts/start_to_to.sh
 # enter image in interactive shell
 ENTRYPOINT /usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh


### PR DESCRIPTION
## Description

This PR ensures building `agoric-upgrade-12` does what's expected, which should be:

- validating integrity after upgrade
- performing actions to set up state in current upgrade
- validate actions modified state as expected

This also means we do not re-run the validation when running the container and shelling in.

### Security Considerations

This ensures the image built has passed tests.

### Scaling Considerations

N/A.

### Documentation Considerations

N/A. Testing infra change.

I feel the current documentation in the Dockerfile is sufficient -- you want everything after `# start-chain boilerplate` for every upgrade (with minor changes particular to new files being added for the version). Maybe some improvement here? 

### Testing Considerations

Verified behavior is as expected:

`make local_sdk build` (agoric-upgrade-12 is the default)
observed tests and actions run during the build process
`make run`
Observe the presence of `$HOME/.agoric/runActions-${THIS_NAME}` which should prevent scripts from re-running. In window 0 (agd) observe only agd output is present and `pre_test.sh`, `actions.sh`, and `test.sh` arent running.

Might make sense to have a test in CI:

- inspecting the filesystem of a built image and ensuring `$HOME/.agoric/runActions-${THIS_NAME}` is present

### Upgrade Considerations

N/A.
