### PR TITLE
await scaledPriceAuthority

### DIFF
--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -7,7 +7,7 @@ import { Nat } from '@endo/nat';
 import { Command } from 'commander';
 import * as cp from 'child_process';
 import { inspect } from 'util';
-import { instanceNameFor } from '@agoric/inter-protocol/src/proposals/price-feed-proposal.js';
+import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
 import { normalizeAddressWithOptions } from '../lib/chain.js';
 import { getNetworkConfig, makeRpcUtils, storageHelper } from '../lib/rpc.js';
 import {
@@ -76,7 +76,7 @@ export const makeOracleCommand = (logger, io = {}) => {
     const utils = await makeRpcUtils({ fetch });
 
     const lookupPriceAggregatorInstance = ([brandIn, brandOut]) => {
-      const name = instanceNameFor(brandIn, brandOut);
+      const name = oracleBrandFeedName(brandIn, brandOut);
       const instance = utils.agoricNames.instance[name];
       if (!instance) {
         logger.debug('known instances:', utils.agoricNames.instance);

--- a/packages/boot/test/bootstrapTests/drivers.ts
+++ b/packages/boot/test/bootstrapTests/drivers.ts
@@ -7,7 +7,7 @@ import {
   FakeStorageKit,
   slotToRemotable,
 } from '@agoric/internal/src/storage-test-utils.js';
-import { instanceNameFor } from '@agoric/inter-protocol/src/proposals/price-feed-proposal.js';
+import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
 
 import {
   AgoricNamesRemotes,
@@ -147,7 +147,7 @@ export const makePriceFeedDriver = async (
   walletFactoryDriver: WalletFactoryDriver,
   oracleAddresses: string[],
 ) => {
-  const priceFeedName = instanceNameFor(collateralBrandKey, 'USD');
+  const priceFeedName = oracleBrandFeedName(collateralBrandKey, 'USD');
 
   const oracleWallets = await Promise.all(
     oracleAddresses.map(addr => walletFactoryDriver.provideSmartWallet(addr)),

--- a/packages/inter-protocol/src/price/README.md
+++ b/packages/inter-protocol/src/price/README.md
@@ -4,6 +4,19 @@ This directory contains the `fluxAggregatorKit.js` contract which takes prices a
 input and outputs a best known price. There are multiple ways to get the price,
 including a PriceAuthority interface.
 
+## Design
+
+The authorities are hierarchical. Many authorities can be registered in the priceAuthorityRegistry.
+
+For oracles, there must be two: the negotiable brand and the _oracle_ brand (an inert one).
+
+The intended flow is that:
+1. a negotiable brand is created (e.g. ATOM)
+2. a price provider says “i can give you quotes for that” and runs price-feed-proposal. That makes “oracleBrands” (which are inert and have a separate identity so that they don’t have the authority to say they’re the real quote for it).
+3. Some higher authority (eg EC, Stakers) decides that should be the quote source for negotiable brand so it registers it under the real brand identity in the registry (with a new instance of a scaledPriceAuthority ).
+
+In practice we do these all in one core proposal. And each vault manager is started with a limit on minting to the EC has another way to gate transactions.
+
 ## Usage
 
 See the [Smart Wallet integration test](/packages/inter-protocol/test/smartWallet/test-oracle-integration.js) for how it's used.

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -354,6 +354,9 @@ export const addAssetToVault = async (
   // don't add the collateral offering to vaultFactory until its price feed is available
   // eslint-disable-next-line no-restricted-syntax -- allow this computed property
   await consumeInstance[oracleBrandFeedName(oracleBrand, 'USD')];
+  // await also the negotiable brand
+  // eslint-disable-next-line no-restricted-syntax -- allow this computed property
+  await consumeInstance[scaledPriceFeedName(issuerName)];
 
   const auctioneerCreator = E.get(auctioneerKit).creatorFacet;
   const schedules = await E(auctioneerCreator).getSchedule();
@@ -430,8 +433,8 @@ export const getManifestForAddAssetToVault = (
           priceAuthorityAdmin: true,
           priceAuthority: true,
         },
-        produce: {
-          scaledPriceAuthorityKits: true,
+        instance: {
+          produce: true,
         },
         installation: {
           consume: { scaledPriceAuthority: true },

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -12,8 +12,11 @@ import { Stable } from '@agoric/internal/src/tokens.js';
 import { TimeMath } from '@agoric/time/src/timeMath.js';
 import { makePromiseKit } from '@endo/promise-kit';
 
-import { instanceNameFor } from './price-feed-proposal.js';
-import { reserveThenGetNames } from './utils.js';
+import {
+  oracleBrandFeedName,
+  reserveThenGetNames,
+  scaledPriceFeedName,
+} from './utils.js';
 
 export * from './startPSM.js';
 
@@ -135,6 +138,7 @@ export const registerScaledPriceAuthority = async (
       priceAuthorityAdmin,
       priceAuthority,
     },
+    instance: { produce: produceInstance },
   },
   { options: { interchainAssetOptions } },
 ) => {
@@ -211,9 +215,11 @@ export const registerScaledPriceAuthority = async (
     }),
   );
 
+  const label = scaledPriceFeedName(issuerName);
+
   const spaKit = await E(startUpgradable)({
     installation: scaledPriceAuthority,
-    label: `scaledPriceAuthority-${issuerName}`,
+    label,
     terms,
   });
 
@@ -224,6 +230,11 @@ export const registerScaledPriceAuthority = async (
     stableBrand,
     true, // force
   );
+
+  // publish into agoricNames so that others can await its presence.
+  // This must stay after registerPriceAuthority above so it's evidence of registration.
+  // eslint-disable-next-line no-restricted-syntax -- computed property
+  produceInstance[label].resolve(spaKit.instance);
 };
 
 // wait a short while after end to allow things to settle
@@ -340,10 +351,9 @@ export const addAssetToVault = async (
     [issuerName],
   );
 
-  const oracleInstanceName = instanceNameFor(oracleBrand, 'USD');
   // don't add the collateral offering to vaultFactory until its price feed is available
   // eslint-disable-next-line no-restricted-syntax -- allow this computed property
-  await consumeInstance[oracleInstanceName];
+  await consumeInstance[oracleBrandFeedName(oracleBrand, 'USD')];
 
   const auctioneerCreator = E.get(auctioneerKit).creatorFacet;
   const schedules = await E(auctioneerCreator).getSchedule();

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -7,7 +7,14 @@ import {
 import { E } from '@endo/far';
 
 import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
-import { reserveThenDeposit, reserveThenGetNames } from './utils.js';
+import {
+  oracleBrandFeedName,
+  reserveThenDeposit,
+  reserveThenGetNames,
+} from './utils.js';
+
+// backwards compatibility
+export { oracleBrandFeedName as instanceNameFor };
 
 const trace = makeTracer('RunPriceFeed', true);
 
@@ -17,9 +24,6 @@ const sanitizePathSegment = name => {
   assertPathSegment(candidate);
   return candidate;
 };
-
-export const instanceNameFor = (inBrandName, outBrandName) =>
-  `${inBrandName}-${outBrandName} price feed`;
 
 /**
  * @typedef {{
@@ -334,7 +338,7 @@ export const startPriceFeeds = async (
     {
       options: {
         priceFeedOptions: {
-          AGORIC_INSTANCE_NAME: instanceNameFor(inBrandName, outBrandName),
+          AGORIC_INSTANCE_NAME: oracleBrandFeedName(inBrandName, outBrandName),
           contractTerms: {
             minSubmissionCount: 2,
             minSubmissionValue: 1,

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -159,3 +159,6 @@ export const makeInstallCache = async (
 
 export const oracleBrandFeedName = (inBrandName, outBrandName) =>
   `${inBrandName}-${outBrandName} price feed`;
+
+export const scaledPriceFeedName = issuerName =>
+  `scaledPriceAuthority-${issuerName}`;

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -156,3 +156,6 @@ export const makeInstallCache = async (
 
   return { wrapInstall, saveCache };
 };
+
+export const oracleBrandFeedName = (inBrandName, outBrandName) =>
+  `${inBrandName}-${outBrandName} price feed`;

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -10,10 +10,8 @@ import {
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import path from 'path';
-import {
-  createPriceFeed,
-  instanceNameFor,
-} from '../../src/proposals/price-feed-proposal.js';
+import { oracleBrandFeedName } from '../../src/proposals/utils.js';
+import { createPriceFeed } from '../../src/proposals/price-feed-proposal.js';
 import { withAmountUtils } from '../supports.js';
 
 // referenced by TS
@@ -187,7 +185,10 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
       {
         options: {
           priceFeedOptions: {
-            AGORIC_INSTANCE_NAME: instanceNameFor(inBrandName, outBrandName),
+            AGORIC_INSTANCE_NAME: oracleBrandFeedName(
+              inBrandName,
+              outBrandName,
+            ),
             contractTerms: {
               minSubmissionCount: 2,
               minSubmissionValue: 1,

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -10,9 +10,9 @@ import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
 import { TimeMath } from '@agoric/time';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/far';
+import { oracleBrandFeedName } from '../../src/proposals/utils.js';
 import { INVITATION_MAKERS_DESC as EC_INVITATION_MAKERS_DESC } from '../../src/econCommitteeCharter.js';
 import { INVITATION_MAKERS_DESC as ORACLE_INVITATION_MAKERS_DESC } from '../../src/price/fluxAggregatorKit.js';
-import { instanceNameFor } from '../../src/proposals/price-feed-proposal.js';
 import { headValue } from '../supports.js';
 import { buildRootObject } from './boot-psm.js';
 import {
@@ -126,7 +126,7 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
    */
   const governedPriceAggregator = await E(agoricNames).lookup(
     'instance',
-    instanceNameFor('ATOM', 'USD'),
+    oracleBrandFeedName('ATOM', 'USD'),
   );
 
   return { oracleWallets, governedPriceAggregator };
@@ -476,7 +476,7 @@ test.serial('govern oracles list', async t => {
 
   const feed = await E(agoricNames).lookup(
     'instance',
-    instanceNameFor('ATOM', 'USD'),
+    oracleBrandFeedName('ATOM', 'USD'),
   );
   t.assert(feed);
 


### PR DESCRIPTION
## Description

In devnet-21 we observed an error,
```
Error: auction observer of [object Alleged: stATOM brand] failed: Error: key (an object) not found in collection "brandIn"
```

It hasn't been reproduced but it's due to a race condition that we should prevent. This prevents it by providing a signal as to when the scaledPriceAuthority (in the real `stATOM` brand) is available, and awaits that before calling code that may use it.

### Security Considerations

Publishing the instance in agoricName. This is okay just as the authority feeds are there.

### Scaling Considerations

--

### Documentation Considerations

- [x]  include more documentation about the design of these feeds. 


### Testing Considerations

Forgoing a test that induces the race condition but this code will be tested. The publishing is tested by the await.

### Upgrade Considerations

Not on-chain code.