### PR TITLE
fix(swing-store): ensure crank savepoint is wrapped in transaction

### DIFF
--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -370,6 +370,10 @@ export function makeSwingStore(dirPath, forceReset, options = {}) {
     inCrank || Fail`establishCrankSavepoint outside of crank`;
     const savepointOrdinal = savepoints.length;
     savepoints.push(savepoint);
+    // We must be in a transaction when creating the savepoint or releasing it
+    // later will cause an autocommit.
+    // See https://github.com/Agoric/agoric-sdk/issues/8423
+    ensureTxn();
     const sql = db.prepare(`SAVEPOINT t${savepointOrdinal}`);
     sql.run();
   }


### PR DESCRIPTION
closes: #8423

## Description

SQLite likes to autocommit when not in transactions. That includes releasing a savepoint. Simple change to ensure we've started a transaction before creating a savepoint.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Comment added to the code. There didn't seem to be any other relevant documentation

### Testing Considerations

With the consistent repro of #8423, I've verified that after the change, following the steps no longer cause an AppHash failure. There does not seem to be a good place to add an automated test for this case.

### Upgrade Considerations

None
