### PR TITLE
Simplify typeGuards that allow instanceHandle or Bundle

### DIFF
--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -280,7 +280,7 @@ export const ZoeStorageManagerIKit = {
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
       M.eref(M.string()),
     ),
-    installBundle: M.call(M.or(InstanceHandleShape, BundleShape))
+    installBundle: M.call(BundleShape)
       .optional(M.string())
       .returns(M.promise()),
     installBundleID: M.call(M.string())
@@ -313,7 +313,7 @@ export const ZoeStorageManagerIKit = {
       InstallationShape,
       M.any(),
       IssuerPKeywordRecordShape,
-      M.or(InstanceHandleShape, BundleShape),
+      InstanceHandleShape,
       M.or(BundleCapShape, BundleShape),
       M.string(),
     ).returns(M.promise()),

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -7,7 +7,6 @@ import {
 } from '@agoric/vat-data';
 import {
   InstallationShape,
-  InstanceHandleShape,
   UnwrappedInstallationShape,
 } from '../typeGuards.js';
 
@@ -81,10 +80,7 @@ export const makeInstallationStorage = (getBundleCapForID, zoeBaggage) => {
 
   const InstallationStorageI = M.interface('InstallationStorage', {
     installBundle: M.call(
-      M.or(
-        InstanceHandleShape,
-        M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
-      ),
+      M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
     )
       .optional(M.string())
       .returns(M.promise()),


### PR DESCRIPTION
closes: #8645

## Description

Two typeGuards in Zoe allowed `M.or(InstanceHandleShape, BundleShape)` where they should have had one or the other.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

Not user visible.

### Testing Considerations

existing tests.

### Upgrade Considerations

This is a mere clean-up; there's no urgency in getting the fix on chain. 

* [ ] There isn't any restriction on changing the TypeGuard of a facet when upgrading, is there?