### PR TITLE
docs: improve hints about cli commands that don't submit offers

### DIFF
--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -15,6 +15,7 @@ import {
   makeWalletUtils,
   outputAction,
   sendAction,
+  sendHint,
 } from '../lib/wallet.js';
 import { bigintReplacer } from '../lib/format.js';
 
@@ -128,7 +129,7 @@ export const makeOracleCommand = (logger, io = {}) => {
         offer,
       });
 
-      console.warn('Now execute the prepared offer');
+      console.warn(sendHint);
     });
 
   oracle
@@ -163,7 +164,7 @@ export const makeOracleCommand = (logger, io = {}) => {
         offer,
       });
 
-      console.warn('Now execute the prepared offer');
+      console.warn(sendHint);
     });
 
   const findOracleCap = async (instance, from, readLatestHead) => {

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -216,8 +216,6 @@ export const makePsmCommand = logger => {
       };
 
       outputExecuteOfferAction(offer);
-
-      console.warn('Now execute the prepared offer');
     });
 
   psm
@@ -272,8 +270,6 @@ export const makePsmCommand = logger => {
       };
 
       outputExecuteOfferAction(offer);
-
-      console.warn('Now execute the prepared offer');
     });
 
   return psm;

--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -54,7 +54,7 @@ export const makeVaultsCommand = logger => {
 
   vaults
     .command('open')
-    .description('open a new vault')
+    .description('Prepare an offer to open a new vault')
     .requiredOption('--giveCollateral <number>', 'Collateral to give', Number)
     .requiredOption('--wantMinted <number>', 'Minted wants', Number)
     .option('--offerId <string>', 'Offer id', String, `openVault-${Date.now()}`)
@@ -76,7 +76,7 @@ export const makeVaultsCommand = logger => {
 
   vaults
     .command('adjust')
-    .description('adjust an existing vault')
+    .description('Prepare an offer to adjust an existing vault')
     .requiredOption(
       '--from <address>',
       'wallet address literal or name',
@@ -121,7 +121,7 @@ export const makeVaultsCommand = logger => {
 
   vaults
     .command('close')
-    .description('close an existing vault')
+    .description('Prepare an offer to close an existing vault')
     .requiredOption(
       '--from <address>',
       'wallet address literal or name',

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -75,7 +75,7 @@ export const outputAction = (bridgeAction, stdout = process.stdout) => {
   stdout.write('\n');
 };
 
-const sendHint =
+export const sendHint =
   'Now use `agoric wallet send ...` to sign and broadcast the offer.\n';
 
 /**
@@ -101,6 +101,7 @@ export const outputExecuteOfferAction = (offer, stdout = process.stdout) => {
     offer,
   };
   outputAction(spendAction, stdout);
+  stdout.write(sendHint);
 };
 
 /**

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -93,15 +93,20 @@ export const outputActionAndHint = (bridgeAction, { stdout, stderr }) => {
 /**
  * @param {import('@agoric/smart-wallet/src/offers.js').OfferSpec} offer
  * @param {Pick<import('stream').Writable,'write'>} [stdout]
+ * @param {Pick<import('stream').Writable,'write'>} [stderr]
  */
-export const outputExecuteOfferAction = (offer, stdout = process.stdout) => {
+export const outputExecuteOfferAction = (
+  offer,
+  stdout = process.stdout,
+  stderr = process.stderr,
+) => {
   /** @type {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} */
   const spendAction = {
     method: 'executeOffer',
     offer,
   };
   outputAction(spendAction, stdout);
-  stdout.write(sendHint);
+  stderr.write(sendHint);
 };
 
 /**


### PR DESCRIPTION
refs: [agoric-3-proposals#34](https://github.com/Agoric/agoric-3-proposals/pull/34)

## Description

While working in the agoric-3-proposal environment, I had to submit a variety of commands to the (local) chain. The inconsistency between different `agops` commands, some of which submitted proposals directly to the chain and others that expected me to submit them separately was confusing. This doesn't make them more similar, it merely documents them better, so commands that only prepare proposals are clearer about that.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

Improved help text

### Testing Considerations

These tools are used in test environments.

### Upgrade Considerations

None.