### PR TITLE
drop Node 16 (EOL)

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.cjs",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "test": "exit 0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@endo/eslint-plugin": "^2.1.0",
     "@jessie.js/eslint-plugin": "^0.4.0",
     "@types/express": "^4.17.17",
-    "@types/node": "^18.11.9",
+    "@types/node": "^18.19.24",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "ava": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "**/protobufjs": "^7.2.4"
   },
   "engines": {
-    "node": "^16.13 || ^18.12 || ^20.9"
+    "node": "^18.12 || ^20.9"
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "bin": {
     "vat": "bin/vat"

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/assert.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -65,7 +65,7 @@
     "exported.js"
   ],
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "extensions": {

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/helpers.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "yarn build:bundles",

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/importManager.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "yarn build:bundles",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/pegasus.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/sparseInts.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/contractHost.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "yarn build:bundles",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "types": "index.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "typeCoverage": {
     "atLeast": 98.79

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -62,7 +62,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/vm-config/package.json
+++ b/packages/vm-config/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/zoeService/zoe.js",
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "scripts": {
     "build": "yarn build:bundles",

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -41,7 +41,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": "^18.12 || ^20.9"
   },
   "ava": {
     "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3573,10 +3573,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^18.11.9":
-  version "18.19.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.3.tgz#e4723c4cb385641d61b983f6fe0b716abd5f8fc0"
-  integrity sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^18.19.24":
+  version "18.19.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.24.tgz#707d8a4907e55901466e60e8f7a62bc6197ace95"
+  integrity sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
## Description

See https://nodejs.dev/en/about/releases/

Node v16 hit EOL on Sep 11. This ~drops it from matrix testing and~ narrows engines from >14 to LTS. 

~It adds a `.node-version` file for those using tools like https://github.com/nodenv (multiple tools observe the file).~

The stricken parts were done in other PRs.

### Security Considerations

Dropping unsupported versions should remove risks of exploits

### Scaling Considerations

n/a

### Documentation Considerations

https://docs.agoric.com/guides/getting-started/ already says to use an LTS version.

### Testing Considerations

CI

### Upgrade Considerations

Consumers using Node 14 or 16 will have to upgrade to 18.