### PR TITLE
chore(types): upgrade TypeScript to 5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier-plugin-jsdoc": "^1.0.0",
     "type-coverage": "^2.26.3",
     "typedoc": "^0.25.4",
-    "typescript": "~5.2.2"
+    "typescript": "~5.3.2"
   },
   "engines": {
     "node": "^16.13 || ^18.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9493,6 +9493,11 @@ typescript@~5.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
+typescript@~5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
+  integrity sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==
+
 uglify-js@^3.1.4:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.8.0.tgz#f3541ae97b2f048d7e7e3aa4f39fd8a1f5d7a805"


### PR DESCRIPTION
## Description

Update TypeScript from 5.2 to 5.3

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html

### Security Considerations

n/a
### Scaling Considerations

n/a
### Documentation Considerations

n/a
### Testing Considerations

CI

### Upgrade Considerations

n/a