### PR TITLE
ci: jobs compatibility with release branch

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -6,7 +6,8 @@ on:
     branches:
       # $default-branch
       - master
-      - release-pismo
+      - 'release-*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -54,13 +55,20 @@ jobs:
         run: npm whoami
       - name: publish to NPM tag
         run: |
-          if [ "${{ github.ref_name }}" = "release-pismo" ]; then
-            # A pismo dev release.
-            TAG=pismo-dev
-          else
-            # Just a dev release.
-            TAG=dev
-          fi
+          case $GITHUB_REF_NAME in
+            release-*)
+              # A pre-release.
+              TAG=${GITHUB_REF_NAME#release-}-dev
+              ;;
+            master)
+              # A trunk dev release.
+              TAG=dev
+              ;;
+            *)
+              # Some other dev release.
+              TAG=other-dev
+              ;;
+          esac
           # without concurrency until https://github.com/Agoric/agoric-sdk/issues/8091
           yarn lerna publish --concurrency 1 --conventional-prerelease --canary --exact \
             --dist-tag=$TAG --preid=$TAG-$(git rev-parse --short=7 HEAD) \
@@ -102,7 +110,7 @@ jobs:
       - uses: nwtgck/actions-netlify@v1.1
         with:
           # Production deployment if a push or merged PR.
-          production-deploy: ${{github.event_name == 'push'}}
+          production-deploy: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
           publish-dir: coverage/html
           # SECURITY: we don't want to hand out the Github token to this action.
           # github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -8,7 +8,7 @@ on:
     branches:
       # $default-branch
       - master
-      - release-pismo
+      - 'release-*'
 
 jobs:
   xs-build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       # $default-branch
       - master
-      - release-pismo
+      - 'release-*'
     tags:
       - '@agoric/sdk@*'
   workflow_dispatch:
@@ -139,16 +139,23 @@ jobs:
         id: docker-tags
         run: |
           set -ex
-          SDK_TAG=$(echo "${{ github.ref_name }}" | sed -ne 's!^@agoric/sdk@!!p')
+          SDK_TAG=$(echo "$GITHUB_REF_NAME" | sed -ne 's!^@agoric/sdk@!!p')
           case $SDK_TAG in
             "")
-              if [ "${{ github.ref_name }}" = "release-pismo" ]; then
-                # A pismo dev release.
-                DOCKER_TAGS=pismo-dev
-              else
-                # Just a dev release.
-                DOCKER_TAGS=dev
-              fi
+              case $GITHUB_REF_NAME in
+                release-*)
+                  # A pre-release.
+                  DOCKER_TAGS=${GITHUB_REF_NAME#release-}-dev
+                  ;;
+                master)
+                  # A trunk dev release.
+                  DOCKER_TAGS=dev
+                  ;;
+                *)
+                  # Some other dev release.
+                  DOCKER_TAGS=other-dev
+                  ;;
+              esac
               ;;
             *)
               # A tagged SDK release.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,7 @@ on:
     branches:
       # $default-branch
       - master
-      - release-pismo
+      - 'release-*'
   pull_request:
   merge_group:
 permissions:

--- a/.github/workflows/pre-check-integration.yml
+++ b/.github/workflows/pre-check-integration.yml
@@ -16,7 +16,7 @@ on:
             github.event_name != 'pull_request' || (
               (
                 github.event.pull_request.base.ref == 'master' ||
-                github.event.pull_request.base.ref == 'release-pismo' ||
+                startsWith(github.event.pull_request.base.ref, 'release-') ||
                 github.event.pull_request.base.ref == 'beta'
               ) &&
               github.event.pull_request.draft == false &&
@@ -37,7 +37,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'force:integration') || (
         (
           github.event.pull_request.base.ref == 'master' ||
-          github.event.pull_request.base.ref == 'release-pismo' ||
+          startsWith(github.event.pull_request.base.ref, 'release-') ||
           github.event.pull_request.base.ref == 'beta'
         ) &&
         github.event.pull_request.draft == false &&


### PR DESCRIPTION

## Description

#8253 changed some push triggers to a general `release-*` instead of just `release-pismo`, but it didn't do so for all jobs.

This PR more thoroughly updates CI jobs to agnostically support any release branch. It is meant to be backported into `release-mainnet1B` as part of #8360

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Introduces a new `other-dev` tag for manually triggered workflows 

### Testing Considerations

Manually, locally

### Upgrade Considerations

Better support publishing for future upgrade branches
