### PR TITLE
fix(zoe): Fix guards to accurately guard args

### DIFF
--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -276,10 +276,12 @@ export const ZoeStorageManagerIKit = harden({
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
       M.eref(M.string()),
     ),
-    installBundle: M.call(M.or(InstanceHandleShape, BundleShape)).returns(
-      M.promise(),
-    ),
-    installBundleID: M.call(M.string()).returns(M.promise()),
+    installBundle: M.call(M.or(InstanceHandleShape, BundleShape))
+      .optional(M.string())
+      .returns(M.promise()),
+    installBundleID: M.call(M.string())
+      .optional(M.string())
+      .returns(M.promise()),
 
     getPublicFacet: M.call(InstanceHandleShape).returns(
       M.eref(M.remotable('PublicFacet')),
@@ -310,6 +312,7 @@ export const ZoeStorageManagerIKit = harden({
       IssuerPKeywordRecordShape,
       M.or(InstanceHandleShape, BundleShape),
       M.or(BundleCapShape, BundleShape),
+      M.string(),
     ).returns(M.promise()),
     unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(
       UnwrappedInstallationShape,
@@ -321,10 +324,10 @@ export const ZoeStorageManagerIKit = harden({
 });
 
 export const ZoeServiceI = M.interface('ZoeService', {
-  install: M.call(M.any()).returns(M.promise()),
-  installBundleID: M.call(M.string()).returns(M.promise()),
+  install: M.call(M.any()).optional(M.string()).returns(M.promise()),
+  installBundleID: M.call(M.string()).optional(M.string()).returns(M.promise()),
   startInstance: M.call(M.eref(InstallationShape))
-    .optional(IssuerPKeywordRecordShape, M.any(), M.any())
+    .optional(IssuerPKeywordRecordShape, M.record(), M.record(), M.string())
     .returns(M.promise()),
   offer: M.call(M.eref(InvitationShape))
     .optional(ProposalShape, PaymentPKeywordRecordShape, M.any())

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -84,8 +84,12 @@ export const makeInstallationStorage = (getBundleCapForID, zoeBaggage) => {
         InstanceHandleShape,
         M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
       ),
-    ).returns(M.promise()),
-    installBundleID: M.call(M.string()).returns(M.promise()),
+    )
+      .optional(M.string())
+      .returns(M.promise()),
+    installBundleID: M.call(M.string())
+      .optional(M.string())
+      .returns(M.promise()),
     unwrapInstallation: M.callWhen(M.await(InstallationShape)).returns(
       UnwrappedInstallationShape,
     ),

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -55,6 +55,15 @@ test(`E(zoe).installBundleID bad id`, async t => {
   });
 });
 
+test(`E(zoe).installBundleID bad label`, async t => {
+  const { zoe } = setup();
+  // @ts-expect-error deliberate invalid arguments for testing
+  await t.throwsAsync(() => E(zoe).installBundleID('a', harden([])), {
+    message:
+      'In "installBundleID" method of (ZoeService): arg 1?: copyArray [] - Must be a string',
+  });
+});
+
 test(`E(zoe).installBundleID(bundleID)`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/atomicSwap`;


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8641 https://github.com/Agoric/agoric-sdk/pull/8514 https://github.com/endojs/endo/pull/1765 https://github.com/endojs/endo/pull/1890

## Description

https://github.com/Agoric/agoric-sdk/pull/8641 throws errors when a call has more arguments than are declared in a method guard. These throws have diagnosed several errors that were otherwise undiagnosed, even after https://github.com/endojs/endo/pull/1765 . After https://github.com/endojs/endo/pull/1765 these mismatches would have been genuine observable runtime bugs that remained undiagnosed by CI, as seen by the clean CI run at https://github.com/Agoric/agoric-sdk/pull/8514 .

This PR reproduces the bug fixes from https://github.com/Agoric/agoric-sdk/pull/8641 by themselves, without the endo-branch directive or the rest of https://github.com/Agoric/agoric-sdk/pull/8514 , testing that these fixes are also compat with current agoric-sdk and should be merged as is.

### Security Considerations

More accurate arg guarding supports better input validation.

### Scaling Considerations

None

### Documentation Considerations

For the methods whose guards are fixed here, we should also check whether the documentation of those methods include those args.

### Testing Considerations

The fact that the bugs fixed in this PR were not detected by https://github.com/Agoric/agoric-sdk/pull/8514 shows that https://github.com/endojs/endo/pull/1765 was too hazardous: It would introduce changes in behavior that could be unlikely to be detected in tests, but be genuine dynamic bugs.

### Upgrade Considerations

See the Upgrade Considerations of https://github.com/endojs/endo/pull/1890