### PR TITLE
feat(swing-store): faster import of swing-store

### DIFF
--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -6,6 +6,7 @@ import tmp from 'tmp';
 import { kunser } from '@agoric/kmarshal';
 import {
   initSwingStore,
+  openSwingStore,
   makeSwingStoreExporter,
   importSwingStore,
 } from '@agoric/swing-store';
@@ -36,7 +37,9 @@ test.before(async t => {
 
 test('state-sync reload', async t => {
   const [dbDir, cleanup] = await tmpDir('testdb');
+  const [importDbDir, cleanupImport] = await tmpDir('importtestdb');
   t.teardown(cleanup);
+  t.teardown(cleanupImport);
 
   const config = {
     snapshotInitial: 2,
@@ -106,7 +109,10 @@ test('state-sync reload', async t => {
     getArtifact: name => artifacts.get(name),
     close: () => 0,
   };
-  const ss2 = await importSwingStore(datasetExporter);
+  const ssi = await importSwingStore(datasetExporter, importDbDir);
+  await ssi.hostStorage.commit();
+  await ssi.hostStorage.close();
+  const ss2 = openSwingStore(importDbDir);
   const c2 = await makeSwingsetController(
     ss2.kernelStorage,
     {},

--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -113,6 +113,7 @@ test('state-sync reload', async t => {
   await ssi.hostStorage.commit();
   await ssi.hostStorage.close();
   const ss2 = openSwingStore(importDbDir);
+  t.teardown(ss2.hostStorage.close);
   const c2 = await makeSwingsetController(
     ss2.kernelStorage,
     {},

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -11,14 +11,16 @@ import { assertComplete } from './assertComplete.js';
  */
 
 /**
- * Function used to create a new swingStore from an object implementing the
+ * Function used to populate a swingStore from an object implementing the
  * exporter API. The exporter API may be provided by a swingStore instance, or
- * implemented by a host to restore data that was previously exported.
+ * implemented by a host to restore data that was previously exported. The
+ * returned swingStore is not suitable for execution, and thus only contains
+ * the host facet for committing the populated swingStore.
  *
  * @param {import('./exporter').SwingStoreExporter} exporter
  * @param {string | null} [dirPath]
  * @param {ImportSwingStoreOptions} [options]
- * @returns {Promise<import('./swingStore').SwingStore>}
+ * @returns {Promise<Pick<import('./swingStore').SwingStore, 'hostStorage' | 'debug'>>}
  */
 export async function importSwingStore(exporter, dirPath = null, options = {}) {
   if (dirPath && typeof dirPath !== 'string') {
@@ -27,11 +29,14 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   const { artifactMode = 'operational', ...makeSwingStoreOptions } = options;
   validateArtifactMode(artifactMode);
 
-  const store = makeSwingStore(dirPath, true, {
-    unsafeFastMode: true,
-    ...makeSwingStoreOptions,
-  });
-  const { kernelStorage, internal } = store;
+  const { hostStorage, kernelStorage, internal, debug } = makeSwingStore(
+    dirPath,
+    true,
+    {
+      unsafeFastMode: true,
+      ...makeSwingStoreOptions,
+    },
+  );
 
   // For every exportData entry, we add a DB record. 'kv' entries are
   // the "kvStore shadow table", and are not associated with any
@@ -124,5 +129,5 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   assertComplete(internal, checkMode);
 
   await exporter.close();
-  return store;
+  return { hostStorage, debug };
 }

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -27,7 +27,10 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   const { artifactMode = 'operational', ...makeSwingStoreOptions } = options;
   validateArtifactMode(artifactMode);
 
-  const store = makeSwingStore(dirPath, true, makeSwingStoreOptions);
+  const store = makeSwingStore(dirPath, true, {
+    unsafeFastMode: true,
+    ...makeSwingStoreOptions,
+  });
   const { kernelStorage, internal } = store;
 
   // For every exportData entry, we add a DB record. 'kv' entries are

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -203,9 +203,29 @@ export function makeSwingStore(dirPath, forceReset, options = {}) {
   // mode that defers merge work for a later attempt rather than block any
   // potential readers or writers. See https://sqlite.org/wal.html for details.
 
+  // However we also allow opening the DB with journaling off, which is unsafe
+  // and doesn't support rollback, but avoids any overhead for large
+  // transactions like for during an import.
+
+  function setUnsafeFastMode(enabled) {
+    const journalMode = enabled ? 'off' : 'wal';
+    const synchronousMode = enabled ? 'normal' : 'full';
+    !db.inTransaction || Fail`must not be in a transaction`;
+
+    db.unsafeMode(!!enabled);
+    // The WAL mode is persistent so it's not possible to switch to a different
+    // mode for an existing DB.
+    const actualMode = db.pragma(`journal_mode=${journalMode}`, {
+      simple: true,
+    });
+    actualMode === journalMode ||
+      filePath === ':memory:' ||
+      Fail`Couldn't set swing-store DB to ${journalMode} mode (is ${actualMode})`;
+    db.pragma(`synchronous=${synchronousMode}`);
+  }
+
   // PRAGMAs have to happen outside a transaction
-  db.exec(`PRAGMA journal_mode=WAL`);
-  db.exec(`PRAGMA synchronous=FULL`);
+  setUnsafeFastMode(options.unsafeFastMode);
 
   // We use IMMEDIATE because the kernel is supposed to be the sole writer of
   // the DB, and if some other process is holding a write lock, we want to find
@@ -481,7 +501,11 @@ export function makeSwingStore(dirPath, forceReset, options = {}) {
   }
 
   /** @type {import('./internal.js').SwingStoreInternal} */
-  const internal = harden({ snapStore, transcriptStore, bundleStore });
+  const internal = harden({
+    snapStore,
+    transcriptStore,
+    bundleStore,
+  });
 
   async function repairMetadata(exporter) {
     return doRepairMetadata(internal, exporter);

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -118,7 +118,11 @@ test('b0 import', async t => {
     },
     close: async () => undefined,
   };
-  const { kernelStorage } = await importSwingStore(exporter);
+  const ss = await importSwingStore(exporter);
+  t.teardown(ss.hostStorage.close);
+  await ss.hostStorage.commit();
+  const serialized = ss.debug.serialize();
+  const { kernelStorage } = initSwingStore(null, { serialized });
   const { bundleStore } = kernelStorage;
   t.truthy(bundleStore.hasBundle(idA));
   t.deepEqual(bundleStore.getBundle(idA), b0A);

--- a/packages/swing-store/test/test-exportImport.js
+++ b/packages/swing-store/test/test-exportImport.js
@@ -322,6 +322,7 @@ async function testExportImport(
   }
   t.is(failureMode, 'none');
   const ssIn = await doImport();
+  t.teardown(ssIn.hostStorage.close);
   await ssIn.hostStorage.commit();
   let dumpsShouldMatch = true;
   if (runMode === 'operational') {

--- a/packages/swing-store/test/test-import.js
+++ b/packages/swing-store/test/test-import.js
@@ -46,6 +46,7 @@ test('import empty', async t => {
   t.teardown(cleanup);
   const exporter = makeExporter(new Map(), new Map());
   const ss = await importSwingStore(exporter, dbDir);
+  t.teardown(ss.hostStorage.close);
   await ss.hostStorage.commit();
   const data = convert(ss.debug.dump());
   t.deepEqual(data, {
@@ -69,6 +70,7 @@ const importTest = test.macro(async (t, mode) => {
 
   // now import
   const ss = await importSwingStore(exporter, dbDir, { artifactMode });
+  t.teardown(ss.hostStorage.close);
   await ss.hostStorage.commit();
   const data = convert(ss.debug.dump());
 


### PR DESCRIPTION
closes: #8521

## Description

Disable journaling and full synchronous pragma modes during import, resulting in an import time for mainnet state of 9 minutes vs 33 minutes.

```
2023-11-09T20:59:28.218650751Z Restoring SwingSet state from snapshot at block height 12416000 with options {"exportDir":"/tmp/agd-swing-store-restore-12416000-727241191","artifactMode":"replay","exportDataMode":"all"}
2023-11-09T21:08:27.095272275Z 9:08PM INF restored swing-store export exportDir=/tmp/agd-swing-store-restore-12416000-727241191 height=12416000 module=x/swingset submodule=SwingStoreExportsHandler
```

Adds a check that the journaling pragma has been successfully applied to prevent running in unsafe conditions.

To avoid confusions and mis-usage, `importSwingStore` no longer returns the `kernelStorage` facet of the SwingStore, to make it clear it cannot be used for execution.

### Security Considerations

This change could technically result in a corrupted DB if interrupted, however the import process in cosmic-swingset writes the expected block height just before commiting. If that block height is not correct on start, the node will refuse to start thanks to hangover checks.

### Scaling Considerations

Cuts disk usage in half during the swing-store import

### Documentation Considerations

None

### Testing Considerations

Manually tested on a patched follower, and modified the state-sync test to reflect the open close of connection.

### Upgrade Considerations

None