### PR TITLE
feat(zoe): prepare-ownable-object

### DIFF
--- a/packages/swingset-liveslots/src/cache.js
+++ b/packages/swingset-liveslots/src/cache.js
@@ -17,7 +17,7 @@ import { Fail } from '@agoric/assert';
 /**
  * @callback CacheDelete
  * @param {string} key
- * @returns {void}
+ * @returns {boolean}
  *
  * @callback CacheFlush
  * @returns {void}
@@ -82,8 +82,9 @@ export function makeCache(readBacking, writeBacking, deleteBacking) {
     },
     delete: key => {
       assert.typeof(key, 'string');
-      stash.delete(key);
+      const result = stash.delete(key);
       dirtyKeys.add(key);
+      return result;
     },
     flush: () => {
       const keys = [...dirtyKeys.keys()];

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -13,12 +13,19 @@ import type {
   WeakMapStore,
   WeakSetStore,
 } from '@agoric/store';
+import type {
+  FarClassOptions,
+  StateShape,
+  Context,
+  KitContext,
+  Revoker,
+  ReceiveRevoker,
+} from '@endo/exo';
 import type { makeWatchedPromiseManager } from './watchedPromises.js';
 
 // TODO should be moved into @endo/patterns and eventually imported here
 // instead of this local definition.
 export type InterfaceGuardKit = Record<string, InterfaceGuard>;
-
 export type { MapStore, Pattern };
 
 // This needs `any` values.  If they were `unknown`, code that uses Baggage
@@ -88,7 +95,12 @@ export type DefineKindOptions<C> = {
    * If provided, it describes the shape of all state records of instances
    * of this kind.
    */
-  stateShape?: { [name: string]: Pattern };
+  stateShape?: StateShape;
+
+  /**
+   * If provided, it is called with a revoke function as an argument.
+   */
+  receiveRevoker?: ReceiveRevoker;
 
   /**
    * Intended for internal use only.

--- a/packages/vat-data/test/test-revoke-virtual.js
+++ b/packages/vat-data/test/test-revoke-virtual.js
@@ -93,8 +93,9 @@ test('test revoke defineVirtualExoClassKit', t => {
     message:
       '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
   });
+  t.is(downCounter.decr(), 6);
   // @ts-expect-error Does not understand that `revoke` is a function.
-  t.is(revoke(downCounter), false);
+  t.is(revoke(downCounter), true);
   t.throws(() => downCounter.decr(), {
     message:
       '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',

--- a/packages/vat-data/test/test-revoke-virtual.js
+++ b/packages/vat-data/test/test-revoke-virtual.js
@@ -1,0 +1,131 @@
+// Modeled on test-revoke-heap-classes.js
+
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { M } from '@agoric/store';
+import {
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+} from '../src/exo-utils.js';
+
+const { apply } = Reflect;
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test revoke defineVirtualExoClass', t => {
+  let revoke;
+  const makeUpCounter = defineVirtualExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  // @ts-expect-error Does not understand that `revoke` is a function.
+  t.is(revoke(upCounter), true);
+  t.throws(() => upCounter.incr(1), {
+    message:
+      '"In \\"incr\\" method of (UpCounter)" may only be applied to a valid instance: "[Alleged: UpCounter]"',
+  });
+});
+
+test('test revoke defineVirtualExoClassKit', t => {
+  let revoke;
+  const makeCounterKit = defineVirtualExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  // @ts-expect-error Does not understand that `revoke` is a function.
+  t.is(revoke(upCounter), true);
+  t.throws(() => upCounter.incr(3), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
+  });
+  // @ts-expect-error Does not understand that `revoke` is a function.
+  t.is(revoke(downCounter), false);
+  t.throws(() => downCounter.decr(), {
+    message:
+      '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});
+
+test('test virtual facet cross-talk', t => {
+  const makeCounterKit = defineVirtualExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.throws(() => apply(upCounter.incr, downCounter, [2]), {
+    message: 'illegal cross-facet access',
+  });
+});

--- a/packages/zoe/src/contractSupport/prepare-ownable-object.js
+++ b/packages/zoe/src/contractSupport/prepare-ownable-object.js
@@ -1,0 +1,232 @@
+import {
+  M,
+  getCopyMapEntries,
+  getInterfaceGuardPayload,
+  mustMatch,
+} from '@endo/patterns';
+import { prepareExoClass } from '@agoric/vat-data';
+import { OfferHandlerI } from '../typeGuards.js';
+
+/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+
+const { Fail, quote: q } = assert;
+const { fromEntries } = Object;
+
+const TransferProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: {
+    onDemand: null,
+  },
+});
+
+export const makePrepareOwnableClass = zcf => {
+  /**
+   * @template {object} CustomDetails
+   * @template {object} State
+   * @template {Record<PropertyKey, CallableFunction>} T methods
+   * @param {Baggage} baggage
+   * @param {string} kindName
+   * @param {import('@endo/patterns').InterfaceGuard} interfaceGuard
+   *   Does not itself provide guards for
+   *   - `getCustomDetails`
+   *   - `makeTranferInvitation`.
+   *
+   *   Rather, those guards are automatically added
+   * @param {(customDetails: CustomDetails) => State} init
+   *   A single-arg function of a `details` param that must
+   *   match `detailsShape`
+   * @param {T & ThisType<{
+   *   self: T,
+   *   state: State,
+   * }>} methods
+   *   Does not itself provide the
+   *   - `makeTransferInvitation` method.
+   *
+   *   Rather, that method is automatically added.
+   *   The `methods` parameter must contain a method for
+   *   - `getCustomDetails`
+   *   whose return result must match `detailsShape`,
+   *   will be in the `customDetails` of the invitation, and
+   *   will be used on the next call to the `init` function.
+   * @param {import('@agoric/vat-data').DefineKindOptions<{
+   *   self: T,
+   *   state: State
+   * }> & {
+   *   detailsShape?: any,
+   * }} [options]
+   *   If `detailsShape` is provided, it will be used to guard the returns of
+   *   `getCustomDetails`.
+   *   A `receiveRevoker` is automatically added.
+   * @returns {(customDetails: CustomDetails) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
+   */
+  const prepareOwnableClass = (
+    baggage,
+    kindName,
+    interfaceGuard,
+    init,
+    methods,
+    options = {},
+  ) => {
+    // ////////////////////////// ownableOptions ///////////////////////////////
+
+    let revokeOwnableObject;
+
+    const {
+      detailsShape = M.any(),
+      receiveRevoker = undefined,
+      ...restOptions
+    } = options;
+    receiveRevoker === undefined ||
+      Fail`Cannot override the automatically added receiveRevoker option in ${q(
+        kindName,
+      )}`;
+
+    /**
+     * Like the provided `options` but without the provided `detailsShape`
+     * and with an automatically added `receiveRevoker`.
+     */
+    const ownableOptions = {
+      ...restOptions,
+      receiveRevoker(revoke) {
+        revokeOwnableObject = revoke;
+      },
+    };
+
+    // ///////////////////// ownableInterfaceGuard /////////////////////////////
+
+    // TODO what about interfaceGuardPayload options?
+    const {
+      interfaceName,
+      methodGuards: {
+        getCustomDetails = undefined,
+        makeTransferInvitation = undefined,
+        ...methodGuards
+      },
+      symbolMethodGuards = undefined,
+    } = getInterfaceGuardPayload(interfaceGuard);
+
+    getCustomDetails === undefined ||
+      Fail`Cannot override the automatically added getCustomDetails guard in ${q(
+        kindName,
+      )}`;
+    makeTransferInvitation === undefined ||
+      Fail`Cannot override the automatically added makeTransferInvitation guard in ${q(
+        interfaceName,
+      )}`;
+
+    let ownableInterfaceMethodGuards;
+    if (symbolMethodGuards === undefined) {
+      ownableInterfaceMethodGuards = harden({
+        ...methodGuards,
+        getCustomDetails: M.call().returns(detailsShape),
+        makeTransferInvitation: M.call().returns(M.promise()),
+      });
+    } else {
+      ownableInterfaceMethodGuards = harden({
+        ...methodGuards,
+        ...fromEntries(getCopyMapEntries(symbolMethodGuards)),
+        getCustomDetails: M.call().returns(detailsShape),
+        makeTransferInvitation: M.call().returns(M.promise()),
+      });
+    }
+
+    /**
+     * Like the provided `interfaceGuard` both with automatically added
+     * method guards for `getCustomDetails` and
+     * `makeTransferInvitation`.
+     */
+    const ownableInterfaceGuard = M.interface(
+      `Ownable_${interfaceName}`,
+      ownableInterfaceMethodGuards,
+    );
+
+    // ////////////////////////// ownableInit //////////////////////////////////
+
+    /**
+     * Like the provided `init` function, but only passes through one argument
+     * after verifying that it mustMatch the `detailsShape`
+     *
+     * @param {Passable} customDetails
+     */
+    const ownableInit = customDetails => {
+      mustMatch(customDetails, detailsShape, `makeOwnable_${q(kindName)}`);
+      return init(customDetails);
+    };
+
+    // /////////////////////// ownableMethods //////////////////////////////////
+
+    const { makeTransferInvitation: mtiMethod = undefined, ...restMethods } =
+      methods;
+
+    mtiMethod === undefined ||
+      Fail`Cannot override the automatically added makeTransferInvitation method in ${q(
+        kindName,
+      )}`;
+
+    const ownableMethods = {
+      ...restMethods,
+      makeTransferInvitation() {
+        const { self } = this;
+        // @ts-expect-error FIXME self needs typing
+        const customDetails = self.getCustomDetails();
+        // eslint-disable-next-line no-use-before-define
+        const transferHandler = makeTransferHandler(customDetails);
+
+        const invitation = zcf.makeInvitation(
+          transferHandler,
+          'transfer',
+          customDetails,
+          TransferProposalShape,
+        );
+        revokeOwnableObject(self);
+        return invitation;
+      },
+    };
+
+    // /////////////////////////////////////////////////////////////////////////
+
+    const makeOwnableObject = prepareExoClass(
+      baggage,
+      // Might be upgrading from a previous non-ownable class of the same
+      // kindName.
+      kindName,
+      ownableInterfaceGuard,
+      ownableInit,
+      // @ts-expect-error Method typing
+      ownableMethods,
+      ownableOptions,
+    );
+
+    let revokeTransferHandler;
+
+    const makeTransferHandler = prepareExoClass(
+      baggage,
+      'TransferHandler',
+      OfferHandlerI,
+      customDetails => ({
+        customDetails,
+      }),
+      {
+        handle(seat) {
+          const {
+            self,
+            state: { customDetails },
+          } = this;
+          seat.exit();
+          revokeTransferHandler(self);
+          return makeOwnableObject(customDetails);
+        },
+      },
+      {
+        receiveRevoker(revoke) {
+          revokeTransferHandler = revoke;
+        },
+      },
+    );
+
+    return makeOwnableObject;
+  };
+  return harden(prepareOwnableClass);
+};
+harden(makePrepareOwnableClass);

--- a/packages/zoe/src/contracts/ownable-counter.js
+++ b/packages/zoe/src/contracts/ownable-counter.js
@@ -1,0 +1,84 @@
+import { M } from '@endo/patterns';
+import { prepareExo } from '@agoric/vat-data';
+import { makePrepareOwnableClass } from '../contractSupport/prepare-ownable-object.js';
+
+/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+
+const CounterI = M.interface('Counter', {
+  incr: M.call().returns(M.bigint()),
+});
+
+const CounterDetailsShape = harden({
+  count: M.bigint(),
+});
+
+/**
+ * @param {ZCF} zcf
+ * @param {{ count: bigint}} privateArgs
+ * @param {Baggage} instanceBaggage
+ */
+export const start = async (zcf, privateArgs, instanceBaggage) => {
+  const { count: startCount = 0n } = privateArgs;
+  assert.typeof(startCount, 'bigint');
+
+  // for use by upgraded versions.
+  const firstTime = !instanceBaggage.has('count');
+  if (firstTime) {
+    instanceBaggage.init('count', startCount);
+  }
+
+  const prepareOwnableClass = makePrepareOwnableClass(zcf);
+
+  const makeOwnableCounter = prepareOwnableClass(
+    instanceBaggage,
+    'OwnableCounter',
+    CounterI,
+    customDetails => {
+      // @ts-expect-error TODO type the counter's `customDetails`
+      const { count } = customDetails;
+      assert(count === instanceBaggage.get('count'));
+      return harden({});
+    },
+    {
+      incr() {
+        const count = instanceBaggage.get('count') + 1n;
+        instanceBaggage.set('count', count);
+        return count;
+      },
+
+      // note: abstract method must be concretely implemented by
+      // ownable objects
+      getCustomDetails() {
+        return harden({
+          count: instanceBaggage.get('count'),
+        });
+      },
+    },
+    {
+      detailsShape: CounterDetailsShape,
+    },
+  );
+
+  const viewCounter = prepareExo(
+    instanceBaggage,
+    'ViewCounter',
+    M.interface('ViewCounter', {
+      view: M.call().returns(M.bigint()),
+    }),
+    {
+      view() {
+        return instanceBaggage.get('count');
+      },
+    },
+  );
+
+  return harden({
+    creatorFacet: makeOwnableCounter(
+      harden({
+        count: startCount,
+      }),
+    ),
+    publicFacet: viewCounter,
+  });
+};
+harden(start);

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -127,7 +127,7 @@ export const InvitationElementShape = M.splitRecord({
 });
 
 export const OfferHandlerI = M.interface('OfferHandler', {
-  handle: M.call(SeatShape).optional(M.any()).returns(M.string()),
+  handle: M.call(SeatShape).optional(M.any()).returns(M.any()),
 });
 
 export const SeatHandleAllocationsShape = M.arrayOf(

--- a/packages/zoe/test/unitTests/contracts/test-ownable-counter.js
+++ b/packages/zoe/test/unitTests/contracts/test-ownable-counter.js
@@ -1,0 +1,112 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import path from 'path';
+
+import bundleSource from '@endo/bundle-source';
+import { E } from '@endo/eventual-send';
+import { GET_METHOD_NAMES } from '@endo/marshal';
+
+import { makeZoeForTest } from '../../../tools/setup-zoe.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const root = `${dirname}/../../../src/contracts/ownable-counter.js`;
+
+test('zoe - ownable-counter contract', async t => {
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
+  const zoe = makeZoeForTest(fakeVatAdmin);
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationBrand = await E(invitationIssuer).getBrand();
+
+  // Pack the contract.
+  const bundle = await bundleSource(root);
+  vatAdminState.installBundle('b1-ownable-counter', bundle);
+  const installation = await E(zoe).installBundleID('b1-ownable-counter');
+
+  const { creatorFacet: firstCounter, publicFacet: viewCounter } = await E(
+    zoe,
+  ).startInstance(
+    installation,
+    undefined,
+    undefined,
+    harden({
+      count: 3n,
+    }),
+    'c1-ownable-counter',
+  );
+
+  // the following tests could invoke `firstCounter` and `viewCounter`
+  // synchronously. But we don't in order to better model the user
+  // code that might be remote.
+
+  t.deepEqual(await E(firstCounter)[GET_METHOD_NAMES](), [
+    '__getInterfaceGuard__',
+    '__getMethodNames__',
+    'getCustomDetails',
+    'incr',
+    'makeTransferInvitation',
+  ]);
+
+  t.is(await E(firstCounter).incr(), 4n);
+  t.is(await E(viewCounter).view(), 4n);
+
+  t.deepEqual(await E(firstCounter).getCustomDetails(), {
+    count: 4n,
+  });
+
+  const invite = await E(firstCounter).makeTransferInvitation();
+
+  t.deepEqual(await E(firstCounter)[GET_METHOD_NAMES](), [
+    '__getInterfaceGuard__',
+    '__getMethodNames__',
+    'getCustomDetails',
+    'incr',
+    'makeTransferInvitation',
+  ]);
+
+  await t.throwsAsync(() => E(firstCounter).getCustomDetails(), {
+    message:
+      '"In \\"getCustomDetails\\" method of (OwnableCounter)" may only be applied to a valid instance: "[Alleged: OwnableCounter]"',
+  });
+  await t.throwsAsync(() => E(firstCounter).incr(), {
+    message:
+      '"In \\"incr\\" method of (OwnableCounter)" may only be applied to a valid instance: "[Alleged: OwnableCounter]"',
+  });
+  t.is(await E(viewCounter).view(), 4n);
+
+  const inviteAmount = await E(invitationIssuer).getAmountOf(invite);
+
+  t.deepEqual(inviteAmount, {
+    brand: invitationBrand,
+    value: [
+      {
+        description: 'transfer',
+        installation,
+        handle: inviteAmount.value[0].handle,
+        instance: inviteAmount.value[0].instance,
+        customDetails: {
+          count: 4n,
+        },
+      },
+    ],
+  });
+
+  const reviveCounterSeat = await E(zoe).offer(invite);
+
+  const counter2 = await E(reviveCounterSeat).getOfferResult();
+  t.is(await E(reviveCounterSeat).hasExited(), true);
+
+  t.is(await E(viewCounter).view(), 4n);
+  t.deepEqual(await E(counter2).getCustomDetails(), {
+    count: 4n,
+  });
+
+  t.is(await E(counter2).incr(), 5n);
+
+  t.is(await E(viewCounter).view(), 5n);
+  t.deepEqual(await E(counter2).getCustomDetails(), {
+    count: 5n,
+  });
+});


### PR DESCRIPTION
Staged on https://github.com/Agoric/agoric-sdk/pull/8020

Alternative to https://github.com/Agoric/agoric-sdk/pull/8022 with improved support API

closes: #XXXX
refs: #8020 #8022 #8021 #8682

## Description

The basic idea of an "ownable object" is to provide general and lower level support for approximately the pattern that vaults implement manually in an adhoc manner: A *ownable object* is an object with a `makeTransferInvitation` method that revokes the object itself, in the sense of inactivating it — it no longer provides any authority. Instead, the exclusively transferable portion of its authority is encapsulated by the returned invitation, in an allegedly legible manner. That invitation can be redeemed, via an `offer` , for a new ownable object in which the transferable authority from the original ownable object is now exercisable.

We call this an "ownable object" since the rights of ownership include
- the right to exercise (use)
- the right to exclusively transfer the rights of ownership
- the right to exclude others from being able to exercise and transfer
- the ability to legibly offer the exclusive transfer of ownership

Objects are about rights to exercise (use) and share, but not transfer, and not legibly.

ERTP is about legible exclusive transfer but not exercise.

The lifecycle of an ownable object, transmuting between an ephemeral ownable object and an invitation to get a new “equivalent” ownable object, combines all attributes together. But the attributes are never directly present at the same time. That’s why it is the lifecycle that combines these.

This notion of "ownable" and "ownership rights" has strong echoes in programming language notions of "ownership types", "linear types", and "affine types". However, none of these, as far as we are aware, has the two-phase lifecycle of our ownable objects. Nor do they provide for legibility of offers to transfer, which is crucial for secure exchange and offer safety.

See [*Necessity* specifications for robustness](https://dl.acm.org/doi/abs/10.1145/3563317)

See https://groups.google.com/g/cap-talk/c/9OU9ZNoB3os/m/gXeu2zs4AgAJ?utm_medium=email&utm_source=footer for a useful real-world analogy for the two-phase ownership cycle.

### Security Considerations

Must ensure that revocation really denies all further authority from the original ownable object, even from messages that are already in the air but not yet delivered.

Need to verify that the legibility can meet invitation legibility goals.

### Scaling Considerations

Switching much usage to revocables and ownables should have big scaling benefits, but this remains to be measured.

### Documentation Considerations

Once ready to be used, not only should this be documented, we should be able to simplify several other APIs in ways that should make them more explainable.

### Testing Considerations

Need to test the hell out of this.

### Upgrade Considerations

The transfer invitations have durable handlers and so are themselves durable and should survive upgrade.

The ownable objects themselves are defined to be durable, so they can survive upgrade.

The `prepareOwnableClass` should be able to upgrade a conventional object that had previously been defined with `prepareExoClass` using the same baggage and kindName.