### PR TITLE
fix(casting): dont crash on bad capdata

### DIFF
--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -112,6 +112,13 @@ export const coalesceWalletState = async (follower, invitationBrand) => {
   // values with oldest last
   const history = [];
   for await (const followerElement of iterateReverse(follower)) {
+    if ('error' in followerElement) {
+      console.error(
+        'Skipping wallet update due to error:',
+        followerElement.error,
+      );
+      continue;
+    }
     history.push(followerElement.value);
   }
 

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -331,11 +331,16 @@ export const makeCosmjsFollower = (
     blockHeight,
     currentBlockHeight,
   ) => {
-    // AWAIT
-    const value = await /** @type {T} */ (
-      unserializer ? E(unserializer).fromCapData(data) : data
-    );
-    return { value, blockHeight, currentBlockHeight };
+    await null;
+    try {
+      // AWAIT
+      const value = await /** @type {T} */ (
+        unserializer ? E(unserializer).fromCapData(data) : data
+      );
+      return { value, blockHeight, currentBlockHeight };
+    } catch (e) {
+      return { blockHeight, currentBlockHeight, error: e, value: undefined };
+    }
   };
 
   /**

--- a/packages/casting/src/types.js
+++ b/packages/casting/src/types.js
@@ -40,12 +40,15 @@ export {};
  */
 
 /**
- * @see {ChangeFollower}
- * @template T
- * @typedef {object} ValueFollowerElement
- * @property {T} value
+ * @typedef {object} ValueFollowerBase
  * @property {number} blockHeight
  * @property {number} currentBlockHeight
+ */
+
+/**
+ * @see {ChangeFollower}
+ * @template T
+ * @typedef {ValueFollowerBase & ({ value: T } | { value: undefined, error: any })} ValueFollowerElement
  */
 
 /**


### PR DESCRIPTION
refs https://github.com/Agoric/ui-kit/issues/57
refs https://github.com/Agoric/agoric-sdk/issues/8579

Explanation in the comment thread of the issue. TL;DR - The follower was crashing silently after hitting bad capdata. This change makes it so that instead it surfaces an `error` instead of a `value` in that case, and keeps yielding more values.

Added a unit test to ensure that it properly surfaces the error and can keep yielding more values afterwards.