### PR TITLE
test: fix bench config

### DIFF
--- a/packages/boot/ava.bench.config.js
+++ b/packages/boot/ava.bench.config.js
@@ -1,5 +1,12 @@
+// NB: keep in sync with package.json
 export default {
+  extensions: {
+    js: true,
+    ts: 'module',
+  },
   files: ['test/**/bench-*.js'],
+  nodeArguments: ['--loader=tsx', '--no-warnings'],
+  require: ['@endo/init/debug.js'],
   timeout: '20m',
   workerThreads: false,
 };


### PR DESCRIPTION
## Description

 https://github.com/Agoric/agoric-sdk/pull/8313 changed supports module to .ts. That [broke the benchmark job](https://github.com/Agoric/agoric-sdk/actions/runs/6229515594/job/16908144246). It was permitted by CI because the benchmark job isn't required.

This gives the benchmark's Ava config the options that are now needed

### Security Considerations

n/a, test
### Scaling Considerations

n/a, test
### Documentation Considerations

none

### Testing Considerations

fixes it

### Upgrade Considerations

n/a, test