### PR TITLE
refactor(ertp): rename reallyPrepareIssuerKit to prepareIssuerKit

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -106,17 +106,6 @@ export const upgradeIssuerKit = (
 harden(upgradeIssuerKit);
 
 /**
- * Confusingly, `prepareIssuerKit` was the original name for `upgradeIssuerKit`,
- * even though it is used only to upgrade a predecessor issuerKit. Use
- * `makeDurableIssuerKit` to make a new one.
- *
- * @deprecated Use `upgradeIssuerKit` instead if that's what you want. Or
- *   `reallyPrepareIssuerKit` if you want the behavior that should have been
- *   bound to this name.
- */
-export const prepareIssuerKit = upgradeIssuerKit;
-
-/**
  * Does baggage already have an issuerKit?
  *
  * @param {Baggage} baggage
@@ -183,9 +172,8 @@ export const makeDurableIssuerKit = (
 harden(makeDurableIssuerKit);
 
 /**
- * What _should_ have been named `prepareIssuerKit`. Used to either revive a
- * predecessor issuerKit, or to make a new durable one if it is absent, and to
- * place it in baggage for the next successor.
+ * Used to either revive a predecessor issuerKit, or to make a new durable one
+ * if it is absent, and to place it in baggage for the next successor.
  *
  * @template {AssetKind} K The name becomes part of the brand in asset
  *   descriptions. The name is useful for debugging and double-checking
@@ -213,7 +201,7 @@ harden(makeDurableIssuerKit);
  * @param {IssuerOptionsRecord} [options]
  * @returns {IssuerKit<K>}
  */
-export const reallyPrepareIssuerKit = (
+export const prepareIssuerKit = (
   issuerBaggage,
   name,
   // @ts-expect-error K could be instantiated with a different subtype of AssetKind
@@ -244,7 +232,7 @@ export const reallyPrepareIssuerKit = (
     return issuerKit;
   }
 };
-harden(reallyPrepareIssuerKit);
+harden(prepareIssuerKit);
 
 /**
  * Used _only_ to make a new issuerKit that is effectively non-durable. This is

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import { reallyPrepareIssuerKit } from '@agoric/ertp';
+import { prepareIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance } from '@agoric/governance';
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
 import { prepareDurablePublishKit } from '@agoric/notifier';
@@ -68,7 +68,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   // xxx uses contract baggage as issuerBagage, assumes one issuer in this contract
   /** @type {import('./roundsManager.js').QuoteKit} */
-  const quoteIssuerKit = reallyPrepareIssuerKit(
+  const quoteIssuerKit = prepareIssuerKit(
     baggage,
     'quote',
     'set',

--- a/packages/vats/src/mintHolder.js
+++ b/packages/vats/src/mintHolder.js
@@ -1,7 +1,7 @@
 // @ts-check
 // @jessie-check
 
-import { reallyPrepareIssuerKit } from '@agoric/ertp';
+import { prepareIssuerKit } from '@agoric/ertp';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -23,7 +23,7 @@ import { reallyPrepareIssuerKit } from '@agoric/ertp';
  */
 function provideIssuerKit(zcf, baggage) {
   const { keyword, assetKind, displayInfo } = zcf.getTerms();
-  return reallyPrepareIssuerKit(baggage, keyword, assetKind, displayInfo);
+  return prepareIssuerKit(baggage, keyword, assetKind, displayInfo);
 }
 
 /** @type {ContractMeta} */

--- a/packages/zoe/src/contractSupport/priceAuthorityQuoteMint.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityQuoteMint.js
@@ -1,4 +1,4 @@
-import { AssetKind, reallyPrepareIssuerKit } from '@agoric/ertp';
+import { AssetKind, prepareIssuerKit } from '@agoric/ertp';
 import { provideDurableMapStore } from '@agoric/vat-data';
 
 /**
@@ -11,7 +11,7 @@ export const provideQuoteMint = baggage => {
     baggage,
     'quoteMintIssuerBaggage',
   );
-  const issuerKit = reallyPrepareIssuerKit(
+  const issuerKit = prepareIssuerKit(
     issuerBaggage,
     'quote',
     AssetKind.SET,

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -2,7 +2,7 @@ import {
   AssetKind,
   IssuerShape,
   BrandShape,
-  reallyPrepareIssuerKit,
+  prepareIssuerKit,
   hasIssuer,
 } from '@agoric/ertp';
 import { initEmpty, M } from '@agoric/store';
@@ -43,7 +43,7 @@ const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   }
 
   const feeIssuerKit = /** @type {IssuerKit<'nat'>} */ (
-    reallyPrepareIssuerKit(
+    prepareIssuerKit(
       mintBaggage,
       feeIssuerConfig.name,
       feeIssuerConfig.assetKind,

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -2,7 +2,7 @@
 
 import { Fail, q } from '@agoric/assert';
 import { provideDurableMapStore } from '@agoric/vat-data';
-import { AssetKind, hasIssuer, reallyPrepareIssuerKit } from '@agoric/ertp';
+import { AssetKind, hasIssuer, prepareIssuerKit } from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';
 
 /**
@@ -28,7 +28,7 @@ export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
     // Upgrade this legacy state by simply deleting it.
     invitationKitBaggage.delete(ZOE_INVITATION_KIT);
   }
-  const invitationKit = reallyPrepareIssuerKit(
+  const invitationKit = prepareIssuerKit(
     invitationKitBaggage,
     'Zoe Invitation',
     AssetKind.SET,


### PR DESCRIPTION
refs: #8497 

## Description

Successor to #8497 . #8497 
   * deprecated the old misnamed `prepareIssuerKit`
   * introduced `reallyPrepareIssuerKit` as a horrible name for what should have been named `prepareIssuerKit`
   * changed all uses of that old name to use a non-deprecated name, leaving no remaining uses of `prepareIssuerKit`

Once #8497 is merged, there will be no remaining uses of the deprecated meaning of `prepareIssuerKit` ***in this repo***, so we can remove it without breaking anything ***in this repo***.

Since `reallyPrepareIssuerKit` is introduced only starting with #8497 , there shouldn't be any other uses of it outside this repo, so we can rename it without preserving the old name as deprecated.

The open question is when would it be safe to merge this PR wrt uses of the deprecated `prepareIssuerKit` outside this repo. Reviewers, opinions?

### Security Considerations

If indeed this PR by itself is a pure refactor with no observable effects, it should have no security implications.


### Scaling Considerations

If indeed this PR by itself is a pure refactor with no observable effects, it should have no scaling implications.


### Documentation Considerations

#8497 Documentation Considerations says

> Hopefully, we can complete that rename before bothering to document this API change.

That is what this PR would do.

### Testing Considerations

If indeed this PR by itself is a pure refactor with no observable effects, it should have no testing implications.


### Upgrade Considerations

If indeed this PR by itself is a pure refactor with no observable effects, it should have no implications for upgrade, modulo possible version skew on uses of the old vs new names.