### PR TITLE
feat: postalSvc contract forwards payments using namesByAddress (prototype)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -82,7 +82,7 @@ in this branch. The release tags will be human-meaningful, the release branch ne
 ```sh
 # Create a release branch.
 now=`date -u +%Y%m%dT%H%M%S`
-git checkout -b release-$now
+git checkout -b prepare-release-$now
 ```
 
 - [ ] Do a `yarn install` to generate tooling needed for the release.

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -139,7 +139,6 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
       // TODO: Stop silently creating mailboxes.
       // https://github.com/Agoric/agoric-sdk/issues/5824
       const { inbound } = provideMailbox(name);
-      // @ts-expect-error bad typedef
       inbound.deliverMessages(newMessages);
     },
 
@@ -147,7 +146,6 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
       // TODO: Stop silently creating mailboxes.
       // https://github.com/Agoric/agoric-sdk/issues/5824
       const { inbound } = provideMailbox(name);
-      // @ts-expect-error bad typedef
       inbound.deliverAck(ack);
     },
   };

--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -6,6 +6,7 @@ import tmp from 'tmp';
 import { kunser } from '@agoric/kmarshal';
 import {
   initSwingStore,
+  openSwingStore,
   makeSwingStoreExporter,
   importSwingStore,
 } from '@agoric/swing-store';
@@ -36,7 +37,9 @@ test.before(async t => {
 
 test('state-sync reload', async t => {
   const [dbDir, cleanup] = await tmpDir('testdb');
+  const [importDbDir, cleanupImport] = await tmpDir('importtestdb');
   t.teardown(cleanup);
+  t.teardown(cleanupImport);
 
   const config = {
     snapshotInitial: 2,
@@ -106,7 +109,10 @@ test('state-sync reload', async t => {
     getArtifact: name => artifacts.get(name),
     close: () => 0,
   };
-  const ss2 = await importSwingStore(datasetExporter);
+  const ssi = await importSwingStore(datasetExporter, importDbDir);
+  await ssi.hostStorage.commit();
+  await ssi.hostStorage.close();
+  const ss2 = openSwingStore(importDbDir);
   const c2 = await makeSwingsetController(
     ss2.kernelStorage,
     {},

--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -113,6 +113,7 @@ test('state-sync reload', async t => {
   await ssi.hostStorage.commit();
   await ssi.hostStorage.close();
   const ss2 = openSwingStore(importDbDir);
+  t.teardown(ss2.hostStorage.close);
   const c2 = await makeSwingsetController(
     ss2.kernelStorage,
     {},

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -56,7 +56,7 @@ export const makeCourierMaker =
     transferProtocol,
   }) => {
     /** @type {Sender} */
-    const send = async (zcfSeat, depositAddress, memo) => {
+    const send = async (zcfSeat, depositAddress, memo, opts) => {
       const tryToSend = async () => {
         const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
         const transferPacket = await E(transferProtocol).makeTransferPacket({
@@ -64,6 +64,7 @@ export const makeCourierMaker =
           remoteDenom: sendDenom,
           depositAddress,
           memo,
+          opts,
         });
 
         // Retain the payment.  We must not proceed on failure.

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -17,9 +17,8 @@ import { assert, details as X, Fail } from '@agoric/assert';
 const ICS20_TRANSFER_SUCCESS_RESULT = 'AQ==';
 
 // ibc-go as late as v3 requires the `sender` to be nonempty, but doesn't
-// actually use it on the receiving side.  We don't need it on the sending side,
-// either, so we can just omit it.
-export const DUMMY_SENDER_ADDRESS = 'pegasus';
+// actually use it on the receiving side.
+export const DEFAULT_SENDER_ADDRESS = 'pegasus';
 
 /**
  * @param {string} s
@@ -51,7 +50,7 @@ const safeJSONParseObject = s => {
  */
 export const parseICS20TransferPacket = async packet => {
   const ics20Packet = safeJSONParseObject(packet);
-  const { amount, denom, receiver, memo } = ics20Packet;
+  const { amount, denom, receiver, memo, opts } = ics20Packet;
 
   assert.typeof(denom, 'string', X`Denom ${denom} must be a string`);
   assert.typeof(receiver, 'string', X`Receiver ${receiver} must be a string`);
@@ -74,6 +73,7 @@ export const parseICS20TransferPacket = async packet => {
     remoteDenom: denom,
     value,
     memo,
+    opts,
   });
 };
 
@@ -89,6 +89,7 @@ export const makeICS20TransferPacket = async ({
   remoteDenom,
   depositAddress,
   memo,
+  opts: { sender = DEFAULT_SENDER_ADDRESS },
 }) => {
   // We're using Nat as a dynamic check for overflow.
   const stringValue = String(Nat(value));
@@ -99,7 +100,7 @@ export const makeICS20TransferPacket = async ({
     amount: stringValue,
     denom: remoteDenom,
     receiver: depositAddress,
-    sender: DUMMY_SENDER_ADDRESS,
+    sender,
     memo,
   };
 

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -457,9 +457,10 @@ const makePegasus = (zcf, board, namesByAddress) => {
      * @param {ERef<Peg>} pegP the peg over which to transfer
      * @param {DepositAddress} depositAddress the remote receiver's address
      * @param {string} [memo] the memo to attach to ics transfer packet
+     * @param {SenderOptions} [opts] additional sender options
      * @returns {Promise<Invitation>} to transfer, make an offer of { give: { Transfer: pegAmount } } to this invitation
      */
-    async makeInvitationToTransfer(pegP, depositAddress, memo = '') {
+    async makeInvitationToTransfer(pegP, depositAddress, memo = '', opts = {}) {
       // Verify the peg.
       const peg = await pegP;
       const denomState = pegToDenomState.get(peg);
@@ -481,7 +482,7 @@ const makePegasus = (zcf, board, namesByAddress) => {
        */
       const offerHandler = zcfSeat => {
         assertProposalShape(zcfSeat, TRANSFER_PROPOSAL_SHAPE);
-        send(zcfSeat, depositAddress, memo);
+        send(zcfSeat, depositAddress, memo, opts);
       };
 
       return zcf.makeInvitation(offerHandler, `pegasus ${sendDenom} transfer`);

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -13,6 +13,7 @@
  * @property {Denom} remoteDenom
  * @property {DepositAddress} depositAddress
  * @property {string} memo
+ * @property {SenderOptions} opts
  */
 
 /**
@@ -47,7 +48,7 @@
  */
 
 /**
- * @typedef {(zcfSeat: ZCFSeat, depositAddress: DepositAddress, memo: string) => Promise<void>} Sender
+ * @typedef {(zcfSeat: ZCFSeat, depositAddress: DepositAddress, memo: string, opt: SenderOptions) => Promise<void>} Sender
  * Successive transfers are not guaranteed to be processed in the order in which they were sent.
  * @typedef {(parts: PacketParts) => Promise<Bytes>} Receiver
  * @typedef {object} Courier
@@ -110,4 +111,9 @@
  * @typedef {object} PegasusConnectionKit
  * @property {ConnectionHandler} handler
  * @property {Subscription<PegasusConnection>} subscription
+ */
+
+/**
+ * @typedef {object} SenderOptions
+ * @property {string} [sender] the sender address attached to the packet to receive any refund
  */

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -104,7 +104,7 @@ async function testRemotePeg(t) {
                   denom: 'portdef/chanabc/uatom',
                   memo: 'I am a memo!',
                   receiver: 'markaccount',
-                  sender: 'pegasus',
+                  sender: 'agoric1jmd7lwdyykrxm5h83nlhg74fctwnky04ufpqtc',
                 },
                 'expected transfer packet',
               );
@@ -247,6 +247,7 @@ async function testRemotePeg(t) {
     pegP,
     'markaccount',
     'I am a memo!',
+    { sender: 'agoric1jmd7lwdyykrxm5h83nlhg74fctwnky04ufpqtc' },
   );
   const seat = await E(zoe).offer(
     transferInvitation,

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -11,14 +11,16 @@ import { assertComplete } from './assertComplete.js';
  */
 
 /**
- * Function used to create a new swingStore from an object implementing the
+ * Function used to populate a swingStore from an object implementing the
  * exporter API. The exporter API may be provided by a swingStore instance, or
- * implemented by a host to restore data that was previously exported.
+ * implemented by a host to restore data that was previously exported. The
+ * returned swingStore is not suitable for execution, and thus only contains
+ * the host facet for committing the populated swingStore.
  *
  * @param {import('./exporter').SwingStoreExporter} exporter
  * @param {string | null} [dirPath]
  * @param {ImportSwingStoreOptions} [options]
- * @returns {Promise<import('./swingStore').SwingStore>}
+ * @returns {Promise<Pick<import('./swingStore').SwingStore, 'hostStorage' | 'debug'>>}
  */
 export async function importSwingStore(exporter, dirPath = null, options = {}) {
   if (dirPath && typeof dirPath !== 'string') {
@@ -27,11 +29,14 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   const { artifactMode = 'operational', ...makeSwingStoreOptions } = options;
   validateArtifactMode(artifactMode);
 
-  const store = makeSwingStore(dirPath, true, {
-    unsafeFastMode: true,
-    ...makeSwingStoreOptions,
-  });
-  const { kernelStorage, internal } = store;
+  const { hostStorage, kernelStorage, internal, debug } = makeSwingStore(
+    dirPath,
+    true,
+    {
+      unsafeFastMode: true,
+      ...makeSwingStoreOptions,
+    },
+  );
 
   // For every exportData entry, we add a DB record. 'kv' entries are
   // the "kvStore shadow table", and are not associated with any
@@ -124,5 +129,5 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   assertComplete(internal, checkMode);
 
   await exporter.close();
-  return store;
+  return { hostStorage, debug };
 }

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -27,7 +27,10 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   const { artifactMode = 'operational', ...makeSwingStoreOptions } = options;
   validateArtifactMode(artifactMode);
 
-  const store = makeSwingStore(dirPath, true, makeSwingStoreOptions);
+  const store = makeSwingStore(dirPath, true, {
+    unsafeFastMode: true,
+    ...makeSwingStoreOptions,
+  });
   const { kernelStorage, internal } = store;
 
   // For every exportData entry, we add a DB record. 'kv' entries are

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -203,9 +203,29 @@ export function makeSwingStore(dirPath, forceReset, options = {}) {
   // mode that defers merge work for a later attempt rather than block any
   // potential readers or writers. See https://sqlite.org/wal.html for details.
 
+  // However we also allow opening the DB with journaling off, which is unsafe
+  // and doesn't support rollback, but avoids any overhead for large
+  // transactions like for during an import.
+
+  function setUnsafeFastMode(enabled) {
+    const journalMode = enabled ? 'off' : 'wal';
+    const synchronousMode = enabled ? 'normal' : 'full';
+    !db.inTransaction || Fail`must not be in a transaction`;
+
+    db.unsafeMode(!!enabled);
+    // The WAL mode is persistent so it's not possible to switch to a different
+    // mode for an existing DB.
+    const actualMode = db.pragma(`journal_mode=${journalMode}`, {
+      simple: true,
+    });
+    actualMode === journalMode ||
+      filePath === ':memory:' ||
+      Fail`Couldn't set swing-store DB to ${journalMode} mode (is ${actualMode})`;
+    db.pragma(`synchronous=${synchronousMode}`);
+  }
+
   // PRAGMAs have to happen outside a transaction
-  db.exec(`PRAGMA journal_mode=WAL`);
-  db.exec(`PRAGMA synchronous=FULL`);
+  setUnsafeFastMode(options.unsafeFastMode);
 
   // We use IMMEDIATE because the kernel is supposed to be the sole writer of
   // the DB, and if some other process is holding a write lock, we want to find
@@ -481,7 +501,11 @@ export function makeSwingStore(dirPath, forceReset, options = {}) {
   }
 
   /** @type {import('./internal.js').SwingStoreInternal} */
-  const internal = harden({ snapStore, transcriptStore, bundleStore });
+  const internal = harden({
+    snapStore,
+    transcriptStore,
+    bundleStore,
+  });
 
   async function repairMetadata(exporter) {
     return doRepairMetadata(internal, exporter);

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -118,7 +118,11 @@ test('b0 import', async t => {
     },
     close: async () => undefined,
   };
-  const { kernelStorage } = await importSwingStore(exporter);
+  const ss = await importSwingStore(exporter);
+  t.teardown(ss.hostStorage.close);
+  await ss.hostStorage.commit();
+  const serialized = ss.debug.serialize();
+  const { kernelStorage } = initSwingStore(null, { serialized });
   const { bundleStore } = kernelStorage;
   t.truthy(bundleStore.hasBundle(idA));
   t.deepEqual(bundleStore.getBundle(idA), b0A);

--- a/packages/swing-store/test/test-exportImport.js
+++ b/packages/swing-store/test/test-exportImport.js
@@ -322,6 +322,7 @@ async function testExportImport(
   }
   t.is(failureMode, 'none');
   const ssIn = await doImport();
+  t.teardown(ssIn.hostStorage.close);
   await ssIn.hostStorage.commit();
   let dumpsShouldMatch = true;
   if (runMode === 'operational') {

--- a/packages/swing-store/test/test-import.js
+++ b/packages/swing-store/test/test-import.js
@@ -46,6 +46,7 @@ test('import empty', async t => {
   t.teardown(cleanup);
   const exporter = makeExporter(new Map(), new Map());
   const ss = await importSwingStore(exporter, dbDir);
+  t.teardown(ss.hostStorage.close);
   await ss.hostStorage.commit();
   const data = convert(ss.debug.dump());
   t.deepEqual(data, {
@@ -69,6 +70,7 @@ const importTest = test.macro(async (t, mode) => {
 
   // now import
   const ss = await importSwingStore(exporter, dbDir, { artifactMode });
+  t.teardown(ss.hostStorage.close);
   await ss.hostStorage.commit();
   const data = convert(ss.debug.dump());
 

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -13,6 +13,7 @@ import type {
   WeakMapStore,
   WeakSetStore,
 } from '@agoric/store';
+import type { makeWatchedPromiseManager } from './watchedPromises.js';
 
 // TODO should be moved into @endo/patterns and eventually imported here
 // instead of this local definition.
@@ -24,6 +25,8 @@ export type { MapStore, Pattern };
 // would need explicit runtime checks or casts for every fetch, which is
 // onerous.
 export type Baggage = MapStore<string, any>;
+
+type WatchedPromisesManager = ReturnType<typeof makeWatchedPromiseManager>;
 
 type Tail<T extends any[]> = T extends [head: any, ...rest: infer Rest]
   ? Rest
@@ -169,8 +172,8 @@ export type VatData = {
     options?: DefineKindOptions<MultiKindContext<S, B>>,
   ) => (...args: P) => KindFacets<B>;
 
-  providePromiseWatcher: unknown;
-  watchPromise: unknown;
+  providePromiseWatcher: WatchedPromisesManager['providePromiseWatcher'];
+  watchPromise: WatchedPromisesManager['watchPromise'];
 
   makeScalarBigMapStore: <K, V>(
     label: string,

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -32,13 +32,14 @@ type Tail<T extends any[]> = T extends [head: any, ...rest: infer Rest]
   ? Rest
   : [];
 
-type MinusContext<
-  F extends (context, ...rest: any[]) => any,
-  P extends any[] = Parameters<F>, // P: are the parameters of F
-  R = ReturnType<F>, // R: the return type of F
-> = (...args: Tail<P>) => R;
+// used to omit the 'context' parameter
+type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R
+  ? (...args: P) => R
+  : never;
 
-export type KindFacet<O> = { [K in keyof O]: MinusContext<O[K]> };
+export type KindFacet<O> = {
+  [K in keyof O]: OmitFirstArg<O[K]>; // omit the 'context' parameter
+};
 
 export type KindFacets<B> = {
   [FacetKey in keyof B]: KindFacet<B[FacetKey]>;

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -1124,6 +1124,7 @@ export const makeVirtualObjectManager = (
     return id;
   };
 
+  /** @type {import('./vatDataTypes').VatData['defineKind']} */
   const defineKind = (tag, init, behavior, options) => {
     const kindID = `${allocateExportID()}`;
     saveVirtualKindDescriptor(kindID, { kindID, tag });
@@ -1139,6 +1140,7 @@ export const makeVirtualObjectManager = (
     );
   };
 
+  /** @type {import('./vatDataTypes').VatData['defineKindMulti']} */
   const defineKindMulti = (tag, init, behavior, options) => {
     const kindID = `${allocateExportID()}`;
     saveVirtualKindDescriptor(kindID, { kindID, tag });
@@ -1178,6 +1180,7 @@ export const makeVirtualObjectManager = (
     return kindHandle;
   };
 
+  /** @type {import('./vatDataTypes').VatData['defineDurableKind']} */
   const defineDurableKind = (kindHandle, init, behavior, options) => {
     kindHandleToID.has(kindHandle) || Fail`unknown handle ${kindHandle}`;
     const kindID = kindHandleToID.get(kindHandle);
@@ -1200,6 +1203,7 @@ export const makeVirtualObjectManager = (
     return maker;
   };
 
+  /** @type {import('./vatDataTypes').VatData['defineDurableKindMulti']} */
   const defineDurableKindMulti = (kindHandle, init, behavior, options) => {
     kindHandleToID.has(kindHandle) || Fail`unknown handle ${kindHandle}`;
     const kindID = kindHandleToID.get(kindHandle);

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -322,7 +322,7 @@ const insistSameCapData = (oldCD, newCD) => {
  * recursion if our returned WeakMap/WeakSet wrappers are subsequently installed
  * on globalThis.
  *
- * @returns {object} a new virtual object manager.
+ * @returns a new virtual object manager.
  *
  * The virtual object manager allows the creation of persistent objects that do
  * not need to occupy memory when they are not in use.  It provides five

--- a/packages/swingset-liveslots/src/watchedPromises.js
+++ b/packages/swingset-liveslots/src/watchedPromises.js
@@ -147,6 +147,12 @@ export function makeWatchedPromiseManager({
     }
   }
 
+  /**
+   *
+   * @param {Promise} p
+   * @param {{onFulfilled?: Function, onRejected?: Function}} watcher
+   * @param  {...any} args
+   */
   function watchPromise(p, watcher, ...args) {
     // The following wrapping defers setting up the promise watcher itself to a
     // later turn so that if the promise to be watched was the return value from

--- a/packages/swingset-liveslots/test/test-durabilityChecks.js
+++ b/packages/swingset-liveslots/test/test-durabilityChecks.js
@@ -15,6 +15,7 @@ async function runDurabilityCheckTest(t, relaxDurabilityRules) {
 
   const durableHolderKind = makeKindHandle('holder');
 
+  /** @param {any} held */
   const initHolder = (held = null) => ({ held });
   const holderBehavior = {
     hold: ({ state }, value) => {

--- a/packages/swingset-liveslots/tools/setup-vat-data.js
+++ b/packages/swingset-liveslots/tools/setup-vat-data.js
@@ -16,7 +16,7 @@ globalThis.VatData = harden({
   defineDurableKind: (...args) => fakeVomKit.vom.defineDurableKind(...args),
   defineDurableKindMulti: (...args) =>
     fakeVomKit.vom.defineDurableKindMulti(...args),
-  makeKindHandle: (...args) => fakeVomKit.vom.makeKindHandle(...args),
+  makeKindHandle: tag => fakeVomKit.vom.makeKindHandle(tag),
   canBeDurable: (...args) => fakeVomKit.vom.canBeDurable(...args),
   providePromiseWatcher: (...args) =>
     fakeVomKit.wpm.providePromiseWatcher(...args),
@@ -48,7 +48,9 @@ export const reincarnate = (options = {}) => {
     WeakSet,
   });
 
+  // @ts-expect-error toStringTag set imperatively so it doesn't show up in the type
   globalThis.WeakMap = fakeVomKit.vom.VirtualObjectAwareWeakMap;
+  // @ts-expect-error ditto
   globalThis.WeakSet = fakeVomKit.vom.VirtualObjectAwareWeakSet;
 
   return { ...options, fakeStore, fakeVomKit };

--- a/packages/swingset-liveslots/tools/setup-vat-data.js
+++ b/packages/swingset-liveslots/tools/setup-vat-data.js
@@ -11,10 +11,14 @@ const { WeakMap, WeakSet } = globalThis;
 let fakeVomKit;
 
 globalThis.VatData = harden({
+  // @ts-expect-error spread argument for non-rest parameter
   defineKind: (...args) => fakeVomKit.vom.defineKind(...args),
+  // @ts-expect-error spread argument for non-rest parameter
   defineKindMulti: (...args) => fakeVomKit.vom.defineKindMulti(...args),
+  // @ts-expect-error spread argument for non-rest parameter
   defineDurableKind: (...args) => fakeVomKit.vom.defineDurableKind(...args),
   defineDurableKindMulti: (...args) =>
+    // @ts-expect-error spread argument for non-rest parameter
     fakeVomKit.vom.defineDurableKindMulti(...args),
   makeKindHandle: tag => fakeVomKit.vom.makeKindHandle(tag),
   canBeDurable: (...args) => fakeVomKit.vom.canBeDurable(...args),

--- a/packages/swingset-liveslots/tools/setup-vat-data.js
+++ b/packages/swingset-liveslots/tools/setup-vat-data.js
@@ -20,7 +20,8 @@ globalThis.VatData = harden({
   canBeDurable: (...args) => fakeVomKit.vom.canBeDurable(...args),
   providePromiseWatcher: (...args) =>
     fakeVomKit.wpm.providePromiseWatcher(...args),
-  watchPromise: (...args) => fakeVomKit.wpm.watchPromise(...args),
+  watchPromise: (p, watcher, ...args) =>
+    fakeVomKit.wpm.watchPromise(p, watcher, ...args),
   makeScalarBigMapStore: (...args) =>
     fakeVomKit.cm.makeScalarBigMapStore(...args),
   makeScalarBigWeakMapStore: (...args) =>

--- a/packages/vat-data/src/index.test-d.ts
+++ b/packages/vat-data/src/index.test-d.ts
@@ -6,6 +6,7 @@ import type {
   KindFacet,
   FunctionsPlusContext,
 } from '@agoric/swingset-liveslots';
+import { VirtualObjectManager } from '@agoric/swingset-liveslots/src/virtualObjectManager.js';
 import {
   defineKind,
   defineKindMulti,
@@ -13,6 +14,9 @@ import {
   defineDurableKind,
   partialAssign,
 } from '.';
+
+// for use in assignments below
+const anyVal = null as any;
 
 /*
 export const makePaymentMaker = (allegedName: string, brand: unknown) => {
@@ -154,7 +158,13 @@ const someBehavior: FunctionsPlusContext<SomeContext, SomeFacet> = {
     return b > context.state.a;
   },
 };
-const someFacet: KindFacet<typeof someBehavior> = null as any;
+const someFacet: KindFacet<typeof someBehavior> = anyVal;
 // @ts-expect-error
 someFacet.gt();
 expectType<boolean>(someFacet.gt(1));
+
+const vom: VirtualObjectManager = anyVal;
+// @ts-expect-error
+vom.missingMethod;
+// @ts-expect-error Expected 0-4 arguments but got 5
+vom.defineDurableKind(anyVal, anyVal, anyVal, anyVal, 'extra');

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@endo/init": "^0.5.59",
     "@agoric/kmarshal": "^0.1.0",
+    "@agoric/vats": "^0.15.1",
     "ava": "^5.3.0",
     "c8": "^7.13.0",
     "import-meta-resolve": "^2.2.1",

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -8,6 +8,7 @@ import { OfferHandlerI, TimerShape } from '../../typeGuards';
 /**
  * @typedef {object} GiMiXTerms
  * @property {import('@agoric/vats').NameHub} namesByAddress
+ * @property {import('@agoric/time/src/types').TimerService} timer
  */
 
 const JobReportProposalShape = M.splitRecord({
@@ -26,6 +27,7 @@ const JobsReportContinuingIKit = {
   invitationMakers: M.interface('JobReportInvitationMaker', {
     JobReport: M.call().returns(M.any()),
   }),
+  kitMustHaveMultipleFacets: M.interface('Stub', {}),
 };
 
 const GimixContractFacetsIKit = harden({
@@ -69,6 +71,7 @@ export const prepare = async (zcf, _privateArgs, baggage) => {
           return makeJobReportInvitation();
         },
       },
+      kitMustHaveMultipleFacets: {},
     },
   );
 

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -7,7 +7,7 @@ import {
   provideDurableMapStore,
 } from '@agoric/vat-data';
 import { AmountMath, AmountShape } from '@agoric/ertp';
-import { OfferHandlerI } from '../../typeGuards';
+import { OfferHandlerI } from '../../typeGuards.js';
 import {
   DeliverProposalShape,
   JobReportProposalShape,

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -1,0 +1,113 @@
+// @ts-nocheck
+/* eslint-disable no-unused-vars */
+import { prepareExoClass } from '@agoric/vat-data';
+import { M } from '@endo/patterns';
+import { OfferHandlerI } from '../../typeGuards';
+
+/**
+ * @typedef {object} GiMiXTerms
+ * @property {import('@agoric/vats').NameHub} namesByAddress
+ */
+
+const JobReportProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: { onDemand: undefined },
+});
+
+const OracleInvitationProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: { onDemand: undefined },
+});
+
+const WorkAgreementProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: { onDemand: undefined },
+});
+
+/**
+ * @param {ZCF<GiMiXTerms>} zcf
+ */
+export const prepare = async (zcf, _privateArgs, baggage) => {
+  const { namesByAddress } = zcf.getTerms();
+
+  const makeJobReportInvitationHandler = prepareExoClass(
+    baggage,
+    'JobReportHandler',
+    OfferHandlerI,
+    () => ({}),
+    {
+      handle(seat) {
+        const { self, state } = this;
+        return 'something';
+      },
+    },
+  );
+
+  const makeOracleInvitationHandler = prepareExoClass(
+    baggage,
+    'OracleInvitationHandler',
+    OfferHandlerI,
+    () => ({}),
+    {
+      handle(seat) {
+        const { self, state } = this;
+        const jobReportInvitationMaker = makeJobReportInvitationHandler();
+        return jobReportInvitationMaker;
+      },
+    },
+  );
+
+  const makeWorkAgreementInvitationHandler = prepareExoClass(
+    baggage,
+    'WorkAgreementHandler',
+    OfferHandlerI,
+    () => ({}),
+    {
+      handle(seat) {
+        const { self, state } = this;
+        const jobId = 'placeholder42';
+        return jobId;
+      },
+    },
+  );
+
+  const makeJobReportInvitation = () => {
+    const jobReportInvitationHandler = makeJobReportInvitationHandler();
+
+    const jobReportInvitationP = zcf.makeInvitation(
+      jobReportInvitationHandler,
+      'gimix job report',
+      undefined,
+      JobReportProposalShape,
+    );
+    return jobReportInvitationP;
+  };
+
+  const makeOracleInvitation = () => {
+    const oracleInvitationHandler = makeOracleInvitationHandler();
+
+    const oracleInvitationP = zcf.makeInvitation(
+      oracleInvitationHandler,
+      'gimix oracle invitation',
+      undefined,
+      OracleInvitationProposalShape,
+    );
+    return oracleInvitationP;
+  };
+
+  const makeWorkAgreementInvitation = () => {
+    const workAgreementInvitationHandler = makeWorkAgreementInvitationHandler();
+
+    const workAgreementP = zcf.makeInvitation(
+      workAgreementInvitationHandler,
+      'gimix work agreement',
+      undefined,
+      WorkAgreementProposalShape,
+    );
+    return workAgreementP;
+  };
+};
+harden(prepare);

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -23,8 +23,7 @@ const { details: X, Fail, quote: q } = assert;
 
 /**
  * @typedef {object} GiMiXTerms
- * @property {import('@agoric/vats').NameHub} namesByAddress
- * @property {import('@agoric/time/src/types').TimerService} timer
+ * @property {Instance} postalService
  */
 
 /**
@@ -33,7 +32,9 @@ const { details: X, Fail, quote: q } = assert;
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const prepare = async (zcf, _privateArgs, baggage) => {
-  const { namesByAddress } = zcf.getTerms();
+  const { postalService } = zcf.getTerms();
+  const zoe = zcf.getZoeService();
+  const postHub = E(zoe).getPublicFacet(postalService);
 
   const workByJob = provideDurableMapStore(
     baggage,
@@ -130,7 +131,7 @@ export const prepare = async (zcf, _privateArgs, baggage) => {
         } = this;
         const { deliverDepositAddr, jobID, issueURL } = report;
 
-        const depositFacetP = E(namesByAddress).lookup(
+        const depositFacetP = E(postHub).lookup(
           deliverDepositAddr,
           'depositFacet',
         );

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -29,6 +29,8 @@ const { details: X, Fail, quote: q } = assert;
 
 /**
  * @param {ZCF<GiMiXTerms>} zcf
+ * @param {unknown} _privateArgs
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const prepare = async (zcf, _privateArgs, baggage) => {
   const { namesByAddress } = zcf.getTerms();

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -128,7 +128,10 @@ export const prepare = async (zcf, _privateArgs, baggage) => {
         } = this;
         const { deliverDepositAddr, jobID, issueURL } = report;
 
-        const depositFacetP = E(namesByAddress).lookup(deliverDepositAddr);
+        const depositFacetP = E(namesByAddress).lookup(
+          deliverDepositAddr,
+          'depositFacet',
+        );
         workByJob.has(jobID) || Fail`Gimix job ${q(jobID)} not found`;
         const {
           issueURL: expectedIssueURL,

--- a/packages/zoe/src/contracts/gimix/gimix.js
+++ b/packages/zoe/src/contracts/gimix/gimix.js
@@ -142,7 +142,7 @@ export const prepare = async (zcf, _privateArgs, baggage) => {
           Fail`Gimix job ${q(jobID)} expected issue ${q(
             expectedIssueURL,
           )} not ${q(issueURL)}`;
-        const deliverInvitation = zcf.makeInvitation(
+        const deliverInvitationP = zcf.makeInvitation(
           makeDeliverHandler(requestorSeat, acceptanceAmount, report),
           'gimix delivery',
           {
@@ -151,7 +151,7 @@ export const prepare = async (zcf, _privateArgs, baggage) => {
           },
           DeliverProposalShape,
         );
-        return E(depositFacetP).receive(deliverInvitation);
+        return deliverInvitationP.then(pmt => E(depositFacetP).receive(pmt));
       },
     },
     harden({

--- a/packages/zoe/src/contracts/gimix/postalSvc.js
+++ b/packages/zoe/src/contracts/gimix/postalSvc.js
@@ -1,0 +1,61 @@
+// @ts-check
+import { E, Far } from '@endo/far';
+import { withdrawFromSeat } from '../../contractSupport/zoeHelpers.js';
+
+const { keys, values } = Object;
+
+/**
+ * @typedef {object} PostalSvcTerms
+ * @property {import('@agoric/vats').NameHub} namesByAddress
+ */
+
+/** @param {ZCF<PostalSvcTerms>} zcf */
+export const start = zcf => {
+  const { namesByAddress, issuers } = zcf.getTerms();
+  console.log('postalSvc issuers', Object.keys(issuers));
+
+  /**
+   * @param {string} addr
+   * @returns {ERef<DepositFacet>}
+   */
+  const getDepositFacet = addr => {
+    assert.typeof(addr, 'string');
+    return E(namesByAddress).lookup(addr, 'depositFacet');
+  };
+
+  /**
+   * @param {string} addr
+   * @param {Payment} pmt
+   */
+  const sendTo = (addr, pmt) => E(getDepositFacet(addr)).receive(pmt);
+
+  /** @param {string} recipient */
+  const makeSendInvitation = recipient => {
+    assert.typeof(recipient, 'string');
+
+    /** @type {OfferHandler} */
+    const handleSend = async seat => {
+      const { give } = seat.getProposal();
+      const depositFacet = await getDepositFacet(recipient);
+      const payouts = await withdrawFromSeat(zcf, seat, give);
+
+      // XXX partial failure? return payments?
+      await Promise.all(
+        values(payouts).map(pmtP =>
+          Promise.resolve(pmtP).then(pmt => E(depositFacet).receive(pmt)),
+        ),
+      );
+      return `sent ${keys(payouts).join(', ')}`;
+    };
+
+    return zcf.makeInvitation(handleSend, 'send');
+  };
+
+  const publicFacet = Far('postalSvc', {
+    lookup: (...path) => E(namesByAddress).lookup(...path),
+    getDepositFacet,
+    sendTo,
+    makeSendInvitation,
+  });
+  return { publicFacet };
+};

--- a/packages/zoe/src/contracts/gimix/start-gimix.js
+++ b/packages/zoe/src/contracts/gimix/start-gimix.js
@@ -72,8 +72,8 @@ export const startGiMiX = async (powers, config = {}) => {
     },
   } = powers;
   const {
-    bundleID = fail('GiMiX bundleID not provided'),
-    oracleAddress = fail('GiMiX oracleAddress not provided'),
+    bundleID = fail('no bundleID; try test-gimix-proposal.js?'),
+    oracleAddress = fail('no oracleAddress; try test-gimix-proposal.js?'),
   } = config.options?.GiMiX ?? {};
 
   const timerId = await E(board).getId(await chainTimerService);

--- a/packages/zoe/src/contracts/gimix/start-gimix.js
+++ b/packages/zoe/src/contracts/gimix/start-gimix.js
@@ -1,0 +1,97 @@
+/**
+ * @file core eval script* to start the GIMiX contract.
+ *
+ * * to turn this module into a script:
+ *   - remove `import` declarations entirely
+ *   - remove `export` keyword from declarations
+ *
+ * The `permit` export specifies the corresponding permit.
+ */
+// @ts-check
+
+import { E } from '@endo/far';
+
+const trace = (...args) => console.log('start-gimix', ...args);
+
+const fail = msg => {
+  throw Error(msg);
+};
+
+/**
+ * @param {BootstrapPowers} powers
+ * @param {{ options?: { GiMiX: {
+ *   bundleID: string;
+ *   oracleAddress: string;
+ * }}}} config
+ */
+export const startGiMiX = async (powers, config = {}) => {
+  const {
+    consume: { agoricNames, board, chainTimerService, namesByAddress, zoe },
+    instance: {
+      // @ts-expect-error going beyond WellKnownName
+      produce: { GiMiX: produceInstance },
+    },
+    issuer: {
+      // @ts-expect-error going beyond WellKnownName
+      produce: { GimixOracle: produceIssuer },
+    },
+    brand: {
+      // @ts-expect-error going beyond WellKnownName
+      produce: { GimixOracle: produceBrand },
+    },
+  } = powers;
+  const {
+    bundleID = fail('GiMiX bundleID not provided'),
+    oracleAddress = fail('GiMiX oracleAddress not provided'),
+  } = config.options?.GiMiX ?? {};
+
+  const timerId = await E(board).getId(await chainTimerService);
+  trace('timer', timerId);
+
+  /** @type {Installation<import('./gimix').prepare>} */
+  const installation = await E(zoe).installBundleID(bundleID);
+
+  const { creatorFacet, instance: gimixInstance } = await E(zoe).startInstance(
+    installation,
+    { Stable: await E(agoricNames).lookup('issuer', 'IST') },
+    { namesByAddress: await namesByAddress, timer: await chainTimerService },
+  );
+  const { brands, issuers } = await E(zoe).getTerms(gimixInstance);
+
+  const oracleInvitation = await E(creatorFacet).makeOracleInvitation();
+  const oracleDepositFacet = await E(namesByAddress).lookup(
+    oracleAddress,
+    'depositFacet',
+  );
+  await E(oracleDepositFacet).receive(oracleInvitation);
+
+  produceInstance.resolve(gimixInstance);
+  produceIssuer.resolve(issuers.GimixOracle);
+  produceBrand.resolve(brands.GimixOracle);
+};
+
+export const manifest = /** @type {const} */ ({
+  [startGiMiX.name]: {
+    consume: {
+      agoricNames: true,
+      board: true,
+      chainTimerService: true,
+      namesByAddress: true,
+      zoe: true,
+    },
+    instance: {
+      produce: { GiMiX: true },
+    },
+    issuer: {
+      produce: { GimixOracle: true },
+    },
+    brand: {
+      produce: { GimixOracle: true },
+    },
+  },
+});
+
+export const permit = JSON.stringify(Object.values(manifest)[0]);
+
+// script completion value
+startGiMiX;

--- a/packages/zoe/src/contracts/gimix/start-postalSvc.js
+++ b/packages/zoe/src/contracts/gimix/start-postalSvc.js
@@ -1,0 +1,106 @@
+/**
+ * @file core eval script* to start the postalSvc contract.
+ *
+ * * see test-gimix-proposal.js to make a script from this file.
+ *
+ * The `permit` export specifies the corresponding permit.
+ */
+// @ts-check
+
+import { E, Far } from '@endo/far';
+
+const { Fail } = assert;
+
+const trace = (...args) => console.log('start-postalSvc', ...args);
+
+const fail = msg => {
+  throw Error(msg);
+};
+
+/**
+ * ref https://github.com/Agoric/agoric-sdk/issues/8408#issuecomment-1741445458
+ *
+ * @param {ERef<import('@agoric/vats').NameAdmin>} namesByAddressAdmin
+ */
+const fixHub = async namesByAddressAdmin => {
+  /** @type {import('@agoric/vats').NameHub} */
+  const hub = Far('Hub work-around', {
+    lookup: async (addr, ...rest) => {
+      await E(namesByAddressAdmin).reserve(addr);
+      const addressAdmin = await E(namesByAddressAdmin).lookupAdmin(addr);
+      assert(addressAdmin, 'no admin???');
+      const addressHub = E(addressAdmin).readonly();
+      if (rest.length === 0) return addressHub;
+      await E(addressAdmin).reserve(rest[0]);
+      return E(addressHub).lookup(...rest);
+    },
+    has: _key => Fail`key space not well defined`,
+    entries: () => Fail`enumeration not supported`,
+    values: () => Fail`enumeration not supported`,
+    keys: () => Fail`enumeration not supported`,
+  });
+  return hub;
+};
+
+/**
+ * @param {BootstrapPowers} powers
+ * @param {{ options?: { postalSvc: {
+ *   bundleID: string;
+ * }}}} config
+ */
+export const startPostalSvc = async (powers, config) => {
+  const {
+    consume: { zoe, namesByAddressAdmin },
+    installation: {
+      // @ts-expect-error not statically known at genesis
+      produce: { postalSvc: produceInstallation },
+    },
+    instance: {
+      // @ts-expect-error not statically known at genesis
+      produce: { postalSvc: produceInstance },
+    },
+  } = powers;
+  const { bundleID = fail(`no bundleID; try test-gimix-proposal.js?`) } =
+    config.options?.postalSvc ?? {};
+
+  /** @type {Installation<import('./postalSvc').start>} */
+  const installation = await E(zoe).installBundleID(bundleID);
+  produceInstallation.resolve(installation);
+
+  const namesByAddress = await fixHub(namesByAddressAdmin);
+
+  const [IST, Invitation] = await Promise.all([
+    E(zoe).getFeeIssuer(),
+    E(zoe).getInvitationIssuer(),
+  ]);
+  const { instance } = await E(zoe).startInstance(
+    installation,
+    { IST, Invitation },
+    { namesByAddress },
+  );
+  produceInstance.resolve(instance);
+
+  trace('postalSvc started');
+};
+
+export const manifest = /** @type {const} */ ({
+  [startPostalSvc.name]: {
+    consume: {
+      agoricNames: true,
+      namesByAddress: true,
+      namesByAddressAdmin: true,
+      zoe: true,
+    },
+    installation: {
+      produce: { postalSvc: true },
+    },
+    instance: {
+      produce: { postalSvc: true },
+    },
+  },
+});
+
+export const permit = JSON.stringify(Object.values(manifest)[0]);
+
+// script completion value
+startPostalSvc;

--- a/packages/zoe/src/contracts/gimix/typeGuards.js
+++ b/packages/zoe/src/contracts/gimix/typeGuards.js
@@ -1,0 +1,62 @@
+import { M, makeCopyBag } from '@endo/patterns';
+import { AmountShape } from '@agoric/ertp';
+import { TimestampShape } from '@agoric/time';
+import { TimerShape } from '../../typeGuards';
+
+export const DeliverProposalShape = M.splitRecord({
+  give: {},
+  want: { Acceptance: AmountShape },
+  exit: { onDemand: null },
+});
+
+export const JobReportProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: { onDemand: null },
+});
+
+export const OracleInvitationProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: { onDemand: null },
+});
+
+export const makeWorkAgreementProposalShape = (oracleBrand, issueURL) =>
+  M.splitRecord({
+    give: { Acceptance: AmountShape },
+    want: {
+      Stamp: {
+        brand: oracleBrand,
+        value: makeCopyBag([[`Fixed ${issueURL}`, 1n]]),
+      },
+    },
+    exit: {
+      afterDeadline: {
+        timer: M.eref(TimerShape),
+        deadline: TimestampShape,
+      },
+    },
+  });
+
+export const ReportShape = harden({
+  deliverDepositAddr: M.string(),
+  jobID: M.nat(),
+  issueURL: M.string(),
+  prURL: M.string(),
+});
+
+export const JobsReportContinuingIKit = {
+  invitationMakers: M.interface('JobReportInvitationMaker', {
+    JobReport: M.call(ReportShape).returns(M.any()),
+  }),
+  kitMustHaveMultipleFacets: M.interface('Stub', {}),
+};
+
+export const GimixContractFacetsIKit = harden({
+  creatorFacet: M.interface('GimixCreatorFacetKit', {
+    makeOracleInvitation: M.call().returns(M.any()),
+  }),
+  publicFacet: M.interface('GimixPublicFacet', {
+    makeWorkAgreementInvitation: M.call(M.string()).returns(M.any()),
+  }),
+});

--- a/packages/zoe/src/contracts/gimix/typeGuards.js
+++ b/packages/zoe/src/contracts/gimix/typeGuards.js
@@ -1,7 +1,7 @@
 import { M, makeCopyBag } from '@endo/patterns';
 import { AmountShape } from '@agoric/ertp';
 import { TimestampShape } from '@agoric/time';
-import { TimerShape } from '../../typeGuards';
+import { TimerShape } from '../../typeGuards.js';
 
 export const DeliverProposalShape = M.splitRecord({
   give: {},

--- a/packages/zoe/src/contracts/gimix/typeGuards.js
+++ b/packages/zoe/src/contracts/gimix/typeGuards.js
@@ -21,14 +21,17 @@ export const OracleInvitationProposalShape = M.splitRecord({
   exit: { onDemand: null },
 });
 
-export const makeWorkAgreementProposalShape = (oracleBrand, issueURL) =>
+export const makeStampAmount = (oracleBrand, issueURL) =>
+  harden({
+    brand: oracleBrand,
+    value: makeCopyBag([[`Fixed ${issueURL}`, 1n]]),
+  });
+
+export const makeWorkAgreementProposalShape = stampAmount =>
   M.splitRecord({
     give: { Acceptance: AmountShape },
     want: {
-      Stamp: {
-        brand: oracleBrand,
-        value: makeCopyBag([[`Fixed ${issueURL}`, 1n]]),
-      },
+      Stamp: stampAmount,
     },
     exit: {
       afterDeadline: {

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -127,7 +127,7 @@ export const InvitationElementShape = M.splitRecord({
 });
 
 export const OfferHandlerI = M.interface('OfferHandler', {
-  handle: M.call(SeatShape).optional(M.any()).returns(M.string()),
+  handle: M.call(SeatShape).optional(M.any()).returns(M.any()),
 });
 
 export const SeatHandleAllocationsShape = M.arrayOf(

--- a/packages/zoe/test/unitTests/contracts/gimix/mintStable.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/mintStable.js
@@ -1,0 +1,28 @@
+// @ts-check
+import { E } from '@endo/far';
+
+/**
+ * @param {bigint} value
+ * @param {{
+ *   centralSupply: ERef<
+ *     Installation<import('@agoric/vats/src/centralSupply.js').start>
+ *   >;
+ *   feeMintAccess: ERef<FeeMintAccess>;
+ *   zoe: ERef<ZoeService>;
+ * }} powers
+ * @returns {Promise<Payment<'nat'>>}
+ */
+export const mintStablePayment = async (
+  value,
+  { centralSupply, feeMintAccess: feeMintAccessP, zoe },
+) => {
+  const feeMintAccess = await feeMintAccessP;
+
+  const { creatorFacet: bootstrapSupplier } = await E(zoe).startInstance(
+    centralSupply,
+    {},
+    { bootstrapPaymentValue: value },
+    { feeMintAccess },
+  );
+  return E(bootstrapSupplier).getBootstrapPayment();
+};

--- a/packages/zoe/test/unitTests/contracts/gimix/module-to-script.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/module-to-script.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+export const redactImportDecls = txt =>
+  txt.replace(/^\s*import\b\s*(.*)/gm, '// REDACTED: $1');
+
+export const omitExportKewords = txt => txt.replace(/^\s*export\b\s*/gm, '');
+
+// cf. ses rejectImportExpressions
+// https://github.com/endojs/endo/blob/ebc8f66e9498f13085a8e64e17fc2f5f7b528faa/packages/ses/src/transforms.js#L143
+export const hideImportExpr = txt => txt.replace(/\bimport\b/g, 'XMPORT');

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix-proposal.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix-proposal.js
@@ -8,28 +8,83 @@ import { permit } from '../../../../src/contracts/gimix/start-gimix.js';
 
 const asset = ref => fileURLToPath(new URL(ref, import.meta.url));
 
-const noImport = txt =>
-  txt.replace(/^\s*import\b\s*(.*)/gm, '// REDACTED: $1\n');
-const noExport = txt => txt.replace(/^\s*export\b\s*/gm, '');
-const defang = txt => txt.replace(/\bimport\b/g, 'XMPORT');
-
-test('gimix', async t => {
-  const { env } = process;
+/**
+ * If $SCRIPT is set, the test(s) below will write
+ * the rendered script to a file by that name.
+ * Likeiwse $PERMIT.
+ *
+ * If $ORACLE_ADDRESS is set, it is substituted into the script.
+ */
+test.before(async t => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
 
+  t.context = {
+    readFile: fsp.readFile,
+    env: process.env,
+    writeFile: fsp.writeFile,
+    bundle: await bundleCache.load(
+      asset('../../../../src/contracts/gimix/gimix.js'),
+      'gimix',
+    ),
+  };
+});
+
+const redactImportDecls = txt =>
+  txt.replace(/^\s*import\b\s*(.*)/gm, '// REDACTED: $1');
+const omitExportKewords = txt => txt.replace(/^\s*export\b\s*/gm, '');
+// cf. ses rejectImportExpressions
+// https://github.com/endojs/endo/blob/ebc8f66e9498f13085a8e64e17fc2f5f7b528faa/packages/ses/src/transforms.js#L143
+const hideImportExpr = txt => txt.replace(/\bimport\b/g, 'XMPORT');
+
+test('module to script: redact imports; omit export keywords', t => {
+  const modText = `
+import { E, Far } from '@endo/far';
+
+/** @param {import('wonderland').Carol} carol */
+export contst alice = (carol) => {
+    E(bob).greet(carol);
+};
+    `;
+
+  const expected = `
+// REDACTED: { E, Far } from '@endo/far';
+
+/** @param {XMPORT('wonderland').Carol} carol */
+contst alice = (carol) => {
+    E(bob).greet(carol);
+};
+    `;
+
+  const script = hideImportExpr(redactImportDecls(omitExportKewords(modText)));
+  t.is(script.trim(), expected.trim());
+});
+
+test('check / save gimix permit', async t => {
   t.notThrows(() => JSON.parse(permit));
 
-  const bundle = await bundleCache.load(
-    asset('../../../../src/contracts/gimix/gimix.js'),
-    'gimix',
-  );
+  // IDEA: check permit against a pattern
 
-  const modText = await fsp.readFile(
+  // @ts-expect-error TODO: types of t.context
+  const { env } = t.context;
+  if (env.PERMIT) {
+    // @ts-expect-error TODO: types of t.context
+    const { writeFile } = t.context;
+    const pretty = JSON.stringify(JSON.parse(permit), null, 2);
+    t.log('write permit to', env.PERMIT);
+    await t.notThrowsAsync(writeFile(env.PERMIT, pretty));
+  }
+});
+
+test('check / render gimix proposal', async t => {
+  // @ts-expect-error TODO: types of t.context
+  const { env, readFile, bundle } = t.context;
+
+  const modText = await readFile(
     asset('../../../../src/contracts/gimix/start-gimix.js'),
     'utf-8',
   );
 
-  let script = defang(noExport(noImport(modText)));
+  let script = hideImportExpr(redactImportDecls(omitExportKewords(modText)));
 
   script = script.replace(
     /bundleID = fail.*/,
@@ -42,16 +97,15 @@ test('gimix', async t => {
       `oracleAddress = ${JSON.stringify(env.ORACLE_ADDRESS)},`,
     );
   }
+
   const c = new Compartment({ E: () => {}, Far: () => {} });
   t.notThrows(() => c.evaluate(script));
 
-  if (env.PERMIT) {
-    const pretty = JSON.stringify(JSON.parse(permit), null, 2);
-    t.log('write permit to', env.PERMIT);
-    await t.notThrowsAsync(fsp.writeFile(env.PERMIT, pretty));
-  }
   if (env.SCRIPT) {
+    // @ts-expect-error TODO: types of t.context
+    const { writeFile } = t.context;
+
     t.log('write script to', env.SCRIPT);
-    await t.notThrowsAsync(fsp.writeFile(env.SCRIPT, script));
+    await t.notThrowsAsync(writeFile(env.SCRIPT, script));
   }
 });

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix-proposal.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix-proposal.js
@@ -1,0 +1,57 @@
+// @ts-check
+import test from 'ava';
+import fsp from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+
+import { permit } from '../../../../src/contracts/gimix/start-gimix.js';
+
+const asset = ref => fileURLToPath(new URL(ref, import.meta.url));
+
+const noImport = txt =>
+  txt.replace(/^\s*import\b\s*(.*)/gm, '// REDACTED: $1\n');
+const noExport = txt => txt.replace(/^\s*export\b\s*/gm, '');
+const defang = txt => txt.replace(/\bimport\b/g, 'XMPORT');
+
+test('gimix', async t => {
+  const { env } = process;
+  const bundleCache = await unsafeMakeBundleCache('bundles/');
+
+  t.notThrows(() => JSON.parse(permit));
+
+  const bundle = await bundleCache.load(
+    asset('../../../../src/contracts/gimix/gimix.js'),
+    'gimix',
+  );
+
+  const modText = await fsp.readFile(
+    asset('../../../../src/contracts/gimix/start-gimix.js'),
+    'utf-8',
+  );
+
+  let script = defang(noExport(noImport(modText)));
+
+  script = script.replace(
+    /bundleID = fail.*/,
+    `bundleID = ${JSON.stringify(`b1-${bundle.endoZipBase64Sha512}`)},`,
+  );
+
+  if (env.ORACLE_ADDRESS) {
+    script = script.replace(
+      /oracleAddress = fail.*/,
+      `oracleAddress = ${JSON.stringify(env.ORACLE_ADDRESS)},`,
+    );
+  }
+  const c = new Compartment({ E: () => {}, Far: () => {} });
+  t.notThrows(() => c.evaluate(script));
+
+  if (env.PERMIT) {
+    const pretty = JSON.stringify(JSON.parse(permit), null, 2);
+    t.log('write permit to', env.PERMIT);
+    await t.notThrowsAsync(fsp.writeFile(env.PERMIT, pretty));
+  }
+  if (env.SCRIPT) {
+    t.log('write script to', env.SCRIPT);
+    await t.notThrowsAsync(fsp.writeFile(env.SCRIPT, script));
+  }
+});

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -12,7 +12,6 @@ import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeCopyBag } from '@endo/patterns';
 import { makeNameHubKit } from '@agoric/vats';
-import { TimeMath } from '@agoric/time';
 import buildManualTimer from '../../../../tools/manualTimer.js';
 import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
 
@@ -21,6 +20,12 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 const DAY = 24 * 60 * 60 * 1000;
 const UNIT6 = 1_000_000n;
+
+/** @type {<T>(x: T | null | undefined) => T} */
+const NonNullish = x => {
+  if (!x) throw Error('null/undefined');
+  return x;
+};
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
 const test = anyTest;
@@ -52,6 +57,9 @@ const makeTestContext = async t => {
     const { nameHub: namesByAddress, nameAdmin: namesByAddressAdmin } =
       makeNameHubKit();
 
+    const invitationIssuer = await E(zoe).getInvitationIssuer();
+    const invitationBrand = await E(invitationIssuer).getBrand();
+
     const istIssuer = await E(zoe).getFeeIssuer();
     const istBrand = await E(istIssuer).getBrand();
     const centralSupply = await E(zoe).install(centralSupplyBundle);
@@ -62,8 +70,8 @@ const makeTestContext = async t => {
 
     // really a namehub...
     const agoricNames = {
-      issuer: { IST: istIssuer },
-      brand: { timerBrand, IST: istBrand },
+      issuer: { IST: istIssuer, Invitation: invitationIssuer },
+      brand: { timerBrand, IST: istBrand, Invitation: invitationBrand },
       installation: { centralSupply },
       instance: {},
     };
@@ -104,6 +112,98 @@ const makeTestContext = async t => {
 
 test.before(async t => (t.context = await makeTestContext(t)));
 
+/**
+ * TODO: refactor as capabilities
+ * @typedef {ReturnType<typeof makeGitHub>} GitHub
+ *
+ * @typedef {PromiseKit<string> & {
+ *   type: 'issue',
+ *   status: 'open' | 'closed'
+ *   assignee?: string
+ * }} IssueStatus
+ * @typedef {{
+ *   type: 'pull',
+ *   author: string,
+ *   fixes: string,
+ *   status?: 'merged'
+ * }} PRStatus
+ */
+const makeGitHub = () => {
+  /** @type {Map<string, IssueStatus | PRStatus>} */
+  const status = new Map();
+
+  const notifyIssue = (issue, pr) => {
+    const st = NonNullish(status.get(issue));
+    assert(st.type === 'issue');
+    const { resolve } = st;
+    resolve(pr);
+  };
+
+  const self = Far('github', {
+    /**
+     * @param {string} owner
+     * @param {string} repo
+     */
+    openIssue: (owner, repo) => {
+      const num = status.size + 1;
+      const url = `https://github.com/${owner}/${repo}/issues/${num}`;
+      const pk = makePromiseKit();
+      status.set(url, { ...pk, type: 'issue', status: 'open' });
+      return url;
+    },
+    assignIssue: (url, name) => {
+      const st = NonNullish(status.get(url));
+      assert(st.type === 'issue');
+      status.set(url, { ...st, assignee: name });
+    },
+    /** @param {string} url */
+    getIssuePromise: url => {
+      const st = NonNullish(status.get(url));
+      assert(st.type === 'issue');
+      return st.promise;
+    },
+    /** @param {string} url */
+    closeIssue: url => {
+      const st = NonNullish(status.get(url));
+      assert(st.type === 'issue');
+      status.set(url, { ...st, status: 'closed' });
+    },
+
+    /**
+     * @param {string} owner
+     * @param {string} repo
+     * @param {string} author - TODO refator as capability
+     * @param {string} fixes issue URL
+     */
+    openPR: (owner, repo, author, fixes) => {
+      const num = status.size + 1;
+      const url = `https://github.com/${owner}/${repo}/pull/${num}`;
+      const pk = makePromiseKit();
+      status.set(url, { type: 'pull', author, fixes });
+      notifyIssue(fixes, url);
+      return url;
+    },
+    /** @param {string} url */
+    mergePR: url => {
+      const st = NonNullish(status.get(url));
+      assert(st.type === 'pull');
+      status.set(url, { ...st, status: 'merged' });
+      const { fixes } = st;
+      return self.closeIssue(fixes);
+    },
+    /** @param {string} url */
+    queryPR: url => {
+      const pull = NonNullish(status.get(url));
+      assert(pull.type === 'pull');
+      const issue = NonNullish(status.get(pull.fixes));
+      assert(issue.type === 'issue');
+      // TODO: data propoerties only. no rights to resolve, etc.
+      return harden({ pull, issue });
+    },
+  });
+  return self;
+};
+
 test('start contract; make work agreement', async t => {
   const coreEval = async oracleDepositP => {
     const { powers, bundle } = t.context;
@@ -132,9 +232,7 @@ test('start contract; make work agreement', async t => {
       { Stable: agoricNames.issuer.IST },
       { namesByAddress, timer: chainTimerService },
     );
-    const {
-      brands: { GimixOracle },
-    } = await E(zoe).getTerms(gimixInstance);
+    const { brands, issuers } = await E(zoe).getTerms(gimixInstance);
 
     const oracleInvitation = await E(creatorFacet).makeOracleInvitation();
     void E(oracleDepositP).receive(oracleInvitation);
@@ -142,7 +240,8 @@ test('start contract; make work agreement', async t => {
     // really a namehub...
     const withGiMix = {
       ...agoricNames,
-      brand: { ...agoricNames.brand, GimixOracle },
+      brand: { ...agoricNames.brand, GimixOracle: brands.GimixOracle },
+      issuer: { ...agoricNames.issuer, GimixOracle: issuers.GimixOracle },
       installation: { ...agoricNames.installation, gimix: installation },
       instance: { ...agoricNames.instance, gimix: gimixInstance },
     };
@@ -150,106 +249,255 @@ test('start contract; make work agreement', async t => {
   };
 
   const sync = {
+    assignIssue: makePromiseKit(),
     oracleDeposit: makePromiseKit(),
+    oracle: makePromiseKit(),
   };
   const { agoricNames, board } = await coreEval(sync.oracleDeposit.promise);
 
   /**
-   * @param {ERef<ZoeService>} zoe
-   * @param {ERef<Purse>} purseP
-   * @param {string} issue
-   * @param {bigint} when
-   * @param {string} timerBoardId
+   * @param {ERef<GitHub>} gitHub
+   * @param {SmartWallet} wallet
+   * @param {PromiseKit<string>} assignIssuePK
    */
   const alice = async (
-    zoe,
-    purseP,
-    issue = 'https://github.com/Agoric/agoric-sdk/issues/8523',
-    bounty = 12n,
+    gitHub,
+    wallet,
+    assignIssuePK,
     when = 1234n,
     timerBoardId = 'board123',
+    bounty = 12n,
   ) => {
     const { make } = AmountMath;
-    const { brand, instance } = agoricNames;
-    const { timerBrand } = brand;
+    const { brand: wkBrand, instance, issuer: wkIssuer } = agoricNames;
+    const { timerBrand } = wkBrand;
     const timer = board.get(timerBoardId);
 
     const gpf = await E(zoe).getPublicFacet(instance.gimix);
 
+    const issue = await E(gitHub).openIssue('alice', 'project1');
+
     const give = {
-      Acceptance: make(brand.IST, bounty * UNIT6),
+      Acceptance: make(wkBrand.IST, bounty * UNIT6),
     };
     t.log('bounty', give);
     const want = {
-      Stamp: make(brand.GimixOracle, makeCopyBag([[`Fixed ${issue}`, 1n]])),
+      Stamp: make(wkBrand.GimixOracle, makeCopyBag([[`Fixed ${issue}`, 1n]])),
     };
 
     /** @type {import('@agoric/time/src/types').TimestampRecord} */
     const deadline = { timerBrand, absValue: when };
     const exit = { afterDeadline: { deadline, timer } };
 
-    const payments = { Acceptance: await E(purseP).withdraw(give.Acceptance) };
     const toMakeAgreement = await E(gpf).makeWorkAgreementInvitation(issue);
-    const seat = await E(zoe).offer(
-      toMakeAgreement,
-      { give, want, exit },
-      payments,
-    );
-    const result = await E(seat).getOfferResult();
+    const { seat, result } = await wallet.offers.executeOffer(toMakeAgreement, {
+      give,
+      want,
+      exit,
+    });
 
     t.log('resulting job id', result);
     t.deepEqual(typeof result, 'string');
+
+    const assignee = 'bob';
+    await E(gitHub).assignIssue(issue, assignee);
+    assignIssuePK.resolve(issue);
+    t.log('alice assigns to', assignee, 'and waits for news on', issue, '...');
+    const pr = await E(gitHub).getIssuePromise(issue);
+    t.log('alice decides to merge', pr);
+    await E(gitHub).mergePR(pr);
+
+    const issuers = {
+      Stamp: wkIssuer.GimixOracle,
+      Acceptance: wkIssuer.IST,
+    };
+    const payouts = await E(seat).getPayouts();
+    const amts = {};
+    for await (const [kw, pmtP] of Object.entries(payouts)) {
+      const pmt = await pmtP;
+      const amt = await E(issuers[kw]).getAmountOf(pmt);
+      t.log('payout', kw, amt);
+      amts[kw] = amt;
+    }
+    t.deepEqual(amts, '@@todo');
   };
 
   /**
+   * @param {import('@agoric/vats').NameAdmin} agoricNamesAdmin
    * @param {ERef<ZoeService>} zoe
-   * @param {import('@endo/promise-kit').PromiseKit<DepositFacet>} depositPK
+   * @typedef {string} Address
+   *
+   * @typedef {{
+   *   depositFacet: DepositFacet,
+   *   offers: {
+   *     executeOffer: (invitation: Invitation, proposal: Proposal) => Promise<{seat: UserSeat, result: any}>
+   *   }
+   * }} SmartWallet
    */
-  const githubOracle = async (zoe, depositPK) => {
-    const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitationPurse = E(invitationIssuer).makeEmptyPurse();
+  const makeWalletFactory = (agoricNamesAdmin, zoe) => {
+    /** @type {Map<Address, SmartWallet>} */
+    const wallets = new Map();
+    const { entries } = Object;
 
+    /**
+     * @param {Address} address
+     * @param {(amt: Amount) => void} [onDeposit]
+     */
+    const provideWallet = (address, onDeposit) => {
+      const purses = new Map();
+      const getPurseForBrand = async brand => {
+        if (purses.has(brand)) {
+          return purses.get(brand);
+        }
+        for (const [name, candidate] of entries(agoricNames.brand)) {
+          if (candidate === brand) {
+            const purse = E(agoricNames.issuer[name]).makeEmptyPurse();
+            purses.set(brand, purse);
+            return purse;
+          }
+        }
+        throw Error('brand not found');
+      };
+
+      /** @type {DepositFacet} */
+      // @ts-expect-error callWhen
+      const depositFacet = Far('deposit', {
+        receive: async pmt => {
+          const brand = await E(pmt).getAllegedBrand();
+          const purse = await getPurseForBrand(brand);
+          const amt = await E(purse).deposit(pmt);
+          void onDeposit(amt);
+          return amt;
+        },
+      });
+
+      const offers = Far('offers', {
+        getPurseForBrand,
+        /**
+         * @param {Invitation} invitation
+         * @param {Proposal} proposal
+         */
+        executeOffer: async (invitation, proposal) => {
+          const { entries } = Object;
+          /** @type {Record<string, Payment>} */
+          const payments = {};
+          for await (const [kw, amt] of entries(proposal.give || {})) {
+            const purse = await getPurseForBrand(amt.brand);
+            const pmt = await E(purse).withdraw(amt);
+            payments[kw] = pmt;
+          }
+          const seat = await E(zoe).offer(invitation, proposal, payments);
+          const result = await E(seat).getOfferResult();
+          return { seat, result };
+        },
+      });
+
+      agoricNamesAdmin.update(address, depositFacet);
+      /** @type {SmartWallet} */
+      const sw = { depositFacet, offers };
+      return sw;
+    };
+
+    return Far('WalletFactory', { provideWallet });
+  };
+
+  /**
+   * @param {SmartWallet} wallet
+   * @param {ERef<GitHub>} gitHub
+   * @param {import('@endo/promise-kit').PromiseKit<Oracle>} oraclePK
+   * @typedef {{
+   *   deliver: (pr: string) => Promise<boolean>,
+   * }} Oracle
+   */
+  const githubOracle = async (wallet, gitHub, oraclePK) => {
     const offerResults = new Map();
 
     const acceptId = 'oracleAccept1';
 
+    const reportIssueDone = async issue => {
+      t.log('ReportIssue', issue);
+      const reporter = offerResults.get(acceptId);
+      const toReport = await E(reporter).JobReport();
+      const seat = await E(zoe).offer(toReport);
+      const result = await E(seat).getOfferResult();
+      t.log('ReportIssue result', result, issue);
+      // get payouts?
+      await E(seat).tryExit();
+    };
+
     // oracle operator does this
     const setup = async amt => {
       t.log('oracle invation amount', amt);
+      const invitationPurse = wallet.offers.getPurseForBrand(amt.brand);
       const invitation = await E(invitationPurse).withdraw(amt);
-      const seat = await E(zoe).offer(invitation, {
-        give: {},
-        want: {},
-        exit: { onDemand: undefined },
-      });
-      const reporter = await E(seat).getOfferResult();
+      const { result: reporter } = await wallet.offers.executeOffer(
+        invitation,
+        {
+          give: {},
+          want: {},
+          exit: { onDemand: undefined },
+        },
+      );
       t.log('oracle reporter', reporter);
       offerResults.set(acceptId, reporter);
     };
 
-    /** @type {DepositFacet} */
-    // @ts-expect-error callWhen
-    const depositFacet = Far('deposit', {
-      receive: async pmt => {
-        // XXX find purse by allegedBrand?
-        // @ts-expect-error callWhen
-        const amt = await E(invitationPurse).deposit(pmt);
-        void setup(amt);
-        return amt;
+    /** @type {Oracle} */
+    const it = Far('OracleWebSvc', {
+      /** @param {string} pr */
+      deliver: async pr => {
+        t.log('oracle claim', pr);
+        const { pull, issue } = await E(gitHub).queryPR(pr);
+        const ok =
+          pull.author === issue.assignee &&
+          pull.status === 'merged' &&
+          issue.status === 'closed';
+        if (ok) {
+          await reportIssueDone(pull.fixes);
+        }
+        return ok;
       },
     });
-    depositPK.resolve(depositFacet);
+    oraclePK.resolve(it);
+  };
+
+  /**
+   * @param {ERef<GitHub>} gitHub
+   * @param {Promise<string>} assignIssueP - issue publication
+   * @param {ERef<SmartWallet>} wallet
+   * @param {ERef<Oracle>} oracle
+   */
+  const bob = async (gitHub, assignIssueP, wallet, oracle) => {
+    const issue = await assignIssueP;
+    const pr = await E(gitHub).openPR('bob', 'alice', 'project1', issue);
+    t.log('bob opens PR', pr);
+    const ok = await E(oracle).deliver(pr);
+    t.truthy(ok);
   };
 
   const { rootNode, data } = makeFakeStorageKit('X');
 
+  const gitHub = Promise.resolve(makeGitHub());
   const {
     faucet,
-    powers: { zoe },
+    powers: { zoe, agoricNamesAdmin },
   } = t.context;
+  const wf = makeWalletFactory(agoricNamesAdmin, zoe);
+
   await Promise.all([
-    alice(zoe, faucet(25n * UNIT6)),
-    githubOracle(zoe, sync.oracleDeposit),
+    alice(
+      gitHub,
+      wf.provideWallet('agoric1alice'),
+      // faucet(25n * UNIT6),
+      sync.assignIssue,
+    ),
+    githubOracle(wf.provideWallet('agoric1oracle'), gitHub, sync.oracle),
+    bob(
+      gitHub,
+      sync.assignIssue.promise,
+      wf.provideWallet('agoric1bob'),
+      sync.oracle.promise,
+    ),
   ]);
   t.log('done');
   t.pass();

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -1,5 +1,140 @@
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+// @ts-check
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+// difference? import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import url from 'url';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { E } from '@endo/far';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import { makeCopyBag } from '@endo/patterns';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { makeNameHubKit } from '@agoric/vats';
+import { TimeMath } from '@agoric/time';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
+const test = anyTest;
+
+const asset = ref => url.fileURLToPath(new URL(ref, import.meta.url));
+
+const makeTestContext = async () => {
+  const bundleCache = await unsafeMakeBundleCache('bundles/');
+
+  const { zoe } = await setUpZoeForTest();
+
+  const bundle = await bundleCache.load(
+    asset('../../../../src/contracts/gimix/gimix.js'),
+    'gimix',
+  );
+
+  const eventLoopIteration = () => new Promise(setImmediate);
+
+  return { zoe, bundle, eventLoopIteration };
+};
+
+test.before(async t => (t.context = await makeTestContext()));
 
 test('gimix', t => {
   t.pass();
 });
+
+const DAY = 24 * 60 * 60 * 1000;
+
+test('start contract; make work agreement', async t => {
+  const { zoe } = t.context;
+
+  const coreEval = async () => {
+    const { bundle } = t.context;
+
+    const manualTimer = buildManualTimer(
+      t.log,
+      BigInt((2020 - 1970) * 365.25 * DAY),
+      {
+        timeStep: BigInt(DAY),
+        eventLoopIteration: t.context.eventLoopIteration,
+      },
+    );
+    /** @type {import('@agoric/time/src/types').TimerService} */
+    const timer = manualTimer;
+    const timerBrand = await E(timer).getTimerBrand();
+    const board = new Map(); // sort of
+    board.set('board123', timer);
+
+    // TODO: add bob's address
+    const { nameHub: namesByAddress } = makeNameHubKit();
+
+    /** @type {Installation<import('../../../../src/contracts/gimix/gimix').prepare>} */
+    const installation = await E(zoe).install(bundle);
+
+    const istIssuer = await E(zoe).getFeeIssuer();
+    const istBrand = await E(istIssuer).getBrand();
+    const { instance: gimixInstance } = await E(zoe).startInstance(
+      installation,
+      { Stable: istIssuer },
+      { namesByAddress, timer },
+    );
+    const {
+      brands: { GimixOracle },
+    } = await E(zoe).getTerms(gimixInstance);
+
+    // really a namehub...
+    const agoricNames = {
+      issuer: { IST: istIssuer },
+      brand: { timerBrand, IST: istBrand, GimixOracle },
+      installation: { gimix: installation },
+      instance: { gimix: gimixInstance },
+    };
+    return { agoricNames, board };
+  };
+  const { agoricNames, board } = await coreEval();
+
+  const alice = async (
+    purse,
+    issue = 'https://github.com/Agoric/agoric-sdk/issues/8523',
+    when = 1234n,
+    timerBoardId = 'board123',
+  ) => {
+    const { make } = AmountMath;
+    const { brand, instance } = agoricNames;
+    const { timerBrand } = brand;
+    const timer = board.get(timerBoardId);
+
+    const gpf = await E(zoe).getPublicFacet(instance.gimix);
+
+    const give = {
+      Acceptance: make(brand.IST, 0n),
+    };
+    t.log('TODO: >0 bounty', give);
+    const want = {
+      Stamp: make(brand.GimixOracle, makeCopyBag([[`Fixed ${issue}`, 1n]])),
+    };
+
+    /** @type {import('@agoric/time/src/types').TimestampRecord} */
+    const deadline = { timerBrand, absValue: when };
+    const exit = { afterDeadline: { deadline, timer } };
+
+    const payments = { Acceptance: await E(purse).withdraw(give.Acceptance) };
+    const toMakeAgreement = await E(gpf).makeWorkAgreementInvitation(issue);
+    const seat = await E(zoe).offer(
+      toMakeAgreement,
+      { give, want, exit },
+      payments,
+    );
+    const result = await E(seat).getOfferResult();
+
+    t.log('resulting job id', result);
+    t.deepEqual(typeof result, 'string');
+  };
+
+  const { rootNode, data } = makeFakeStorageKit('X');
+
+  const _faucet = () => {
+    const purse = E(agoricNames.issuer.IST).makeEmptyPurse();
+    return purse;
+  };
+
+  await Promise.all([alice(_faucet())]);
+  t.pass();
+});
+
+test.todo('make work agreement at wallet bridge / vstorage level');

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -14,9 +14,11 @@ import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import { makeNameHubKit } from '@agoric/vats';
 import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
 import { TimeMath } from '@agoric/time';
+import { deeplyFulfilledObject } from '@agoric/internal';
 
-import { makeZoeKitForTest } from '../../../../tools/setup-zoe.js';
 import buildManualTimer from '../../../../tools/manualTimer.js';
+import { makeZoeKitForTest } from '../../../../tools/setup-zoe.js';
+import { startGiMiX } from '../../../../src/contracts/gimix/start-gimix.js/index.js';
 import { mintStablePayment } from './mintStable.js';
 
 const DAY = 24 * 60 * 60 * 1000;

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -4,7 +4,7 @@
 // eslint-disable-next-line import/order
 import { test as anyTest } from '../../../../tools/prepare-test-env-ava.js';
 
-import url from 'url';
+import { fileURLToPath } from 'url';
 import { E, Far } from '@endo/far';
 import { makeCopyBag } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -32,7 +32,7 @@ const NonNullish = x => {
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
 const test = anyTest;
 
-const asset = ref => url.fileURLToPath(new URL(ref, import.meta.url));
+const asset = ref => fileURLToPath(new URL(ref, import.meta.url));
 
 const makeTestContext = async t => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
@@ -146,28 +146,28 @@ const makeGitHub = log => {
      */
     openIssue: ({ owner, repo }) => {
       const num = status.size + 1;
-      const url = `https://github.com/${owner}/${repo}/issues/${num}`;
+      const issueURL = `https://github.com/${owner}/${repo}/issues/${num}`;
       const pk = makePromiseKit();
-      status.set(url, { ...pk, type: 'issue', num, status: 'open' });
-      return url;
+      status.set(issueURL, { ...pk, type: 'issue', num, status: 'open' });
+      return issueURL;
     },
-    assignIssue: (url, name) => {
-      const st = NonNullish(status.get(url));
+    assignIssue: (issueURL, name) => {
+      const st = NonNullish(status.get(issueURL));
       assert(st.type === 'issue');
-      status.set(url, { ...st, assignee: name });
+      status.set(issueURL, { ...st, assignee: name });
     },
-    /** @param {string} url */
-    getIssuePromise: url => {
-      const st = NonNullish(status.get(url));
+    /** @param {string} issueURL */
+    getIssuePromise: issueURL => {
+      const st = NonNullish(status.get(issueURL));
       assert(st.type === 'issue');
       return st.promise;
     },
-    /** @param {string} url */
-    closeIssue: url => {
-      const st = NonNullish(status.get(url));
+    /** @param {string} issueURL */
+    closeIssue: issueURL => {
+      const st = NonNullish(status.get(issueURL));
       assert(st.type === 'issue');
-      status.set(url, { ...st, status: 'closed' });
-      // log('closed', url);
+      status.set(issueURL, { ...st, status: 'closed' });
+      // log('closed', issueURL);
     },
 
     /**
@@ -179,23 +179,23 @@ const makeGitHub = log => {
      */
     openPR: ({ owner, repo, author, fixes }) => {
       const num = status.size + 1;
-      const url = `https://github.com/${owner}/${repo}/pull/${num}`;
+      const prURL = `https://github.com/${owner}/${repo}/pull/${num}`;
       const pk = makePromiseKit();
-      status.set(url, { type: 'pull', num, author, fixes });
-      notifyIssue(fixes, url);
-      return url;
+      status.set(prURL, { type: 'pull', num, author, fixes });
+      notifyIssue(fixes, prURL);
+      return prURL;
     },
-    /** @param {string} url */
-    mergePR: url => {
-      const st = NonNullish(status.get(url));
+    /** @param {string} prURL */
+    mergePR: prURL => {
+      const st = NonNullish(status.get(prURL));
       assert(st.type === 'pull');
-      status.set(url, { ...st, status: 'merged' });
+      status.set(prURL, { ...st, status: 'merged' });
       const { fixes } = st;
       self.closeIssue(fixes);
     },
-    /** @param {string} url */
-    queryPR: url => {
-      const pull = NonNullish(status.get(url));
+    /** @param {string} prURL */
+    queryPR: prURL => {
+      const pull = NonNullish(status.get(prURL));
       assert(pull.type === 'pull');
       const issue = NonNullish(status.get(pull.fixes));
       assert(issue.type === 'issue');

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -1,6 +1,5 @@
 /* global setImmediate */
 // @ts-check
-/* eslint-disable no-unused-vars */
 // eslint-disable-next-line import/order
 import { test as anyTest } from '../../../../tools/prepare-test-env-ava.js';
 
@@ -185,7 +184,7 @@ const makeGitHub = _log => {
     openPR: ({ owner, repo, author, fixes }) => {
       const num = status.size + 1;
       const prURL = `https://github.com/${owner}/${repo}/pull/${num}`;
-      const pk = makePromiseKit();
+      // const pk = makePromiseKit();
       status.set(prURL, { type: 'pull', num, author, fixes });
       notifyIssue(fixes, prURL);
       return prURL;

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line import/order
 import { test as anyTest } from '../../../../tools/prepare-test-env-ava.js';
 
-import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { E, Far } from '@endo/far';
 import { makeCopyBag } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -12,7 +12,6 @@ import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js'
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 // import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeNameHubKit, makePromiseSpace } from '@agoric/vats';
-import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
 import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import { TimeMath } from '@agoric/time';
@@ -39,7 +38,8 @@ const NonNullish = x => {
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
 const test = anyTest;
 
-const asset = ref => fileURLToPath(new URL(ref, import.meta.url));
+const myRequire = createRequire(import.meta.url);
+const asset = specifier => myRequire.resolve(specifier);
 
 const makeTestContext = async t => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
@@ -47,6 +47,10 @@ const makeTestContext = async t => {
   const bundle = await bundleCache.load(
     asset('../../../../src/contracts/gimix/gimix.js'),
     'gimix',
+  );
+  const centralSupplyBundle = await bundleCache.load(
+    asset('@agoric/vats/src/centralSupply.js'),
+    'centralSupply',
   );
 
   const eventLoopIteration = () => new Promise(setImmediate);

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -11,7 +11,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
-import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+// import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeNameHubKit } from '@agoric/vats';
 import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
 import { TimeMath } from '@agoric/time';
@@ -22,6 +22,8 @@ import { mintStablePayment } from './mintStable.js';
 
 const DAY = 24 * 60 * 60 * 1000;
 const UNIT6 = 1_000_000n;
+
+const { entries } = Object;
 
 /** @type {<T>(x: T | null | undefined) => T} */
 const NonNullish = x => {
@@ -94,7 +96,7 @@ const makeTestContext = async t => {
   const powers = await bootstrap();
 
   const {
-    agoricNames: { installation, issuer },
+    agoricNames: { installation },
   } = powers;
   /** @param {bigint} value */
   const faucet = async value =>
@@ -127,7 +129,8 @@ test.before(async t => (t.context = await makeTestContext(t)));
  *   status?: 'merged'
  * }} PRStatus
  */
-const makeGitHub = log => {
+
+const makeGitHub = _log => {
   /** @type {Map<string, IssueStatus | PRStatus>} */
   const status = new Map();
 
@@ -213,14 +216,8 @@ test('execute work agreement', async t => {
    */
   const coreEval = async (oracleDepositP, oracleInvitedPK) => {
     const { powers, bundle } = t.context;
-    const {
-      agoricNames,
-      board,
-      chainTimerService,
-      namesByAddress,
-      namesByAddressAdmin,
-      zoe,
-    } = powers;
+    const { agoricNames, board, chainTimerService, namesByAddress, zoe } =
+      powers;
 
     // const id = await E(board).getId(chainTimerService);
     board.set('board123', chainTimerService);
@@ -274,6 +271,9 @@ test('execute work agreement', async t => {
    * @param {ERef<GitHub>} gitHub
    * @param {SmartWallet} wallet
    * @param {PromiseKit<{jobID: string, issue: string}>} assignIssuePK
+   * @param {bigint} dur
+   * @param {string} timerBoardId
+   * @param {bigint} bounty
    */
   const alice = async (
     gitHub,
@@ -285,9 +285,9 @@ test('execute work agreement', async t => {
   ) => {
     const { make } = AmountMath;
     const { brand: wkBrand, instance, issuer: wkIssuer } = agoricNames;
-    const { timerBrand } = wkBrand;
     const timer = board.get(timerBoardId);
 
+    // eslint-disable-next-line no-use-before-define
     const gpf = await E(zoe).getPublicFacet(instance.gimix);
 
     const issue = await E(gitHub).openIssue({
@@ -364,9 +364,8 @@ test('execute work agreement', async t => {
    * }} SmartWallet
    */
   const makeWalletFactory = (namesByAddressAdmin, zoe) => {
-    /** @type {Map<Address, SmartWallet>} */
-    const wallets = new Map();
-    const { entries } = Object;
+    // /** @type {Map<Address, SmartWallet>} */
+    // const wallets = new Map();
 
     /**
      * @param {Address} address
@@ -408,7 +407,6 @@ test('execute work agreement', async t => {
          * @param {unknown} [offerArgs]
          */
         executeOffer: async (invitation, proposal, offerArgs) => {
-          const { entries } = Object;
           /** @type {Record<string, Payment>} */
           const payments = {};
           for await (const [kw, amt] of entries(proposal.give || {})) {
@@ -577,7 +575,7 @@ test('execute work agreement', async t => {
     t.deepEqual(amts, want);
   };
 
-  const { rootNode, data } = makeFakeStorageKit('X');
+  // const { rootNode, data } = makeFakeStorageKit('X');
 
   const gitHub = Promise.resolve(makeGitHub(t.log));
   const {

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -466,7 +466,7 @@ test('execute work agreement', async t => {
 
       const my = makeNameHubKit();
       my.nameAdmin.update('depositFacet', depositFacet);
-      await E(namesByAddressAdmin).update(address, my.nameHub);
+      await E(namesByAddressAdmin).update(address, my.nameHub, my.nameAdmin);
       /** @type {SmartWallet} */
       const sw = { id, depositFacet, offers };
       return sw;

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -27,7 +27,9 @@ const { entries } = Object;
 
 /** @type {<T>(x: T | null | undefined) => T} */
 const NonNullish = x => {
-  if (!x) throw Error('null/undefined');
+  if (x === null || x === undefined) {
+    throw Error('null/undefined');
+  }
   return x;
 };
 

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -1,0 +1,5 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+test('gimix', t => {
+  t.pass();
+});

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -5,19 +5,20 @@
 import { test as anyTest } from '../../../../tools/prepare-test-env-ava.js';
 
 import url from 'url';
-import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E, Far } from '@endo/far';
+import { makeCopyBag } from '@endo/patterns';
+import { makePromiseKit } from '@endo/promise-kit';
+
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { makeCopyBag } from '@endo/patterns';
 import { makeNameHubKit } from '@agoric/vats';
-import buildManualTimer from '../../../../tools/manualTimer.js';
 import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
-
-import { mintStablePayment } from './mintStable.js';
-import { makePromiseKit } from '@endo/promise-kit';
 import { TimeMath } from '@agoric/time';
+
+import { makeZoeKitForTest } from '../../../../tools/setup-zoe.js';
+import buildManualTimer from '../../../../tools/manualTimer.js';
+import { mintStablePayment } from './mintStable.js';
 
 const DAY = 24 * 60 * 60 * 1000;
 const UNIT6 = 1_000_000n;

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -1,16 +1,19 @@
+/* global setImmediate */
 // @ts-check
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-// difference? import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+/* eslint-disable no-unused-vars */
+// eslint-disable-next-line import/order
+import { test as anyTest } from '../../../../tools/prepare-test-env-ava.js';
+
 import url from 'url';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E } from '@endo/far';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeCopyBag } from '@endo/patterns';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeNameHubKit } from '@agoric/vats';
 import { TimeMath } from '@agoric/time';
+import { setUpZoeForTest } from '../../../../tools/setup-zoe.js';
+import buildManualTimer from '../../../../tools/manualTimer.js';
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
 const test = anyTest;
@@ -128,12 +131,12 @@ test('start contract; make work agreement', async t => {
 
   const { rootNode, data } = makeFakeStorageKit('X');
 
-  const _faucet = () => {
+  const faucet = () => {
     const purse = E(agoricNames.issuer.IST).makeEmptyPurse();
     return purse;
   };
 
-  await Promise.all([alice(_faucet())]);
+  await Promise.all([alice(faucet())]);
   t.pass();
 });
 

--- a/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-gimix.js
@@ -166,7 +166,7 @@ const makeGitHub = log => {
       const st = NonNullish(status.get(url));
       assert(st.type === 'issue');
       status.set(url, { ...st, status: 'closed' });
-      log('closed', url);
+      // log('closed', url);
     },
 
     /**
@@ -297,7 +297,7 @@ test('execute work agreement', async t => {
     const give = {
       Acceptance: make(wkBrand.IST, bounty * UNIT6),
     };
-    t.log('bounty', give);
+    t.log('alice offers to give', give);
     const want = {
       Stamp: make(wkBrand.GimixOracle, makeCopyBag([[`Fixed ${issue}`, 1n]])),
     };
@@ -320,7 +320,7 @@ test('execute work agreement', async t => {
       { give, want, exit },
     );
 
-    t.log('resulting job id', jobID);
+    t.log('alice offer result job id', jobID);
     t.deepEqual(typeof jobID, 'bigint');
 
     const assignee = 'bob';
@@ -328,7 +328,7 @@ test('execute work agreement', async t => {
     assignIssuePK.resolve({ jobID, issue });
     t.log('alice assigns to', assignee, 'and waits for news on', issue, '...');
     const pr = await E(gitHub).getIssuePromise(issue);
-    t.log('alice decides to merge', pr);
+    t.log('alice merges', pr);
     await E(gitHub).mergePR(pr);
 
     const issuers = {
@@ -459,7 +459,7 @@ test('execute work agreement', async t => {
       prURL,
       deliverDepositAddr,
     }) => {
-      t.log('reportJobDone', { jobID, issueURL, deliverDepositAddr });
+      t.log('oralce makes JobReport', { jobID, issueURL, deliverDepositAddr });
       const reporter = NonNullish(offerResults.get(acceptId));
       const toReport = await E(reporter.invitationMakers).JobReport({
         deliverDepositAddr,
@@ -467,12 +467,11 @@ test('execute work agreement', async t => {
         jobID,
         prURL,
       });
-      const { seat, result } = await E(wallet.offers).executeOffer(
+      const { seat } = await E(wallet.offers).executeOffer(
         toReport,
         {},
         { issueURL, deliverDepositAddr },
       );
-      t.log('JobReport result', result, jobID);
       // get payouts?
       await E(seat).tryExit();
       reported.resolve(jobID);
@@ -480,7 +479,7 @@ test('execute work agreement', async t => {
 
     // oracle operator does this
     const setup = async amt => {
-      t.log('oracle invation amount', amt);
+      t.log('oracle received invation', amt);
       /** @type {Promise<Purse<'set'>>} */
       // @ts-expect-error assetkind
       const invitationPurse = wallet.offers.getPurseForBrand(amt.brand);
@@ -489,7 +488,7 @@ test('execute work agreement', async t => {
         invitation,
         { give: {}, want: {} },
       );
-      t.log('oracle reporter', reporter);
+      t.log('oracle offer result', reporter);
       offerResults.set(acceptId, reporter);
     };
 
@@ -502,7 +501,7 @@ test('execute work agreement', async t => {
        */
       deliver: async (prURL, jobID, deliverDepositAddr) => {
         const { pull, issue } = await E(gitHub).queryPR(prURL);
-        t.log('oracle claim', prURL, { pull, issue });
+        t.log('oracle evaluates delivery claim', jobID, { pull, issue });
         const ok =
           pull.author === issue.assignee &&
           pull.status === 'merged' &&
@@ -552,7 +551,7 @@ test('execute work agreement', async t => {
       agoricNames.brand.Invitation,
     );
     const invitationsAmt = await E(invitationPurse).getCurrentAmount();
-    t.log('bob has invitations', invitationsAmt);
+    t.log('bob invitation balance', invitationsAmt);
 
     const ipmt = await E(invitationPurse).withdraw(invitationsAmt);
     const { make } = AmountMath;

--- a/packages/zoe/test/unitTests/contracts/gimix/test-module-to-script.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-module-to-script.js
@@ -1,0 +1,30 @@
+// @ts-check
+import test from 'ava';
+import {
+  hideImportExpr,
+  omitExportKewords,
+  redactImportDecls,
+} from './module-to-script.js';
+
+test('module to script: redact imports; omit export keywords', t => {
+  const modText = `
+import { E, Far } from '@endo/far';
+
+/** @param {import('wonderland').Carol} carol */
+export contst alice = (carol) => {
+    E(bob).greet(carol);
+};
+      `;
+
+  const expected = `
+// REDACTED: { E, Far } from '@endo/far';
+
+/** @param {XMPORT('wonderland').Carol} carol */
+contst alice = (carol) => {
+    E(bob).greet(carol);
+};
+      `;
+
+  const script = hideImportExpr(redactImportDecls(omitExportKewords(modText)));
+  t.is(script.trim(), expected.trim());
+});

--- a/packages/zoe/test/unitTests/contracts/gimix/test-postalSvc.js
+++ b/packages/zoe/test/unitTests/contracts/gimix/test-postalSvc.js
@@ -1,0 +1,148 @@
+// @ts-check
+// eslint-disable-next-line import/order
+import { test as anyTest } from '../../../../tools/prepare-test-env-ava.js';
+
+import { createRequire } from 'module';
+
+import { E, Far } from '@endo/far';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { makeNameHubKit, makePromiseSpace } from '@agoric/vats';
+import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+import { makeZoeKitForTest } from '../../../../tools/setup-zoe.js';
+import { startPostalSvc } from '../../../../src/contracts/gimix/start-postalSvc.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
+const test = anyTest;
+
+const myRequire = createRequire(import.meta.url);
+/** @param {string} specifier */
+const asset = specifier => myRequire.resolve(specifier);
+
+/**
+ * Wrap Zoe exo in a record so that we can override methods.
+ *
+ * Roughly equivalent to {@link bindAllMethods}
+ * in @agoric/internal, but that's a private API and
+ * this contract should perhaps not be in agoric-sdk.
+ *
+ * @param {ZoeService} zoeExo
+ */
+const wrapZoe = zoeExo => {
+  /** @type {ZoeService} */
+  // @ts-expect-error mock
+  const mock = {
+    // XXX all the methods used in this test; there may be others.
+    getFeeIssuer: () => zoeExo.getFeeIssuer(),
+    getInvitationIssuer: () => zoeExo.getInvitationIssuer(),
+    installBundleID: (...args) => zoeExo.installBundleID(...args),
+    startInstance: (...args) => zoeExo.startInstance(...args),
+    getTerms: (...args) => zoeExo.getTerms(...args),
+    getPublicFacet: (...args) => zoeExo.getPublicFacet(...args),
+    offer: (...args) => zoeExo.offer(...args),
+  };
+  return mock;
+};
+
+const makeTestContext = async t => {
+  const bundleCache = await unsafeMakeBundleCache('bundles/');
+  const bundle = await bundleCache.load(
+    asset('../../../../src/contracts/gimix/postalSvc.js'),
+    'gimix',
+  );
+
+  const bootstrap = async () => {
+    const { produce, consume } = makePromiseSpace();
+
+    const { zoeService } = makeZoeKitForTest();
+    /** @param {string} bID */
+    const install1BundleID = bID => {
+      assert.equal(bID, `b1-${bundle.endoZipBase64Sha512}`);
+      return zoeService.install(bundle);
+    };
+    const zoe = Far('ZoeService', {
+      ...wrapZoe(zoeService),
+      installBundleID: install1BundleID,
+    });
+    produce.zoe.resolve(zoe);
+
+    const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
+      makeNameHubKit();
+    const spaces = await makeWellKnownSpaces(agoricNamesAdmin, t.log, [
+      'installation',
+      'instance',
+    ]);
+
+    produce.agoricNames.resolve(agoricNames);
+
+    const { nameAdmin: namesByAddressAdmin } = makeNameHubKit();
+    produce.namesByAddressAdmin.resolve(namesByAddressAdmin);
+
+    /** @type {BootstrapPowers}}  */
+    // @ts-expect-error mock
+    const powers = { produce, consume, ...spaces };
+
+    return powers;
+  };
+
+  const powers = await bootstrap();
+  return { bundle, powers };
+};
+
+test.before(async t => (t.context = await makeTestContext(t)));
+
+test('deliver payment using address', async t => {
+  const addr1 = 'agoric1receiver';
+
+  const rxd = [];
+  const depositFacet = Far('DepositFacet', {
+    /** @param {Payment} pmt */
+    receive: async pmt => {
+      rxd.push(pmt);
+      // XXX should return amount of pmt
+    },
+  });
+
+  const { powers, bundle } = t.context;
+  const { agoricNames, zoe, namesByAddressAdmin } = powers.consume;
+
+  await startPostalSvc(powers, {
+    options: { postalSvc: { bundleID: `b1-${bundle.endoZipBase64Sha512}` } },
+  });
+
+  const instance = await E(agoricNames).lookup('instance', 'postalSvc');
+
+  const my = makeNameHubKit();
+  my.nameAdmin.update('depositFacet', depositFacet);
+  await E(namesByAddressAdmin).update(addr1, my.nameHub, my.nameAdmin);
+
+  const { issuers, brands } = await E(zoe).getTerms(instance);
+  const postalSvc = E(zoe).getPublicFacet(instance);
+  const purse = await E(issuers.IST).makeEmptyPurse();
+
+  const pmt1 = await E(purse).withdraw(AmountMath.make(brands.IST, 0n));
+
+  // XXX should test that return value is amount
+  t.log('send IST with public facet to', addr1);
+  await E(postalSvc).sendTo(addr1, pmt1);
+  t.deepEqual(rxd, [pmt1]);
+
+  {
+    const Payment = AmountMath.make(brands.IST, 0n);
+    const pmt2 = await E(purse).withdraw(Payment);
+    const pmt3 = await E(postalSvc).makeSendInvitation(addr1);
+    const Invitation = await E(issuers.Invitation).getAmountOf(pmt3);
+    const proposal = { give: { Payment, Invitation } };
+    t.log('make offer to send IST, Invitation to', addr1);
+    const seat = E(zoe).offer(
+      E(postalSvc).makeSendInvitation(addr1),
+      proposal,
+      { Payment: pmt2, Invitation: pmt3 },
+    );
+    const result = await E(seat).getOfferResult();
+    t.deepEqual(rxd, [pmt1, pmt2, pmt3]);
+    t.is(result, 'sent Payment, Invitation');
+  }
+});
+
+test.todo('partial failure: send N+1 payments where >= 1 delivery fails');


### PR DESCRIPTION
## Description

This contract is a reusable component for sending payments using `namesByAddress` to look up a `depositFacet`.
A contract such as GiMiX or swaparoo only needs this instance in its terms.

Or an offer can go straight to this contract. The script here starts the contract with the Zoe Fee and Invitation issuers.

It's something of a work-around for the regression in the wallet where this feature wasn't shipped in production.
I'm not sure it should be merged, let alone shipped in production. Maybe it should be moved to an example app.

cc @michaelfig @samsiegart @dtribble 

### Security Considerations

TODO:
 - [ ] add missing pattern guards
 - [ ] make upgradeable?
 - [ ] integration test on a chain
 - [ ] what forms of docs?
 - [ ] creatorFacet method to add issuers?
 - [ ] governed API to add issuers?

### Testing Considerations

currently:

```console
agoric-sdk/packages/zoe$ yarn test test/unitTests/contracts/gimix/test-postalSvc.js 
$ ava --verbose test/unitTests/contracts/gimix/test-postalSvc.js

[bundleTool] bundles/ bundle-gimix.js valid: 121 files bundled at 2023-11-18T00:58:21.248Z with size 1017305 
postalSvc issuers [ 'IST', 'Invitation' ]
  ✔ deliver payment using address (360ms)
    ℹ send IST with public facet to agoric1receiver
    ℹ make offer to send IST, Invitation to agoric1receiver
start-postalSvc postalSvc started
  ─

  1 test passed
```
