### PR TITLE
xsnap without git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,16 @@ packages/stat-logger
 **/swingset-kernel-state
 **/_agstate
 .vagrant
+
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
+#
+# We avoid copying these into a docker build context, because we're
+# also not copying the .git directories. If someone runs "docker
+# build" from a non-clean agoric-sdk tree, the build context would
+# have moddable/ source files but no moddable/.git, and that would be
+# confused with an unpacked NPM tarball. See
+# packages/xsnap/src/build.js for details.
+
 packages/xsnap/moddable
 packages/xsnap/xsnap-native

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,9 +53,6 @@ jobs:
         run: echo "GIT_REVISION=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Save GIT_COMMIT
         run: echo "GIT_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: Save commit hash, url of submodules to environment
-        run: |
-          node packages/xsnap/src/build.js --show-env >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -84,14 +81,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: '${{ env.REGISTRY }}/agoric/agoric-sdk:${{ env.BUILD_TAG }}'
-          # When changing/adding entries here, make sure to search the whole
-          # project for `@@AGORIC_DOCKER_SUBMODULES@@`
           build-args: |
             GIT_COMMIT=${{env.GIT_COMMIT}}
-            MODDABLE_COMMIT_HASH=${{env.MODDABLE_COMMIT_HASH}}
-            MODDABLE_URL=${{env.MODDABLE_URL}}
-            XSNAP_NATIVE_COMMIT_HASH=${{env.XSNAP_NATIVE_COMMIT_HASH}}
-            XSNAP_NATIVE_URL=${{env.XSNAP_NATIVE_URL}}
             GIT_REVISION=${{env.GIT_REVISION}}
       - name: Build and Push setup
         uses: docker/build-push-action@v4

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -53,7 +53,7 @@ RUN \
   yarn build
 
 # Remove dev dependencies.
-RUN rm -rf packages/xsnap/moddable packages/xsnap/xsnap-native/build/tmp
+RUN rm -rf packages/xsnap/moddable packages/xsnap/xsnap-native/xsnap/build/tmp
 # FIXME: This causes bundling differences.  https://github.com/endojs/endo/issues/919
 # RUN yarn install --frozen-lockfile --production --network-timeout 100000
 

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -38,7 +38,9 @@ WORKDIR /usr/src/agoric-sdk
 COPY . .
 
 # add retry for qemu arm64 network fetching and mui issues with qemu
-RUN bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
+RUN \
+    XSNAP_IS_IN_DOCKER=1 \
+    bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
 
 # Need to build the Node.js node extension that uses our above Golang shared library.
 COPY --from=cosmos-go /usr/src/agoric-sdk/golang/cosmos/build golang/cosmos/build/

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -34,13 +34,6 @@ RUN set -eux; \
 # The js build container
 FROM node:18-bullseye AS build-js
 
-# When changing/adding entries here, make sure to search the whole project for
-# `@@AGORIC_DOCKER_SUBMODULES@@`
-ARG MODDABLE_COMMIT_HASH
-ARG MODDABLE_URL
-ARG XSNAP_NATIVE_COMMIT_HASH
-ARG XSNAP_NATIVE_URL
-
 WORKDIR /usr/src/agoric-sdk
 COPY . .
 
@@ -51,14 +44,10 @@ RUN bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 
 COPY --from=cosmos-go /usr/src/agoric-sdk/golang/cosmos/build golang/cosmos/build/
 RUN cd golang/cosmos && yarn build:gyp
 
-# Check out the specified submodule versions.
-# When changing/adding entries here, make sure to search the whole project for
-# `@@AGORIC_DOCKER_SUBMODULES@@`
+# XSNAP_IS_IN_DOCKER tells xsnap that it needs to git-clone the
+# submodules. See packages/xsnap/src/build.js for details
 RUN \
-  MODDABLE_COMMIT_HASH="$MODDABLE_COMMIT_HASH" \
-  MODDABLE_URL="$MODDABLE_URL" \
-  XSNAP_NATIVE_COMMIT_HASH="$XSNAP_NATIVE_COMMIT_HASH" \
-  XSNAP_NATIVE_URL="$XSNAP_NATIVE_URL" \
+  XSNAP_IS_IN_DOCKER=1 \
   yarn build
 
 # Remove dev dependencies.

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -25,8 +25,7 @@ docker-build: docker-build-sdk docker-build-solo \
 	docker-build-setup docker-build-ssh-node
 
 docker-build-sdk:
-	bargs=`node ../xsnap/src/build.js --show-env | sed -e 's/^/ --build-arg=/'`; \
-	docker build $$bargs --build-arg=GIT_REVISION=$(GIT_REVISION) \
+	docker build --build-arg=GIT_REVISION=$(GIT_REVISION) \
 		-t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
 	docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 

--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,0 @@
-MODDABLE_URL=https://github.com/agoric-labs/moddable.git
-MODDABLE_COMMIT_HASH=f6c5951fc055e4ca592b9166b9ae3cbb9cca6bf0
-XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
-XSNAP_NATIVE_COMMIT_HASH=2d8ccb76b8508e490d9e03972bb4c64f402d5135

--- a/packages/xsnap/build.json
+++ b/packages/xsnap/build.json
@@ -1,0 +1,10 @@
+{
+  "moddable": {
+    "url": "https://github.com/agoric-labs/moddable.git",
+    "hash": "f6c5951fc055e4ca592b9166b9ae3cbb9cca6bf0"
+  },
+  "xsnap_native": {
+    "url": "https://github.com/agoric-labs/xsnap-pub",
+    "hash": "2d8ccb76b8508e490d9e03972bb4c64f402d5135"
+  }
+}

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "repl": "node src/xsrepl.js",
-    "build": "touch doing.xsnap.build && node src/build.js",
-    "postinstall": "touch doing.xsnap.postinstall && yarn build",
+    "build": "node src/build.js",
+    "postinstall": "yarn build",
     "clean": "rm -rf xsnap-native/xsnap/build",
     "lint": "run-s --continue-on-error lint:*",
     "lint:js": "eslint 'src/**/*.js' 'test/**/*.js' api.js",

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -45,7 +45,7 @@
   "files": [
     "LICENSE*",
     "api.js",
-    "build.env",
+    "build.json",
     "src",
     "moddable/licenses",
     "moddable/readme.md",

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -12,11 +12,8 @@
   },
   "scripts": {
     "repl": "node src/xsrepl.js",
-    "build:bin": "if test -d ./test; then node src/build.js; else yarn build:from-env; fi",
-    "build:env": "test -d ./test && node src/build.js --show-env > build.env",
-    "build:from-env": "{ cat build.env; echo node src/build.js; } | xargs env",
-    "build": "yarn build:bin && yarn build:env",
-    "postinstall": "yarn build:from-env",
+    "build": "touch doing.xsnap.build && node src/build.js",
+    "postinstall": "touch doing.xsnap.postinstall && yarn build",
     "clean": "rm -rf xsnap-native/xsnap/build",
     "lint": "run-s --continue-on-error lint:*",
     "lint:js": "eslint 'src/**/*.js' 'test/**/*.js' api.js",
@@ -49,7 +46,19 @@
     "LICENSE*",
     "api.js",
     "build.env",
-    "src"
+    "src",
+    "moddable/licenses",
+    "moddable/readme.md",
+    "moddable/tools",
+    "moddable/xs",
+    "moddable/modules/data/text",
+    "moddable/modules/data/base64",
+    "xsnap-native/README.md",
+    "xsnap-native/xsnap/documentation",
+    "xsnap-native/xsnap/makefiles",
+    "xsnap-native/xsnap/readme.md",
+    "xsnap-native/xsnap/sources",
+    "xsnap-native/xsnap/xsbug-node"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -212,8 +212,8 @@ const readBuildJSON = async (envRecordFile, { fs }) => {
 };
 
 const writeBuildJSON = async (envRecordFile, build, { fs }) => {
-  const data = JSON.stringify(build, undefined, 2) + '\n';
-  await fs.writeFile(envRecordFile, data);
+  const data = JSON.stringify(build, undefined, 2);
+  await fs.writeFile(envRecordFile, `${data}\n`);
 };
 
 /**
@@ -223,9 +223,10 @@ const writeBuildJSON = async (envRecordFile, build, { fs }) => {
  *   stdout: typeof process.stdout,
  *   spawn: typeof import('child_process').spawn,
  *   fs: {
+ *     readFile: typeof import('fs').promises.readFile,
+ *     writeFile: typeof import('fs').promises.writeFile,
  *     existsSync: typeof import('fs').existsSync,
  *     rmdirSync: typeof import('fs').rmdirSync,
- *     readFile: typeof import('fs').promises.readFile,
  *   },
  *   os: {
  *     type: typeof import('os').type,
@@ -275,7 +276,7 @@ async function main(args, { env, spawn, fs, os }) {
           didGit = true;
           await submodule.update(); // requires git
         } else {
-          console.log(`${key} case C: have submodule/ but not .git : do nothing`);
+          console.log(`${key} case C: have submodule/, not .git : do nothing`);
         }
       } else {
         console.log(`${key} case A: no submodule/ directory : do init`);


### PR DESCRIPTION
Use presence/absence of submodule directories and their `.git` metadata to distinguish between an agoric-sdk clone and an unpacked NPM tarball. Use `git submodule update --init` in the first case, and leave the sources alone in the last case.

Still needs real tests, but manual testing passes.

refs #8536
