### PR TITLE
ci: workaround GH auth changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,12 @@ on:
   schedule:
     - cron: '17 6 * * *'
 
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  statuses: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -14,6 +14,12 @@ on:
       - auto_merge_disabled
   merge_group:
 
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  statuses: read
+
 jobs:
   wait-integration-pre-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Something changed in the organization settings, or on GH, but the default `GITHUB_TOKEN` doesn't seem to allow check creations anymore, so try to be explicit about the permissions needed.