### PR TITLE
feat: support starting contracts governed by any committee (WIP)

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -177,6 +177,7 @@ harden(produceStartUpgradable);
  *   governedParams: Record<string, unknown>;
  *   timer: ERef<import('@agoric/time').TimerService>;
  *   contractGovernor: ERef<Installation>;
+ *   governorCustomTerms: Record<string, unknown>;
  *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet'];
  * }} govArgs
  * @returns {Promise<GovernanceFacetKit<SF>>}
@@ -190,7 +191,13 @@ const startGovernedInstance = async (
     privateArgs,
     label,
   },
-  { governedParams, timer, contractGovernor, economicCommitteeCreatorFacet },
+  {
+    governedParams,
+    timer,
+    contractGovernor,
+    governorCustomTerms,
+    economicCommitteeCreatorFacet,
+  },
 ) => {
   const poserInvitationP = E(
     economicCommitteeCreatorFacet,
@@ -219,6 +226,7 @@ const startGovernedInstance = async (
         issuerKeywordRecord,
         label,
       },
+      ...governorCustomTerms,
     }),
   );
   const governorFacets = await E(zoe).startInstance(
@@ -282,7 +290,7 @@ export const produceStartGovernedUpgradable = async ({
    */
   const contractKits = zone.mapStore('GovernedContractKits');
 
-  /** @type {startGovernedUpgradable} */
+  /** @type {StartGovernedUpgradable} */
   const startGovernedUpgradable = async ({
     installation,
     issuerKeywordRecord,

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -177,8 +177,11 @@ harden(produceStartUpgradable);
  *   governedParams: Record<string, unknown>;
  *   timer: ERef<import('@agoric/time').TimerService>;
  *   contractGovernor: ERef<Installation>;
- *   governorCustomTerms: Record<string, unknown>;
- *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet'];
+ *   governorCustomTerms?: Record<string, unknown>;
+ *   committeeCreatorFacet: ERef<CommitteeStartResult['creatorFacet']>;
+ *   economicCommitteeCreatorFacet?: ERef<
+ *     import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet']
+ *   >;
  * }} govArgs
  * @returns {Promise<GovernanceFacetKit<SF>>}
  */
@@ -191,17 +194,15 @@ const startGovernedInstance = async (
     privateArgs,
     label,
   },
-  {
-    governedParams,
-    timer,
-    contractGovernor,
-    governorCustomTerms,
-    economicCommitteeCreatorFacet,
-  },
+  { governedParams, timer, contractGovernor, governorCustomTerms, ...rest },
 ) => {
-  const poserInvitationP = E(
-    economicCommitteeCreatorFacet,
-  ).getPoserInvitation();
+  // For backwards compatibility when this function assumed EC
+  const committee =
+    'economicCommitteeCreatorFacet' in rest
+      ? rest.economicCommitteeCreatorFacet
+      : rest.committeeCreatorFacet;
+  assert(committee, 'missing committee creator facet in startGovernedInstance');
+  const poserInvitationP = E(committee).getPoserInvitation();
   const [initialPoserInvitation, electorateInvitationAmount] =
     await Promise.all([
       poserInvitationP,
@@ -234,7 +235,6 @@ const startGovernedInstance = async (
     {},
     governorTerms,
     harden({
-      economicCommitteeCreatorFacet,
       governed: {
         ...privateArgs,
         initialPoserInvitation,
@@ -298,6 +298,8 @@ export const produceStartGovernedUpgradable = async ({
     terms,
     privateArgs,
     label,
+    governorCustomTerms,
+    committeeCreatorFacet,
   }) => {
     const facets = await startGovernedInstance(
       {
@@ -312,7 +314,9 @@ export const produceStartGovernedUpgradable = async ({
         governedParams,
         timer: chainTimerService,
         contractGovernor,
-        economicCommitteeCreatorFacet,
+        governorCustomTerms,
+        committeeCreatorFacet,
+        economicCommitteeCreatorFacet, // backwards-compatible name for committeeCreatorFacet
       },
     );
     const kit = harden({ ...facets, label });

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -93,6 +93,7 @@ export const startWalletFactory = async (
       econCharterKit,
       startUpgradable,
       startGovernedUpgradable,
+      economicCommitteeCreatorFacet,
     },
     produce: { client, walletFactoryStartResult, provisionPoolStartResult },
     installation: {
@@ -193,6 +194,7 @@ export const startWalletFactory = async (
         value: AmountMath.make(feeBrand, perAccountInitialValue),
       },
     },
+    committeeCreatorFacet: economicCommitteeCreatorFacet,
   });
   provisionPoolStartResult.resolve(ppFacets);
   instanceProduce.provisionPool.resolve(ppFacets.instance);
@@ -270,6 +272,7 @@ export const WALLET_FACTORY_MANIFEST = {
       namesByAddressAdmin: true,
       startUpgradable: true,
       startGovernedUpgradable: true,
+      economicCommitteeCreatorFacet: true,
       econCharterKit: 'psmCharter',
     },
     produce: {

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -257,6 +257,11 @@ type WellKnownSpaces = {
   };
 };
 
+type CommitteeStartResult =
+  import('@agoric/zoe/src/zoeService/utils').StartResult<
+    typeof import('@agoric/governance/src/committee.js').start
+  >;
+
 type StartGovernedUpgradableOpts<SF extends GovernableStartFn> = {
   installation: ERef<Installation<SF>>;
   issuerKeywordRecord?: IssuerKeywordRecord;
@@ -270,6 +275,8 @@ type StartGovernedUpgradableOpts<SF extends GovernableStartFn> = {
     'initialPoserInvitation'
   >;
   label: string;
+  governorCustomTerms?: Record<string, unknown>;
+  committeeCreatorFacet: ERef<CommitteeStartResult['creatorFacet']>;
 };
 
 type StartGovernedUpgradable = <SF extends GovernableStartFn>(
@@ -362,7 +369,12 @@ type ChainBootstrapSpaceT = {
   startUpgradable: StartUpgradable;
   /** kits stored by startUpgradable */
   contractKits: MapStore<Instance, StartedInstanceKitWithLabel>;
-  /** Convience function for starting contracts governed by the Econ Committee */
+  /**
+   * Convienence function for starting contracts governed by a committeee.
+   *
+   * NB: When the committeeCreatorFacet parameter is omitted, it defaults to the
+   * Economic Committee.
+   */
   startGovernedUpgradable: StartGovernedUpgradable;
   /** kits stored by startGovernedUpgradable */
   governedContractKits: MapStore<


### PR DESCRIPTION
refs: #8330

## Description

Analagous to `startGovernedUpgradable`, add `startMyGovernedUpgradable` with one more parameter: `committeeCreatorFacet`.

Includes an alternative to `agoric run` / `writeCoreProposals` for maintaining the code as a module but evaluating it as a script. (based on a hackathon prototype: [test-gimix-proposal.js](https://github.com/Agoric/agoric-sdk/blob/dc-gimix-test1/packages/zoe/test/unitTests/contracts/gimix/test-gimix-proposal.js))

### Security / Upgrade Considerations

Lots of authority is required to set up this helper:
 - `governedContractKits` exposes creator facets of many contracts
 - `diagnostics` grants authority to delete/replace privateArgs needed to later upgrade other contracts (see also #8378)

But in return, later MN-2 proposals can be granted exactly this authority that they need without granting those wide authorities.

### Documentation Considerations

Should be documented in [Declaring Required Capabilities](https://docs.agoric.com/guides/coreeval/permissions.html) under 
[Permissioned Contract Deployment](https://docs.agoric.com/guides/coreeval/).

### Scaling Considerations

none, AFAICT

### Testing Considerations

only minimally tested so far:

 - [x] doesn't throw when evaluated in a compartment
 - [ ] starting a governed contract works

