### PR TITLE
chore(deps): bump better-sqlite to 9.1

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -56,7 +56,7 @@
     "@endo/zip": "^0.2.34",
     "ansi-styles": "^6.2.1",
     "anylogger": "^0.21.0",
-    "better-sqlite3": "^8.2.0",
+    "better-sqlite3": "^9.1.1",
     "import-meta-resolve": "^2.2.1",
     "microtime": "^3.1.0",
     "semver": "^6.3.0",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -22,7 +22,7 @@
     "@agoric/assert": "^0.6.0",
     "@endo/init": "^0.5.59",
     "@endo/marshal": "^0.8.8",
-    "better-sqlite3": "^8.2.0",
+    "better-sqlite3": "^9.1.1",
     "chalk": "^5.2.0",
     "deterministic-json": "^1.0.5",
     "inquirer": "^8.2.2",

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/package.json
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {},
   "dependencies": {
     "ava": "^5.3.1",
-    "better-sqlite3": "^8.5.1",
+    "better-sqlite3": "^9.1.1",
     "execa": "^7.2.0"
   },
   "scripts": {

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -27,7 +27,7 @@
     "@endo/bundle-source": "^2.7.0",
     "@endo/check-bundle": "^0.2.21",
     "@endo/nat": "^4.1.30",
-    "better-sqlite3": "^8.2.0"
+    "better-sqlite3": "^9.1.1"
   },
   "devDependencies": {
     "@endo/init": "^0.5.59",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/sdk-trace-base": "~1.9.0",
     "@opentelemetry/semantic-conventions": "~1.9.0",
     "anylogger": "^0.21.0",
-    "better-sqlite3": "^8.2.0",
+    "better-sqlite3": "^9.1.1",
     "bufferfromfile": "agoric-labs/BufferFromFile#Agoric-built",
     "tmp": "^0.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2955,13 +2955,13 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
-better-sqlite3@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-8.2.0.tgz#4ef6185b88992723de7e00cfa67585ac59f320bd"
-  integrity sha512-8eTzxGk9535SB3oSNu0tQ6I4ZffjVCBUjKHN9QeeIFtphBX0sEd0NxAuglBNR9TO5ThnxBB7GqzfcYo9kjadJQ==
+better-sqlite3@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-9.1.1.tgz#f139b180a08ed396e660a0601a46ceefd78b832c"
+  integrity sha512-FhW7bS7cXwkB2SFnPJrSGPmQerVSCzwBgmQ1cIRcYKxLsyiKjljzCbyEqqhYXo5TTBqt5BISiBj2YE2Sy2ynaA==
   dependencies:
     bindings "^1.5.0"
-    prebuild-install "^7.1.0"
+    prebuild-install "^7.1.1"
 
 big-integer@^1.6.44:
   version "1.6.51"
@@ -8046,7 +8046,7 @@ pprof-format@^2.0.7:
   resolved "https://registry.yarnpkg.com/pprof-format/-/pprof-format-2.0.7.tgz#526e4361f8b37d16b2ec4bb0696b5292de5046a4"
   integrity sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA==
 
-prebuild-install@^7.1.0:
+prebuild-install@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
   integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==


### PR DESCRIPTION
The only breaking change in the major bump was dropping Node 16, which is EOL

https://github.com/WiseLibs/better-sqlite3/releases/tag/v9.0.0
