### PR TITLE
docs: identify language in some markdown blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ also need:
 To check that everything is working before you start, or
 to thoroughly check a contribution, run:
 
-```
+```sh
 yarn # short for: yarn install
 yarn build
 yarn test

--- a/docs/env.md
+++ b/docs/env.md
@@ -114,7 +114,7 @@ Affects: solo
 
 This enables a proxy so that the solo bridge interface (/wallet-bridge.html) is backed by the smart wallet (/wallet/bridge.html). Dapps designed for the solo bridge can enable this until they connect to the smart wallet directly.
 
-```
+```sh
 BRIDGE_TARGET=http://localhost:3001 make BASE_PORT=8002 scenario3-run
 ```
 

--- a/packages/ERTP/docs/INPUT_VALIDATION.md
+++ b/packages/ERTP/docs/INPUT_VALIDATION.md
@@ -76,7 +76,7 @@ Object.defineProperty(object1, 'value', {
  },
 });
 ```
-```sh
+```console
 > object1.value
 1n
 > object1.value

--- a/packages/SwingSet/README.md
+++ b/packages/SwingSet/README.md
@@ -15,7 +15,7 @@ this is insufficient to provide persistence across restarts.
 
 More docs are in the works. For now, try:
 
-```
+```console
 $ npm install
 $ npm test
 $ bin/vat run demo/encouragementBot
@@ -26,7 +26,7 @@ expected to stabilize for a while.
 
 ## REPL Shell
 
-```
+```console
 $ bin/vat shell demo/encouragementBot
 vat>
 ```

--- a/packages/SwingSet/docs/debugging.md
+++ b/packages/SwingSet/docs/debugging.md
@@ -7,7 +7,7 @@ demos in debug mode, add the following
 to `.vscode/launch.json`. (The arguments can of course be changed to
 run different versions of the demo):
 
-```
+```json
 {
   "version": "0.2.0",
   "configurations": [

--- a/packages/SwingSet/docs/delivery.md
+++ b/packages/SwingSet/docs/delivery.md
@@ -1281,9 +1281,9 @@ Vat-2 then gets a `dispatch.deliver(target=o+3001, msg={method: "foo", args:
 * `syscall.resolve(to=Fulfill())`, showing how queued messages are then rejected
 * `syscall.resolve(to=Rejection())`, ditto
 
-```
+```js
 p1 = make_promise();
-x~.foo(p1);
+E(x).foo(p1);
 function foo(arg) {
   return p1;
 }

--- a/packages/SwingSet/docs/devices.md
+++ b/packages/SwingSet/docs/devices.md
@@ -32,7 +32,7 @@ argument lists and delivered from one vat to another like normal objects.
 However, they cannot be the target of a `syscall.send`. Instead, a special
 `syscall.callNow` accepts a device reference as its first argument:
 
-```
+```js
 syscall.callNow(device, argsbytes, slots) -> { bytes, slots }
 ```
 
@@ -48,7 +48,7 @@ allowing userspace code to use `E(presence).method(args) -> promise` instead
 of raw syscalls. It provides a similar frontend to `callNow`, which looks
 like:
 
-```
+```js
 retval = D(devicenode).method(args)
 ```
 
@@ -62,7 +62,7 @@ device does not get to hear about the results of delivering the message.
 
 The `deviceSlots` wrapper exposes `sendOnly` with a special wrapper:
 
-```
+```js
 SO(presence).method(args)
 ```
 

--- a/packages/SwingSet/docs/dynamic-vats.md
+++ b/packages/SwingSet/docs/dynamic-vats.md
@@ -150,7 +150,7 @@ const {
 
 To find out when the vat is terminated (either explicitly or due to a metering fault), you can wait for the `done()` Promise to fire. It will be resolved normally if the vat invokes `vatPowers.exitVat(reason)`. It will be rejected if the vat invokes `vatPowers.exitVatWithFailure(reason)`, if the adminNode holder uses `E(adminNode).terminateWithFailure(reason)`, if the vat suffers a metering fault, or if the vat is halted for any other reason (illegal syscall, etc).
 
-```
+```js
 E(adminNode).done()
   .then(() => console.log(`the vat was intentionally shut down`) )
   .catch(error => console.log(`surprise halt: ${error}`) );

--- a/packages/SwingSet/docs/how-to-replay.md
+++ b/packages/SwingSet/docs/how-to-replay.md
@@ -22,7 +22,7 @@ By modifying the replay tool, you can control how the replay is performed:
 
 Suppose you have an agoric chain node (validator or non-voting fullnode) that keeps its state in `~/.ag-chain-cosmos/`. After stopping the node (so the database is not being modified during read), the following invocation will extract a list of vatIDs to choose from:
 
-```
+```console
 $ node extract-transcript-from-kerneldb.js ~/.ag-chain-cosmos/data/agoric
 
 all vats:
@@ -54,7 +54,7 @@ v24 : (dynamic) {"managerType":"xs-worker"}    (1 deliveries)
 
 To replay the "zoe" vat, first extract the transcript:
 
-```
+```console
 $ node extract-transcript-from-kerneldb.js ~/.ag-chain-cosmos/data/agoric zoe
 
 extracting transcript for vat v11 into transcript-v11.sst
@@ -66,7 +66,7 @@ $ ls -l transcript-v11.sst
 
 You can look at the last line of the transcript to see how many deliveries it includes, which can help you estimate how far along the replay is going later:
 
-```
+```console
 $ tail -1 transcript-v11.sst
 
 {"transcriptNum":29905,"d":["message","o+12",{"method":"getDisplayInfo","args":{"body":"[]","slots":[]},"result":"p-28997"}],"syscalls":[{"d":["resolve",[["p-28997",false,{"body":"{\"decimalPlaces\":6}","slots":[]}]]],"response":null}]}
@@ -74,7 +74,7 @@ $ tail -1 transcript-v11.sst
 
 This transcript has 29905 deliveries. Note that you can compress the transcript (`gzip transcript-v11.sst`), to save space, and the replay tool will decompress it as it runs. The tool accepts both `.sst` and `.sst.gz` files.
 
-```
+```console
 $ gzip transcript-v11.sst
 $ ls
 -rw-r--r-- 1 warner warner  2436123 May 17 19:24 transcript-v11.sst.gz
@@ -83,7 +83,7 @@ $ node -r esm replay-transcript.js transcript-v11.sst.gz
 
 Then, to perform the replay, use the `replay-transcript` tool:
 
-```
+```console
 $ node -r esm replay-transcript.js transcript-v11.sst.gz
 using transcript transcript-v11.sst.gz
 manager created

--- a/packages/cosmic-proto/MAINTAINERS.md
+++ b/packages/cosmic-proto/MAINTAINERS.md
@@ -23,7 +23,7 @@ including `agoric-cli`, which we encourage to use these published stubs.
 To prepare this package, we created an IDL tree under the directory `proto`
 that includes our transitive dependencies.
 
-```console
+```sh
 mkdir -p proto
 cd proto
 ln -s ../../../golang/cosmos/proto/agoric .
@@ -52,4 +52,3 @@ To surface additional stubs:
    symbolic links for aliasing when necessary.
 
 [1] http://google.github.io/proto-lens/installing-protoc.html
-

--- a/packages/cosmic-swingset/README.md
+++ b/packages/cosmic-swingset/README.md
@@ -52,7 +52,7 @@ agd --help
 
 #### Scenario 3 : no testnet (develop off-chain demo)
 
-In this scenario, you run: 
+In this scenario, you run:
 - a **solo node** with the server-side Pixel Demo running and exposing an HTTP server in localhost
 - a **web browser** connecting to the solo node and enabling user interaction with the Pixel Demo
 
@@ -76,7 +76,7 @@ The HTML frontend code is pure JS/DOM (no additional libraries yet) in the
 
 #### Scenario 2: a single local testnet node (develop on-chain demo)
 
-In this scenario, you run: 
+In this scenario, you run:
 - one or several **solo node(s)** each exposing an HTTP server in localhost (each to a different port)
 - a **single local blockchain testnet node** with the server-side Pixel Demo running
 - a **web browser** connecting to each solo node via a different port and enabling user interaction with the Pixel Demo
@@ -107,12 +107,12 @@ You can communicate with the node by opening http://localhost:8000/
 You can start other solo nodes with `make scenario2-run-client BASE_PORT=8001` and `make scenario2-run-client BASE_PORT=8002` and communicate with them respectively with on http://localhost:8001/ and http://localhost:8002/
 
 
-  
+
 #### Scenario 1: your own local testnet (develop testnet provisioner)
 
-In this scenario, you run: 
+In this scenario, you run:
 - a **solo node** exposing an HTTP server in localhost
-- a **several local blockchain testnet nodes** with the server-side Pixel Demo running on top. 
+- a **several local blockchain testnet nodes** with the server-side Pixel Demo running on top.
 - a **web browser** connecting to the solo node and enabling user interaction with the Pixel Demo
 
 This scenario is only useful for moving toward deploying the local source code as a new testnet. Before using this scenario, you should test your on-chain code under Scenario 2.
@@ -132,7 +132,7 @@ See [Testnet Tutorial](#testnet-tutorial) for more guidance.
 
 #### Scenario 0: a public testnet (kick the tires)
 
-In this scenario, you run: 
+In this scenario, you run:
 - a **solo node** exposing an HTTP server in localhost
 - a **web browser** connecting to the solo node and enabling user interaction with the Pixel Demo
 
@@ -148,7 +148,7 @@ Alternatively, running the solo node from a Docker image and no local source cod
 
 Now go to http://localhost:8000/ to interact with your new solo node.
 
-Learn more about ERTP [here](https://agoric.com/documentation/ertp/guide/). 
+Learn more about ERTP [here](https://agoric.com/documentation/ertp/guide/).
 
 ### Initial Endowments
 
@@ -194,7 +194,7 @@ If you are not running on Linux, you will need to use Docker to provide the setu
 
 If you want to install the Docker image scripts on this machine, run:
 
-```
+```sh
 $ sudo make docker-install
 ```
 

--- a/packages/pegasus/demo.md
+++ b/packages/pegasus/demo.md
@@ -1,6 +1,6 @@
 In agoric-sdk, start the chain:
 
-```
+```sh
 yarn build
 cd packages/cosmic-swingset
 make scenario2-setup-nobuild
@@ -26,7 +26,7 @@ enabled = false
 host = '127.0.0.1'
 port = 3001
 
-[[chains]]                                                               
+[[chains]]
 id = 'agoric'
 rpc_addr = 'http://127.0.0.1:26657'
 grpc_addr = 'http://127.0.0.1:9090'
@@ -39,13 +39,13 @@ max_gas = 3000000
 gas_price = { price = 0.001, denom = 'uist' }
 gas_adjustment = 0.1
 clock_drift = '5s'
-trusting_period = '14days'                                               
+trusting_period = '14days'
 
 [chains.trust_threshold]
 numerator = '1'
 denominator = '3'
 
-[[chains]]                                                               
+[[chains]]
 id = 'cosmoshub-testnet'
 rpc_addr = 'https://rpc.testnet.cosmos.network:443'
 grpc_addr = 'https://grpc.testnet.cosmos.network:443'
@@ -58,7 +58,7 @@ max_gas = 3000000
 gas_price = { price = 0.001, denom = 'uphoton' }
 gas_adjustment = 0.1
 clock_drift = '5s'
-trusting_period = '14days'                                               
+trusting_period = '14days'
 
 [chains.trust_threshold]
 numerator = '1'
@@ -128,7 +128,7 @@ hermes start
 
 Using golang relayer:
 
-```
+```sh
 i=7; rly light init -f agoric && rly light init -f stargate-final && rly paths generate stargate-final agoric transfer$i --port=transfer && rly tx link transfer$i -d -o 3s && rly start transfer$i -d --time-threshold=5m
 ```
 

--- a/packages/xsnap/README.md
+++ b/packages/xsnap/README.md
@@ -22,7 +22,7 @@ Some time later, possibly on a different computer…
 
 ```js
 const decoder = new TextDecoder();
-const worker = await xsnap({ 
+const worker = await xsnap({
   snapshotStream: fs.createFileStream('bootstrap.xss'),
 });
 const response = await worker.issueCommand('1');
@@ -57,7 +57,7 @@ The REPL supports special commands `load` and `save` for snapshots, and `quit`
 to quit.
 Load and save don't take arguments; just type the file name on the next prompt.
 
-```sh
+```console
 $ xsrepl
 xs> globalThis.x = 42;
 xs> x
@@ -67,7 +67,7 @@ file> temp.xss
 xs> quit
 ```
 
-```sh
+```console
 $ xsrepl
 xs> load
 file> temp.xss


### PR DESCRIPTION
I really like syntax highlighting.

See https://github.com/endojs/endo/pull/1800

Reviewers, I suggest reviewing with "hide whitespace". The occasional invisible whitespace normalizations were due to my editor, not me.