### PR TITLE
chore(swingset): re-enable test of unrecognizable orphan cleanup

### DIFF
--- a/packages/SwingSet/test/gc-kernel.test.js
+++ b/packages/SwingSet/test/gc-kernel.test.js
@@ -1165,9 +1165,7 @@ test('terminated vat', async t => {
   // t.is(refcounts[doomedExport1Kref], undefined);
   t.falsy(owners[doomedExport1Kref]);
 
-  // TODO: we still fail to clean up the [0,0] kref: #3378 is about finding
-  // somewhere to delete the .refcount key
-  // t.is(refcounts[doomedExport2Kref], undefined);
+  t.is(refcounts[doomedExport2Kref], undefined);
   t.falsy(owners[doomedExport2Kref]);
 });
 


### PR DESCRIPTION
This clause was commented out because bug #3378 was still pending at the time. I think we happened to fix that as a side-effect of adding `syscall.abandonExport` for #4951 (in PR #4957), but didn't realize we could re-enable the clause.

closes #3378
