### PR TITLE
fix(swing-store): increase export timeout

### DIFF
--- a/packages/swing-store/src/exporter.js
+++ b/packages/swing-store/src/exporter.js
@@ -92,7 +92,11 @@ export function makeSwingStoreExporter(dirPath, options = {}) {
   validateArtifactMode(artifactMode);
 
   const filePath = dbFileInDirectory(dirPath);
-  const db = sqlite3(filePath);
+  const db = sqlite3(filePath, { timeout: 30000 });
+  const journalMode = db.pragma(`journal_mode=wal`, {
+    simple: true,
+  });
+  journalMode === 'wal' || Fail`DB not in WAL mode (is in ${journalMode} mode)`;
 
   // Execute the data export in a (read) transaction, to ensure that we are
   // capturing the state of the database at a single point in time. Our close()


### PR DESCRIPTION
closes: #8523

## Description

During swing-store export, open the DB with a larger timeout (default 5s), and make sure the DB is in WAL mode. #8522 changed the journaling during import to `off` which means a freshly imported DB cannot start a transaction. Furthermore starting a transaction (or switching the journal mode) requires temporarily acquiring some locks in the DB, which seems to conflict with the long transactions active during swingset execution, so increase the timeout during export to hopefully resolve the SQLITE_BUSY issues we've seen.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually verified an export right after a state-sync import is possible again.

Will try syncing a node where the SQLITE_BUSY errors reproduced consistently before.

### Upgrade Considerations

None
