### PR TITLE
BridgeMessage types

### DIFF
--- a/packages/cosmic-swingset/src/types.d.ts
+++ b/packages/cosmic-swingset/src/types.d.ts
@@ -28,4 +28,16 @@ export type PleaseProvisionAction = {
   submitter: string;
 };
 
-export type BridgeMessage = CoreEvalAction | PleaseProvisionAction;
+/**
+ * @see VbankBalanceUpdate in vbank.go
+ */
+export type VbankBalanceUpdateAction = {
+  type: 'VBANK_BALANCE_UPDATE';
+  nonce: string;
+  updated: Array<{ address: string; denom: string; amount: string }>;
+};
+
+export type BridgeMessage =
+  | CoreEvalAction
+  | PleaseProvisionAction
+  | VbankBalanceUpdateAction;

--- a/packages/cosmic-swingset/src/types.d.ts
+++ b/packages/cosmic-swingset/src/types.d.ts
@@ -1,3 +1,4 @@
+import { QueuedActionType } from '@agoric/internal/src/action-types.js';
 import type {
   CoreEval,
   CoreEvalSDKType,
@@ -12,8 +13,19 @@ interface BlockInfo {
  * @see coreEvalAction in proposal.go
  */
 export type CoreEvalAction = BlockInfo & {
-  type: ActionTypes.CORE_EVAL;
+  type: 'CORE_EVAL';
   evals: CoreEvalSDKType[];
 };
 
-export type BridgeMessage = CoreEvalAction;
+/**
+ * @see provisionAction in msg_server.go
+ */
+export type PleaseProvisionAction = {
+  type: 'PLEASE_PROVISION';
+  address: string;
+  nickname: string;
+  powerFlags: PowerFlags.SMART_WALLET;
+  submitter: string;
+};
+
+export type BridgeMessage = CoreEvalAction | PleaseProvisionAction;

--- a/packages/cosmic-swingset/src/types.d.ts
+++ b/packages/cosmic-swingset/src/types.d.ts
@@ -1,0 +1,19 @@
+import type {
+  CoreEval,
+  CoreEvalSDKType,
+} from '@agoric/cosmic-proto/agoric/swingset/swingset.js';
+
+interface BlockInfo {
+  blockHeight: number;
+  blockTime: number;
+}
+
+/**
+ * @see coreEvalAction in proposal.go
+ */
+export type CoreEvalAction = BlockInfo & {
+  type: ActionTypes.CORE_EVAL;
+  evals: CoreEvalSDKType[];
+};
+
+export type BridgeMessage = CoreEvalAction;

--- a/packages/cosmic-swingset/src/types.d.ts
+++ b/packages/cosmic-swingset/src/types.d.ts
@@ -4,35 +4,41 @@ import type {
   CoreEvalSDKType,
 } from '@agoric/cosmic-proto/agoric/swingset/swingset.js';
 
-interface BlockInfo {
-  blockHeight: number;
-  blockTime: number;
+// TODO move `walletFlags.js` from @agoric/vats to @agoric/cosmic-proto
+type PowerFlag = 'SMART_WALLET' | 'REMOTE_WALLET';
+
+// NB: keep these manually synced until we build these types out of the Golang
+// structs or use some other shared type truth
+// https://github.com/Agoric/agoric-sdk/issues/8545
+
+interface ActionContext<T extends Uppercase<string>> {
+  type: T;
+  blockHeight: string;
+  blockTime: string;
 }
 
 /**
  * @see coreEvalAction in proposal.go
  */
-export type CoreEvalAction = BlockInfo & {
-  type: 'CORE_EVAL';
+export type CoreEvalAction = ActionContext<'CORE_EVAL'> & {
   evals: CoreEvalSDKType[];
 };
 
 /**
  * @see provisionAction in msg_server.go
  */
-export type PleaseProvisionAction = {
-  type: 'PLEASE_PROVISION';
+export type PleaseProvisionAction = ActionContext<'PLEASE_PROVISION'> & {
   address: string;
   nickname: string;
-  powerFlags: PowerFlags.SMART_WALLET;
+  powerFlags: PowerFlag[];
   submitter: string;
+  autoProvision: boolean;
 };
 
 /**
  * @see VbankBalanceUpdate in vbank.go
  */
-export type VbankBalanceUpdateAction = {
-  type: 'VBANK_BALANCE_UPDATE';
+export type VbankBalanceUpdateAction = ActionContext<'VBANK_BALANCE_UPDATE'> & {
   nonce: string;
   updated: Array<{ address: string; denom: string; amount: string }>;
 };

--- a/packages/cosmic-swingset/src/types.js
+++ b/packages/cosmic-swingset/src/types.js
@@ -1,0 +1,2 @@
+// Empty JS file to correspond with types.d.ts
+export {};

--- a/packages/cosmic-swingset/tsconfig.json
+++ b/packages/cosmic-swingset/tsconfig.json
@@ -1,6 +1,9 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  },
   "include": [
     "calc-*.js",
     "src/**/*.js",

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -23,6 +23,10 @@ import {
 import { InstanceHandleShape } from '@agoric/zoe/src/typeGuards.js';
 import { isUpgradeDisconnection } from '@agoric/internal/src/upgrade-api.js';
 
+/**
+ * @import {BridgeMessage} from '@agoric/cosmic-swingset/src/types.js';
+ */
+
 const trace = makeTracer('ProvPool');
 
 const FIRST_UPPER_KEYWORD = /^[A-Z][a-zA-Z0-9_$]*$/;
@@ -88,9 +92,10 @@ export const prepareBridgeProvisionTool = zone =>
       forHandler,
     }),
     {
+      /** @param {BridgeMessage} obj */
       async fromBridge(obj) {
-        obj.type === 'PLEASE_PROVISION' ||
-          Fail`Unrecognized request ${obj.type}`;
+        if (obj.type !== 'PLEASE_PROVISION')
+          throw Fail`Unrecognized request ${obj.type}`;
         trace('PLEASE_PROVISION', obj);
         const { address, powerFlags } = obj;
         powerFlags.includes(PowerFlags.SMART_WALLET) ||

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -98,6 +98,8 @@ export const prepareBridgeProvisionTool = zone =>
           throw Fail`Unrecognized request ${obj.type}`;
         trace('PLEASE_PROVISION', obj);
         const { address, powerFlags } = obj;
+        // XXX expects powerFlags to be an array, but if it's a string then
+        // this allows a string that has 'SMART_WALLET' in it.
         powerFlags.includes(PowerFlags.SMART_WALLET) ||
           Fail`missing SMART_WALLET in powerFlags`;
 

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -377,9 +377,12 @@ test('makeBridgeProvisionTool handles duplicate requests', async t => {
   t.log('1st request to provision a SMART_WALLET for', address);
   await handler.fromBridge({
     type: 'PLEASE_PROVISION',
+    blockHeight: '123',
+    blockTime: '1737432662',
     address,
+    autoProvision: true,
     nickname: 'test',
-    powerFlags: PowerFlags.SMART_WALLET,
+    powerFlags: [PowerFlags.SMART_WALLET],
     submitter: address,
   });
 
@@ -396,9 +399,12 @@ test('makeBridgeProvisionTool handles duplicate requests', async t => {
   t.log('2nd request to provision a SMART_WALLET for', address);
   await handler.fromBridge({
     type: 'PLEASE_PROVISION',
+    blockHeight: '123',
+    blockTime: '1737432662',
     address,
+    autoProvision: true,
     nickname: 'test',
-    powerFlags: PowerFlags.SMART_WALLET,
+    powerFlags: [PowerFlags.SMART_WALLET],
     submitter: address,
   });
   t.is(

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -378,7 +378,9 @@ test('makeBridgeProvisionTool handles duplicate requests', async t => {
   await handler.fromBridge({
     type: 'PLEASE_PROVISION',
     address,
+    nickname: 'test',
     powerFlags: PowerFlags.SMART_WALLET,
+    submitter: address,
   });
 
   t.deepEqual(
@@ -395,7 +397,9 @@ test('makeBridgeProvisionTool handles duplicate requests', async t => {
   await handler.fromBridge({
     type: 'PLEASE_PROVISION',
     address,
+    nickname: 'test',
     powerFlags: PowerFlags.SMART_WALLET,
+    submitter: address,
   });
   t.is(
     myDepositFacet,

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -20,6 +20,10 @@ import { BASIC_BOOTSTRAP_PERMITS } from './basic-behaviors.js';
 import { agoricNamesReserved, callProperties, extractPowers } from './utils.js';
 import { makeScopedBridge } from '../bridge.js';
 
+/**
+ * @import {BridgeMessage} from '@agoric/cosmic-swingset/src/types.js';
+ */
+
 const { keys } = Object;
 
 /**
@@ -57,10 +61,10 @@ export const bridgeCoreEval = async allPowers => {
 
   // Register a coreEval handler over the bridge.
   const handler = Far('coreHandler', {
+    /** @param {BridgeMessage} obj */
     async fromBridge(obj) {
       switch (obj.type) {
         case 'CORE_EVAL': {
-          /** @type {import('@agoric/cosmic-proto/swingset/swingset.js').CoreEvalProposalSDKType} */
           const { evals } = obj;
           return Promise.all(
             evals.map(({ json_permits: jsonPermit, js_code: code }) =>

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -155,6 +155,7 @@ export const bridgeProvisioner = async ({
   // Register a provisioning handler over the bridge.
   const handler = provisioning
     ? Far('provisioningHandler', {
+        /** @param {BridgeMessage} obj */
         async fromBridge(obj) {
           switch (obj.type) {
             case 'PLEASE_PROVISION': {

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -192,8 +192,7 @@ const prepareBankChannelHandler = zone =>
           case 'VBANK_BALANCE_UPDATE': {
             const { denomToAddressUpdater } = this.state;
             for (const update of obj.updated) {
-              // @ts-expect-error FIXME vbank.go says 'nonce' is on `obj`
-              const { address, denom, amount: value, nonce } = update;
+              const { address, denom, amount } = update;
               /** @type {BalanceUpdater | undefined} */
               let updater;
               try {
@@ -206,7 +205,7 @@ const prepareBankChannelHandler = zone =>
               }
               if (updater) {
                 try {
-                  updater.update(value, nonce);
+                  updater.update(amount, obj.nonce);
                 } catch (e) {
                   // ??? Is this an invariant that should complain louder?
 

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -24,7 +24,7 @@ import {
 /**
  * @import {Guarded} from '@endo/exo';
  * @import {Passable, RemotableObject} from '@endo/pass-style';
- * @import {VirtualPurseController} from './virtual-purse.js';
+ * @import {BridgeMessage} from '@agoric/cosmic-swingset/src/types.js';
  */
 
 const { VirtualPurseControllerI } = makeVirtualPurseKitIKit();
@@ -186,11 +186,13 @@ const prepareBankChannelHandler = zone =>
     /** @param {MapStore<string, MapStore<string, BalanceUpdater>>} denomToAddressUpdater */
     denomToAddressUpdater => ({ denomToAddressUpdater }),
     {
+      /** @param {BridgeMessage} obj */
       async fromBridge(obj) {
-        switch (obj && obj.type) {
+        switch (obj?.type) {
           case 'VBANK_BALANCE_UPDATE': {
             const { denomToAddressUpdater } = this.state;
             for (const update of obj.updated) {
+              // @ts-expect-error FIXME vbank.go says 'nonce' is on `obj`
               const { address, denom, amount: value, nonce } = update;
               /** @type {BalanceUpdater | undefined} */
               let updater;


### PR DESCRIPTION
_incidental_

## Description

Define a union type for for BridgeMessage that a `fromBridge` handler can narrow.

That revealed an inert bug in `nonce` handling which this also fixes.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

CI suffices

### Upgrade Considerations

technically affects runtime of vat-bank by correcting the `nonce` handling. But since that case isn't encountered in production I think it's okay to land this and let it be included in whatever future deployment in which that vat is upgraded. 