### PR TITLE
SECURITY.md updates and ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+SECURITY.md @Agoric/security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The current `master` and `release-pismo` branches are supported with security updates.
+The current `master` and only the latest `agoric-upgrade-*` tagged release and pre-release are supported with security updates.
 
 ## Coordinated Vulnerability Disclosure
 


### PR DESCRIPTION
closes: #8171

## Description

This PR makes revisions to `SECURITY.md` to reflect currently supported versions. 

We also add a `CODEOWNERS` file and make `SECURITY.md` owned by the security team (@Agoric/sec). Since the team is ultimately accountable for the expectations set in this doc, we want to make sure modifications are reviewed by security for awareness and input.
