### PR TITLE
feat(ertp): Upgrade quotes to drop newly optional recovery sets

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -86,13 +86,13 @@ harden(setupIssuerKit);
 const INSTANCE_KEY = 'issuer';
 /**
  * The key at which the issuerKit's `RecoverySetsOption` state is stored.
- * Introduced by an upgrade, so may be absent on an ancestor. See
+ * Introduced by an upgrade, so may be absent on a predecessor incarnation. See
  * `RecoverySetsOption` for defaulting behavior.
  */
 const RECOVERY_SETS_STATE = 'recoverySetsState';
 
 /**
- * Used _only_ to upgrade an ancestor issuerKit. Use `makeDurableIssuerKit` to
+ * Used _only_ to upgrade a predecessor issuerKit. Use `makeDurableIssuerKit` to
  * make a new one.
  *
  * @template {AssetKind} K
@@ -126,8 +126,8 @@ export const upgradeIssuerKit = (
   const recoverySetsState = recoverySetsOption || oldRecoverySetsState;
   return setupIssuerKit(
     issuerRecord,
-    issuerBaggage,
     recoverySetsState,
+    issuerBaggage,
     optShutdownWithFailure,
   );
 };
@@ -135,7 +135,7 @@ harden(upgradeIssuerKit);
 
 /**
  * Confusingly, `prepareIssuerKit` was the original name for `upgradeIssuerKit`,
- * even though it is used only to upgrade an ancestor issuerKit. Use
+ * even though it is used only to upgrade a predecessor issuerKit. Use
  * `makeDurableIssuerKit` to make a new one.
  *
  * @deprecated Use `upgradeIssuerKit` instead if that's what you want. Or
@@ -161,9 +161,9 @@ export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
  * payment is often referred to in the singular as "an invitation".)
  *
  * `recoverySetsOption` added in upgrade. Note that `IssuerOptionsRecord` is
- * never stored, so we never need to worry about inheriting one from an ancestor
- * predating the introduction of recovery sets. See `RecoverySetsOption` for
- * defaulting behavior.
+ * never stored, so we never need to worry about inheriting one from a
+ * predecessor predating the introduction of recovery sets. See
+ * `RecoverySetsOption` for defaulting behavior.
  *
  * @typedef {Partial<{
  *   elementShape: Pattern;
@@ -229,9 +229,9 @@ export const makeDurableIssuerKit = (
 harden(makeDurableIssuerKit);
 
 /**
- * What _should_ have been named `prepareIssuerKit`. Used to either revive an
- * ancestor issuer kit, or to make a new durable if it absent, and to place it
- * in baggage for the next successor.
+ * What _should_ have been named `prepareIssuerKit`. Used to either revive a
+ * predecessor issuerKit, or to make a new durable one if it is absent, and to
+ * place it in baggage for the next successor.
  *
  * @template {AssetKind} K The name becomes part of the brand in asset
  *   descriptions. The name is useful for debugging and double-checking

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import { assert } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { assertPattern } from '@agoric/store';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 
@@ -10,6 +10,8 @@ import { preparePaymentLedger } from './paymentLedger.js';
 
 import './types-ambient.js';
 
+// TODO Why does TypeScript lose the `MapStore` typing of `Baggage` here, even
+// though it knows the correct type at the exporting `@agoric/vat-data`
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
 /**
@@ -22,8 +24,12 @@ import './types-ambient.js';
  */
 
 /**
+ * Used _only_ internally, to make a new issuerKit or to revive an old one.
+ *
  * @template {AssetKind} K
  * @param {IssuerRecord<K>} issuerRecord
+ * @param {RecoverySetsOption} recoverySetsState Omitted from issuerRecord
+ *   because it was added in an upgrade.
  * @param {Baggage} issuerBaggage
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
  *   the middle of an atomic action (which btw should never happen), it
@@ -36,6 +42,7 @@ import './types-ambient.js';
  */
 const setupIssuerKit = (
   { name, assetKind, displayInfo, elementShape },
+  recoverySetsState,
   issuerBaggage,
   optShutdownWithFailure = undefined,
 ) => {
@@ -61,6 +68,7 @@ const setupIssuerKit = (
     assetKind,
     cleanDisplayInfo,
     elementShape,
+    recoverySetsState,
     optShutdownWithFailure,
   );
 
@@ -76,8 +84,17 @@ harden(setupIssuerKit);
 
 /** The key at which the issuer record is stored. */
 const INSTANCE_KEY = 'issuer';
+/**
+ * The key at which the issuerKit's `RecoverySetsOption` state is stored.
+ * Introduced by an upgrade, so may be absent on an ancestor. See
+ * `RecoverySetsOption` for defaulting behavior.
+ */
+const RECOVERY_SETS_STATE = 'recoverySetsState';
 
 /**
+ * Used _only_ to upgrade an ancestor issuerKit. Use `makeDurableIssuerKit` to
+ * make a new one.
+ *
  * @template {AssetKind} K
  * @param {Baggage} issuerBaggage
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
@@ -87,28 +104,77 @@ const INSTANCE_KEY = 'issuer';
  *   unit of computation, like the enclosing vat, can be shutdown before
  *   anything else is corrupted by that corrupted state. See
  *   https://github.com/Agoric/agoric-sdk/issues/3434
+ * @param {RecoverySetsOption} [recoverySetsOption] Added in upgrade, so last
+ *   and optional. See `RecoverySetsOption` for defaulting behavior.
  * @returns {IssuerKit<K>}
  */
-export const prepareIssuerKit = (
+export const upgradeIssuerKit = (
   issuerBaggage,
   optShutdownWithFailure = undefined,
+  recoverySetsOption = undefined,
 ) => {
   const issuerRecord = issuerBaggage.get(INSTANCE_KEY);
-  return setupIssuerKit(issuerRecord, issuerBaggage, optShutdownWithFailure);
+  const oldRecoverySetsState = issuerBaggage.has(RECOVERY_SETS_STATE)
+    ? issuerBaggage.get(RECOVERY_SETS_STATE)
+    : 'hasRecoverySets';
+  if (
+    oldRecoverySetsState === 'noRecoverySets' &&
+    recoverySetsOption === 'hasRecoverySets'
+  ) {
+    Fail`Cannot (yet?) upgrade from 'noRecoverySets' to 'hasRecoverySets'`;
+  }
+  const recoverySetsState = recoverySetsOption || oldRecoverySetsState;
+  return setupIssuerKit(
+    issuerRecord,
+    issuerBaggage,
+    recoverySetsState,
+    optShutdownWithFailure,
+  );
 };
-harden(prepareIssuerKit);
+harden(upgradeIssuerKit);
 
 /**
- * Does baggage already have an issuer from prepareIssuerKit()? That is: does it
- * have the relevant keys defined?
+ * Confusingly, `prepareIssuerKit` was the original name for `upgradeIssuerKit`,
+ * even though it is used only to upgrade an ancestor issuerKit. Use
+ * `makeDurableIssuerKit` to make a new one.
+ *
+ * @deprecated Use `upgradeIssuerKit` instead if that's what you want. Or
+ *   `reallyPrepareIssuerKit` if you want the behavior that should have been
+ *   bound to this name.
+ */
+export const prepareIssuerKit = upgradeIssuerKit;
+
+/**
+ * Does baggage already have an issuerKit?
  *
  * @param {Baggage} baggage
  */
 export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
 
-/** @typedef {Partial<{ elementShape: Pattern }>} IssuerOptionsRecord */
+/**
+ * `elementShape`, may only be present for collection-style amounts. If present,
+ * it is a `Pattern` that every element of this issuerKits's amounts must
+ * satisfy. For example, the Zoe Invitation issuerKit uses an elementShape
+ * describing the invitation details for an individual invitation. An invitation
+ * purse or payment has an amount that can only be a set of these. (Though
+ * typically, the amount of an invitation payment is a singleton set. Such a
+ * payment is often referred to in the singular as "an invitation".)
+ *
+ * `recoverySetsOption` added in upgrade. Note that `IssuerOptionsRecord` is
+ * never stored, so we never need to worry about inheriting one from an ancestor
+ * predating the introduction of recovery sets. See `RecoverySetsOption` for
+ * defaulting behavior.
+ *
+ * @typedef {Partial<{
+ *   elementShape: Pattern;
+ *   recoverySetsOption: RecoverySetsOption;
+ * }>} IssuerOptionsRecord
+ */
 
 /**
+ * Used _only_ to make a _new_ durable issuer, i.e., the initial incarnation of
+ * that issuer.
+ *
  * @template {AssetKind} K The name becomes part of the brand in asset
  *   descriptions. The name is useful for debugging and double-checking
  *   assumptions, but should not be trusted wrt any external namespace. For
@@ -142,15 +208,106 @@ export const makeDurableIssuerKit = (
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
   optShutdownWithFailure = undefined,
-  { elementShape = undefined } = {},
+  { elementShape = undefined, recoverySetsOption = undefined } = {},
 ) => {
-  const issuerData = harden({ name, assetKind, displayInfo, elementShape });
+  const issuerData = harden({
+    name,
+    assetKind,
+    displayInfo,
+    elementShape,
+  });
   issuerBaggage.init(INSTANCE_KEY, issuerData);
-  return setupIssuerKit(issuerData, issuerBaggage, optShutdownWithFailure);
+  const recoverySetsState = recoverySetsOption || 'hasRecoverySets';
+  issuerBaggage.init(RECOVERY_SETS_STATE, recoverySetsState);
+  return setupIssuerKit(
+    issuerData,
+    recoverySetsState,
+    issuerBaggage,
+    optShutdownWithFailure,
+  );
 };
 harden(makeDurableIssuerKit);
 
 /**
+ * What _should_ have been named `prepareIssuerKit`. Used to either revive an
+ * ancestor issuer kit, or to make a new durable if it absent, and to place it
+ * in baggage for the next successor.
+ *
+ * @template {AssetKind} K The name becomes part of the brand in asset
+ *   descriptions. The name is useful for debugging and double-checking
+ *   assumptions, but should not be trusted wrt any external namespace. For
+ *   example, anyone could create a new issuer kit with name 'BTC', but it is
+ *   not bitcoin or even related. It is only the name according to that issuer
+ *   and brand.
+ *
+ *   The assetKind will be used to import a specific mathHelpers from the
+ *   mathHelpers library. For example, natMathHelpers, the default, is used for
+ *   basic fungible tokens.
+ *
+ *   `displayInfo` gives information to the UI on how to display the amount.
+ * @param {Baggage} issuerBaggage
+ * @param {string} name
+ * @param {K} [assetKind]
+ * @param {AdditionalDisplayInfo} [displayInfo]
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
+ *   the middle of an atomic action (which btw should never happen), it
+ *   potentially leaves its ledger in a corrupted state. If this function was
+ *   provided, then the failed atomic action will call it, so that some larger
+ *   unit of computation, like the enclosing vat, can be shutdown before
+ *   anything else is corrupted by that corrupted state. See
+ *   https://github.com/Agoric/agoric-sdk/issues/3434
+ * @param {IssuerOptionsRecord} [options]
+ * @returns {IssuerKit<K>}
+ */
+export const reallyPrepareIssuerKit = (
+  issuerBaggage,
+  name,
+  // @ts-expect-error K could be instantiated with a different subtype of AssetKind
+  assetKind = AssetKind.NAT,
+  displayInfo = harden({}),
+  optShutdownWithFailure = undefined,
+  options = {},
+) => {
+  if (hasIssuer(issuerBaggage)) {
+    const { elementShape: _ = undefined, recoverySetsOption = undefined } =
+      options;
+    const issuerKit = upgradeIssuerKit(
+      issuerBaggage,
+      optShutdownWithFailure,
+      recoverySetsOption,
+    );
+
+    // TODO check consistency with name, assetKind, displayInfo, elementShape.
+    // Consistency either means that these are the same, or that they differ
+    // in a direction we are prepared to upgrade. Note that it is the
+    // responsibility of `upgradeIssuerKit` to check consistency of
+    // `recoverySetsOption`, so continue to not do that here.
+
+    // @ts-expect-error Type parameter confusion.
+    return issuerKit;
+  } else {
+    const issuerKit = makeDurableIssuerKit(
+      issuerBaggage,
+      name,
+      assetKind,
+      displayInfo,
+      optShutdownWithFailure,
+      options,
+    );
+    return issuerKit;
+  }
+};
+harden(reallyPrepareIssuerKit);
+
+/**
+ * Used _only_ to make a new issuerKit that is effectively non-durable. This is
+ * currently done by making a durable one in a baggage not reachable from
+ * anywhere. TODO Once rebuilt on zones, this should instead just build on the
+ * virtual zone. See https://github.com/Agoric/agoric-sdk/pull/7116
+ *
+ * Currently used for testing only. Should probably continue to be used for
+ * testing only.
+ *
  * @template {AssetKind} [K='nat'] The name becomes part of the brand in asset
  *   descriptions. The name is useful for debugging and double-checking
  *   assumptions, but should not be trusted wrt any external namespace. For
@@ -182,7 +339,7 @@ export const makeIssuerKit = (
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
   optShutdownWithFailure = undefined,
-  { elementShape = undefined } = {},
+  { elementShape = undefined, recoverySetsOption = undefined } = {},
 ) =>
   makeDurableIssuerKit(
     makeScalarBigMapStore('dropped issuer kit', { durable: true }),
@@ -190,6 +347,6 @@ export const makeIssuerKit = (
     assetKind,
     displayInfo,
     optShutdownWithFailure,
-    { elementShape },
+    { elementShape, recoverySetsOption },
   );
 harden(makeIssuerKit);

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -160,6 +160,17 @@ export const preparePaymentLedger = (
   }
 
   /**
+   * An issuer may choose to omit recovery sets. The quote issuer, for example,
+   * omits recovery sets since its "payments" do not actually represent
+   * transferable value. Recovery sets preserve payments that are otherwise
+   * inaccessible, so that they can be recovered. This is their point. But this
+   * means that useless payments might accumulate into a large storage leak.
+   * Quote payments should never need to be recovered, since one can always ask
+   * for a more recent quote. Thus, they should not pay the cost of this
+   * potential storage leak.
+   *
+   * For an issuerKit that has not opted out of recovery sets...
+   *
    * A withdrawn live payment is associated with the recovery set of the purse
    * it was withdrawn from. Let's call these "recoverable" payments. All
    * recoverable payments are live, but not all live payments are recoverable.

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -224,19 +224,19 @@
  * Issuers first became durable with recovery sets and no option to suppress
  * them. Thus, absence of a `RecoverySetsOption` state is equivalent to
  * `'hasRecoverySets'`. By contrast, the absence of `RecoverySetsOption` provide
- * parameter defaults to the ancestor's `RecoverySetsOption` state, or
+ * parameter defaults to the predecessor's `RecoverySetsOption` state, or
  * `'hasRecoverySets'` if none.
  *
  * The `'noRecoverySets'` state, if used for the first incarnation, makes an
  * issuer without recovery sets. If used for a successor incarnation, no matter
- * whether the ancestor was `'hasRecoverySets'` or `'noRecoverySets'`,
+ * whether the predecessor was `'hasRecoverySets'` or `'noRecoverySets'`,
  *
  * - will start emptying recovery sets,
  * - will prevent any new payments from being added to recovery sets,
  * - and (controversially) will not provide access via recovery sets of any
  *   payments that have not yet been emptied out.
  *
- * At this time, a `'noRecoverySets'` ancestor cannot be upgraded to a
+ * At this time, a `'noRecoverySets'` predecessor cannot be upgraded to a
  * `'hasRecoverySets'` successor. If it turns out this transition is needed, it
  * can likely be supported in a future upgrade.
  *

--- a/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
@@ -8,7 +8,7 @@ import {
 import {
   AssetKind,
   makeDurableIssuerKit,
-  prepareIssuerKit,
+  upgradeIssuerKit,
 } from '../../../src/index.js';
 
 export const prepareErtpService = (baggage, exitVatWithFailure) => {
@@ -36,7 +36,7 @@ export const prepareErtpService = (baggage, exitVatWithFailure) => {
   });
 
   for (const issuerBaggage of issuerBaggageSet.values()) {
-    prepareIssuerKit(issuerBaggage, exitVatWithFailure);
+    upgradeIssuerKit(issuerBaggage, exitVatWithFailure);
   }
 
   return ertpService;

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -1,10 +1,6 @@
 // @jessie-check
 
-import {
-  hasIssuer,
-  makeDurableIssuerKit,
-  prepareIssuerKit,
-} from '@agoric/ertp';
+import { reallyPrepareIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance } from '@agoric/governance';
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
 import { prepareDurablePublishKit } from '@agoric/notifier';
@@ -72,9 +68,14 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   // xxx uses contract baggage as issuerBagage, assumes one issuer in this contract
   /** @type {import('./roundsManager.js').QuoteKit} */
-  const quoteIssuerKit = hasIssuer(baggage)
-    ? prepareIssuerKit(baggage)
-    : makeDurableIssuerKit(baggage, 'quote', 'set');
+  const quoteIssuerKit = reallyPrepareIssuerKit(
+    baggage,
+    'quote',
+    'set',
+    undefined,
+    undefined,
+    { recoverySetsOption: 'noRecoverySets' },
+  );
 
   const {
     highPrioritySendersManager,

--- a/packages/vats/src/mintHolder.js
+++ b/packages/vats/src/mintHolder.js
@@ -1,11 +1,7 @@
 // @ts-check
 // @jessie-check
 
-import {
-  hasIssuer,
-  makeDurableIssuerKit,
-  prepareIssuerKit,
-} from '@agoric/ertp';
+import { reallyPrepareIssuerKit } from '@agoric/ertp';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -26,12 +22,8 @@ import {
  * @param {Baggage} baggage
  */
 function provideIssuerKit(zcf, baggage) {
-  if (!hasIssuer(baggage)) {
-    const { keyword, assetKind, displayInfo } = zcf.getTerms();
-    return makeDurableIssuerKit(baggage, keyword, assetKind, displayInfo);
-  } else {
-    return prepareIssuerKit(baggage);
-  }
+  const { keyword, assetKind, displayInfo } = zcf.getTerms();
+  return reallyPrepareIssuerKit(baggage, keyword, assetKind, displayInfo);
 }
 
 /** @type {ContractMeta} */

--- a/packages/zoe/src/contractSupport/priceAuthorityQuoteMint.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityQuoteMint.js
@@ -1,34 +1,23 @@
-import {
-  AssetKind,
-  makeDurableIssuerKit,
-  prepareIssuerKit,
-} from '@agoric/ertp';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { AssetKind, reallyPrepareIssuerKit } from '@agoric/ertp';
+import { provideDurableMapStore } from '@agoric/vat-data';
 
 /**
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
+ * @returns {ERef<Mint<'set'>>}
  */
 export const provideQuoteMint = baggage => {
-  /** @type {ERef<Mint<'set'>>} */
-  let baggageQuoteMint;
-  if (baggage.has(`quoteMintIssuerBaggage`)) {
-    const issuerBaggage = baggage.get(`quoteMintIssuerBaggage`);
-    baggageQuoteMint = /** @type {Mint<'set'>} */ (
-      prepareIssuerKit(issuerBaggage).mint
-    );
-  } else {
-    const issuerBaggage = makeScalarBigMapStore(
-      `scaledPriceAuthority quoteMintIssuerBaggage`,
-      { durable: true },
-    );
-    baggage.init(`quoteMintIssuerBaggage`, issuerBaggage);
-    baggageQuoteMint = makeDurableIssuerKit(
-      issuerBaggage,
-      'quote',
-      AssetKind.SET,
-    ).mint;
-  }
-
-  return baggageQuoteMint;
+  const issuerBaggage = provideDurableMapStore(
+    baggage,
+    'quoteMintIssuerBaggage',
+  );
+  const issuerKit = reallyPrepareIssuerKit(
+    issuerBaggage,
+    'quote',
+    AssetKind.SET,
+    undefined,
+    undefined,
+    { recoverySetsOption: 'noRecoverySets' },
+  );
+  return issuerKit.mint;
 };

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -41,13 +41,15 @@ const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
     // Upgrade this legacy state by simply deleting it.
     mintBaggage.delete(FEE_MINT_KIT);
   }
-  /** @type {IssuerKit} */
-  const feeIssuerKit = reallyPrepareIssuerKit(
-    mintBaggage,
-    feeIssuerConfig.name,
-    feeIssuerConfig.assetKind,
-    feeIssuerConfig.displayInfo,
-    shutdownZoeVat,
+
+  const feeIssuerKit = /** @type {IssuerKit<'nat'>} */ (
+    reallyPrepareIssuerKit(
+      mintBaggage,
+      feeIssuerConfig.name,
+      feeIssuerConfig.assetKind,
+      feeIssuerConfig.displayInfo,
+      shutdownZoeVat,
+    )
   );
 
   const FeeMintIKit = harden({

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -1,9 +1,9 @@
 import {
-  makeDurableIssuerKit,
   AssetKind,
-  prepareIssuerKit,
   IssuerShape,
   BrandShape,
+  reallyPrepareIssuerKit,
+  hasIssuer,
 } from '@agoric/ertp';
 import { initEmpty, M } from '@agoric/store';
 import {
@@ -13,8 +13,9 @@ import {
 } from '@agoric/vat-data';
 import { FeeMintAccessShape } from '../typeGuards.js';
 
-const { Fail } = assert;
+const { Fail, quote: q } = assert;
 
+/** @deprecated Redundant. Just omit it. */
 const FEE_MINT_KIT = 'FeeMintKit';
 
 export const defaultFeeIssuerConfig = harden(
@@ -32,19 +33,22 @@ export const defaultFeeIssuerConfig = harden(
  */
 const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const mintBaggage = provideDurableMapStore(zoeBaggage, 'mintBaggage');
-  if (!mintBaggage.has(FEE_MINT_KIT)) {
-    /** @type {IssuerKit} */
-    const feeIssuerKit = makeDurableIssuerKit(
-      mintBaggage,
-      feeIssuerConfig.name,
-      feeIssuerConfig.assetKind,
-      feeIssuerConfig.displayInfo,
-      shutdownZoeVat,
-    );
-    mintBaggage.init(FEE_MINT_KIT, feeIssuerKit);
-  } else {
-    prepareIssuerKit(mintBaggage, shutdownZoeVat);
+  if (mintBaggage.has(FEE_MINT_KIT)) {
+    hasIssuer(mintBaggage) ||
+      Fail`Legacy ${q(
+        FEE_MINT_KIT,
+      )} must be redundant with normal storing of issuerKit in issuerBaggage`;
+    // Upgrade this legacy state by simply deleting it.
+    mintBaggage.delete(FEE_MINT_KIT);
   }
+  /** @type {IssuerKit} */
+  const feeIssuerKit = reallyPrepareIssuerKit(
+    mintBaggage,
+    feeIssuerConfig.name,
+    feeIssuerConfig.assetKind,
+    feeIssuerConfig.displayInfo,
+    shutdownZoeVat,
+  );
 
   const FeeMintIKit = harden({
     feeMint: M.interface('FeeMint', {
@@ -66,13 +70,13 @@ const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
           const { facets } = this;
           facets.feeMintAccess === allegedFeeMintAccess ||
             Fail`The object representing access to the fee brand mint was not provided`;
-          return mintBaggage.get(FEE_MINT_KIT);
+          return feeIssuerKit;
         },
         getFeeIssuer() {
-          return mintBaggage.get(FEE_MINT_KIT).issuer;
+          return feeIssuerKit.issuer;
         },
         getFeeBrand() {
-          return mintBaggage.get(FEE_MINT_KIT).brand;
+          return feeIssuerKit.brand;
         },
       },
       // feeMintAccess is an opaque durable object representing the right to get

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,13 +1,13 @@
 // @jessie-check
 
+import { Fail } from '@agoric/assert';
 import { provideDurableMapStore } from '@agoric/vat-data';
-import {
-  AssetKind,
-  makeDurableIssuerKit,
-  prepareIssuerKit,
-} from '@agoric/ertp';
+import { AssetKind, hasIssuer, reallyPrepareIssuerKit } from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';
 
+/**
+ * Not deprecated because the first use below is still correct.
+ */
 const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
 
 /**
@@ -15,26 +15,27 @@ const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
  * @param {ShutdownWithFailure | undefined} shutdownZoeVat
  */
 export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
-  /** @type {IssuerKit<'set'> | undefined} */
-  let invitationKit;
-
   const invitationKitBaggage = provideDurableMapStore(
     baggage,
     ZOE_INVITATION_KIT,
   );
-  if (!invitationKitBaggage.has(ZOE_INVITATION_KIT)) {
-    invitationKit = makeDurableIssuerKit(
-      invitationKitBaggage,
-      'Zoe Invitation',
-      AssetKind.SET,
-      undefined,
-      shutdownZoeVat,
-      { elementShape: InvitationElementShape },
-    );
-    invitationKitBaggage.init(ZOE_INVITATION_KIT, invitationKit);
-  } else {
-    invitationKit = prepareIssuerKit(invitationKitBaggage);
+  if (invitationKitBaggage.has(ZOE_INVITATION_KIT)) {
+    // This legacy second use of ZOE_INVITATION_KIT is unneeded.
+    hasIssuer(invitationKitBaggage) ||
+      Fail`Legacy use of ${q(
+        ZOE_INVITATION_KIT,
+      )} must be redundant with normal storing of issuerKit in issuerBaggage`;
+    // Upgrade this legacy state by simply deleting it.
+    invitationKitBaggage.delete(ZOE_INVITATION_KIT);
   }
+  const invitationKit = reallyPrepareIssuerKit(
+    invitationKitBaggage,
+    'Zoe Invitation',
+    AssetKind.SET,
+    undefined,
+    shutdownZoeVat,
+    { elementShape: InvitationElementShape },
+  );
 
   return harden({
     invitationIssuer: invitationKit.issuer,

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import { Fail } from '@agoric/assert';
+import { Fail, q } from '@agoric/assert';
 import { provideDurableMapStore } from '@agoric/vat-data';
 import { AssetKind, hasIssuer, reallyPrepareIssuerKit } from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -3,7 +3,7 @@ import {
   AssetKind,
   makeDurableIssuerKit,
   AmountMath,
-  prepareIssuerKit,
+  upgradeIssuerKit,
 } from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
@@ -122,7 +122,7 @@ export const makeZoeStorageManager = (
     'zoeMintBaggageSet',
   );
   for (const issuerBaggage of zoeMintBaggageSet.values()) {
-    prepareIssuerKit(issuerBaggage);
+    upgradeIssuerKit(issuerBaggage);
   }
 
   const makeZoeMint = prepareExoClass(


### PR DESCRIPTION
closes: https://github.com/Agoric/agoric-sdk/issues/8400
refs: https://github.com/Agoric/agoric-sdk/issues/8417 https://github.com/Agoric/agoric-sdk/issues/8404 https://github.com/Agoric/agoric-sdk/issues/8401

## Description

Take 2 of https://github.com/Agoric/agoric-sdk/pull/8406

Make recovery sets optional.

Enable an old issuer with recovery sets to be upgraded to one without, that also empties and suppresses any recovery sets it inherits.

Upgrade quote issuers to empty and suppress their recovery sets. This is 
* appropriate for quote issuers because quote "payments" do not actually transfer tradable value. A new quote can always be obtained that is at least as good as an old lost quote.
* needed, because many existing quotes have been otherwise dropped, but are being pointlessly retained only by recovery sets.

One of the solution strategies for #8400 previously discussed is to deposit or burn the old quote "payments" in the recovery sets, in order to clean them up. This would be somewhat more traumatic for clients, though tolerably so. A client holding a pre-upgrade quote "payment" would find that it had been burned, requiring them to get a new payment if they wished to continue holding a valid one. This PR is much less traumatic. By just dropping the old recovery sets, any old payments that are actually being held remain as valid as they were. The only trauma would be anyone counting on recovering payments from recovery sets. We are confident no code using quotes does so.

### Security Considerations

Recovery sets are a safety feature. This PR introduces the option to suppress that safety feature, including by upgrading old issuers with that feature to one without. If such an upgrade could be done maliciously, clients depending on this safety feature could be surprised by its absence.

### Scaling Considerations

This PR is motivated by one scaling consideration: The storage leak of retaining old useless payments. In particular, dropped quote "payments".

If merged before #8417 is fixed, this PR would also cause a painful scaling issue. On upgrade, it will likely make a massive number of quote "payments" unreachable all at once. Currently, this will cause a large amount of gc-driven cleanup activity during that one crank and block, which can be problematic. Instead, the PR is written assuming #8417 has already been fixed, and depends on it to spread out the resulting gc-driven cleanup activity over a number of future cranks and blocks. Thus, the PR should not be merged until after #8417 is fixed.

Separate from this PR, we should find those places where we drop live payments of any kind, and see if we can safely burn or deposit them before dropping them.

### Documentation Considerations

Any documentation of issuer creation should document the new option for suppressing recovery sets. This should explain both the storage-leak hazard of not suppressing them and the safety hazard of suppressing them.

Any documentation on use of recovery sets to recover old payments should make clear that this feature is now optional, and some issuers, such as the quote issuers, omit the feature.

### Testing Considerations

The most important tests needed are the upgrade tests, discussed in the next section.

Even aside from upgrade, this PR needs more tests before it can become ready for review. At the time of this writing, all that is tested is that this PR does not break any existing tests. 
- [ ] We also need tests that create issuerKits without recovery sets, and test that these behave as expected.

Since the point of opting out of upgrade tests is to avoid a durable storage leak, we should have 
- [ ] a test where durable storage consumption grows linearly in the number of created and dropped payments with recovery sets, 
- [ ] and (after gc) maintains a steady state without recovery sets. 

Need to find out how to write such a test.

### Upgrade Considerations

Need to test 
- [ ] that old quote issuers with recovery sets upgrade to new quote issuers without recovery sets, 
- [ ] that otherwise they continue to pass all the same tests
- [ ] that their behavior now reflects the suppression of recovery sets
- [ ] that the old space for dropped payments is indeed recovered
- [ ] Once #8417 is fixed, that the work of recovering that storage is adequately spread out across cranks and blocks.

We should also test
- [ ] that an old issuer without recovery sets cannot (yet?) be upgraded into an issuer with recovery sets. That is the intent as of this PR. Eager for feedback whether this upgrade direction should be supported. We could, but I'd rather not if no one would use it.