### PR TITLE
fix: solo lookup of wallet UI

### DIFF
--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -485,8 +485,14 @@ const start = async (basedir, argv) => {
   const { 'agoric-wallet': { htmlBasedir = 'ui/build', deploy = [] } = {} } =
     JSON.parse(fs.readFileSync(pjs, 'utf-8'));
 
+  const htmlBasePath = String(htmlBasedir).replace(
+    /^\.\.\/\.\.\/node_modules\//,
+    '',
+  );
+
   const agWallet = path.dirname(pjs);
-  const agWalletHtml = path.resolve(agWallet, htmlBasedir);
+  const agWalletHtmlUrl = await importMetaResolve(htmlBasePath, packageUrl);
+  const agWalletHtml = new URL(agWalletHtmlUrl).pathname;
 
   let hostport;
   await Promise.all(

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "author": "Agoric",
   "agoric-wallet": {
-    "htmlBasedir": "../../node_modules/@agoric/wallet-ui/build",
+    "htmlBasedir": "@agoric/wallet-ui/build",
     "deploy": [
       "./api/deploy.js"
     ]


### PR DESCRIPTION
Refs: #8380

## Description

During testing of #8374, we encountered an issue when opening the wallet UI (`agoric open`) where the wallet UI exposed by `ag-solo` (port 8000), would failed to load from `dapp-foo/node_modules/node_modules/@agoric/wallet-ui/build/index.html`.

This changes the solo to use `import.resolve` to locate the `htmlBasedir` relative to the `@agoric/wallet` package, and removes the now unnecessary `../../node_modules` relative path.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually tested as patch over the `agoric-upgrade-11` NPM packages in a dapp. Other integration tests should cover the rest.

### Upgrade Considerations

None
