### PR TITLE
feat: when zcfSeats exit or fail, delete objects holding cycles

### DIFF
--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -35,6 +35,7 @@ export const makeMakeExiter = baggage => {
       exit() {
         const { state } = this;
         state.zcfSeat.exit();
+        state.zcfSeat = undefined;
       },
     },
     {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -159,6 +159,7 @@ export const createSeatManager = (
         assertNoStagedAllocation(self);
         doExitSeat(self);
         E(zoeInstanceAdmin).exitSeat(zcfSeatToSeatHandle.get(self), completion);
+        zcfSeatToSeatHandle.delete(self);
       },
       fail(
         reason = Error(
@@ -179,6 +180,7 @@ export const createSeatManager = (
             zcfSeatToSeatHandle.get(self),
             harden(reason),
           );
+          zcfSeatToSeatHandle.delete(self);
         }
         return reason;
       },


### PR DESCRIPTION
refs: #8401
refs: #8672 
refs: #8682

## Description

Drop cyclic references to zcfSeats and seatHandles when seats exit so GC can collect more cycles.

in zcfSeat.js: zcfSeatToSeatHandle.delete(self)
in exit.js:    state.zccfSeat = undefined

### Security Considerations

N/A

### Scaling Considerations

Vast improvement in reducing retained garbage.

### Documentation Considerations

Not visible to users

### Testing Considerations

No tests added. It would be very hard to demonstrate freed objects in a test.

### Upgrade Considerations

This is intended to be part of a fairly large collection of updates to Zoe/ZCF.