### PR TITLE
Sync with an endo that rejects extra args

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -246,7 +246,7 @@ export async function makeSwingsetController(
     warehousePolicy,
     overrideVatManagerOptions,
   };
-  /** @type { ReturnType<typeof import('../kernel').default> } */
+  /** @type { ReturnType<typeof import('../kernel/kernel.js').default> } */
   const kernel = buildKernel(
     kernelEndowments,
     deviceEndowments,

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -81,7 +81,7 @@ export function makeStartXSnap(options) {
     };
   }
 
-  /** @type { import('@agoric/xsnap/src/xsnap').XSnapOptions } */
+  /** @type { import('@agoric/xsnap/src/xsnap.js').XSnapOptions } */
   const xsnapOpts = {
     os: osType(),
     fs: { ...fs, ...fs.promises, tmpName },

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -255,7 +255,7 @@ export function makeVatWarehouse({
   // console.debug('makeVatWarehouse', { warehousePolicy });
 
   /**
-   * @typedef { ReturnType<typeof import('./vatTranslator').makeVatTranslators> } VatTranslators
+   * @typedef { ReturnType<typeof import('./vatTranslator.js').makeVatTranslators> } VatTranslators
    * @typedef {{
    *   manager: VatManager,
    *   translators: VatTranslators,

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -117,8 +117,8 @@ export {};
  * @typedef { DeviceInvocationResultOk | DeviceInvocationResultError } DeviceInvocationResult
  *
  * @typedef { { transcriptCount: number } } VatStats
- * @typedef { ReturnType<typeof import('./kernel/state/vatKeeper').makeVatKeeper> } VatKeeper
- * @typedef { ReturnType<typeof import('./kernel/state/kernelKeeper').default> } KernelKeeper
+ * @typedef { ReturnType<typeof import('./kernel/state/vatKeeper.js').makeVatKeeper> } VatKeeper
+ * @typedef { ReturnType<typeof import('./kernel/state/kernelKeeper.js').default> } KernelKeeper
  * @typedef { Awaited<ReturnType<typeof import('@agoric/xsnap').xsnap>> } XSnap
  * @typedef { (dr: VatDeliveryResult) => void } SlogFinishDelivery
  * @typedef { (ksr: KernelSyscallResult, vsr: VatSyscallResult) => void } SlogFinishSyscall

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -133,6 +133,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../../tools/bootstrap-relay.js', {
     defaultManagerType,

--- a/packages/agoric-cli/src/commands/gov.js
+++ b/packages/agoric-cli/src/commands/gov.js
@@ -79,7 +79,7 @@ export const makeGovCommand = (_logger, io = {}) => {
    * given a sendFrom address; else print it.
    *
    * @param {{
-   *   toOffer: (agoricNames: *, current: import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord | undefined) => OfferSpec,
+   *   toOffer: (agoricNames: *, current: import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord | undefined) => OfferSpec,
    *   sendFrom?: string | undefined,
    *   keyringBackend: string,
    *   instanceName?: string,

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -34,7 +34,7 @@ const bidInvitationShape = harden({
 });
 
 /** @typedef {import('@agoric/vats/tools/board-utils.js').VBankAssetDetail } AssetDescriptor */
-/** @typedef {import('@agoric/smart-wallet/src/smartWallet').TryExitOfferAction } TryExitOfferAction */
+/** @typedef {import('@agoric/smart-wallet/src/smartWallet.js').TryExitOfferAction } TryExitOfferAction */
 /** @typedef {import('@agoric/inter-protocol/src/auction/auctionBook.js').OfferSpec}  BidSpec */
 /** @typedef {import('@agoric/inter-protocol/src/auction/scheduler.js').ScheduleNotification} ScheduleNotification */
 /** @typedef {import('@agoric/inter-protocol/src/auction/auctionBook.js').BookDataNotification} BookDataNotification */

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -36,7 +36,7 @@ harden(normalizeAddressWithOptions);
 
 /**
  * @param {ReadonlyArray<string>} swingsetArgs
- * @param {import('./rpc').MinimalNetworkConfig & {
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
  *   from: string,
  *   fees?: string,
  *   dryRun?: boolean,
@@ -110,7 +110,7 @@ export const fetchSwingsetParams = net => {
 harden(fetchSwingsetParams);
 
 /**
- * @param {import('./rpc').MinimalNetworkConfig & {
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
  *   execFileSync: typeof import('child_process').execFileSync,
  *   delay: (ms: number) => Promise<void>,
  *   period?: number,
@@ -150,7 +150,7 @@ export const pollBlocks = opts => async lookup => {
 
 /**
  * @param {string} txhash
- * @param {import('./rpc').MinimalNetworkConfig & {
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
  *   execFileSync: typeof import('child_process').execFileSync,
  *   delay: (ms: number) => Promise<void>,
  *   period?: number,

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -89,7 +89,7 @@ export const asBoardRemote = x => {
 /**
  * Summarize the balances array as user-facing informative tuples
  *
- * @param {import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord['purses']} purses
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord['purses']} purses
  * @param {AssetDescriptor[]} assets
  */
 export const purseBalanceTuples = (purses, assets) => {
@@ -172,7 +172,7 @@ export const offerStatusTuples = (state, agoricNames) => {
 };
 
 /**
- * @param {import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord} current
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} current
  * @param {ReturnType<import('@agoric/smart-wallet/src/utils.js').makeWalletStateCoalescer>['state']} coalesced
  * @param {import('./wallet.js').AgoricNamesRemotes} agoricNames
  */

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -23,13 +23,13 @@ const emptyCurrentRecord = {
 /**
  * @param {string} addr
  * @param {Pick<import('./rpc.js').RpcUtils, 'readLatestHead'>} io
- * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord>}
+ * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>}
  */
 export const getCurrent = async (addr, { readLatestHead }) => {
   // Partial because older writes may not have had all properties
   // NB: assumes changes are only additions
   let current =
-    /** @type {Partial<import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord> | undefined} */ (
+    /** @type {Partial<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord> | undefined} */ (
       await readLatestHead(`published.wallet.${addr}.current`)
     );
   if (current === undefined) {
@@ -58,7 +58,7 @@ export const getCurrent = async (addr, { readLatestHead }) => {
 /**
  * @param {string} addr
  * @param {Pick<import('./rpc.js').RpcUtils, 'readLatestHead'>} io
- * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet').UpdateRecord>}
+ * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord>}
  */
 export const getLastUpdate = (addr, { readLatestHead }) => {
   // @ts-expect-error cast
@@ -66,7 +66,7 @@ export const getLastUpdate = (addr, { readLatestHead }) => {
 };
 
 /**
- * @param {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} bridgeAction
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').BridgeAction} bridgeAction
  * @param {Pick<import('stream').Writable,'write'>} [stdout]
  */
 export const outputAction = (bridgeAction, stdout = process.stdout) => {
@@ -79,7 +79,7 @@ const sendHint =
   'Now use `agoric wallet send ...` to sign and broadcast the offer.\n';
 
 /**
- * @param {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} bridgeAction
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').BridgeAction} bridgeAction
  * @param {{
  *   stdout: Pick<import('stream').Writable,'write'>,
  *   stderr: Pick<import('stream').Writable,'write'>,
@@ -95,7 +95,7 @@ export const outputActionAndHint = (bridgeAction, { stdout, stderr }) => {
  * @param {Pick<import('stream').Writable,'write'>} [stdout]
  */
 export const outputExecuteOfferAction = (offer, stdout = process.stdout) => {
-  /** @type {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} */
+  /** @type {import('@agoric/smart-wallet/src/smartWallet.js').BridgeAction} */
   const spendAction = {
     method: 'executeOffer',
     offer,
@@ -105,7 +105,7 @@ export const outputExecuteOfferAction = (offer, stdout = process.stdout) => {
 
 /**
  * @deprecated use `.current` node for current state
- * @param {import('@agoric/casting').Follower<import('@agoric/casting').ValueFollowerElement<import('@agoric/smart-wallet/src/smartWallet').UpdateRecord>>} follower
+ * @param {import('@agoric/casting').Follower<import('@agoric/casting').ValueFollowerElement<import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord>>} follower
  * @param {Brand<'set'>} [invitationBrand]
  */
 export const coalesceWalletState = async (follower, invitationBrand) => {
@@ -135,8 +135,8 @@ export const coalesceWalletState = async (follower, invitationBrand) => {
  * Sign and broadcast a wallet-action.
  *
  * @throws { Error & { code: number } } if transaction fails
- * @param {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} bridgeAction
- * @param {import('./rpc').MinimalNetworkConfig & {
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').BridgeAction} bridgeAction
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
  *   from: string,
  *   fees?: string,
  *   verbose?: boolean,

--- a/packages/base-zone/tools/greeter.js
+++ b/packages/base-zone/tools/greeter.js
@@ -44,7 +44,6 @@ export const GreeterWithAdminI = M.interface('GreeterWithAdmin', {
  */
 export const prepareGreeterSingleton = (zone, label, nick) => {
   const myThis = Object.freeze({ state: { nick } });
-  // @ts-expect-error Until https://github.com/endojs/endo/pull/1771
   return zone.exo(label, GreeterWithAdminI, {
     ...bindAllMethodsTo(greetFacet, myThis),
     ...bindAllMethodsTo(adminFacet, myThis),
@@ -55,7 +54,6 @@ export const prepareGreeterSingleton = (zone, label, nick) => {
  * @param {import('../src/types.js').Zone} zone
  */
 export const prepareGreeter = zone =>
-  // @ts-expect-error Until https://github.com/endojs/endo/pull/1771
   zone.exoClass('Greeter', GreeterWithAdminI, nick => ({ nick }), {
     ...greetFacet,
     ...adminFacet,

--- a/packages/base-zone/tools/testers.js
+++ b/packages/base-zone/tools/testers.js
@@ -65,7 +65,7 @@ const secondThrows = (t, fn, spec = alreadyExceptionSpec) => {
 
 /**
  * @param {import('ava').Assertions} t
- * @param {import('../src/index').Zone} rootZone
+ * @param {import('../src/index.js').Zone} rootZone
  */
 export const testFirstZoneIncarnation = (t, rootZone) => {
   const subZone = secondThrows(t, () => rootZone.subZone('sub'));
@@ -94,7 +94,7 @@ export const testFirstZoneIncarnation = (t, rootZone) => {
 
 /**
  * @param {import('ava').Assertions} t
- * @param {import('../src/index').Zone} rootZone
+ * @param {import('../src/index.js').Zone} rootZone
  */
 export const testSecondZoneIncarnation = (t, rootZone) => {
   const subZone = secondThrows(t, () => rootZone.subZone('sub'));

--- a/packages/cache/src/cache.js
+++ b/packages/cache/src/cache.js
@@ -12,7 +12,7 @@ import { makeScalarStoreCoordinator } from './store.js';
  */
 
 /**
- * @param {ERef<import('./types').Coordinator>} [coordinator]
+ * @param {ERef<import('./types.js').Coordinator>} [coordinator]
  */
 export const makeCache = (coordinator = makeScalarStoreCoordinator()) => {
   /**

--- a/packages/cache/src/state.js
+++ b/packages/cache/src/state.js
@@ -30,7 +30,7 @@ export const makeState = (value, priorState = GROUND_STATE) =>
 /**
  * Wrap a state store to have a default value using the GROUND_STATE
  *
- * @param {MapStore<string, import('./state').State>} stateStore
+ * @param {MapStore<string, import('./state.js').State>} stateStore
  */
 export const withGroundState = stateStore => ({
   ...stateStore,

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -40,9 +40,9 @@ const makeKeyToString = (sanitize = obj => obj) => {
  * @param {(obj: unknown) => unknown} sanitize Process keys and values with
  * this function before storing them
  * @param {{
- * get(key: string): import('./state').State;
- * set(key: string, value: import('./state').State): void;
- * init(key: string, value: import('./state').State): void;
+ * get(key: string): import('./state.js').State;
+ * set(key: string, value: import('./state.js').State): void;
+ * init(key: string, value: import('./state.js').State): void;
  * }} stateStore
  * @returns {Promise<unknown>} the value of the updated state
  */
@@ -56,8 +56,8 @@ const applyCacheTransaction = async (
   /**
    * Retrieve a potential updated state from the transaction.
    *
-   * @param {import('./state').State} basisState
-   * @returns {Promise<import('./state').State | null>} the updated state, or null if no longer applicable
+   * @param {import('./state.js').State} basisState
+   * @returns {Promise<import('./state.js').State | null>} the updated state, or null if no longer applicable
    */
   const getUpdatedState = async basisState => {
     const { value } = basisState;
@@ -106,7 +106,7 @@ const applyCacheTransaction = async (
 };
 
 /**
- * @param {MapStore<string, import('./state').State>} stateStore
+ * @param {MapStore<string, import('./state.js').State>} stateStore
  * @param {ERef<Marshaller>} marshaller
  * @returns {Promise<string>}
  */
@@ -124,7 +124,7 @@ const stringifyStateStore = async (stateStore, marshaller) => {
  * Make a cache coordinator backed by a MapStore.  This coordinator doesn't
  * currently enforce any cache eviction, but that would be a useful feature.
  *
- * @param {MapStore<string, import('./state').State>} [stateStore]
+ * @param {MapStore<string, import('./state.js').State>} [stateStore]
  * @param {(obj: unknown) => unknown} [sanitize] Process keys and values with
  * this function before storing them. Defaults to deeplyFulfilled.
  */
@@ -136,7 +136,7 @@ export const makeScalarStoreCoordinator = (
 
   const defaultStateStore = withGroundState(stateStore);
 
-  /** @type {import('./types').Coordinator} */
+  /** @type {import('./types.js').Coordinator} */
   const coord = Far('store cache coordinator', {
     getRecentValue: async key => {
       const keyStr = await serializePassable(key);
@@ -169,7 +169,7 @@ export const makeScalarStoreCoordinator = (
 /**
  * Don't write any marshalled value that's older than what's already pushed
  *
- * @param {MapStore<string, import('./state').State>} stateStore
+ * @param {MapStore<string, import('./state.js').State>} stateStore
  * @param {ERef<Marshaller>} marshaller
  * @param {ERef<StorageNode>} storageNode
  * @returns {<T>(storedValue: T) => Promise<T>}
@@ -216,7 +216,7 @@ export const makeChainStorageCoordinator = (storageNode, marshaller) => {
     storageNode,
   );
 
-  /** @type {import('./types').Coordinator} */
+  /** @type {import('./types.js').Coordinator} */
   const coord = Far('store cache coordinator', {
     getRecentValue: async key => {
       const keyStr = await serializePassable(key);

--- a/packages/casting/src/casting-spec.js
+++ b/packages/casting/src/casting-spec.js
@@ -5,7 +5,7 @@ const { toAscii } = encodingStar;
 
 /**
  * @param {string} storagePath
- * @returns {import('./types').CastingSpec}
+ * @returns {import('./types.js').CastingSpec}
  */
 const swingsetPathToCastingSpec = storagePath =>
   harden({
@@ -22,7 +22,7 @@ const NO_DATA_VALUE = new Uint8Array([255]);
 /**
  * @param {string} storagePath
  * @param {string} [storeName]
- * @returns {import('./types').CastingSpec}
+ * @returns {import('./types.js').CastingSpec}
  */
 const vstoragePathToCastingSpec = (storagePath, storeName = 'vstorage') => {
   const elems = storagePath ? storagePath.split('.') : [];
@@ -58,7 +58,7 @@ export const vstorageKeySpecToPath = ({ storeName, storeSubkey }) => {
 export const DEFAULT_PATH_CONVERTER = vstoragePathToCastingSpec;
 
 /**
- * @type {Record<string, (path: string) => import('./types').CastingSpec>}
+ * @type {Record<string, (path: string) => import('./types.js').CastingSpec>}
  */
 export const pathPrefixToConverters = harden({
   'swingset:': swingsetPathToCastingSpec,
@@ -68,7 +68,7 @@ export const pathPrefixToConverters = harden({
 
 /**
  * @param {string} specString
- * @returns {import('./types').CastingSpec}
+ * @returns {import('./types.js').CastingSpec}
  */
 export const makeCastingSpecFromString = specString => {
   assert.typeof(specString, 'string');
@@ -88,7 +88,7 @@ const te = new TextEncoder();
 
 /**
  * @param {any} specObj
- * @returns {import('./types').CastingSpec}
+ * @returns {import('./types.js').CastingSpec}
  */
 export const makeCastingSpecFromObject = specObj => {
   const {
@@ -127,7 +127,7 @@ export const makeCastingSpecFromObject = specObj => {
 
 /**
  * @param {ERef<any>} specCap
- * @returns {Promise<import('./types').CastingSpec>}
+ * @returns {Promise<import('./types.js').CastingSpec>}
  */
 export const makeCastingSpecFromRef = async specCap => {
   const specObj = await E(specCap).getStoreKey();
@@ -138,7 +138,7 @@ export const makeCastingSpecFromRef = async specCap => {
  * Create an abstract type from a given source representation
  *
  * @param {ERef<unknown>} sourceP
- * @returns {Promise<import('./types').CastingSpec>}
+ * @returns {Promise<import('./types.js').CastingSpec>}
  */
 export const makeCastingSpec = async sourceP => {
   const spec = await sourceP;

--- a/packages/casting/src/change-follower.js
+++ b/packages/casting/src/change-follower.js
@@ -4,8 +4,8 @@ import { DEFAULT_KEEP_POLLING } from './defaults.js';
 /**
  * Just return an unspecified allegedValue every poll period.
  *
- * @param {import('./types').Leader} leader
- * @returns {Promise<import('./types.js').Follower<import('./types').CastingChange>>}
+ * @param {import('./types.js').Leader} leader
+ * @returns {Promise<import('./types.js').Follower<import('./types.js').CastingChange>>}
  */
 export const makePollingChangeFollower = async leader => {
   const { keepPolling = DEFAULT_KEEP_POLLING } = await E(leader).getOptions();

--- a/packages/casting/src/defaults.js
+++ b/packages/casting/src/defaults.js
@@ -95,7 +95,7 @@ export const MAKE_DEFAULT_DECODER = () => {
 /**
  * Unserialize the JSONable data.
  *
- * @type {() => import('./types').Unserializer}
+ * @type {() => import('./types.js').Unserializer}
  */
 export const MAKE_DEFAULT_UNSERIALIZER = () => {
   const ifaceAllegedPrefix = 'Alleged: ';

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -90,8 +90,8 @@ const proofs = ['strict', 'none', 'optimistic'];
 /**
  * @template T
  * @param {any} sourceP
- * @param {import('./types').LeaderOrMaker} [leaderOrMaker]
- * @param {import('./types').FollowerOptions} [options]
+ * @param {import('./types.js').LeaderOrMaker} [leaderOrMaker]
+ * @param {import('./types.js').FollowerOptions} [options]
  * @returns {ValueFollower<T>}
  */
 export const makeCosmjsFollower = (

--- a/packages/casting/src/follower.js
+++ b/packages/casting/src/follower.js
@@ -11,12 +11,12 @@ import { makeCastingSpec } from './casting-spec.js';
 
 /**
  * @template T
- * @param {ERef<import('./types').CastingSpec>} spec
+ * @param {ERef<import('./types.js').CastingSpec>} spec
  */
 const makeSubscriptionFollower = spec => {
   const transform = value =>
     harden({ value, blockHeight: NaN, currentBlockHeight: NaN });
-  /** @type {import('./types').Follower<import('./types.js').ValueFollowerElement<T>>} */
+  /** @type {import('./types.js').Follower<import('./types.js').ValueFollowerElement<T>>} */
   const follower = Far('subscription/notifier follower', {
     getLatestIterable: async () => {
       const { notifier, subscription } = await spec;
@@ -53,10 +53,10 @@ const makeSubscriptionFollower = spec => {
 
 /**
  * @template T
- * @param {ERef<import('./types').CastingSpec> | string} specP
- * @param {import('./types').LeaderOrMaker} [leaderOrMaker]
- * @param {import('./types').FollowerOptions} [options]
- * @returns {Promise<import('./follower-cosmjs').ValueFollower<T>>}
+ * @param {ERef<import('./types.js').CastingSpec> | string} specP
+ * @param {import('./types.js').LeaderOrMaker} [leaderOrMaker]
+ * @param {import('./types.js').FollowerOptions} [options]
+ * @returns {Promise<import('./follower-cosmjs.js').ValueFollower<T>>}
  */
 export const makeFollower = async (specP, leaderOrMaker, options) => {
   const spec = await makeCastingSpec(specP);

--- a/packages/casting/src/iterable.js
+++ b/packages/casting/src/iterable.js
@@ -22,7 +22,7 @@ export const mapAsyncIterable = (iterable, transform) => {
  * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
  *
  * @template T
- * @param {ERef<import('./types').Follower<T>>} follower
+ * @param {ERef<import('./types.js').Follower<T>>} follower
  */
 export const iterateLatest = follower =>
   // For now, just pass through the iterable.

--- a/packages/deploy-script-support/src/install.js
+++ b/packages/deploy-script-support/src/install.js
@@ -3,7 +3,7 @@ import './externalTypes.js';
 
 import { E } from '@endo/far';
 
-/** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
+/** @typedef {import('@agoric/deploy-script-support/src/externalTypes.js').Petname} Petname */
 
 // XXX board is Board but specifying that leads to type errors with imports which aren't worth fixing right now
 /**

--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -4,7 +4,7 @@ import { assert } from '@agoric/assert';
 // Avoid pulling in too many dependencies like notifiers
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 
-/** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
+/** @typedef {import('@agoric/deploy-script-support/src/externalTypes.js').Petname} Petname */
 
 /**
  * @typedef {object} OfferHelperConfig

--- a/packages/deploy-script-support/src/saveIssuer.js
+++ b/packages/deploy-script-support/src/saveIssuer.js
@@ -1,12 +1,12 @@
 // @ts-check
 import { E } from '@endo/far';
 
-/** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
+/** @typedef {import('@agoric/deploy-script-support/src/externalTypes.js').Petname} Petname */
 
 /**
  * @param {ERef<any>} walletAdmin - an internal type of the
  * wallet, not defined here
- * @param {ERef<import('./startInstance').IssuerManager>} issuerManager
+ * @param {ERef<import('./startInstance.js').IssuerManager>} issuerManager
  */
 export const makeSaveIssuer = (walletAdmin, issuerManager) => {
   /**

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -2,7 +2,7 @@
 import { assert } from '@agoric/assert';
 import { E, passStyleOf } from '@endo/far';
 
-/** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
+/** @typedef {import('@agoric/deploy-script-support/src/externalTypes.js').Petname} Petname */
 
 /**
  * @template T

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -9,7 +9,7 @@ import { E } from '@endo/far';
 
 import { makeStartInstance } from '../../src/startInstance.js';
 
-/** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
+/** @typedef {import('@agoric/deploy-script-support/src/externalTypes.js').Petname} Petname */
 
 test('startInstance', async t => {
   const MOOLA_BRAND_PETNAME = 'moola';

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -32,7 +32,7 @@ const publicMixinAPI = harden({
 
 /**
  * @param {ZCF<GovernanceTerms<{}> & {}>} zcf
- * @param {import('./contractGovernance/typedParamManager').TypedParamManager<any>} paramManager
+ * @param {import('./contractGovernance/typedParamManager.js').TypedParamManager<any>} paramManager
  */
 export const validateElectorate = (zcf, paramManager) => {
   const { governedParams } = zcf.getTerms();
@@ -55,7 +55,7 @@ harden(validateElectorate);
  *
  * @template {import('./contractGovernance/typedParamManager.js').ParamTypesMap} T
  * @param {ZCF<GovernanceTerms<{}> & {}>} zcf
- * @param {import('./contractGovernance/typedParamManager').TypedParamManager<T>} paramManager
+ * @param {import('./contractGovernance/typedParamManager.js').TypedParamManager<T>} paramManager
  */
 const facetHelpers = (zcf, paramManager) => {
   // validate async to wait for params to be finished
@@ -245,7 +245,7 @@ const facetHelpers = (zcf, paramManager) => {
  * parameter values, and the governance guarantees only hold if they're not used
  * directly by the governed contract.
  *
- * @template {import('./contractGovernance/typedParamManager').ParamTypesMap} M
+ * @template {import('./contractGovernance/typedParamManager.js').ParamTypesMap} M
  *   Map of types of custom governed terms
  * @param {ZCF<GovernanceTerms<M>>} zcf
  * @param {Invitation} initialPoserInvitation

--- a/packages/governance/tools/puppetGovernance.js
+++ b/packages/governance/tools/puppetGovernance.js
@@ -43,7 +43,7 @@ export const setUpGovernedContract = async (
 
   /**
    * @type {[
-   * Installation<import('./puppetContractGovernor').start>,
+   * Installation<import('./puppetContractGovernor.js').start>,
    * Installation<any>,
    * Installation<T>,
    * ]}

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -160,7 +160,7 @@ const makeCloseOffer = ({ brand }, opts, previousOffer) => {
 /**
  * @param {string} vaultId
  * @param {Promise<
- *   import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord
+ *   import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord
  * >} currentP
  * @returns {Promise<string>} offer id in which the vault was made
  */

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -27,8 +27,8 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
  *
  * @typedef {import('@agoric/time').Timestamp} Timestamp
  *
- * @typedef {import('@agoric/time').RelativeTime} RelativeTime // TODO: use
- *   RelativeTime, not RelativeTimeValue
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime //
+ *   TODO: use RelativeTime, not RelativeTimeValue
  *
  * @typedef {import('@agoric/time').RelativeTimeValue} RelativeTimeValue
  *

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -27,8 +27,8 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
  *
  * @typedef {import('@agoric/time').Timestamp} Timestamp
  *
- * @typedef {import('@agoric/time').RelativeTime} RelativeTime //
- *   TODO: use RelativeTime, not RelativeTimeValue
+ * @typedef {import('@agoric/time').RelativeTime} RelativeTime // TODO: use
+ *   RelativeTime, not RelativeTimeValue
  *
  * @typedef {import('@agoric/time').RelativeTimeValue} RelativeTimeValue
  *

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -101,12 +101,14 @@ export const prepareRoundsManagerKit = baggage =>
       contract: M.interface(
         'contract',
         {
-          authenticateQuote: M.call(M.any()).returns(M.any()),
-          makeCreateQuote: M.call().optional(M.any()).returns(M.any()),
-          eligibleForSpecificRound: M.call(M.any()).returns(M.boolean()),
-          getRoundData: M.call(M.any()).returns(M.promise()),
-          getRoundStatus: M.call(M.any()).returns(M.record()),
-          oracleRoundStateSuggestRound: M.call(M.any()).returns(M.record()),
+          authenticateQuote: M.call().rest(M.any()).returns(M.any()),
+          makeCreateQuote: M.call().rest(M.any()).returns(M.any()),
+          eligibleForSpecificRound: M.call().rest(M.any()).returns(M.boolean()),
+          getRoundData: M.call().rest(M.any()).returns(M.promise()),
+          getRoundStatus: M.call().rest(M.any()).returns(M.record()),
+          oracleRoundStateSuggestRound: M.call()
+            .rest(M.any())
+            .returns(M.record()),
         },
         // TODO(6571) stop sloppy
         { sloppy: true },

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -10,7 +10,7 @@ const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 const EC_HIGH_PRIORITY_SENDERS_NAMESPACE = 'economicCommittee';
 
 /**
- * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
+ * @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers
  * @param {{ options: { voterAddresses: Record<string, string> } }} param1
  */
 export const inviteCommitteeMembers = async (
@@ -51,7 +51,7 @@ export const inviteCommitteeMembers = async (
 
 harden(inviteCommitteeMembers);
 
-/** @param {import('./econ-behaviors').EconomyBootstrapPowers} powers */
+/** @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers */
 export const startEconCharter = async ({
   consume: { zoe },
   produce: { econCharterKit },
@@ -72,7 +72,7 @@ export const startEconCharter = async ({
     }),
   );
 
-  /** @type {Promise<import('./econ-behaviors').EconCharterStartResult>} */
+  /** @type {Promise<import('./econ-behaviors.js').EconCharterStartResult>} */
   const startResult = E(zoe).startInstance(
     charterInstall,
     undefined,
@@ -88,7 +88,7 @@ harden(startEconCharter);
 /**
  * Introduce charter to governed creator facets.
  *
- * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
+ * @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers
  */
 export const addGovernorsToEconCharter = async ({
   consume: { reserveKit, vaultFactoryKit, econCharterKit, auctioneerKit },
@@ -126,7 +126,7 @@ export const addGovernorsToEconCharter = async ({
 harden(addGovernorsToEconCharter);
 
 /**
- * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
+ * @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers
  * @param {{ options: { voterAddresses: Record<string, string> } }} param1
  */
 export const inviteToEconCharter = async (

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -75,7 +75,7 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 
 /**
  * @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<
- *   import('../econCommitteeCharter')['start']
+ *   import('../econCommitteeCharter.js')['start']
  * >} EconCharterStartResult
  */
 /**

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -293,7 +293,7 @@ export const getManifestForPriceFeed = async (
 });
 
 /**
- * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
+ * @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers
  * @param {object} [config]
  * @param {object} [config.options]
  * @param {string[]} [config.options.demoOracleAddresses]

--- a/packages/inter-protocol/src/proposals/startEconCommittee.js
+++ b/packages/inter-protocol/src/proposals/startEconCommittee.js
@@ -21,7 +21,7 @@ const sanitizePathSegment = name => {
  */
 
 /**
- * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
+ * @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers
  * @param {object} config
  * @param {object} [config.options]
  * @param {EconCommitteeOptions} [config.options.econCommitteeOptions]

--- a/packages/inter-protocol/src/provisionPool.js
+++ b/packages/inter-protocol/src/provisionPool.js
@@ -46,7 +46,7 @@ harden(meta);
  *   initialPoserInvitation: Invitation;
  *   storageNode: StorageNode;
  *   marshaller: Marshaller;
- *   metricsOverride?: import('./provisionPoolKit').MetricsNotification;
+ *   metricsOverride?: import('./provisionPoolKit.js').MetricsNotification;
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -24,7 +24,7 @@ import { Far, deeplyFulfilled } from '@endo/marshal';
 const { details: X, quote: q, Fail } = assert;
 
 /**
- * @typedef {import('@agoric/zoe/src/zoeService/utils').Instance<
+ * @typedef {import('@agoric/zoe/src/zoeService/utils.js').Instance<
  *   import('@agoric/inter-protocol/src/psm/psm.js').start
  * >} PsmInstance
  */
@@ -34,7 +34,7 @@ const { details: X, quote: q, Fail } = assert;
  * @property {ERef<BankManager>} bankManager
  * @property {ERef<import('@agoric/vats').NameAdmin>} namesByAddressAdmin
  * @property {ERef<
- *   import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']
+ *   import('@agoric/vats/src/core/startWalletFactory.js').WalletFactoryStartResult['creatorFacet']
  * >} walletFactory
  */
 

--- a/packages/inter-protocol/src/psm/types.js
+++ b/packages/inter-protocol/src/psm/types.js
@@ -1,3 +1,3 @@
 // @jessie-check
 
-/** @typedef {import('./psm').PsmPublicFacet} PsmPublicFacet */
+/** @typedef {import('./psm.js').PsmPublicFacet} PsmPublicFacet */

--- a/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
@@ -11,8 +11,8 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
  * debt-to-collateral come first.)
  */
 
-/** @typedef {import('./vault').Vault} Vault */
-/** @typedef {import('./storeUtils').CompositeKey} CompositeKey */
+/** @typedef {import('./vault.js').Vault} Vault */
+/** @typedef {import('./storeUtils.js').CompositeKey} CompositeKey */
 
 /** @param {MapStore<string, Vault>} store */
 export const makeOrderedVaultStore = store => {

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -76,7 +76,7 @@ const makeVaultDirectorParams = (
 harden(makeVaultDirectorParams);
 
 /**
- * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').ParamTypesMapFromRecord<
+ * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager.js').ParamTypesMapFromRecord<
  *     ReturnType<typeof makeVaultDirectorParams>
  *   >} VaultDirectorParams
  */

--- a/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
@@ -13,7 +13,7 @@ import {
   normalizedCollRatio,
 } from './storeUtils.js';
 
-/** @typedef {import('./vault').Vault} Vault */
+/** @typedef {import('./vault.js').Vault} Vault */
 /** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
 
 const trace = makeTracer('PVaults', true);

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -1,15 +1,15 @@
 // @jessie-check
 
 /**
- * @typedef {import('./vault').VaultNotification} VaultNotification
+ * @typedef {import('./vault.js').VaultNotification} VaultNotification
  *
- * @typedef {import('./vault').Vault} Vault
+ * @typedef {import('./vault.js').Vault} Vault
  *
- * @typedef {import('./vaultKit').VaultKit} VaultKit
+ * @typedef {import('./vaultKit.js').VaultKit} VaultKit
  *
- * @typedef {import('./vaultManager').VaultManager} VaultManager
+ * @typedef {import('./vaultManager.js').VaultManager} VaultManager
  *
- * @typedef {import('./vaultManager').CollateralManager} CollateralManager
+ * @typedef {import('./vaultManager.js').CollateralManager} CollateralManager
  *
  * @typedef {import('../reserve/assetReserve.js').AssetReserveLimitedCreatorFacet} AssetReserveCreatorFacet
  *

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -85,7 +85,7 @@ const validTransitions = {
 // XXX masks typedef from types.js, but using that causes circular def problems
 /**
  * @typedef {object} VaultManager
- * @property {() => Subscriber<import('./vaultManager').AssetState>} getAssetSubscriber
+ * @property {() => Subscriber<import('./vaultManager.js').AssetState>} getAssetSubscriber
  * @property {(collateralAmount: Amount) => Amount<'nat'>} maxDebtFor
  * @property {() => Brand} getCollateralBrand
  * @property {(base: string) => string} scopeDescription

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -69,7 +69,7 @@ const trace = makeTracer('VD', true);
  *   state: State;
  * }>} MethodContext
  *
- * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<
+ * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager.js').TypedParamManager<
  *     import('./params.js').VaultDirectorParams
  *   >} VaultDirectorParamManager
  */

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -35,7 +35,7 @@ const trace = makeTracer('VF', true);
 
 /**
  * @typedef {ZCF<
- *   GovernanceTerms<import('./params').VaultDirectorParams> & {
+ *   GovernanceTerms<import('./params.js').VaultDirectorParams> & {
  *     auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet;
  *     priceAuthority: ERef<PriceAuthority>;
  *     reservePublicFacet: AssetReservePublicFacet;

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -13,9 +13,9 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 /**
  * @typedef {{
  *   autoRefund: Installation<
- *     import('@agoric/zoe/src/contracts/automaticRefund').start
+ *     import('@agoric/zoe/src/contracts/automaticRefund.js').start
  *   >;
- *   auctioneer: Installation<import('../../src/auction/auctioneer').start>;
+ *   auctioneer: Installation<import('../../src/auction/auctioneer.js').start>;
  *   governor: Installation<
  *     import('@agoric/governance/src/contractGovernor.js')['start']
  *   >;

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -89,7 +89,7 @@ export const metricsTracker = async (t, publicFacet) => {
 
 /**
  * @param {import('ava').ExecutionContext} t
- * @param {import('../src/vaultFactory/vaultManager').CollateralManager} publicFacet
+ * @param {import('../src/vaultFactory/vaultManager.js').CollateralManager} publicFacet
  */
 export const vaultManagerMetricsTracker = async (t, publicFacet) => {
   let totalDebtEver = 0n;
@@ -97,7 +97,7 @@ export const vaultManagerMetricsTracker = async (t, publicFacet) => {
    * @type {Awaited<
    *   ReturnType<
    *     typeof subscriptionTracker<
-   *       import('../src/vaultFactory/vaultManager').MetricsNotification
+   *       import('../src/vaultFactory/vaultManager.js').MetricsNotification
    *     >
    *   >
    * >}

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -734,6 +734,7 @@ test('extra give wantMintedInvitation', async t => {
 const makeMockBankManager = t => {
   /** @type {BankManager} */
   const bankManager = Far('mock BankManager', {
+    __getInterfaceGuard__: () => undefined,
     getAssetSubscription: () => assert.fail('not impl'),
     getModuleAccountAddress: () => assert.fail('not impl'),
     getRewardDistributorDepositFacet: () =>

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -751,7 +751,7 @@ const makeMockBankManager = t => {
 };
 
 test('restore PSM: startPSM with previous metrics, params', async t => {
-  /** @type {import('../../src/proposals/econ-behaviors').EconomyBootstrapPowers} */
+  /** @type {import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers} */
   // @ts-expect-error mock
   const { produce, consume } = makePromiseSpace();
   const { agoricNames, agoricNamesAdmin, spaces } =

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -54,8 +54,8 @@ const setupReserveBootstrap = async (t, timer, farZoeKit) => {
 
 /**
  * @typedef {{
- *   reserveCreatorFacet: import('../../src/reserve/assetReserve').AssetReserveLimitedCreatorFacet;
- *   reservePublicFacet: import('../../src/reserve/assetReserve').AssetReservePublicFacet;
+ *   reserveCreatorFacet: import('../../src/reserve/assetReserve.js').AssetReserveLimitedCreatorFacet;
+ *   reservePublicFacet: import('../../src/reserve/assetReserve.js').AssetReservePublicFacet;
  *   instance: Instance;
  * }} ReserveKit
  */

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -244,7 +244,7 @@ export const currentPurseBalance = (record, brand) => {
  * @param {ERef<CommitteeElectoratePublic>} committeePublic
  * @param {string} voterAcceptanceOID
  * @returns {Promise<
- *   import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec
+ *   import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec
  * >}
  */
 export const voteForOpenQuestion = async (
@@ -257,7 +257,7 @@ export const voteForOpenQuestion = async (
   const { positions, questionHandle } = await E(question).getDetails();
   const yesPosition = harden([positions[0]]);
 
-  /** @type {import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
   const getVoteSpec = {
     source: 'continuing',
     previousOffer: voterAcceptanceOID,

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -374,7 +374,7 @@ test.serial('govern oracles list', async t => {
     'econCommitteeCharter',
   );
   /**
-   * @type {import('@agoric/zoe/src/zoeService/utils').Instance<
+   * @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<
    *   import('@agoric/governance/src/committee.js')['start']
    * >}
    */
@@ -419,7 +419,7 @@ test.serial('govern oracles list', async t => {
 
   // Accept the EC invitation makers ///////////
   {
-    /** @type {import('@agoric/smart-wallet/src/invitations').PurseInvitationSpec} */
+    /** @type {import('@agoric/smart-wallet/src/invitations.js').PurseInvitationSpec} */
     const getInvMakersSpec = {
       source: 'purse',
       instance: econCharter,
@@ -482,7 +482,7 @@ test.serial('govern oracles list', async t => {
 
   // Call for a vote to addOracles ////////////////////////////////
   {
-    /** @type {import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec} */
+    /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
     const proposeInvitationSpec = {
       source: 'continuing',
       previousOffer: 'acceptEcInvitationOID',
@@ -538,7 +538,7 @@ test.serial('govern oracles list', async t => {
 
   // Call for a vote to removeOracles ////////////////////////////////
   {
-    /** @type {import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec} */
+    /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
     const proposeInvitationSpec = {
       source: 'continuing',
       previousOffer: 'acceptEcInvitationOID',

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -67,7 +67,7 @@ test('null swap', async t => {
   const computedState = coalesceUpdates(E(wallet).getUpdatesSubscriber());
   const currents = sequenceCurrents(E(wallet).getCurrentSubscriber());
 
-  /** @type {import('@agoric/smart-wallet/src/invitations').AgoricContractInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').AgoricContractInvitationSpec} */
   const invitationSpec = {
     source: 'agoricContract',
     instancePath: ['psm-IST-AUSD'],
@@ -124,7 +124,7 @@ test('want stable', async t => {
   await wallet.getDepositFacet().receive(payment);
 
   t.log('Execute the swap');
-  /** @type {import('@agoric/smart-wallet/src/invitations').AgoricContractInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').AgoricContractInvitationSpec} */
   const invitationSpec = {
     source: 'agoricContract',
     instancePath: ['psm-IST-AUSD'],
@@ -169,7 +169,7 @@ test('want stable (insufficient funds)', async t => {
   await wallet.getDepositFacet().receive(payment);
 
   t.log('Execute the swap');
-  /** @type {import('@agoric/smart-wallet/src/invitations').AgoricContractInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').AgoricContractInvitationSpec} */
   const invitationSpec = {
     source: 'agoricContract',
     instancePath: ['psm-IST-AUSD'],
@@ -266,7 +266,7 @@ test('govern offerFilter', async t => {
 
   // The purse has the invitation to get the makers ///////////
 
-  /** @type {import('@agoric/smart-wallet/src/invitations').PurseInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').PurseInvitationSpec} */
   const getInvMakersSpec = {
     source: 'purse',
     instance: econCharter,
@@ -307,7 +307,7 @@ test('govern offerFilter', async t => {
   t.is(voteInvitationDetail.description, 'Voter0');
   t.is(voteInvitationDetail.instance, economicCommittee);
 
-  /** @type {import('@agoric/smart-wallet/src/invitations').PurseInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').PurseInvitationSpec} */
   const getCommitteeInvMakersSpec = {
     source: 'purse',
     instance: economicCommittee,
@@ -336,7 +336,7 @@ test('govern offerFilter', async t => {
 
   // Call for a vote ////////////////////////////////
 
-  /** @type {import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec} */
+  /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
   const proposeInvitationSpec = {
     source: 'continuing',
     previousOffer: 'acceptEcInvitationOID',

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -187,7 +187,7 @@ export const subscriptionKey = subscription => {
 
 /**
  * @param {ERef<{
- *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord;
+ *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord;
  * }>} hasTopics
  * @param {string} subscriberName
  */
@@ -222,7 +222,7 @@ export const headValueLegacy = async subscription => {
 /**
  * @param {import('ava').ExecutionContext} t
  * @param {ERef<{
- *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord;
+ *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord;
  * }>} hasTopics
  * @param {string} topicName
  * @param {string} path

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -43,10 +43,10 @@ export const buildRootObject = async () => {
    *     import('@agoric/governance/src/committee.js')['start']
    *   >;
    *   fluxAggregatorV1?: Installation<
-   *     import('../../../src/price/fluxAggregatorContract').start
+   *     import('../../../src/price/fluxAggregatorContract.js').start
    *   >;
    *   puppetContractGovernor?: Installation<
-   *     import('@agoric/governance/tools/puppetContractGovernor').start
+   *     import('@agoric/governance/tools/puppetContractGovernor.js').start
    *   >;
    * }}
    */

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -71,13 +71,13 @@ export const buildRootObject = async () => {
    *   >;
    *   psmV1?: Installation<PsmSF>;
    *   puppetContractGovernor?: Installation<
-   *     import('@agoric/governance/tools/puppetContractGovernor').start
+   *     import('@agoric/governance/tools/puppetContractGovernor.js').start
    *   >;
    * }}
    */
   const installations = {};
 
-  /** @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<PsmSF>} */
+  /** @type {import('@agoric/governance/tools/puppetContractGovernor.js').PuppetContractGovernorKit<PsmSF>} */
   let governorFacets;
 
   /**
@@ -122,9 +122,11 @@ export const buildRootObject = async () => {
     /**
      * @param {{
      *   vatAdmin: ReturnType<
-     *     import('@agoric/swingset-vat/src/vats/vat-admin/vat-vat-admin')['buildRootObject']
+     *     import('@agoric/swingset-vat/src/vats/vat-admin/vat-vat-admin.js')['buildRootObject']
      *   >;
-     *   zoe: ReturnType<import('@agoric/vats/src/vat-zoe')['buildRootObject']>;
+     *   zoe: ReturnType<
+     *     import('@agoric/vats/src/vat-zoe.js')['buildRootObject']
+     *   >;
      * }} vats
      * @param {any} devices
      */

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -56,20 +56,20 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee')['start']
+   *     import('@agoric/governance/src/committee.js')['start']
    *   >;
    *   assetReserveV1?: Installation<
-   *     import('../../../src/reserve/assetReserve')['start']
+   *     import('../../../src/reserve/assetReserve.js')['start']
    *   >;
    *   puppetContractGovernor?: Installation<
-   *     import('@agoric/governance/tools/puppetContractGovernor')['start']
+   *     import('@agoric/governance/tools/puppetContractGovernor.js')['start']
    *   >;
    * }}
    */
   const installations = {};
 
   /**
-   * @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<
+   * @type {import('@agoric/governance/tools/puppetContractGovernor.js').PuppetContractGovernorKit<
    *     import('../../../src/reserve/assetReserve.js').start
    *   >}
    */

--- a/packages/inter-protocol/test/test-provisionPool.js
+++ b/packages/inter-protocol/test/test-provisionPool.js
@@ -63,7 +63,7 @@ const makeTestContext = async () => {
   const committeeInstall = await E(zoe).install(committeeBundle);
   const psmInstall = await E(zoe).install(psmBundle);
   const centralSupply = await E(zoe).install(centralSupplyBundle);
-  /** @type {Installation<import('../src/provisionPool')['start']>} */
+  /** @type {Installation<import('../src/provisionPool.js')['start']>} */
   const policyInstall = await E(zoe).install(policyBundle);
 
   const mintLimit = AmountMath.make(mintedBrand, MINT_LIMIT);
@@ -328,7 +328,7 @@ const makeWalletFactoryKitForAddresses = async addresses => {
   };
 
   const done = new Set();
-  /** @type {import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']} */
+  /** @type {import('@agoric/vats/src/core/startWalletFactory.js').WalletFactoryStartResult['creatorFacet']} */
   const walletFactory = Far('mock walletFactory', {
     provideSmartWallet: async (addr, _b, nameAdmin) => {
       const wallet = wallets.get(addr);

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -29,7 +29,7 @@ import {
   withAmountUtils,
 } from '../supports.js';
 
-/** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
+/** @typedef {import('../../src/vaultFactory/vaultFactory.js').VaultFactoryContract} VFC */
 
 const trace = makeTracer('VFDriver');
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -61,7 +61,7 @@ const contractRoots = {
   auctioneer: './src/auction/auctioneer.js',
 };
 
-/** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
+/** @typedef {import('../../src/vaultFactory/vaultFactory.js').VaultFactoryContract} VFC */
 
 const trace = makeTracer('TestVF', false);
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -62,7 +62,7 @@ const contractRoots = {
   auctioneer: './src/auction/auctioneer.js',
 };
 
-/** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
+/** @typedef {import('../../src/vaultFactory/vaultFactory.js').VaultFactoryContract} VFC */
 
 const trace = makeTracer('TestST', false);
 

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -20,12 +20,12 @@ const ownKeys =
 
 /**
  * @template {(...args: unknown[]) => any} I
- * @typedef {import('./types').Callback<I>} Callback
+ * @typedef {import('./types.js').Callback<I>} Callback
  */
 
 /**
  * @template {(...args: unknown[]) => any} I
- * @typedef {import('./types').SyncCallback<I>} SyncCallback
+ * @typedef {import('./types.js').SyncCallback<I>} SyncCallback
  */
 
 /** @template T @typedef {import('@endo/eventual-send').RemotableBrand<{}, T> & T} Farable */

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -130,7 +130,7 @@ export const prepareChainStorageNode = zone => {
   /**
    * Create a storage node for a given backing storage interface and path.
    *
-   * @param {import('./callback').Callback<(message: StorageMessage) => any>} messenger a callback
+   * @param {import('./callback.js').Callback<(message: StorageMessage) => any>} messenger a callback
    * for sending a storageMessage object to the storage implementation
    * (cf. golang/cosmos/x/vstorage/vstorage.go)
    * @param {string} path
@@ -145,7 +145,7 @@ export const prepareChainStorageNode = zone => {
     'ChainStorageNode',
     ChainStorageNodeI,
     /**
-     * @param {import('./callback').Callback<(message: StorageMessage) => any>} messenger
+     * @param {import('./callback.js').Callback<(message: StorageMessage) => any>} messenger
      * @param {string} path
      * @param {object} [options]
      * @param {boolean} [options.sequence]

--- a/packages/internal/test/test-callback.js
+++ b/packages/internal/test/test-callback.js
@@ -14,15 +14,15 @@ test('near function callbacks', t => {
    */
   const f = (a, b, c) => `${a + b}${c}`;
 
-  /** @type {import('../src/callback').SyncCallback<typeof f>} */
+  /** @type {import('../src/callback.js').SyncCallback<typeof f>} */
   const cb0 = cb.makeSyncFunctionCallback(f);
   t.deepEqual(cb0, { target: f, bound: [], isSync: true });
 
-  /** @type {import('../src/callback').SyncCallback<(b: number, c: string) => string>} */
+  /** @type {import('../src/callback.js').SyncCallback<(b: number, c: string) => string>} */
   const cb1 = cb.makeSyncFunctionCallback(f, 9);
   t.deepEqual(cb1, { target: f, bound: [9], isSync: true });
 
-  /** @type {import('../src/callback').SyncCallback<(c: string) => string>} */
+  /** @type {import('../src/callback.js').SyncCallback<(c: string) => string>} */
   const cb2 = cb.makeSyncFunctionCallback(f, 9, 10);
   t.deepEqual(cb2, { target: f, bound: [9, 10], isSync: true });
 
@@ -40,7 +40,7 @@ test('near function callbacks', t => {
   t.is(cb.callSync(cb2, 'go'), '19go');
 
   const cbp2 =
-    /** @type {import('../src/callback').SyncCallback<(...args: unknown[]) => any>} */ ({
+    /** @type {import('../src/callback.js').SyncCallback<(...args: unknown[]) => any>} */ ({
       target: Promise.resolve(f),
       methodName: undefined,
       bound: [9, 10],
@@ -72,15 +72,15 @@ test('near method callbacks', t => {
     },
   };
 
-  /** @type {import('../src/callback').SyncCallback<typeof o.m1>} */
+  /** @type {import('../src/callback.js').SyncCallback<typeof o.m1>} */
   const cb0 = cb.makeSyncMethodCallback(o, 'm1');
   t.deepEqual(cb0, { target: o, methodName: 'm1', bound: [], isSync: true });
 
-  /** @type {import('../src/callback').SyncCallback<(b: number, c: string) => string>} */
+  /** @type {import('../src/callback.js').SyncCallback<(b: number, c: string) => string>} */
   const cb1 = cb.makeSyncMethodCallback(o, 'm1', 9);
   t.deepEqual(cb1, { target: o, methodName: 'm1', bound: [9], isSync: true });
 
-  /** @type {import('../src/callback').SyncCallback<(c: string) => string>} */
+  /** @type {import('../src/callback.js').SyncCallback<(c: string) => string>} */
   const cb2 = cb.makeSyncMethodCallback(o, 'm1', 9, 10);
   t.deepEqual(cb2, {
     target: o,
@@ -98,7 +98,7 @@ test('near method callbacks', t => {
     isSync: true,
   });
 
-  /** @type {import('../src/callback').SyncCallback<(c: string) => string>} */
+  /** @type {import('../src/callback.js').SyncCallback<(c: string) => string>} */
   const cb4 = cb.makeSyncMethodCallback(o, m2, 9, 10);
   t.deepEqual(cb4, { target: o, methodName: m2, bound: [9, 10], isSync: true });
 
@@ -145,7 +145,7 @@ test('far method callbacks', async t => {
     },
   });
 
-  /** @type {import('../src/callback').Callback<(c: string) => Promise<string>>} */
+  /** @type {import('../src/callback.js').Callback<(c: string) => Promise<string>>} */
   const cbp2 = cb.makeMethodCallback(Promise.resolve(o), 'm1', 9, 10);
   t.like(cbp2, { methodName: 'm1', bound: [9, 10] });
   t.assert(cbp2.target instanceof Promise);
@@ -153,7 +153,7 @@ test('far method callbacks', async t => {
   t.assert(p2r instanceof Promise);
   t.is(await p2r, '19go');
 
-  /** @type {import('../src/callback').Callback<(c: string) => Promise<string>>} */
+  /** @type {import('../src/callback.js').Callback<(c: string) => Promise<string>>} */
   const cbp3 = cb.makeMethodCallback(Promise.resolve(o), m2, 9, 10);
   t.like(cbp3, { methodName: m2, bound: [9, 10] });
   t.assert(cbp3.target instanceof Promise);
@@ -175,7 +175,7 @@ test('far function callbacks', async t => {
    */
   const f = async (a, b, c) => `${a + b}${c}`;
 
-  /** @type {import('../src/callback').Callback<(c: string) => Promise<string>>} */
+  /** @type {import('../src/callback.js').Callback<(c: string) => Promise<string>>} */
   const cbp2 = cb.makeFunctionCallback(Promise.resolve(f), 9, 10);
   t.like(cbp2, { bound: [9, 10] });
   t.assert(cbp2.target instanceof Promise);

--- a/packages/network/test/test-network-misc.js
+++ b/packages/network/test/test-network-misc.js
@@ -18,10 +18,10 @@ const log = false ? console.log : () => {};
 
 /**
  * @param {any} t
- * @returns {import('../src').ProtocolHandler} A testing handler
+ * @returns {import('../src.js').ProtocolHandler} A testing handler
  */
 const makeProtocolHandler = t => {
-  /** @type {import('../src').ListenHandler} */
+  /** @type {import('../src.js').ListenHandler} */
   let l;
   let lp;
   let nonce = 0;
@@ -109,7 +109,7 @@ test('protocol connection listen', async t => {
 
   const port = await protocol.bind('/net/ordered/ordered/some-portname');
 
-  /** @type {import('../src').ListenHandler} */
+  /** @type {import('../src.js').ListenHandler} */
   const listener = Far('listener', {
     async onListen(p, listenHandler) {
       t.is(p, port, `port is tracked in onListen`);
@@ -193,7 +193,7 @@ test('loopback protocol', async t => {
 
   const port = await protocol.bind('/loopback/foo');
 
-  /** @type {import('../src').ListenHandler} */
+  /** @type {import('../src.js').ListenHandler} */
   const listener = Far('listener', {
     async onAccept(_p, _localAddr, _remoteAddr, _listenHandler) {
       return harden({

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -73,7 +73,7 @@ async function testRemotePeg(t) {
   );
 
   /**
-   * @type {import('../src/pegasus').Pegasus}
+   * @type {import('../src/pegasus.js').Pegasus}
    */
   const pegasus = publicAPI;
   const network = makeNetworkProtocol(makeLoopbackProtocolHandler());
@@ -84,7 +84,7 @@ async function testRemotePeg(t) {
   /**
    * Pretend we're Gaia.
    *
-   * @type {import('@agoric/network/src').Connection?}
+   * @type {import('@agoric/network/src.js').Connection?}
    */
   let gaiaConnection;
   E(portP).addListener(

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -62,7 +62,7 @@ const MAX_PIPE_LENGTH = 2;
  * @param {ERef<import('@agoric/vats').NameHub>} agoricNames
  * @param {Brand<'set'>} invitationBrand
  * @param {Purse<'set'>} invitationsPurse
- * @param {(fromOfferId: string) => import('./types').InvitationMakers} getInvitationContinuation
+ * @param {(fromOfferId: string) => import('./types.js').InvitationMakers} getInvitationContinuation
  */
 export const makeInvitationsHelper = (
   zoe,

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -9,7 +9,7 @@ import { makePaymentsHelper } from './payments.js';
 /**
  * @typedef {{
  *   id: OfferId,
- *   invitationSpec: import('./invitations').InvitationSpec,
+ *   invitationSpec: import('./invitations.js').InvitationSpec,
  *   proposal: Proposal,
  *   offerArgs?: unknown
  * }} OfferSpec
@@ -35,10 +35,10 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
  * @param {ERef<Issuer<'set'>>} opts.invitationIssuer
  * @param {object} opts.powers
  * @param {Pick<Console, 'info'| 'error'>} opts.powers.logger
- * @param {(spec: import('./invitations').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
+ * @param {(spec: import('./invitations.js').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
  * @param {(brand: Brand) => Promise<Purse>} opts.powers.purseForBrand
  * @param {(status: OfferStatus) => void} opts.onStatusChange
- * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').InvitationMakers, publicSubscribers: import('./types').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord ) => Promise<void>} opts.onNewContinuingOffer
+ * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types.js').InvitationMakers, publicSubscribers: import('./types.js').PublicSubscribers | import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord ) => Promise<void>} opts.onNewContinuingOffer
  */
 export const makeOfferExecutor = ({
   zoe,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -106,7 +106,7 @@ const trace = makeTracer('SmrtWlt');
  *   brand: Brand,
  *   displayInfo: DisplayInfo,
  *   issuer: Issuer,
- *   petname: import('./types').Petname
+ *   petname: import('./types.js').Petname
  * }} BrandDescriptor
  * For use by clients to describe brands to users. Includes `displayInfo` to save a remote call.
  */
@@ -114,7 +114,7 @@ const trace = makeTracer('SmrtWlt');
 /**
  * @typedef {{
  *   address: string,
- *   bank: ERef<import('@agoric/vats/src/vat-bank').Bank>,
+ *   bank: ERef<import('@agoric/vats/src/vat-bank.js').Bank>,
  *   currentStorageNode: StorageNode,
  *   invitationPurse: Purse<'set'>,
  *   walletStorageNode: StorageNode,
@@ -139,7 +139,7 @@ const trace = makeTracer('SmrtWlt');
  *
  * @typedef {Readonly<UniqueParams & {
  *   paymentQueues: MapStore<Brand, Array<Payment>>,
- *   offerToInvitationMakers: MapStore<string, import('./types').InvitationMakers>,
+ *   offerToInvitationMakers: MapStore<string, import('./types.js').InvitationMakers>,
  *   offerToPublicSubscriberPaths: MapStore<string, Record<string, string>>,
  *   offerToUsedInvitation: MapStore<string, Amount>,
  *   purseBalances: MapStore<Purse, Amount>,
@@ -621,7 +621,7 @@ export const prepareSmartWallet = (baggage, shared) => {
                 }
               }
             },
-            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').InvitationMakers, publicSubscribers?: import('./types').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord) => Promise<void>} */
+            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types.js').InvitationMakers, publicSubscribers?: import('./types.js').PublicSubscribers | import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord) => Promise<void>} */
             onNewContinuingOffer: async (
               offerId,
               invitationAmount,

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -9,7 +9,7 @@ const trace = makeTracer('WUTIL', false);
 
 /** @param {Brand<'set'>} [invitationBrand] */
 export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
-  /** @type {Map<import('./offers').OfferId, import('./offers').OfferStatus>} */
+  /** @type {Map<import('./offers.js').OfferId, import('./offers.js').OfferStatus>} */
   const offerStatuses = new Map();
   /** @type {Map<Brand, Amount>} */
   const balances = new Map();
@@ -17,11 +17,11 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
   /**
    * keyed by description; xxx assumes unique
    *
-   * @type {Map<import('./offers').OfferId, { acceptedIn: import('./offers').OfferId, description: string, instance: Instance }>}
+   * @type {Map<import('./offers.js').OfferId, { acceptedIn: import('./offers.js').OfferId, description: string, instance: Instance }>}
    */
   const invitationsReceived = new Map();
 
-  /** @param {import('./smartWallet').UpdateRecord | {}} updateRecord newer than previous */
+  /** @param {import('./smartWallet.js').UpdateRecord | {}} updateRecord newer than previous */
   const update = updateRecord => {
     if (!('updated' in updateRecord)) {
       return;
@@ -93,7 +93,7 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
  * If this proves to be a problem we can add an option to this or a related
  * utility to reset state from RPC.
  *
- * @param {ERef<Subscriber<import('./smartWallet').UpdateRecord>>} updates
+ * @param {ERef<Subscriber<import('./smartWallet.js').UpdateRecord>>} updates
  * @param {Brand<'set'>} [invitationBrand]
  */
 export const coalesceUpdates = (updates, invitationBrand) => {
@@ -125,7 +125,7 @@ export const assertHasData = async follower => {
 /**
  * Handles the case of falsy argument so the caller can consistently await.
  *
- * @param {import('./types.js').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord} [subscribers]
+ * @param {import('./types.js').PublicSubscribers | import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord} [subscribers]
  * @returns {ERef<Record<string, string>> | null}
  */
 export const objectMapStoragePath = subscribers => {

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -68,7 +68,7 @@ export const makeAssetRegistry = assetPublisher => {
    *   brand: Brand,
    *   displayInfo: DisplayInfo,
    *   issuer: Issuer,
-   *   petname: import('./types').Petname
+   *   petname: import('./types.js').Petname
    * }} BrandDescriptor
    * For use by clients to describe brands to users. Includes `displayInfo` to save a remote call.
    */
@@ -119,12 +119,12 @@ export const makeAssetRegistry = assetPublisher => {
  *
  * @typedef {{
  *   getAssetSubscription: () => ERef<
- *     IterableEachTopic<import('@agoric/vats/src/vat-bank').AssetDescriptor>>
+ *     IterableEachTopic<import('@agoric/vats/src/vat-bank.js').AssetDescriptor>>
  * }} AssetPublisher
  *
  * @typedef {boolean} isRevive
  * @typedef {{
- *   reviveWallet: (address: string) => Promise<import('./smartWallet').SmartWallet>,
+ *   reviveWallet: (address: string) => Promise<import('./smartWallet.js').SmartWallet>,
  *   ackWallet: (address: string) => isRevive,
  * }} WalletReviver
  */
@@ -250,16 +250,16 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     {
       /**
        * @param {string} address
-       * @param {ERef<import('@agoric/vats/src/vat-bank').Bank>} bank
-       * @param {ERef<import('@agoric/vats/').NameAdmin>} namesByAddressAdmin
-       * @returns {Promise<[wallet: import('./smartWallet').SmartWallet, isNew: boolean]>} wallet
+       * @param {ERef<import('@agoric/vats/src/vat-bank.js').Bank>} bank
+       * @param {ERef<import('@agoric/vats/src/types.js').NameAdmin>} namesByAddressAdmin
+       * @returns {Promise<[wallet: import('./smartWallet.js').SmartWallet, isNew: boolean]>} wallet
        *   along with a flag to distinguish between looking up an existing wallet
        *   and creating a new one.
        */
       provideSmartWallet(address, bank, namesByAddressAdmin) {
         let isNew = false;
 
-        /** @type {(address: string) => Promise<import('./smartWallet').SmartWallet>} */
+        /** @type {(address: string) => Promise<import('./smartWallet.js').SmartWallet>} */
         const maker = async _address => {
           const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
           const walletStorageNode = E(storageNode).makeChildNode(address);

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -154,7 +154,7 @@ export const makeMockTestSpace = async log => {
 };
 
 /**
- * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord}>} hasTopics
+ * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord}>} hasTopics
  * @param {string} subscriberName
  */
 export const topicPath = (hasTopics, subscriberName) => {

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
@@ -110,15 +110,15 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     {
       /**
        * @param {string} address
-       * @param {ERef<import('@agoric/vats/src/vat-bank').Bank>} bank
-       * @param {ERef<import('@agoric/vats/').NameAdmin>} namesByAddressAdmin
-       * @returns {Promise<[import('../../../src/smartWallet').SmartWallet, boolean]>} wallet
+       * @param {ERef<import('@agoric/vats/src/vat-bank.js').Bank>} bank
+       * @param {ERef<import('@agoric/vats/src/types.js').NameAdmin>} namesByAddressAdmin
+       * @returns {Promise<[import('../../../src/smartWallet.js').SmartWallet, boolean]>} wallet
        *   along with a flag to distinguish between looking up an existing wallet
        *   and creating a new one.
        */
       provideSmartWallet(address, bank, namesByAddressAdmin) {
         let makerCalled = false;
-        /** @type {() => Promise<import('../../../src/smartWallet').SmartWallet>} */
+        /** @type {() => Promise<import('../../../src/smartWallet.js').SmartWallet>} */
         const maker = async () => {
           const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
           const walletStorageNode = E(storageNode).makeChildNode(address);

--- a/packages/swing-store/src/bundleStore.js
+++ b/packages/swing-store/src/bundleStore.js
@@ -15,7 +15,7 @@ import { createSHA256 } from './hasher.js';
  * @typedef { EndoZipBase64Bundle | GetExportBundle | NestedEvaluateBundle } Bundle
  */
 /**
- * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
+ * @typedef { import('./exporter.js').SwingStoreExporter } SwingStoreExporter
  * @typedef { import('./internal.js').ArtifactMode } ArtifactMode
  *
  * @typedef {{

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -17,10 +17,10 @@ import { assertComplete } from './assertComplete.js';
  * returned swingStore is not suitable for execution, and thus only contains
  * the host facet for committing the populated swingStore.
  *
- * @param {import('./exporter').SwingStoreExporter} exporter
+ * @param {import('./exporter.js').SwingStoreExporter} exporter
  * @param {string | null} [dirPath]
  * @param {ImportSwingStoreOptions} [options]
- * @returns {Promise<Pick<import('./swingStore').SwingStore, 'hostStorage' | 'debug'>>}
+ * @returns {Promise<Pick<import('./swingStore.js').SwingStore, 'hostStorage' | 'debug'>>}
  */
 export async function importSwingStore(exporter, dirPath = null, options = {}) {
   if (dirPath && typeof dirPath !== 'string') {

--- a/packages/swing-store/src/internal.js
+++ b/packages/swing-store/src/internal.js
@@ -1,9 +1,9 @@
 import { Fail, q } from '@agoric/assert';
 
 /**
- * @typedef { import('./snapStore').SnapStoreInternal } SnapStoreInternal
- * @typedef { import('./transcriptStore').TranscriptStoreInternal } TranscriptStoreInternal
- * @typedef { import('./bundleStore').BundleStoreInternal } BundleStoreInternal
+ * @typedef { import('./snapStore.js').SnapStoreInternal } SnapStoreInternal
+ * @typedef { import('./transcriptStore.js').TranscriptStoreInternal } TranscriptStoreInternal
+ * @typedef { import('./bundleStore.js').BundleStoreInternal } BundleStoreInternal
  *
  * @typedef {{
  *    transcriptStore: TranscriptStoreInternal,

--- a/packages/swing-store/src/repairMetadata.js
+++ b/packages/swing-store/src/repairMetadata.js
@@ -25,7 +25,7 @@ import { assertComplete } from './assertComplete.js';
  * `hostStorage.commit()` when they are ready.
  *
  * @param {import('./internal.js').SwingStoreInternal} internal
- * @param {import('./exporter').SwingStoreExporter} exporter
+ * @param {import('./exporter.js').SwingStoreExporter} exporter
  * @returns {Promise<void>}
  */
 export async function doRepairMetadata(internal, exporter) {

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -26,11 +26,11 @@ import { buffer } from './util.js';
 
 /**
  * @template T
- *  @typedef { import('./exporter').AnyIterableIterator<T> } AnyIterableIterator<T>
+ *  @typedef { import('./exporter.js').AnyIterableIterator<T> } AnyIterableIterator<T>
  */
 
 /**
- * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
+ * @typedef { import('./exporter.js').SwingStoreExporter } SwingStoreExporter
  * @typedef { import('./internal.js').ArtifactMode } ArtifactMode
  *
  * @typedef {{

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -17,18 +17,18 @@ import { makeSnapStoreIO } from './snapStoreIO.js';
 import { doRepairMetadata } from './repairMetadata.js';
 
 /**
- * @typedef { import('./kvStore').KVStore } KVStore
+ * @typedef { import('./kvStore.js').KVStore } KVStore
  *
- * @typedef { import('./snapStore').SnapStore } SnapStore
- * @typedef { import('./snapStore').SnapshotResult } SnapshotResult
+ * @typedef { import('./snapStore.js').SnapStore } SnapStore
+ * @typedef { import('./snapStore.js').SnapshotResult } SnapshotResult
  *
- * @typedef { import('./transcriptStore').TranscriptStore } TranscriptStore
- * @typedef { import('./transcriptStore').TranscriptStoreDebug } TranscriptStoreDebug
+ * @typedef { import('./transcriptStore.js').TranscriptStore } TranscriptStore
+ * @typedef { import('./transcriptStore.js').TranscriptStoreDebug } TranscriptStoreDebug
  *
- * @typedef { import('./bundleStore').BundleStore } BundleStore
- * @typedef { import('./bundleStore').BundleStoreDebug } BundleStoreDebug
+ * @typedef { import('./bundleStore.js').BundleStore } BundleStore
+ * @typedef { import('./bundleStore.js').BundleStoreDebug } BundleStoreDebug
  *
- * @typedef { import('./exporter').KVPair } KVPair
+ * @typedef { import('./exporter.js').KVPair } KVPair
  *
  * @typedef {{
  *   kvStore: KVStore, // a key-value API object to load and store data on behalf of the kernel
@@ -49,7 +49,7 @@ import { doRepairMetadata } from './repairMetadata.js';
  *   close: () => Promise<void>,   // shutdown the store, abandoning any uncommitted changes
  *   diskUsage?: () => number, // optional stats method
  *   setExportCallback: (cb: (updates: KVPair[]) => void) => void, // Set a callback invoked by swingStore when new serializable data is available for export
- *   repairMetadata: (exporter: import('./exporter').SwingStoreExporter) => Promise<void>,
+ *   repairMetadata: (exporter: import('./exporter.js').SwingStoreExporter) => Promise<void>,
  * }} SwingStoreHostStorage
  */
 

--- a/packages/swing-store/src/util.js
+++ b/packages/swing-store/src/util.js
@@ -6,7 +6,7 @@ import { Buffer } from 'buffer';
  * 'stream/consumers' package, which unfortunately only exists in newer versions
  * of Node.
  *
- * @param {import('./exporter').AnyIterable<Uint8Array>} inStream
+ * @param {import('./exporter.js').AnyIterable<Uint8Array>} inStream
  */
 export const buffer = async inStream => {
   const chunks = [];

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -34,7 +34,7 @@ const { details: X } = assert;
  * @param {*} syscall  Kernel syscall interface that the vat will have access to
  * @param {*} forVatID  Vat ID label, for use in debug diagnostics
  * @param {*} vatPowers
- * @param {import('./types').LiveSlotsOptions} liveSlotsOptions
+ * @param {import('./types.js').LiveSlotsOptions} liveSlotsOptions
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent, gcAndFinalize,
  *                      meterControl }
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} console
@@ -1469,7 +1469,7 @@ function build(
   }
 
   /**
-   * @param {import('./types').VatDeliveryObject} delivery
+   * @param {import('./types.js').VatDeliveryObject} delivery
    * @returns {void | Promise<void>}
    */
   function dispatchToUserspace(delivery) {
@@ -1534,7 +1534,7 @@ function build(
   }
 
   /**
-   * @param { import('./types').SwingSetCapData } _disconnectObjectCapData
+   * @param { import('./types.js').SwingSetCapData } _disconnectObjectCapData
    * @returns {Promise<void>}
    */
   async function stopVat(_disconnectObjectCapData) {
@@ -1586,7 +1586,7 @@ function build(
    * terminate the vat). Userspace should not be able to cause the delivery
    * to fail: only a bug in liveslots should trigger a failure.
    *
-   * @param {import('./types').VatDeliveryObject} delivery
+   * @param {import('./types.js').VatDeliveryObject} delivery
    * @returns {Promise<void>}
    */
   async function dispatch(delivery) {
@@ -1637,7 +1637,7 @@ function build(
  * @param {*} syscall  Kernel syscall interface that the vat will have access to
  * @param {*} forVatID  Vat ID label, for use in debug diagostics
  * @param {*} vatPowers
- * @param {import('./types').LiveSlotsOptions} liveSlotsOptions
+ * @param {import('./types.js').LiveSlotsOptions} liveSlotsOptions
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} [liveSlotsConsole]
  * @param {*} [buildVatNamespace]

--- a/packages/swingset-liveslots/src/message.js
+++ b/packages/swingset-liveslots/src/message.js
@@ -3,7 +3,7 @@ import { insistCapData } from './capdata.js';
 
 /**
  * @typedef {{
- * methargs: import('./types').SwingSetCapData, // of [method, args]
+ * methargs: import('./types.js').SwingSetCapData, // of [method, args]
  * result: string | undefined | null,
  * }} Message
  */

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -314,7 +314,7 @@ const insistSameCapData = (oldCD, newCD) => {
  * @param {import('@endo/marshal').FromCapData<string>} unserialize  Unserializer for this vat
  * @param {*} assertAcceptableSyscallCapdataSize  Function to check for oversized
  *   syscall params
- * @param {import('./types').LiveSlotsOptions} [liveSlotsOptions]
+ * @param {import('./types.js').LiveSlotsOptions} [liveSlotsOptions]
  * @param {{ WeakMap: typeof WeakMap, WeakSet: typeof WeakSet }} [powers]
  * Specifying the underlying WeakMap/WeakSet objects to wrap with
  * VirtualObjectAwareWeakMap/Set.  By default, capture the ones currently

--- a/packages/swingset-xsnap-supervisor/scripts/build-bundle.js
+++ b/packages/swingset-xsnap-supervisor/scripts/build-bundle.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
-import '@endo/init';
+// Adopting legacy until Babel heals from property override mistakes.
+// https://github.com/endojs/endo/issues/1846
+import '@endo/init/legacy.js';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -78,11 +78,11 @@ export const makeSlogSender = async opts => {
   /**
    * @typedef {{
    *   init: {
-   *     message: import('./slog-sender-pipe-entrypoint').InitMessage;
+   *     message: import('./slog-sender-pipe-entrypoint.js').InitMessage;
    *     reply: SlogSenderInitReply;
    *   };
    *   flush: {
-   *     message: import('./slog-sender-pipe-entrypoint').FlushMessage;
+   *     message: import('./slog-sender-pipe-entrypoint.js').FlushMessage;
    *     reply: SlogSenderFlushReply;
    *   };
    * }} SlogSenderWaitMessagesAndReplies

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -4,6 +4,7 @@
   "description": "Timestamps, time math, timer service API definition",
   "type": "module",
   "main": "index.js",
+  "types": "index.js",
   "engines": {
     "node": ">=14.15.0"
   },

--- a/packages/time/test/test-timeMath.js
+++ b/packages/time/test/test-timeMath.js
@@ -3,11 +3,11 @@ import { Far } from '@endo/far';
 import { TimeMath } from '../src/timeMath.js';
 
 /**
- * @typedef {import('../src/types').TimerBrand} TimerBrand
- * @typedef {import('../src/types').Timestamp} Timestamp
- * @typedef {import('../src/types').RelativeTime} RelativeTime
- * @typedef {import('../src/types').TimestampValue} TimestampValue
- * @typedef {import('../src/types').TimeMathType} TimeMathType
+ * @typedef {import('../src/types.js').TimerBrand} TimerBrand
+ * @typedef {import('../src/types.js').Timestamp} Timestamp
+ * @typedef {import('../src/types.js').RelativeTime} RelativeTime
+ * @typedef {import('../src/types.js').TimestampValue} TimestampValue
+ * @typedef {import('../src/types.js').TimeMathType} TimeMathType
  *
  */
 

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -42,7 +42,7 @@ const prepareScopedManager = zone => {
      * @param {{
      *   outbound: (bridgeId: string, obj: unknown) => Promise<any>;
      * }} toBridge
-     * @param {import('./types').BridgeHandler} [inboundHandler]
+     * @param {import('./types.js').BridgeHandler} [inboundHandler]
      */
     (bridgeId, toBridge, inboundHandler) => ({
       bridgeId,

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -697,7 +697,7 @@ export const addBankAssets = async ({
 };
 harden(addBankAssets);
 
-/** @type {import('./lib-boot').BootstrapManifest} */
+/** @type {import('./lib-boot.js').BootstrapManifest} */
 export const BASIC_BOOTSTRAP_PERMITS = {
   bridgeCoreEval: true, // Needs all the powers.
   [makeOracleBrands.name]: {

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -498,7 +498,7 @@ export const connectChainFaucet = async ({ consume: { client } }) => {
 };
 harden(connectChainFaucet);
 
-/** @type {import('./lib-boot').BootstrapManifest} */
+/** @type {import('./lib-boot.js').BootstrapManifest} */
 export const SHARED_CHAIN_BOOTSTRAP_MANIFEST = {
   ...BASIC_BOOTSTRAP_PERMITS,
 

--- a/packages/vats/src/core/sim-behaviors.js
+++ b/packages/vats/src/core/sim-behaviors.js
@@ -39,7 +39,7 @@ export const grantRunBehaviors = async ({
 };
 harden(grantRunBehaviors);
 
-/** @type {import('./lib-boot').BootstrapManifest} */
+/** @type {import('./lib-boot.js').BootstrapManifest} */
 export const SIM_CHAIN_BOOTSTRAP_PERMITS = {
   [installSimEgress.name]: {
     vatParameters: { argv: { hardcodedClientAddresses: true } },

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -17,7 +17,7 @@ const trace = makeTracer('StartWF');
 /**
  * @param {ERef<ZoeService>} zoe
  * @param {Installation<
- *   import('@agoric/smart-wallet/src/walletFactory').start
+ *   import('@agoric/smart-wallet/src/walletFactory.js').start
  * >} inst
  *
  * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -199,7 +199,7 @@ harden(runModuleBehaviors);
 const noop = harden(() => {});
 
 /**
- * @param {ERef<import('../types').NameAdmin>} nameAdmin
+ * @param {ERef<import('../types.js').NameAdmin>} nameAdmin
  * @param {typeof console.log} [log]
  */
 export const makePromiseSpaceForNameHub = (nameAdmin, log = noop) => {
@@ -227,7 +227,7 @@ export const makePromiseSpaceForNameHub = (nameAdmin, log = noop) => {
 };
 
 /**
- * @param {ERef<import('../types').NameAdmin>} parentAdmin
+ * @param {ERef<import('../types.js').NameAdmin>} parentAdmin
  * @param {typeof console.log} [log]
  * @param {string[]} [kinds]
  */
@@ -299,7 +299,7 @@ export const makeMyAddressNameAdminKit = address => {
   // Create a name hub for this address.
   const { nameHub, nameAdmin: rawMyAddressNameAdmin } = makeNameHubKit();
 
-  /** @type {import('../types').MyAddressNameAdmin} */
+  /** @type {import('../types.js').MyAddressNameAdmin} */
   const myAddressNameAdmin = Far('myAddressNameAdmin', {
     ...rawMyAddressNameAdmin,
     getMyAddress: () => address,

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -37,7 +37,7 @@ export const NameHubIKit = harden({
     update: M.call(KeyShape, M.any())
       .optional(M.remotable('newAdminValue'))
       .returns(M.any()),
-    lookupAdmin: M.call(KeyShape).returns(M.promise()),
+    lookupAdmin: M.call().rest(M.arrayOf(KeyShape)).returns(M.promise()),
     delete: M.call(KeyShape).returns(M.any()),
     readonly: M.call().returns(M.remotable()),
   }),

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -141,7 +141,7 @@ export const prepareNameHubKit = zone => {
   /** @param {{}} me */
   const my = me => provideWeak(ephemera, me, init1);
 
-  /** @type {() => import('./types').NameHubKit} */
+  /** @type {() => import('./types.js').NameHubKit} */
   const makeNameHubKit = zone.exoClassKit(
     'NameHubKit',
     NameHubIKit,
@@ -150,7 +150,7 @@ export const prepareNameHubKit = zone => {
       /** @type {MapStore<string, unknown>} */
       keyToValue: zone.detached().mapStore('nameKey'),
 
-      /** @type {MapStore<string, import('./types').NameAdmin>} */
+      /** @type {MapStore<string, import('./types.js').NameAdmin>} */
       keyToAdmin: zone.detached().mapStore('nameKey'),
 
       /** @type {undefined | { write: (item: unknown) => void }} */

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -33,7 +33,7 @@ const BridgeChannelI = M.interface('BridgeChannel', {
 });
 
 /**
- * @typedef {import('./virtual-purse').VirtualPurseController} VirtualPurseController
+ * @typedef {import('./virtual-purse.js').VirtualPurseController} VirtualPurseController
  *
  * @typedef {Awaited<ReturnType<ReturnType<typeof prepareVirtualPurse>>>} VirtualPurse
  */

--- a/packages/vats/src/vat-provisioning.js
+++ b/packages/vats/src/vat-provisioning.js
@@ -56,7 +56,7 @@ const prepareSpecializedNameAdmin = zone => {
         // XXX relies on callers not to provide other admins via update()
         // TODO: enforce?
 
-        /** @type {import('./types').MyAddressNameAdmin} */
+        /** @type {import('./types.js').MyAddressNameAdmin} */
         // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
         // @ts-ignore cast
         const myAdmin = nameAdmin.lookupAdmin(address);

--- a/packages/vats/test/test-bootstrapPayment.js
+++ b/packages/vats/test/test-bootstrapPayment.js
@@ -12,7 +12,7 @@ import { feeIssuerConfig } from '../src/core/utils.js';
 
 /**
  * @template T @typedef
- *   {import('@agoric/zoe/src/zoeService/utils').Installation<T>}
+ *   {import('@agoric/zoe/src/zoeService/utils.js').Installation<T>}
  *   Installation<T>
  */
 /**

--- a/packages/vats/test/test-vpurse.js
+++ b/packages/vats/test/test-vpurse.js
@@ -54,7 +54,7 @@ const setup = (t, zone, escrowValue = 0n) => {
     },
   });
 
-  /** @type {import('../src/virtual-purse').VirtualPurseController} */
+  /** @type {import('../src/virtual-purse.js').VirtualPurseController} */
   const vpcontroller = zone.exo('TestController', undefined, {
     getBalances(b) {
       t.is(b, brand);

--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -7,7 +7,7 @@
  * @property {PurseActions} actions
  */
 
-/** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
+/** @typedef {import('@agoric/deploy-script-support/src/externalTypes.js').Petname} Petname */
 
 /**
  * @typedef {PursesJSONState & PursesAddedState} PursesFullState
@@ -93,6 +93,6 @@
  * would make them part of the WalletUser available as `home.wallet` in the
  * REPL.  Then, the Wallet UI could use that instead.
  *
- * @typedef {import('./lib-wallet').WalletRoot['admin']}
+ * @typedef {import('./lib-wallet.js').WalletRoot['admin']}
  * WalletAdminFacet
  */

--- a/packages/xsnap-lockdown/scripts/build-bundle.js
+++ b/packages/xsnap-lockdown/scripts/build-bundle.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
-import '@endo/init';
+// Adopting legacy until Babel heals from property override mistakes.
+// https://github.com/endojs/endo/issues/1846
+import '@endo/init/legacy.js';
 import path from 'path';
 import { promises as fsp } from 'fs';
 import crypto from 'crypto';

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -66,7 +66,7 @@ function deepDifference(x, y) {
  * @param {(msg: TapMessage) => void} send
  *
  * @typedef { ReturnType<typeof tapFormat> } TapFormat
- * @typedef {import('./avaXS').TapMessage} TapMessage
+ * @typedef {import('./avaXS.js').TapMessage} TapMessage
  */
 function tapFormat(send) {
   return freeze({

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -91,7 +91,7 @@ function isMatch(specimen, pattern) {
  *
  * @typedef {{ total: number, pass: number, fail: { filename: string, name: string }[] }} TestResults
  * @typedef { 'ok' | 'not ok' | 'SKIP' } Status
- * @typedef {ReturnType<typeof import('./xsnap').xsnap>} XSnap
+ * @typedef {ReturnType<typeof import('./xsnap.js').xsnap>} XSnap
  */
 async function runTestScript(
   filename,

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -9,7 +9,7 @@
 
 /**
  * @template T
- * @typedef {import('./defer').Deferred<T>} Deferred
+ * @typedef {import('./defer.js').Deferred<T>} Deferred
  */
 
 import { finished } from 'stream/promises';

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -7,7 +7,7 @@ import '@endo/init';
 
 /**
  * @template T
- * @typedef {import('./defer').Deferred<T>} Deferred
+ * @typedef {import('./defer.js').Deferred<T>} Deferred
  */
 import * as childProcess from 'child_process';
 import fs from 'fs';

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -276,10 +276,12 @@ export const ZoeStorageManagerIKit = harden({
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
       M.eref(M.string()),
     ),
-    installBundle: M.call(M.or(InstanceHandleShape, BundleShape)).returns(
-      M.promise(),
-    ),
-    installBundleID: M.call(M.string()).returns(M.promise()),
+    installBundle: M.call(M.or(InstanceHandleShape, BundleShape))
+      .optional(M.string())
+      .returns(M.promise()),
+    installBundleID: M.call(M.string())
+      .optional(M.string())
+      .returns(M.promise()),
 
     getPublicFacet: M.call(InstanceHandleShape).returns(
       M.eref(M.remotable('PublicFacet')),
@@ -310,6 +312,7 @@ export const ZoeStorageManagerIKit = harden({
       IssuerPKeywordRecordShape,
       M.or(InstanceHandleShape, BundleShape),
       M.or(BundleCapShape, BundleShape),
+      M.string(),
     ).returns(M.promise()),
     unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(
       UnwrappedInstallationShape,
@@ -321,8 +324,8 @@ export const ZoeStorageManagerIKit = harden({
 });
 
 export const ZoeServiceI = M.interface('ZoeService', {
-  install: M.call(M.any()).returns(M.promise()),
-  installBundleID: M.call(M.string()).returns(M.promise()),
+  install: M.call(M.any()).optional(M.string()).returns(M.promise()),
+  installBundleID: M.call(M.string()).optional(M.string()).returns(M.promise()),
   startInstance: M.call(M.eref(InstallationShape))
     .optional(IssuerPKeywordRecordShape, M.any(), M.any())
     .returns(M.promise()),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -327,7 +327,7 @@ export const ZoeServiceI = M.interface('ZoeService', {
   install: M.call(M.any()).optional(M.string()).returns(M.promise()),
   installBundleID: M.call(M.string()).optional(M.string()).returns(M.promise()),
   startInstance: M.call(M.eref(InstallationShape))
-    .optional(IssuerPKeywordRecordShape, M.any(), M.any())
+    .optional(IssuerPKeywordRecordShape, M.any(), M.any(), M.string())
     .returns(M.promise()),
   offer: M.call(M.eref(InvitationShape))
     .optional(ProposalShape, PaymentPKeywordRecordShape, M.any())

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -84,8 +84,12 @@ export const makeInstallationStorage = (getBundleCapForID, zoeBaggage) => {
         InstanceHandleShape,
         M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
       ),
-    ).returns(M.promise()),
-    installBundleID: M.call(M.string()).returns(M.promise()),
+    )
+      .optional(M.string())
+      .returns(M.promise()),
+    installBundleID: M.call(M.string())
+      .optional(M.string())
+      .returns(M.promise()),
     unwrapInstallation: M.callWhen(M.await(InstallationShape)).returns(
       UnwrappedInstallationShape,
     ),

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -133,7 +133,7 @@
  * @property {import('./utils.js').GetPublicFacet} getPublicFacet
  * @property {GetBrands} getBrands
  * @property {GetIssuers} getIssuers
- * @property {import('./utils').GetTerms} getTerms
+ * @property {import('./utils.js').GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
  * @property {SetOfferFilter} setOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -23,7 +23,7 @@ const { Fail, quote: q } = assert;
  * @param {() => ERef<BundleCap>} getZcfBundleCapP
  * @param {(id: string) => BundleCap} getBundleCapByIdNow
  * @param {Baggage} zoeBaggage
- * @returns {import('./utils').StartInstance}
+ * @returns {import('./utils.js').StartInstance}
  */
 export const makeStartInstance = (
   startInstanceAccess,

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -28,12 +28,12 @@
  *
  * @property {InstallBundle} install
  * @property {InstallBundleID} installBundleID
- * @property {import('./utils').StartInstance} startInstance
+ * @property {import('./utils.js').StartInstance} startInstance
  * @property {Offer} offer
- * @property {import('./utils').GetPublicFacet} getPublicFacet
+ * @property {import('./utils.js').GetPublicFacet} getPublicFacet
  * @property {GetIssuers} getIssuers
  * @property {GetBrands} getBrands
- * @property {import('./utils').GetTerms} getTerms
+ * @property {import('./utils.js').GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstance} getInstance
@@ -66,19 +66,19 @@
 
 /**
  * @callback GetIssuers
- * @param {import('./utils').Instance<any>} instance
+ * @param {import('./utils.js').Instance<any>} instance
  * @returns {Promise<IssuerKeywordRecord>}
  */
 
 /**
  * @callback GetBrands
- * @param {import('./utils').Instance<any>} instance
+ * @param {import('./utils.js').Instance<any>} instance
  * @returns {Promise<BrandKeywordRecord>}
  */
 
 /**
  * @callback GetOfferFilter
- * @param {import('./utils').Instance<any>} instance
+ * @param {import('./utils.js').Instance<any>} instance
  * @returns {string[]}
  */
 
@@ -90,14 +90,14 @@
 
 /**
  * @callback GetInstallationForInstance
- * @param {import('./utils').Instance<any>} instance
+ * @param {import('./utils.js').Instance<any>} instance
  * @returns {Promise<Installation>}
  */
 
 /**
  * @callback GetInstance
  * @param {ERef<Invitation>} invitation
- * @returns {Promise<import('./utils').Instance<any>>}
+ * @returns {Promise<import('./utils.js').Instance<any>>}
  */
 
 /**
@@ -271,7 +271,7 @@
  */
 
 /**
- * @typedef {import('./utils').Instance<any>} Instance
+ * @typedef {import('./utils.js').Instance<any>} Instance
  */
 
 /**
@@ -295,7 +295,7 @@
 /**
  * @typedef {object} InvitationDetails
  * @property {Installation} installation
- * @property {import('./utils').Instance<any>} instance
+ * @property {import('./utils.js').Instance<any>} instance
  * @property {InvitationHandle} handle
  * @property {string} description
  * @property {Record<string, any>} [customDetails]
@@ -303,12 +303,12 @@
 
 /**
  * @template [SF=any] contract start function
- * @typedef {import('./utils').Installation<SF>} Installation
+ * @typedef {import('./utils.js').Installation<SF>} Installation
  */
 
 /**
  * @template {Installation} I
- * @typedef {import('./utils').InstallationStart<I>} InstallationStart
+ * @typedef {import('./utils.js').InstallationStart<I>} InstallationStart
  */
 
 /**

--- a/packages/zoe/test/unitTests/test-zoe-startInstance.js
+++ b/packages/zoe/test/unitTests/test-zoe-startInstance.js
@@ -23,24 +23,35 @@ test('bad installation', async t => {
 
 function isEmptyFacet(t, facet) {
   t.is(passStyleOf(facet), 'remotable');
-  t.deepEqual(Object.getOwnPropertyNames(facet), []);
+  t.deepEqual(
+    Object.getOwnPropertyNames(facet).filter(name => !name.startsWith('__')),
+    [],
+  );
 }
 
 function facetHasMethods(t, facet, names) {
   t.is(passStyleOf(facet), 'remotable');
-  t.deepEqual(Object.getOwnPropertyNames(facet), names);
+  t.deepEqual(
+    Object.getOwnPropertyNames(facet).filter(name => !name.startsWith('__')),
+    names,
+  );
 }
 
 test('no issuerKeywordRecord, no terms', async t => {
   const result = await setupZCFTest();
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
-  t.deepEqual(Object.getOwnPropertyNames(result.startInstanceResult).sort(), [
-    'adminFacet',
-    'creatorFacet',
-    'creatorInvitation',
-    'instance',
-    'publicFacet',
-  ]);
+  t.deepEqual(
+    Object.getOwnPropertyNames(result.startInstanceResult)
+      .filter(name => !name.startsWith('__'))
+      .sort(),
+    [
+      'adminFacet',
+      'creatorFacet',
+      'creatorInvitation',
+      'instance',
+      'publicFacet',
+    ],
+  );
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
   facetHasMethods(t, result.startInstanceResult.publicFacet, [
@@ -54,21 +65,27 @@ test('promise for installation', async t => {
 
   const result = await startInstanceResult;
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
-  t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
-    'adminFacet',
-    'creatorFacet',
-    'creatorInvitation',
-    'instance',
-    'publicFacet',
-  ]);
+  t.deepEqual(
+    Object.getOwnPropertyNames(result)
+      .filter(name => !name.startsWith('__'))
+      .sort(),
+    [
+      'adminFacet',
+      'creatorFacet',
+      'creatorInvitation',
+      'instance',
+      'publicFacet',
+    ],
+  );
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
   facetHasMethods(t, result.publicFacet, ['makeInvitation']);
-  t.deepEqual(getStringMethodNames(result.adminFacet), [
-    'getVatShutdownPromise',
-    'restartContract',
-    'upgradeContract',
-  ]);
+  t.deepEqual(
+    getStringMethodNames(result.adminFacet).filter(
+      name => !name.startsWith('__'),
+    ),
+    ['getVatShutdownPromise', 'restartContract', 'upgradeContract'],
+  );
 });
 
 test('terms, issuerKeywordRecord switched', async t => {

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -134,7 +134,9 @@ test(`E(zoe).getPublicFacet - no instance`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getPublicFacet(), {
     message:
-      /In "getPublicFacet" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
+      // Or pattern of golden error tolerant across versions of endo.
+      // TODO: Remove first disjunct once no longer needed
+      /In "getPublicFacet" method of \(ZoeService\): (?:arg 0: .*"\[undefined\]" - Must be a remotable|Expected at least 1 arguments: \[\])/,
   });
 });
 
@@ -165,7 +167,9 @@ test(`zoe.getIssuers - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getIssuers(), {
     message:
-      /In "getIssuers" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
+      // Or pattern of golden error tolerant across versions of endo.
+      // TODO: Remove first disjunct once no longer needed
+      /In "getIssuers" method of \(ZoeService\): (?:arg 0: .*"\[undefined\]" - Must be a remotable|Expected at least 1 arguments: \[\])/,
   });
 });
 
@@ -196,7 +200,9 @@ test(`zoe.getBrands - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getBrands(), {
     message:
-      /In "getBrands" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
+      // Or pattern of golden error tolerant across versions of endo.
+      // TODO: Remove first disjunct once no longer needed
+      /In "getBrands" method of \(ZoeService\): (?:arg 0: .*"\[undefined\]" - Must be a remotable|Expected at least 1 arguments: \[\])/,
   });
 });
 
@@ -252,7 +258,9 @@ test(`zoe.getTerms - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getTerms(), {
     message:
-      /In "getTerms" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
+      // Or pattern of golden error tolerant across versions of endo.
+      // TODO: Remove first disjunct once no longer needed
+      /In "getTerms" method of \(ZoeService\): (?:arg 0: .*"\[undefined\]" - Must be a remotable|Expected at least 1 arguments: \[\])/,
   });
 });
 

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -96,7 +96,7 @@ test(`E(zoe).getPublicFacet`, async t => {
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
   vatAdminState.installBundle('b1-refund', bundle);
-  /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>} */
+  /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund.js').start>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { publicFacet, instance } = await E(zoe).startInstance(installation);
   await t.throwsAsync(() =>
@@ -224,7 +224,7 @@ test(`zoe.getTerms`, async t => {
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
   vatAdminState.installBundle('b1-refund', bundle);
-  /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>} */
+  /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund.js').start>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(
     installation,

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -707,7 +707,10 @@ test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t 
   const { zcf } = await setupZCFTest();
   const makeZCFSeat = () => zcf.makeEmptySeatKit().zcfSeat;
   const seat = makeZCFSeat();
-  t.deepEqual(getStringMethodNames(seat), expectedStringMethods.sort());
+  t.deepEqual(
+    getStringMethodNames(seat).filter(name => !name.startsWith('__')),
+    expectedStringMethods.sort(),
+  );
 });
 
 test(`zcfSeat.getProposal from zcf.makeEmptySeatKit`, async t => {

--- a/packages/zone/src/durable.js
+++ b/packages/zone/src/durable.js
@@ -89,6 +89,10 @@ export const makeDurableZone = (baggage, baseLabel = 'durableZone') => {
   /** @type {import('.').Zone['exoClass']} */
   const exoClass = (...args) => prepareExoClass(baggage, ...args);
   /** @type {import('.').Zone['exoClassKit']} */
+  // @ts-ignore This type check regressed inexplicably with the release
+  // following after @endo/exo@0.2.6.
+  // The lint error does not occur in local lint, but does in integration with
+  // @agoric/vats, so can not be suppressed with ts-expect-error.
   const exoClassKit = (...args) => prepareExoClassKit(baggage, ...args);
   /** @type {import('.').Zone['exo']} */
   const exo = (...args) => prepareExo(baggage, ...args);

--- a/scripts/get-packed-versions.sh
+++ b/scripts/get-packed-versions.sh
@@ -18,6 +18,9 @@ cd -- "$WORKDIR" 1>&2
 # Install and build the source directory.
 yarn install 1>&2
 yarn build 1>&2
+
+yarn lerna run build:types 1>&2
+
 yarn --silent workspaces info | jq -r '.[].location' | while read -r dir; do
   # Skip private packages.
   echo "dir=$dir" 1>&2


### PR DESCRIPTION
#endo-branch: markm-1888-reject-extra-args

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
depends on: https://github.com/endojs/endo/pull/1890
staged on: https://github.com/Agoric/agoric-sdk/pull/8514
helps with: https://github.com/endojs/endo/issues/1888
refs: https://github.com/Agoric/agoric-sdk/pull/8642

## Description

Run agoric-sdk against https://github.com/Agoric/agoric-sdk/pull/8642 , an endo that rejects extra args in order to fix https://github.com/endojs/endo/issues/1888 . This pair rides on the work @kriskowal already did with the  https://github.com/endojs/endo/pull/1889 , https://github.com/Agoric/agoric-sdk/pull/8514 pair.

These rejections have already diagnosed several extra-arg bugs that were undiagnosed in https://github.com/Agoric/agoric-sdk/pull/8514 , even though they would be genuine observable dynamic buggy behavior. This PR also fixes all these it finds, in order to get back to a clean CI. But, all these fixes should be migrated to https://github.com/Agoric/agoric-sdk/pull/8642 , where they would be a candidate for merging. That these fixes also result in a clean CI run there says that they should work both before and after these changes to endo.

### Security Considerations

Better input validation is good.

Fewer bugs is good.

### Scaling Considerations

None

### Documentation Considerations

See https://github.com/endojs/endo/pull/1890

### Testing Considerations

The extra strictness of testing here only helps diagnose bugs that actually happen dynamically. There may still be more bugs in our code that are not detected by this PR's CI run. Separate from this PR, we need to manually check for agreement between three expressions of various exo APIs
   * The implementation
   * The interface guard
   * The type, if explicit

If an explicit static type declaration is omitted, we try to infer static types from the interface guards. In that case, some of these mismatches may indeed be caught statically.

### Upgrade Considerations

See https://github.com/endojs/endo/pull/1890
