### PR TITLE
fix latest NPM packages

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,7 +22,7 @@
     "lint": "exit 0"
   },
   "files": [
-    "eslint-config.json"
+    "eslint-config.*"
   ],
   "peerDependencies": {
     "@endo/eslint-plugin": "0.4.4",

--- a/packages/governance/test/unitTests/test-puppetContractGovernor.js
+++ b/packages/governance/test/unitTests/test-puppetContractGovernor.js
@@ -6,6 +6,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
+import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 
 import { CONTRACT_ELECTORATE, ParamTypes } from '../../src/index.js';
 import { setUpGovernedContract } from '../../tools/puppetGovernance.js';
@@ -156,4 +157,21 @@ test('call API directly', async t => {
     await E(E(governorFacets.creatorFacet).getPublicFacet()).getApiCalled(),
     1,
   );
+});
+
+test('add issuerKeywordRecord', async t => {
+  const zoe = await makeZoeForTest();
+  const issuerKit = makeIssuerKit('Food', AssetKind.COPY_BAG);
+  const timer = buildManualTimer(t.log);
+  const { governorFacets } = await setUpGovernedContract(
+    zoe,
+    E(zoe).install(governedBundleP),
+    timer,
+    governedTerms,
+    {},
+    { Food: issuerKit.issuer },
+  );
+
+  const instance = await E(governorFacets.creatorFacet).getInstance();
+  t.deepEqual(await E(zoe).getIssuers(instance), { Food: issuerKit.issuer });
 });

--- a/packages/governance/tools/puppetGovernance.js
+++ b/packages/governance/tools/puppetGovernance.js
@@ -28,6 +28,7 @@ const autoRefundBundleP = makeBundle(
  * @param {import('@agoric/swingset-vat/src/vats/timer/vat-timer.js').TimerService} timer
  * @param {{ [k: string]: any, governedParams?: Record<string, unknown>, governedApis?: string[] }} termsOfGoverned
  * @param {{}} privateArgsOfGoverned
+ * @param {IssuerKeywordRecord} [issuerKeywordRecord]
  */
 export const setUpGovernedContract = async (
   zoe,
@@ -35,6 +36,7 @@ export const setUpGovernedContract = async (
   timer,
   termsOfGoverned = {},
   privateArgsOfGoverned = {},
+  issuerKeywordRecord = {},
 ) => {
   const [contractGovernorBundle, autoRefundBundle] = await Promise.all([
     contractGovernorBundleP,
@@ -87,7 +89,7 @@ export const setUpGovernedContract = async (
     governedContractInstallation: governed,
     governed: {
       terms: governedTermsWithElectorate,
-      issuerKeywordRecord: {},
+      issuerKeywordRecord,
     },
   };
 

--- a/packages/internal/src/node/createBundles.js
+++ b/packages/internal/src/node/createBundles.js
@@ -1,3 +1,4 @@
+/* global process */
 // Use modules not prefixed with `node:` since some deploy scripts may
 // still be running in esm emulation
 import path from 'path';
@@ -29,7 +30,13 @@ export const createBundlesFromAbsolute = async sourceBundles => {
 
   for (const args of cacheToArgs.values()) {
     console.log(BUNDLE_SOURCE_PROGRAM, ...args);
-    const { status } = spawnSync(prog, args, { stdio: 'inherit' });
+    const env = /** @type {NodeJS.ProcessEnv} */ (
+      /** @type {unknown} */ ({
+        __proto__: process.env,
+        LOCKDOWN_OVERRIDE_TAMING: 'severe',
+      })
+    );
+    const { status } = spawnSync(prog, args, { stdio: 'inherit', env });
     status === 0 ||
       Fail`${q(BUNDLE_SOURCE_PROGRAM)} failed with status ${q(status)}`;
   }

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -142,6 +142,7 @@ export const makeAssetRegistry = assetPublisher => {
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const prepare = async (zcf, privateArgs, baggage) => {
+  const upgrading = baggage.has('walletsByAddress');
   const { agoricNames, board, assetPublisher } = zcf.getTerms();
 
   const zoe = zcf.getZoeService();
@@ -292,7 +293,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   if (walletBridgeManager) {
     // NB: may not be in service when creatorFacet is used, or ever
     // It can't be awaited because that fails vat restart
-    const upgrading = baggage.has('walletsByAddress');
     if (upgrading) {
       void E(walletBridgeManager).setHandler(handleWalletAction);
     } else {

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -76,9 +76,11 @@ const makeFakeBridgeManager = () =>
           return E(handler).fromBridge(obj);
         },
         initHandler(newHandler) {
+          !handler || Fail`Handler already set`;
           handler = newHandler;
         },
         setHandler(newHandler) {
+          !!handler || Fail`Handler not set`;
           handler = newHandler;
         },
       });

--- a/packages/solo/src/entrypoint.js
+++ b/packages/solo/src/entrypoint.js
@@ -7,7 +7,7 @@ import 'esm';
 
 // we need to enable Math.random as a workaround for 'brace-expansion' module
 // (dep chain: temp->glob->minimatch->brace-expansion)
-import '@endo/init';
+import '@endo/init/legacy.js';
 
 import process from 'process';
 import path from 'path';

--- a/packages/solo/src/pipe-entrypoint.js
+++ b/packages/solo/src/pipe-entrypoint.js
@@ -1,7 +1,7 @@
 /* global process */
 // @ts-check
 import '@endo/init/pre-bundle-source.js';
-import '@endo/init';
+import '@endo/init/unsafe-fast.js';
 
 import { parse, stringify } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -483,8 +483,14 @@ const start = async (basedir, argv) => {
   const { 'agoric-wallet': { htmlBasedir = 'ui/build', deploy = [] } = {} } =
     JSON.parse(fs.readFileSync(pjs, 'utf-8'));
 
+  const htmlBasePath = String(htmlBasedir).replace(
+    /^\.\.\/\.\.\/node_modules\//,
+    '',
+  );
+
   const agWallet = path.dirname(pjs);
-  const agWalletHtml = path.resolve(agWallet, htmlBasedir);
+  const agWalletHtmlUrl = await importMetaResolve(htmlBasePath, packageUrl);
+  const agWalletHtml = new URL(agWalletHtmlUrl).pathname;
 
   let hostport;
   await Promise.all(

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -38,6 +38,7 @@
     "src/**/*.js",
     "src/**/*.d.ts",
     "test/**/*.js",
+    "tools",
     "exported.js"
   ],
   "repository": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "author": "Agoric",
   "agoric-wallet": {
-    "htmlBasedir": "../../node_modules/@agoric/wallet-ui/build",
+    "htmlBasedir": "@agoric/wallet-ui/build",
     "deploy": [
       "./api/deploy.js"
     ]


### PR DESCRIPTION
Fixes #8380

## Description

Follow up to #8360 and #8374. The new NPM packages were not sufficient to get our partner to test a dapp as expected. This PR cherry picks a few more existing and new fixes that were needed. It was not 100% sufficient to run without an agoric-sdk checkout because of their reliance of a cosmos based testnet (see #8033), and makefile targets in `cosmic-swingset`, however that's a separate issue.

This PR is constructed with the following git-rebase-todo

```
# Pull Request #8322
pick 97cb7158f fix(walletFactory): move upgrading check before baggage is populated (#8322)

# Pull Request #8351
pick 9f89f97d4 feat: puppetGovernor pass the Issuerkeywordrecord through (#8351)

# Partial Pull Request #7921
pick 1ab049437 build: export tools from swingset-liveslots

# Partial Pull Request #7922
pick 379277e77 fix: export of eslint-config.cjs

# Branch Agoric-mhofman-fix-solo-wallet-ui
label base-Agoric-mhofman-fix-solo-wallet-ui
pick c57885107 fix(solo): correct lookup of wallet-ui
pick 1ac063e79 fix(wallet): don't assume node_modules layout
label Agoric-mhofman-fix-solo-wallet-ui
reset base-Agoric-mhofman-fix-solo-wallet-ui
merge -C bf2e680e7 Agoric-mhofman-fix-solo-wallet-ui # Merge pull request #8392 from Agoric/mhofman/fix-solo-wallet-ui

# Branch Agoric-mhofman-workaround-babel-override-mistake
label base-Agoric-mhofman-workaround-babel-override-mistake
pick 584ec6248 fix(solo): use alternative endo init
pick 877c1a13d fix(internal): severe override taming for bundle-source
label Agoric-mhofman-workaround-babel-override-mistake
reset base-Agoric-mhofman-workaround-babel-override-mistake
merge -C 1831bf3fd Agoric-mhofman-workaround-babel-override-mistake # Merge pull request #8391 from Agoric/mhofman/workaround-babel-override-mistake
```

### Security Considerations

This PR picks a change switching the override and error taming of the solo to a severe/unsafe mode respectively. This should be safe as only our trusted code should be impacted.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Verified these changes applied as patches are sufficient to get KREAd working with their testing flow.

### Upgrade Considerations

Only a wallet factory change affects runtime code, however it's only to make it compatible with both a bootstrap and upgrade start, and safe to include even though not technically 100% matching of the code that was deployed in the core eval, but that's what the tag is for. No other contract code is affected.