### PR TITLE
fewer runtime imports for types

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -34,5 +34,8 @@
   "homepage": "https://github.com/Agoric/agoric-sdk/tree/HEAD/golang/cosmos",
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",
     "prettier-plugin-jsdoc": "^1.0.0",
+    "type-coverage": "^2.26.3",
     "typescript": "~5.2.2"
   },
   "engines": {

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build tsconfig.build.json",
+    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build --clean tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' src/types.js",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava",

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -82,5 +82,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -84,6 +84,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 90.37
   }
 }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -98,6 +98,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 75.26
   }
 }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -96,5 +96,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -8,7 +8,7 @@ import {
   insistVatDeliveryResult,
 } from '../../lib/message.js';
 import '../../types-ambient.js';
-import './types.js';
+/// <reference path="./types.js" />
 
 /**
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -7,8 +7,8 @@ import {
   insistVatSyscallObject,
   insistVatDeliveryResult,
 } from '../../lib/message.js';
-import '../../types-ambient.js';
-/// <reference path="./types.js" />
+
+/// <reference path="../../types-ambient.js" />
 
 /**
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject
@@ -27,7 +27,7 @@ function parentLog(first, ...args) {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-/** @param { (item: Tagged) => unknown } [handleUpstream] */
+/** @param { (item: import('./types.js').Tagged) => unknown } [handleUpstream] */
 const makeRevokableHandleCommandKit = handleUpstream => {
   /**
    * @param {Uint8Array} msg
@@ -96,7 +96,7 @@ export function makeXsSubprocessFactory({
 
     const mk = makeManagerKit();
 
-    /** @type { (item: Tagged) => unknown } */
+    /** @type { (item: import('./types.js').Tagged) => unknown } */
     function handleUpstream([type, ...args]) {
       parentLog(vatID, `handleUpstream`, type, args.length);
       switch (type) {
@@ -148,7 +148,7 @@ export function makeXsSubprocessFactory({
       init: snapshotInfo && { from: 'snapStore', vatID },
     });
 
-    /** @type { (item: Tagged) => Promise<WorkerResults> } */
+    /** @type { (item: import('./types.js').Tagged) => Promise<import('./types.js').WorkerResults> } */
     async function issueTagged(item) {
       parentLog(item[0], '...', item.length - 1);
       const result = await worker.issueStringCommand(JSON.stringify(item));
@@ -185,7 +185,7 @@ export function makeXsSubprocessFactory({
      */
     async function deliverToWorker(delivery) {
       parentLog(vatID, `sending delivery`, delivery);
-      /** @type { WorkerResults } */
+      /** @type { import('./types.js').WorkerResults } */
       let result;
       await null;
       try {

--- a/packages/SwingSet/src/kernel/vat-loader/types.js
+++ b/packages/SwingSet/src/kernel/vat-loader/types.js
@@ -1,3 +1,5 @@
+export {};
+
 /**
  * @typedef { [string, ...unknown[]] } Tagged
  * @typedef { { meterType: string, allocate: number|null, compute: number|null } }

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -41,6 +41,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 83.97
   }
 }

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -39,5 +39,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "2m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -94,5 +94,8 @@
     ],
     "timeout": "2m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -96,6 +96,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 77.53
   }
 }

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -11,11 +11,6 @@ import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { objectMap } from '@agoric/internal';
 import { M, matches } from '@agoric/store';
 
-// XXX scare away ambient type zombies to fix ScheduleNotification.activeStartTime etc.
-// https://github.com/Agoric/agoric-sdk/issues/6512
-// https://github.com/Agoric/agoric-sdk/issues/6343
-import '@agoric/inter-protocol/src/vaultFactory/types.js';
-
 import { normalizeAddressWithOptions, pollBlocks } from '../lib/chain.js';
 import {
   asBoardRemote,

--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -41,6 +41,7 @@ export const makePspawn = ({
    * @param {string} cmd command name to run
    * @param {Array<string>} cargs arguments to the command
    * @param {object} param2
+   * @param {string} [param2.cwd]
    * @param {string | [string, string, string]} [param2.stdio] standard IO
    * specification
    * @param {Record<string, string | undefined>} [param2.env] environment

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -1,11 +1,9 @@
 import chalk from 'chalk';
 import { makePspawn } from './helpers.js';
 
-// Ambient types. Needed only for dev but this does a runtime import.
-// https://github.com/Agoric/agoric-sdk/issues/6512
-import '@endo/captp/src/types.js';
-import '@agoric/swingset-vat/exported.js';
-import '@agoric/network/exported.js';
+/// <reference types="@endo/captp/src/types.js" />
+/// <reference types="@agoric/swingset-vat/exported.js" />
+/// <reference types="@agoric/network/exported.js" />
 
 // Use either an absolute template URL, or find it relative to DAPP_URL_BASE.
 const gitURL = (relativeOrAbsoluteURL, base) => {

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-// ambient types
-import '@agoric/ertp/src/types-ambient.js';
 import { makeBoardRemote } from '@agoric/vats/tools/board-utils.js';
 
 /** @typedef {import('@agoric/vats/tools/board-utils.js').BoardRemote} BoardRemote */

--- a/packages/agoric-cli/tools/resm-plugin/package.json
+++ b/packages/agoric-cli/tools/resm-plugin/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "@endo/eventual-send": "^0.17.2",
     "@endo/marshal": "^0.8.5"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -47,5 +47,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 100
   }
 }

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -18,7 +18,7 @@
 // is a record of a failed attempt to remove '.types'.
 // To satisfy CI, not only do we need to keep the file,
 // but we need to import it here as well.
-import './types.js';
+/// <reference path="./types.js" />
 
 /** @typedef {import('@endo/marshal').Checker} Checker */
 

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -51,5 +51,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -53,6 +53,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 86.48
   }
 }

--- a/packages/boot/index.js
+++ b/packages/boot/index.js
@@ -1,3 +1,0 @@
-// @ts-check
-// Ambient types
-import '@agoric/vats/src/core/types-ambient.js';

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -83,6 +83,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 85.68
   }
 }

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -81,5 +81,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -79,6 +79,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 67.19
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -77,5 +77,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -45,5 +45,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "20m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -47,6 +47,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 86.81
   }
 }

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -5,8 +5,6 @@ import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { untilTrue } from '@agoric/internal';
 import { withGroundState, makeState } from './state.js';
 
-import './types.js';
-
 /**
  * @param {(obj: unknown) => unknown} [sanitize]
  * @returns {(key: Passable) => Promise<string>}

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -60,6 +60,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 88.12
   }
 }

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -58,5 +58,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/casting/src/casting-spec.js
+++ b/packages/casting/src/casting-spec.js
@@ -1,8 +1,6 @@
 import * as encodingStar from '@cosmjs/encoding';
 import { E, getInterfaceOf } from '@endo/far';
 
-import './types.js';
-
 const { toAscii } = encodingStar;
 
 /**

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -57,6 +57,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": null
   }
 }

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -55,5 +55,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -65,5 +65,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "20m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -67,6 +67,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 79.4
   }
 }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -73,6 +73,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 79.84
   }
 }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -71,5 +71,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -1,9 +1,7 @@
 // @ts-check
 
-// Ambient types. Needed only for dev but this does a runtime import.
-// https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/time';
-import '@agoric/zoe/exported.js';
+/// <reference types="../../time/src/types.js" />
+/// <reference path="../../zoe/exported.js" />
 
 import { E } from '@endo/far';
 import bundleSource from '@endo/bundle-source';

--- a/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
+++ b/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
@@ -2,12 +2,15 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/far';
-import '@agoric/vats/src/core/types-ambient.js';
 import {
   makeAgoricNamesAccess,
   runModuleBehaviors,
 } from '@agoric/vats/src/core/utils.js';
 import { makeCoreProposalBehavior } from '../../src/coreProposalBehavior.js';
+
+// TODO remove this stubborn case
+// https://github.com/Agoric/agoric-sdk/issues/6512
+import '@agoric/vats/src/core/types-ambient.js';
 
 // TODO: we need to rewrite writeCoreProposal.js to produce BundleIDs,
 // although this test doesn't exercise that.

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -35,5 +35,8 @@
   },
   "devDependencies": {
     "readline-transform": "^1.0.0"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -37,6 +37,6 @@
     "readline-transform": "^1.0.0"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 61.49
   }
 }

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/package.json
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/package.json
@@ -17,5 +17,8 @@
       "*/**/post.test.js"
     ],
     "timeout": "30m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -76,6 +76,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 83.56
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -74,5 +74,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "yarn build:bundles",
     "build:bundles": "node ./scripts/build-bundles.js",
-    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build tsconfig.build.json",
+    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build --clean tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' src/types.js",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -1,9 +1,8 @@
-// Ambient types. https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/network/exported.js';
-import '@agoric/ertp/exported.js';
-import '@agoric/zoe/exported.js';
+/// <reference path="../../network/exported.js" />
+/// <reference path="../../ERTP/exported.js" />
+/// <reference path="../../zoe/exported.js" />
 
-import './types-ambient.js';
+/// <reference path="./types-ambient.js" />
 
 export {
   ChoiceMethod,

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -100,7 +100,7 @@ const build = async (log, zoe) => {
   });
 };
 
-/** @type {BuildRootObjectForTestVat} */
+/** @type {import('@agoric/swingset-vat/src/kernel/vat-loader/types.js').BuildRootObjectForTestVat} */
 export const buildRootObject = vatPowers =>
   Far('root', {
     /** @param {ZoeService} zoe */

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
@@ -109,7 +109,7 @@ const build = async (log, zoe) => {
  * @typedef {ReturnType<Awaited<ReturnType<typeof build>>['createVoter']>} EVatVoter
  */
 
-/** @type {BuildRootObjectForTestVat} */
+/** @type {import('@agoric/swingset-vat/src/kernel/vat-loader/types.js').BuildRootObjectForTestVat} */
 export const buildRootObject = vatPowers =>
   Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 82.1
   }
 }

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -45,5 +45,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 93.45
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -80,5 +80,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import './types.js';
+/// <reference path="./types.js" />
 
 import {
   CONTRACT_ELECTORATE,

--- a/packages/inter-protocol/src/vaultFactory/type-imports.js
+++ b/packages/inter-protocol/src/vaultFactory/type-imports.js
@@ -1,4 +1,4 @@
 // @jessie-check
 
 import '@agoric/zoe/exported.js';
-import './types.js';
+/// <reference path="./types.js" />

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -48,5 +48,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 92.26
   }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -62,5 +62,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -64,6 +64,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 76.57
   }
 }

--- a/packages/network/src/bytes.js
+++ b/packages/network/src/bytes.js
@@ -1,4 +1,4 @@
-import './types.js';
+/// <reference path="./types.js" />
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 
 /* eslint-disable no-bitwise */

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -6,7 +6,7 @@ import { whileTrue } from '@agoric/internal';
 import { toBytes } from './bytes.js';
 
 import '@agoric/store/exported.js';
-import './types.js';
+/// <reference path="./types.js" />
 
 /**
  * Compatibility note: this must match what our peers use, so don't change it

--- a/packages/network/src/router.js
+++ b/packages/network/src/router.js
@@ -4,7 +4,7 @@ import { Fail } from '@agoric/assert';
 import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network.js';
 
 import '@agoric/store/exported.js';
-import './types.js';
+/// <reference path="./types.js" />
 
 /**
  * @template T

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build tsconfig.build.json",
+    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build --clean tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' src/types.js",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -75,6 +75,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 89.74
   }
 }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -73,5 +73,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "2m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -66,5 +66,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -68,6 +68,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 90.04
   }
 }

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -42,6 +42,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 100
   }
 }

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -40,5 +40,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -65,5 +65,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -67,6 +67,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 86.97
   }
 }

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -76,5 +76,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -78,6 +78,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 68.59
   }
 }

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -34,6 +34,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 100
   }
 }

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -32,5 +32,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -60,5 +60,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "2m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -62,6 +62,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 50
   }
 }

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -35,6 +35,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 62.06
   }
 }

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -33,5 +33,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -58,5 +58,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "2m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -60,6 +60,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 85.52
   }
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -47,5 +47,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "2m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -49,6 +49,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 75.52
   }
 }

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -62,5 +62,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -64,6 +64,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 71.48
   }
 }

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -58,6 +58,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 53.14
   }
 }

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -56,5 +56,8 @@
       "@endo/init/debug.js"
     ],
     "timeout": "2m"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -50,5 +50,8 @@
     ],
     "timeout": "2m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -52,6 +52,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 83.64
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -62,5 +62,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -64,6 +64,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 87.55
   }
 }

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -53,6 +53,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 86.95
   }
 }

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -51,5 +51,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -41,6 +41,6 @@
     "node": ">=14.15.0"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 98.23
   }
 }

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=14.15.0"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -76,6 +76,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 90.86
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -74,5 +74,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -5,7 +5,7 @@ import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { M, getInterfaceGuardPayload } from '@endo/patterns';
 
-import './types.js';
+/// <reference path="./types.js" />
 import {
   makeSyncMethodCallback,
   prepareGuardedAttenuator,

--- a/packages/vm-config/package.json
+++ b/packages/vm-config/package.json
@@ -49,6 +49,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 100
   }
 }

--- a/packages/vm-config/package.json
+++ b/packages/vm-config/package.json
@@ -47,5 +47,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -61,5 +61,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -47,7 +47,7 @@ import '@agoric/store/exported.js';
 import '@agoric/zoe/exported.js';
 
 import './internal-types.js';
-import './types.js';
+/// <reference path="./types.js" />
 
 // does nothing
 const noActionStateChangeHandler = _newState => {};

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -45,5 +45,8 @@
     ],
     "timeout": "2m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -47,6 +47,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 73.51
   }
 }

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -66,6 +66,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 94.43
   }
 }

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -64,5 +64,8 @@
     ],
     "timeout": "2m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -132,5 +132,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "yarn build:bundles",
     "build:bundles": "node scripts/build-bundles.js",
-    "prepack": "echo \"export {}; \" | cat - tools/types-ambient.js > tools/types.js && tsc --build tsconfig.build.json",
+    "prepack": "echo \"export {}; \" | cat - tools/types-ambient.js > tools/types.js && tsc --build --clean tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' tools/types.js",
     "test": "ava --verbose",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -134,6 +134,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 81.5
   }
 }

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -29,7 +29,6 @@ import { prepareZcMint } from './zcfMint.js';
 
 /// <reference path="../internal-types.js" />
 /// <reference path="./internal-types.js" />
-/// <reference path="../../../SwingSet/src/types-ambient.js" />
 
 /** @typedef {import('@agoric/ertp').IssuerOptionsRecord} IssuerOptionsRecord */
 

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -24,12 +24,12 @@ import { makeMakeExiter } from './exit.js';
 import { makeOfferHandlerStorage } from './offerHandlerStorage.js';
 import { createSeatManager } from './zcfSeat.js';
 
-import '../internal-types.js';
-import './internal-types.js';
-
-import '@agoric/swingset-vat/src/types-ambient.js';
 import { HandleOfferI, InvitationHandleShape } from '../typeGuards.js';
 import { prepareZcMint } from './zcfMint.js';
+
+/// <reference path="../internal-types.js" />
+/// <reference path="./internal-types.js" />
+/// <reference path="../../../SwingSet/src/types-ambient.js" />
 
 /** @typedef {import('@agoric/ertp').IssuerOptionsRecord} IssuerOptionsRecord */
 

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -1,4 +1,4 @@
-import './types.js';
+/// <reference path="./types.js" />
 import { q, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 import { assertRecord } from '@endo/marshal';

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -1,4 +1,4 @@
-import './types.js';
+/// <reference path="./types.js" />
 
 import { AmountMath, isNatValue } from '@agoric/ertp';
 import { assert } from '@agoric/assert';

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -1,4 +1,4 @@
-import './types.js';
+/// <reference path="./types.js" />
 
 import { makePromiseKit } from '@endo/promise-kit';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -1,5 +1,5 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
-import './types.js';
+/// <reference path="./types.js" />
 
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -1,5 +1,5 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
-import './types.js';
+/// <reference path="./types.js" />
 
 import { makePromiseKit } from '@endo/promise-kit';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -1,4 +1,4 @@
-import './types.js';
+/// <reference path="./types.js" />
 // eslint-disable-next-line no-restricted-syntax
 import './loan/types.js';
 import './callSpread/types.js';

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -1,4 +1,4 @@
-import './types.js';
+/// <reference path="./types.js" />
 
 import { Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -33,7 +33,7 @@ import {
   ratiosSame,
 } from '../contractSupport/ratio.js';
 
-import '@agoric/ertp/src/types-ambient.js';
+/// <reference path="../../../ERTP/exported.js" />
 
 /** @typedef {bigint | number | string} ParsableNumber */
 /**

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -4,7 +4,7 @@ import { q, Fail } from '@agoric/assert';
 import { objectMap } from '@agoric/internal';
 import { provideDurableWeakMapStore } from '@agoric/vat-data';
 
-import './types.js';
+/// <reference path="./types.js" />
 import './internal-types.js';
 
 import { cleanKeywords } from '../cleanProposal.js';

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -10,11 +10,10 @@
  * currently. When the brand has an assetKind itself, AmountMath will
  * validate that.
  */
-// Ambient types. https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/ertp/exported.js';
-import '@agoric/store/exported.js';
 
-import '../internal-types.js';
+/// <reference path="../../../ERTP/exported.js" />
+/// <reference path="../../../store/exported.js" />
+/// <reference path="../internal-types.js" />
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -21,7 +21,7 @@ import { prepareInvitationKit } from './makeInvitation.js';
 import { makeInstanceAdminStorage } from './instanceAdminStorage.js';
 import { makeInstallationStorage } from './installationStorage.js';
 
-import './types.js';
+/// <reference path="./types.js" />
 import './internal-types.js';
 import {
   InstanceStorageManagerIKit,

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -52,5 +52,8 @@
     ],
     "timeout": "20m",
     "workerThreads": false
+  },
+  "typeCoverage": {
+    "atLeast": 0
   }
 }

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -54,6 +54,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 0
+    "atLeast": 96.33
   }
 }

--- a/scripts/update-typeCoverage-floor.sh
+++ b/scripts/update-typeCoverage-floor.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# For each package.json that has mentions typeCoverage,
+# run the tool to update the value
+SDK=$PWD
+
+for package in packages/*/package.json; do \
+   if grep --quiet typeCoverage "$SDK/$package"; then
+      dir=$(dirname "$package")
+      echo "$dir"
+      cd "$SDK/$dir" || exit 1
+      # This can raise or lower the amount. "--update-if-higher" will only raise it,
+      # but this gives us more flexibility. Reviewers should evaluate whether
+      # lowering is warranted.
+      yarn --silent type-coverage --update
+   fi
+done

--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,10 +4762,10 @@ fast-diff@^1.1.2, fast-diff@^1.2.0:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+fast-glob@3, fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -4773,10 +4773,10 @@ fast-glob@3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
-  integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
+fast-glob@3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -6921,6 +6921,13 @@ minimatch@3.0.5:
   dependencies:
     brace-expansion "^1.1.7"
 
+"minimatch@6 || 7 || 8 || 9", minimatch@^9.0.1:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -6935,13 +6942,6 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.1:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -6951,7 +6951,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -7280,7 +7280,7 @@ normalize-package-data@^4.0.0:
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@3, normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -9323,17 +9323,17 @@ tsd@^0.28.1:
     path-exists "^4.0.0"
     read-pkg-up "^7.0.0"
 
+"tslib@1 || 2", tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tslib@^1.8.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
-  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
-
-tsutils@~3.21.0:
+tsutils@3, tsutils@~3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
@@ -9364,6 +9364,25 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-coverage-core@^2.26.3:
+  version "2.26.3"
+  resolved "https://registry.yarnpkg.com/type-coverage-core/-/type-coverage-core-2.26.3.tgz#47e2c8225f582d1ca9551c2bace20836b295c944"
+  integrity sha512-rzNdW/tClHJvsUiy787b/UX53bNh1Dn7A5KqZDQjkL3j7iKFv/KnTolxDBBgTPcK4Zn9Ab7WLrik7cXw2oZZqw==
+  dependencies:
+    fast-glob "3"
+    minimatch "6 || 7 || 8 || 9"
+    normalize-path "3"
+    tslib "1 || 2"
+    tsutils "3"
+
+type-coverage@^2.26.3:
+  version "2.26.3"
+  resolved "https://registry.yarnpkg.com/type-coverage/-/type-coverage-2.26.3.tgz#0033d4718dacae4bb8e963b3778b7a1b0f3dd6b9"
+  integrity sha512-gDD8D2mnBngM/lJFYv3zNUf0/GGh9u+JkcNiTDljKNpWVnwzZa0fmI38CPJR0oYF7ALnV26xeN+BoyMubS/nwg==
+  dependencies:
+    minimist "1"
+    type-coverage-core "^2.26.3"
 
 type-fest@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
refs: #6512 

## Description

To help with #6512 @mhofman suggested [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-).

That does the trick for a lot of the cases, which are included here. The ones left I had some trouble with and I'll leave for another PR.

### Security Considerations

n/a
### Scaling Considerations

n/a

### Documentation Considerations

We could say that devs should use the triple-slash instead of import for types imports, but it doesn't yet work reliably. So this is just some progress.

### Testing Considerations

CI
### Upgrade Considerations

Could possibly affect consumers of these packages but can't affect runtime.
