### PR TITLE
all imports .js

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -80,6 +80,10 @@ module.exports = {
     jsdoc: {
       mode: 'typescript',
     },
+    'import/resolver': {
+      typescript: true,
+      node: true,
+    },
   },
   ignorePatterns: [
     'coverage/**',

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -75,6 +75,8 @@ jobs:
       # build the API docs to verify it works
       - name: build API docs
         run: yarn docs
+      - name: build root tsconfig
+        run: yarn build-ts
 
   lint-rest:
     timeout-minutes: 15

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-jessie": "^0.0.6",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-ava": "^14.0.0",
     "eslint-plugin-github": "^4.10.0",
     "eslint-plugin-import": "^2.25.3",

--- a/packages/benchmark/benchmark/benchmark-liquidation.js
+++ b/packages/benchmark/benchmark/benchmark-liquidation.js
@@ -2,7 +2,7 @@
 import { bench } from '../src/benchmarkerator.js';
 
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { scale6 } from '@agoric/boot/tools/liquidation.ts';
+import { scale6 } from '@agoric/boot/tools/liquidation.js';
 
 const setupData = {
   vaults: [

--- a/packages/benchmark/src/benchmarkerator.js
+++ b/packages/benchmark/src/benchmarkerator.js
@@ -13,12 +13,12 @@ import '@agoric/cosmic-swingset/src/launch-chain.js';
 import { Fail } from '@agoric/assert';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
-import { makeSwingsetTestKit } from '@agoric/boot/tools/supports.ts';
+import { makeSwingsetTestKit } from '@agoric/boot/tools/supports.js';
 import {
   makeWalletFactoryDriver,
   makeGovernanceDriver,
-} from '@agoric/boot/tools/drivers.ts';
-import { makeLiquidationTestKit } from '@agoric/boot/tools/liquidation.ts';
+} from '@agoric/boot/tools/drivers.js';
+import { makeLiquidationTestKit } from '@agoric/boot/tools/liquidation.js';
 
 // When I was a child my family took a lot of roadtrips around California to go
 // camping and backpacking and so on.  It was not uncommon in those days (nor is
@@ -48,7 +48,7 @@ import { makeLiquidationTestKit } from '@agoric/boot/tools/liquidation.ts';
  * @typedef {{
  *    options: Record<string, string>,
  *    argv: string[],
- *    actors: Record<string, import('@agoric/boot/tools/drivers.ts').SmartWalletDriver>,
+ *    actors: Record<string, import('@agoric/boot/tools/drivers.js').SmartWalletDriver>,
  *    tools: Record<string, unknown>,
  *    title?: string,
  *    rounds?: number,

--- a/packages/boot/test/bootstrapTests/test-addAssets.ts
+++ b/packages/boot/test/bootstrapTests/test-addAssets.ts
@@ -6,8 +6,8 @@ import { TimeMath } from '@agoric/time';
 import {
   LiquidationTestContext,
   makeLiquidationTestContext,
-} from '../../tools/liquidation.ts';
-import { makeProposalExtractor } from '../../tools/supports.ts';
+} from '../../tools/liquidation.js';
+import { makeProposalExtractor } from '../../tools/supports.js';
 
 const test = anyTest as TestFn<
   LiquidationTestContext & {

--- a/packages/boot/test/bootstrapTests/test-demo-config.ts
+++ b/packages/boot/test/bootstrapTests/test-demo-config.ts
@@ -3,7 +3,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { PowerFlags } from '@agoric/vats/src/walletFlags.js';
 
 import type { TestFn } from 'ava';
-import { makeSwingsetTestKit, keyArrayEqual } from '../../tools/supports.ts';
+import { makeSwingsetTestKit, keyArrayEqual } from '../../tools/supports.js';
 
 const { keys } = Object;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-1.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-1.ts
@@ -12,7 +12,7 @@ import {
   makeLiquidationTestContext,
   scale6,
   LiquidationSetup,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-2b.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-2b.ts
@@ -9,9 +9,8 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { NonNullish } from '@agoric/assert';
-import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import type { TestFn } from 'ava';
-import { ScheduleNotification } from '@agoric/inter-protocol/src/auction/scheduler.js';
+import { type ScheduleNotification } from '@agoric/inter-protocol/src/auction/scheduler.js';
 import {
   LiquidationSetup,
   LiquidationTestContext,

--- a/packages/boot/test/bootstrapTests/test-liquidation-2b.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-2b.ts
@@ -17,7 +17,7 @@ import {
   LiquidationTestContext,
   makeLiquidationTestContext,
   scale6,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-concurrent-1.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-concurrent-1.ts
@@ -12,7 +12,7 @@ import {
   likePayouts,
   makeLiquidationTestContext,
   scale6,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-liquidation-concurrent-2b.ts
+++ b/packages/boot/test/bootstrapTests/test-liquidation-concurrent-2b.ts
@@ -15,7 +15,7 @@ import {
   ensureVaultCollateral,
   makeLiquidationTestContext,
   scale6,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-vats-restart.ts
+++ b/packages/boot/test/bootstrapTests/test-vats-restart.ts
@@ -13,8 +13,8 @@ import type { EconomyBootstrapSpace } from '@agoric/inter-protocol/src/proposals
 import {
   makeProposalExtractor,
   makeSwingsetTestKit,
-} from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+} from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 const { Fail } = assert;
 

--- a/packages/boot/test/bootstrapTests/test-vaults-integration.ts
+++ b/packages/boot/test/bootstrapTests/test-vaults-integration.ts
@@ -12,7 +12,7 @@ import {
   slotToBoardRemote,
 } from '@agoric/vats/tools/board-utils.js';
 import type { TestFn } from 'ava';
-import { ParamChangesOfferArgs } from '@agoric/inter-protocol/src/econCommitteeCharter.js';
+import { type ParamChangesOfferArgs } from '@agoric/inter-protocol/src/econCommitteeCharter.js';
 import { makeSwingsetTestKit } from '../../tools/supports.js';
 import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 

--- a/packages/boot/test/bootstrapTests/test-vaults-integration.ts
+++ b/packages/boot/test/bootstrapTests/test-vaults-integration.ts
@@ -13,9 +13,8 @@ import {
 } from '@agoric/vats/tools/board-utils.js';
 import type { TestFn } from 'ava';
 import { ParamChangesOfferArgs } from '@agoric/inter-protocol/src/econCommitteeCharter.js';
-
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';

--- a/packages/boot/test/bootstrapTests/test-vaults-upgrade.ts
+++ b/packages/boot/test/bootstrapTests/test-vaults-upgrade.ts
@@ -15,8 +15,8 @@ import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-
 import { ExecutionContext, TestFn } from 'ava';
 import { FakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { EconomyBootstrapSpace } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';

--- a/packages/boot/test/bootstrapTests/test-vaults-upgrade.ts
+++ b/packages/boot/test/bootstrapTests/test-vaults-upgrade.ts
@@ -13,8 +13,8 @@ import { Far, makeMarshal } from '@endo/marshal';
 import { SECONDS_PER_YEAR } from '@agoric/inter-protocol/src/interest.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
 import { ExecutionContext, TestFn } from 'ava';
-import { FakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { EconomyBootstrapSpace } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
+import { type FakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import { type EconomyBootstrapSpace } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import { makeSwingsetTestKit } from '../../tools/supports.js';
 import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 

--- a/packages/boot/test/bootstrapTests/test-walletSurvivesZoeRestart.ts
+++ b/packages/boot/test/bootstrapTests/test-walletSurvivesZoeRestart.ts
@@ -10,7 +10,7 @@ import {
   LiquidationTestContext,
   makeLiquidationTestContext,
   LiquidationSetup,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/test-zcf-upgrade.ts
+++ b/packages/boot/test/bootstrapTests/test-zcf-upgrade.ts
@@ -15,8 +15,8 @@ import {
   matchAmount,
   makeProposalExtractor,
   makeSwingsetTestKit,
-} from '../../tools/supports.ts';
-import { makeZoeDriver } from '../../tools/drivers.ts';
+} from '../../tools/supports.js';
+import { makeZoeDriver } from '../../tools/drivers.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);

--- a/packages/boot/test/bootstrapTests/walletFactory.ts
+++ b/packages/boot/test/bootstrapTests/walletFactory.ts
@@ -1,9 +1,9 @@
 import {
-  AgoricNamesRemotes,
+  type AgoricNamesRemotes,
   makeAgoricNamesRemotesFromFakeStorage,
 } from '@agoric/vats/tools/board-utils.js';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 const { Fail } = assert;
 

--- a/packages/boot/test/upgrading/test-upgrade-vats.js
+++ b/packages/boot/test/upgrading/test-upgrade-vats.js
@@ -5,7 +5,7 @@ import { BridgeId } from '@agoric/internal';
 import { buildVatController } from '@agoric/swingset-vat';
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
-import { matchAmount, matchIter, matchRef } from '../../tools/supports.ts';
+import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
 
 /**
  * @type {import('ava').TestFn<{}>}

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -23,7 +23,7 @@ import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type { TimerService } from '@agoric/time';
 import type { OfferMaker } from '@agoric/smart-wallet/src/types.js';
 import type { RunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
-import type { SwingsetTestKit } from './supports.ts';
+import type { SwingsetTestKit } from './supports.js';
 
 export const makeWalletFactoryDriver = async (
   runUtils: RunUtils,

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -4,13 +4,13 @@ import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { SECONDS_PER_MINUTE } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
 import {
-  FakeStorageKit,
+  type FakeStorageKit,
   slotToRemotable,
 } from '@agoric/internal/src/storage-test-utils.js';
 import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
 
 import {
-  AgoricNamesRemotes,
+  type AgoricNamesRemotes,
   boardSlottingMarshaller,
 } from '@agoric/vats/tools/board-utils.js';
 import type {

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -4,7 +4,7 @@ import {
   SECONDS_PER_MINUTE,
 } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import {
-  AgoricNamesRemotes,
+  type AgoricNamesRemotes,
   makeAgoricNamesRemotesFromFakeStorage,
 } from '@agoric/vats/tools/board-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -70,7 +70,11 @@ module.exports = {
     'jsdoc/check-param-names': 'error',
     'jsdoc/check-syntax': 'error',
 
-    'import/extensions': ['warn', 'ignorePackages'],
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      { js: 'always', ts: 'never' },
+    ],
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/packages/time/index.js
+++ b/packages/time/index.js
@@ -1,4 +1,3 @@
 export * from './src/timeMath.js';
 export * from './src/typeGuards.js';
-// eslint-disable-next-line import/export -- just types
 export * from './src/types.js';

--- a/packages/vat-data/src/index.test-d.ts
+++ b/packages/vat-data/src/index.test-d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-use-before-define */
+// eslint-disable-next-line import/no-extraneous-dependencies -- thinks this is non-test code
 import { expectType } from 'tsd';
 import type {
   KindFacets,
@@ -6,7 +7,7 @@ import type {
   KindFacet,
   FunctionsPlusContext,
 } from '@agoric/swingset-liveslots';
-import { VirtualObjectManager } from '@agoric/swingset-liveslots/src/virtualObjectManager.js';
+import { type VirtualObjectManager } from '@agoric/swingset-liveslots/src/virtualObjectManager.js';
 import {
   defineKind,
   defineKindMulti,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4264,6 +4264,14 @@ enhance-visitors@^1.0.0:
   dependencies:
     lodash "^4.13.1"
 
+enhanced-resolve@^5.12.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
+  integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -4458,6 +4466,19 @@ eslint-import-resolver-node@^0.3.7:
     debug "^3.2.7"
     is-core-module "^2.11.0"
     resolve "^1.22.1"
+
+eslint-import-resolver-typescript@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz#7b983680edd3f1c5bce1a5829ae0bc2d57fe9efa"
+  integrity sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==
+  dependencies:
+    debug "^4.3.4"
+    enhanced-resolve "^5.12.0"
+    eslint-module-utils "^2.7.4"
+    fast-glob "^3.3.1"
+    get-tsconfig "^4.5.0"
+    is-core-module "^2.11.0"
+    is-glob "^4.0.3"
 
 eslint-module-utils@^2.7.4:
   version "2.7.4"
@@ -4894,6 +4915,17 @@ fast-glob@3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -5235,6 +5267,13 @@ get-tsconfig@^4.4.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.0.tgz#06ce112a1463e93196aa90320c35df5039147e34"
   integrity sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
+get-tsconfig@^4.5.0:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.2.tgz#0dcd6fb330391d46332f4c6c1bf89a6514c2ddce"
+  integrity sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -9233,6 +9272,11 @@ table@^6.7.1:
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
+
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 tar-fs@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
refs: #8651

## Description

The recent Endo sync changed all imports to have extensions. This makes the consistently `.js` (even for `.ts` files) by configuring eslint to resolve TS.

Finally it adds `build-ts` to CI to prevent regressions of that ability. (There were a couple)

In draft because the `.ts` import doesn't work in ava-xs. The `.ts` does. So some options:
1) stop running ava-xs for tests that import .ts (at present, the bootstrap tests)
2) teach ava-xs to import .ts
3) allow .ts (and enable `allowImportingTsExtensions` so build:ts can resolve it)

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
