### PR TITLE
chore: fix release instructions and tools

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -117,7 +117,7 @@ prior=$(git tag -l | sed -ne 's!^@agoric/sdk@\([0-9]*\).*!\1!p' | sort -n | tail
 SDKVER=$(( prior + 1 ))
 git tag @agoric/sdk@$SDKVER
 # Push the branch.
-git push -u origin release-$now
+git push -u origin prepare-release-$now
 # Tell which packages have actual news.
 scripts/have-news HEAD^ > have-news.md
 ```

--- a/scripts/get-released-tags
+++ b/scripts/get-released-tags
@@ -5,7 +5,7 @@ otherTags=
 if test -z "$cmd"; then
   cmd=echo
 fi
-for tag in $(git tag -l | grep -E '@[.0-9]+$'); do
+for tag in $(git tag -l --contains HEAD | grep -E '@[0-9.]+(-[^.]*\.[0-9.]+)?$'); do
   case $tag in
   @agoric/sdk@*) sdkTags="$sdkTags $tag" ;;
   @agoric/cosmos@*)


### PR DESCRIPTION
refs: #8375

## Description

Fix a couple issues in the Maintainers instructions and the release tags tool found during the upgrade-12 release process. The prepare branch was changed in #8375, but not all occurrences were updated correctly. Also these releases use a pre-version which was filtered out by the release tag regexp.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Keeping maintainers doc up to date.

### Testing Considerations

Found after manually going through the documented steps, no automated test exists.

### Upgrade Considerations

None
