### PR TITLE
refactor(x/swingset): Consolidate swingset message definition and initialization

### DIFF
--- a/golang/cosmos/x/swingset/keeper/msg_server.go
+++ b/golang/cosmos/x/swingset/keeper/msg_server.go
@@ -90,7 +90,6 @@ func (keeper msgServer) DeliverInbound(goCtx context.Context, msg *types.MsgDeli
 	}
 
 	err := keeper.routeAction(ctx, msg, action)
-	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err
 	}
@@ -112,10 +111,8 @@ func (keeper msgServer) WalletAction(goCtx context.Context, msg *types.MsgWallet
 		BlockHeight: ctx.BlockHeight(),
 		BlockTime:   ctx.BlockTime().Unix(),
 	}
-	// fmt.Fprintf(os.Stderr, "Context is %+v\n", ctx)
 
 	err = keeper.routeAction(ctx, msg, action)
-	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +134,7 @@ func (keeper msgServer) WalletSpendAction(goCtx context.Context, msg *types.MsgW
 		BlockHeight: ctx.BlockHeight(),
 		BlockTime:   ctx.BlockTime().Unix(),
 	}
-	// fmt.Fprintf(os.Stderr, "Context is %+v\n", ctx)
+
 	err = keeper.routeAction(ctx, msg, action)
 	if err != nil {
 		return nil, err
@@ -173,7 +170,6 @@ func (keeper msgServer) provisionIfNeeded(ctx sdk.Context, owner sdk.AccAddress)
 	}
 
 	err := keeper.routeAction(ctx, msg, action)
-	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return err
 	}
@@ -204,7 +200,6 @@ func (keeper msgServer) Provision(goCtx context.Context, msg *types.MsgProvision
 	}
 
 	err = keeper.routeAction(ctx, msg, action)
-	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +222,6 @@ func (keeper msgServer) InstallBundle(goCtx context.Context, msg *types.MsgInsta
 	}
 
 	err = keeper.routeAction(ctx, msg, action)
-	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Defines context-derived `blockHeight` and `blockTime` and (most importantly) an interface-derived `type` for the JSON serialization of all "action" messages headed towards swingset in one place rather than in disjoint type definitions scattered throughout the code.

Alternatively, the `type` values could be defined even closer to individual structs by means of reflection[^1] or [custom `MarshalJSON` methods](https://pkg.go.dev/encoding/json#example-package-CustomMarshalJSON)[^2]. But I feel like this approach strikes the right balance given the small count of message types.

[^1]:
    [e.g.](https://go.dev/play/p/swB0cc3qFUU), ``` type walletSpendAction struct { Type string `json:"type" default:"WALLET_SPEND_ACTION"`; … } ``` with
    ```go
    if typeField, ok := reflect.TypeOf(action).Elem().FieldByName("Type"); ok {
    	action.Type = typeField.Tag.Get("default")
    }
    ```
[^2]:
    [e.g.](https://go.dev/play/p/0OkZE9WSjTE), ``` type walletSpendAction struct { Type walletSpendType `json:"type"`; … } ``` with
    ```go
    type walletSpendActionType struct{}
    func (_ *walletSpendActionType) MarshalJSON() ([]byte, error) { return []byte(`"WALLET_SPEND_ACTION"`), nil }
    ```

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

This should help anyone looking at either the Go or JS side of SwingSet messaging better correlate I/O with the other side.

### Testing Considerations

n/a

### Upgrade Considerations

n/a