### PR TITLE
feat(types): coreEvalEnv

### DIFF
--- a/packages/inter-protocol/test/psm/gov-add-psm.js
+++ b/packages/inter-protocol/test/psm/gov-add-psm.js
@@ -26,7 +26,7 @@ const config = {
 };
 
 /** @param {unknown} permittedPowers see gov-add-psm-permit.json */
-const main = async permittedPowers => {
+const govAddPsm = async permittedPowers => {
   console.log('starting PSM:', DAI);
   const {
     consume: { feeMintAccess: _, ...restC },
@@ -43,4 +43,4 @@ const main = async permittedPowers => {
 };
 
 // "export" from script
-main;
+govAddPsm;

--- a/packages/inter-protocol/test/psm/gov-replace-committee.js
+++ b/packages/inter-protocol/test/psm/gov-replace-committee.js
@@ -1,5 +1,6 @@
 /* global E */
-// @ts-nocheck
+// @ts-check
+/// <reference types="@agoric/vats/src/core/core-eval-env"/>
 /**
  * @file Script to replace the econ governance committee in a SwingSet Core Eval
  *   (aka big hammer)
@@ -26,12 +27,12 @@ const { values } = Object;
 const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 
 /**
- * @param {ERef<NameAdmin>} nameAdmin
+ * @param {ERef<import('@agoric/vats').NameAdmin>} nameAdmin
  * @param {string[][]} paths
  */
 const reserveThenGetNamePaths = async (nameAdmin, paths) => {
   /**
-   * @param {ERef<NameAdmin>} nextAdmin
+   * @param {ERef<import('@agoric/vats').NameAdmin>} nextAdmin
    * @param {string[]} path
    */
   const nextPath = async (nextAdmin, path) => {

--- a/packages/vats/src/core/boot-chain.js
+++ b/packages/vats/src/core/boot-chain.js
@@ -17,6 +17,7 @@ const modules = {
   behaviors: { ...behaviors },
   utils: { ...utils },
 };
+/** @typedef {typeof modules} BootstrapModules */
 
 export const MANIFEST = CHAIN_BOOTSTRAP_MANIFEST;
 

--- a/packages/vats/src/core/core-eval-env.d.ts
+++ b/packages/vats/src/core/core-eval-env.d.ts
@@ -1,0 +1,37 @@
+/* eslint-disable */
+/**
+ * @file typesdef for the CoreEval environment
+ *
+ *   To use add this to the top of the proposal: /// <reference
+ *   types="@agoric/vats/src/core/core-eval-env"/>
+ *
+ *   That directive has to be before imports, but this one's only useful in
+ *   modules that have no imports or named exports.
+ */
+
+import type { VatData } from '@agoric/swingset-liveslots/src/vatDataTypes.js';
+import type { E, Far, getInterfaceOf, passStyleOf } from '@endo/far';
+import type { Assert, VirtualConsole } from 'ses';
+import type { BootstrapModules } from './boot-chain.js';
+
+// Provided by 'CORE_EVAL' handler in chain-behaviors.js
+declare global {
+  // bootstrap modules
+  var behaviors: BootstrapModules['behaviors'];
+  var utils: BootstrapModules['utils'];
+
+  // @endo/far exports
+  var E: E;
+  var Far: Far;
+  var getInterfaceOfFar: getInterfaceOfFar;
+  var passStyleOfFar: passStyleOfFar;
+
+  // endowments
+  var VatData: VatData;
+  var assert: Assert;
+
+  // console is a VirtualConsole but this directive fails to override the extant global `console`
+  // var console: VirtualConsole;
+
+  // Base64 and URL are not available in all environments
+}

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -397,7 +397,7 @@ type BootstrapPowers = BootstrapSpace & {
   vatPowers: { [prop: string]: any; D: DProxy };
   vatParameters: BootstrapVatParams;
   runBehaviors: (manifest: unknown) => Promise<unknown>;
-  modules: Record<string, Record<string, any>>;
+  modules: import('./boot-chain.js').BootstrapModules;
 };
 
 type BootstrapSpace = WellKnownSpaces &

--- a/packages/vats/test/test-vat-bank-integration.js
+++ b/packages/vats/test/test-vat-bank-integration.js
@@ -72,7 +72,7 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
     vats: /** @type {any} */ ({}),
     vatPowers: /** @type {any} */ ({}),
     runBehaviors: /** @type {any} */ ({}),
-    modules: {},
+    modules: /** @type {any} */ ({}),
     ...spaces,
   });
 


### PR DESCRIPTION
closes: #8643

## Description

Provides a typedef file that puts into `global` env what is available within a Core-Eval 

Eslint still needs to have the globals declared. I looked into the `eslint-env` directive, but that appears not to be extensible and is [going away in v9](https://github.com/eslint/eslint/pull/17390/) anyway.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

Something to put into docs.agoric.com?

### Testing Considerations

CI

### Upgrade Considerations

n/a