### PR TITLE
ci: use a manual check for integration-test-result

### DIFF
--- a/.github/actions/get-latest-check/action.yml
+++ b/.github/actions/get-latest-check/action.yml
@@ -1,0 +1,82 @@
+name: Get latest check
+description: "Get the latest integration-test-result check associated with the workflow's commit"
+
+inputs:
+  create-if-needed:
+    description: 'Create a new check if a previous check is not suitable'
+    default: false
+
+outputs:
+  run_id:
+    description: 'The id of the integration-test-result check'
+    value: ${{ steps.attach-check.outputs.result }}
+
+runs:
+  using: composite
+  steps:
+    - name: Attach integration-test-result check
+      id: attach-check
+      uses: actions/github-script@v6
+      env:
+        CREATE_IF_NEEDED: '${{ inputs.create-if-needed }}'
+      with:
+        result-encoding: string
+        script: |
+          let createIfNeeded = process.env.CREATE_IF_NEEDED === 'true'
+          let runId;
+          const currentWorkflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+          const head_sha = context.eventName === 'pull_request' ?
+          context.payload.pull_request.head.sha : context.sha
+
+          async function attachRun(run) {
+            if (!run) {
+              core.setFailed(`No integration-test-result check found for commit ${head_sha}`)
+              return
+            }
+            console.log('Latest integration-test-result check run:', run.html_url)
+            if (run.status === 'completed') {
+              core.setFailed(`Latest integration-test-result check status is already completed`)
+              return
+            }
+            if (run.output.summary) {
+              if (run.output.summary.includes(currentWorkflowRunUrl)) {
+                console.log('Latest integration-test-result check is already attached to this workflow run, using.')
+                return run.id
+              } else {
+                core.setFailed(`Latest integration-test-result check found attached to workflow run: ${run.output.summary}`)
+                return
+              }
+            }
+
+            const res = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: run.id,
+              output: {
+                title: 'Integration Test Aggregate Result',
+                summary: `Synthetic check capturing the result of the <a href="${currentWorkflowRunUrl}">integration-test workflow run</a>`,
+              },
+            })
+            console.log(`Attached integration-test-result check to this workflow run`)
+            return run.id
+          }
+
+          const runs = await github.paginate(github.rest.checks.listForRef, {
+            ...context.repo,
+            ref: head_sha,
+            check_name: "integration-test-result",
+          })
+          core.debug(`integration-test-result check runs: ${JSON.stringify(runs, null, 2)}`)
+          runId = await attachRun(runs.sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at))[0])
+
+          if (!runId && createIfNeeded) {
+            process.exitCode = 0
+            const res = await github.rest.checks.create({
+              ...context.repo,
+              head_sha,
+              name: "integration-test-result",
+            })
+            core.debug('check create response: ${JSON.stringify(res, null, 2)}')
+            console.log('created integration-test-result check:', res.data.html_url)
+            runId = await attachRun(res.data)
+          }
+          return runId

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,6 +49,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: Recreate integration-test-result if needed
+        id: get-pending-integration-result
+        uses: ./.github/actions/get-latest-check
+        with:
+          create-if-needed: true
       - name: Reconfigure git to use HTTP authentication
         run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
         shell: bash
@@ -124,6 +129,11 @@ jobs:
         with:
           submodules: 'true'
           path: ./agoric-sdk
+      - name: Recreate integration-test-result if needed
+        id: get-pending-integration-result
+        uses: ./agoric-sdk/.github/actions/get-latest-check
+        with:
+          create-if-needed: true
       - run: sudo packages/deployment/scripts/install-deps.sh
         working-directory: ./agoric-sdk
       - uses: ./agoric-sdk/.github/actions/restore-golang
@@ -243,6 +253,11 @@ jobs:
           echo "=== After cleanup:"
           df -h
       - uses: actions/checkout@v3
+      - name: Recreate integration-test-result if needed
+        id: get-pending-integration-result
+        uses: ./.github/actions/get-latest-check
+        with:
+          create-if-needed: true
       - name: docker build (sdk)
         # Produces ghcr.io/agoric/agoric-sdk:latest used in the following upgrade test.
         # TODO: Build this only once, not for every bootstrap-version.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -271,22 +271,68 @@ jobs:
         with:
           datadog-token: ${{ secrets.DATADOG_API_KEY }}
 
-  integration-test-result:
+  set-integration-result-in-progress:
+    needs: pre_check
+    if: needs.pre_check.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-pending-integration-result
+        uses: ./.github/actions/get-latest-check
+        with:
+          create-if-needed: true
+      - name: Update integration-test-result check to in-progress
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const runId = "${{ steps.get-pending-integration-result.outputs.run_id }}";
+            const res = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: runId,
+              status: "in_progress",
+            })
+            core.debug(`Check update response: ${JSON.stringify(res, null, 2)}`)
+            console.log(`Updated check ${runId} to in-progress`)
+
+  finalize-integration-result:
     needs:
       - pre_check
       - getting-started
       - deployment-test
       - test-docker-build
-    if: (needs.pre_check.outputs.should_run == 'true' && (success() || failure() || cancelled())) || needs.pre_check.outputs.previous_success == 'true'
+    if: >-
+      always() &&
+      needs.pre_check.result == 'success' &&
+      needs.getting-started.result != 'cancelled' &&
+      needs.deployment-test.result != 'cancelled' &&
+      needs.test-docker-build.result != 'cancelled' &&
+      (
+        needs.pre_check.outputs.should_run == 'true' ||
+        needs.pre_check.outputs.previous_success == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
-      - name: Check job results
-        shell: bash
-        run: |
-          cat <<EOF
-            needs ${{ toJSON(needs) }}
-          EOF
-          [ "${{ needs.pre_check.outputs.previous_success }}" = "true" ] && exit 0
-          [ "${{ needs.getting-started.result }}" = "success" ] || exit 1
-          [ "${{ needs.deployment-test.result }}" = "success" ] || exit 1
-          [ "${{ needs.test-docker-build.result }}" = "success" ] || exit 1
+      - uses: actions/checkout@v3
+      - id: get-pending-integration-result
+        uses: ./.github/actions/get-latest-check
+        with:
+          create-if-needed: true
+      - name: Publish integration-test-result
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const runId = "${{ steps.get-pending-integration-result.outputs.run_id }}";
+            const previousSuccess = ${{ needs.pre_check.outputs.previous_success }};
+            const gettingStartedTestSuccess = "${{ needs.getting-started.result }}" === "success";
+            const deploymentTestSuccess = "${{ needs.deployment-test.result }}" === "success";
+            const testDockerBuildSuccess = "${{ needs.test-docker-build.result }}" === "success";
+            const conclusion = previousSuccess || (gettingStartedTestSuccess && deploymentTestSuccess && testDockerBuildSuccess) ?
+              'success' : 'failure';
+            const res = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: runId,
+              conclusion,
+            })
+            core.debug(`Check update response: ${JSON.stringify(res, null, 2)}`)
+            console.log(`Updated check ${runId} to ${conclusion}`)

--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -15,21 +15,27 @@ on:
   merge_group:
 
 jobs:
-  pre_check:
-    uses: ./.github/workflows/pre-check-integration.yml
-
   wait-integration-pre-checks:
-    needs: pre_check
-    if: needs.pre_check.outputs.merge_requested == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: wait
-        shell: bash
-        run: |
-          cat <<EOF
-            needs ${{ toJSON(needs.pre_check.outputs) }}
-          EOF
-          sleep 15
+      - name: Create integration-test-result check
+        id: create-check
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const head_sha = context.eventName === 'pull_request' ?
+            context.payload.pull_request.head.sha : context.sha
+            const res = await github.rest.checks.create({
+              ...context.repo,
+              head_sha,
+              name: "integration-test-result",
+            })
+            core.debug('check create response: ${JSON.stringify(res, null, 2)}')
+            console.log('created integration-test-result', res.data.html_url)
+            return res.data.id
+    outputs:
+      run_id: ${{ steps.create-check.outputs.result }}
 
   merge-strategy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Changes the `integration-test-result` check to a check created and managed through the GitHub API to solve the constant problems with mergify based merges.

This change causes a queued `integration-test-result` check to be created as soon as the labels change, which will allow mergify to find this check when it evaluates its rules instead of a potentially missing or outdate one.

Then the integration test is updated to find and update the status of this check. This includes some bug fixes to make sure a runner fail (reported as a skipped job) causes the status to be reported as failed. The status check is reported while not tripping up the "previous successful run" checks

### Security Considerations

None

### Scaling Considerations

This does not revert the cancel of concurrent job, we can revisit later

### Documentation Considerations

No new documentation

### Testing Considerations

Heavily iterated upon in a new repo setup to replicate agoric-sdk's mergify setup: https://github.com/Agoric/mergify-experiements/pull/2

Feel free to play with labels in this PR too.

### Upgrade Considerations

None
