### PR TITLE
drop feeMintAccess in AssetReserve; it burns but doesn't mint

### DIFF
--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -101,7 +101,6 @@ const SHARED_MAIN_MANIFEST = harden({
       board: 'board',
       chainStorage: true,
       diagnostics: true,
-      feeMintAccess: 'zoe',
       chainTimerService: 'timer',
       zoe: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -98,7 +98,6 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 export const setupReserve = async ({
   consume: {
     board,
-    feeMintAccess: feeMintAccessP,
     chainStorage,
     chainTimerService,
     diagnostics,
@@ -123,12 +122,10 @@ export const setupReserve = async ({
   trace('setupReserve');
   const poserInvitationP = E(committeeCreator).getPoserInvitation();
 
-  const [poserInvitation, poserInvitationAmount, feeMintAccess] =
-    await Promise.all([
-      poserInvitationP,
-      E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
-      feeMintAccessP,
-    ]);
+  const [poserInvitation, poserInvitationAmount] = await Promise.all([
+    poserInvitationP,
+    E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
+  ]);
 
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
@@ -141,14 +138,13 @@ export const setupReserve = async ({
       governedContractInstallation: reserveInstallation,
       governed: {
         terms: reserveTerms,
-        issuerKeywordRecord: { Central: centralIssuer },
+        issuerKeywordRecord: { Fee: centralIssuer },
         label: 'reserve',
       },
     }),
   );
   const privateArgs = {
     governed: {
-      feeMintAccess,
       initialPoserInvitation: poserInvitation,
       marshaller,
       storageNode,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -38,7 +38,6 @@ harden(meta);
  *   }
  * >} zcf
  * @param {{
- *   feeMintAccess: FeeMintAccess;
  *   initialPoserInvitation: Invitation;
  *   marshaller: ERef<Marshaller>;
  *   storageNode: ERef<StorageNode>;
@@ -57,24 +56,13 @@ export const start = async (zcf, privateArgs, baggage) => {
     privateArgs.marshaller,
   );
 
-  /** @type {() => Promise<ZCFMint<'nat'>>} */
-  const takeFeeMint = async () => {
-    if (baggage.has('feeMint')) {
-      return baggage.get('feeMint');
-    }
+  // TODO(cth): delete once it has run on chain. It cleans up after #8323
+  if (baggage.has('feeMint')) {
+    baggage.delete('feeMint');
+  }
 
-    const feeMintTemp = await zcf.registerFeeMint(
-      'Fee',
-      privateArgs.feeMintAccess,
-    );
-    baggage.init('feeMint', feeMintTemp);
-    return feeMintTemp;
-  };
-  trace('awaiting takeFeeMint');
-  const feeMint = await takeFeeMint();
   const storageNode = await privateArgs.storageNode;
   const makeAssetReserveKit = await prepareAssetReserveKit(baggage, {
-    feeMint,
     makeRecorderKit,
     storageNode,
     zcf,

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -30,9 +30,6 @@ export const buildRootObject = async () => {
   /** @type {ZoeService} */
   let zoeService;
 
-  /** @type {FeeMintAccess} */
-  let feeMintAccess;
-
   /**
    * @type {Subscriber<
    *   import('../../../src/reserve/assetReserveKit.js').MetricsNotification
@@ -121,11 +118,7 @@ export const buildRootObject = async () => {
   return Far('root', {
     bootstrap: async (vats, devices) => {
       vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
-      ({ feeMintAccess, zoeService } = await E(vats.zoe).buildZoe(
-        vatAdmin,
-        undefined,
-        'zcf',
-      ));
+      ({ zoeService } = await E(vats.zoe).buildZoe(vatAdmin, undefined, 'zcf'));
 
       const v1BundleId = await E(vatAdmin).getBundleIDByName(arV1BundleName);
       v1BundleId || Fail`bundleId must not be empty`;
@@ -192,7 +185,6 @@ export const buildRootObject = async () => {
         {
           governed: {
             ...staticPrivateArgs,
-            feeMintAccess,
             initialPoserInvitation,
           },
         },
@@ -245,8 +237,6 @@ export const buildRootObject = async () => {
       const arAdminFacet = await E(governorFacets.creatorFacet).getAdminFacet();
       const upgradeResult = await E(arAdminFacet).upgradeContract(bundleId, {
         ...staticPrivateArgs,
-        // @ts-expect-error mock
-        feeMintAccess: undefined,
         initialPoserInvitation,
       });
       assert.equal(upgradeResult.incarnationNumber, 1);


### PR DESCRIPTION
fixes: #8323

## Description

Stop passing feeMintAccess to AssetReserve. It calls `burn()`, but not `mint()`, so [POLA says](https://wiki.c2.com/?PrincipleOfLeastAuthority) it should have a. weaker authority.

### Security Considerations

Yes

### Scaling Considerations

N/A

### Documentation Considerations

POLA should be more widely known.

### Testing Considerations

It's tough to test for tightening of authority.

### Upgrade Considerations

This is not urgent to get onto the chain.
The change to econ-behaviors.js should not be merged separately from the contract changes.
