### PR TITLE
fix(walletFactory): move upgrading check before baggage is populated

### DIFF
--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -142,6 +142,7 @@ export const makeAssetRegistry = assetPublisher => {
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const prepare = async (zcf, privateArgs, baggage) => {
+  const upgrading = baggage.has('walletsByAddress');
   const { agoricNames, board, assetPublisher } = zcf.getTerms();
 
   const zoe = zcf.getZoeService();
@@ -292,7 +293,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   if (walletBridgeManager) {
     // NB: may not be in service when creatorFacet is used, or ever
     // It can't be awaited because that fails vat restart
-    const upgrading = baggage.has('walletsByAddress');
     if (upgrading) {
       void E(walletBridgeManager).setHandler(handleWalletAction);
     } else {

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -76,9 +76,11 @@ const makeFakeBridgeManager = () =>
           return E(handler).fromBridge(obj);
         },
         initHandler(newHandler) {
+          !handler || Fail`Handler already set`;
           handler = newHandler;
         },
         setHandler(newHandler) {
+          handler || Fail`Handler not set`;
           handler = newHandler;
         },
       });

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -80,7 +80,7 @@ const makeFakeBridgeManager = () =>
           handler = newHandler;
         },
         setHandler(newHandler) {
-          handler || Fail`Handler not set`;
+          !!handler || Fail`Handler not set`;
           handler = newHandler;
         },
       });


### PR DESCRIPTION
closes: #8321
refs: #8311

## Description

The `baggage.has('walletsByAddress')` check has to come before the `provideDurableMapStore(baggage, 'walletsByAddress')` call.

### Testing Considerations

 - [x] IOU a unit test

Meanwhile, @carlos-kryha , if you find a moment to try this fix, please let us know how it goes.

### Security / Scaling / Documentation Considerations

none

### Upgrade Considerations

This fixes the non-upgrade case, i.e. the 1st incarnation case.
