### PR TITLE
backport walletFactory improvements on top of upgrade-11 branch

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/.gitignore
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/.gitignore
@@ -1,0 +1,2 @@
+upgrade-walletFactory-permit.json
+upgrade-walletFactory.js

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-. ./upgrade-test-scripts/env_setup.sh
+# Dockerfile in upgrade-test sets:
+# WORKDIR /usr/src/agoric-sdk/
+# Overriding it during development has occasionally been useful.
+SDK=${SDK:-/usr/src/agoric-sdk}
+. $SDK/upgrade-test-scripts/env_setup.sh
 
 # Enable debugging
 set -x
-
-# CWD is agoric-sdk
-upgrade11=./upgrade-test-scripts/agoric-upgrade-11
 
 # hacky restore of pruned artifacts
 killAgd
@@ -45,3 +46,22 @@ agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-bac
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault3 -o jsonlines | jq -r '.vaultState') "closed" "vault3 is closed"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault3 -o jsonlines | jq -r '.locked.value') "0" "vault3 contains no collateral"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault3 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault3 has no debt"
+
+upgrade11=$SDK/upgrade-test-scripts/agoric-upgrade-11
+cd $upgrade11
+
+## build proposal and install bundles
+./tools/mint-ist.sh
+./wallet-all-ertp/wf-install-bundles.sh
+
+## upgrade wallet factory
+./wallet-all-ertp/wf-propose.sh
+
+## start game1
+./wallet-all-ertp/wf-game-propose.sh
+
+# Pay 0.25IST join the game and get some places
+node ./wallet-all-ertp/gen-game-offer.mjs Shire Mordor >/tmp/,join.json
+agops perf satisfaction --from $GOV1ADDR --executeOffer /tmp/,join.json --keyring-backend=test
+
+cd $SDK

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/pre_test.sh
@@ -8,6 +8,8 @@ waitForBlock 5
 # CWD is agoric-sdk
 upgrade11=./upgrade-test-scripts/agoric-upgrade-11
 
+test_val "$(agd query vstorage children published.boardAux -o json | jq .children)" "[]" "no boardAux children yet"
+
 # validate agoric-upgrade-10 metrics after update
 
 test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 3 "we have three vaults"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/test.sh
@@ -23,3 +23,45 @@ mv $TMP_GENESIS_DIR/priv_validator_state.json $HOME/.agoric/data
 mv $TMP_GENESIS_DIR/* $HOME/.agoric/config/
 rm -rf $EXPORT_DIR
 startAgd
+
+testMinChildren() {
+    path=$1
+    min=$2
+    line="$(agd query vstorage children $path -o jsonlines)"
+    ok=$(echo $line | jq ".children | length | . > $min")
+    test_val "$ok" "true" "$path: more than $min children"
+}
+
+# Check brand aux data for more than just vbank assets
+testMinChildren published.boardAux 3
+
+testDisplayInfo() {
+    name=$1
+    expected=$2
+
+    line="$(agoric follow -lF :published.agoricNames.brand -o text)"
+    # find brand by name, then corresponding slot
+    id=$(echo $line | jq --arg name "$name" -r '.slots as $slots | .body | gsub("^#";"") | fromjson | .[] | select(.[0] == $name) | .[1] | capture("^[$](?<slot>0|[1-9][0-9]*)") | .slot | $slots[. | tonumber]')
+    echo $name Id: $id
+
+    line="$(agoric follow -lF :published.boardAux.$id -o jsonlines)"
+    displayInfo="$(echo $line | jq -c .displayInfo)"
+    test_val "$displayInfo" "$expected" "$name displayInfo from boardAux"
+}
+
+testDisplayInfo IST '{"assetKind":"nat","decimalPlaces":6}'
+
+testPurseValuePayload() {
+    addr=$1
+    wkAsset=$2
+    expected=$3
+
+    line="$(agoric follow -lF :published.wallet.$addr.current -o jsonlines)"
+    # HACK: selecting brand by allegedName
+    payload=$(echo $line | jq --arg name "$wkAsset" -c '.purses[] | select(.brand | contains($name)) | .balance.value.payload')
+    test_val "$payload" "$expected" "$wkAsset purse for $addr"
+}
+
+# Smart wallet handles game Place assets?
+testDisplayInfo Place '{"assetKind":"copyBag"}'
+testPurseValuePayload $GOV1ADDR Place '[["Shire","1"],["Mordor","1"]]'

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/tools/mint-ist.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/tools/mint-ist.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "$GOV1ADDR" ]; then
+    echo run env_setup.sh to set GOV1ADDR
+    exit 1
+fi
+
+micro=000000
+
+# send some collateral to gov1
+agd tx bank send validator $GOV1ADDR 20123$micro${ATOM_DENOM} \
+     --keyring-backend=test --chain-id=agoriclocal --yes -bblock -o json
+
+export PATH=/usr/src/agoric-sdk/packages/agoric-cli/bin:$PATH
+agops vaults open --giveCollateral 5000 --wantMinted 20000 > /tmp/offer.json
+agops perf satisfaction --executeOffer /tmp/offer.json --from gov1 --keyring-backend=test

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/tools/parseProposals.mjs
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/tools/parseProposals.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+
+const Fail = (template, ...args) => {
+  throw Error(String.raw(template, ...args.map(val => String(val))));
+};
+
+/**
+ * Parse output of `agoric run proposal-builder.js`
+ *
+ * @param {string} txt
+ *
+ * adapted from packages/boot/test/bootstrapTests/supports.js
+ */
+const parseProposalParts = txt => {
+  const evals = [
+    ...txt.matchAll(/swingset-core-eval (?<permit>\S+) (?<script>\S+)/g),
+  ].map(m => {
+    if (!m.groups) throw Fail`Invalid proposal output ${m[0]}`;
+    const { permit, script } = m.groups;
+    return { permit, script };
+  });
+  evals.length || Fail`No swingset-core-eval found in proposal output: ${txt}`;
+
+  const bundles = [...txt.matchAll(/swingset install-bundle @([^\n]+)/gm)].map(
+    ([, bundle]) => bundle,
+  );
+  bundles.length || Fail`No bundles found in proposal output: ${txt}`;
+
+  return { evals, bundles };
+};
+
+const main = (stdin, readFileSync) => {
+  const input = readFileSync(stdin.fd).toString();
+  const parts = parseProposalParts(input);
+  // relies on console.log printing to stdout unmodified
+  console.log(JSON.stringify(parts));
+};
+
+main(process.stdin, fs.readFileSync);

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/gen-game-offer.mjs
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/gen-game-offer.mjs
@@ -1,0 +1,116 @@
+/* eslint-disable @jessie.js/safe-await-separator */
+/* global process */
+import assert from 'assert';
+import { execFile } from 'child_process';
+
+const ISTunit = 1_000_000n; // aka displayInfo: { decimalPlaces: 6 }
+const CENT = ISTunit / 100n;
+
+const [_node, _script, ...choices] = process.argv;
+
+const toSec = ms => BigInt(Math.round(ms / 1000));
+
+const id = `join-${Date.now()}`;
+
+// look up boardIDs for brands, instances in agoricNames
+
+// poor-man's zx
+const $ = cmd => {
+  console.error(cmd);
+  const [file, ...args] = cmd.split(' ');
+
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { encoding: 'utf8' }, (err, out) => {
+      if (err) return reject(err);
+      resolve(out);
+    });
+  });
+};
+
+const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
+const fromSmallCapsEntries = txt => {
+  const { body, slots } = JSON.parse(txt);
+  const theEntries = zip(JSON.parse(body.slice(1)), slots).map(
+    ([[name, ref], boardID]) => {
+      const iface = ref.replace(/^\$\d+\./, '');
+      return [name, { iface, boardID }];
+    },
+  );
+  return Object.fromEntries(theEntries);
+};
+
+const wkInstance = fromSmallCapsEntries(
+  await $('agoric follow -lF :published.agoricNames.instance -o text'),
+);
+assert(wkInstance.VaultFactory);
+
+const wkBrand = fromSmallCapsEntries(
+  await $('agoric follow -lF :published.agoricNames.brand -o text'),
+);
+assert(wkBrand.IST);
+assert(wkBrand.Place);
+
+const slots = []; // XXX global mutable state
+
+// XXX should use @endo/marshal
+const smallCaps = {
+  Nat: n => `+${n}`,
+  replacer: (k, v) =>
+    typeof v === 'bigint'
+      ? `+${v}`
+      : typeof v === 'symbol'
+      ? `%${v.description}`
+      : v,
+  // XXX mutates obj
+  ref: obj => {
+    if (obj.ix) return obj.ix;
+    const ix = slots.length;
+    slots.push(obj.boardID);
+    obj.ix = `$${ix}.Alleged: ${obj.iface}`;
+    return obj.ix;
+  },
+};
+
+const AmountMath = {
+  make: (brand, value) => ({
+    brand: smallCaps.ref(brand),
+    value: typeof value === 'bigint' ? smallCaps.Nat(value) : value,
+  }),
+};
+
+const makeTagged = (tag, payload) => ({
+  '#tag': tag,
+  payload,
+});
+
+const makeCopyBag = entries => makeTagged('copyBag', entries);
+const want = {
+  Places: AmountMath.make(
+    wkBrand.Place,
+    makeCopyBag(choices.map(name => [name, 1n])),
+  ),
+};
+
+const give = { Price: AmountMath.make(wkBrand.IST, 25n * CENT) };
+const body = {
+  method: 'executeOffer',
+  offer: {
+    id,
+    invitationSpec: {
+      source: 'contract',
+      instance: smallCaps.ref(wkInstance.game1),
+      publicInvitationMaker: 'makeJoinInvitation',
+    },
+    proposal: { give, want },
+  },
+};
+
+console.error(JSON.stringify(body.offer, smallCaps.replacer, 1));
+
+const capData = {
+  body: `#${JSON.stringify(body, smallCaps.replacer)}`,
+  slots,
+};
+const action = JSON.stringify(capData);
+
+console.log(action);

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/wf-game-propose.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/wf-game-propose.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Propose and carry out starting game contract
+
+SDK=${SDK:-/usr/src/agoric-sdk}
+UP11=${UP11:-$SDK/upgrade-test-scripts/agoric-upgrade-11}
+WFUP=${WFUP:-$UP11/wallet-all-ertp}
+
+cd $WFUP
+
+. $SDK/upgrade-test-scripts/env_setup.sh
+. $UP11/env_setup.sh
+
+TITLE="Start Game1 Contract"
+
+DESC="Start Game1 and register well-known Place issuer"
+
+# TODO: fix error recovery (or don't bother with it at all)
+[ -f ./start-game1-permit.json ] || (echo run wf-install-bundle.sh first ; exit 1)
+
+agd tx gov submit-proposal \
+  swingset-core-eval ./start-game1-permit.json ./start-game1.js \
+    --title="$TITLE" --description="$DESC" \
+    --from=validator --keyring-backend=test \
+    --deposit=10000000ubld \
+    --gas=auto --gas-adjustment=1.2 \
+    --chain-id=agoriclocal --yes -b block -o json
+
+agd --chain-id=agoriclocal query gov proposals --output json | \
+  jq -c '.proposals[] | [.proposal_id,.voting_end_time,.status]';
+
+voteLatestProposalAndWait

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/wf-install-bundles.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/wf-install-bundles.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Install bundles for walletFactory upgrade
+
+set -e
+
+SDK=${SDK:-/usr/src/agoric-sdk}
+UP11=${UP11:-$SDK/upgrade-test-scripts/agoric-upgrade-11}
+
+cd $UP11/wallet-all-ertp
+
+echo +++ run walletFactory, game upgrade proposal builders +++
+(agoric run $SDK/packages/vats/scripts/build-walletFactory-upgrade.js; \
+agoric run $SDK/packages/vats/scripts/build-game1-start.js
+ )>/tmp/,run.log
+bundles=$($UP11/tools/parseProposals.mjs </tmp/,run.log | jq -r '.bundles[]' | sort -u )
+
+echo +++ proposal evals for later +++
+/bin/pwd
+ls ./upgrade-walletFactory* ./start-game1*
+
+echo +++++ install bundles +++++
+
+# TODO: try `agoric publish` to better track outcome
+install_bundle() {
+  agd tx swingset install-bundle "@$1" \
+    --from gov1 --keyring-backend=test --gas=auto \
+    --chain-id=agoriclocal -bblock --yes -o json
+}
+
+for b in $bundles; do 
+  echo installing $b
+  install_bundle $b
+done

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/wf-propose.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/wallet-all-ertp/wf-propose.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Propose and carry out Wallet Factory upgrade
+
+set -e
+
+SDK=${SDK:-/usr/src/agoric-sdk}
+UP11=${UP11:-$SDK/upgrade-test-scripts/agoric-upgrade-11}
+WFUP=${WFUP:-$UP11/wallet-all-ertp}
+
+cd $WFUP
+
+# import voteLatestProposalAndWait
+. $UP11/env_setup.sh
+. $UP11/../env_setup.sh
+
+TITLE="Add NFT/non-vbank support in WalletFactory"
+DESC="Upgrade WalletFactory to support arbitrary ERTP assets such as NFTs"
+
+if [ ! -f ./upgrade-walletFactory-permit.json ]; then
+  file ./upgrade-walletFactory-permit.json
+  echo run wfup.js proposal builder first
+  exit 1
+fi
+
+agd tx gov submit-proposal \
+  swingset-core-eval ./upgrade-walletFactory-permit.json ./upgrade-walletFactory.js \
+    --title="$TITLE" --description="$DESC" \
+    --from=validator --keyring-backend=test \
+    --deposit=10000000ubld \
+    --gas=auto --gas-adjustment=1.2 \
+    --chain-id=agoriclocal --yes -b block -o json
+
+agd query gov proposals --output json | \
+  jq -c '.proposals[] | [.proposal_id,.voting_end_time,.status]';
+
+voteLatestProposalAndWait

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -121,7 +121,6 @@ test('want stable', async t => {
   t.log('Fund the wallet');
   assert(anchor.mint);
   const payment = anchor.mint.mintPayment(anchor.make(swapSize));
-  // @ts-expect-error deposit does take a FarRef<Payment>
   await wallet.getDepositFacet().receive(payment);
 
   t.log('Execute the swap');
@@ -167,7 +166,6 @@ test('want stable (insufficient funds)', async t => {
   t.log('Fund the wallet insufficiently');
   assert(anchor.mint);
   const payment = anchor.mint.mintPayment(anchor.make(anchorFunding));
-  // @ts-expect-error deposit does take a FarRef<Payment>
   await wallet.getDepositFacet().receive(payment);
 
   t.log('Execute the swap');
@@ -380,7 +378,6 @@ test('deposit multiple payments to unknown brand', async t => {
   // assume that if the call succeeds then it's in durable storage.
   for await (const amt of [1n, 2n]) {
     const payment = rial.mint.mintPayment(rial.make(amt));
-    // @ts-expect-error deposit does take a FarRef<Payment>
     const result = await wallet.getDepositFacet().receive(harden(payment));
     // successful request but not deposited
     t.deepEqual(result, { brand: rial.brand, value: 0n });

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -378,9 +378,9 @@ test('deposit multiple payments to unknown brand', async t => {
   // assume that if the call succeeds then it's in durable storage.
   for await (const amt of [1n, 2n]) {
     const payment = rial.mint.mintPayment(rial.make(amt));
-    const result = await wallet.getDepositFacet().receive(harden(payment));
-    // successful request but not deposited
-    t.deepEqual(result, { brand: rial.brand, value: 0n });
+    await t.throwsAsync(wallet.getDepositFacet().receive(harden(payment)), {
+      message: /cannot deposit .*: no purse/,
+    });
   }
 });
 

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -218,14 +218,15 @@ export const makeMockChainStorageRoot = () => {
      *
      * @param {string} path
      * @param {import('./lib-chainStorage.js').Marshaller} marshaller
+     * @param {number} [index]
      * @returns {unknown}
      */
-    getBody: (path, marshaller = defaultMarshaller) => {
+    getBody: (path, marshaller = defaultMarshaller, index = -1) => {
       data.size || Fail`no data in storage`;
       /** @type {ReturnType<typeof import('@endo/marshal').makeMarshal>['fromCapData']} */
       const fromCapData = (...args) =>
         Reflect.apply(marshaller.fromCapData, marshaller, args);
-      return unmarshalFromVstorage(data, path, fromCapData);
+      return unmarshalFromVstorage(data, path, fromCapData, index);
     },
     keys: () => [...data.keys()],
   });

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -17,9 +17,11 @@
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.3.0",
+    "@endo/bundle-source": "^2.5.2",
     "@endo/captp": "^3.1.1",
     "@endo/init": "^0.5.56",
-    "ava": "^5.2.0"
+    "ava": "^5.2.0",
+    "import-meta-resolve": "^2.2.1"
   },
   "dependencies": {
     "@agoric/assert": "^0.6.0",

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.3.0",
-    "@endo/bundle-source": "^2.5.2",
+    "@endo/bundle-source": "^2.5.1",
     "@endo/captp": "^3.1.1",
     "@endo/init": "^0.5.56",
     "ava": "^5.2.0",

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -1,4 +1,5 @@
 import { E, passStyleOf } from '@endo/far';
+import { deeplyFulfilledObject } from '@agoric/internal';
 import { makePaymentsHelper } from './payments.js';
 
 /**
@@ -80,14 +81,14 @@ export const makeOfferExecutor = ({
         // 1. Prepare values and validate synchronously.
         const { id, invitationSpec, proposal, offerArgs } = offerSpec;
 
+        /** @type {PaymentKeywordRecord | undefined} */
+        const paymentKeywordRecord = await (proposal?.give &&
+          deeplyFulfilledObject(paymentsManager.withdrawGive(proposal.give)));
+
         const invitation = invitationFromSpec(invitationSpec);
         const invitationAmount = await E(invitationIssuer).getAmountOf(
           invitation,
         );
-
-        const paymentKeywordRecord = proposal?.give
-          ? paymentsManager.withdrawGive(proposal.give)
-          : undefined;
 
         // 2. Begin executing offer
         // No explicit signal to user that we reached here but if anything above

--- a/packages/smart-wallet/src/proposals/upgrade-walletFactory-proposal.js
+++ b/packages/smart-wallet/src/proposals/upgrade-walletFactory-proposal.js
@@ -1,0 +1,103 @@
+// @ts-check
+import { E } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
+import { allValues } from '@agoric/internal';
+
+console.warn('upgrade-walletFactory-proposal.js module evaluating');
+
+const { Fail } = assert;
+
+// vstorage paths under published.*
+const BOARD_AUX = 'boardAux';
+
+const marshalData = makeMarshal(_val => Fail`data only`);
+
+/**
+ * @param { BootstrapPowers } powers
+ *
+ * @param {object} config
+ * @param {{ walletFactoryRef: VatSourceRef & { bundleID: string } }} config.options
+ */
+export const upgradeWalletFactory = async (
+  {
+    consume: { contractKits: kitsP, instancePrivateArgs: argsP },
+    instance: {
+      consume: { walletFactory: wfInstanceP },
+    },
+  },
+  config,
+) => {
+  console.log('upgradeWalletFactory: config', config);
+  const { walletFactoryRef } = config.options;
+
+  console.log('upgradeWalletFactory: awaiting instance');
+  const wfInstance = await wfInstanceP;
+  console.log('upgradeWalletFactory: awaiting contract kits');
+  const { contractKits, instancePrivateArgs } = await allValues({
+    contractKits: kitsP,
+    instancePrivateArgs: argsP,
+  });
+  const { adminFacet } = contractKits.get(wfInstance);
+  /** @type {Parameters<typeof import('../walletFactory').prepare>[1]} */
+  // @ts-expect-error cast
+  const unsettledArgs = instancePrivateArgs.get(wfInstance);
+  const privateArgs = await allValues(unsettledArgs);
+  console.log('upgradeWalletFactory: upgrading with privateArgs', privateArgs);
+  await E(adminFacet).upgradeContract(walletFactoryRef.bundleID, privateArgs);
+  console.log('upgradeWalletFactory: done');
+};
+harden(upgradeWalletFactory);
+
+/**
+ * @param { BootstrapPowers } powers
+ */
+export const publishAgoricBrandsDisplayInfo = async ({
+  consume: { agoricNames, board, chainStorage },
+}) => {
+  // chainStorage type includes undefined, which doesn't apply here.
+  // @ts-expect-error UNTIL https://github.com/Agoric/agoric-sdk/issues/8247
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  const publishBrandInfo = async brand => {
+    const [id, displayInfo, allegedName] = await Promise.all([
+      E(board).getId(brand),
+      E(brand).getDisplayInfo(),
+      E(brand).getAllegedName(),
+    ]);
+    const node = E(boardAux).makeChildNode(id);
+    const aux = marshalData.toCapData(harden({ allegedName, displayInfo }));
+    await E(node).setValue(JSON.stringify(aux));
+  };
+
+  /** @type {ERef<NameHub>} */
+  const brandHub = E(agoricNames).lookup('brand');
+  const brands = await E(brandHub).values();
+  // tolerate failure; in particular, for the timer brand
+  await Promise.allSettled(brands.map(publishBrandInfo));
+};
+harden(publishAgoricBrandsDisplayInfo);
+
+/** @type { import("@agoric/vats/src/core/lib-boot").BootstrapManifest } */
+const manifest = {
+  [upgradeWalletFactory.name]: {
+    // include rationale for closely-held, high authority capabilities
+    consume: {
+      contractKits: `to upgrade walletFactory using its adminFacet`,
+      instancePrivateArgs: `to get privateArgs for walletFactory`,
+    },
+    // widely-shared, low authority instance handles need no rationale
+    instance: {
+      consume: { walletFactory: true, provisionPool: true },
+    },
+  },
+  [publishAgoricBrandsDisplayInfo.name]: {
+    consume: { agoricNames: true, board: true, chainStorage: true },
+  },
+};
+harden(manifest);
+
+export const getManifestForUpgrade = (_powers, { walletFactoryRef }) => {
+  return harden({
+    manifest,
+    options: { walletFactoryRef },
+  });
+};

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -1,5 +1,4 @@
 import {
-  AmountMath,
   AmountShape,
   BrandShape,
   DisplayInfoShape,
@@ -7,15 +6,23 @@ import {
   PaymentShape,
   PurseShape,
 } from '@agoric/ertp';
-import { StorageNodeShape } from '@agoric/internal';
+import { StorageNodeShape, makeTracer } from '@agoric/internal';
 import { observeNotifier } from '@agoric/notifier';
 import { M, mustMatch } from '@agoric/store';
-import { appendToStoredArray } from '@agoric/store/src/stores/store-utils.js';
-import { makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
 import {
-  prepareRecorderKit,
+  appendToStoredArray,
+  provideLazy,
+} from '@agoric/store/src/stores/store-utils.js';
+import {
+  makeScalarBigMapStore,
+  makeScalarBigWeakMapStore,
+  prepareExoClassKit,
+  provide,
+} from '@agoric/vat-data';
+import {
   SubscriberShape,
   TopicsRecordShape,
+  prepareRecorderKit,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
 import { makeInvitationsHelper } from './invitations.js';
@@ -24,6 +31,8 @@ import { shape } from './typeGuards.js';
 import { objectMapStoragePath } from './utils.js';
 
 const { Fail, quote: q } = assert;
+
+const trace = makeTracer('SmrtWlt');
 
 /**
  * @file Smart wallet module
@@ -132,8 +141,8 @@ const { Fail, quote: q } = assert;
  * - `purseBalances` is a cache of what we've received from purses. Held so we can publish all balances on change.
  *
  * @typedef {Readonly<UniqueParams & {
- *   paymentQueues: MapStore<Brand, Array<import('@endo/far').FarRef<Payment>>>,
- *   offerToInvitationMakers: MapStore<string, import('./types').RemoteInvitationMakers>,
+ *   paymentQueues: MapStore<Brand, Array<Payment>>,
+ *   offerToInvitationMakers: MapStore<string, import('./types').InvitationMakers>,
  *   offerToPublicSubscriberPaths: MapStore<string, Record<string, string>>,
  *   offerToUsedInvitation: MapStore<string, Amount>,
  *   purseBalances: MapStore<RemotePurse, Amount>,
@@ -143,16 +152,66 @@ const { Fail, quote: q } = assert;
  *   liveOfferSeats: WeakMapStore<import('./offers.js').OfferId, UserSeat<unknown>>,
  * }>} ImmutableState
  *
+ * @typedef {BrandDescriptor & { purse: Purse }} PurseRecord
  * @typedef {{
  * }} MutableState
  */
+
+/**
+ * NameHub reverse-lookup, finding 0 or more names for a target value
+ *
+ * TODO: consider moving to nameHub.js?
+ *
+ * @param {unknown} target - passable Key
+ * @param {ERef<NameHub>} nameHub
+ */
+const namesOf = async (target, nameHub) => {
+  const entries = await E(nameHub).entries();
+  const matches = [];
+  for (const [name, candidate] of entries) {
+    if (candidate === target) {
+      matches.push(name);
+    }
+  }
+  return harden(matches);
+};
+
+/**
+ * Check that an issuer and its brand belong to each other.
+ *
+ * TODO: move to ERTP?
+ *
+ * @param {Issuer} issuer
+ * @param {Brand} brand
+ * @returns {Promise<boolean>} true iff the the brand and issuer match
+ */
+const checkMutual = (issuer, brand) =>
+  Promise.all([
+    E(issuer)
+      .getBrand()
+      .then(b => b === brand),
+    E(brand).isMyIssuer(issuer),
+  ]).then(checks => checks.every(Boolean));
+
+export const BRAND_TO_PURSES_KEY = 'brandToPurses';
+
+const getBrandToPurses = (walletPurses, key) => {
+  const brandToPurses = provideLazy(walletPurses, key, _k => {
+    /** @type {MapStore<Brand, PurseRecord[]>} */
+    const store = makeScalarBigMapStore('purses by brand', {
+      durable: true,
+    });
+    return store;
+  });
+  return brandToPurses;
+};
 
 /**
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {SharedParams} shared
  */
 export const prepareSmartWallet = (baggage, shared) => {
-  const { registry: _, ...passableShared } = shared;
+  const { registry: _r, ...passableShared } = shared;
   mustMatch(
     harden(passableShared),
     harden({
@@ -166,6 +225,15 @@ export const prepareSmartWallet = (baggage, shared) => {
   );
 
   const makeRecorderKit = prepareRecorderKit(baggage, shared.publicMarshaller);
+
+  const walletPurses = provide(baggage, BRAND_TO_PURSES_KEY, () => {
+    trace('make purses by wallet and save in baggage at', BRAND_TO_PURSES_KEY);
+    /** @type {WeakMapStore<unknown, MapStore<Brand, PurseRecord[]>>} */
+    const store = makeScalarBigWeakMapStore('purses by wallet', {
+      durable: true,
+    });
+    return store;
+  });
 
   /**
    *
@@ -245,6 +313,9 @@ export const prepareSmartWallet = (baggage, shared) => {
     helper: M.interface('helperFacetI', {
       assertUniqueOfferId: M.call(M.string()).returns(),
       updateBalance: M.call(PurseShape, AmountShape).optional('init').returns(),
+      getPurseIfKnownBrand: M.call(BrandShape)
+        .optional(M.eref(M.remotable()))
+        .returns(M.promise()),
       publishCurrentState: M.call().returns(),
       watchPurse: M.call(M.eref(PurseShape)).returns(M.promise()),
     }),
@@ -369,6 +440,63 @@ export const prepareSmartWallet = (baggage, shared) => {
             },
           });
         },
+
+        /**
+         * Provide a purse given a NameHub of issuers and their
+         * brands.
+         *
+         * We current support only one NameHub, agoricNames, and
+         * hence one purse per brand. But we store an array of them
+         * to facilitate a transition to decentralized introductions.
+         *
+         * @param {Brand} brand
+         * @param {ERef<NameHub>} known - namehub with brand, issuer branches
+         * @returns {Promise<Purse | undefined>} undefined if brand is not known
+         */
+        async getPurseIfKnownBrand(brand, known) {
+          const { helper, self } = this.facets;
+          const brandToPurses = getBrandToPurses(walletPurses, self);
+
+          if (brandToPurses.has(brand)) {
+            const purses = brandToPurses.get(brand);
+            if (purses.length > 0) {
+              // UNTIL https://github.com/Agoric/agoric-sdk/issues/6126
+              // multiple purses
+              return purses[0].purse;
+            }
+          }
+
+          const found = await namesOf(brand, E(known).lookup('brand'));
+          if (found.length === 0) {
+            return undefined;
+          }
+          const [edgeName] = found;
+          const issuer = await E(known).lookup('issuer', edgeName);
+
+          // Even though we rely on this nameHub, double-check
+          // that the issuer and the brand belong to each other.
+          if (!(await checkMutual(issuer, brand))) {
+            // if they don't, it's not a "known" brand in a coherent way
+            return undefined;
+          }
+
+          // Accept the issuer; rely on it in future offers.
+          const [displayInfo, purse] = await Promise.all([
+            E(issuer).getDisplayInfo(),
+            E(issuer).makeEmptyPurse(),
+          ]);
+
+          // adopt edgeName as petname
+          // NOTE: for decentralized introductions, qualify edgename by nameHub petname
+          const petname = edgeName;
+          const assetInfo = { petname, brand, issuer, purse, displayInfo };
+          appendToStoredArray(brandToPurses, brand, assetInfo);
+          // NOTE: when we decentralize introduction of issuers,
+          // process queued payments for this brand.
+
+          void helper.watchPurse(purse);
+          return purse;
+        },
       },
       /**
        * Similar to {DepositFacet} but async because it has to look up the purse.
@@ -379,10 +507,12 @@ export const prepareSmartWallet = (baggage, shared) => {
          *
          * If the purse doesn't exist, we hold the payment in durable storage.
          *
-         * @param {import('@endo/far').FarRef<Payment>} payment
-         * @returns {Promise<Amount>} amounts for deferred deposits will be empty
+         * @param {Payment} payment
+         * @returns {Promise<Amount>}
+         * @throws if there's not yet a purse, though the payment is held to try again when there is
          */
         async receive(payment) {
+          const { helper } = this.facets;
           const { paymentQueues: queues, bank, invitationPurse } = this.state;
           const { registry, invitationBrand } = shared;
           const brand = await E(payment).getAllegedBrand();
@@ -390,17 +520,24 @@ export const prepareSmartWallet = (baggage, shared) => {
           // When there is a purse deposit into it
           if (registry.has(brand)) {
             const purse = E(bank).getPurse(brand);
-            // @ts-expect-error deposit does take a FarRef<Payment>
             return E(purse).deposit(payment);
           } else if (invitationBrand === brand) {
-            // @ts-expect-error deposit does take a FarRef<Payment>
+            // @ts-expect-error narrow assetKind to 'set'
             return E(invitationPurse).deposit(payment);
+          }
+
+          const purse = await helper.getPurseIfKnownBrand(
+            brand,
+            shared.agoricNames,
+          );
+          if (purse) {
+            return E(purse).deposit(payment);
           }
 
           // When there is no purse, save the payment into a queue.
           // It's not yet ever read but a future version of the contract can
           appendToStoredArray(queues, brand, payment);
-          return AmountMath.makeEmpty(brand);
+          throw Fail`cannot deposit payment with brand ${brand}: no purse`;
         },
       },
       offers: {
@@ -448,12 +585,21 @@ export const prepareSmartWallet = (baggage, shared) => {
                * @returns {Promise<RemotePurse>}
                */
               purseForBrand: async brand => {
+                const { helper } = facets;
                 if (registry.has(brand)) {
                   // @ts-expect-error RemotePurse cast
                   return E(bank).getPurse(brand);
                 } else if (invitationBrand === brand) {
                   // @ts-expect-error RemotePurse cast
                   return invitationPurse;
+                }
+
+                const purse = await helper.getPurseIfKnownBrand(
+                  brand,
+                  shared.agoricNames,
+                );
+                if (purse) {
+                  return purse;
                 }
                 throw Fail`cannot find/make purse for ${brand}`;
               },

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -1,3 +1,5 @@
+// backported types are out of sync
+// @ts-nocheck
 import {
   AmountShape,
   BrandShape,
@@ -666,7 +668,7 @@ export const prepareSmartWallet = (baggage, shared) => {
          * Umarshals the actionCapData and delegates to the appropriate action handler.
          *
          * @param {import('@endo/marshal').CapData<string>} actionCapData of type BridgeAction
-         * @param {boolean} [canSpend=false]
+         * @param {boolean} [canSpend]
          * @returns {Promise<void>}
          */
         handleBridgeAction(actionCapData, canSpend = false) {

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -16,18 +16,18 @@ import { shape } from './typeGuards.js';
 
 const trace = makeTracer('WltFct');
 
+export const customTermsShape = harden({
+  agoricNames: M.eref(M.remotable('agoricNames')),
+  board: M.eref(M.remotable('board')),
+  assetPublisher: M.eref(M.remotable('Bank')),
+});
+
 export const privateArgsShape = harden(
   M.splitRecord(
     { storageNode: M.eref(M.remotable('StorageNode')) },
     { walletBridgeManager: M.eref(M.remotable('walletBridgeManager')) },
   ),
 );
-
-export const customTermsShape = harden({
-  agoricNames: M.eref(M.remotable('agoricNames')),
-  board: M.eref(M.remotable('board')),
-  assetPublisher: M.eref(M.remotable('Bank')),
-});
 
 /**
  * Provide a NameHub for this address and insert depositFacet only if not
@@ -292,10 +292,20 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   if (walletBridgeManager) {
     // NB: may not be in service when creatorFacet is used, or ever
     // It can't be awaited because that fails vat restart
-    void E(walletBridgeManager).initHandler(handleWalletAction);
+    const upgrading = baggage.has('walletsByAddress');
+    if (upgrading) {
+      void E(walletBridgeManager).setHandler(handleWalletAction);
+    } else {
+      void E(walletBridgeManager).initHandler(handleWalletAction);
+    }
   }
 
   return {
     creatorFacet,
   };
 };
+harden(prepare);
+
+// So we can consistently import `start` from contracts.
+// Can't be a value export because Zoe enforces that contracts export one or the other.
+/** @typedef {typeof prepare} start */

--- a/packages/smart-wallet/test/gameAssetContract.js
+++ b/packages/smart-wallet/test/gameAssetContract.js
@@ -1,0 +1,68 @@
+/** @file illustrates using non-vbank assets */
+
+// deep import to avoid dependency on all of ERTP, vat-data
+import { AmountShape } from '@agoric/ertp';
+import { AmountMath, AssetKind } from '@agoric/ertp/src/amountMath.js';
+import { makeTracer } from '@agoric/internal';
+import { M, getCopyBagEntries } from '@agoric/store';
+import { atomicRearrange } from '@agoric/zoe/src/contractSupport/index.js';
+import { E, Far } from '@endo/far';
+
+const { Fail, quote: q } = assert;
+
+const trace = makeTracer('Game', true);
+
+/** @param {Amount<'copyBag'>} amt */
+const totalPlaces = amt => {
+  /** @type {[unknown, bigint][]} */
+  const entries = getCopyBagEntries(amt.value); // XXX getCopyBagEntries returns any???
+  const total = entries.reduce((acc, [_place, qty]) => acc + qty, 0n);
+  return total;
+};
+
+/**
+ * @param {ZCF<{joinPrice: Amount}>} zcf
+ */
+export const start = async zcf => {
+  const { joinPrice } = zcf.getTerms();
+  const stableIssuer = await E(zcf.getZoeService()).getFeeIssuer();
+  zcf.saveIssuer(stableIssuer, 'Price');
+
+  const { zcfSeat: gameSeat } = zcf.makeEmptySeatKit();
+  const mint = await zcf.makeZCFMint('Place', AssetKind.COPY_BAG);
+
+  const joinShape = harden({
+    give: { Price: AmountShape },
+    want: { Places: AmountShape },
+    exit: M.any(),
+  });
+
+  /** @param {ZCFSeat} playerSeat */
+  const joinHook = playerSeat => {
+    const { give, want } = playerSeat.getProposal();
+    trace('join', 'give', give, 'want', want.Places.value);
+
+    AmountMath.isGTE(give.Price, joinPrice) ||
+      Fail`${q(give.Price)} below joinPrice of ${q(joinPrice)}}`;
+
+    totalPlaces(want.Places) <= 3n || Fail`only 3 places allowed when joining`;
+
+    atomicRearrange(
+      zcf,
+      harden([
+        [playerSeat, gameSeat, give],
+        [mint.mintGains(want), playerSeat, want],
+      ]),
+    );
+    playerSeat.exit(true);
+    return 'welcome to the game';
+  };
+
+  const publicFacet = Far('API', {
+    makeJoinInvitation: () =>
+      zcf.makeInvitation(joinHook, 'join', undefined, joinShape),
+  });
+
+  return harden({ publicFacet });
+};
+harden(start);

--- a/packages/smart-wallet/test/gameAssetContract.js
+++ b/packages/smart-wallet/test/gameAssetContract.js
@@ -1,11 +1,10 @@
 /** @file illustrates using non-vbank assets */
 
 // deep import to avoid dependency on all of ERTP, vat-data
-import { AmountShape } from '@agoric/ertp';
+import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
 import { AmountMath, AssetKind } from '@agoric/ertp/src/amountMath.js';
 import { makeTracer } from '@agoric/internal';
 import { M, getCopyBagEntries } from '@agoric/store';
-import { atomicRearrange } from '@agoric/zoe/src/contractSupport/index.js';
 import { E, Far } from '@endo/far';
 
 const { Fail, quote: q } = assert;
@@ -47,13 +46,12 @@ export const start = async zcf => {
 
     totalPlaces(want.Places) <= 3n || Fail`only 3 places allowed when joining`;
 
-    atomicRearrange(
-      zcf,
-      harden([
-        [playerSeat, gameSeat, give],
-        [mint.mintGains(want), playerSeat, want],
-      ]),
-    );
+    // We use the deprecated stage/reallocate API
+    // so that we can test this with the version of zoe on mainnet1B.
+    playerSeat.decrementBy(gameSeat.incrementBy(give));
+    const tmp = mint.mintGains(want);
+    playerSeat.incrementBy(tmp.decrementBy(want));
+    zcf.reallocate(playerSeat, tmp, gameSeat);
     playerSeat.exit(true);
     return 'welcome to the game';
   };

--- a/packages/smart-wallet/test/start-game1-proposal.js
+++ b/packages/smart-wallet/test/start-game1-proposal.js
@@ -1,0 +1,122 @@
+// @ts-check
+import { E } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+
+console.warn('start-game1-proposal.js module evaluating');
+
+const { Fail } = assert;
+
+// vstorage paths under published.*
+const BOARD_AUX = 'boardAux';
+
+const marshalData = makeMarshal(_val => Fail`data only`);
+
+const IST_UNIT = 1_000_000n;
+const CENT = IST_UNIT / 100n;
+
+/**
+ * Make a storage node for auxilliary data for a value on the board.
+ *
+ * @param {ERef<StorageNode>} chainStorage
+ * @param {string} boardId
+ */
+const makeBoardAuxNode = async (chainStorage, boardId) => {
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  return E(boardAux).makeChildNode(boardId);
+};
+
+const publishBrandInfo = async (chainStorage, board, brand) => {
+  const [id, displayInfo] = await Promise.all([
+    E(board).getId(brand),
+    E(brand).getDisplayInfo(),
+  ]);
+  const node = makeBoardAuxNode(chainStorage, id);
+  const aux = marshalData.toCapData(harden({ displayInfo }));
+  await E(node).setValue(JSON.stringify(aux));
+};
+
+/**
+ * Core eval script to start contract
+ *
+ * @param {BootstrapPowers} permittedPowers
+ */
+export const startGameContract = async permittedPowers => {
+  console.error('startGameContract()...');
+  const {
+    consume: { agoricNames, board, chainStorage, startUpgradable, zoe },
+    brand: {
+      // @ts-expect-error dynamic extension to promise space
+      produce: { Place: producePlaceBrand },
+    },
+    issuer: {
+      // @ts-expect-error dynamic extension to promise space
+      produce: { Place: producePlaceIssuer },
+    },
+    instance: {
+      // @ts-expect-error dynamic extension to promise space
+      produce: { game1: produceInstance },
+    },
+  } = permittedPowers;
+
+  const istBrand = await E(agoricNames).lookup('brand', 'IST');
+  const ist = {
+    brand: istBrand,
+  };
+  // NOTE: joinPrice could be configurable
+  const terms = { joinPrice: AmountMath.make(ist.brand, 25n * CENT) };
+
+  // agoricNames gets updated each time; the promise space only once XXXXXXX
+  const installation = await E(agoricNames).lookup('installation', 'game1');
+
+  const { instance } = await E(startUpgradable)({
+    installation,
+    label: 'game1',
+    terms,
+  });
+  console.log('CoreEval script: started game contract', instance);
+  const {
+    brands: { Place: brand },
+    issuers: { Place: issuer },
+  } = await E(zoe).getTerms(instance);
+
+  console.log('CoreEval script: share via agoricNames:', brand);
+
+  produceInstance.reset();
+  produceInstance.resolve(instance);
+
+  producePlaceBrand.reset();
+  producePlaceIssuer.reset();
+  producePlaceBrand.resolve(brand);
+  producePlaceIssuer.resolve(issuer);
+
+  await publishBrandInfo(chainStorage, board, brand);
+  console.log('game1 (re)installed');
+};
+
+/** @type { import("@agoric/vats/src/core/lib-boot").BootstrapManifest } */
+const gameManifest = {
+  [startGameContract.name]: {
+    consume: {
+      agoricNames: true,
+      board: true, // to publish boardAux info for game NFT
+      chainStorage: true, // to publish boardAux info for game NFT
+      startUpgradable: true, // to start contract and save adminFacet
+      zoe: true, // to get contract terms, including issuer/brand
+    },
+    installation: { consume: { game1: true } },
+    issuer: { produce: { Place: true } },
+    brand: { produce: { Place: true } },
+    instance: { produce: { game1: true } },
+  },
+};
+harden(gameManifest);
+
+export const getManifestForGame1 = ({ restoreRef }, { game1Ref }) => {
+  return harden({
+    manifest: gameManifest,
+    installations: {
+      game1: restoreRef(game1Ref),
+    },
+  });
+};

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -94,8 +94,10 @@ export const makeMockTestSpace = async log => {
     /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat, loadCriticalVat: (n: 'mints') => MintsVat }} } */ (
       space
     );
-  const { agoricNames, spaces } = await makeAgoricNamesAccess();
+  const { agoricNames, agoricNamesAdmin, spaces } =
+    await makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
+  produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
   const { zoe, feeMintAccessP } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
@@ -111,7 +111,6 @@ export const buildRootObject = async () => {
       const payment = moolaKit.mint.mintPayment(
         AmountMath.make(moolaKit.brand, 100n),
       );
-      // @ts-expect-error casting far for test
       await E(depositFacet).receive(payment);
 
       return true;

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -1,3 +1,5 @@
+/* backported code conforms to newer coding standards */
+/* eslint-disable no-await-in-loop */
 // @ts-check
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E, Far } from '@endo/far';

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -1,12 +1,22 @@
 // @ts-check
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import { E } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
-import { makeIssuerKit } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { makeScalarMapStore } from '@agoric/store';
+import { makeCopyBag, makeScalarMapStore } from '@agoric/store';
+import { makePromiseKit } from '@endo/promise-kit';
+import bundleSource from '@endo/bundle-source';
+import { makeMarshal } from '@endo/marshal';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { makeDefaultTestContext } from './contexts.js';
-import { makeMockTestSpace } from './supports.js';
+import { ActionType, headValue, makeMockTestSpace } from './supports.js';
+import { makeImportContext } from '../src/marshal-contexts.js';
+
+const { Fail } = assert;
+
+const importSpec = spec =>
+  importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
 const test = anyTest;
@@ -33,11 +43,14 @@ const bigIntReplacer = (_key, val) =>
 
 const range = qty => [...Array(qty).keys()];
 
+// We use test.serial() because
+// agoricNames and vstorage are shared mutable state.
+
 /**
  * NOTE: this doesn't test all forms of work.
  * A better test would measure inter-vat messages or some such.
  */
-test('avoid O(wallets) storage writes for a new asset', async t => {
+test.serial('avoid O(wallets) storage writes for a new asset', async t => {
   const bankManager = t.context.consume.bankManager;
 
   let chainStorageWrites = 0;
@@ -87,4 +100,440 @@ test('avoid O(wallets) storage writes for a new asset', async t => {
   // the only kind of balance we have yet.
   t.is(base.addedWrites, 0);
   t.is(exp.addedWrites, 0);
+});
+
+const BOARD_AUX = 'boardAux';
+/**
+ * Make a storage node for auxilliary data for a value on the board.
+ *
+ * @param {ERef<StorageNode>} chainStorage
+ * @param {string} boardId
+ */
+const makeBoardAuxNode = async (chainStorage, boardId) => {
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  return E(boardAux).makeChildNode(boardId);
+};
+
+const marshalData = makeMarshal(_val => Fail`data only`);
+
+/** @type {<T>(xP: Promise<T | null | undefined>) => Promise<T>} */
+const the = async xP => {
+  const x = await xP;
+  assert(x != null, 'resolution is unexpectedly nullish');
+  return x;
+};
+
+/** @typedef {import('@agoric/internal/src/storage-test-utils.js').MockChainStorageRoot} MockVStorageRoot */
+
+const IST_UNIT = 1_000_000n;
+const CENT = IST_UNIT / 100n;
+
+/** @param {import('ava').ExecutionContext<Awaited<ReturnType<makeDefaultTestContext>>>} t */
+const makeScenario = t => {
+  /**
+   * A player and their user agent (wallet UI, signer)
+   *
+   * @param {string} addr
+   * @param {PromiseKit<*>} bridgeKit - to announce UI is ready
+   * @param {MockVStorageRoot} vsRPC - access to vstorage via RPC
+   * @param {typeof t.context.sendToBridge} broadcastMsg
+   * @param {*} walletUpdates - access to wallet updates via RPC
+   */
+  const aPlayer = async (
+    addr,
+    bridgeKit,
+    vsRPC,
+    broadcastMsg,
+    walletUpdates,
+  ) => {
+    const ctx = makeImportContext();
+    const vsGet = path =>
+      E(vsRPC).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
+
+    // Ingest well-known brands, instances.
+    // Wait for vstorage publication to settle first.
+    await eventLoopIteration();
+    /** @type {Record<string, Brand>} */
+    // @ts-expect-error unsafe testing cast
+    const wkBrand = Object.fromEntries(await vsGet(`agoricNames.brand`));
+    await vsGet(`agoricNames.instance`);
+    t.log(addr, 'wallet UI: ingest well-known brands', wkBrand.Place);
+
+    assert(broadcastMsg);
+    /** @param {import('../src/smartWallet.js').BridgeAction} action */
+    const signAndBroadcast = async action => {
+      const actionEncoding = ctx.fromBoard.toCapData(action);
+      const addIssuerMsg = {
+        type: ActionType.WALLET_SPEND_ACTION,
+        owner: addr,
+        spendAction: JSON.stringify(actionEncoding),
+        blockTime: 0,
+        blockHeight: 0,
+      };
+      t.log(addr, 'walletUI: broadcast signed message', action.method);
+      await broadcastMsg(addIssuerMsg);
+    };
+
+    const auxInfo = async obj => {
+      const slot = ctx.fromBoard.toCapData(obj).slots[0];
+      return vsGet(`${BOARD_AUX}.${slot}`);
+    };
+
+    const { entries } = Object;
+    const uiBridge = Far('UIBridge', {
+      /** @param {import('@endo/marshal').CapData<string>} offerEncoding */
+      proposeOffer: async offerEncoding => {
+        /** @type {import('../src/offers.js').OfferSpec} */
+        const offer = ctx.fromBoard.fromCapData(offerEncoding);
+        const { give, want } = offer.proposal;
+        for await (const [kw, amt] of entries({ ...give, ...want })) {
+          // @ts-expect-error
+          const { displayInfo } = await auxInfo(amt.brand);
+          const kind = displayInfo?.assetKind === 'nat' ? 'fungible' : 'NFT';
+          t.log('wallet:', kind, 'display for', kw, amt.brand);
+        }
+        t.log(addr, 'walletUI: approve offer:', offer.id);
+        await signAndBroadcast(harden({ method: 'executeOffer', offer }));
+      },
+    });
+    bridgeKit.resolve(uiBridge);
+    return walletUpdates;
+  };
+
+  return { aPlayer };
+};
+
+test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
+  const pettyCashQty = 1000n;
+  const pettyCashPK = makePromiseKit();
+
+  const publishBrandInfo = async (chainStorage, board, brand) => {
+    const [id, displayInfo] = await Promise.all([
+      E(board).getId(brand),
+      E(brand).getDisplayInfo(),
+    ]);
+    const node = makeBoardAuxNode(chainStorage, id);
+    const aux = marshalData.toCapData(harden({ displayInfo }));
+    await E(node).setValue(JSON.stringify(aux));
+  };
+
+  /**
+   * @param {BootstrapPowers} powers
+   * @param {Record<string, Bundle>} bundles
+   */
+  const finishBootstrap = async ({ consume }, bundles) => {
+    const kindAdmin = kind => E(consume.agoricNamesAdmin).lookupAdmin(kind);
+
+    const publishAgoricNames = async () => {
+      const { board, chainStorage } = consume;
+      const pubm = E(board).getPublishingMarshaller();
+      const namesNode = await E(chainStorage)?.makeChildNode('agoricNames');
+      assert(namesNode);
+      for (const kind of ['brand', 'instance']) {
+        const kindNode = await E(namesNode).makeChildNode(kind);
+        const kindUpdater = Far('Updater', {
+          write: async x => {
+            // console.log('marshal for vstorage write', x);
+            const capData = await E(pubm).toCapData(x);
+            await E(kindNode).setValue(JSON.stringify(capData));
+          },
+        });
+        await E(kindAdmin(kind)).onUpdate(kindUpdater);
+      }
+      t.log('bootstrap: share agoricNames updates via vstorage RPC');
+    };
+
+    const shareIST = async () => {
+      const { chainStorage, bankManager, board, feeMintAccess, zoe } = consume;
+      const stable = await E(zoe)
+        .getFeeIssuer()
+        .then(issuer => {
+          return E(issuer)
+            .getBrand()
+            .then(brand => ({ issuer, brand }));
+        });
+      await E(kindAdmin('issuer')).update('IST', stable.issuer);
+      await E(kindAdmin('brand')).update('IST', stable.brand);
+      // TODO: publishBrandInfo for all brands in agoricNames.brand
+      await publishBrandInfo(chainStorage, board, stable.brand);
+
+      const invitation = await E(E(zoe).getInvitationIssuer()).getBrand();
+      await E(kindAdmin('brand')).update('Zoe Invitation', invitation);
+
+      const { creatorFacet: supplier } = await E(zoe).startInstance(
+        E(zoe).install(bundles.centralSupply),
+        {},
+        { bootstrapPaymentValue: pettyCashQty * IST_UNIT },
+        { feeMintAccess: await feeMintAccess },
+      );
+      const bootPmt = await E(supplier).getBootstrapPayment();
+      const stableSupply = E(stable.issuer).makeEmptyPurse();
+      await E(stableSupply).deposit(bootPmt);
+      pettyCashPK.resolve(stableSupply);
+
+      await E(bankManager).addAsset(
+        'uist',
+        'IST',
+        'Inter Stable Token',
+        stable,
+      );
+    };
+
+    await Promise.all([publishAgoricNames(), shareIST()]);
+  };
+
+  /**
+   * Core eval script to start contract
+   *
+   * @param {BootstrapPowers} permittedPowers
+   * @param {Bundle} bundle - in prod: a bundleId
+   */
+  const startGameContract = async ({ consume }, bundle) => {
+    const { agoricNames, agoricNamesAdmin, board, chainStorage, zoe } = consume;
+    const istBrand = await E(agoricNames).lookup('brand', 'IST');
+    const ist = {
+      brand: istBrand,
+    };
+    const terms = { joinPrice: AmountMath.make(ist.brand, 25n * CENT) };
+    const installationP = E(zoe).install(bundle); // in prod: installBundleId
+    // in prod: use startUpgradeable() to save adminFacet
+    const { instance } = await E(zoe).startInstance(installationP, {}, terms);
+    t.log('CoreEval script: started game contract', instance);
+    const {
+      brands: { Place: brand },
+      issuers: { Place: issuer },
+    } = await E(zoe).getTerms(instance);
+
+    t.log('CoreEval script: share via agoricNames:', brand);
+    const kindAdmin = kind => E(agoricNamesAdmin).lookupAdmin(kind);
+    await Promise.all([
+      E(kindAdmin('instance')).update('game1', instance),
+      E(kindAdmin('issuer')).update('Place', issuer),
+      E(kindAdmin('brand')).update('Place', brand),
+      publishBrandInfo(the(chainStorage), board, brand),
+    ]);
+  };
+
+  /**
+   * @param {MockVStorageRoot} rpc - access to vstorage (in prod: via RPC)
+   * @param {*} walletBridge - iframe connection to wallet UI
+   */
+  const dappFrontEnd = async (rpc, walletBridge) => {
+    const { fromEntries } = Object;
+    const ctx = makeImportContext();
+    await eventLoopIteration();
+    const vsGet = path =>
+      E(rpc).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
+
+    // @ts-expect-error unsafe testing cast
+    const wkBrand = fromEntries(await vsGet(`agoricNames.brand`));
+    // @ts-expect-error unsafe testing cast
+    const wkInstance = fromEntries(await vsGet(`agoricNames.instance`));
+    t.log('game UI: ingested well-known brands:', wkBrand.Place);
+
+    const choices = ['Park Place', 'Boardwalk'];
+    const want = {
+      Places: AmountMath.make(
+        wkBrand.Place,
+        makeCopyBag(choices.map(name => [name, 1n])),
+      ),
+    };
+    const give = { Price: AmountMath.make(wkBrand.IST, 25n * CENT) };
+    /** @type {import('../src/offers.js').OfferSpec} */
+    const offer1 = harden({
+      id: 'joinGame1234',
+      invitationSpec: {
+        source: 'contract',
+        instance: wkInstance.game1,
+        publicInvitationMaker: 'makeJoinInvitation',
+      },
+      proposal: { give, want },
+    });
+    t.log('game UI: propose offer of 0.25IST for', choices.join(', '));
+    await E(walletBridge).proposeOffer(ctx.fromBoard.toCapData(offer1));
+  };
+
+  // TODO: hoist the functions above out of the test
+  // so that t.context is not in scope?
+  const { consume, simpleProvideWallet, sendToBridge } = t.context;
+
+  const bundles = {
+    game: await importSpec('./gameAssetContract.js').then(bundleSource),
+    centralSupply: await importSpec('@agoric/vats/src/centralSupply.js').then(
+      bundleSource,
+    ),
+  };
+
+  const fundWalletAndSubscribe = async (addr, istQty) => {
+    const purse = pettyCashPK.promise;
+    const spendBrand = await E(purse).getAllegedBrand();
+    const spendingPmt = await E(purse).withdraw(
+      AmountMath.make(spendBrand, istQty * IST_UNIT),
+    );
+    const wallet = simpleProvideWallet(addr);
+    t.log('deposit', istQty, 'IST into wallet of', addr);
+    await E(E(wallet).getDepositFacet()).receive(spendingPmt);
+    const updates = await E(wallet).getUpdatesSubscriber();
+    return updates;
+  };
+
+  /** @type {BootstrapPowers} */
+  // @ts-expect-error mock
+  const somePowers = { consume };
+
+  /** @type {MockVStorageRoot} */
+  // @ts-expect-error mock
+  const mockStorage = await consume.chainStorage;
+  await finishBootstrap(somePowers, bundles);
+  t.log(
+    'install game contract bundle with hash:',
+    bundles.game.endoZipBase64Sha512.slice(0, 24),
+    '...',
+  );
+
+  {
+    const addr1 = 'agoric1player1';
+    const walletUIbridge = makePromiseKit();
+    const { aPlayer } = makeScenario(t);
+
+    const [_1, _2, updates] = await Promise.all([
+      startGameContract(somePowers, bundles.game),
+      dappFrontEnd(mockStorage, walletUIbridge.promise),
+      aPlayer(
+        addr1,
+        walletUIbridge,
+        mockStorage,
+        sendToBridge,
+        fundWalletAndSubscribe(addr1, 10n),
+      ),
+    ]);
+
+    /** @type {[string, bigint][]} */
+    const expected = [
+      ['Park Place', 1n],
+      ['Boardwalk', 1n],
+    ];
+
+    /** @type {import('../src/smartWallet.js').UpdateRecord} */
+    const update = await headValue(updates);
+    assert(update.updated === 'offerStatus');
+    // t.log(update.status);
+    t.like(update, {
+      updated: 'offerStatus',
+      status: {
+        id: 'joinGame1234',
+        invitationSpec: { publicInvitationMaker: 'makeJoinInvitation' },
+        numWantsSatisfied: 1,
+        payouts: { Places: { value: { payload: expected } } },
+        result: 'welcome to the game',
+      },
+    });
+    const {
+      status: { id, result, payouts },
+    } = update;
+    // @ts-expect-error cast value to copyBag
+    const names = payouts?.Places.value.payload.map(([name, _qty]) => name);
+    t.log(id, 'result:', result, ', payouts:', names.join(', '));
+
+    // wallet balance was also updated
+    const ctx = makeImportContext();
+    const vsGet = (path, ix = -1) =>
+      mockStorage.getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard, ix);
+    /** @type {Record<string, Brand>} */
+    const wkb = Object.fromEntries(
+      // @ts-expect-error unsafe testing cast
+      vsGet(`agoricNames.brand`),
+    );
+    vsGet(`agoricNames.instance`);
+
+    const balanceUpdate = vsGet(`wallet.${addr1}`, -2);
+    t.deepEqual(balanceUpdate, {
+      updated: 'balance',
+      currentAmount: { brand: wkb.Place, value: makeCopyBag(expected) },
+    });
+  }
+});
+
+test.serial('non-vbank asset: give before deposit', async t => {
+  /**
+   * Goofy client: proposes to give Places before we have any
+   *
+   * @param {MockVStorageRoot} rpc - access to vstorage (in prod: via RPC)
+   * @param {*} walletBridge - iframe connection to wallet UI
+   */
+  const goofyClient = async (rpc, walletBridge) => {
+    const { fromEntries } = Object;
+    const ctx = makeImportContext();
+    const vsGet = path =>
+      E(rpc).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
+    // @ts-expect-error unsafe testing cast
+    const wkBrand = fromEntries(await vsGet(`agoricNames.brand`));
+    // @ts-expect-error unsafe testing cast
+    const wkInstance = fromEntries(await vsGet(`agoricNames.instance`));
+
+    const choices = ['Disney Land'];
+    const give = {
+      Places: AmountMath.make(
+        wkBrand.Place,
+        makeCopyBag(choices.map(name => [name, 1n])),
+      ),
+    };
+    const want = { Price: AmountMath.make(wkBrand.IST, 25n * CENT) };
+
+    /** @type {import('../src/offers.js').OfferSpec} */
+    const offer1 = harden({
+      id: 'joinGame2345',
+      invitationSpec: {
+        source: 'contract',
+        instance: wkInstance.game1,
+        publicInvitationMaker: 'makeJoinInvitation',
+      },
+      proposal: { give, want },
+    });
+    t.log('goofy client: propose to give', choices.join(', '));
+    await E(walletBridge).proposeOffer(ctx.fromBoard.toCapData(offer1));
+  };
+
+  {
+    const addr2 = 'agoric1player2';
+    const walletUIbridge = makePromiseKit();
+    // await eventLoopIteration();
+
+    const { simpleProvideWallet, consume, sendToBridge } = t.context;
+    const wallet = simpleProvideWallet(addr2);
+    const updates = await E(wallet).getUpdatesSubscriber();
+    /** @type {MockVStorageRoot} */
+    // @ts-expect-error mock
+    const mockStorage = await consume.chainStorage;
+    const { aPlayer } = makeScenario(t);
+
+    aPlayer(addr2, walletUIbridge, mockStorage, sendToBridge, updates);
+    const c2 = goofyClient(mockStorage, walletUIbridge.promise);
+    await t.throwsAsync(c2, { message: /Withdrawal of {.*} failed/ });
+    await eventLoopIteration();
+
+    // wallet balance was also updated
+    const ctx = makeImportContext();
+    const vsGet = (path, ix = -1) =>
+      mockStorage.getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard, ix);
+    vsGet(`agoricNames.brand`);
+    vsGet(`agoricNames.instance`);
+
+    /** @type {import('../src/smartWallet.js').UpdateRecord & {updated: 'offerStatus'}} */
+    let offerUpdate;
+    let ix = -1;
+    for (;;) {
+      /** @type {import('../src/smartWallet.js').UpdateRecord} */
+      // @ts-expect-error
+      const update = vsGet(`wallet.${addr2}`, ix);
+      if (update.updated === 'offerStatus') {
+        offerUpdate = update;
+        break;
+      }
+      ix -= 1;
+    }
+
+    t.regex(offerUpdate.status.error || '', /Withdrawal of {.*} failed/);
+    t.log(offerUpdate.status.id, offerUpdate.status.error);
+  }
 });

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -75,7 +75,9 @@ test.serial('avoid O(wallets) storage writes for a new asset', async t => {
   };
 
   const simulate = async (qty, denom, name) => {
-    range(qty).forEach(startUser);
+    for (const idx of range(qty)) {
+      void startUser(idx);
+    }
     await eventLoopIteration();
     const initialWrites = chainStorageWrites;
 

--- a/packages/vats/scripts/build-game1-start.js
+++ b/packages/vats/scripts/build-game1-start.js
@@ -1,0 +1,34 @@
+/**
+ * @file Proposal Builder: Start Game with non-vbank Place NFT asset
+ *
+ * Usage:
+ *   agoric run build-game1-start.js
+ */
+
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { getManifestForGame1 } from '@agoric/smart-wallet/test/start-game1-proposal.js';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const game1ProposalBuilder = async ({ publishRef, install }) => {
+  return harden({
+    sourceSpec: '@agoric/smart-wallet/test/start-game1-proposal.js',
+    getManifestCall: [
+      getManifestForGame1.name,
+      {
+        game1Ref: publishRef(
+          install(
+            '@agoric/smart-wallet/test/gameAssetContract.js',
+            '../bundles/bundle-game1.js',
+            { persist: true },
+          ),
+        ),
+      },
+    ],
+  });
+};
+
+/** @type {DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('start-game1', game1ProposalBuilder);
+};

--- a/packages/vats/scripts/build-walletFactory-upgrade.js
+++ b/packages/vats/scripts/build-walletFactory-upgrade.js
@@ -1,0 +1,35 @@
+/**
+ * @file Proposal Builder: Upgrade walletFactory
+ *
+ * Usage:
+ *   agoric run build-walletFactory-upgrade.js
+ */
+
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { getManifestForUpgrade } from '@agoric/smart-wallet/src/proposals/upgrade-walletFactory-proposal.js';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) => {
+  return harden({
+    sourceSpec:
+      '@agoric/smart-wallet/src/proposals/upgrade-walletFactory-proposal.js',
+    getManifestCall: [
+      getManifestForUpgrade.name,
+      {
+        walletFactoryRef: publishRef(
+          install(
+            '@agoric/smart-wallet/src/walletFactory.js',
+            '../bundles/bundle-walletFactory.js',
+            { persist: true },
+          ),
+        ),
+      },
+    ],
+  });
+};
+
+/** @type {DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('upgrade-walletFactory', defaultProposalBuilder);
+};

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -115,7 +115,7 @@ export const makeHistoryReviver = (entries, slotToVal = undefined) => {
   const vsMap = new Map(entries);
   const fromCapData = (...args) =>
     Reflect.apply(board.fromCapData, board, args);
-  const getItem = key => unmarshalFromVstorage(vsMap, key, fromCapData);
+  const getItem = key => unmarshalFromVstorage(vsMap, key, fromCapData, -1);
   const children = prefix => {
     prefix.endsWith('.') || Fail`prefix must end with '.'`;
     return harden([


### PR DESCRIPTION
closes: #8305
refs: #8308 (alternative approach), #8156

## Description / Testing / Upgrade Considerations

back-port #8071, #8147 to the [release-mainnet1B](https://github.com/Agoric/agoric-sdk/tree/release-mainnet1B) branch in preparation for upgrading walletFactory by way of a core-eval on top of agoric-upgrade-11.

 - The first 6 commits are cherry-picked from #8071 directly.
 - The 7th comes from #8147 but with non-trivial changes because, for example, it has files in the `builders` package that doesn't exist in the mainnet branch.
 - The last few commits are administrative details such as a `yarn.lock` update due to an additional devDependency in packages/smart-wallet: `import-meta-resolve`, and some changes in our coding style.

Note: This is a long way from testing that every aspect of walletFactory remains working after an upgrade. It's just the same tests that were judged sufficient to address #8156.

### Security / Scaling Considerations

Nothing new here.

### Documentation Considerations

A discussion of the upgrade proposal should be shared via community.agoric.com.
