### PR TITLE
refactor ZoeSeat to drop cyclic structure that blocked GC

### DIFF
--- a/a3p-integration/README.md
+++ b/a3p-integration/README.md
@@ -102,9 +102,9 @@ code, and must be rebuilt every time there is a change. The
 `/scripts/generate-a3p-submission.sh` script contains commands to generate the
 core-eval content and move it to the expected proposal package's submission
 directory. It is executed as part of `a3p-integration`'s `build:submission` step.
-Each proposal that requires such a build step should add a `submission` entry in
-the `agoricProposal` section of package.json. This value specifies the name of
-another entry which gives parameters to be passed to `generate-a3p-submission.sh`.
+Each proposal that requires such a build step should add a `build:submission`
+rule in its  package.json to specify the details of proposals that require a
+build step.
 
 ## Building synthetic-chain images
 

--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -24,7 +24,8 @@
     ]
   },
   "scripts": {
-    "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops"
+    "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops",
+    "build:submission": "../../../scripts/generate-a3p-submission.sh probe-zcf-bundle a:upgrade-next probeZcfBundle probe-submission"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/a3p-integration/proposals/b:localchain/package.json
+++ b/a3p-integration/proposals/b:localchain/package.json
@@ -17,5 +17,8 @@
       "!submission"
     ]
   },
+  "scripts": {
+    "build:submission": "../../../scripts/generate-a3p-submission.sh test-localchain b:localchain"
+  },
   "packageManager": "yarn@4.1.0"
 }

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -35,6 +35,7 @@ export const makeMakeExiter = baggage => {
       exit() {
         const { state } = this;
         state.zcfSeat.exit();
+        state.zcfSeat = undefined;
       },
     },
     {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -159,6 +159,7 @@ export const createSeatManager = (
         assertNoStagedAllocation(self);
         doExitSeat(self);
         E(zoeInstanceAdmin).exitSeat(zcfSeatToSeatHandle.get(self), completion);
+        zcfSeatToSeatHandle.delete(self);
       },
       fail(
         reason = Error(
@@ -179,6 +180,7 @@ export const createSeatManager = (
             zcfSeatToSeatHandle.get(self),
             harden(reason),
           );
+          zcfSeatToSeatHandle.delete(self);
         }
         return reason;
       },

--- a/packages/zoe/src/zoeService/originalZoeSeat.js
+++ b/packages/zoe/src/zoeService/originalZoeSeat.js
@@ -17,7 +17,23 @@ import {
 
 const { Fail } = assert;
 
-const OriginalZoeSeatIKit = harden({
+export const coreUserSeatMethods = harden({
+  getProposal: M.call().returns(M.promise()),
+  getPayouts: M.call().returns(M.promise()),
+  getPayout: M.call(KeywordShape).returns(M.promise()),
+  getOfferResult: M.call().returns(M.promise()),
+  hasExited: M.call().returns(M.promise()),
+  numWantsSatisfied: M.call().returns(M.promise()),
+  getFinalAllocation: M.call().returns(M.promise()),
+  getExitSubscriber: M.call().returns(M.any()),
+});
+
+export const ZoeUserSeatShape = M.interface('UserSeat', {
+  ...coreUserSeatMethods,
+  tryExit: M.call().returns(M.promise()),
+});
+
+export const OriginalZoeSeatIKit = harden({
   zoeSeatAdmin: M.interface('ZoeSeatAdmin', {
     replaceAllocation: M.call(AmountKeywordRecordShape).returns(),
     exit: M.call(M.any()).returns(),
@@ -33,17 +49,7 @@ const OriginalZoeSeatIKit = harden({
       M.promise(),
     ),
   }),
-  userSeat: M.interface('UserSeat', {
-    getProposal: M.call().returns(M.promise()),
-    getPayouts: M.call().returns(M.promise()),
-    getPayout: M.call(KeywordShape).returns(M.promise()),
-    getOfferResult: M.call().returns(M.promise()),
-    hasExited: M.call().returns(M.promise()),
-    tryExit: M.call().returns(M.promise()),
-    numWantsSatisfied: M.call().returns(M.promise()),
-    getFinalAllocation: M.call().returns(M.promise()),
-    getExitSubscriber: M.call().returns(M.any()),
-  }),
+  userSeat: ZoeUserSeatShape,
 });
 
 const assertHasNotExited = (c, msg) => {

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -992,7 +992,7 @@ test(`userSeat.getPayout() should throw from zcf.makeEmptySeatKit`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(userSeat).getPayout(), {
     message:
-      'In "getPayout" method of (ZoeSeatKit userSeat): Expected at least 1 arguments: []',
+      'In "getPayout" method of (ZoeUserSeat userSeat): Expected at least 1 arguments: []',
   });
 });
 

--- a/scripts/generate-a3p-submission-dirs.sh
+++ b/scripts/generate-a3p-submission-dirs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ueo pipefail
+
+for proposal in ./proposals/?:*
+do
+  cd $proposal
+  yarn run build:submission
+  cd -
+done


### PR DESCRIPTION
closes: #8672

## Description

Refactor ZoeSeat to be composed of two separate Exos, so that dropping one can allow the cyclic structure described in #8672 to be GC'd.

### Security Considerations

N/A

### Scaling Considerations

Vast improvement in reducing retained garbage.

### Documentation Considerations

Invisible to users.

### Testing Considerations

Needs further testing in the upgrade environment to demonstrate
 * classic ZoeSeats continue to function (and continue to retain cycles)
 * New ZoeSeats break the cycles when exited.

All existing tests in packages/zoe pass, with two tests requiring minor changes to error messages.

### Upgrade Considerations

See above.