### PR TITLE
chore(cosmos): update max block size

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -104,6 +104,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
 	gaiaappparams "github.com/Agoric/agoric-sdk/golang/cosmos/app/params"
@@ -795,7 +796,7 @@ func NewAgoricApp(
 		upgradeName     = "agoric-upgrade-12"
 		upgradeNameTest = "agorictest-upgrade-12"
 	)
-	
+
 	app.UpgradeKeeper.SetUpgradeHandler(
 		upgradeName,
 		upgrade12Handler(app, upgradeName),
@@ -831,6 +832,11 @@ func upgrade12Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgr
 		app.CheckControllerInited(false)
 		// Record the plan to send to SwingSet
 		app.upgradePlan = &plan
+
+		// Reflect default BlockParams.MaxBytes change to current params
+		cp := app.BaseApp.GetConsensusParams(ctx)
+		cp.Block.MaxBytes = tmtypes.DefaultBlockParams().MaxBytes
+		app.BaseApp.StoreConsensusParams(ctx, cp)
 
 		// Always run module migrations
 		mvm, err := app.mm.RunMigrations(ctx, app.configurator, fromVm)

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.6.0
+	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tendermint/tendermint v0.34.23
 	github.com/tendermint/tm-db v0.6.7
@@ -105,7 +106,6 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.13.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tendermint/btcd v0.1.1 // indirect
@@ -142,7 +142,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 // At least until post-v0.34.14 is released with
 // https://github.com/tendermint/tendermint/issue/6899 resolved.
-replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3
+replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.4
 
 // We need a fork of cosmos-sdk until all of the differences are merged.
 replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.3

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -84,8 +84,8 @@ github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.3 h1:CMWOJYFHoRpKnNt2l90
 github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.3/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
-github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3 h1:aq6F1r3RQkKUYNeMNjRxgGn3dayvKnDK/R6gQF0WoFs=
-github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3/go.mod h1:rXVrl4OYzmIa1I91av3iLv2HS0fGSiucyW9J4aMTpKI=
+github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.4 h1:NWqGDUk5UkkXxsEVRtCWFpMeuCtu2MyRtC0Cib7sKH8=
+github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.4/go.mod h1:rXVrl4OYzmIa1I91av3iLv2HS0fGSiucyW9J4aMTpKI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -150,7 +150,7 @@ RUN . ./upgrade-test-scripts/start_to_to.sh
 ARG DEST_IMAGE
 FROM ${DEST_IMAGE} as agoric-upgrade-12
 ARG BOOTSTRAP_MODE
-ENV THIS_NAME=agoric-upgrade-12 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ENV THIS_NAME=agoric-upgrade-12 BOOTSTRAP_MODE=${BOOTSTRAP_MODE} USE_JS=1
 COPY --from=propose-agoric-upgrade-12 /root/.agoric /root/.agoric
 # start-chain boilerplate
 WORKDIR /usr/src/agoric-sdk/

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-12/pre.test.js
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-12/pre.test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 
 import { waitForBlock } from '../commonUpgradeHelpers.js';
+import { agd } from '../cliHelper.js';
 import { getIncarnation } from './tools/vat-status.js';
 
 test.before(async () => {
@@ -17,4 +18,15 @@ test(`Ensure Zoe Vat is at 0`, async t => {
 test('Ensure Network Vat is at 0', async t => {
   const incarnation = await getIncarnation('network');
   t.is(incarnation, 0);
+});
+
+test('Ensure MaxBytes param was updated', async t => {
+  const { value: rawParams } = await agd.query(
+    'params',
+    'subspace',
+    'baseapp',
+    'BlockParams',
+  );
+  const blockParams = JSON.parse(rawParams);
+  t.is(blockParams.max_bytes, '5242880');
 });


### PR DESCRIPTION
fixes: #8483

## Description

Update the `BlockParams.MaxBytes` value during upgrade-12 to reflect the new lower default adopted in https://github.com/agoric-labs/tendermint/pull/36

This change does not change the max allowed size the param can have, and the param remains fully configurable by governance.

### Security Considerations

Mitigation for a public Tendermint/CometBFT advisory, for which the Agoric chain is not impacted beyond slow blocks, something that can already happen safely on the Agoric chain.

### Scaling Considerations

None

### Documentation Considerations
None

### Testing Considerations

Docker upgrade test added to verify the param has been changed after upgrade

### Upgrade Considerations

Chain software upgrade required.
