### PR TITLE
feat: puppetGovernor pass the IssuerKeywordRecord through

### DIFF
--- a/packages/governance/test/unitTests/test-puppetContractGovernor.js
+++ b/packages/governance/test/unitTests/test-puppetContractGovernor.js
@@ -7,6 +7,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
+import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 
 import { CONTRACT_ELECTORATE, ParamTypes } from '../../src/index.js';
 import { setUpGovernedContract } from '../../tools/puppetGovernance.js';
@@ -157,4 +158,21 @@ test('call API directly', async t => {
     await E(E(governorFacets.creatorFacet).getPublicFacet()).getApiCalled(),
     1,
   );
+});
+
+test('add issuerKeywordRecord', async t => {
+  const zoe = await makeZoeForTest();
+  const issuerKit = makeIssuerKit('Food', AssetKind.COPY_BAG);
+  const timer = buildManualTimer(t.log);
+  const { governorFacets } = await setUpGovernedContract(
+    zoe,
+    E(zoe).install(governedBundleP),
+    timer,
+    governedTerms,
+    {},
+    { Food: issuerKit.issuer },
+  );
+
+  const instance = await E(governorFacets.creatorFacet).getInstance();
+  t.deepEqual(await E(zoe).getIssuers(instance), { Food: issuerKit.issuer });
 });

--- a/packages/governance/tools/puppetGovernance.js
+++ b/packages/governance/tools/puppetGovernance.js
@@ -26,6 +26,7 @@ const autoRefundBundleP = makeBundle(
  * @param {import('@agoric/swingset-vat/src/vats/timer/vat-timer.js').TimerService} timer
  * @param {{ [k: string]: any, governedParams?: Record<string, unknown>, governedApis?: string[] }} termsOfGoverned
  * @param {{}} privateArgsOfGoverned
+ * @param {IssuerKeywordRecord} [issuerKeywordRecord]
  */
 export const setUpGovernedContract = async (
   zoe,
@@ -33,6 +34,7 @@ export const setUpGovernedContract = async (
   timer,
   termsOfGoverned = {},
   privateArgsOfGoverned = {},
+  issuerKeywordRecord = {},
 ) => {
   const [contractGovernorBundle, autoRefundBundle] = await Promise.all([
     contractGovernorBundleP,
@@ -85,7 +87,7 @@ export const setUpGovernedContract = async (
     governedContractInstallation: governed,
     governed: {
       terms: governedTermsWithElectorate,
-      issuerKeywordRecord: {},
+      issuerKeywordRecord,
     },
   };
 


### PR DESCRIPTION
closes: #8350

## Description

Make PuppetGovernor pass the IssuerKeywordRecord through to the governed contract.

### Security Considerations

This is test-only, so no effect.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Added a test.

### Upgrade Considerations

None
