### PR TITLE
deps(agoric): cleanup deps

### DIFF
--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -31,7 +31,8 @@
     "@agoric/deploy-script-support": "^0.10.3",
     "@agoric/cosmic-swingset": "^0.41.3",
     "ava": "^5.3.0",
-    "c8": "^7.13.0"
+    "c8": "^7.13.0",
+    "dd-trace": "^4.11.1"
   },
   "dependencies": {
     "@agoric/access-token": "^0.4.21",
@@ -55,7 +56,6 @@
     "@cosmjs/math": "^0.30.1",
     "@cosmjs/proto-signing": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
-    "@cosmjs/tendermint-rpc": "^0.30.1",
     "@endo/bundle-source": "^2.7.0",
     "@endo/captp": "^3.1.4",
     "@endo/compartment-mapper": "^0.9.1",
@@ -68,7 +68,6 @@
     "anylogger": "^0.21.0",
     "chalk": "^5.2.0",
     "commander": "^10.0.0",
-    "dd-trace": "^4.11.1",
     "deterministic-json": "^1.0.5",
     "esm": "agoric-labs/esm#Agoric-built",
     "inquirer": "^8.2.2",


### PR DESCRIPTION
## Description

Some drive-by cleaning of agoric-cli deps:
- `dd-trace` should not be installed when pulling the `agoric` package from NPM, so moving to dev dependencies
- `@cosmjs/tendermint-rpc` is not actually used directly by `agoric-cli`

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

None

### Upgrade Considerations

None
