### PR TITLE
feat: auctioneer detects failing priceAuthority; requests new one

### DIFF
--- a/packages/builders/scripts/vats/restart-vats.js
+++ b/packages/builders/scripts/vats/restart-vats.js
@@ -9,6 +9,8 @@ export const defaultProposalBuilder = async () => {
     'feeDistributor',
     // skip so vaultManager can have prices upon restart; these have been tested as restartable
     'scaledPriceAuthority-ATOM',
+    // If this is killed, and the above is left alive, quoteNotifier throws
+    'ATOM-USD_price_feed',
   ];
 
   return harden({

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -202,7 +202,7 @@ export const watchQuoteNotifier = async (notifierP, watcher, ...args) => {
  * @type {(brand: Brand) => {
  *   prioritizedVaults: ReturnType<typeof makePrioritizedVaults>;
  *   storedQuotesNotifier: import('@agoric/notifier').StoredNotifier<PriceQuote>;
- *   storedCollateralQuote: PriceQuote;
+ *   storedCollateralQuote: PriceQuote | null;
  * }}
  */
 // any b/c will be filled after start()
@@ -459,7 +459,6 @@ export const prepareVaultManagerKit = (
               // notifier immediately, we'll trigger an infinite loop, so try
               // to restart each time we get a request.
 
-              // @ts-expect-error reset value
               ephemera.storedCollateralQuote = null;
             },
           });

--- a/packages/inter-protocol/test/auction/test-auctionBook.js
+++ b/packages/inter-protocol/test/auction/test-auctionBook.js
@@ -80,16 +80,19 @@ const assembleAuctionBook = async basics => {
 
 test('states', async t => {
   const basics = await setupBasics();
-  const { moolaKit, simoleanKit } = basics;
-  const { book } = await assembleAuctionBook(basics);
+  const { moolaKit, moola, simoleanKit, simoleans } = basics;
+  const { pa, book } = await assembleAuctionBook(basics);
+
+  pa.setPrice(makeRatioFromAmounts(moola(9n), simoleans(10n)));
+  await eventLoopIteration();
 
   book.captureOraclePriceForRound();
   book.setStartingRate(makeRatio(90n, moolaKit.brand, 100n));
   t.deepEqual(
     book.getCurrentPrice(),
     makeRatioFromAmounts(
-      AmountMath.makeEmpty(moolaKit.brand),
-      AmountMath.make(simoleanKit.brand, 100n),
+      AmountMath.make(moolaKit.brand, 81_000_000_000n),
+      AmountMath.make(simoleanKit.brand, 100_000_000_000n),
     ),
   );
 });

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -58,7 +58,7 @@ const test = anyTest;
 
 const trace = makeTracer('Test AuctContract', false);
 
-const defaultParams = {
+const defaultParams = harden({
   StartFrequency: 40n,
   ClockStep: 5n,
   StartingRate: 10500n,
@@ -66,7 +66,7 @@ const defaultParams = {
   DiscountStep: 2000n,
   AuctionStartDelay: 10n,
   PriceLockPeriod: 3n,
-};
+});
 
 const makeTestContext = async () => {
   const { zoe, feeMintAccessP } = await setUpZoeForTest();
@@ -144,7 +144,12 @@ export const setupServices = async (t, params = defaultParams) => {
  */
 const makeAuctionDriver = async (t, params = defaultParams) => {
   const { zoe, bid } = t.context;
-  /** @type {MapStore<Brand, { setPrice: (r: Ratio) => void }>} */
+  /**
+   * @type {MapStore<
+   *   Brand,
+   *   import('@agoric/zoe/tools/manualPriceAuthority.js').ManualPriceAuthority
+   * >}
+   */
   const priceAuthorities = makeScalarMapStore();
 
   const { space, timer, registry } = await setupServices(t, params);
@@ -345,6 +350,19 @@ const makeAuctionDriver = async (t, params = defaultParams) => {
     getReserveBalance(keyword) {
       const reserveCF = E.get(reserveKit).creatorFacet;
       return E.get(E(reserveCF).getAllocations())[keyword];
+    },
+    async replacePriceAuthority(brandIn, brandOut, initialPrice) {
+      priceAuthorities.get(brandIn).disable();
+
+      const newPa = makeManualPriceAuthority({
+        actualBrandIn: brandIn,
+        actualBrandOut: brandOut,
+        timer,
+        initialPrice,
+      });
+      priceAuthorities.set(brandIn, newPa);
+
+      await E(registry).registerPriceAuthority(newPa, brandIn, brandOut, true);
     },
   };
 };
@@ -1188,7 +1206,7 @@ test.serial('add assets to open auction', async t => {
 test.serial('multiple collaterals', async t => {
   const { collateral, bid } = t.context;
 
-  const params = defaultParams;
+  const params = { ...defaultParams };
   params.LowestRate = 2500n;
 
   const driver = await makeAuctionDriver(t, params);
@@ -1421,7 +1439,7 @@ test.serial('time jumps forward', async t => {
   const schedules = await driver.getSchedule();
   t.is(schedules.nextAuctionSchedule?.startTime.absValue, 1570n);
   t.is(schedules.liveAuctionSchedule?.startTime.absValue, 1530n);
-  t.is(schedules.liveAuctionSchedule?.endTime.absValue, 1550n);
+  t.is(schedules.liveAuctionSchedule?.endTime.absValue, 1545n);
 });
 
 // serial because dynamicConfig is shared across tests
@@ -1479,7 +1497,8 @@ test.serial('add collateral type during auction', async t => {
   await driver.advanceTo(185n, 'wait');
 
   await scheduleTracker.assertChange({
-    nextDescendingStepTime: { absValue: 190n },
+    activeStartTime: null,
+    nextDescendingStepTime: { absValue: 210n },
   });
 
   t.true(await E(seat).hasExited());
@@ -1491,7 +1510,76 @@ test.serial('add collateral type during auction', async t => {
   await assertPayouts(t, liqSeat, bid, collateral, 231n, 800n);
 
   await scheduleTracker.assertChange({
-    activeStartTime: null,
-    nextDescendingStepTime: { absValue: 210n },
+    activeStartTime: TimeMath.coerceTimestampRecord(210n, timerBrand),
+    nextStartTime: { absValue: 250n },
+    nextDescendingStepTime: { absValue: 215n },
   });
+});
+
+// serial because dynamicConfig is shared across tests
+test.serial('replace priceAuthority', async t => {
+  const { collateral, bid } = t.context;
+  const driver = await makeAuctionDriver(t);
+
+  await driver.setupCollateralAuction(collateral, collateral.make(100n));
+  await driver.updatePriceAuthority(
+    makeRatioFromAmounts(bid.make(20n), collateral.make(10n)),
+  );
+  await eventLoopIteration();
+
+  // invalidate the old PA that the auction is relying on.
+  await driver.replacePriceAuthority(
+    collateral.brand,
+    bid.brand,
+    makeRatioFromAmounts(bid.make(15n), collateral.make(10n)),
+  );
+  // provide new price via the new authority. The auction must switch to see it
+  await driver.updatePriceAuthority(
+    makeRatioFromAmounts(bid.make(5n), collateral.make(10n)),
+  );
+
+  const seat = await driver.bidForCollateralSeat(
+    bid.make(125n),
+    collateral.make(100n),
+  );
+  t.is(await E(seat).getOfferResult(), 'Your bid has been accepted');
+
+  // The driver must be advanced to 167 to stop at lockTime, so the price is
+  // locked, else the goods won't be sold at auction.
+  await driver.advanceTo(167n);
+  await driver.advanceTo(170n);
+  let schedules = await driver.getSchedule();
+  assert(schedules.liveAuctionSchedule);
+  t.is(schedules.liveAuctionSchedule.startTime.absValue, 170n);
+  t.is(schedules.liveAuctionSchedule.endTime.absValue, 185n);
+
+  await driver.advanceTo(175n);
+  await driver.advanceTo(180n);
+  await driver.advanceTo(185n);
+  await driver.advanceTo(200n);
+
+  await eventLoopIteration();
+
+  await driver.advanceTo(207n);
+  await driver.advanceTo(210n);
+  await driver.advanceTo(215n);
+  await driver.advanceTo(220n);
+
+  await driver.advanceTo(230n);
+  await driver.depositCollateral(collateral.make(400n), collateral, {
+    goal: bid.make(200n),
+  });
+
+  await driver.advanceTo(247n);
+  await driver.advanceTo(250n);
+  await driver.advanceTo(255n);
+  await driver.advanceTo(260n);
+  await driver.advanceTo(265n);
+
+  schedules = await driver.getSchedule();
+
+  t.is(schedules.nextAuctionSchedule?.startTime.absValue, 290n);
+  t.true(await E(seat).hasExited());
+
+  await assertPayouts(t, seat, bid, collateral, 72n, 100n);
 });

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -6,6 +6,7 @@ import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import {
   ceilMultiplyBy,
+  makeRatio,
   makeRatioFromAmounts,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
@@ -15,6 +16,9 @@ import { deeplyFulfilled } from '@endo/marshal';
 
 import { NonNullish } from '@agoric/assert';
 import { eventLoopIteration } from '@agoric/notifier/tools/testSupports.js';
+import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data/src/index.js';
+
 import {
   setupReserve,
   startAuctioneer,
@@ -215,15 +219,27 @@ const setupServices = async (t, initialPrice, priceBase) => {
   const { consume, produce } = space;
   t.context.consume = consume;
 
-  // Cheesy hack for easy use of manual price authority
-  const priceAuthority = makeManualPriceAuthority({
+  // priceAuthorityReg is the registry, which contains and multiplexes multiple
+  // individual priceAuthorities, including aethManualPA.
+  // priceAuthorityAdmin supports registering more individual priceAuthorities
+  // with the registry.
+  const aethManualPA = makeManualPriceAuthority({
     actualBrandIn: aeth.brand,
     actualBrandOut: run.brand,
     initialPrice: makeRatioFromAmounts(initialPrice, priceBase),
     timer,
     quoteIssuerKit: makeIssuerKit('quote', AssetKind.SET),
   });
-  produce.priceAuthority.resolve(priceAuthority);
+  const baggage = makeScalarBigMapStore('baggage');
+  const { priceAuthority: priceAuthorityReg, adminFacet: priceAuthorityAdmin } =
+    providePriceAuthorityRegistry(baggage);
+  await E(priceAuthorityAdmin).registerPriceAuthority(
+    aethManualPA,
+    aeth.brand,
+    run.brand,
+  );
+
+  produce.priceAuthority.resolve(priceAuthorityReg);
 
   const {
     installation: { produce: iProduce },
@@ -276,6 +292,7 @@ const setupServices = async (t, initialPrice, priceBase) => {
 
   return {
     zoe,
+    timer,
     governor: {
       governorInstance,
       governorPublicFacet: E(zoe).getPublicFacet(governorInstance),
@@ -288,7 +305,9 @@ const setupServices = async (t, initialPrice, priceBase) => {
       vfPublic,
       aethVaultManager,
     },
-    priceAuthority,
+    priceAuthority: priceAuthorityReg,
+    priceAuthorityAdmin,
+    aethManualPA,
   };
 };
 
@@ -307,7 +326,7 @@ export const makeManagerDriver = async (
   const { zoe, aeth, run } = t.context;
   const {
     vaultFactory: { lender, vaultFactory, vfPublic },
-    priceAuthority,
+    aethManualPA,
     timer,
   } = services;
   const publicTopics = await E(lender).getPublicTopics();
@@ -450,6 +469,22 @@ export const makeManagerDriver = async (
     addVaultType: async keyword => {
       /** @type {IssuerKit<'nat'>} */
       const kit = makeIssuerKit(keyword.toLowerCase());
+
+      // for now, this priceAuthority never reports prices, but having one is
+      // sufficient to get a vaultManager running.
+      const pa = makeManualPriceAuthority({
+        actualBrandIn: kit.brand,
+        actualBrandOut: run.brand,
+        timer,
+        initialPrice: makeRatio(100n, run.brand, 100n, kit.brand),
+      });
+
+      await services.priceAuthorityAdmin.registerPriceAuthority(
+        pa,
+        kit.brand,
+        run.brand,
+      );
+
       const manager = await E(vaultFactory).addVaultType(
         kit.issuer,
         keyword,
@@ -477,7 +512,7 @@ export const makeManagerDriver = async (
       });
     },
     /** @param {Amount<'nat'>} p */
-    setPrice: p => priceAuthority.setPrice(makeRatioFromAmounts(p, priceBase)),
+    setPrice: p => aethManualPA.setPrice(makeRatioFromAmounts(p, priceBase)),
     // XXX the paramPath should be implied by the object `setGovernedParam` is being called on.
     // e.g. the manager driver should know the paramPath is `{ key: { collateralBrand: aeth.brand } }`
     // and the director driver should `{ key: 'governedParams }`

--- a/packages/inter-protocol/test/vaultFactory/test-replacePriceAuthority.js
+++ b/packages/inter-protocol/test/vaultFactory/test-replacePriceAuthority.js
@@ -155,6 +155,7 @@ export const setupElectorateReserveAndAuction = async (
   await setupReserve(space);
   // const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
 
+  /** @type {import('@agoric/vat-data').Baggage} */
   const paBaggage = makeScalarMapStore();
   const { priceAuthority, adminFacet: registry } =
     providePriceAuthorityRegistry(paBaggage);

--- a/packages/inter-protocol/test/vaultFactory/test-replacePriceAuthority.js
+++ b/packages/inter-protocol/test/vaultFactory/test-replacePriceAuthority.js
@@ -1,0 +1,430 @@
+import '@agoric/zoe/exported.js';
+import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { allValues, makeTracer, objectMap } from '@agoric/internal';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { buildManualTimer } from '@agoric/swingset-vat/tools/manual-timer.js';
+import { E } from '@endo/eventual-send';
+import { deeplyFulfilled } from '@endo/marshal';
+import { TimeMath } from '@agoric/time';
+import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
+import { makeScalarMapStore } from '@agoric/vat-data/src/index.js';
+import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
+import { makeNotifierFromAsyncIterable, subscribeEach } from '@agoric/notifier';
+
+import {
+  installPuppetGovernance,
+  produceInstallations,
+  setupBootstrap,
+  setUpZoeForTest,
+  withAmountUtils,
+} from '../supports.js';
+import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.js';
+import {
+  setupReserve,
+  startAuctioneer,
+  SECONDS_PER_DAY as ONE_DAY,
+  SECONDS_PER_HOUR as ONE_HOUR,
+  SECONDS_PER_WEEK as ONE_WEEK,
+  startVaultFactory,
+} from '../../src/proposals/econ-behaviors.js';
+
+import '../../src/vaultFactory/types.js';
+import { defaultParamValues } from './vaultFactoryUtils.js';
+
+/**
+ * @typedef {Record<string, any> & {
+ *   aeth: IssuerKit & import('../supports.js').AmountUtils;
+ *   run: IssuerKit & import('../supports.js').AmountUtils;
+ *   bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>;
+ *   rates: VaultManagerParamValues;
+ *   interestTiming: InterestTiming;
+ *   zoe: ZoeService;
+ * }} Context
+ */
+
+/** @type {import('ava').TestFn<Context>} */
+
+const test = unknownTest;
+
+const contractRoots = {
+  faucet: './test/vaultFactory/faucet.js',
+  VaultFactory: './src/vaultFactory/vaultFactory.js',
+  reserve: './src/reserve/assetReserve.js',
+  auctioneer: './src/auction/auctioneer.js',
+};
+
+/** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
+
+const trace = makeTracer('Test replc PriceAuthority', false);
+
+// Define locally to test that vaultFactory uses these values
+export const Phase = /** @type {const} */ ({
+  ACTIVE: 'active',
+  LIQUIDATING: 'liquidating',
+  CLOSED: 'closed',
+  LIQUIDATED: 'liquidated',
+  TRANSFER: 'transfer',
+});
+
+test.before(async t => {
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
+  const stableIssuer = await E(zoe).getFeeIssuer();
+  const stableBrand = await E(stableIssuer).getBrand();
+  // @ts-expect-error missing mint
+  const run = withAmountUtils({ issuer: stableIssuer, brand: stableBrand });
+  const aeth = withAmountUtils(
+    makeIssuerKit('aEth', 'nat', { decimalPlaces: 6 }),
+  );
+
+  const bundleCache = await unsafeMakeBundleCache('./bundles/'); // package-relative
+  // note that the liquidation might be a different bundle name
+  const bundles = await allValues({
+    faucet: bundleCache.load(contractRoots.faucet, 'faucet'),
+    VaultFactory: bundleCache.load(contractRoots.VaultFactory, 'VaultFactory'),
+    reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
+    auctioneer: bundleCache.load(contractRoots.auctioneer, 'auction'),
+  });
+  const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+
+  const feeMintAccess = await feeMintAccessP;
+  const contextPs = {
+    zoe,
+    feeMintAccess,
+    bundles,
+    installation,
+    electorateTerms: undefined,
+    interestTiming: {
+      chargingPeriod: 2n,
+      recordingPeriod: 6n,
+    },
+    minInitialDebt: 50n,
+    referencedUi: undefined,
+    rates: defaultParamValues(run.brand),
+  };
+  const frozenCtx = await deeplyFulfilled(harden(contextPs));
+  t.context = {
+    ...frozenCtx,
+    bundleCache,
+    aeth,
+    run,
+  };
+  trace(t, 'CONTEXT');
+});
+
+/**
+ * @param {import('ava').ExecutionContext<Context>} t
+ * @param {IssuerKit<'nat'>} run
+ * @param {IssuerKit<'nat'>} aeth
+ * @param {NatValue[] | Ratio} priceOrList
+ * @param {RelativeTime} quoteInterval
+ * @param {Amount | undefined} unitAmountIn
+ * @param {Partial<import('../../src/auction/params.js').AuctionParams>} actionParamArgs
+ */
+export const setupElectorateReserveAndAuction = async (
+  t,
+  run,
+  aeth,
+  priceOrList,
+  quoteInterval,
+  unitAmountIn,
+  {
+    StartFrequency = ONE_WEEK,
+    DiscountStep = 2000n,
+    LowestRate = 5500n,
+    ClockStep = 2n,
+    StartingRate = 10_500n,
+    AuctionStartDelay = 10n,
+    PriceLockPeriod = 3n,
+  },
+) => {
+  const {
+    zoe,
+    electorateTerms = { committeeName: 'The Cabal', committeeSize: 1 },
+    timer,
+  } = t.context;
+
+  const space = await setupBootstrap(t, timer);
+  installPuppetGovernance(zoe, space.installation.produce);
+  produceInstallations(space, t.context.installation);
+
+  await startEconomicCommittee(space, electorateTerms);
+  await setupReserve(space);
+  // const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
+
+  const paBaggage = makeScalarMapStore();
+  const { priceAuthority, adminFacet: registry } =
+    providePriceAuthorityRegistry(paBaggage);
+  space.produce.priceAuthority.resolve(priceAuthority);
+
+  const pa = makeManualPriceAuthority({
+    actualBrandIn: aeth.brand,
+    actualBrandOut: run.brand,
+    timer,
+    initialPrice: makeRatio(1000n, run.brand, 100n, aeth.brand),
+  });
+  await E(registry).registerPriceAuthority(pa, aeth.brand, run.brand, true);
+
+  const auctionParams = {
+    StartFrequency,
+    ClockStep,
+    StartingRate,
+    LowestRate,
+    DiscountStep,
+    AuctionStartDelay,
+    PriceLockPeriod,
+  };
+
+  await startAuctioneer(space, { auctionParams });
+  return { space, thePriceAuthority: pa, registry };
+};
+
+/**
+ * NOTE: called separately by each test so zoe/priceAuthority don't interfere
+ *
+ * @param {import('ava').ExecutionContext<Context>} t
+ * @param {NatValue[] | Ratio} priceOrList
+ * @param {Amount | undefined} unitAmountIn
+ * @param {import('@agoric/time').TimerService} timer
+ * @param {RelativeTime} quoteInterval
+ * @param {bigint} stableInitialLiquidity
+ * @param {Partial<import('../../src/auction/params.js').AuctionParams>} [auctionParams]
+ */
+const setupServices = async (
+  t,
+  priceOrList,
+  unitAmountIn,
+  timer = buildManualTimer(),
+  quoteInterval = 1n,
+  stableInitialLiquidity,
+  auctionParams = {},
+) => {
+  const {
+    zoe,
+    run,
+    aeth,
+    interestTiming,
+    minInitialDebt,
+    referencedUi,
+    rates,
+  } = t.context;
+  t.context.timer = timer;
+
+  const { space, thePriceAuthority, registry } =
+    await setupElectorateReserveAndAuction(
+      t,
+      // @ts-expect-error inconsistent types with withAmountUtils
+      run,
+      aeth,
+      priceOrList,
+      quoteInterval,
+      unitAmountIn,
+      auctionParams,
+    );
+
+  const { consume } = space;
+
+  const {
+    installation: { produce: iProduce },
+  } = space;
+  iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
+  iProduce.liquidate.resolve(t.context.installation.liquidate);
+  await startVaultFactory(
+    space,
+    { interestTiming, options: { referencedUi } },
+    minInitialDebt,
+  );
+
+  const governorCreatorFacet = E.get(
+    consume.vaultFactoryKit,
+  ).governorCreatorFacet;
+  /** @type {Promise<VaultFactoryCreatorFacet>} */
+  const vaultFactoryCreatorFacetP = E.get(consume.vaultFactoryKit).creatorFacet;
+  const reserveCreatorFacet = E.get(consume.reserveKit).creatorFacet;
+  const reservePublicFacet = E.get(consume.reserveKit).publicFacet;
+  // XXX just pass through reserveKit from the space
+  const reserveKit = { reserveCreatorFacet, reservePublicFacet };
+
+  // Add a vault that will lend on aeth collateral
+  /** @type {Promise<VaultManager>} */
+  const aethVaultManagerP = E(vaultFactoryCreatorFacetP).addVaultType(
+    aeth.issuer,
+    'AEth',
+    rates,
+  );
+  /** @typedef {import('../../src/proposals/econ-behaviors.js').AuctioneerKit} AuctioneerKit */
+  /** @typedef {import('@agoric/zoe/tools/manualPriceAuthority.js').ManualPriceAuthority} ManualPriceAuthority */
+  /**
+   * @type {[
+   *   any,
+   *   VaultFactoryCreatorFacet,
+   *   VFC['publicFacet'],
+   *   VaultManager,
+   *   AuctioneerKit,
+   *   ManualPriceAuthority,
+   *   CollateralManager,
+   * ]}
+   */
+  const [
+    governorInstance,
+    vaultFactory, // creator
+    vfPublic,
+    aethVaultManager,
+    auctioneerKit,
+    priceAuthority,
+    aethCollateralManager,
+  ] = await Promise.all([
+    E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
+    vaultFactoryCreatorFacetP,
+    E.get(consume.vaultFactoryKit).publicFacet,
+    aethVaultManagerP,
+    consume.auctioneerKit,
+    /** @type {Promise<ManualPriceAuthority>} */ (consume.priceAuthority),
+    E(aethVaultManagerP).getPublicFacet(),
+  ]);
+  trace(t, 'pa', {
+    governorInstance,
+    vaultFactory,
+    vfPublic,
+    priceAuthority: !!priceAuthority,
+  });
+
+  const { g, v } = {
+    g: {
+      governorInstance,
+      governorPublicFacet: E(zoe).getPublicFacet(governorInstance),
+      governorCreatorFacet,
+    },
+    v: {
+      vaultFactory,
+      vfPublic,
+      aethVaultManager,
+      aethCollateralManager,
+    },
+  };
+
+  await E(auctioneerKit.creatorFacet).addBrand(aeth.issuer, 'Aeth');
+
+  return {
+    zoe,
+    governor: g,
+    vaultFactory: v,
+    runKit: { issuer: run.issuer, brand: run.brand },
+    priceAuthority,
+    reserveKit,
+    auctioneerKit,
+    thePriceAuthority,
+    registry,
+  };
+};
+
+const setClockAndAdvanceNTimes = async (timer, times, start, incr = 1n) => {
+  let currentTime = start;
+  // first time through is at START, then n TIMES more plus INCR
+  for (let i = 0; i <= times; i += 1) {
+    trace('advancing clock to ', currentTime);
+    await timer.advanceTo(TimeMath.absValue(currentTime));
+    await eventLoopIteration();
+    currentTime = TimeMath.addAbsRel(currentTime, TimeMath.relValue(incr));
+  }
+  return currentTime;
+};
+
+// Calculate the nominalStart time (when liquidations happen), and the priceLock
+// time (when prices are locked). Advance the clock to the priceLock time, then
+// to the nominal start time. return the nominal start time and the auction
+// start time, so the caller can check on liquidations in process before
+// advancing the clock.
+const startAuctionClock = async (auctioneerKit, manualTimer) => {
+  const schedule = await E(auctioneerKit.creatorFacet).getSchedule();
+  const priceDelay = await E(auctioneerKit.publicFacet).getPriceLockPeriod();
+  const { startTime, startDelay } = schedule.nextAuctionSchedule;
+  const nominalStart = TimeMath.subtractAbsRel(startTime, startDelay);
+  const priceLockTime = TimeMath.subtractAbsRel(nominalStart, priceDelay);
+  await manualTimer.advanceTo(TimeMath.absValue(priceLockTime));
+  await eventLoopIteration();
+
+  await manualTimer.advanceTo(TimeMath.absValue(nominalStart));
+  await eventLoopIteration();
+  return { startTime, time: nominalStart };
+};
+
+test('replace priceAuthority', async t => {
+  const { aeth, run, rates: defaultRates } = t.context;
+
+  // Interest is charged daily, and auctions are every week, so we'll charge
+  // interest a few times before the second auction.
+  t.context.interestTiming = {
+    chargingPeriod: ONE_DAY,
+    recordingPeriod: ONE_DAY,
+  };
+
+  // Add a vaultManager with 10000 aeth collateral at a 200 aeth/Minted rate
+  const rates = harden({
+    ...defaultRates,
+    // charge 200% interest
+    interestRate: run.makeRatio(200n),
+    liquidationMargin: run.makeRatio(103n),
+  });
+  t.context.rates = rates;
+
+  // charge interest on every tick
+  const manualTimer = buildManualTimer();
+  const services = await setupServices(
+    t,
+    makeRatio(100n, run.brand, 10n, aeth.brand),
+    aeth.make(1n),
+    manualTimer,
+    ONE_WEEK,
+    500n,
+    { StartFrequency: ONE_HOUR },
+  );
+
+  const {
+    auctioneerKit,
+    reserveKit: { reserveCreatorFacet },
+  } = services;
+  await E(reserveCreatorFacet).addIssuer(aeth.issuer, 'Aeth');
+
+  // initial loan /////////////////////////////////////
+  const { aethVaultManager } = services.vaultFactory;
+
+  const publicFacet = await E(aethVaultManager).getPublicFacet();
+  const publicTopics = await E(publicFacet).getPublicTopics();
+  const subscription = subscribeEach(publicTopics.metrics.subscriber);
+  const aethVaultNotifier = await makeNotifierFromAsyncIterable(subscription);
+
+  const newPa = makeManualPriceAuthority({
+    actualBrandIn: aeth.brand,
+    actualBrandOut: run.brand,
+    timer: t.context.timer,
+    initialPrice: makeRatio(70n, run.brand, 10n, aeth.brand),
+  });
+  await E(services.registry).registerPriceAuthority(
+    newPa,
+    aeth.brand,
+    run.brand,
+    true,
+  );
+  services.thePriceAuthority.disable();
+
+  await eventLoopIteration();
+
+  let update = await E(aethVaultNotifier).getUpdateSince();
+  let startTime;
+  ({ startTime } = await startAuctionClock(auctioneerKit, manualTimer));
+  await setClockAndAdvanceNTimes(manualTimer, 2n, startTime, 2n);
+
+  await eventLoopIteration();
+  ({ startTime } = await startAuctionClock(auctioneerKit, manualTimer));
+  await setClockAndAdvanceNTimes(manualTimer, 2n, startTime, 2n);
+
+  update = await E(aethVaultNotifier).getUpdateSince(update.updateCount);
+  t.deepEqual(
+    update.value.lockedQuote?.numerator,
+    AmountMath.make(aeth.brand, 1000_000n),
+  );
+});

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -20,7 +20,6 @@ import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority
 
 import { documentStorageSchema } from '@agoric/governance/tools/storageDoc.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { makeScriptedPriceAuthority } from '@agoric/zoe/tools/scriptedPriceAuthority.js';
 import { E } from '@endo/eventual-send';
 import { deeplyFulfilled } from '@endo/marshal';
 import { calculateCurrentDebt } from '../../src/interest-math.js';
@@ -156,44 +155,25 @@ const setupServices = async (
   const runPayment = await getRunFromFaucet(t, stableInitialLiquidity);
   trace(t, 'faucet', { stableInitialLiquidity, runPayment });
 
-  const { space } = await setupElectorateReserveAndAuction(
-    t,
-    // @ts-expect-error inconsistent types with withAmountUtils
-    run,
-    aeth,
-    priceOrList,
-    quoteInterval,
-    unitAmountIn,
-    { StartFrequency: startFrequency },
-  );
+  const { space, priceAuthorityAdmin, aethTestPriceAuthority } =
+    await setupElectorateReserveAndAuction(
+      t,
+      // @ts-expect-error inconsistent types with withAmountUtils
+      run,
+      aeth,
+      priceOrList,
+      quoteInterval,
+      unitAmountIn,
+      { StartFrequency: startFrequency },
+    );
 
-  const { consume, produce } = space;
-
-  const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
-  // Cheesy hack for easy use of manual price authority
-  const pa = Array.isArray(priceOrList)
-    ? makeScriptedPriceAuthority({
-        actualBrandIn: aeth.brand,
-        actualBrandOut: run.brand,
-        priceList: priceOrList,
-        timer,
-        quoteMint: quoteIssuerKit.mint,
-        unitAmountIn,
-        quoteInterval,
-      })
-    : makeManualPriceAuthority({
-        actualBrandIn: aeth.brand,
-        actualBrandOut: run.brand,
-        initialPrice: priceOrList,
-        timer,
-        quoteIssuerKit,
-      });
-  produce.priceAuthority.resolve(pa);
+  const { consume } = space;
 
   const {
     installation: { produce: iProduce },
   } = space;
   iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
+
   iProduce.liquidate.resolve(t.context.installation.liquidate);
   await startVaultFactory(
     space,
@@ -267,13 +247,36 @@ const setupServices = async (
 
   return {
     zoe,
+    timer,
     governor: g,
     vaultFactory: v,
     runKit: { issuer: run.issuer, brand: run.brand },
-    priceAuthority,
     reserveKit,
     space,
+    priceAuthorityAdmin,
+    aethTestPriceAuthority,
   };
+};
+
+const addPriceAuthority = async (collateralIssuerKit, services) => {
+  const { priceAuthorityAdmin, timer, runKit } = services;
+
+  const pa = makeManualPriceAuthority({
+    actualBrandIn: collateralIssuerKit.brand,
+    actualBrandOut: runKit.brand,
+    timer,
+    initialPrice: makeRatio(
+      100n,
+      runKit.brand,
+      100n,
+      collateralIssuerKit.brand,
+    ),
+  });
+  await E(priceAuthorityAdmin).registerPriceAuthority(
+    pa,
+    collateralIssuerKit.brand,
+    runKit.brand,
+  );
 };
 
 test('first', async t => {
@@ -1574,6 +1577,7 @@ test('addVaultType: invalid args do not modify state', async t => {
   );
 
   const { vaultFactory } = services.vaultFactory;
+  await addPriceAuthority(chit, services);
 
   const failsForSameReason = async p =>
     p
@@ -1607,6 +1611,7 @@ test('addVaultType: extra, unexpected params', async t => {
   );
 
   const { vaultFactory } = services.vaultFactory;
+  await addPriceAuthority(chit, services);
 
   const params = { ...defaultParamValues(aeth.brand), shoeSize: 10 };
   const extraParams = { ...params, shoeSize: 10 };
@@ -1654,6 +1659,8 @@ test('director notifiers', async t => {
 
   // add a vault type
   const chit = makeIssuerKit('chit');
+  await addPriceAuthority(chit, services);
+
   await E(vaultFactory).addVaultType(
     chit.issuer,
     'Chit',

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -4,6 +4,8 @@ import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data/src/index.js';
+import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
 
 import { makeScriptedPriceAuthority } from '@agoric/zoe/tools/scriptedPriceAuthority.js';
 import { E } from '@endo/eventual-send';
@@ -96,8 +98,13 @@ export const setupElectorateReserveAndAuction = async (
   await setupReserve(space);
   const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
 
-  // Cheesy hack for easy use of manual price authority
-  const pa = Array.isArray(priceOrList)
+  // priceAuthorityReg is the registry, which contains and multiplexes multiple
+  // individual priceAuthorities, including aethPriceAuthority.
+  // priceAuthorityAdmin supports registering more individual priceAuthorities
+  // with the registry.
+  /** @type {import('@agoric/zoe/tools/manualPriceAuthority.js').ManualPriceAuthority} */
+  // @ts-expect-error scriptedPriceAuthority doesn't actually match this, but manualPriceAuthority does
+  const aethTestPriceAuthority = Array.isArray(priceOrList)
     ? makeScriptedPriceAuthority({
         actualBrandIn: aeth.brand,
         actualBrandOut: run.brand,
@@ -114,7 +121,16 @@ export const setupElectorateReserveAndAuction = async (
         timer,
         quoteIssuerKit,
       });
-  space.produce.priceAuthority.resolve(pa);
+  const baggage = makeScalarBigMapStore('baggage');
+  const { priceAuthority: priceAuthorityReg, adminFacet: priceAuthorityAdmin } =
+    providePriceAuthorityRegistry(baggage);
+  await E(priceAuthorityAdmin).registerPriceAuthority(
+    aethTestPriceAuthority,
+    aeth.brand,
+    run.brand,
+  );
+
+  space.produce.priceAuthority.resolve(priceAuthorityReg);
 
   const auctionParams = {
     StartFrequency,
@@ -127,7 +143,12 @@ export const setupElectorateReserveAndAuction = async (
   };
 
   await startAuctioneer(space, { auctionParams });
-  return { space };
+  return {
+    space,
+    priceAuthority: priceAuthorityReg,
+    priceAuthorityAdmin,
+    aethTestPriceAuthority,
+  };
 };
 
 /**


### PR DESCRIPTION
refs: #8675

## Description

When `observeNotifier()` on the `quoteNotifier` detects an error, request a new notifier and restart the observer.

### Security Considerations

robustness for the chain.

### Scaling Considerations

Not a scaling issue.

### Documentation Considerations

No user docs required.

### Testing Considerations

Added a test that the auctioneer switches when the manual authority throws an error. 

### Upgrade Considerations

The priceAuthority is holding onto [cyclic data structures involving exitObjects](https://github.com/Agoric/agoric-sdk/issues/8401). In order to force GC of those objects, we plan to [fix the problem in Zoe](https://github.com/Agoric/agoric-sdk/pull/8682) and then abandon the old priceAuthorities. This fix allows the Auctions to survive when the old priceAuthority is killed.