### PR TITLE
refactor: use guard getters

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -47,6 +47,7 @@
     "@endo/far": "^0.2.21",
     "@endo/marshal": "^0.8.8",
     "@endo/nat": "^4.1.30",
+    "@endo/patterns": "^0.2.5",
     "@endo/promise-kit": "^0.2.59"
   },
   "devDependencies": {

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import { M, matches } from '@agoric/store';
+import { M, matches, getInterfaceGuardPayload } from '@endo/patterns';
 
 export const BrandShape = M.remotable('Brand');
 export const IssuerShape = M.remotable('Issuer');
@@ -212,7 +212,7 @@ export const makeIssuerInterfaces = (
   });
 
   const DepositFacetI = M.interface('DepositFacet', {
-    receive: PurseI.methodGuards.deposit,
+    receive: getInterfaceGuardPayload(PurseI).methodGuards.deposit,
   });
 
   const PurseIKit = harden({

--- a/packages/base-zone/tools/greeter.js
+++ b/packages/base-zone/tools/greeter.js
@@ -1,4 +1,4 @@
-import { M } from '@endo/patterns';
+import { M, getInterfaceGuardPayload } from '@endo/patterns';
 
 /**
  * @template {{}} T
@@ -33,8 +33,8 @@ export const adminFacet = {
 };
 
 export const GreeterWithAdminI = M.interface('GreeterWithAdmin', {
-  ...GreeterI.methodGuards,
-  ...GreeterAdminI.methodGuards,
+  ...getInterfaceGuardPayload(GreeterI).methodGuards,
+  ...getInterfaceGuardPayload(GreeterAdminI).methodGuards,
 });
 
 /**
@@ -44,6 +44,7 @@ export const GreeterWithAdminI = M.interface('GreeterWithAdmin', {
  */
 export const prepareGreeterSingleton = (zone, label, nick) => {
   const myThis = Object.freeze({ state: { nick } });
+  // @ts-expect-error Until https://github.com/endojs/endo/pull/1771
   return zone.exo(label, GreeterWithAdminI, {
     ...bindAllMethodsTo(greetFacet, myThis),
     ...bindAllMethodsTo(adminFacet, myThis),
@@ -54,6 +55,7 @@ export const prepareGreeterSingleton = (zone, label, nick) => {
  * @param {import('../src/types.js').Zone} zone
  */
 export const prepareGreeter = zone =>
+  // @ts-expect-error Until https://github.com/endojs/endo/pull/1771
   zone.exoClass('Greeter', GreeterWithAdminI, nick => ({ nick }), {
     ...greetFacet,
     ...adminFacet,

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { E } from '@endo/far';
 import { isObject, isPassableSymbol } from '@endo/marshal';
-import { getInterfaceGuardPayload } from '@endo/patterns';
+import { getInterfaceMethodKeys } from '@endo/patterns';
 
 const { Fail, quote: q } = assert;
 
@@ -315,9 +315,7 @@ harden(prepareAttenuator);
  * @param {string} [opts.tag]
  */
 export const prepareGuardedAttenuator = (zone, interfaceGuard, opts = {}) => {
-  // TODO: Handle symbolMethodGuards too?
-  const { methodGuards } = getInterfaceGuardPayload(interfaceGuard);
-  const methodNames = ownKeys(methodGuards);
+  const methodNames = getInterfaceMethodKeys(interfaceGuard);
   const makeAttenuator = prepareAttenuator(zone, methodNames, {
     ...opts,
     interfaceGuard,

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { E } from '@endo/far';
 import { isObject, isPassableSymbol } from '@endo/marshal';
+import { getInterfaceGuardPayload } from '@endo/patterns';
 
 const { Fail, quote: q } = assert;
 
@@ -315,7 +316,7 @@ harden(prepareAttenuator);
  */
 export const prepareGuardedAttenuator = (zone, interfaceGuard, opts = {}) => {
   // TODO: Handle symbolMethodGuards too?
-  const { methodGuards } = interfaceGuard;
+  const { methodGuards } = getInterfaceGuardPayload(interfaceGuard);
   const methodNames = ownKeys(methodGuards);
   const makeAttenuator = prepareAttenuator(zone, methodNames, {
     ...opts,

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -2,7 +2,7 @@
 
 import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
 import { E, Far } from '@endo/far';
-import { M } from '@endo/patterns';
+import { M, getInterfaceGuardPayload } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
 
 import './types-ambient.js';
@@ -46,14 +46,16 @@ export const ForkableAsyncIterableIteratorShape = M.interface(
 );
 
 export const IterableEachTopicI = M.interface('IterableEachTopic', {
-  subscribeAfter: SubscriberI.methodGuards.subscribeAfter,
+  subscribeAfter:
+    getInterfaceGuardPayload(SubscriberI).methodGuards.subscribeAfter,
   [Symbol.asyncIterator]: M.call().returns(
     M.remotable('ForkableAsyncIterableIterator'),
   ),
 });
 
 export const IterableLatestTopicI = M.interface('IterableLatestTopic', {
-  getUpdateSince: SubscriberI.methodGuards.getUpdateSince,
+  getUpdateSince:
+    getInterfaceGuardPayload(SubscriberI).methodGuards.getUpdateSince,
   [Symbol.asyncIterator]: M.call().returns(
     M.remotable('ForkableAsyncIterableIterator'),
   ),

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -38,6 +38,7 @@
     "@endo/import-bundle": "^0.4.1",
     "@endo/marshal": "^0.8.8",
     "@endo/nat": "^4.1.30",
+    "@endo/patterns": "^0.2.5",
     "@endo/promise-kit": "^0.2.59",
     "import-meta-resolve": "^2.2.1",
     "jessie.js": "^0.3.2"

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -3,7 +3,7 @@
 import { assert, NonNullish } from '@agoric/assert';
 import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
-import { M } from '@agoric/store';
+import { M, getInterfaceGuardPayload } from '@endo/patterns';
 
 import './types.js';
 import {
@@ -48,7 +48,7 @@ export const NameHubIKit = harden({
 /** @param {import('@agoric/zone').Zone} zone */
 export const prepareMixinMyAddress = zone => {
   const MixinI = M.interface('MyAddressNameAdmin', {
-    ...NameHubIKit.nameAdmin.methodGuards,
+    ...getInterfaceGuardPayload(NameHubIKit.nameAdmin).methodGuards,
     getMyAddress: M.call().returns(M.string()),
   });
   /**

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -9,7 +9,8 @@ import {
   prepareDurablePublishKit,
   subscribeEach,
 } from '@agoric/notifier';
-import { M, provideLazy } from '@agoric/store';
+import { M, getInterfaceGuardPayload } from '@endo/patterns';
+import { provideLazy } from '@agoric/store';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { E, Far } from '@endo/far';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
@@ -26,8 +27,10 @@ const { Fail } = assert;
 const { VirtualPurseControllerI } = makeVirtualPurseKitIKit();
 
 const BridgeChannelI = M.interface('BridgeChannel', {
-  fromBridge: BridgeScopedManagerI.methodGuards.fromBridge,
-  toBridge: BridgeScopedManagerI.methodGuards.toBridge,
+  fromBridge:
+    getInterfaceGuardPayload(BridgeScopedManagerI).methodGuards.fromBridge,
+  toBridge:
+    getInterfaceGuardPayload(BridgeScopedManagerI).methodGuards.toBridge,
 });
 
 /**

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -13,6 +13,7 @@ import {
 
 import '@agoric/ertp/exported.js';
 import '@agoric/notifier/exported.js';
+import { getInterfaceGuardPayload } from '@endo/patterns';
 
 const { Fail } = assert;
 
@@ -48,7 +49,7 @@ export const makeVirtualPurseKitIKit = (
   });
 
   const DepositFacetI = M.interface('DepositFacet', {
-    receive: VirtualPurseI.methodGuards.deposit,
+    receive: getInterfaceGuardPayload(VirtualPurseI).methodGuards.deposit,
   });
 
   const RetainRedeemI = M.interface('RetainRedeem', {
@@ -57,8 +58,8 @@ export const makeVirtualPurseKitIKit = (
   });
 
   const UtilsI = M.interface('Utils', {
-    retain: RetainRedeemI.methodGuards.retain,
-    redeem: RetainRedeemI.methodGuards.redeem,
+    retain: getInterfaceGuardPayload(RetainRedeemI).methodGuards.retain,
+    redeem: getInterfaceGuardPayload(RetainRedeemI).methodGuards.redeem,
     recoverableClaim: M.callWhen(M.await(PaymentShape))
       .optional(amountShape)
       .returns(PaymentShape),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -224,7 +224,7 @@ export const InstanceStorageManagerIKit = harden({
       InstanceHandleShape,
       M.remotable('instanceAdmin'),
     ).returns(M.promise()),
-    deleteInstanceAdmin: M.call(InstanceAdminI).returns(),
+    deleteInstanceAdmin: M.call(InstanceAdminShape).returns(),
     makeInvitation: M.call(InvitationHandleShape, M.string())
       .optional(M.record(), M.pattern())
       .returns(PaymentShape),


### PR DESCRIPTION
To pave the way for https://github.com/endojs/endo/pull/1712 , switch from directly accessing the fields of guards to using the guard type's validating payload getter, and then accessing the fields of the payload.

See also https://github.com/endojs/endo/pull/1771, which would enable us to remove the two `@ts-expect-error`s that we had to add.