### PR TITLE
feat(extract-proposal): organize proposals into steps

### DIFF
--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -367,7 +367,14 @@ export const makeSwingsetTestKit = async (
     configPath,
     [],
     {},
-    { debugName: 'TESTBOOT', verbose, slogSender, profileVats, debugVats },
+    {
+      callerWillEvaluateCoreProposals: false,
+      debugName: 'TESTBOOT',
+      verbose,
+      slogSender,
+      profileVats,
+      debugVats,
+    },
   );
   console.timeLog('makeBaseSwingsetTestKit', 'buildSwingset');
 

--- a/packages/cosmic-swingset/economy-template.json
+++ b/packages/cosmic-swingset/economy-template.json
@@ -1,138 +1,146 @@
-[
-  "@agoric/builders/scripts/vats/init-core.js",
-  "@agoric/builders/scripts/vats/init-network.js",
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
-    "entrypoint": "defaultProposalBuilder",
-    "args": [
+{
+  "steps": [
+    [
+      "@agoric/builders/scripts/vats/init-core.js"
+    ],
+    [
+      "@agoric/builders/scripts/vats/init-network.js",
+      "@agoric/builders/scripts/pegasus/init-core.js"
+    ],
+    [
       {
-        "econCommitteeOptions": {
-          "committeeSize": 1
-        },
-        "minInitialPoolLiquidity": "0"
+        "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+        "entrypoint": "defaultProposalBuilder",
+        "args": [
+          {
+            "econCommitteeOptions": {
+              "committeeSize": 1
+            },
+            "minInitialPoolLiquidity": "0"
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+        "entrypoint": "defaultProposalBuilder",
+        "args": [
+          {
+            "interchainAssetOptions": {
+              "denom": "ibc/toyatom",
+              "decimalPlaces": 4,
+              "keyword": "ATOM",
+              "oracleBrand": "ATOM",
+              "proposedName": "ATOM"
+            }
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+        "entrypoint": "psmProposalBuilder",
+        "args": [
+          {
+            "anchorOptions": {
+              "denom": "ibc/toyusdc",
+              "decimalPlaces": 6,
+              "keyword": "USDC_axl",
+              "proposedName": "USD Coin"
+            }
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+        "entrypoint": "psmProposalBuilder",
+        "args": [
+          {
+            "anchorOptions": {
+              "denom": "ibc/usdc5678",
+              "decimalPlaces": 6,
+              "keyword": "USDC_grv",
+              "proposedName": "USC Coin"
+            }
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+        "entrypoint": "psmProposalBuilder",
+        "args": [
+          {
+            "anchorOptions": {
+              "denom": "ibc/usdt1234",
+              "decimalPlaces": 6,
+              "keyword": "USDT_axl",
+              "proposedName": "Tether USD"
+            }
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+        "entrypoint": "psmProposalBuilder",
+        "args": [
+          {
+            "anchorOptions": {
+              "denom": "ibc/toyollie",
+              "decimalPlaces": 6,
+              "keyword": "USDT_grv",
+              "proposedName": "Tether USD"
+            }
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+        "entrypoint": "psmProposalBuilder",
+        "args": [
+          {
+            "anchorOptions": {
+              "denom": "ibc/toyellie",
+              "decimalPlaces": 6,
+              "keyword": "AUSD",
+              "proposedName": "Anchor USD"
+            }
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+        "entrypoint": "defaultProposalBuilder",
+        "args": [
+          {
+            "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+            "oracleAddresses": [
+              "@PRIMARY_ADDRESS@",
+              "agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y"
+            ],
+            "IN_BRAND_LOOKUP": [
+              "agoricNames",
+              "oracleBrand",
+              "ATOM"
+            ],
+            "IN_BRAND_DECIMALS": 6,
+            "OUT_BRAND_LOOKUP": [
+              "agoricNames",
+              "oracleBrand",
+              "USD"
+            ],
+            "OUT_BRAND_DECIMALS": 4
+          }
+        ]
+      },
+      {
+        "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
+        "entrypoint": "defaultProposalBuilder",
+        "args": [
+          {
+            "voterAddresses": {
+              "someone": "@PRIMARY_ADDRESS@"
+            }
+          }
+        ]
       }
     ]
-  },
-  "@agoric/builders/scripts/pegasus/init-core.js",
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-    "entrypoint": "defaultProposalBuilder",
-    "args": [
-      {
-        "interchainAssetOptions": {
-          "denom": "ibc/toyatom",
-          "decimalPlaces": 4,
-          "keyword": "ATOM",
-          "oracleBrand": "ATOM",
-          "proposedName": "ATOM"
-        }
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-    "entrypoint": "psmProposalBuilder",
-    "args": [
-      {
-        "anchorOptions": {
-          "denom": "ibc/toyusdc",
-          "decimalPlaces": 6,
-          "keyword": "USDC_axl",
-          "proposedName": "USD Coin"
-        }
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-    "entrypoint": "psmProposalBuilder",
-    "args": [
-      {
-        "anchorOptions": {
-          "denom": "ibc/usdc5678",
-          "decimalPlaces": 6,
-          "keyword": "USDC_grv",
-          "proposedName": "USC Coin"
-        }
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-    "entrypoint": "psmProposalBuilder",
-    "args": [
-      {
-        "anchorOptions": {
-          "denom": "ibc/usdt1234",
-          "decimalPlaces": 6,
-          "keyword": "USDT_axl",
-          "proposedName": "Tether USD"
-        }
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-    "entrypoint": "psmProposalBuilder",
-    "args": [
-      {
-        "anchorOptions": {
-          "denom": "ibc/toyollie",
-          "decimalPlaces": 6,
-          "keyword": "USDT_grv",
-          "proposedName": "Tether USD"
-        }
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-    "entrypoint": "psmProposalBuilder",
-    "args": [
-      {
-        "anchorOptions": {
-          "denom": "ibc/toyellie",
-          "decimalPlaces": 6,
-          "keyword": "AUSD",
-          "proposedName": "Anchor USD"
-        }
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
-    "entrypoint": "defaultProposalBuilder",
-    "args": [
-      {
-        "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
-        "oracleAddresses": [
-          "@PRIMARY_ADDRESS@",
-          "agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y"
-        ],
-        "IN_BRAND_LOOKUP": [
-          "agoricNames",
-          "oracleBrand",
-          "ATOM"
-        ],
-        "IN_BRAND_DECIMALS": 6,
-        "OUT_BRAND_LOOKUP": [
-          "agoricNames",
-          "oracleBrand",
-          "USD"
-        ],
-        "OUT_BRAND_DECIMALS": 4
-      }
-    ]
-  },
-  {
-    "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
-    "entrypoint": "defaultProposalBuilder",
-    "args": [
-      {
-        "voterAddresses": {
-          "someone": "@PRIMARY_ADDRESS@"
-        }
-      }
-    ]
-  }
-]
+  ]
+}

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -11,12 +11,37 @@ import {
 } from './coreProposalBehavior.js';
 
 /**
- * @typedef {string | { module: string, entrypoint: string, args?: Array<unknown> }} ConfigProposal
+ * @typedef {string | {module: string, entrypoint?: string, args?: Array<unknown>}} ConfigProposal
+ */
+
+/**
+ * @typedef {ConfigProposal[] | {steps: ConfigProposal[][]}} CoreProposals
  */
 
 const { Fail } = assert;
 
 const req = createRequire(import.meta.url);
+
+/**
+ * @param  {...(CoreProposals | undefined | null)} args
+ * @returns {CoreProposals}
+ */
+export const mergeCoreProposals = (...args) => {
+  /** @type {ConfigProposal[][]} */
+  const steps = [];
+  for (const coreProposal of args) {
+    if (!coreProposal) {
+      continue;
+    }
+    if ('steps' in coreProposal) {
+      steps.push(...coreProposal.steps);
+    } else {
+      steps.push(coreProposal);
+    }
+  }
+  return harden({ steps });
+};
+harden(mergeCoreProposals);
 
 /**
  * @param {(ModuleSpecifier | FilePath)[]} paths
@@ -43,12 +68,12 @@ const findModule = (initDir, srcSpec) =>
 /**
  * @param {{ bundleID?: string, bundleName?: string }} handle - mutated then hardened
  * @param {string} sourceSpec - the specifier of a module to load
- * @param {number} sequence - the sequence number of the proposal
+ * @param {string} key - the key of the proposal
  * @param {string} piece - the piece of the proposal
  * @returns {Promise<[string, any]>}
  */
-const namedHandleToBundleSpec = async (handle, sourceSpec, sequence, piece) => {
-  handle.bundleName = `coreProposal${sequence}_${piece}`;
+const namedHandleToBundleSpec = async (handle, sourceSpec, key, piece) => {
+  handle.bundleName = `coreProposal${String(key)}_${piece}`;
   harden(handle);
   return harden([handle.bundleName, { sourceSpec }]);
 };
@@ -64,12 +89,12 @@ const namedHandleToBundleSpec = async (handle, sourceSpec, sequence, piece) => {
  * but for sim-chain and such, they can be declared statically in
  * the chain configuration, in which case they are run at bootstrap.
  *
- * @param {ConfigProposal[]} coreProposals - governance
+ * @param {CoreProposals} coreProposals - governance
  * proposals to run at chain bootstrap for scenarios such as sim-chain.
  * @param {FilePath} [dirname]
  * @param {object} [opts]
  * @param {typeof makeEnactCoreProposalsFromBundleRef} [opts.makeEnactCoreProposals]
- * @param {(i: number) => number} [opts.getSequenceForProposal]
+ * @param {(key: PropertyKey) => PropertyKey} [opts.getSequenceForProposal]
  * @param {typeof namedHandleToBundleSpec} [opts.handleToBundleSpec]
  */
 export const extractCoreProposalBundles = async (
@@ -79,7 +104,7 @@ export const extractCoreProposalBundles = async (
 ) => {
   const {
     makeEnactCoreProposals = makeEnactCoreProposalsFromBundleRef,
-    getSequenceForProposal = i => i,
+    getSequenceForProposal = key => key,
     handleToBundleSpec = namedHandleToBundleSpec,
   } = opts || {};
 
@@ -91,159 +116,177 @@ export const extractCoreProposalBundles = async (
   /** @type {Map<{ bundleID?: string, bundleName?: string }, { source: string, bundle?: string }>} */
   const bundleHandleToAbsolutePaths = new Map();
 
+  const proposalSteps =
+    'steps' in coreProposals ? coreProposals.steps : [coreProposals];
   const bundleToSource = new Map();
-  const extracted = await Promise.all(
-    coreProposals.map(async (coreProposal, i) => {
-      // console.debug(`Parsing core proposal:`, coreProposal);
+  const extractedSteps = await Promise.all(
+    proposalSteps.map((proposalStep, i) =>
+      Promise.all(
+        proposalStep.map(async (coreProposal, j) => {
+          const key = `${i}.${j}`;
+          // console.debug(`Parsing core proposal:`, coreProposal);
 
-      /** @type {string} */
-      let entrypoint;
-      /** @type {unknown[]} */
-      let args;
-      /** @type {string} */
-      let module;
-      if (typeof coreProposal === 'string') {
-        module = coreProposal;
-        entrypoint = 'defaultProposalBuilder';
-        args = [];
-      } else {
-        ({ module, entrypoint, args = [] } = coreProposal);
-      }
-
-      typeof module === 'string' ||
-        Fail`coreProposal module ${module} must be string`;
-      typeof entrypoint === 'string' ||
-        Fail`coreProposal entrypoint ${entrypoint} must be string`;
-      Array.isArray(args) || Fail`coreProposal args ${args} must be array`;
-
-      const thisProposalBundleHandles = new Set();
-      assert(getSequenceForProposal);
-      const thisProposalSequence = getSequenceForProposal(i);
-      const initPath = findModule(dirname, module);
-      const initDir = path.dirname(initPath);
-      /** @type {Record<string, import('./externalTypes.js').ProposalBuilder>} */
-      const ns = await import(initPath);
-      const install = (srcSpec, bundlePath) => {
-        const absoluteSrc = findModule(initDir, srcSpec);
-        const bundleHandle = {};
-        const absolutePaths = { source: absoluteSrc };
-        if (bundlePath) {
-          const absoluteBundle = pathResolve(initDir, bundlePath);
-          absolutePaths.bundle = absoluteBundle;
-          const oldSource = bundleToSource.get(absoluteBundle);
-          if (oldSource) {
-            oldSource === absoluteSrc ||
-              Fail`${bundlePath} already installed from ${oldSource}, now ${absoluteSrc}`;
+          /** @type {string} */
+          let entrypoint;
+          /** @type {unknown[]} */
+          let args;
+          /** @type {string} */
+          let module;
+          if (typeof coreProposal === 'string') {
+            module = coreProposal;
+            entrypoint = 'defaultProposalBuilder';
+            args = [];
           } else {
-            bundleToSource.set(absoluteBundle, absoluteSrc);
+            ({
+              module,
+              entrypoint = 'defaultProposalBuilder',
+              args = [],
+            } = coreProposal);
           }
-        }
-        // Don't harden the bundleHandle since we need to set the bundleName on
-        // its unique identity later.
-        thisProposalBundleHandles.add(bundleHandle);
-        bundleHandleToAbsolutePaths.set(bundleHandle, harden(absolutePaths));
-        return bundleHandle;
-      };
-      /** @type {import('./externalTypes.js').PublishBundleRef} */
-      const publishRef = async handleP => {
-        const handle = await handleP;
-        // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
-        // @ts-ignore xxx types
-        bundleHandleToAbsolutePaths.has(handle) ||
-          Fail`${handle} not in installed bundles`;
-        return handle;
-      };
-      const proposal = await ns[entrypoint](
-        {
-          publishRef,
-          // @ts-expect-error not statically verified to return a full obj
-          install,
-        },
-        ...args,
-      );
 
-      // Add the proposal bundle handles in sorted order.
-      const bundleSpecEntries = await Promise.all(
-        [...thisProposalBundleHandles.keys()]
-          .map(handle => [handle, bundleHandleToAbsolutePaths.get(handle)])
-          .sort(([_hnda, { source: a }], [_hndb, { source: b }]) => {
-            if (a < b) {
-              return -1;
+          typeof module === 'string' ||
+            Fail`coreProposal module ${module} must be string`;
+          typeof entrypoint === 'string' ||
+            Fail`coreProposal entrypoint ${entrypoint} must be string`;
+          Array.isArray(args) || Fail`coreProposal args ${args} must be array`;
+
+          const thisProposalBundleHandles = new Set();
+          assert(getSequenceForProposal);
+          const thisProposalSequence = getSequenceForProposal(key);
+          const initPath = findModule(dirname, module);
+          const initDir = path.dirname(initPath);
+          /** @type {Record<string, import('./externalTypes.js').ProposalBuilder>} */
+          const ns = await import(initPath);
+          const install = (srcSpec, bundlePath) => {
+            const absoluteSrc = findModule(initDir, srcSpec);
+            const bundleHandle = {};
+            const absolutePaths = { source: absoluteSrc };
+            if (bundlePath) {
+              const absoluteBundle = pathResolve(initDir, bundlePath);
+              absolutePaths.bundle = absoluteBundle;
+              const oldSource = bundleToSource.get(absoluteBundle);
+              if (oldSource) {
+                oldSource === absoluteSrc ||
+                  Fail`${bundlePath} already installed from ${oldSource}, now ${absoluteSrc}`;
+              } else {
+                bundleToSource.set(absoluteBundle, absoluteSrc);
+              }
             }
-            if (a > b) {
-              return 1;
-            }
-            return 0;
-          })
-          .map(async ([handle, absolutePaths], j) => {
-            // Transform the bundle handle identity into a bundleName reference.
-            const specEntry = await handleToBundleSpec(
-              handle,
-              absolutePaths.source,
-              thisProposalSequence,
-              String(j),
+            // Don't harden the bundleHandle since we need to set the bundleName on
+            // its unique identity later.
+            thisProposalBundleHandles.add(bundleHandle);
+            bundleHandleToAbsolutePaths.set(
+              bundleHandle,
+              harden(absolutePaths),
             );
-            harden(handle);
-            return specEntry;
-          }),
-      );
+            return bundleHandle;
+          };
+          /** @type {import('./externalTypes.js').PublishBundleRef} */
+          const publishRef = async handleP => {
+            const handle = await handleP;
+            // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
+            // @ts-ignore xxx types
+            bundleHandleToAbsolutePaths.has(handle) ||
+              Fail`${handle} not in installed bundles`;
+            return handle;
+          };
+          const proposal = await ns[entrypoint](
+            {
+              publishRef,
+              // @ts-expect-error not statically verified to return a full obj
+              install,
+            },
+            ...args,
+          );
 
-      // Now that we've assigned all the bundleNames and hardened the
-      // handles, we can extract the behavior bundle.
-      const { sourceSpec, getManifestCall } = await deeplyFulfilledObject(
-        harden(proposal),
-      );
+          // Add the proposal bundle handles in sorted order.
+          const bundleSpecEntries = await Promise.all(
+            [...thisProposalBundleHandles.keys()]
+              .map(handle => [handle, bundleHandleToAbsolutePaths.get(handle)])
+              .sort(([_hnda, { source: a }], [_hndb, { source: b }]) => {
+                if (a < b) {
+                  return -1;
+                }
+                if (a > b) {
+                  return 1;
+                }
+                return 0;
+              })
+              .map(async ([handle, absolutePaths], k) => {
+                // Transform the bundle handle identity into a bundleName reference.
+                const specEntry = await handleToBundleSpec(
+                  handle,
+                  absolutePaths.source,
+                  thisProposalSequence,
+                  String(k),
+                );
+                harden(handle);
+                return specEntry;
+              }),
+          );
 
-      const proposalSource = pathResolve(initDir, sourceSpec);
-      const proposalNS = await import(proposalSource);
-      const [manifestGetterName, ...manifestGetterArgs] = getManifestCall;
-      manifestGetterName in proposalNS ||
-        Fail`proposal ${proposalSource} missing export ${manifestGetterName}`;
-      const { manifest: customManifest } = await proposalNS[manifestGetterName](
-        harden({ restoreRef: () => null }),
-        ...manifestGetterArgs,
-      );
+          // Now that we've assigned all the bundleNames and hardened the
+          // handles, we can extract the behavior bundle.
+          const { sourceSpec, getManifestCall } = await deeplyFulfilledObject(
+            harden(proposal),
+          );
 
-      const behaviorBundleHandle = {};
-      const specEntry = await handleToBundleSpec(
-        behaviorBundleHandle,
-        proposalSource,
-        thisProposalSequence,
-        'behaviors',
-      );
-      bundleSpecEntries.unshift(specEntry);
+          const proposalSource = pathResolve(initDir, sourceSpec);
+          const proposalNS = await import(proposalSource);
+          const [manifestGetterName, ...manifestGetterArgs] = getManifestCall;
+          manifestGetterName in proposalNS ||
+            Fail`proposal ${proposalSource} missing export ${manifestGetterName}`;
+          const { manifest: customManifest } = await proposalNS[
+            manifestGetterName
+          ](harden({ restoreRef: () => null }), ...manifestGetterArgs);
 
-      bundleHandleToAbsolutePaths.set(
-        behaviorBundleHandle,
-        harden({
-          source: proposalSource,
+          const behaviorBundleHandle = {};
+          const specEntry = await handleToBundleSpec(
+            behaviorBundleHandle,
+            proposalSource,
+            thisProposalSequence,
+            'proposalNS',
+          );
+          bundleSpecEntries.unshift(specEntry);
+
+          bundleHandleToAbsolutePaths.set(
+            behaviorBundleHandle,
+            harden({
+              source: proposalSource,
+            }),
+          );
+
+          return /** @type {const} */ ([
+            key,
+            {
+              ref: behaviorBundleHandle,
+              call: getManifestCall,
+              customManifest,
+              bundleSpecs: bundleSpecEntries,
+            },
+          ]);
         }),
-      );
-
-      return harden({
-        ref: behaviorBundleHandle,
-        call: getManifestCall,
-        customManifest,
-        bundleSpecs: bundleSpecEntries,
-      });
-    }),
+      ),
+    ),
   );
 
   // Extract all the bundle specs in already-sorted order.
   const bundles = Object.fromEntries(
-    extracted.flatMap(({ bundleSpecs }) => bundleSpecs),
+    extractedSteps.flatMap(step =>
+      step.flatMap(([_key, { bundleSpecs }]) => bundleSpecs),
+    ),
   );
   harden(bundles);
 
-  // Extract the manifest references and calls.
-  const metadataRecords = extracted.map(({ ref, call, customManifest }) => ({
-    ref,
-    call,
-    customManifest,
-  }));
-  harden(metadataRecords);
+  const codeSteps = extractedSteps.map(extractedStep => {
+    // Extract the manifest references and calls.
+    const metadataRecords = extractedStep.map(([_key, extractedSpec]) => {
+      const { ref, call, customManifest } = extractedSpec;
+      return { ref, call, customManifest };
+    });
+    harden(metadataRecords);
 
-  const code = `\
+    const code = `\
 // This is generated by @agoric/deploy-script-support/src/extract-proposal.js - DO NOT EDIT
 /* eslint-disable */
 
@@ -260,11 +303,13 @@ const enactCoreProposals = ((
 ) => makeEnactCoreProposals({ metadataRecords, E }))();
 enactCoreProposals;
 `;
+    return defangAndTrim(code);
+  });
 
   // console.debug('created bundles from proposals:', coreProposals, bundles);
-  return {
+  return harden({
     bundles,
-    code: defangAndTrim(code),
+    codeSteps,
     bundleHandleToAbsolutePaths,
-  };
+  });
 };

--- a/packages/swingset-runner/src/chain.js
+++ b/packages/swingset-runner/src/chain.js
@@ -167,12 +167,15 @@ export async function initEmulatedChain(config, configPath) {
   const bootVat = config.vats[config.bootstrap];
   await null;
   if (coreProposals) {
-    const { bundles, code } = await extractCoreProposalBundles(
+    const { bundles, codeSteps } = await extractCoreProposalBundles(
       coreProposals,
       configPath,
     );
     config.bundles = { ...config.bundles, ...bundles };
-    bootVat.parameters = { ...bootVat.parameters, coreProposalCode: code };
+    bootVat.parameters = {
+      ...bootVat.parameters,
+      coreProposalCodeSteps: codeSteps,
+    };
   }
 
   const batchChainStorage = (method, args) =>

--- a/packages/vats/src/core/boot-chain.js
+++ b/packages/vats/src/core/boot-chain.js
@@ -29,7 +29,7 @@ export const MANIFEST = CHAIN_BOOTSTRAP_MANIFEST;
  *   logger: (msg) => void;
  * }} vatPowers
  * @param {{
- *   coreProposalCode?: string;
+ *   coreProposalCodeSteps?: string[];
  * }} vatParameters
  * @param {import('@agoric/vat-data').Baggage} baggage
  */

--- a/packages/vats/src/core/boot-sim.js
+++ b/packages/vats/src/core/boot-sim.js
@@ -30,7 +30,7 @@ const modules = harden({ behaviors: { ...behaviors }, utils: { ...utils } });
  *   logger: (msg) => void;
  * }} vatPowers
  * @param {{
- *   coreProposalCode?: string;
+ *   coreProposalCodeSteps?: string[];
  * }} vatParameters
  */
 export const buildRootObject = (vatPowers, vatParameters) => {

--- a/packages/vats/src/core/boot-solo.js
+++ b/packages/vats/src/core/boot-solo.js
@@ -35,7 +35,7 @@ const modules = harden({
  * }} vatPowers
  * @param {{
  *   bootstrapManifest?: Record<string, Record<string, unknown>>;
- *   coreProposalCode?: string;
+ *   coreProposalCodeSteps?: string[];
  * }} vatParameters
  */
 export const buildRootObject = (vatPowers, vatParameters) => {

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -98,8 +98,8 @@ export const makeBootstrap = (
     );
 
     const namesVat = namedVat.consume.agoricNames;
-    const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
-      await E(namesVat).getNameHubKit();
+    const nameHubKit = await E(namesVat).getNameHubKit();
+    const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } = nameHubKit;
     const spaces = await makeWellKnownSpaces(agoricNamesAdmin, log);
     produce.agoricNames.resolve(agoricNames);
     produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
@@ -136,21 +136,12 @@ export const makeBootstrap = (
 
     await runBehaviors(bootManifest);
 
-    const { coreProposalCode } = vatParameters;
-    if (!coreProposalCode) {
+    /** @type {{ coreProposalCodeSteps?: string[] }} */
+    const { coreProposalCodeSteps } = vatParameters;
+    if (!coreProposalCodeSteps) {
       return;
     }
 
-    // Start the governance from the core proposals.
-    const coreEvalMessage = {
-      type: 'CORE_EVAL',
-      evals: [
-        {
-          json_permits: 'true',
-          js_code: coreProposalCode,
-        },
-      ],
-    };
     /**
      * @type {{
      *   coreEvalBridgeHandler: Promise<import('../types.js').BridgeHandler>;
@@ -158,7 +149,20 @@ export const makeBootstrap = (
      */
     // @ts-expect-error cast
     const { coreEvalBridgeHandler } = consume;
-    await E(coreEvalBridgeHandler).fromBridge(coreEvalMessage);
+
+    // Start the governance from the core proposals.
+    for await (const coreProposalCode of coreProposalCodeSteps) {
+      const coreEvalMessage = {
+        type: 'CORE_EVAL',
+        evals: [
+          {
+            json_permits: 'true',
+            js_code: coreProposalCode,
+          },
+        ],
+      };
+      await E(coreEvalBridgeHandler).fromBridge(coreEvalMessage);
+    }
   };
 
   // For testing supports

--- a/packages/vm-config/decentral-devnet-config.json
+++ b/packages/vm-config/decentral-devnet-config.json
@@ -2,159 +2,167 @@
   "$comment": "This SwingSet config file (see loadSwingsetConfigFile) includes non-production facilities such as a faucet. Pending #5819, it includes vaults in coreProposals; once #5819 is done, vaults are expected to be added by devnet governance.",
   "bootstrap": "bootstrap",
   "defaultReapInterval": 1000,
-  "coreProposals": [
-    "@agoric/builders/scripts/vats/init-core.js",
-    "@agoric/builders/scripts/vats/init-network.js",
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
-      "entrypoint": "defaultProposalBuilder",
-      "args": [
+  "coreProposals": {
+    "steps": [
+      [
+        "@agoric/builders/scripts/vats/init-core.js"
+      ],
+      [
+        "@agoric/builders/scripts/vats/init-network.js"
+      ],
+      [
         {
-          "econCommitteeOptions": {
-            "committeeSize": 3
-          },
-          "referencedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
-          "minInitialPoolLiquidity": "0"
+          "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "econCommitteeOptions": {
+                "committeeSize": 3
+              },
+              "referencedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
+              "minInitialPoolLiquidity": "0"
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "interchainAssetOptions": {
+                "denom": "ibc/toyatom",
+                "decimalPlaces": 6,
+                "initialPrice": 12.34,
+                "keyword": "ATOM",
+                "oracleBrand": "ATOM",
+                "proposedName": "ATOM"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/toyusdc",
+                "decimalPlaces": 6,
+                "keyword": "USDC_axl",
+                "proposedName": "USD Coin"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/usdc5678",
+                "decimalPlaces": 6,
+                "keyword": "USDC_grv",
+                "proposedName": "USC Coin"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/usdt1234",
+                "decimalPlaces": 6,
+                "keyword": "USDT_axl",
+                "proposedName": "Tether USD"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/toyollie",
+                "decimalPlaces": 6,
+                "keyword": "USDT_grv",
+                "proposedName": "Tether USD"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/toyellie",
+                "decimalPlaces": 6,
+                "keyword": "AUSD",
+                "proposedName": "Anchor USD"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "contractTerms": {
+                "POLL_INTERVAL": 30,
+                "maxSubmissionCount": 1000,
+                "minSubmissionCount": 3,
+                "restartDelay": 1,
+                "timeout": 10,
+                "minSubmissionValue": 1,
+                "maxSubmissionValue": 9007199254740991
+              },
+              "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+              "oracleAddresses": [
+                "agoric10vjkvkmpp9e356xeh6qqlhrny2htyzp8hf88fk",
+                "agoric1qj07c7vfk3knqdral0sej7fa6eavkdn8vd8etf",
+                "agoric1lw4e4aas9q84tq0q92j85rwjjjapf8dmnllnft",
+                "agoric1ra0g6crtsy6r3qnpu7ruvm7qd4wjnznyzg5nu4",
+                "agoric1zj6vrrrjq4gsyr9lw7dplv4vyejg3p8j2urm82"
+              ],
+              "IN_BRAND_LOOKUP": [
+                "agoricNames",
+                "oracleBrand",
+                "ATOM"
+              ],
+              "IN_BRAND_DECIMALS": 6,
+              "OUT_BRAND_LOOKUP": [
+                "agoricNames",
+                "oracleBrand",
+                "USD"
+              ],
+              "OUT_BRAND_DECIMALS": 4
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "voterAddresses": {
+                "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+                "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+                "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-      "entrypoint": "defaultProposalBuilder",
-      "args": [
-        {
-          "interchainAssetOptions": {
-            "denom": "ibc/toyatom",
-            "decimalPlaces": 6,
-            "initialPrice": 12.34,
-            "keyword": "ATOM",
-            "oracleBrand": "ATOM",
-            "proposedName": "ATOM"
-          }
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-      "entrypoint": "psmProposalBuilder",
-      "args": [
-        {
-          "anchorOptions": {
-            "denom": "ibc/toyusdc",
-            "decimalPlaces": 6,
-            "keyword": "USDC_axl",
-            "proposedName": "USD Coin"
-          }
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-      "entrypoint": "psmProposalBuilder",
-      "args": [
-        {
-          "anchorOptions": {
-            "denom": "ibc/usdc5678",
-            "decimalPlaces": 6,
-            "keyword": "USDC_grv",
-            "proposedName": "USC Coin"
-          }
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-      "entrypoint": "psmProposalBuilder",
-      "args": [
-        {
-          "anchorOptions": {
-            "denom": "ibc/usdt1234",
-            "decimalPlaces": 6,
-            "keyword": "USDT_axl",
-            "proposedName": "Tether USD"
-          }
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-      "entrypoint": "psmProposalBuilder",
-      "args": [
-        {
-          "anchorOptions": {
-            "denom": "ibc/toyollie",
-            "decimalPlaces": 6,
-            "keyword": "USDT_grv",
-            "proposedName": "Tether USD"
-          }
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
-      "entrypoint": "psmProposalBuilder",
-      "args": [
-        {
-          "anchorOptions": {
-            "denom": "ibc/toyellie",
-            "decimalPlaces": 6,
-            "keyword": "AUSD",
-            "proposedName": "Anchor USD"
-          }
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
-      "entrypoint": "defaultProposalBuilder",
-      "args": [
-        {
-          "contractTerms": {
-            "POLL_INTERVAL": 30,
-            "maxSubmissionCount": 1000,
-            "minSubmissionCount": 3,
-            "restartDelay": 1,
-            "timeout": 10,
-            "minSubmissionValue": 1,
-            "maxSubmissionValue": 9007199254740991
-          },
-          "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
-          "oracleAddresses": [
-            "agoric10vjkvkmpp9e356xeh6qqlhrny2htyzp8hf88fk",
-            "agoric1qj07c7vfk3knqdral0sej7fa6eavkdn8vd8etf",
-            "agoric1lw4e4aas9q84tq0q92j85rwjjjapf8dmnllnft",
-            "agoric1ra0g6crtsy6r3qnpu7ruvm7qd4wjnznyzg5nu4",
-            "agoric1zj6vrrrjq4gsyr9lw7dplv4vyejg3p8j2urm82"
-          ],
-          "IN_BRAND_LOOKUP": [
-            "agoricNames",
-            "oracleBrand",
-            "ATOM"
-          ],
-          "IN_BRAND_DECIMALS": 6,
-          "OUT_BRAND_LOOKUP": [
-            "agoricNames",
-            "oracleBrand",
-            "USD"
-          ],
-          "OUT_BRAND_DECIMALS": 4
-        }
-      ]
-    },
-    {
-      "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
-      "entrypoint": "defaultProposalBuilder",
-      "args": [
-        {
-          "voterAddresses": {
-            "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
-            "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
-            "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "vats": {
     "bootstrap": {
       "sourceSpec": "@agoric/vats/src/core/boot-chain.js",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #8219
related: [#8441](https://github.com/Agoric/agoric-sdk/issues/8441)

## Description

Given `coreProposals: ParallelProposals | { steps: ParallelProposals[] }` (with `typedef ParallelProposals = Proposal[]`), return `codeSteps: string[]` from `extractCoreProposalBundles`.  Then execute each `ParallelProposals` in parallel, fully draining the kernel run queue before proceeding to the next step.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
Would be useful to document the coreProposals mechanism and call out the meaning of `.steps` fields if present.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Tested with `packages/cosmic-swingset/economy-template.json`.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
Makes `coreProposals` processing more flexible than simply evaluating all of them in parallel.