### PR TITLE
build(cosmos): prevent macOS `filesize exceeds vmsize`

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -32,13 +32,18 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(VersionName) \
 		-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
 gcflags =
+shared_ldflags = $(ldflags)
 
 ifneq ($(GO_DEBUG),)
 ldflags += -compressdwarf=false
 gcflags += -N -l
+else ifeq ($(shell uname -s 2>/dev/null),Darwin)
+# Darwin's latest ld crashes with https://github.com/Agoric/agoric-sdk/issues/8367
+shared_ldflags += -w
 endif
 
 BUILD_FLAGS := -tags "$(build_tags)" -gcflags '$(gcflags)' -ldflags '$(ldflags)'
+SHARED_BUILD_FLAGS := -tags "$(build_tags)" -gcflags '$(gcflags)' -ldflags '$(shared_ldflags)'
 
 all: compile-chain
 
@@ -69,7 +74,8 @@ compile-gyp:
 	rm -f binding.gyp
 
 compile-libdaemon: go-mod-cache
-	go build -v $(MOD_READONLY) $(BUILD_FLAGS) -buildmode=c-shared -o build/libagcosmosdaemon.so ./cmd/libdaemon/main.go
+	go build -v $(MOD_READONLY) $(SHARED_BUILD_FLAGS) -buildmode=c-shared \
+		-o build/libagcosmosdaemon.so ./cmd/libdaemon/main.go
 
 go-mod-cache: go.sum
 	@echo "--> Download go modules to local cache"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #8367 

## Description

On the latest macOS, the linker (`ld`) chokes on Go `-buildmode=c-shared` of `libagcosmosdaemon.so`.  This PR works around the problem by specifying `-ldflags -w` only on Darwin to disable DWARF generation when building that shared library.

This should be acceptable, since DWARF is used only for debugging (by `dlv`), and the shared library configuration already cannot be debugged using `dlv`.  When the split VM configuration #7061 is usable, it can be debugged with `dlv` on the `agd` executable, which will still have DWARF support.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Tested manually on macOS, where the build was failing before this patch.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a
