### PR TITLE
feat: guard ContractGovernorKit

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,7 +130,8 @@ jobs:
           path: ./agoric-sdk
       - uses: ./agoric-sdk/.github/actions/restore-node
         with:
-          node-version: 18.x
+          # XXX loadgen not compatible with 18.19 https://github.com/Agoric/agoric-sdk/pull/8365#issuecomment-1848003597
+          node-version: 18.18
           path: ./agoric-sdk
           # Forces xsnap to initialize all memory to random data, which increases
           # the chances the content of snapshots may deviate between validators


### PR DESCRIPTION
## Description

@0xpatrickdev recently added guards to https://github.com/CrabblePitch/crabbleProtocol/pull/161/ . I was surprised to find they weren't already defined.

Here they are. In the future they can be imported to maintain the same interface.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

self-documenting

### Testing Considerations

Already covered

### Upgrade Considerations

No change to the interfaces. Future changes will have to maintain compatibility.