### PR TITLE
feat: add exporter.getHostKV() API

### DIFF
--- a/packages/cosmic-swingset/src/import-kernel-db.js
+++ b/packages/cosmic-swingset/src/import-kernel-db.js
@@ -145,6 +145,9 @@ export const performStateSyncImport = async (
   // Represent the data in `exportDir` as a SwingSetExporter object.
   /** @type {import('@agoric/swing-store').SwingStoreExporter} */
   const exporter = harden({
+    getHostKV(_key) {
+      return undefined;
+    },
     async *getExportData() {
       log?.('importing export data');
       const exportData = createReadStream(

--- a/packages/swing-store/test/exports.js
+++ b/packages/swing-store/test/exports.js
@@ -76,6 +76,9 @@ export function buildData() {
  */
 export function makeExporter(exportData, artifacts) {
   return {
+    getHostKV(_key) {
+      return undefined;
+    },
     async *getExportData() {
       for (const [key, value] of exportData.entries()) {
         /** @type { import('../src/exporter.js').KVPair } */

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -106,6 +106,9 @@ test('b0 import', async t => {
   const idA = makeB0ID(b0A);
   const nameA = `bundle.${idA}`;
   const exporter = {
+    getHostKV(_key) {
+      return undefined;
+    },
     async *getExportData() {
       yield /** @type {const} */ ([nameA, idA]);
     },
@@ -134,6 +137,9 @@ test('b0 bad import', async t => {
   const idA = makeB0ID(b0A);
   const nameA = `bundle.${idA}`;
   const exporter = {
+    getHostKV(_key) {
+      return undefined;
+    },
     async *getExportData() {
       yield /** @type {const} */ ([nameA, idA]);
     },

--- a/packages/swing-store/test/test-export.js
+++ b/packages/swing-store/test/test-export.js
@@ -34,6 +34,8 @@ const exportTest = test.macro(async (t, mode) => {
   const ss1 = initSwingStore(dbDir, options);
   const ks = ss1.kernelStorage;
 
+  ss1.hostStorage.kvStore.set('host.h1', 'hostvalue1');
+
   // build a DB with four spans (one in an old incarnation, two
   // historical but current incarnation, only one inUse) and two
   // snapshots (only one inUSe)
@@ -85,6 +87,13 @@ const exportTest = test.macro(async (t, mode) => {
     artifactMode = 'debug';
   }
   const exporter = makeSwingStoreExporter(dbDir, { artifactMode });
+
+  // hostKV
+  t.is(exporter.getHostKV('host.h1'), 'hostvalue1');
+  t.is(exporter.getHostKV('host.hmissing'), undefined);
+  t.throws(() => exporter.getHostKV('nonhost'), {
+    message: 'getHostKV requires host keys',
+  });
 
   // exportData
   {


### PR DESCRIPTION
Add a new API to the exporter, `exporter.getHostKV(key)`, so that the cosmic-swingset state-sync exporter process can query `host.height` without accidentally creating a read-write transaction too.

refs #8523
