### PR TITLE
refactor(vats): Clarify the chain-behaviors core-eval fromBridge handler

### DIFF
--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -95,12 +95,9 @@ export const bridgeCoreEval = async allPowers => {
       await Promise.all(
         evals.map(coreEval => {
           // Run in a new turn to avoid crosstalk of the evaluations.
-          return Promise.resolve()
-            .then(() => evaluateCoreEval(coreEval))
-            .catch(err => {
-              console.error('CORE_EVAL failed:', err);
-              throw err;
-            });
+          const evalP = E(evaluateCoreEval)(coreEval);
+          evalP.catch(err => console.error('CORE_EVAL failed:', err));
+          return evalP;
         }),
       );
     },

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -60,13 +60,13 @@ export const bridgeCoreEval = async allPowers => {
    */
 
   /**
-   * Evaluates code in a single-use compartment to get a "behavior" which is
-   * then invoked with powers attenuated according to permits.
+   * Runs code in a single-use compartment to get a "behavior" which is then
+   * invoked with powers attenuated according to permits.
    *
    * @param {CoreEval} coreEval
    * @returns {unknown}
    */
-  const evaluateCoreEval = ({ json_permits: permitsSrc, js_code: code }) => {
+  const executeCoreEval = ({ json_permits: permitsSrc, js_code: code }) => {
     const permits = JSON.parse(permitsSrc);
     const powers = extractPowers(permits, {
       evaluateBundleCap,
@@ -95,7 +95,7 @@ export const bridgeCoreEval = async allPowers => {
       await Promise.all(
         evals.map(coreEval => {
           // Run in a new turn to avoid crosstalk of the evaluations.
-          const evalP = E(evaluateCoreEval)(coreEval);
+          const evalP = E(executeCoreEval)(coreEval);
           evalP.catch(err => console.error('CORE_EVAL failed:', err));
           return evalP;
         }),

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -60,8 +60,8 @@ export const bridgeCoreEval = async allPowers => {
    */
 
   /**
-   * Evaluates code in a single-use compartment to get a "behavior"
-   * which is then invoked with powers attenuated according to permits.
+   * Evaluates code in a single-use compartment to get a "behavior" which is
+   * then invoked with powers attenuated according to permits.
    *
    * @param {CoreEval} coreEval
    * @returns {unknown}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < 
v                                 Thanks for creating a PR! 
 > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Followup from your explanation of how core-eval works to make it more clear in the code:
* Replace the single-case switch with an assertion.
* Extract the main logic into an `evaluateCoreEval` helper.
* Replace `return Promise.all(...).then(_ => {})` with `await Promise.all(...)`.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a

### Upgrade Considerations

This code is unlikely to run on the agoric-3 mainnet because AFAIK there are no plans to upgrade the bootstrap vat, but should still be as clear as possible for all future uses (local development, testing, other chains, etc.).