### PR TITLE
Workaround babel override mistake

### DIFF
--- a/packages/internal/src/node/createBundles.js
+++ b/packages/internal/src/node/createBundles.js
@@ -1,3 +1,4 @@
+/* global process */
 // Use modules not prefixed with `node:` since some deploy scripts may
 // still be running in esm emulation
 import path from 'path';
@@ -29,7 +30,13 @@ export const createBundlesFromAbsolute = async sourceBundles => {
 
   for (const args of cacheToArgs.values()) {
     console.log(BUNDLE_SOURCE_PROGRAM, ...args);
-    const { status } = spawnSync(prog, args, { stdio: 'inherit' });
+    const env = /** @type {NodeJS.ProcessEnv} */ (
+      /** @type {unknown} */ ({
+        __proto__: process.env,
+        LOCKDOWN_OVERRIDE_TAMING: 'severe',
+      })
+    );
+    const { status } = spawnSync(prog, args, { stdio: 'inherit', env });
     status === 0 ||
       Fail`${q(BUNDLE_SOURCE_PROGRAM)} failed with status ${q(status)}`;
   }

--- a/packages/solo/src/entrypoint.js
+++ b/packages/solo/src/entrypoint.js
@@ -7,7 +7,7 @@ import 'esm';
 
 // we need to enable Math.random as a workaround for 'brace-expansion' module
 // (dep chain: temp->glob->minimatch->brace-expansion)
-import '@endo/init';
+import '@endo/init/legacy.js';
 
 import process from 'process';
 import path from 'path';

--- a/packages/solo/src/pipe-entrypoint.js
+++ b/packages/solo/src/pipe-entrypoint.js
@@ -1,7 +1,7 @@
 /* global process */
 // @ts-check
 import '@endo/init/pre-bundle-source.js';
-import '@endo/init';
+import '@endo/init/unsafe-fast.js';
 
 import { parse, stringify } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';


### PR DESCRIPTION
Refs: #8380

## Description

These are all the override tamings I found necessary to workaround https://github.com/babel/babel/issues/15995 which is entrained by `@endo/bundle-source`.

### Security Considerations

All this should be safe since it only affects our trusted orchestration code. For the `solo` I would prefer an entrypoint in `@endo/init` that only triggered the override taming without unsafe error taming, but I don't think we open any attack surface regardless.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually tested as patches on top of `release-mainnet1B` / `latest` NPM packages in a dapp that depends on a babel version with this issue.

### Upgrade Considerations

None
