### PR TITLE
generate HTML documentation from TS/JSDoc

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -72,6 +72,9 @@ jobs:
       # eslint
       - name: yarn lint primary
         run: ./scripts/lint-with-types.sh primary
+      # build the API docs to verify it works
+      - name: build API docs
+        run: yarn docs
 
   lint-rest:
     timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ bundles
 bundle-*.js
 compiled
 dist
+api-docs
 
 # misc
 /.vagrant

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -12,3 +12,13 @@ So our best solution is to have one source of truth for the types and auto-gener
 - `src/types.d.ts` is built automatically from types-ambient
   - `prepack` copies types-ambient.js to types.js and appends 'export {};' to turn it into a module, then builds
   - `postpack` deletes the new types.js and .d.ts files
+
+## Generating API docs
+
+We use [TypeDoc](https://typedoc.org/) to render API docs in HTML.
+
+```sh
+yarn docs
+open api-docs/index.html
+```
+

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prettier": "^3.0.3",
     "prettier-plugin-jsdoc": "^1.0.0",
     "type-coverage": "^2.26.3",
+    "typedoc": "^0.25.4",
     "typescript": "~5.2.2"
   },
   "engines": {
@@ -64,6 +65,7 @@
   "scripts": {
     "clean": "yarn lerna run --no-bail clean",
     "check-dependencies": "node ./scripts/check-mismatched-dependencies.cjs",
+    "docs": "typedoc --tsconfig tsconfig.build.json",
     "lerna": "lerna",
     "link-cli": "yarn run create-agoric-cli",
     "create-agoric-cli": "node ./scripts/create-agoric-cli.cjs",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "test:xs": "yarn workspaces run test:xs",
     "build": "yarn workspaces run build",
     "postinstall": "patch-package",
+    "build-ts": "tsc --build tsconfig.build.json",
     "build-xs-worker": "cd packages/xs-vat-worker && yarn build:xs-lin"
   },
   "ava": {

--- a/packages/ERTP/typedoc.json
+++ b/packages/ERTP/typedoc.json
@@ -1,0 +1,12 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js"
+    ],
+    "validation": {
+        "notExported": false,
+        "invalidLink": false,
+    }
+}

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -553,10 +553,10 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
    * Allocate a new koid.
    *
    * @param {string} ownerID
-   * @param {undefined | bigint} id
+   * @param {bigint} [id]
    * @returns {string}
    */
-  function addKernelObject(ownerID, id = undefined) {
+  function addKernelObject(ownerID, id) {
     // providing id= is only for unit tests
     insistVatID(ownerID);
     if (id === undefined) {

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -11,7 +11,7 @@
  * @callback BaseAssert
  * The `assert` function itself.
  *
- * @param {*} flag The truthy/falsy value
+ * @param {any} flag The truthy/falsy value
  * @param {Details} [optDetails] The details to throw
  * @param {ErrorConstructor} [ErrorConstructor] An optional alternate error
  * constructor to use.
@@ -58,8 +58,8 @@
  * The `assert.equal` method
  *
  * Assert that two values must be `Object.is`.
- * @param {*} actual The value we received
- * @param {*} expected What we wanted
+ * @param {any} actual The value we received
+ * @param {any} expected What we wanted
  * @param {Details} [optDetails] The details to throw
  * @param {ErrorConstructor} [ErrorConstructor] An optional alternate error
  * constructor to use.
@@ -207,7 +207,7 @@
  * ```
  *
  * @callback AssertQuote
- * @param {*} payload What to declassify
+ * @param {any} payload What to declassify
  * @param {(string|number)} [spaces]
  * @returns {StringablePayload} The declassified payload
  */

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -193,12 +193,13 @@
  * payload itself is still passed unquoted to the console as it would be
  * without `quote`.
  *
+ * @example
  * For example, the following will reveal the expected sky color, but not the
  * actual incorrect sky color, in the thrown error's message:
  * ```js
  * sky.color === expectedColor || Fail`${sky.color} should be ${quote(expectedColor)}`;
  * ```
- *
+ * @example
  * The normal convention is to locally rename `details` to `X` and `quote` to `q`
  * like `const { details: X, quote: q } = assert;`, so the above example would then be
  * ```js

--- a/packages/assert/typedoc.json
+++ b/packages/assert/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/assert.js",
+        "src/types.js",
+    ]
+}

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -25,7 +25,7 @@ import {
 
 import type { ExecutionContext as AvaT } from 'ava';
 
-import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.ts';
+import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
 
 const trace = makeTracer('BSTSupport', false);
 

--- a/packages/cosmic-swingset/calc-rpcport.js
+++ b/packages/cosmic-swingset/calc-rpcport.js
@@ -11,6 +11,8 @@ import toml from '@iarna/toml';
 
 const configString = fs.readFileSync(process.argv[2]).toString();
 const config = toml.parse(configString);
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore Property 'laddr' does not exist on type 'AnyJson'
 const { laddr } = config.rpc; // like tcp://0.0.0.0:26657
 // eslint-disable-next-line no-useless-escape
 const m = laddr.match(/^tcp:\/\/([\d\.]+):(\d+)$/);

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -41,6 +41,7 @@ const QuorumRule = /** @type {const} */ ({
 const positionIncluded = (positions, p) => positions.some(e => keyEQ(e, p));
 
 /**
+ * @internal
  * @param {QuestionSpec} allegedQuestionSpec
  * @returns {QuestionSpec}
  */

--- a/packages/governance/typedoc.json
+++ b/packages/governance/typedoc.json
@@ -1,0 +1,11 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js",
+        // FIXME hitting errors like: Failed to find JSDoc tag for ParamValueTyped after parsing comment, please file a bug report.
+        // "src/types-ambient.js",
+        "tools/puppetGovernance.js",
+    ]
+}

--- a/packages/inter-protocol/typedoc.json
+++ b/packages/inter-protocol/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js",
+        "src/clientSupport.js",
+    ]
+}

--- a/packages/internal/src/batched-deliver.js
+++ b/packages/internal/src/batched-deliver.js
@@ -3,12 +3,12 @@
 export const DEFAULT_BATCH_TIMEOUT_MS = 1000;
 
 /**
- * @typedef {(message: any[], ackNum: number) => void} DeliverMessages
+ * @typedef {(message: any[], ackNum: number) => Promise<void>} DeliverMessages
  */
 
 /**
  * @param {DeliverMessages} deliver
- * @param {{ clearTimeout: NodeJS.clearTimeout, setTimeout: NodeJS.setTimeout }} io
+ * @param {{ clearTimeout: import('node:timers').clearTimeout, setTimeout: import('node:timers').setTimeout }} io
  * @param {number} batchTimeoutMs
  */
 export function makeBatchedDeliver(
@@ -34,7 +34,7 @@ export function makeBatchedDeliver(
         // Transfer the batched messages to the deliver function.
         const msgs = batchedMessages;
         batchedMessages = [];
-        deliver(msgs, latestAckNum);
+        void deliver(msgs, latestAckNum);
       }, batchTimeoutMs);
     }
 

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -7,7 +7,7 @@ import { isPromise, makePromiseKit } from '@endo/promise-kit';
 import { makeQueue } from '@endo/stream';
 import { asyncGenerate, makeSet } from 'jessie.js';
 
-const { entries, fromEntries, keys, values } = Object;
+const { fromEntries, keys, values } = Object;
 const { ownKeys } = Reflect;
 
 const { details: X, quote: q, Fail } = assert;
@@ -42,51 +42,7 @@ export const fromUniqueEntries = allEntries => {
 };
 harden(fromUniqueEntries);
 
-/**
- * By analogy with how `Array.prototype.map` will map the elements of
- * an array to transformed elements of an array of the same shape,
- * `objectMap` will do likewise for the string-named own enumerable
- * properties of an object.
- *
- * Typical usage applies `objectMap` to a CopyRecord, i.e.,
- * an object for which `passStyleOf(original) === 'copyRecord'`. For these,
- * none of the following edge cases arise. The result will be a CopyRecord
- * with exactly the same property names, whose values are the mapped form of
- * the original's values.
- *
- * When the original is not a CopyRecord, some edge cases to be aware of
- *    * No matter how mutable the original object, the returned object is
- *      hardened.
- *    * Only the string-named enumerable own properties of the original
- *      are mapped. All other properties are ignored.
- *    * If any of the original properties were accessors, `Object.entries`
- *      will cause its `getter` to be called and will use the resulting
- *      value.
- *    * No matter whether the original property was an accessor, writable,
- *      or configurable, all the properties of the returned object will be
- *      non-writable, non-configurable, data properties.
- *    * No matter what the original object may have inherited from, and
- *      no matter whether it was a special kind of object such as an array,
- *      the returned object will always be a plain object inheriting directly
- *      from `Object.prototype` and whose state is only these new mapped
- *      own properties.
- *
- * With these differences, even if the original object was not a CopyRecord,
- * if all the mapped values are Passable, then the returned object will be
- * a CopyRecord.
- *
- * @template {Record<string, any>} O
- * @param {O} original
- * @template R map result
- * @param {(value: O[keyof O], key: keyof O) => R} mapFn
- * @returns {{ [P in keyof O]: R}}
- */
-export const objectMap = (original, mapFn) => {
-  const ents = entries(original);
-  const mapEnts = ents.map(([k, v]) => [k, mapFn(v, k)]);
-  return harden(fromEntries(mapEnts));
-};
-harden(objectMap);
+export { objectMap } from '@endo/patterns';
 
 /**
  * @param {Array<string | symbol>} leftNames

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -10,6 +10,7 @@ import { subscribeEach } from './subscribe.js';
 /**
  * NB: does not yet survive upgrade https://github.com/Agoric/agoric-sdk/issues/6893
  *
+ * @alpha
  * @template T
  * @param {Subscriber<T>} subscriber
  * @param {(v: T) => void} consumeValue

--- a/packages/notifier/typedoc.json
+++ b/packages/notifier/typedoc.json
@@ -1,0 +1,8 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js",
+    ]
+}

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -132,7 +132,8 @@
 // ///////////////////////// Deprecated Legacy /////////////////////////////////
 
 /**
- * @template K,V
+ * @template K
+ * @template V
  * @typedef {object} LegacyWeakMap LegacyWeakMap is deprecated. Use WeakMapStore
  *   instead if possible.
  * @property {(key: K) => boolean} has Check if a key exists
@@ -145,7 +146,8 @@
  */
 
 /**
- * @template K,V
+ * @template K
+ * @template V
  * @typedef {object} LegacyMap LegacyMap is deprecated. Use MapStore instead if
  *   possible.
  * @property {(key: K) => boolean} has Check if a key exists

--- a/packages/store/typedoc.json
+++ b/packages/store/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js",
+        "src/types.js"
+    ]
+}

--- a/packages/swingset-liveslots/README.md
+++ b/packages/swingset-liveslots/README.md
@@ -1,0 +1,2 @@
+# SwingSet Liveslots
+

--- a/packages/swingset-liveslots/src/message.js
+++ b/packages/swingset-liveslots/src/message.js
@@ -32,7 +32,7 @@ export function insistMessage(message) {
 
 /**
  * @param {unknown} vdo
- * @returns {asserts vdo is VatDeliveryObject}
+ * @returns {asserts vdo is import('./types').VatDeliveryObject}
  */
 
 export function insistVatDeliveryObject(vdo) {
@@ -114,7 +114,7 @@ export function insistVatDeliveryResult(vdr) {
 
 /**
  * @param {unknown} vso
- * @returns {asserts vso is VatSyscallObject}
+ * @returns {asserts vso is import('./types').VatSyscallObject}
  */
 
 export function insistVatSyscallObject(vso) {
@@ -194,7 +194,7 @@ export function insistVatSyscallObject(vso) {
 
 /**
  * @param {unknown} vsr
- * @returns {asserts vsr is VatSyscallResult}
+ * @returns {asserts vsr is import('./types').VatSyscallResult}
  */
 
 export function insistVatSyscallResult(vsr) {

--- a/packages/swingset-liveslots/typedoc.json
+++ b/packages/swingset-liveslots/typedoc.json
@@ -1,0 +1,10 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js",
+        "src/types.js",
+        "src/vatDataTypes.js",
+    ]
+}

--- a/packages/time/typedoc.json
+++ b/packages/time/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/timeMath.js",
+        "src/types.js"
+    ]
+}

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -42,9 +42,12 @@ export {
   prepareSingleton,
 } from './exo-utils.js';
 
-/** @typedef {import('@agoric/swingset-liveslots').Baggage} Baggage */
 /** @typedef {import('@agoric/swingset-liveslots').DurableKindHandle} DurableKindHandle */
 /** @template T @typedef {import('@agoric/swingset-liveslots').DefineKindOptions<T>} DefineKindOptions */
+
+// Copy this type because aliasing it by `import('@agoric/swingset-liveslots').Baggage`
+// causes this error in typedoc: Expected a symbol for node with kind Identifier
+/** @typedef {MapStore<string, any>} Baggage */
 
 // //////////////////////////// deprecated /////////////////////////////////////
 

--- a/packages/vat-data/typedoc.json
+++ b/packages/vat-data/typedoc.json
@@ -1,0 +1,8 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/index.js",
+    ]
+}

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -243,6 +243,7 @@ export const connectFaucet = async ({
   },
   produce: { mints },
 }) => {
+  assert(mints);
   const vats = {
     mints: E(loadVat)('mints'),
   };

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -341,6 +341,7 @@ type ChainBootstrapSpaceT = {
    * Vault Factory. ONLY FOR DISASTER RECOVERY
    */
   instancePrivateArgs: Map<Instance, unknown>;
+  mints?: MintsVat;
   namesByAddress: import('../types.js').NameHub;
   namesByAddressAdmin: import('../types.js').NamesByAddressAdmin;
   pegasusConnections: import('@agoric/vats').NameHubKit;

--- a/packages/vats/src/proposals/zcf-proposal.js
+++ b/packages/vats/src/proposals/zcf-proposal.js
@@ -3,7 +3,7 @@ import { E } from '@endo/far';
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     vatAdminSvc: VatAdminSve;
+ *     vatAdminSvc: VatAdminSvc;
  *     vatStore: MapStore<string, CreateVatResults>;
  *   };
  * }} powers

--- a/packages/zoe/typedoc.json
+++ b/packages/zoe/typedoc.json
@@ -1,0 +1,16 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "src/contractSupport/index.js",
+        "src/contractSupport/types.js",
+        "src/contractFacet/types-ambient.d.ts",
+        "src/contractFacet/types.ts",
+        "src/zoeService/types.js",
+        "src/zoeService/utils.d.ts",
+        "src/zoeService/zoe.js",
+        "src/types.js",
+        "tools/manualTimer.js",
+    ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,36 @@
+/* Visit Visit https://www.typescriptlang.org/tsconfig to read more about this file */
+{
+    "extends": [
+        "./tsconfig.json",
+        "./tsconfig-build-options.json"
+    ],
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "outDir": "./build"
+    },
+    "exclude": [
+        "packages/agoric-cli",
+        "packages/benchmark",
+        "packages/cosmic-swingset",
+        "packages/deployment",
+        "packages/import-manager",
+        "packages/solo",
+        "packages/stat-logger",
+        "packages/swingset-runner",
+        "packages/telemetry",
+        "packages/xsnap/moddable",
+        "packages/xsnap/xsnap-native",
+        "packages/xsnap-lockdown",
+        "**/build",
+        "**/dist",
+        "**/docs",
+        "**/*.umd.js",
+        "**/proposals",
+        "**/scripts",
+        "**/test"
+    ],
+    "include": [
+        "./**/*.ts",
+        "packages/**/*.js"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,17 +4,16 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": true,
-
     "allowJs": true,
     "checkJs": true,
     "strict": false,
     "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
-
     "noEmit": true
   },
   "include": [
-    ".eslintrc.cjs"
+    ".eslintrc.cjs",
+    "dist"
   ]
 }

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "includeVersion": true
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "entryPoints": [
+    "packages/*"
+  ],
+  "exclude": [
+    "packages/cosmic-proto/"
+  ],
+  "name": "API documentation of Agoric SDK ",
+  "entryPointStrategy": "packages",
+  "out": "api-docs",
+  "includeVersion": true,
+  "logLevel": "Verbose"
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,6 @@
+// XXX retrofits for type deficiencies in external packages
+
+declare module '@endo/nat' {
+  export function Nat(specimen: unknown): bigint;
+  export function isNat(specimen: unknown): boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,6 +2633,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -6136,7 +6141,7 @@ json5@^2.2.2:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@3.2.0:
+jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
@@ -6458,6 +6463,11 @@ lru-cache@^7.14.0, lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.0.tgz#b9e2a6a72a129d81ab317202d93c7691df727e61"
   integrity sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -6539,6 +6549,11 @@ map-obj@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 matcher@^5.0.0:
   version "5.0.0"
@@ -6921,7 +6936,7 @@ minimatch@3.0.5:
   dependencies:
     brace-expansion "^1.1.7"
 
-"minimatch@6 || 7 || 8 || 9", minimatch@^9.0.1:
+"minimatch@6 || 7 || 8 || 9", minimatch@^9.0.1, minimatch@^9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
@@ -8698,6 +8713,16 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
+shiki@^0.14.1:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.5.tgz#375dd214e57eccb04f0daf35a32aa615861deb93"
+  integrity sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==
+  dependencies:
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -9448,6 +9473,16 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typedoc@^0.25.4:
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.4.tgz#5c2c0677881f504e41985f29d9aef0dbdb6f1e6f"
+  integrity sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
+    shiki "^0.14.1"
+
 "typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
@@ -9616,6 +9651,16 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 walk-up-path@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
refs: #4291

## Description

Use [TypeDoc](https://typedoc.org/) to generate API docs from the JSDoc and TypeScript annotations

Demo: https://agoric-api-docs-demo.pages.dev/

### Security Considerations

Perhaps more visibility of internal APIs, but not showing anything that's not already in the repo.

### Scaling Considerations

n/a

### Documentation Considerations

Should not be published for external consumption in its current state. We'll need to use tags like [@beta](https://typedoc.org/tags/beta/)  or [@internal ](https://typedoc.org/tags/internal/) and config options to exclude those from public builds.

I figure we'll want multiple targets:
- a build step that [publishes each change to master](https://github.com/TypeStrong/typedoc/issues/1485#issuecomment-1796185086), for internal consumption 
- a release step that publishes a version for external consumption

### Testing Considerations

Let's get this working and in our own CI to ensure it continues to work. We can kick the tires and figure out requirements before publish visibility.

### Upgrade Considerations

n/a