### PR TITLE
Price feed benchmarks

### DIFF
--- a/packages/benchmark/benchmark/benchmark-liquidation.js
+++ b/packages/benchmark/benchmark/benchmark-liquidation.js
@@ -1,0 +1,233 @@
+// eslint-disable-next-line import/order
+import { bench } from '../src/benchmarkerator.js';
+
+import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
+import { scale6 } from '@agoric/boot/tools/liquidation.ts';
+
+const setupData = {
+  vaults: [
+    {
+      atom: 15,
+      ist: 100,
+      debt: 100.5,
+    },
+  ],
+  bids: [
+    {
+      give: '80IST',
+      discount: 0.1,
+    },
+  ],
+  price: {
+    starting: 12.34,
+    trigger: 9.99,
+  },
+  auction: {
+    start: {
+      collateral: 15,
+      debt: 100.5,
+    },
+    end: {
+      collateral: 9.659301,
+      debt: 0,
+    },
+  },
+};
+
+const outcome = {
+  bids: [
+    {
+      payouts: {
+        Bid: 0,
+        Collateral: 8.897786,
+      },
+    },
+  ],
+  reserve: {
+    allocations: {
+      ATOM: 6.102214,
+    },
+    shortfall: 20.5,
+  },
+  vaultsSpec: [
+    {
+      locked: 3.373,
+    },
+  ],
+  vaultsActual: [
+    {
+      locked: 3.525747,
+    },
+  ],
+};
+
+const liquidationOptions = {
+  collateralBrandKey: 'ATOM',
+  managerIndex: 0,
+};
+
+const setup = async context => {
+  const { managerIndex } = liquidationOptions;
+  const { walletFactoryDriver } = context.tools;
+
+  const metricsPath = `published.vaultFactory.managers.manager${managerIndex}.metrics`;
+  const buyer = await walletFactoryDriver.provideSmartWallet('agoric1buyer');
+  const minter = await walletFactoryDriver.provideSmartWallet('agoric1minter');
+
+  return { metricsPath, buyer, minter };
+};
+
+const setupRound = async (context, round) => {
+  const { collateralBrandKey, managerIndex } = liquidationOptions;
+  const { setupVaults, placeBids } = context.tools;
+
+  await setupVaults(
+    collateralBrandKey,
+    managerIndex,
+    setupData,
+    round * setupData.vaults.length,
+  );
+  await placeBids(collateralBrandKey, 'agoric1buyer', setupData);
+};
+
+const executeRound = async (context, round) => {
+  const { collateralBrandKey, managerIndex } = liquidationOptions;
+  const { advanceTimeBy, advanceTimeTo, priceFeedDrivers, readLatest } =
+    context.tools;
+
+  const { metricsPath } = context.config;
+
+  // ---------------
+  //  Change price to trigger liquidation
+  // ---------------
+
+  await priceFeedDrivers[collateralBrandKey].setPrice(9.99);
+
+  // check nothing liquidating yet
+  const liveSchedule = readLatest('published.auction.schedule');
+  assert(liveSchedule.activeStartTime === null);
+  const metrics1 = readLatest(metricsPath);
+  assert(
+    metrics1.numActiveVaults === setupData.vaults.length &&
+      metrics1.numLiquidatingVaults === 0,
+  );
+
+  // advance time to start an auction
+  console.log(collateralBrandKey, 'step 1 of 10');
+  await advanceTimeTo(liveSchedule.nextDescendingStepTime);
+  const metrics2 = readLatest(metricsPath);
+  assert(
+    metrics2.numActiveVaults === 0 &&
+      metrics2.numLiquidatingVaults === setupData.vaults.length &&
+      metrics2.liquidatingCollateral.value ===
+        scale6(setupData.auction.start.collateral) &&
+      metrics2.liquidatingDebt.value === scale6(setupData.auction.start.debt) &&
+      metrics2.lockedQuote === null,
+  );
+
+  console.log(collateralBrandKey, 'step 2 of 10');
+  await advanceTimeBy(3, 'minutes');
+  let auctionBook = readLatest(`published.auction.book${managerIndex}`);
+  assert(
+    auctionBook.collateralAvailable.value ===
+      scale6(setupData.auction.start.collateral) &&
+      auctionBook.startCollateral.value ===
+        scale6(setupData.auction.start.collateral) &&
+      auctionBook.startProceedsGoal.value ===
+        scale6(setupData.auction.start.debt),
+  );
+
+  console.log(collateralBrandKey, 'step 3 of 10');
+  await advanceTimeBy(3, 'minutes');
+
+  console.log(collateralBrandKey, 'step 4 of 10');
+  await advanceTimeBy(3, 'minutes');
+
+  let buyerWallet = readLatest('published.wallet.agoric1buyer');
+  assert(
+    buyerWallet.status.id === `${collateralBrandKey}-bid1` &&
+      buyerWallet.status.payouts.Collateral.value ===
+        scale6(outcome.bids[0].payouts.Collateral) &&
+      buyerWallet.status.payouts.Bid.value ===
+        scale6(outcome.bids[0].payouts.Bid),
+  );
+
+  console.log(collateralBrandKey, 'step 5 of 10');
+  await advanceTimeBy(3, 'minutes');
+
+  console.log(collateralBrandKey, 'step 6 of 10');
+  await advanceTimeBy(3, 'minutes');
+  auctionBook = readLatest(`published.auction.book${managerIndex}`);
+  assert(auctionBook.collateralAvailable.value === 6102214n);
+
+  console.log(collateralBrandKey, 'step 7 of 10');
+  await advanceTimeBy(3, 'minutes');
+
+  console.log(collateralBrandKey, 'step 8 of 10');
+  await advanceTimeBy(3, 'minutes');
+
+  console.log(collateralBrandKey, 'step 9 of 10');
+  await advanceTimeBy(3, 'minutes');
+
+  const metrics3 = readLatest(metricsPath);
+  const roundB = BigInt(round);
+  assert(
+    metrics3.numActiveVaults === 0 &&
+      metrics3.numLiquidationsCompleted === setupData.vaults.length * round &&
+      metrics3.numLiquidatingVaults === 0 &&
+      metrics3.retainedCollateral.value === 0n &&
+      metrics3.totalCollateral.value === 0n &&
+      metrics3.totalCollateralSold.value === 8897786n * roundB &&
+      metrics3.totalDebt.value === 0n &&
+      metrics3.totalOverageReceived.value === 0n &&
+      metrics3.totalProceedsReceived.value === 80000000n * roundB &&
+      metrics3.totalShortfallReceived.value === 20500000n * roundB,
+  );
+
+  console.log(collateralBrandKey, 'step 10 of 10');
+
+  buyerWallet = readLatest('published.wallet.agoric1buyer');
+  assert(
+    buyerWallet.status.id === `${collateralBrandKey}-bid1` &&
+      buyerWallet.status.payouts.Collateral.value ===
+        scale6(outcome.bids[0].payouts.Collateral) &&
+      buyerWallet.status.payouts.Bid.value ===
+        scale6(outcome.bids[0].payouts.Bid),
+  );
+
+  // check reserve balances
+  const metrics4 = readLatest('published.reserve.metrics');
+  assert(
+    metrics4.allocations[collateralBrandKey].value ===
+      scale6(outcome.reserve.allocations[collateralBrandKey]) * roundB &&
+      metrics4.shortfallBalance.value ===
+        scale6(outcome.reserve.shortfall) * roundB,
+  );
+};
+
+const finishRound = async (context, round) => {
+  const { collateralBrandKey } = liquidationOptions;
+  const { minter } = context.config;
+
+  await 47; // sacrifice to the gods of asynchrony
+  for (let i = 0; i < setupData.vaults.length; i += 1) {
+    await minter.executeOfferMaker(
+      Offers.vaults.CloseVault,
+      {
+        offerId: `${collateralBrandKey}-bid${i}`,
+        collateralBrandKey,
+        giveMinted: 0,
+      },
+      `open-${collateralBrandKey}-vault${round * setupData.vaults.length + i}`,
+    );
+  }
+};
+
+bench.addBenchmark('price feed with liquidation', {
+  setup,
+  setupRound,
+  executeRound,
+  finishRound,
+});
+
+await bench.run();

--- a/packages/benchmark/benchmark/benchmark-pricefeed.js
+++ b/packages/benchmark/benchmark/benchmark-pricefeed.js
@@ -1,0 +1,40 @@
+import { bench } from '../src/benchmarkerator.js';
+
+const setupData = {
+  vaults: [],
+  price: { starting: 12.34 },
+};
+
+const liquidationOptions = {
+  collateralBrandKey: 'ATOM',
+  managerIndex: 0,
+};
+
+const setup = async context => {
+  const { collateralBrandKey, managerIndex } = liquidationOptions;
+  const { setupVaults } = context.tools;
+
+  await setupVaults(
+    collateralBrandKey,
+    managerIndex,
+    setupData,
+    setupData.vaults.length,
+  );
+
+  return {};
+};
+
+const executeRound = async (context, round) => {
+  const { collateralBrandKey } = liquidationOptions;
+  const { priceFeedDrivers } = context.tools;
+
+  console.log(`price feed round #${round}`);
+  await priceFeedDrivers[collateralBrandKey].setPrice(9.99);
+};
+
+bench.addBenchmark('price feed without liquidation', {
+  setup,
+  executeRound,
+});
+
+await bench.run();

--- a/packages/benchmark/doc/benchmarkerator.md
+++ b/packages/benchmark/doc/benchmarkerator.md
@@ -84,6 +84,25 @@ optional except for `executeRound`:
   benchmark.  The `round` argument is the number of the benchmark round
   that this call to `executeRound` is being asked to execute (counting from 1).
 
+`setupRound: (context: BenchmarkContext, round: number) => Promise<void>`
+
+  A optional async method which is called to perform initializations required
+  for a single round of the benchmark.  It is called immediately before calling
+  `executeRound` but its execution time and any resources it consumes will not
+  be accounted against the stats for the round in question.  The `round`
+  argument is the number of the benchmark round that the corresponding call to
+  `executeRound` is being asked to execute (counting from 1).
+
+`finishRound: (context: BenchmarkContext, round: number) => Promise<void>`
+
+  A optional async method which is called to perform teardowns required by a
+  single round of the benchmark.  It is called immediately after calling
+  `executeRound` but its execution time and any resources it consumes will not
+  be accounted against the stats for the round in question (or the round that
+  follows).  The `round` argument is the number of the benchmark round that the
+  corresponding call to `executeRound` that just completed execution (counting
+  from 1).
+
 `finish?: (context: BenchmarkContext) => Promise<void>`
 
   An optional async method to perform any post-run teardown that you need to do.

--- a/packages/benchmark/src/benchmarkerator.js
+++ b/packages/benchmark/src/benchmarkerator.js
@@ -440,6 +440,8 @@ const printBenchmarkStats = stats => {
     `${stats.rounds} rounds in ${stats.elapsedTime}ns (${stats.timePerRound.toFixed(3)}/round})`,
   );
 
+  // There are lots of temp variables used here simply so things lay out cleanly
+  // in the source text.  Don't try to read too much meaning into the names themselves.
   const wc1 = 32;
   const hc1 = `${'Counter'.padEnd(wc1)}`;
   const dc1 = `${''.padEnd(wc1, '-')}`;
@@ -592,7 +594,8 @@ export const makeBenchmarkerator = async () => {
     agoricNamesRemotes,
     walletFactoryDriver,
     governanceDriver,
-    like: () => {},
+    // @ts-expect-error missing 'skip' property of real Ava like
+    t: { like: () => {} }, // XXX noop
   });
 
   const actors = {

--- a/packages/boot/test/bootstrapTests/test-addAssets.ts
+++ b/packages/boot/test/bootstrapTests/test-addAssets.ts
@@ -6,7 +6,7 @@ import { TimeMath } from '@agoric/time';
 import {
   LiquidationTestContext,
   makeLiquidationTestContext,
-} from './liquidation.ts';
+} from '../../tools/liquidation.ts';
 import { makeProposalExtractor } from '../../tools/supports.ts';
 
 const test = anyTest as TestFn<

--- a/packages/boot/test/bootstrapTests/test-liquidation-1.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-1.ts
@@ -12,7 +12,7 @@ import {
   makeLiquidationTestContext,
   scale6,
   LiquidationSetup,
-} from './liquidation.ts';
+} from '../../tools/liquidation.ts';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-2b.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-2b.ts
@@ -17,7 +17,7 @@ import {
   LiquidationTestContext,
   makeLiquidationTestContext,
   scale6,
-} from './liquidation.ts';
+} from '../../tools/liquidation.ts';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-concurrent-1.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-concurrent-1.ts
@@ -12,7 +12,7 @@ import {
   likePayouts,
   makeLiquidationTestContext,
   scale6,
-} from './liquidation.ts';
+} from '../../tools/liquidation.ts';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-concurrent-2b.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-concurrent-2b.ts
@@ -15,7 +15,7 @@ import {
   ensureVaultCollateral,
   makeLiquidationTestContext,
   scale6,
-} from './liquidation.ts';
+} from '../../tools/liquidation.ts';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-walletSurvivesZoeRestart.ts
+++ b/packages/boot/test/bootstrapTests/test-walletSurvivesZoeRestart.ts
@@ -12,7 +12,7 @@ import {
   makeLiquidationTestContext,
   scale6,
   LiquidationSetup,
-} from './liquidation.ts';
+} from '../../tools/liquidation.ts';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -197,6 +197,8 @@ export const makePriceFeedDriver = async (
     },
   };
 };
+harden(makePriceFeedDriver);
+export type PriceFeedDriver = Awaited<ReturnType<typeof makePriceFeedDriver>>;
 
 export const makeGovernanceDriver = async (
   testKit: SwingsetTestKit,
@@ -318,6 +320,8 @@ export const makeGovernanceDriver = async (
     ecMembers,
   };
 };
+harden(makeGovernanceDriver);
+export type GovernanceDriver = Awaited<ReturnType<typeof makeGovernanceDriver>>;
 
 export const makeZoeDriver = async (testKit: SwingsetTestKit) => {
   const { EV } = testKit.runUtils;
@@ -402,3 +406,5 @@ export const makeZoeDriver = async (testKit: SwingsetTestKit) => {
     },
   };
 };
+harden(makeZoeDriver);
+export type ZoeDriver = Awaited<ReturnType<typeof makeZoeDriver>>;

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -315,6 +315,7 @@ export const makeGovernanceDriver = async (
       await enactLatestProposal();
       await testKit.advanceTimeBy(1, 'minutes');
     },
+    ecMembers,
   };
 };
 

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -9,8 +9,11 @@ import {
 } from '@agoric/vats/tools/board-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import type { ExecutionContext } from 'ava';
-import { makeSwingsetTestKit } from './supports.ts';
+import { type SwingsetTestKit, makeSwingsetTestKit } from './supports.ts';
 import {
+  type GovernanceDriver,
+  type PriceFeedDriver,
+  type WalletFactoryDriver,
   makeGovernanceDriver,
   makePriceFeedDriver,
   makeWalletFactoryDriver,
@@ -76,10 +79,7 @@ export const makeLiquidationTestKit = async ({
   governanceDriver: GovernanceDriver;
   t: Pick<ExecutionContext, 'like'>;
 }) => {
-  const priceFeedDrivers = {} as Record<
-    string,
-    Awaited<ReturnType<typeof makePriceFeedDriver>>
-  >;
+  const priceFeedDrivers = {} as Record<string, PriceFeedDriver>;
 
   console.timeLog('DefaultTestContext', 'priceFeedDriver');
 

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -68,7 +68,13 @@ export const makeLiquidationTestKit = async ({
   agoricNamesRemotes,
   walletFactoryDriver,
   governanceDriver,
-  like,
+  t,
+}: {
+  swingsetTestKit: SwingsetTestKit;
+  agoricNamesRemotes: AgoricNamesRemotes;
+  walletFactoryDriver: WalletFactoryDriver;
+  governanceDriver: GovernanceDriver;
+  t: Pick<ExecutionContext, 'like'>;
 }) => {
   const priceFeedDrivers = {} as Record<
     string,
@@ -91,7 +97,7 @@ export const makeLiquidationTestKit = async ({
     const managerPath = `published.vaultFactory.managers.manager${managerIndex}`;
     const { advanceTimeBy, readLatest } = swingsetTestKit;
 
-    await 0;
+    await null;
     if (!priceFeedDrivers[collateralBrandKey]) {
       priceFeedDrivers[collateralBrandKey] = await makePriceFeedDriver(
         collateralBrandKey,
@@ -143,7 +149,7 @@ export const makeLiquidationTestKit = async ({
     );
 
     // confirm Relevant Governance Parameter Assumptions
-    like(readLatest(`${managerPath}.governance`), {
+    t.like(readLatest(`${managerPath}.governance`), {
       current: {
         DebtLimit: { value: { value: DebtLimitValue } },
         InterestRate: {
@@ -168,7 +174,7 @@ export const makeLiquidationTestKit = async ({
         },
       },
     });
-    like(readLatest('published.auction.governance'), {
+    t.like(readLatest('published.auction.governance'), {
       current: {
         AuctionStartDelay: { type: 'relativeTime', value: { relValue: 2n } },
         ClockStep: {
@@ -201,7 +207,7 @@ export const makeLiquidationTestKit = async ({
       const notification = readLatest(
         `published.vaultFactory.managers.manager${managerIndex}.vaults.vault${vaultIndex}`,
       );
-      like(notification, partial);
+      t.like(notification, partial);
     },
   };
 
@@ -228,7 +234,7 @@ export const makeLiquidationTestKit = async ({
         wantMinted: setup.vaults[i].ist,
         giveCollateral: setup.vaults[i].atom,
       });
-      like(minter.getLatestUpdateRecord(), {
+      t.like(minter.getLatestUpdateRecord(), {
         updated: 'offerStatus',
         status: { id: offerId, numWantsSatisfied: 1 },
       });
@@ -276,7 +282,7 @@ export const makeLiquidationTestKit = async ({
         ...setup.bids[i],
         maxBuy,
       });
-      like(
+      t.like(
         swingsetTestKit.readLatest(`published.wallet.${buyerWalletAddress}`),
         {
           status: {
@@ -346,7 +352,7 @@ export const makeLiquidationTestContext = async t => {
     agoricNamesRemotes,
     walletFactoryDriver,
     governanceDriver,
-    like: t.like,
+    t,
   });
   return {
     ...swingsetTestKit,

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -9,12 +9,12 @@ import {
 } from '@agoric/vats/tools/board-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import type { ExecutionContext } from 'ava';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
+import { makeSwingsetTestKit } from './supports.ts';
 import {
   makeGovernanceDriver,
   makePriceFeedDriver,
   makeWalletFactoryDriver,
-} from '../../tools/drivers.ts';
+} from './drivers.ts';
 
 export type LiquidationSetup = {
   vaults: {
@@ -63,52 +63,13 @@ export const likePayouts = ({ Bid, Collateral }) => ({
   },
 });
 
-export const makeLiquidationTestContext = async t => {
-  console.time('DefaultTestContext');
-  const swingsetTestKit = await makeSwingsetTestKit(t.log, 'bundles/vaults', {
-    configSpecifier: '@agoric/vm-config/decentral-main-vaults-config.json',
-  });
-
-  const { runUtils, storage } = swingsetTestKit;
-  console.timeLog('DefaultTestContext', 'swingsetTestKit');
-  const { EV } = runUtils;
-
-  // Wait for ATOM to make it into agoricNames
-  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
-  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
-
-  // has to be late enough for agoricNames data to have been published
-  const agoricNamesRemotes: AgoricNamesRemotes =
-    makeAgoricNamesRemotesFromFakeStorage(swingsetTestKit.storage);
-  const refreshAgoricNamesRemotes = () => {
-    Object.assign(
-      agoricNamesRemotes,
-      makeAgoricNamesRemotesFromFakeStorage(swingsetTestKit.storage),
-    );
-  };
-  agoricNamesRemotes.brand.ATOM || Fail`ATOM missing from agoricNames`;
-  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
-
-  const walletFactoryDriver = await makeWalletFactoryDriver(
-    runUtils,
-    storage,
-    agoricNamesRemotes,
-  );
-  console.timeLog('DefaultTestContext', 'walletFactoryDriver');
-
-  const governanceDriver = await makeGovernanceDriver(
-    swingsetTestKit,
-    agoricNamesRemotes,
-    walletFactoryDriver,
-    // TODO read from the config file
-    [
-      'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
-      'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',
-      'agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a',
-    ],
-  );
-  console.timeLog('DefaultTestContext', 'governanceDriver');
-
+export const makeLiquidationTestKit = async ({
+  swingsetTestKit,
+  agoricNamesRemotes,
+  walletFactoryDriver,
+  governanceDriver,
+  like,
+}) => {
   const priceFeedDrivers = {} as Record<
     string,
     Awaited<ReturnType<typeof makePriceFeedDriver>>
@@ -130,21 +91,22 @@ export const makeLiquidationTestContext = async t => {
     const managerPath = `published.vaultFactory.managers.manager${managerIndex}`;
     const { advanceTimeBy, readLatest } = swingsetTestKit;
 
-    !priceFeedDrivers[collateralBrandKey] ||
-      Fail`setup for ${collateralBrandKey} already ran`;
-    priceFeedDrivers[collateralBrandKey] = await makePriceFeedDriver(
-      collateralBrandKey,
-      agoricNamesRemotes,
-      walletFactoryDriver,
-      // TODO read from the config file
-      [
-        'agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr',
-        'agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8',
-        'agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78',
-        'agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p',
-        'agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj',
-      ],
-    );
+    await 0;
+    if (!priceFeedDrivers[collateralBrandKey]) {
+      priceFeedDrivers[collateralBrandKey] = await makePriceFeedDriver(
+        collateralBrandKey,
+        agoricNamesRemotes,
+        walletFactoryDriver,
+        // TODO read from the config file
+        [
+          'agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr',
+          'agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8',
+          'agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78',
+          'agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p',
+          'agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj',
+        ],
+      );
+    }
 
     // price feed logic treats zero time as "unset" so advance to nonzero
     await advanceTimeBy(1, 'seconds');
@@ -181,7 +143,7 @@ export const makeLiquidationTestContext = async t => {
     );
 
     // confirm Relevant Governance Parameter Assumptions
-    t.like(readLatest(`${managerPath}.governance`), {
+    like(readLatest(`${managerPath}.governance`), {
       current: {
         DebtLimit: { value: { value: DebtLimitValue } },
         InterestRate: {
@@ -206,7 +168,7 @@ export const makeLiquidationTestContext = async t => {
         },
       },
     });
-    t.like(readLatest('published.auction.governance'), {
+    like(readLatest('published.auction.governance'), {
       current: {
         AuctionStartDelay: { type: 'relativeTime', value: { relValue: 2n } },
         ClockStep: {
@@ -239,7 +201,7 @@ export const makeLiquidationTestContext = async t => {
       const notification = readLatest(
         `published.vaultFactory.managers.manager${managerIndex}.vaults.vault${vaultIndex}`,
       );
-      t.like(notification, partial);
+      like(notification, partial);
     },
   };
 
@@ -247,6 +209,7 @@ export const makeLiquidationTestContext = async t => {
     collateralBrandKey: string,
     managerIndex: number,
     setup: LiquidationSetup,
+    base: number = 0,
   ) => {
     await setupStartingState({
       collateralBrandKey,
@@ -258,14 +221,14 @@ export const makeLiquidationTestContext = async t => {
       await walletFactoryDriver.provideSmartWallet('agoric1minter');
 
     for (let i = 0; i < setup.vaults.length; i += 1) {
-      const offerId = `open-${collateralBrandKey}-vault${i}`;
+      const offerId = `open-${collateralBrandKey}-vault${base + i}`;
       await minter.executeOfferMaker(Offers.vaults.OpenVault, {
         offerId,
         collateralBrandKey,
         wantMinted: setup.vaults[i].ist,
         giveCollateral: setup.vaults[i].atom,
       });
-      t.like(minter.getLatestUpdateRecord(), {
+      like(minter.getLatestUpdateRecord(), {
         updated: 'offerStatus',
         status: { id: offerId, numWantsSatisfied: 1 },
       });
@@ -313,7 +276,7 @@ export const makeLiquidationTestContext = async t => {
         ...setup.bids[i],
         maxBuy,
       });
-      t.like(
+      like(
         swingsetTestKit.readLatest(`published.wallet.${buyerWalletAddress}`),
         {
           status: {
@@ -327,15 +290,71 @@ export const makeLiquidationTestContext = async t => {
   };
 
   return {
-    ...swingsetTestKit,
-    agoricNamesRemotes,
     check,
-    governanceDriver,
     priceFeedDrivers,
-    refreshAgoricNamesRemotes,
-    walletFactoryDriver,
     setupVaults,
     placeBids,
+  };
+};
+
+export const makeLiquidationTestContext = async t => {
+  const swingsetTestKit = await makeSwingsetTestKit(t.log, 'bundles/vaults');
+  console.time('DefaultTestContext');
+
+  const { runUtils, storage } = swingsetTestKit;
+  console.timeLog('DefaultTestContext', 'swingsetTestKit');
+  const { EV } = runUtils;
+
+  // Wait for ATOM to make it into agoricNames
+  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
+  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
+
+  // has to be late enough for agoricNames data to have been published
+  const agoricNamesRemotes: AgoricNamesRemotes =
+    makeAgoricNamesRemotesFromFakeStorage(storage);
+  const refreshAgoricNamesRemotes = () => {
+    Object.assign(
+      agoricNamesRemotes,
+      makeAgoricNamesRemotesFromFakeStorage(storage),
+    );
+  };
+  agoricNamesRemotes.brand.ATOM || Fail`ATOM missing from agoricNames`;
+  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
+
+  const walletFactoryDriver = await makeWalletFactoryDriver(
+    runUtils,
+    storage,
+    agoricNamesRemotes,
+  );
+  console.timeLog('DefaultTestContext', 'walletFactoryDriver');
+
+  const governanceDriver = await makeGovernanceDriver(
+    swingsetTestKit,
+    agoricNamesRemotes,
+    walletFactoryDriver,
+    // TODO read from the config file
+    [
+      'agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce',
+      'agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang',
+      'agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h',
+    ],
+  );
+  console.timeLog('DefaultTestContext', 'governanceDriver');
+
+  const liquidationTestKit = await makeLiquidationTestKit({
+    swingsetTestKit,
+    agoricNamesRemotes,
+    walletFactoryDriver,
+    governanceDriver,
+    like: t.like,
+  });
+  return {
+    ...swingsetTestKit,
+    ...liquidationTestKit,
+    agoricNamesRemotes,
+    refreshAgoricNamesRemotes,
+    walletFactoryDriver,
+    governanceDriver,
   };
 };
 

--- a/packages/vm-config/decentral-itest-vaults-config.json
+++ b/packages/vm-config/decentral-itest-vaults-config.json
@@ -105,6 +105,34 @@
       ]
     },
     {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+            "decimalPlaces": 18,
+            "keyword": "DAI_axl",
+            "proposedName": "DAI"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/3D5291C23D776C3AA7A7ABB34C7B023193ECD2BC42EA19D3165B2CF9652117E7",
+            "decimalPlaces": 18,
+            "keyword": "DAI_grv",
+            "proposedName": "DAI"
+          }
+        }
+      ]
+    },
+    {
       "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
       "entrypoint": "defaultProposalBuilder",
       "args": [
@@ -112,7 +140,7 @@
           "contractTerms": {
             "POLL_INTERVAL": 30,
             "maxSubmissionCount": 1000,
-            "minSubmissionCount": 1,
+            "minSubmissionCount": 3,
             "restartDelay": 1,
             "timeout": 10,
             "minSubmissionValue": 1,
@@ -120,8 +148,11 @@
           },
           "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
           "oracleAddresses": [
-            "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
-            "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang"
+            "agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr",
+            "agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8",
+            "agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78",
+            "agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p",
+            "agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj"
           ],
           "IN_BRAND_LOOKUP": [
             "agoricNames",


### PR DESCRIPTION
Implement benchmarks for price feeds with	and without liquidation.

This includes adjustments to the boot tooling to accommodate its use for benchmarking, as well as improvements and enhancements to the bechmarkerator API that were required to make these benchmarks possible.

Closes #8496
