### PR TITLE
typedefs for Zoe privateArgs

### DIFF
--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -462,9 +462,9 @@ export const startRewardDistributor = async ({
     });
 
   /**
-   * @type {Awaited<
-   *   ReturnType<typeof import('../feeDistributor.js').makeFeeDistributor>
-   * > & { adminFacet: AdminFacet; instance: Instance }}
+   * @type {StartedInstanceKit<
+   *   typeof import('@agoric/inter-protocol/src/feeDistributor.js').start
+   * >}
    */
   const instanceKit = await E(zoe).startInstance(
     feeDistributor,
@@ -473,7 +473,6 @@ export const startRewardDistributor = async ({
     undefined,
     'feeDistributor',
   );
-  /** @type {ERef<import('../feeDistributor.js').FeeDestination>} */
   await E(instanceKit.creatorFacet).setDestinations({
     ...(rewardDistributorDepositFacet && {
       RewardDistributor: E(

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -197,7 +197,7 @@ async function makePsmDriver(t, customTerms) {
   // Each driver needs its own to avoid state pollution between tests
   const mockChainStorage = makeMockChainStorageRoot();
 
-  /** @type {Awaited<ReturnType<import('../../src/psm/psm.js').start>>} */
+  /** @type {StartedInstanceKit<import('../../src/psm/psm.js').start>} */
   const { creatorFacet, publicFacet } = await E(zoe).startInstance(
     psmInstall,
     harden({ AUSD: anchor.issuer }),

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -276,6 +276,8 @@ export const buildRootObject = async () => {
       ).getAdminFacet();
       const upgradeResult = await E(psmAdminFacet).upgradeContract(bundleId, {
         ...staticPrivateArgs,
+        // @ts-expect-error mock
+        feeMintAccess: undefined,
         initialPoserInvitation,
       });
       // incremented from zero

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -245,6 +245,8 @@ export const buildRootObject = async () => {
       const arAdminFacet = await E(governorFacets.creatorFacet).getAdminFacet();
       const upgradeResult = await E(arAdminFacet).upgradeContract(bundleId, {
         ...staticPrivateArgs,
+        // @ts-expect-error mock
+        feeMintAccess: undefined,
         initialPoserInvitation,
       });
       assert.equal(upgradeResult.incarnationNumber, 1);

--- a/packages/vats/src/proposals/null-upgrade-zoe-proposal.js
+++ b/packages/vats/src/proposals/null-upgrade-zoe-proposal.js
@@ -3,7 +3,7 @@ import { E } from '@endo/far';
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     vatAdminSvc: VatAdminSve;
+ *     vatAdminSvc: VatAdminSvc;
  *     vatStore: MapStore<string, CreateVatResults>;
  *   };
  * }} powers

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -244,4 +244,4 @@ type ContractStartFnResult<PF, CF> = {
   creatorInvitation?: Promise<Invitation<R, A>> | undefined;
 };
 type ContractOf<S> = import('../zoeService/utils').ContractOf<S>;
-type AdminFacet = import('../zoeService/utils').AdminFacet;
+type AdminFacet = import('../zoeService/utils').AdminFacet<any>;

--- a/packages/zoe/src/zoeService/utils.test-d.ts
+++ b/packages/zoe/src/zoeService/utils.test-d.ts
@@ -1,0 +1,33 @@
+import type { StartedInstanceKit } from './utils';
+
+const someContractStartFn = (
+  zcf: ZCF,
+  privateArgs: { someNumber: number; someString: string },
+) => {};
+
+type PsmInstanceKit = StartedInstanceKit<typeof someContractStartFn>;
+
+const psmInstanceKit: PsmInstanceKit = null as any;
+
+// @ts-expect-error missing privateArgs argument
+void psmInstanceKit.adminFacet.restartContract();
+
+const partial = {
+  someNumber: 1,
+};
+// @ts-expect-error missing member of privateArgs argument
+void psmInstanceKit.adminFacet.restartContract(partial);
+
+// valid privateArgs now with 'marshaller'
+void psmInstanceKit.adminFacet.restartContract({
+  ...partial,
+  someString: 'str',
+});
+
+// @ts-expect-error missing member of privateArgs argument
+void psmInstanceKit.adminFacet.upgradeContract('whatever', partial);
+// valid privateArgs now with 'marshaller'
+void psmInstanceKit.adminFacet.upgradeContract('whatever', {
+  ...partial,
+  someString: 'str',
+});


### PR DESCRIPTION
## Description

`startInstance` validated the type of the privateArgs param but `restartContract` and `upgradeContract` did not. This shortcoming recently cost a significant amount of time debugging.

This PR fills that gap and adds regression tests.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Adds regression tests.

### Upgrade Considerations

n/a
