### PR TITLE
feat: agd query vstorage trailing slash for children

### DIFF
--- a/golang/cosmos/x/vstorage/README.md
+++ b/golang/cosmos/x/vstorage/README.md
@@ -37,22 +37,20 @@ This is used by the SwingSet "bridge".
  
 ## CLI
 
-A blockchain node may be interrogated by RPC using `agd [--node $url] query vstorage $command` via [client/cli](./client/cli/query.go).
-* `children [--height $blockHeight] [-o {text,json}] [$path]`
-* `data [--height $blockHeight] [-o {text,json}] $path`
+A blockchain node may be interrogated by RPC using `agd [--node $url] query vstorage path` via [client/cli](./client/cli/query.go). (See command help for options and variants `data` and `children`.)
 
 Examples:
 ```sh
-$ agd --node https://main.rpc.agoric.net:443/ query vstorage children published.reserve
+$ agd --node https://main.rpc.agoric.net:443/ query vstorage path published.reserve.
 children:
 - governance
 - metrics
 pagination: null
 
-$ agd --node https://main.rpc.agoric.net:443/ query vstorage children -o json published.reserve
+$ agd --node https://main.rpc.agoric.net:443/ query vstorage path -o json published.reserve.
 {"children":["governance","metrics"],"pagination":null}
 
-$ agd --node https://main.rpc.agoric.net:443/ query vstorage data published.reserve.metrics
+$ agd --node https://main.rpc.agoric.net:443/ query vstorage path published.reserve.metrics
 value: '{"blockHeight":"11030240","values":["{\"body\":\"#{\\\"allocations\\\":{\\\"Fee\\\":{\\\"brand\\\":\\\"$0.Alleged:
   IST brand\\\",\\\"value\\\":\\\"+20053582387\\\"}},\\\"shortfallBalance\\\":{\\\"brand\\\":\\\"$0\\\",\\\"value\\\":\\\"+0\\\"},\\\"totalFeeBurned\\\":{\\\"brand\\\":\\\"$0\\\",\\\"value\\\":\\\"+0\\\"},\\\"totalFeeMinted\\\":{\\\"brand\\\":\\\"$0\\\",\\\"value\\\":\\\"+0\\\"}}\",\"slots\":[\"board0257\"]}"]}'
 ```


### PR DESCRIPTION
## Description

I find myself using `agd query vstorage` by descending paths and sometimes querying data. Having to go back to the command to change `data` vs children` is a bit cumbersome.

This adds a `path` command that queries _children_ if there's a trailing dot and _data_ otherwise. This maintains backwards compatibility with the extant commands for each.

Future work could be to add an option to recursively query down the tree.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

Backwards compatible. Though the recursive option might change the output. Maybe I should change it now to handle that case?