### PR TITLE
refactor: delay addition of issuer to auctioneer until a good time

### DIFF
--- a/packages/boot/test/bootstrapTests/test-addAssets.ts
+++ b/packages/boot/test/bootstrapTests/test-addAssets.ts
@@ -133,7 +133,7 @@ test('addAsset to active auction', async t => {
   t.log('proposal executed');
 
   const schedulesAfter = await EV(auctioneerKit.creatorFacet).getSchedule();
-  // TimeMath.compareAbs() complains that the brands don't match
+  // TimeMath.compareAbs() can't handle brands processed by kmarshall
   t.truthy(
     schedules.nextAuctionSchedule.endTime.absValue <
       schedulesAfter.nextAuctionSchedule.endTime.absValue,

--- a/packages/boot/test/bootstrapTests/test-addAssets.ts
+++ b/packages/boot/test/bootstrapTests/test-addAssets.ts
@@ -1,0 +1,196 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import type { TestFn } from 'ava';
+
+import { TimeMath } from '@agoric/time';
+import {
+  LiquidationTestContext,
+  makeLiquidationTestContext,
+} from './liquidation.ts';
+
+const test = anyTest as TestFn<LiquidationTestContext>;
+
+const auctioneerPath = 'published.auction';
+
+test.before(async t => {
+  t.context = await makeLiquidationTestContext(t);
+  const proposal = await t.context.buildProposal({
+    package: 'builders',
+    packageScriptName: 'build:add-STARS-proposal',
+  });
+
+  t.log('installing proposal');
+  // share a single proposal so tests don't stomp on each other's files; It has
+  // to be edited by each so as not to re-use keywords.
+  for await (const bundle of proposal.bundles) {
+    await t.context.controller.validateAndInstallBundle(bundle);
+  }
+  t.log('installed', proposal.bundles.length, 'bundles');
+  // @ts-expect-error override
+  t.context.proposal = proposal;
+  t.log('installed', proposal.bundles.length, 'bundles');
+});
+
+test.after.always(t => {
+  // This will fail if a subset of tests are run. It detects that three
+  // collaterals were added to the auction after ATOM.
+  t.like(t.context.readLatest(`${auctioneerPath}.book3`), {
+    currentPriceLevel: null,
+  });
+  return t.context.shutdown && t.context.shutdown();
+});
+
+test('addAsset to quiescent auction', async t => {
+  const {
+    advanceTimeTo,
+    readLatest,
+    // @ts-expect-error override
+    proposal,
+  } = t.context;
+
+  // stringify, modify and parse because modifying a deep copy was fragile.
+  const proposalJSON = JSON.stringify(proposal);
+  const proposalMod = proposalJSON.replaceAll('STARS', 'COMETS');
+  const proposalNew = JSON.parse(proposalMod);
+
+  const bridgeMessage = {
+    type: 'CORE_EVAL',
+    evals: proposalNew.evals,
+  };
+
+  const { EV } = t.context.runUtils;
+
+  const auctioneerKit = await EV.vat('bootstrap').consumeItem('auctioneerKit');
+  const schedules = await EV(auctioneerKit.creatorFacet).getSchedule();
+  const { liveAuctionSchedule, nextAuctionSchedule } = schedules;
+  const nextEndTime = liveAuctionSchedule
+    ? liveAuctionSchedule.endTime
+    : nextAuctionSchedule.endTime;
+  const fiveMinutes = harden({
+    relValue: 5n * 60n,
+    timerBrand: nextEndTime.timerBrand,
+  });
+  const nextQuiescentTime = TimeMath.addAbsRel(nextEndTime, fiveMinutes);
+  await advanceTimeTo(nextQuiescentTime);
+
+  const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
+    'coreEvalBridgeHandler',
+  );
+  await EV(coreEvalBridgeHandler).fromBridge(bridgeMessage);
+  t.log('add-STARS proposal executed');
+
+  t.like(readLatest(`${auctioneerPath}.book1`), {
+    currentPriceLevel: null,
+  });
+});
+
+test('addAsset to active auction', async t => {
+  const {
+    advanceTimeTo,
+    readLatest,
+    // @ts-expect-error override
+    proposal,
+  } = t.context;
+  const { EV } = t.context.runUtils;
+
+  t.like(readLatest(`${auctioneerPath}.book0`), { startPrice: null });
+
+  const auctioneerKit = await EV.vat('bootstrap').consumeItem('auctioneerKit');
+  const schedules = await EV(auctioneerKit.creatorFacet).getSchedule();
+  const { nextAuctionSchedule } = schedules;
+  t.truthy(nextAuctionSchedule);
+  const nextStartTime = nextAuctionSchedule.startTime;
+  const fiveMinutes = harden({
+    relValue: 5n * 60n,
+    timerBrand: nextStartTime.timerBrand,
+  });
+  const futureBusyTime = TimeMath.addAbsRel(nextStartTime, fiveMinutes);
+
+  await advanceTimeTo(futureBusyTime);
+
+  t.log('launching proposal');
+
+  const proposalJSON = JSON.stringify(proposal);
+  const proposalMod = proposalJSON
+    .replaceAll('STARS', 'PLANETS')
+    .replaceAll('ibc/987C17B1', 'ibc/987C17B2');
+  const proposalNew = JSON.parse(proposalMod);
+
+  const bridgeMessage = {
+    type: 'CORE_EVAL',
+    evals: proposalNew.evals,
+  };
+  t.log({ bridgeMessage });
+
+  const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
+    'coreEvalBridgeHandler',
+  );
+  EV(coreEvalBridgeHandler).fromBridge(bridgeMessage);
+
+  const nextEndTime = nextAuctionSchedule.endTime;
+  const afterEndTime = TimeMath.addAbsRel(nextEndTime, fiveMinutes);
+  await advanceTimeTo(afterEndTime);
+
+  const schedulesAfter = await EV(auctioneerKit.creatorFacet).getSchedule();
+  // brand equality is broken
+  t.truthy(
+    schedules.nextAuctionSchedule.endTime.absValue <
+      schedulesAfter.nextAuctionSchedule.endTime.absValue,
+  );
+
+  t.like(readLatest(`${auctioneerPath}.book1`), { currentPriceLevel: null });
+});
+
+test('addAsset to auction starting soon', async t => {
+  const {
+    advanceTimeTo,
+    // @ts-expect-error override
+    proposal,
+    readLatest,
+  } = t.context;
+  const { EV } = t.context.runUtils;
+
+  const auctioneerKit = await EV.vat('bootstrap').consumeItem('auctioneerKit');
+  const schedules = await EV(auctioneerKit.creatorFacet).getSchedule();
+  const { nextAuctionSchedule } = schedules;
+  t.truthy(nextAuctionSchedule);
+  const nextStartTime = nextAuctionSchedule.startTime;
+  const fiveMinutes = harden({
+    relValue: 5n * 60n,
+    timerBrand: nextStartTime.timerBrand,
+  });
+  const tooCloseTime = TimeMath.subtractAbsRel(nextStartTime, fiveMinutes);
+
+  await advanceTimeTo(tooCloseTime);
+
+  const proposalJSON = JSON.stringify(proposal);
+  const proposalMod = proposalJSON
+    .replaceAll('STARS', 'MOONS')
+    .replaceAll('ibc/987C17B1', 'ibc/987C17B3');
+  const proposalNew = JSON.parse(proposalMod);
+
+  t.log('launching proposal');
+  const bridgeMessage = {
+    type: 'CORE_EVAL',
+    evals: proposalNew.evals,
+  };
+  t.log({ bridgeMessage });
+
+  const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
+    'coreEvalBridgeHandler',
+  );
+  EV(coreEvalBridgeHandler).fromBridge(bridgeMessage);
+
+  const nextEndTime = nextAuctionSchedule.endTime;
+  const afterEndTime = TimeMath.addAbsRel(nextEndTime, fiveMinutes);
+  await advanceTimeTo(afterEndTime);
+
+  t.log('add-STARS proposal executed');
+
+  const schedulesAfter = await EV(auctioneerKit.creatorFacet).getSchedule();
+  t.truthy(
+    schedules.nextAuctionSchedule.endTime.absValue <
+      schedulesAfter.nextAuctionSchedule.endTime.absValue,
+  );
+  t.like(readLatest(`${auctioneerPath}.book1`), { currentPriceLevel: null });
+});

--- a/packages/boot/test/bootstrapTests/test-addAssets.ts
+++ b/packages/boot/test/bootstrapTests/test-addAssets.ts
@@ -132,7 +132,7 @@ test('addAsset to active auction', async t => {
   await advanceTimeTo(afterEndTime);
 
   const schedulesAfter = await EV(auctioneerKit.creatorFacet).getSchedule();
-  // brand equality is broken
+  // TimeMath.compareAbs() complains that the brands don't match
   t.truthy(
     schedules.nextAuctionSchedule.endTime.absValue <
       schedulesAfter.nextAuctionSchedule.endTime.absValue,

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -46,6 +46,7 @@
     "@endo/far": "^0.2.21",
     "@endo/marshal": "^0.8.8",
     "@endo/nat": "^4.1.30",
+    "@endo/promise-kit": "^0.2.59",
     "jessie.js": "^0.3.2"
   },
   "devDependencies": {

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -1,15 +1,23 @@
 // @jessie-check
+// @ts-check
 
+import { ToFarFunction } from '@endo/captp';
+import { Far } from '@endo/marshal';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { deeplyFulfilledObject } from '@agoric/internal';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { parseRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { E } from '@endo/far';
 import { Stable } from '@agoric/internal/src/tokens.js';
+import { TimeMath } from '@agoric/time/src/timeMath.js';
+import { makePromiseKit } from '@endo/promise-kit';
+
 import { instanceNameFor } from './price-feed-proposal.js';
 import { reserveThenGetNames } from './utils.js';
 
 export * from './startPSM.js';
+
+const { quote: q } = assert;
 
 /**
  * @typedef {object} InterchainAssetOptions
@@ -24,8 +32,10 @@ export * from './startPSM.js';
  * @property {number} [initialPrice]
  */
 
+/** @typedef {import('./econ-behaviors.js').EconomyBootstrapPowers} EconomyBootstrapPowers */
+
 /**
- * @param {EconomyBootstrapPowers} powers
+ * @param {BootstrapPowers} powers
  * @param {object} config
  * @param {object} config.options
  * @param {InterchainAssetOptions} config.options.interchainAssetOptions
@@ -216,7 +226,65 @@ export const registerScaledPriceAuthority = async (
   );
 };
 
-/** @typedef {import('./econ-behaviors.js').EconomyBootstrapPowers} EconomyBootstrapPowers */
+// wait a short while after end to allow things to settle
+const BUFFER = 5n * 60n;
+// let's insist on 20 minutes leeway for running the scripts
+const COMPLETION = 20n * 60n;
+
+// If there is a liveSchedule, 1) run now if start is far enough away,
+// otherwise, 2) run after endTime.
+// If neither liveSchedule nor nextSchedule is defined, 3) run now.
+// If there is only a nextSchedule, 4) run now if startTime is far enough away,
+// else 5) run after endTime
+const whenQuiescent = async (schedules, timer, thunk) => {
+  const { nextAuctionSchedule, liveAuctionSchedule } = schedules;
+  const now = await E(timer).getCurrentTimestamp();
+
+  const waker = Far('addAssetWaker', { wake: () => thunk() });
+
+  if (liveAuctionSchedule) {
+    const safeStart = TimeMath.subtractAbsRel(
+      liveAuctionSchedule.startTime,
+      COMPLETION,
+    );
+
+    if (TimeMath.compareAbs(safeStart, now) < 0) {
+      // case 2
+      console.warn(
+        `Add Asset after live schedule's endtime: ${q(
+          liveAuctionSchedule.endTime,
+        )}`,
+      );
+
+      return E(timer).setWakeup(
+        TimeMath.addAbsRel(liveAuctionSchedule.endTime, BUFFER),
+        waker,
+      );
+    }
+  }
+
+  if (!liveAuctionSchedule && nextAuctionSchedule) {
+    const safeStart = TimeMath.subtractAbsRel(
+      nextAuctionSchedule.startTime,
+      COMPLETION,
+    );
+    if (TimeMath.compareAbs(safeStart, now) < 0) {
+      // case 5
+      console.warn(
+        `Add Asset after next schedule's endtime: ${q(
+          nextAuctionSchedule.endTime,
+        )}`,
+      );
+      return E(timer).setWakeup(
+        TimeMath.addAbsRel(nextAuctionSchedule.endTime, BUFFER),
+        waker,
+      );
+    }
+  }
+
+  console.warn(`Add Asset immediately`, thunk);
+  return thunk();
+};
 
 /**
  * @param {EconomyBootstrapPowers} powers
@@ -228,7 +296,12 @@ export const registerScaledPriceAuthority = async (
  */
 export const addAssetToVault = async (
   {
-    consume: { vaultFactoryKit, agoricNamesAdmin, auctioneerKit },
+    consume: {
+      vaultFactoryKit,
+      agoricNamesAdmin,
+      auctioneerKit,
+      chainTimerService,
+    },
     brand: {
       consume: { [Stable.symbol]: stableP },
     },
@@ -263,6 +336,21 @@ export const addAssetToVault = async (
   // eslint-disable-next-line no-restricted-syntax -- allow this computed property
   await consumeInstance[oracleInstanceName];
 
+  const auctioneerCreator = E.get(auctioneerKit).creatorFacet;
+  const schedules = await E(auctioneerCreator).getSchedule();
+
+  const finishPromiseKit = makePromiseKit();
+  const addBrandThenResolve = ToFarFunction('addBrandThenResolve', async () => {
+    await E(auctioneerCreator).addBrand(interchainIssuer, keyword);
+    finishPromiseKit.resolve(true);
+    return true;
+  });
+
+  // schedules actions on a timer (or does it immediately).
+  // finishPromiseKit signals completion.
+  void whenQuiescent(schedules, chainTimerService, addBrandThenResolve);
+  await finishPromiseKit.promise;
+
   const stable = await stableP;
   const vaultFactoryCreator = E.get(vaultFactoryKit).creatorFacet;
   await E(vaultFactoryCreator).addVaultType(interchainIssuer, keyword, {
@@ -277,8 +365,6 @@ export const addAssetToVault = async (
     mintFee: makeRatio(50n, stable, 10_000n),
     liquidationPenalty: makeRatio(1n, stable),
   });
-  const auctioneerCreator = E.get(auctioneerKit).creatorFacet;
-  await E(auctioneerCreator).addBrand(interchainIssuer, keyword);
 };
 
 export const getManifestForAddAssetToVault = (
@@ -338,6 +424,7 @@ export const getManifestForAddAssetToVault = (
           auctioneerKit: 'auctioneer',
           vaultFactoryKit: 'vaultFactory',
           agoricNamesAdmin: true,
+          chainTimerService: true,
         },
         brand: {
           consume: { [Stable.symbol]: true },


### PR DESCRIPTION
closes: #8347

## Description

When adding a new asset type, delay until the auction is quiescent, so as not to trigger #8296.

### Security Considerations

Don't break the chain.

### Scaling Considerations

Not an issue here.

### Documentation Considerations

Not applicable.

### Testing Considerations

I added bootstrapTests that wait until a propitious or hazardous time to add the collateral, and verify that addAssetsToVault waits for the auction to quiesce, and succeeds in adding a new collateral type.

### Upgrade Considerations

This applies to adding asset types, not upgrading contracts.
