### PR TITLE
fix(vstorage)!: Enforce path validation

### DIFF
--- a/golang/cosmos/x/vstorage/types/path_keys_test.go
+++ b/golang/cosmos/x/vstorage/types/path_keys_test.go
@@ -10,68 +10,68 @@ import (
 func Test_Key_Encoding(t *testing.T) {
 	tests := []struct {
 		name        string
-		childStr    string
+		path        string
 		key         []byte
 		errContains string
 	}{
 		{
-			name:     "empty path",
-			childStr: "",
-			key:      []byte("0\x00"),
+			name: "empty path",
+			path: "",
+			key:  []byte("0\x00"),
 		},
 		{
-			name:     "single-segment path",
-			childStr: "some",
-			key:      []byte("1\x00some"),
+			name: "single-segment path",
+			path: "some",
+			key:  []byte("1\x00some"),
 		},
 		{
-			name:     "multi-segment path",
-			childStr: "some.child.grandchild",
-			key:      []byte("3\x00some\x00child\x00grandchild"),
+			name: "multi-segment path",
+			path: "some.child.grandchild",
+			key:  []byte("3\x00some\x00child\x00grandchild"),
 		},
 		{
-			name:     "non-letters",
-			childStr: "-_0_-",
-			key:      []byte("1\x00-_0_-"),
+			name: "non-letters",
+			path: "-_0_-",
+			key:  []byte("1\x00-_0_-"),
 		},
 		{
 			name:        "lone dot",
-			childStr:    ".",
+			path:        ".",
 			errContains: "starts with separator",
 		},
 		{
 			name:        "starts with dot",
-			childStr:    ".foo",
+			path:        ".foo",
 			errContains: "starts with separator",
 		},
 		{
 			name:        "ends with dot",
-			childStr:    "foo.",
+			path:        "foo.",
 			errContains: "ends with separator",
 		},
 		{
 			name:        "empty path segment",
-			childStr:    "foo..bar",
+			path:        "foo..bar",
 			errContains: "doubled separators",
 		},
 		{
 			name:        "invalid path character U+0000 NUL",
-			childStr:    "foo\x00bar",
+			path:        "foo\x00bar",
 			errContains: "invalid character",
 		},
 		{
 			name:        "invalid path character U+002F SOLIDUS",
-			childStr:    "foo/bar",
+			path:        "foo/bar",
 			errContains: "invalid character",
 		},
 		{
 			name:        "invalid path character U+005C REVERSE SOLIDUS",
-			childStr:    "foo\\bar",
+			path:        "foo\\bar",
 			errContains: "invalid character",
 		},
 		{
 			name:        "invalid path character U+007C VERTICAL LINE",
-			childStr:    "foo|bar",
+			path:        "foo|bar",
 			errContains: "invalid character",
 		},
 	}
@@ -79,11 +79,11 @@ func Test_Key_Encoding(t *testing.T) {
 	for _, tt := range tests {
 		if tt.key != nil {
 			t.Run(tt.name, func(t *testing.T) {
-				if key := PathToEncodedKey(tt.childStr); !bytes.Equal(key, tt.key) {
-					t.Errorf("pathToKey(%q) = %v, want %v", tt.childStr, key, tt.key)
+				if key := PathToEncodedKey(tt.path); !bytes.Equal(key, tt.key) {
+					t.Errorf("pathToKey(%q) = []byte(%q), want []byte(%q)", tt.path, key, tt.key)
 				}
-				if childStr := EncodedKeyToPath(tt.key); childStr != tt.childStr {
-					t.Errorf("keyToString(%v) = %q, want %q", tt.key, childStr, tt.childStr)
+				if path := EncodedKeyToPath(tt.key); path != tt.path {
+					t.Errorf("keyToPath([]byte(%q)) = %q, want %q", tt.key, path, tt.path)
 				}
 			})
 			continue
@@ -95,13 +95,13 @@ func Test_Key_Encoding(t *testing.T) {
 				if err := recover(); err != nil {
 					errStr := fmt.Sprintf("%v", err)
 					if !strings.Contains(errStr, expect) {
-						t.Errorf("pathToKey(%q) = error %q, want error %v", tt.childStr, errStr, expect)
+						t.Errorf("pathToKey(%q) = error %q, want error %v", tt.path, errStr, expect)
 					}
 				} else {
-					t.Errorf("pathToKey(%q) = []byte(%q), want error %v", tt.childStr, key, expect)
+					t.Errorf("pathToKey(%q) = []byte(%q), want error %v", tt.path, key, expect)
 				}
 			}()
-			key = PathToEncodedKey(tt.childStr)
+			key = PathToEncodedKey(tt.path)
 		})
 	}
 }

--- a/golang/cosmos/x/vstorage/types/path_keys_test.go
+++ b/golang/cosmos/x/vstorage/types/path_keys_test.go
@@ -2,40 +2,106 @@ package types
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 )
 
 func Test_Key_Encoding(t *testing.T) {
 	tests := []struct {
-		name     string
-		childStr string
-		key      []byte
+		name        string
+		childStr    string
+		key         []byte
+		errContains string
 	}{
 		{
-			name:     "empty key is prefixed",
+			name:     "empty path",
 			childStr: "",
 			key:      []byte("0\x00"),
 		},
 		{
-			name:     "some key string",
+			name:     "single-segment path",
 			childStr: "some",
 			key:      []byte("1\x00some"),
 		},
 		{
-			name:     "dot-separated",
+			name:     "multi-segment path",
 			childStr: "some.child.grandchild",
 			key:      []byte("3\x00some\x00child\x00grandchild"),
+		},
+		{
+			name:     "non-letters",
+			childStr: "-_0_-",
+			key:      []byte("1\x00-_0_-"),
+		},
+		{
+			name:        "lone dot",
+			childStr:    ".",
+			errContains: "starts with separator",
+		},
+		{
+			name:        "starts with dot",
+			childStr:    ".foo",
+			errContains: "starts with separator",
+		},
+		{
+			name:        "ends with dot",
+			childStr:    "foo.",
+			errContains: "ends with separator",
+		},
+		{
+			name:        "empty path segment",
+			childStr:    "foo..bar",
+			errContains: "doubled separators",
+		},
+		{
+			name:        "invalid path character U+0000 NUL",
+			childStr:    "foo\x00bar",
+			errContains: "invalid character",
+		},
+		{
+			name:        "invalid path character U+002F SOLIDUS",
+			childStr:    "foo/bar",
+			errContains: "invalid character",
+		},
+		{
+			name:        "invalid path character U+005C REVERSE SOLIDUS",
+			childStr:    "foo\\bar",
+			errContains: "invalid character",
+		},
+		{
+			name:        "invalid path character U+007C VERTICAL LINE",
+			childStr:    "foo|bar",
+			errContains: "invalid character",
 		},
 	}
 
 	for _, tt := range tests {
+		if tt.key != nil {
+			t.Run(tt.name, func(t *testing.T) {
+				if key := PathToEncodedKey(tt.childStr); !bytes.Equal(key, tt.key) {
+					t.Errorf("pathToKey(%q) = %v, want %v", tt.childStr, key, tt.key)
+				}
+				if childStr := EncodedKeyToPath(tt.key); childStr != tt.childStr {
+					t.Errorf("keyToString(%v) = %q, want %q", tt.key, childStr, tt.childStr)
+				}
+			})
+			continue
+		}
+		expect := tt.errContains
 		t.Run(tt.name, func(t *testing.T) {
-			if key := PathToEncodedKey(tt.childStr); !bytes.Equal(key, tt.key) {
-				t.Errorf("pathToKey(%q) = %v, want %v", tt.childStr, key, tt.key)
-			}
-			if childStr := EncodedKeyToPath(tt.key); childStr != tt.childStr {
-				t.Errorf("keyToString(%v) = %q, want %q", tt.key, childStr, tt.childStr)
-			}
+			var key []byte
+			defer func() {
+				if err := recover(); err != nil {
+					errStr := fmt.Sprintf("%v", err)
+					if !strings.Contains(errStr, expect) {
+						t.Errorf("pathToKey(%q) = error %q, want error %v", tt.childStr, errStr, expect)
+					}
+				} else {
+					t.Errorf("pathToKey(%q) = []byte(%q), want error %v", tt.childStr, key, expect)
+				}
+			}()
+			key = PathToEncodedKey(tt.childStr)
 		})
 	}
 }

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -95,6 +95,7 @@ harden(assertCapData);
 // Must be nonempty and disallow (unescaped) `.`, and for simplicity
 // (and future possibility of e.g. escaping) we currently limit to
 // ASCII alphanumeric plus underscore and dash.
+// Should remain consistent with golang/cosmos/x/vstorage/types/path_keys.go
 const pathSegmentPattern = /^[a-zA-Z0-9_-]{1,100}$/;
 
 /** @type {(name: string) => void} */


### PR DESCRIPTION
Fixes #8337

## Description

Improves the cross-referenced Go and JS documentation of vstorage path structure, and updates the Go code to correctly enforce it.

### Security Considerations

This change means that vat storage keys are no longer generally valid in vstorage paths, but that is acceptable because they are now stored in the swingset module rather than in vstorage.

### Scaling Considerations

There should be a small but largely irrelevant improvement in the performance of validating paths, which are now scanned only once if valid.

### Documentation Considerations

n/a

### Testing Considerations

Nothing should be needed beyond the included unit tests.

### Upgrade Considerations

Existing tests should validate the assumption that vat storage keys are not used in vstorage paths.