### PR TITLE
chore(cosmos): update cosmos-sdk

### DIFF
--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -145,7 +145,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.4
 
 // We need a fork of cosmos-sdk until all of the differences are merged.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.3
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.4
 
 replace github.com/cosmos/gaia/v7 => github.com/Agoric/ag0/v7 v7.0.2-alpha.agoric.1
 

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -80,8 +80,8 @@ github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6/go.mod h1:
 github.com/adlio/schema v1.3.3 h1:oBJn8I02PyTB466pZO1UZEn1TV5XLlifBSyMrmHl/1I=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.3 h1:CMWOJYFHoRpKnNt2l90e5tEMy9phxkDEjQKfsCUHtgU=
-github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.3/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
+github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.4 h1:OU1rRq0qS+5KNe7eF7ceXPpHeXWj+JSbUpHgiQTml2E=
+github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.4/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.4 h1:NWqGDUk5UkkXxsEVRtCWFpMeuCtu2MyRtC0Cib7sKH8=


### PR DESCRIPTION
closes: #8325

## Description

Update cosmos-sdk to a new tag that only contains the state-sync payload size fix.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

The cosmos-sdk fix has been repeatedly tested on mainnet by using a follower with the patch manually applied

### Upgrade Considerations

Part of upgrade-12
