### PR TITLE
fix(agoric-cli): fix broken `agoric open`

### DIFF
--- a/packages/agoric-cli/src/open.js
+++ b/packages/agoric-cli/src/open.js
@@ -5,8 +5,8 @@ import { getAccessToken } from '@agoric/access-token';
 
 import { assert, details as X } from '@agoric/assert';
 
-export default async function walletMain(progname, rawArgs, powers, opts) {
-  const { anylogger, fs } = powers;
+export default async function walletMain(_progname, _rawArgs, powers, opts) {
+  const { anylogger } = powers;
   const console = anylogger('agoric:wallet');
 
   let suffix;
@@ -39,10 +39,10 @@ export default async function walletMain(progname, rawArgs, powers, opts) {
     1000,
   );
 
-  const walletAccessToken = await getAccessToken(opts.hostport, {
-    console,
-    fs,
-  }).catch(e => console.error(`Trying to fetch access token:`, e));
+  const walletAccessToken = await getAccessToken(opts.hostport).catch(e => {
+    console.error(`Trying to fetch access token:`, e);
+    throw e;
+  });
 
   clearInterval(progressTimer);
   process.stderr.write('\n');

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -154,6 +154,11 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
     t.is(await startResult.promise, true, `swingset running before timeout`);
     clearTimeout(timeout);
 
+    const openP = myMain(['open', '--no-browser'], {
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    t.is(await openP, 0, `open --no-browser exits successfully`);
+
     const testDeploy = async (deployCmd, opts = {}) => {
       const deployResult = makePromiseKit();
       const deployP = myMain(


### PR DESCRIPTION
An unused extra `powers` argument to `getAccessToken` interfered with its latest API change and produced `undefined` access tokens.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Small but impactful fix: `agoric open` was broken.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
This only broke `agoric open` (attempting to look up the key failed, and failure did not crash the process).  `ag-solo` did not supply a `powers` argument, and it failed safe by rejecting the bad key.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Updated getting-started test for `agoric open --no-browser`.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a