### PR TITLE
export types from timer package

### DIFF
--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -20,12 +20,12 @@ import { TimeMath } from '@agoric/time';
 // client). Everything else should remain in the DB.
 
 /**
- * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
- * @typedef {import('@agoric/time/src/types').TimestampRecord} TimestampRecord
- * @typedef {import('@agoric/time/src/types').TimestampValue} TimestampValue
- * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
- * @typedef {import('@agoric/time/src/types').RelativeTimeValue} RelativeTimeValue
- * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ * @typedef {import('@agoric/time').Timestamp} Timestamp
+ * @typedef {import('@agoric/time').TimestampRecord} TimestampRecord
+ * @typedef {import('@agoric/time').TimestampValue} TimestampValue
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime
+ * @typedef {import('@agoric/time').RelativeTimeValue} RelativeTimeValue
+ * @typedef {import('@agoric/time').TimerService} TimerService
  *
  * @typedef {object} Handler
  * Handler is a user-provided Far object with .wake(time) used for callbacks

--- a/packages/SwingSet/tools/manual-timer.js
+++ b/packages/SwingSet/tools/manual-timer.js
@@ -6,8 +6,8 @@ import { TimeMath } from '@agoric/time';
 import { buildRootObject } from '../src/vats/timer/vat-timer.js';
 
 /**
- * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
- * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ * @typedef {import('@agoric/time').Timestamp} Timestamp
+ * @typedef {import('@agoric/time').TimerService} TimerService
  * @typedef {import('../src/devices/timer/device-timer.js').Waker} Waker
  *
  * @typedef {object} ManualTimerCallbacks

--- a/packages/agoric-cli/src/commands/auction.js
+++ b/packages/agoric-cli/src/commands/auction.js
@@ -114,7 +114,7 @@ export const makeAuctionCommand = (
          * but TimeMath.toRel prodocues a RelativeTime (which may be a bare bigint).
          *
          * @param {bigint} relValue
-         * @returns {import('@agoric/time/src/types').RelativeTimeRecord}
+         * @returns {import('@agoric/time').RelativeTimeRecord}
          */
         const toRel = relValue => ({ timerBrand, relValue });
 

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -65,12 +65,12 @@ const makeFormatters = assets => {
     r4(100 - (Number(r.numerator.value) / Number(r.denominator.value)) * 100);
 
   // XXX real TimeMath.absValue requires real Remotable timerBrand
-  /** @param {import('@agoric/time/src/types.js').Timestamp} ts */
+  /** @param {import('@agoric/time').Timestamp} ts */
   const absValue = ts => (typeof ts === 'bigint' ? ts : ts.absValue);
 
-  /** @param {import('@agoric/time/src/types.js').Timestamp} tr */
+  /** @param {import('@agoric/time').Timestamp} tr */
   const absTime = tr => new Date(Number(absValue(tr)) * 1000).toISOString();
-  /** @param {import('@agoric/time/src/types.js').RelativeTimeRecord} tr */
+  /** @param {import('@agoric/time').RelativeTimeRecord} tr */
   const relTime = tr =>
     new Date(Number(tr.relValue) * 1000).toISOString().slice(11, 19);
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-1.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-1.ts
@@ -256,7 +256,7 @@ const checkFlow1 = async (
     {
       const { nextDescendingStepTime, nextStartTime } = readLatest(
         'published.auction.schedule',
-      ) as Record<string, import('@agoric/time/src/types.js').TimestampRecord>;
+      ) as Record<string, import('@agoric/time').TimestampRecord>;
       t.is(nextDescendingStepTime.absValue, nextStartTime.absValue);
     }
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-concurrent-1.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-concurrent-1.ts
@@ -396,7 +396,7 @@ test('concurrent flow 1', async t => {
     /**
      * @type {Record<
      *   string,
-     *   import('@agoric/time/src/types.js').TimestampRecord
+     *   import('@agoric/time').TimestampRecord
      * >}
      */
     const { nextDescendingStepTime, nextStartTime } = readLatest(

--- a/packages/boot/test/bootstrapTests/test-walletSurvivesZoeRestart.ts
+++ b/packages/boot/test/bootstrapTests/test-walletSurvivesZoeRestart.ts
@@ -277,7 +277,7 @@ const checkFlow1 = async (
     {
       const { nextDescendingStepTime, nextStartTime } = readLatest(
         'published.auction.schedule',
-      ) as Record<string, import('@agoric/time/src/types.js').TimestampRecord>;
+      ) as Record<string, import('@agoric/time').TimestampRecord>;
       t.is(nextDescendingStepTime.absValue, nextStartTime.absValue);
     }
 

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -20,7 +20,7 @@ import type {
 } from '@agoric/smart-wallet/src/smartWallet.js';
 import type { WalletFactoryStartResult } from '@agoric/vats/src/core/startWalletFactory.js';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
-import type { TimerService } from '@agoric/time/src/types.js';
+import type { TimerService } from '@agoric/time';
 import type { OfferMaker } from '@agoric/smart-wallet/src/types.js';
 import type { RunUtils } from '@agoric/swingset-vat/tools/run-utils.ts';
 import type { SwingsetTestKit } from './supports.ts';

--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -30,7 +30,7 @@ const makeApiInvocationPositions = (apiMethodName, methodArgs) => {
  *
  * @param {ERef<{ [methodName: string]: (...args: any) => unknown }>} governedApis
  * @param {Array<string | symbol>} governedNames names of the governed API methods
- * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
+ * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {() => Promise<PoserFacet>} getUpdatedPoserFacet
  * @returns {ApiGovernor}
  */

--- a/packages/governance/src/contractGovernance/governFilter.js
+++ b/packages/governance/src/contractGovernance/governFilter.js
@@ -26,7 +26,7 @@ const makeOfferFilterPositions = strings => {
 /**
  * Setup to allow governance to block some invitations.
  *
- * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
+ * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {() => Promise<PoserFacet>} getUpdatedPoserFacet
  * @param {GovernedCreatorFacet<{}>} governedCF
  * @returns {FilterGovernor}

--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -54,7 +54,7 @@ const assertBallotConcernsParam = (paramSpec, questionSpec) => {
 /**
  * @param {ERef<ParamManagerRetriever>} paramManagerRetriever
  * @param {Instance} contractInstance
- * @param {import('@agoric/time/src/types').TimerService} timer
+ * @param {import('@agoric/time').TimerService} timer
  * @param {() => Promise<PoserFacet>} getUpdatedPoserFacet
  * @returns {ParamGovernor}
  */

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -47,8 +47,8 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  * @property {(name: string, value: Ratio) => ParamManagerBuilder} addRatio
  * @property {(name: string, value: import('@endo/marshal').CopyRecord<unknown>) => ParamManagerBuilder} addRecord
  * @property {(name: string, value: string) => ParamManagerBuilder} addString
- * @property {(name: string, value: import('@agoric/time/src/types').Timestamp) => ParamManagerBuilder} addTimestamp
- * @property {(name: string, value: import('@agoric/time/src/types').RelativeTime) => ParamManagerBuilder} addRelativeTime
+ * @property {(name: string, value: import('@agoric/time').Timestamp) => ParamManagerBuilder} addTimestamp
+ * @property {(name: string, value: import('@agoric/time').RelativeTime) => ParamManagerBuilder} addRelativeTime
  * @property {(name: string, value: any) => ParamManagerBuilder} addUnknown
  * @property {() => AnyParamManager} build
  */
@@ -197,13 +197,13 @@ const makeParamManagerBuilder = (publisherKit, zoe) => {
     return builder;
   };
 
-  /** @type {(name: string, value: import('@agoric/time/src/types').Timestamp, builder: ParamManagerBuilder) => ParamManagerBuilder} */
+  /** @type {(name: string, value: import('@agoric/time').Timestamp, builder: ParamManagerBuilder) => ParamManagerBuilder} */
   const addTimestamp = (name, value, builder) => {
     buildCopyParam(name, value, assertTimestamp, ParamTypes.TIMESTAMP);
     return builder;
   };
 
-  /** @type {(name: string, value: import('@agoric/time/src/types').RelativeTime, builder: ParamManagerBuilder) => ParamManagerBuilder} */
+  /** @type {(name: string, value: import('@agoric/time').RelativeTime, builder: ParamManagerBuilder) => ParamManagerBuilder} */
   const addRelativeTime = (name, value, builder) => {
     buildCopyParam(name, value, assertRelativeTime, ParamTypes.RELATIVE_TIME);
     return builder;

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -68,7 +68,7 @@ harden(validateQuestionFromCounter);
 
 /**
  * @typedef {StandardTerms} ContractGovernorTerms
- * @property {import('@agoric/time/src/types').TimerService} timer
+ * @property {import('@agoric/time').TimerService} timer
  * @property {Installation} governedContractInstallation
  */
 
@@ -122,7 +122,7 @@ harden(validateQuestionFromCounter);
  * GovernorPublic,
  * GovernorCreatorFacet<PF,CF>,
  * {
- *   timer: import('@agoric/time/src/types').TimerService,
+ *   timer: import('@agoric/time').TimerService,
  *   governedContractInstallation: Installation<CF>,
  *   governed: {
  *     issuerKeywordRecord: IssuerKeywordRecord,
@@ -136,7 +136,7 @@ harden(validateQuestionFromCounter);
  *
  * @template {GovernableStartFn} SF Start function of governed contract
  * @param {ZCF<{
- *   timer: import('@agoric/time/src/types').TimerService,
+ *   timer: import('@agoric/time').TimerService,
  *   governedContractInstallation: Installation<SF>,
  *   governed: {
  *     issuerKeywordRecord: IssuerKeywordRecord,

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -15,7 +15,7 @@ const trace = makeTracer('CGK', false);
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {{
- *   timer: import('@agoric/time/src/types').TimerService,
+ *   timer: import('@agoric/time').TimerService,
  *   zoe: ERef<ZoeService>,
  * }} powers
  */

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -6,7 +6,7 @@ import { deeplyFulfilled, Far } from '@endo/marshal';
  * @typedef {object} QuestionRecord
  * @property {ERef<VoteCounterCreatorFacet>} voteCap
  * @property {VoteCounterPublicFacet} publicFacet
- * @property {import('@agoric/time/src/types').Timestamp} deadline
+ * @property {import('@agoric/time').Timestamp} deadline
  */
 
 /**

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -31,8 +31,8 @@
 
 /**
  * @typedef { Amount | Brand | Installation | Instance | bigint |
- *   Ratio | string | import('@agoric/time/src/types').TimestampRecord |
- *   import('@agoric/time/src/types').RelativeTimeRecord | unknown } ParamValue
+ *   Ratio | string | import('@agoric/time').TimestampRecord |
+ *   import('@agoric/time').RelativeTimeRecord | unknown } ParamValue
  */
 
 // XXX better to use the manifest constant ParamTypes
@@ -331,8 +331,8 @@
 
 /**
  * @typedef {object} ClosingRule
- * @property {ERef<Timer>} timer
- * @property {import('@agoric/time/src/types').Timestamp} deadline
+ * @property {ERef<import('@agoric/time').TimerService>} timer
+ * @property {import('@agoric/time').Timestamp} deadline
  */
 
 /**
@@ -346,7 +346,7 @@
  * @property {VoteCounterPublicFacet} publicFacet
  * @property {VoteCounterCreatorFacet} creatorFacet
  * @property {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('./binaryVoteCounter.js').start>} instance
- * @property {import('@agoric/time/src/types').Timestamp} deadline
+ * @property {import('@agoric/time').Timestamp} deadline
  * @property {Handle<'Question'>} questionHandle
  */
 
@@ -430,8 +430,8 @@
  * @property {(name: string) => bigint} getNat
  * @property {(name: string) => Ratio} getRatio
  * @property {(name: string) => string} getString
- * @property {(name: string) => import('@agoric/time/src/types').TimestampRecord} getTimestamp
- * @property {(name: string) => import('@agoric/time/src/types').RelativeTimeRecord} getRelativeTime
+ * @property {(name: string) => import('@agoric/time').TimestampRecord} getTimestamp
+ * @property {(name: string) => import('@agoric/time').RelativeTimeRecord} getRelativeTime
  * @property {(name: string) => any} getUnknown
  * @property {(name: string, proposedValue: ParamValue) => ParamValue} getVisibleValue - for
  *   most types, the visible value is the same as proposedValue. For Invitations
@@ -613,7 +613,7 @@
  *
  * @callback VoteOnParamChanges
  * @param {Installation} voteCounterInstallation
- * @param {import('@agoric/time/src/types').Timestamp} deadline
+ * @param {import('@agoric/time').Timestamp} deadline
  * @param {ParamChangesSpec<P>} paramSpec
  * @returns {Promise<ContractGovernanceVoteResult>}
  */
@@ -623,14 +623,14 @@
  * @param {string} apiMethodName
  * @param {unknown[]} methodArgs
  * @param {Installation} voteCounterInstallation
- * @param {import('@agoric/time/src/types').Timestamp} deadline
+ * @param {import('@agoric/time').Timestamp} deadline
  * @returns {Promise<ContractGovernanceVoteResult>}
  */
 
 /**
  * @callback VoteOnOfferFilter
  * @param {Installation} voteCounterInstallation
- * @param {import('@agoric/time/src/types').Timestamp} deadline
+ * @param {import('@agoric/time').Timestamp} deadline
  * @param {string[]} strings
  * @returns {Promise<ContractGovernanceVoteResult>}
  */
@@ -669,7 +669,7 @@
 
 /**
  * @typedef {object} GovernedContractTerms
- * @property {import('@agoric/time/src/types').TimerService} timer
+ * @property {import('@agoric/time').TimerService} timer
  * @property {IssuerKeywordRecord} issuerKeywordRecord
  * @property {object} privateArgs
  */

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -21,8 +21,8 @@ const makeVoterVat = async (log, vats, zoe) => {
 
 /**
  * @param {Pick<QuestionDetails, 'issue' | 'positions' | 'electionType'>} qDetails
- * @param {import('@agoric/time/src/types').Timestamp} closingTime
- * @param {{ electorateFacet: import('../../../src/committee.js').CommitteeElectorateCreatorFacet, installations: Record<string, Installation>, timer: import('@agoric/time/src/types').TimerService }} tools
+ * @param {import('@agoric/time').Timestamp} closingTime
+ * @param {{ electorateFacet: import('../../../src/committee.js').CommitteeElectorateCreatorFacet, installations: Record<string, Installation>, timer: import('@agoric/time').TimerService }} tools
  * @param {*} quorumRule
  */
 const createQuestion = async (qDetails, closingTime, tools, quorumRule) => {

--- a/packages/governance/tools/puppetContractGovernor.js
+++ b/packages/governance/tools/puppetContractGovernor.js
@@ -17,7 +17,7 @@ import { makeApiInvocationPositions } from '../src/contractGovernance/governApi.
 /**
  * @template {GovernableStartFn} SF Start function of governed contract
  * @param {ZCF<{
- *   timer: import('@agoric/time/src/types').TimerService,
+ *   timer: import('@agoric/time').TimerService,
  *   governedContractInstallation: Installation<SF>,
  *   governed: {
  *     issuerKeywordRecord?: IssuerKeywordRecord,

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -383,7 +383,7 @@ export const distributeProportionalSharesWithLimits = (
 /**
  * @param {ZCF<
  *   GovernanceTerms<typeof auctioneerParamTypes> & {
- *     timerService: import('@agoric/time/src/types').TimerService;
+ *     timerService: import('@agoric/time').TimerService;
  *     reservePublicFacet: AssetReservePublicFacet;
  *     priceAuthority: PriceAuthority;
  *   }

--- a/packages/inter-protocol/src/auction/params.js
+++ b/packages/inter-protocol/src/auction/params.js
@@ -70,7 +70,7 @@ export const auctioneerParamTypes = harden({
  * @property {bigint} DiscountStep
  * @property {RelativeTime} AuctionStartDelay
  * @property {RelativeTime} PriceLockPeriod
- * @property {import('@agoric/time/src/types').TimerBrand} TimerBrand
+ * @property {import('@agoric/time').TimerBrand} TimerBrand
  */
 
 /** @param {AuctionParams} initial */
@@ -147,7 +147,7 @@ harden(makeAuctioneerParamManager);
 
 /**
  * @param {{ storageNode: ERef<StorageNode>; marshaller: ERef<Marshaller> }} caps
- * @param {ERef<Timer>} timer
+ * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {ERef<PriceAuthority>} priceAuthority
  * @param {ERef<AssetReservePublicFacet>} reservePublicFacet
  * @param {AuctionParams} params

--- a/packages/inter-protocol/src/auction/scheduleMath.js
+++ b/packages/inter-protocol/src/auction/scheduleMath.js
@@ -83,7 +83,7 @@ export const computeRoundTiming = (params, baseTime) => {
   // computed start is `startDelay + baseTime + freq - (baseTime mod freq)`.
   // That is, if there are hourly starts, we add an hour to the time, and
   // subtract baseTime mod freq. Then we add the delay.
-  /** @type {import('@agoric/time/src/types').TimestampRecord} */
+  /** @type {import('@agoric/time').TimestampRecord} */
   const startTime = TimeMath.addAbsRel(
     TimeMath.addAbsRel(
       baseTime,

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -71,9 +71,9 @@ const nominalStartTime = nextSchedule =>
 
 /**
  * @param {AuctionDriver} auctionDriver
- * @param {import('@agoric/time/src/types').TimerService} timer
+ * @param {import('@agoric/time').TimerService} timer
  * @param {Awaited<import('./params.js').AuctionParamManager>} params
- * @param {import('@agoric/time/src/types').TimerBrand} timerBrand
+ * @param {import('@agoric/time').TimerBrand} timerBrand
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').Recorder<ScheduleNotification>} scheduleRecorder
  * @param {StoredSubscription<GovernanceSubscriptionState>} paramUpdateSubscription
  */
@@ -362,8 +362,8 @@ export const makeScheduler = async (
 
 /**
  * @typedef {object} Schedule
- * @property {import('@agoric/time/src/types').TimestampRecord} startTime
- * @property {import('@agoric/time/src/types').TimestampRecord} endTime
+ * @property {import('@agoric/time').TimestampRecord} startTime
+ * @property {import('@agoric/time').TimestampRecord} endTime
  * @property {NatValue} steps
  * @property {NatValue} endRate
  * @property {RelativeTime} startDelay

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -20,9 +20,9 @@ export const meta = {
 harden(meta);
 
 /**
- * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime
  *
- * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ * @typedef {import('@agoric/time').TimerService} TimerService
  */
 
 /**

--- a/packages/inter-protocol/src/interest.js
+++ b/packages/inter-protocol/src/interest.js
@@ -11,9 +11,9 @@ import { Fail } from '@agoric/assert';
 import { TimeMath } from '@agoric/time';
 
 /**
- * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
+ * @typedef {import('@agoric/time').Timestamp} Timestamp
  *
- * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime
  */
 
 export const SECONDS_PER_YEAR = 60n * 60n * 24n * 365n;

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -15,7 +15,7 @@ const trace = makeTracer('FluxAgg', false);
 /**
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
  *
- * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ * @typedef {import('@agoric/time').TimerService} TimerService
  */
 
 /** @type {ContractMeta} */

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -25,14 +25,14 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
 /**
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
  *
- * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
+ * @typedef {import('@agoric/time').Timestamp} Timestamp
  *
- * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime //
- *   TODO: use RelativeTime, not RelativeTimeValue
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime // TODO: use
+ *   RelativeTime, not RelativeTimeValue
  *
- * @typedef {import('@agoric/time/src/types').RelativeTimeValue} RelativeTimeValue
+ * @typedef {import('@agoric/time').RelativeTimeValue} RelativeTimeValue
  *
- * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ * @typedef {import('@agoric/time').TimerService} TimerService
  */
 
 /** @type {(quote: PriceQuote) => PriceDescription} */

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -16,9 +16,9 @@ const { add, subtract, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
 
 /** @typedef {import('./priceOracleKit.js').OracleStatus} OracleStatus */
 /**
- * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
+ * @typedef {import('@agoric/time').Timestamp} Timestamp
  *
- * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ * @typedef {import('@agoric/time').TimerService} TimerService
  */
 
 /** @type {string} */

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -252,7 +252,7 @@ const COMPLETION = 20n * 60n;
  * is far enough away, else 5) run after endTime
  *
  * @param {import('../auction/scheduler.js').FullSchedule} schedules
- * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
+ * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {() => void} thunk
  */
 const whenQuiescent = async (schedules, timer, thunk) => {

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -13,10 +13,10 @@ import { makeCancelTokenMaker } from '../auction/util.js';
 
 const trace = makeTracer('LIQ');
 
-/** @typedef {import('@agoric/time/src/types').TimerService} TimerService */
-/** @typedef {import('@agoric/time/src/types').TimerWaker} TimerWaker */
-/** @typedef {import('@agoric/time/src/types').CancelToken} CancelToken */
-/** @typedef {import('@agoric/time/src/types').RelativeTimeRecord} RelativeTimeRecord */
+/** @typedef {import('@agoric/time').TimerService} TimerService */
+/** @typedef {import('@agoric/time').TimerWaker} TimerWaker */
+/** @typedef {import('@agoric/time').CancelToken} CancelToken */
+/** @typedef {import('@agoric/time').RelativeTimeRecord} RelativeTimeRecord */
 
 const makeCancelToken = makeCancelTokenMaker('liq');
 
@@ -65,7 +65,7 @@ const cancelWakeups = timer => {
  * @param {TimerWaker} opts.liquidationWaker
  * @param {TimerWaker} opts.reschedulerWaker
  * @param {import('../auction/scheduler.js').Schedule} opts.nextAuctionSchedule
- * @param {import('@agoric/time/src/types').TimestampRecord} opts.now
+ * @param {import('@agoric/time').TimestampRecord} opts.now
  * @param {ParamStateRecord} opts.params
  * @returns {void}
  */

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -131,7 +131,7 @@ export const vaultParamPattern = M.splitRecord(
  *   minInitialDebt: Amount<'nat'>;
  *   bootstrapPaymentValue: bigint;
  *   priceAuthority: ERef<PriceAuthority>;
- *   timer: ERef<import('@agoric/time/src/types').TimerService>;
+ *   timer: ERef<import('@agoric/time').TimerService>;
  *   reservePublicFacet: AssetReservePublicFacet;
  *   interestTiming: InterestTiming;
  *   shortfallInvitationAmount: Amount<'set'>;

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -19,9 +19,9 @@
  *
  * @typedef {import('./vaultFactory.js').VaultFactoryContract['publicFacet']} VaultFactoryPublicFacet
  *
- * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
+ * @typedef {import('@agoric/time').Timestamp} Timestamp
  *
- * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime
  */
 
 /**
@@ -58,8 +58,8 @@
  * @property {AddVaultType} addVaultType
  * @property {() => Allocation} getRewardAllocation
  * @property {() => Promise<Invitation<string, never>>} makeCollectFeesInvitation
- * @property {() => import('@agoric/time/src/types').TimerWaker} makeLiquidationWaker
- * @property {() => import('@agoric/time/src/types').TimerWaker} makePriceLockWaker
+ * @property {() => import('@agoric/time').TimerWaker} makeLiquidationWaker
+ * @property {() => import('@agoric/time').TimerWaker} makePriceLockWaker
  */
 
 /**

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -81,7 +81,7 @@ const shortfallInvitationKey = 'shortfallInvitation';
  * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
  * @param {VaultDirectorParamManager} directorParamManager
  * @param {ZCFMint<'nat'>} debtMint
- * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
+ * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {ERef<import('../auction/auctioneer.js').AuctioneerPublicFacet>} auctioneer
  * @param {ERef<StorageNode>} storageNode
  * @param {ERef<Marshaller>} marshaller

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -39,7 +39,7 @@ const trace = makeTracer('VF', true);
  *     auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet;
  *     priceAuthority: ERef<PriceAuthority>;
  *     reservePublicFacet: AssetReservePublicFacet;
- *     timerService: import('@agoric/time/src/types').TimerService;
+ *     timerService: import('@agoric/time').TimerService;
  *   }
  * >} VaultFactoryZCF
  */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -70,7 +70,7 @@ const { details: X, Fail, quote: q } = assert;
 const trace = makeTracer('VM');
 
 /** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
-/** @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime */
+/** @typedef {import('@agoric/time').RelativeTime} RelativeTime */
 
 // Metrics naming scheme: nouns are present values; past-participles are accumulative.
 /**

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -22,7 +22,7 @@ import {
   setUpInstallations,
 } from './tools.js';
 
-/** @typedef {import('@agoric/time/src/types').TimerService} TimerService */
+/** @typedef {import('@agoric/time').TimerService} TimerService */
 
 test('schedule start to finish', async t => {
   const { zcf, zoe } = await setupZCFTest();

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -25,7 +25,7 @@ const charterRoot = './src/econCommitteeCharter.js'; // package relative
 /** @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit */
 
 /**
- * @param {import('@agoric/time/src/types').TimerService} timer
+ * @param {import('@agoric/time').TimerService} timer
  * @param {FarZoeKit} [farZoeKit]
  */
 export const setupPsmBootstrap = async (

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -55,7 +55,7 @@ harden(setUpZoeForTest);
 
 /**
  * @param {any} t
- * @param {import('@agoric/time/src/types').TimerService} [optTimer]
+ * @param {import('@agoric/time').TimerService} [optTimer]
  */
 export const setupBootstrap = async (t, optTimer) => {
   const trace = makeTracer('PromiseSpace', false);

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -128,7 +128,7 @@ test.before(async t => {
  * @param {import('ava').ExecutionContext<Context>} t
  * @param {NatValue[] | Ratio} priceOrList
  * @param {Amount | undefined} unitAmountIn
- * @param {import('@agoric/time/src/types').TimerService} timer
+ * @param {import('@agoric/time').TimerService} timer
  * @param {RelativeTime} quoteInterval
  * @param {bigint} stableInitialLiquidity
  * @param {bigint} [startFrequency]

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -126,7 +126,7 @@ test.before(async t => {
  * @param {import('ava').ExecutionContext<Context>} t
  * @param {NatValue[] | Ratio} priceOrList
  * @param {Amount | undefined} unitAmountIn
- * @param {import('@agoric/time/src/types').TimerService} timer
+ * @param {import('@agoric/time').TimerService} timer
  * @param {RelativeTime} quoteInterval
  * @param {bigint} stableInitialLiquidity
  * @param {Partial<import('../../src/auction/params.js').AuctionParams>} [auctionParams]

--- a/packages/time/index.js
+++ b/packages/time/index.js
@@ -1,2 +1,4 @@
 export * from './src/timeMath.js';
 export * from './src/typeGuards.js';
+// eslint-disable-next-line import/export -- just types
+export * from './src/types.js';

--- a/packages/time/src/timeMath.js
+++ b/packages/time/src/timeMath.js
@@ -3,23 +3,13 @@ import { mustMatch } from '@endo/patterns';
 import { RelativeTimeRecordShape, TimestampRecordShape } from './typeGuards.js';
 
 const { Fail, quote: q } = assert;
-/**
- * @typedef {import('@endo/marshal').RankComparison} RankComparison
- *
- * @typedef {import('./types').TimerBrand} TimerBrand
- * @typedef {import('./types').Timestamp} Timestamp
- * @typedef {import('./types').RelativeTime} RelativeTime
- * @typedef {import('./types').RelativeTimeValue} RelativeTimeValue
- * @typedef {import('./types').TimestampValue} TimestampValue
- * @typedef {import('./types').TimeMathType} TimeMathType
- */
 
 /**
  * `agreedTimerBrand` is internal to this module.
  *
- * @param {TimerBrand | undefined} leftBrand
- * @param {TimerBrand | undefined} rightBrand
- * @returns {TimerBrand | undefined}
+ * @param {import('./types').TimerBrand | undefined} leftBrand
+ * @param {import('./types').TimerBrand | undefined} rightBrand
+ * @returns {import('./types').TimerBrand | undefined}
  */
 const agreedTimerBrand = (leftBrand, rightBrand) => {
   if (leftBrand === undefined) {
@@ -44,9 +34,9 @@ const agreedTimerBrand = (leftBrand, rightBrand) => {
  * this logic. It does the error checking between the operands, and returns
  * the brand, if any, that should label the resulting time value.
  *
- * @param {Timestamp | RelativeTime} left
- * @param {Timestamp | RelativeTime} right
- * @returns {TimerBrand | undefined}
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} left
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} right
+ * @returns {import('./types').TimerBrand | undefined}
  */
 const sharedTimerBrand = (left, right) => {
   const leftBrand = typeof left === 'bigint' ? undefined : left.timerBrand;
@@ -59,10 +49,10 @@ const sharedTimerBrand = (left, right) => {
  * operators in the case where the returned time should be a `Timestamp`
  * rather than a `RelativeTime`.
  *
- * @param {Timestamp | RelativeTime} left
- * @param {Timestamp | RelativeTime} right
- * @param {TimestampValue} absValue
- * @returns {Timestamp}
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} left
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} right
+ * @param {import('./types').TimestampValue} absValue
+ * @returns {import('./types').Timestamp}
  */
 const absLike = (left, right, absValue) => {
   Nat(absValue);
@@ -82,10 +72,10 @@ const absLike = (left, right, absValue) => {
  * operators in the case where the returned time should be a `RelativeTime`
  * rather than a `Timestamp`.
  *
- * @param {Timestamp | RelativeTime} left
- * @param {Timestamp | RelativeTime} right
- * @param {RelativeTimeValue} relValue
- * @returns {RelativeTime}
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} left
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} right
+ * @param {import('./types').RelativeTimeValue} relValue
+ * @returns {import('./types').RelativeTime}
  */
 const relLike = (left, right, relValue) => {
   Nat(relValue);
@@ -197,11 +187,11 @@ const modRelRel = (rel, step) =>
  * `compareValues` is internal to this module, and used to implement
  * the time comparison operators.
  *
- * @param {Timestamp | RelativeTime} left
- * @param {Timestamp | RelativeTime} right
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} left
+ * @param {import('./types').Timestamp | import('./types').RelativeTime} right
  * @param {bigint} v1
  * @param {bigint} v2
- * @returns {RankComparison}
+ * @returns {import('@endo/marshal').RankComparison}
  */
 const compareValues = (left, right, v1, v2) => {
   sharedTimerBrand(left, right);
@@ -247,7 +237,7 @@ const compareValues = (left, right, v1, v2) => {
  * operand, and return a labeled time object with the brand of the labeled
  * operand.
  *
- * @type {TimeMathType}
+ * @type {import('./types').TimeMathType}
  */
 export const TimeMath = harden({
   absValue,

--- a/packages/time/src/types.js
+++ b/packages/time/src/types.js
@@ -1,0 +1,2 @@
+// Empty JS file to correspond with types.d.ts
+export {};

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -175,7 +175,7 @@ harden(produceStartUpgradable);
  * }} zoeArgs
  * @param {{
  *   governedParams: Record<string, unknown>;
- *   timer: ERef<import('@agoric/time/src/types').TimerService>;
+ *   timer: ERef<import('@agoric/time').TimerService>;
  *   contractGovernor: ERef<Installation>;
  *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet'];
  * }} govArgs

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -316,7 +316,7 @@ type ChainBootstrapSpaceT = {
   board: import('@agoric/vats').Board;
   bridgeManager: import('../types.js').BridgeManager | undefined;
   chainStorage: StorageNode | null;
-  chainTimerService: import('@agoric/time/src/types').TimerService;
+  chainTimerService: import('@agoric/time').TimerService;
   client: ClientManager;
   clientCreator: any;
   coreEvalBridgeHandler: import('../types.js').BridgeHandler;

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -26,7 +26,7 @@ import './internal-types.js';
  * board: ERef<import('@agoric/vats').Board>,
  * cacheStorageNode: ERef<StorageNode>,
  * localTimerPollInterval?: bigint,
- * localTimerService?: import('@agoric/time/src/types').TimerService,
+ * localTimerService?: import('@agoric/time').TimerService,
  * myAddressNameAdmin: ERef<import('@agoric/vats').MyAddressNameAdmin>,
  * namesByAddress: ERef<NameHub>,
  * timerDevice?: unknown,

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -1,6 +1,4 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
-/// <reference types="@agoric/time/src/types.d.ts" />
-
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { assert, q, Fail } from '@agoric/assert';
@@ -64,7 +62,7 @@ export const PriceAuthorityI = M.interface('PriceAuthority', {
  * @param {object} opts
  * @param {Issuer<'set'>} opts.quoteIssuer
  * @param {ERef<Notifier<unknown>>} opts.notifier
- * @param {ERef<import('@agoric/time/src/types').TimerService>} opts.timer
+ * @param {ERef<import('@agoric/time').TimerService>} opts.timer
  * @param {PriceQuoteCreate} opts.createQuote
  * @param {Brand<'nat'>} opts.actualBrandIn
  * @param {Brand<'nat'>} opts.actualBrandOut

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -10,7 +10,7 @@ import { makeNotifier } from '@agoric/notifier';
  * @param {Brand<'set'>} quoteBrand
  * @param {Amount<'nat'>} amountIn
  * @param {Amount<'nat'>} amountOut
- * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
+ * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {import('@agoric/time').Timestamp} timestamp
  * @param {ERef<Mint<'set'>>} quoteMint
  * @returns {Promise<PriceQuote>}

--- a/packages/zoe/src/contractSupport/priceQuote.js
+++ b/packages/zoe/src/contractSupport/priceQuote.js
@@ -25,7 +25,7 @@ export const getPriceDescription = quote => {
 export const getAmountIn = quote => getPriceDescription(quote).amountIn;
 /** @param {PriceQuote} quote */
 export const getAmountOut = quote => getPriceDescription(quote).amountOut;
-/** @type {(quote: PriceQuote) => import('@agoric/time/src/types').Timestamp} */
+/** @type {(quote: PriceQuote) => import('@agoric/time').Timestamp} */
 export const getTimestamp = quote => getPriceDescription(quote).timestamp;
 
 /** @param {Brand<'nat'>} brand */

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -37,7 +37,7 @@ const SECOND_PRICE = 'second-price';
  * null } want: { Asset: null } }.
  *
  * @param {ZCF<{
- * timeAuthority: import('@agoric/time/src/types').TimerService,
+ * timeAuthority: import('@agoric/time').TimerService,
  * winnerPriceOption?: FIRST_PRICE | SECOND_PRICE,
  * bidDuration: bigint,
  * }>} zcf

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Notifier<import('@agoric/time/src/types').TimestampRecord>} PeriodNotifier
+ * @typedef {Notifier<import('@agoric/time').TimestampRecord>} PeriodNotifier
  *
  *  The Notifier that provides notifications that periods have passed.
  *  Since notifiers can't be relied on to produce an output every time
@@ -35,7 +35,7 @@
  *   The rate in basis points that will be multiplied with the debt on
  *   every period to compound interest.
  *
- * @property {import('@agoric/time/src/types').RelativeTime} interestPeriod
+ * @property {import('@agoric/time').RelativeTime} interestPeriod
  *
  * @property {Brand} loanBrand
  * @property {Brand} collateralBrand
@@ -162,14 +162,14 @@
  *   The AsyncIterable to notify when a period has occurred
  *
  * @property {Ratio} interestRate
- * @property {import('@agoric/time/src/types').RelativeTime} interestPeriod
+ * @property {import('@agoric/time').RelativeTime} interestPeriod
  *
  *  the period at which the outstanding debt increases by the interestRate
  *
  * @property {ZCF} zcf
  *
  * @property {LoanConfigWithBorrowerMinusDebt} configMinusGetDebt
- * @property {import('@agoric/time/src/types').Timestamp} basetime The starting point from which to calculate
+ * @property {import('@agoric/time').Timestamp} basetime The starting point from which to calculate
  * interest.
  */
 
@@ -182,7 +182,7 @@
  * @property {PriceAuthority} priceAuthority
  * @property {PeriodNotifier} periodNotifier
  * @property {bigint} interestRate
- * @property {import('@agoric/time/src/types').RelativeTime} interestPeriod
+ * @property {import('@agoric/time').RelativeTime} interestPeriod
  * @property {ZCFSeat} lenderSeat
  */
 
@@ -205,7 +205,7 @@
  * triggered the liquidation. This may be lower than expected if the
  * price is moving quickly.
  *
- * @property {() => import('@agoric/time/src/types').Timestamp} getLastCalculationTimestamp
+ * @property {() => import('@agoric/time').Timestamp} getLastCalculationTimestamp
  *
  * Get the timestamp at which the debt was most recently recalculated.
  *

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -45,7 +45,7 @@ export const makeDebtCalculator = debtCalculatorConfig => {
   const config = { ...configMinusGetDebt, getDebt };
 
   const periodObserver = Far('periodObserver', {
-    /** @type {(timestamp: import('@agoric/time/src/types.js').TimestampRecord) => void} */
+    /** @type {(timestamp: import('@agoric/time').TimestampRecord) => void} */
     updateState: timestamp => {
       let updatedLoan = false;
       // we could calculate the number of required updates and multiply by a power

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -58,7 +58,7 @@ const start = zcf => {
    *
    * @param {AmountKeywordRecord} price
    * @param {AmountKeywordRecord} assets
-   * @param {Timer} timeAuthority
+   * @param {import('@agoric/time').TimerService} timeAuthority
    * @param {any} deadline
    * @returns {Promise<Payment>}
    */

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,6 +1,4 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
-/// <reference types="@agoric/time/src/types.d.ts" />
-
 import { Fail, q } from '@agoric/assert';
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { assertAllDefined } from '@agoric/internal';
@@ -53,7 +51,7 @@ const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
  * is a stub until we complete what is now in `fluxAggregatorKit.js`.
  *
  * @param {ZCF<{
- * timer: import('@agoric/time/src/types').TimerService,
+ * timer: import('@agoric/time').TimerService,
  * POLL_INTERVAL: bigint,
  * brandIn: Brand<'nat'>,
  * brandOut: Brand<'nat'>,
@@ -127,7 +125,7 @@ const start = async (zcf, privateArgs) => {
 
   /**
    * @typedef {object} OracleRecord
-   * @property {(timestamp: import('@agoric/time/src/types').Timestamp) => Promise<void>} [querier]
+   * @property {(timestamp: import('@agoric/time').Timestamp) => Promise<void>} [querier]
    * @property {Ratio} lastSample
    * @property {OracleKey} oracleKey
    */
@@ -144,7 +142,7 @@ const start = async (zcf, privateArgs) => {
 
   // Wake every POLL_INTERVAL and run the queriers.
   const repeaterP = E(timer).makeRepeater(0n, POLL_INTERVAL);
-  /** @type {import('@agoric/time/src/types').TimerWaker} */
+  /** @type {import('@agoric/time').TimerWaker} */
   const waker = Far('waker', {
     async wake(timestamp) {
       // Run all the queriers.
@@ -167,7 +165,7 @@ const start = async (zcf, privateArgs) => {
   /**
    * @param {object} param0
    * @param {Ratio} [param0.overridePrice]
-   * @param {import('@agoric/time/src/types').TimestampRecord} [param0.timestamp]
+   * @param {import('@agoric/time').TimestampRecord} [param0.timestamp]
    */
   const makeCreateQuote = ({ overridePrice, timestamp } = {}) =>
     /**
@@ -259,7 +257,7 @@ const start = async (zcf, privateArgs) => {
     );
 
   /**
-   * @param {import('@agoric/time/src/types').Timestamp} timestamp
+   * @param {import('@agoric/time').Timestamp} timestamp
    */
   const updateQuote = async timestamp => {
     timestamp = TimeMath.coerceTimestampRecord(timestamp, timerBrand);
@@ -593,11 +591,11 @@ const start = async (zcf, privateArgs) => {
       const oracle = await E(zoe).getPublicFacet(oracleInstance);
       assert(records.has(record), 'Oracle record is already deleted');
 
-      /** @type {import('@agoric/time/src/types').Timestamp} */
+      /** @type {import('@agoric/time').Timestamp} */
       let lastWakeTimestamp = 0n;
 
       /**
-       * @param {import('@agoric/time/src/types').Timestamp} timestamp
+       * @param {import('@agoric/time').Timestamp} timestamp
        */
       record.querier = async timestamp => {
         // Submit the query.

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -245,7 +245,7 @@
  */
 
 /**
- * @typedef {import('@agoric/time/src/types').Timestamp} Deadline
+ * @typedef {import('@agoric/time').Timestamp} Deadline
  */
 
 /**

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -245,15 +245,6 @@
  */
 
 /**
- * @typedef {import('@agoric/time').Timestamp} Deadline
- */
-
-/**
- * @typedef {object} Timer
- * @property {(deadline: Deadline, wakerP: ERef<Waker>) => void} setWakeup
- */
-
-/**
  * @typedef {object} OnDemandExitRule
  * @property {null} onDemand
  */
@@ -265,7 +256,7 @@
 
 /**
  * @typedef {object} AfterDeadlineExitRule
- * @property {{timer:Timer, deadline:Deadline}} afterDeadline
+ * @property {{timer: import('@agoric/time').TimerService, deadline: import('@agoric/time').Timestamp}} afterDeadline
  */
 
 /**

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -26,8 +26,8 @@ const timestampLTE = (a, b) => TimeMath.compareAbs(a, b) <= 0;
  * @property {Brand<'nat'>} actualBrandOut
  * @property {Array<number>} [priceList]
  * @property {Array<[number, number]>} [tradeList]
- * @property {ERef<import('@agoric/time/src/types').TimerService>} timer
- * @property {import('@agoric/time/src/types').RelativeTime} [quoteInterval]
+ * @property {ERef<import('@agoric/time').TimerService>} timer
+ * @property {import('@agoric/time').RelativeTime} [quoteInterval]
  * @property {ERef<Mint<'set'>>} [quoteMint]
  * @property {Amount<'nat'>} [unitAmountIn]
  */
@@ -84,7 +84,7 @@ export async function makeFakePriceAuthority(options) {
   const quoteBrand = await E(quoteIssuer).getBrand();
 
   /**
-   * @type {NotifierRecord<import('@agoric/time/src/types').Timestamp>}
+   * @type {NotifierRecord<import('@agoric/time').Timestamp>}
    * We need to have a notifier driven by the
    * TimerService because if the timer pushes updates to individual
    * QuoteNotifiers, we have a dependency inversion and the timer can never know
@@ -104,7 +104,7 @@ export async function makeFakePriceAuthority(options) {
    *
    * @param {Amount<'nat'>} amountIn
    * @param {Brand} brandOut
-   * @param {import('@agoric/time/src/types').Timestamp} quoteTime
+   * @param {import('@agoric/time').Timestamp} quoteTime
    * @returns {PriceQuote}
    */
   function priceInQuote(amountIn, brandOut, quoteTime) {
@@ -136,7 +136,7 @@ export async function makeFakePriceAuthority(options) {
   /**
    * @param {Brand<'nat'>} brandIn
    * @param {Amount<'nat'>} amountOut
-   * @param {import('@agoric/time/src/types').Timestamp} quoteTime
+   * @param {import('@agoric/time').Timestamp} quoteTime
    * @returns {PriceQuote}
    */
   function priceOutQuote(brandIn, amountOut, quoteTime) {
@@ -158,7 +158,7 @@ export async function makeFakePriceAuthority(options) {
   let latestTick;
 
   // clients who are waiting for a specific timestamp
-  /** @type { [when: import('@agoric/time/src/types').Timestamp, resolve: (quote: PriceQuote) => void][] } */
+  /** @type { [when: import('@agoric/time').Timestamp, resolve: (quote: PriceQuote) => void][] } */
   let timeClients = [];
 
   // Check if a comparison request has been satisfied.

--- a/packages/zoe/tools/internal-types.js
+++ b/packages/zoe/tools/internal-types.js
@@ -10,5 +10,5 @@
  */
 
 /**
- * @typedef {import('@agoric/time/src/types').TimerService & ManualTimerAdmin} ManualTimer
+ * @typedef {import('@agoric/time').TimerService & ManualTimerAdmin} ManualTimer
  */

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -16,7 +16,7 @@ import {
  * @param {Brand<'nat'>} options.actualBrandIn
  * @param {Brand<'nat'>} options.actualBrandOut
  * @param {Ratio} options.initialPrice
- * @param {import('@agoric/time/src/types').TimerService} options.timer
+ * @param {import('@agoric/time').TimerService} options.timer
  * @param {IssuerKit<'set'>} [options.quoteIssuerKit]
  * @returns {PriceAuthority & { setPrice: (Ratio) => void }}
  */

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -13,7 +13,7 @@ const { Fail } = assert;
 
 /**
  * @typedef {{
- *  timeStep?: import('@agoric/time/src/types').RelativeTime | bigint,
+ *  timeStep?: import('@agoric/time').RelativeTime | bigint,
  *  eventLoopIteration?: () => Promise<void>,
  * }} ZoeManualTimerOptions
  */
@@ -53,7 +53,7 @@ const nolog = (..._args) => {};
  * boundaries
  *
  * @param {(...args: any[]) => void} [log]
- * @param {import('@agoric/time/src/types').Timestamp | bigint} [startValue=0n]
+ * @param {import('@agoric/time').Timestamp | bigint} [startValue=0n]
  * @param {ZoeManualTimerOptions} [options]
  * @returns {ManualTimer}
  */

--- a/packages/zoe/tools/scriptedOracle.js
+++ b/packages/zoe/tools/scriptedOracle.js
@@ -14,7 +14,7 @@ import { Far } from '@endo/marshal';
  *
  * @param {Record<string, any>} script
  * @param {Installation<import('../src/contracts/oracle.js').OracleStart>} oracleInstallation
- * @param {import('@agoric/time/src/types').TimerService} timer
+ * @param {import('@agoric/time').TimerService} timer
  * @param {ZoeService} zoe
  * @param {Issuer} feeIssuer
  */

--- a/packages/zoe/tools/scriptedPriceAuthority.js
+++ b/packages/zoe/tools/scriptedPriceAuthority.js
@@ -65,7 +65,7 @@ export function makeScriptedPriceAuthority(options) {
       );
   }
 
-  /** @type {ERef<Notifier<import('@agoric/time/src/types').Timestamp>>} */
+  /** @type {ERef<Notifier<import('@agoric/time').Timestamp>>} */
   const notifier = E(timer).makeNotifier(0n, quoteInterval);
   const priceAuthorityOptions = harden({
     timer,

--- a/packages/zoe/tools/types-ambient.js
+++ b/packages/zoe/tools/types-ambient.js
@@ -21,9 +21,9 @@
  * The amount supplied to a trade
  * @property {Amount<'nat'>} amountOut
  * The quoted result of trading `amountIn`
- * @property {import('@agoric/time/src/types').TimerService} timer
+ * @property {import('@agoric/time').TimerService} timer
  * The service that gave the `timestamp`
- * @property {import('@agoric/time/src/types').TimestampRecord} timestamp
+ * @property {import('@agoric/time').TimestampRecord} timestamp
  * A timestamp according to `timer` for the quote
  * @property {any} [conditions]
  * Additional conditions for the quote
@@ -68,7 +68,7 @@
  *
  * @property {(brandIn: Brand,
  *             brandOut: Brand
- * ) => ERef<import('@agoric/time/src/types').TimerService>} getTimerService
+ * ) => ERef<import('@agoric/time').TimerService>} getTimerService
  * Get the timer used in PriceQuotes for a given brandIn/brandOut pair
  *
  * @property {(amountIn: Amount<'nat'>,
@@ -78,7 +78,7 @@
  * `amountIn`.  The rate at which these are issued may be very different between
  * `priceAuthorities`.
  *
- * @property {(deadline: import('@agoric/time/src/types').Timestamp,
+ * @property {(deadline: import('@agoric/time').Timestamp,
  *             amountIn: Amount<'nat'>,
  *             brandOut: Brand<'nat'>
  * ) => Promise<PriceQuote>} quoteAtTime
@@ -146,7 +146,7 @@
  * @callback PriceQuery
  * @param {PriceCalculator} calcAmountIn
  * @param {PriceCalculator} calcAmountOut
- * @returns {{ amountIn: Amount<'nat'>, amountOut: Amount<'nat'>, timestamp?: import('@agoric/time/src/types').TimestampRecord } | undefined}
+ * @returns {{ amountIn: Amount<'nat'>, amountOut: Amount<'nat'>, timestamp?: import('@agoric/time').TimestampRecord } | undefined}
  */
 
 /**


### PR DESCRIPTION
## Description

While doing a code review with @0xpatrickdev and @dckc we saw a typedef for `setWakeup` that did not have the cancel taoken. That was a stale one in Zoe from 3 yrs ago.

This instead import `TimerService` from `@agoric/time`. To do that I had to export the type from index instead of the deep `src/types`. Once that was done I want ahead and simplified all the deep imports.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
