### PR TITLE
drop tests for Node 16

### DIFF
--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x', '18.x']
+        node-version: ['18.x', '20.x']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/node-version.md
+++ b/docs/node-version.md
@@ -1,0 +1,16 @@
+# Node.js version
+
+This repo supports the Active and Maintenance LTS versions of Node.js.
+
+From https://nodejs.org/en/about/previous-releases:
+> Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.
+
+
+
+## Updating
+
+When a new version becomes Active LTS:
+- [ ] update integrations to use it (e.g. `.github/workflows/integration.yml`)
+- [ ] update the .node-version hint to use it
+- [ ] update Node.js test ranges to remove the EOLed version and add the new LTS
+- [ ] update package.json engines to allow the two LTS versions


### PR DESCRIPTION
refs: #8365

## Description

Adopting Node 16 was blocked on some failures: https://github.com/Agoric/agoric-sdk/pull/8365#issuecomment-1847966489 . They seem to all be resolved now,
- https://github.com/Agoric/agoric-sdk/pull/8829

This removes Node 16 checks. It also documents how to handle Node LTS changes.

### Security Considerations
n/a
### Scaling Considerations

n/a

### Documentation Considerations

Adds docs

### Testing Considerations

CI suffices

### Upgrade Considerations

Does not impact code