### PR TITLE
Endo sync types

### DIFF
--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -1,7 +1,7 @@
 import { Fail, q } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
-import { TimeMath } from '@agoric/time';
+import { TimeMath, TimestampShape } from '@agoric/time';
 import { M, makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
 import {
   calculateMedian,
@@ -98,21 +98,25 @@ export const prepareRoundsManagerKit = baggage =>
     'RoundsManager',
     {
       helper: UnguardedHelperI,
-      contract: M.interface(
-        'contract',
-        {
-          authenticateQuote: M.call().rest(M.any()).returns(M.any()),
-          makeCreateQuote: M.call().rest(M.any()).returns(M.any()),
-          eligibleForSpecificRound: M.call().rest(M.any()).returns(M.boolean()),
-          getRoundData: M.call().rest(M.any()).returns(M.promise()),
-          getRoundStatus: M.call().rest(M.any()).returns(M.record()),
-          oracleRoundStateSuggestRound: M.call()
-            .rest(M.any())
-            .returns(M.record()),
-        },
-        // TODO(6571) stop sloppy
-        { sloppy: true },
-      ),
+      contract: M.interface('contract', {
+        authenticateQuote: M.call([M.record()]).returns(M.any()),
+        makeCreateQuote: M.call()
+          .optional({
+            overrideValueOut: M.number(),
+            timestamp: TimestampShape,
+          })
+          .returns(M.any()),
+        eligibleForSpecificRound: M.call(
+          M.any(),
+          M.bigint(),
+          TimestampShape,
+        ).returns(M.boolean()),
+        getRoundData: M.call(M.any()).returns(M.promise()),
+        getRoundStatus: M.call(M.bigint()).returns(M.record()),
+        oracleRoundStateSuggestRound: M.call(M.any(), TimestampShape).returns(
+          M.record(),
+        ),
+      }),
       oracle: M.interface('oracle', {
         handlePush: M.call(M.record(), M.record()).returns(M.promise()),
       }),

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -14,8 +14,8 @@ const ownKeys =
   );
 
 /**
- * @template T
- * @typedef {(...args: Parameters<ReturnType<prepareAttenuator>>) => Farable<T>} MakeAttenuator
+ * @template {import('@endo/exo/src/exo-makers.js').Methods} T
+ * @typedef {(...args: Parameters<ReturnType<prepareAttenuator>>) => import('@endo/exo/src/exo-makers.js').Farable<T>} MakeAttenuator
  */
 
 /**
@@ -27,8 +27,6 @@ const ownKeys =
  * @template {(...args: unknown[]) => any} I
  * @typedef {import('./types.js').SyncCallback<I>} SyncCallback
  */
-
-/** @template T @typedef {import('@endo/eventual-send').RemotableBrand<{}, T> & T} Farable */
 
 /**
  * @param {unknown} key

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -1,5 +1,5 @@
 // @jessie-check
-
+/* eslint-disable @typescript-eslint/prefer-ts-expect-error -- for casting from deprecated types that aren't worth fixing */
 import { initEmpty } from '@agoric/store';
 
 import { provide, VatData as globalVatData } from './vat-data-bindings.js';
@@ -31,6 +31,7 @@ export const ignoreContext =
 harden(ignoreContext);
 
 // TODO: Find a good home for this function used by @agoric/vat-data and testing code
+/** @param {import('@agoric/swingset-liveslots').VatData} VatData */
 export const makeExoUtils = VatData => {
   const {
     defineKind,
@@ -101,9 +102,11 @@ export const makeExoUtils = VatData => {
    *   self: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').Guarded<T>}
    */
   const defineVirtualExoClass = (tag, interfaceGuard, init, methods, options) =>
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+    // @ts-ignore cast
     defineKind(tag, init, methods, {
       ...options,
       thisfulMethods: true,
@@ -118,14 +121,14 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
-   *   facets: T,
+   *   facets: import('@endo/exo/src/exo-makers.js').GuardedKit<T>,
    *   state: ReturnType<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').GuardedKit<T>}
    */
   const defineVirtualExoClassKit = (
     tag,
@@ -134,6 +137,7 @@ export const makeExoUtils = VatData => {
     facets,
     options,
   ) =>
+    // @ts-ignore cast
     defineKindMulti(tag, init, facets, {
       ...options,
       thisfulMethods: true,
@@ -155,7 +159,7 @@ export const makeExoUtils = VatData => {
    *   self: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').Guarded<T>}
    */
   const defineDurableExoClass = (
     kindHandle,
@@ -164,6 +168,7 @@ export const makeExoUtils = VatData => {
     methods,
     options,
   ) =>
+    // @ts-ignore cast
     defineDurableKind(kindHandle, init, methods, {
       ...options,
       thisfulMethods: true,
@@ -178,14 +183,14 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
-   *   facets: T,
+   *   facets: import('@endo/exo/src/exo-makers.js').GuardedKit<T>,
    *   state: ReturnType<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').GuardedKit<T>}
    */
   const defineDurableExoClassKit = (
     kindHandle,
@@ -194,6 +199,7 @@ export const makeExoUtils = VatData => {
     facets,
     options,
   ) =>
+    // @ts-ignore cast
     defineDurableKindMulti(kindHandle, init, facets, {
       ...options,
       thisfulMethods: true,
@@ -216,7 +222,7 @@ export const makeExoUtils = VatData => {
    *   self: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').Guarded<T>}
    */
   const prepareExoClass = (
     baggage,
@@ -243,14 +249,14 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
-   *   facets: T,
+   *   facets: import('@endo/exo/src/exo-makers.js').GuardedKit<T>,
    *   state: ReturnType<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').GuardedKit<T>}
    */
   const prepareExoClassKit = (
     baggage,
@@ -276,7 +282,7 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuard | undefined} interfaceGuard
    * @param {M} methods
    * @param {DefineKindOptions<{ self: M }>} [options]
-   * @returns {M & RemotableBrand<{}, M>}
+   * @returns {import('@endo/exo/src/exo-makers.js').Guarded<M>}
    */
   const prepareExo = (
     baggage,
@@ -305,7 +311,7 @@ export const makeExoUtils = VatData => {
    * @param {string} kindName
    * @param {M} methods
    * @param {DefineKindOptions<{ self: M }>} [options]
-   * @returns {M & RemotableBrand<{}, M>}
+   * @returns {import('@endo/exo/src/exo-makers.js').Guarded<M>}
    */
   const prepareSingleton = (baggage, kindName, methods, options = undefined) =>
     prepareExo(baggage, kindName, undefined, methods, options);

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -42,6 +42,7 @@ export const makeExoUtils = VatData => {
   } = VatData;
 
   /**
+   * @deprecated Use Exos/ExoClasses instead of Kinds
    * @param {Baggage} baggage
    * @param {string} kindName
    * @returns {DurableKindHandle}
@@ -325,8 +326,8 @@ export const makeExoUtils = VatData => {
     prepareExoClass,
     prepareExoClassKit,
     prepareExo,
-    prepareSingleton,
 
+    prepareSingleton,
     provideKindHandle,
     prepareKind,
     prepareKindMulti,

--- a/packages/zone/src/durable.js
+++ b/packages/zone/src/durable.js
@@ -89,10 +89,6 @@ export const makeDurableZone = (baggage, baseLabel = 'durableZone') => {
   /** @type {import('.').Zone['exoClass']} */
   const exoClass = (...args) => prepareExoClass(baggage, ...args);
   /** @type {import('.').Zone['exoClassKit']} */
-  // @ts-ignore This type check regressed inexplicably with the release
-  // following after @endo/exo@0.2.6.
-  // The lint error does not occur in local lint, but does in integration with
-  // @agoric/vats, so can not be suppressed with ts-expect-error.
   const exoClassKit = (...args) => prepareExoClassKit(baggage, ...args);
   /** @type {import('.').Zone['exo']} */
   const exo = (...args) => prepareExo(baggage, ...args);


### PR DESCRIPTION
refs: #8651

## Description

The recent Endo sync had many hurdles so some were deferred to land it. One was a types regression.

This fixes that by importing the Endo types where appropriate. It also improves the accuracy of the Exo helpers in vat-data by guarding the `this.facets`. 


### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

CI

### Upgrade Considerations

`roundsManager` now has a tighter runtime check. It describes the actual interface so it should be backwards compatible. 