### PR TITLE
feat: allow clawback vesting accounts to return grants

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -106,7 +106,7 @@ t:
 
 TM_URL           := file://$(shell go list -m -f '{{ .Dir }}' github.com/tendermint/tendermint)/proto/tendermint
 GOGO_PROTO_URL   := file://$(shell go list -m -f '{{ .Dir }}' github.com/gogo/protobuf)
-IBC_PROTO_URL    := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/ibc-go/v3)/proto/ibc/core
+IBC_PROTO_URL    := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/ibc-go/v4)/proto/ibc/core
 COSMOS_SDK_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/cosmos-sdk)/proto/cosmos
 
 GOGO_PROTO_TYPES  = third_party/proto/gogoproto

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -158,7 +158,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 replace github.com/tendermint/tendermint => github.com/agoric-labs/cometbft v0.34.27-alpha.agoric.3
 
 // We need a fork of cosmos-sdk until all of the differences are merged.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.16-alpha.agoric.2
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.16-alpha.agoric.3
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../../../forks/cosmos-sdk

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -93,8 +93,8 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agoric-labs/cometbft v0.34.27-alpha.agoric.3 h1:RrKcZClqKav60DA4XEEskEwSsNB3l4ENkBVR66jORvQ=
 github.com/agoric-labs/cometbft v0.34.27-alpha.agoric.3/go.mod h1:BcCbhKv7ieM0KEddnYXvQZR+pZykTKReJJYf7YC7qhw=
-github.com/agoric-labs/cosmos-sdk v0.45.16-alpha.agoric.2 h1:zwYWlYI1le3ctFlgnOX0tFDnTa5jCxKaLfFfNbTJuOg=
-github.com/agoric-labs/cosmos-sdk v0.45.16-alpha.agoric.2/go.mod h1:T0VCPrAAeps81/pnD8b0+oBCMDxrkrD48W1t/XYYUeI=
+github.com/agoric-labs/cosmos-sdk v0.45.16-alpha.agoric.3 h1:kEcWMDCGVHOrk9FBvHPCgpVK4uCjHtoKDbRQqj5T4Og=
+github.com/agoric-labs/cosmos-sdk v0.45.16-alpha.agoric.3/go.mod h1:T0VCPrAAeps81/pnD8b0+oBCMDxrkrD48W1t/XYYUeI=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=

--- a/golang/cosmos/x/lien/keeper/account.go
+++ b/golang/cosmos/x/lien/keeper/account.go
@@ -16,16 +16,16 @@ import (
 // In addition to the methods declared in authtypes.AccountI, additional
 // expectations are enforced dynamically through casting and reflection:
 //
-//	- non-module accounts are expected to obey the GenesisAccount interface,
-//	i.e. to have a Validate() method;
+//   - non-module accounts are expected to obey the GenesisAccount interface,
+//     i.e. to have a Validate() method;
 //
-//	- UnpackInterfacesMessage is needed for unpacking accounts embedded
-//	in an Any message;
+//   - UnpackInterfacesMessage is needed for unpacking accounts embedded
+//     in an Any message;
 //
-//	- MarshalYAML() is used for String rendering;
+//   - MarshalYAML() is used for String rendering;
 //
-//	- protobuf Messages are expected to implement a number of "XXX"-prefixed
-//	methods not visible in the Message interface.
+//   - protobuf Messages are expected to implement a number of "XXX"-prefixed
+//     methods not visible in the Message interface.
 //
 // Declaring the expected methods here allows them to implicitly fall through
 // to an embedded omniAccount.
@@ -116,7 +116,7 @@ func (uva unlockedVestingAccount) GetOriginalVesting() sdk.Coins {
 	return sdk.NewCoins()
 }
 
-//GetDelegatedFree implements the vestexported.VestingAccount interface.
+// GetDelegatedFree implements the vestexported.VestingAccount interface.
 func (uva unlockedVestingAccount) GetDelegatedFree() sdk.Coins {
 	return uva.lien.Delegated
 }
@@ -170,6 +170,11 @@ func (fca fakeClawbackAccount) Clawback(ctx sdk.Context, action vestexported.Cla
 func (fca fakeClawbackAccount) PostReward(ctx sdk.Context, reward sdk.Coins, action vestexported.RewardAction) error {
 	// perform no action here, but lienAccount can divert lien
 	return nil
+}
+
+// ReturnGrants implements the vestexported.ClawbackVestingAccountI interface.
+func (fca fakeClawbackAccount) ReturnGrants(ctx sdk.Context, action vestexported.ReturnGrantAction) error {
+	return action.TakeGrants(ctx, fca.omniGrantAccount) // XXX or just fail here
 }
 
 // LienAccount wraps an omniClawbackAccount to implement lien encumbrance.


### PR DESCRIPTION
closes: #8570

## Description

Pick up new `agd tx auth vesting return-grants` command from latest cosmos-sdk.

Adapt lien account wrappers for the new method.

### Security Considerations

Allows the limited ability to transfer staked and unbonding tokens. This does not subvert the issues addressed by the unbonding delay, as they can only be transferred to the funder of the grant, not an arbitrary 3rd party.

### Scaling Considerations

Like clawback, this is a relatively expensive operation.

### Documentation Considerations

Command documentation should be adequate.

### Testing Considerations

Need to ensure end-to-end functioning of the command in the presence of the lien wrappers.

### Upgrade Considerations

N/A: doesn't affect stored data
