### PR TITLE
fix(casting): properly follow an unpopulated node

### DIFF
--- a/packages/agoric-cli/src/follow.js
+++ b/packages/agoric-cli/src/follow.js
@@ -142,9 +142,12 @@ export default async function followerMain(progname, rawArgs, powers, opts) {
       verbose && console.warn('Following', spec);
       const castingSpec = makeCastingSpec(spec);
       const follower = makeFollower(castingSpec, leader, followerOptions);
-      for await (const { value, blockHeight, currentBlockHeight } of iterate(
-        follower,
-      )) {
+      for await (const obj of iterate(follower)) {
+        if ('error' in obj) {
+          console.error('Error following:', obj.error);
+          continue;
+        }
+        const { value, blockHeight, currentBlockHeight } = obj;
         const blockHeightPrefix = opts.blockHeight ? `${blockHeight}:` : '';
         const currentBlockHeightPrefix = opts.currentBlockHeight
           ? `${currentBlockHeight}:`

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -450,9 +450,11 @@ export const makeCosmjsFollower = (
     // contain data.
     await null;
     for (;;) {
-      ({ value: cursorData, height: cursorBlockHeight } =
+      let thisHeight;
+      ({ value: cursorData, height: thisHeight } =
         await getDataAtHeight(cursorBlockHeight));
       if (cursorData.length !== 0) {
+        cursorBlockHeight = thisHeight;
         const cursorStreamCell = streamCellForData(
           cursorBlockHeight,
           cursorData,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #8601

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

If the multistore entry being followed was not yet created, the `@agoric/casting` follower would fixate on the current block height, and not try advancing the cursor to the latest entry.  This fix keeps trying the latest entry to see if it has any new contents.

Also add follow error handling to `agoric follow`.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Manually tested in UIs.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a
