### PR TITLE
restore 'store' types

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -84,6 +84,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 90.37
+    "atLeast": 90.6
   }
 }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -100,6 +100,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 75.26
+    "atLeast": 75.36
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -96,6 +96,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 77.42
+    "atLeast": 77.5
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -96,6 +96,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 77.53
+    "atLeast": 77.42
   }
 }

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -53,6 +53,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 86.48
+    "atLeast": 88.7
   }
 }

--- a/packages/base-zone/src/heap.js
+++ b/packages/base-zone/src/heap.js
@@ -1,6 +1,5 @@
 // @ts-check
 // @jessie-check
-/// <reference path="./store-types.d.ts" />
 
 import { Far } from '@endo/far';
 import { makeExo, defineExoClass, defineExoClassKit } from '@endo/exo';

--- a/packages/base-zone/src/store-types.d.ts
+++ b/packages/base-zone/src/store-types.d.ts
@@ -1,3 +1,0 @@
-// Prevent the compiler from complaining about the @agoric/store type not being
-// defined if `"noImplicitAny": true` is set in tsconfig.json.
-declare module '@agoric/store';

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -84,6 +84,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 85.68
+    "atLeast": 88.05
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -80,6 +80,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 67.19
+    "atLeast": 67.05
   }
 }

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -60,6 +60,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 88.07
+    "atLeast": 89.5
   }
 }

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -60,6 +60,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 88.12
+    "atLeast": 88.07
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -67,6 +67,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 79.4
+    "atLeast": 79.32
   }
 }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -73,6 +73,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 79.84
+    "atLeast": 80.06
   }
 }

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -37,6 +37,6 @@
     "readline-transform": "^1.0.0"
   },
   "typeCoverage": {
-    "atLeast": 61.49
+    "atLeast": 60.14
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -76,6 +76,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 82.81
+    "atLeast": 89.27
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -76,6 +76,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 83.56
+    "atLeast": 82.81
   }
 }

--- a/packages/governance/test/swingsetTests/utils.js
+++ b/packages/governance/test/swingsetTests/utils.js
@@ -7,6 +7,8 @@ const nullMarshaller = makeMarshal(
 );
 
 export const remoteNullMarshaller = makeExo('nullMarshaller', undefined, {
+  serialize: val => nullMarshaller.toCapData(val),
+  unserialize: slot => nullMarshaller.fromCapData(slot),
   toCapData: val => nullMarshaller.toCapData(val),
   fromCapData: slot => nullMarshaller.fromCapData(slot),
 });

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -83,6 +83,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.45
+    "atLeast": 93.49
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -83,6 +83,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.49
+    "atLeast": 95.83
   }
 }

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -9,7 +9,7 @@ import { subscribeEach } from '@agoric/notifier';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { buildManualTimer } from '@agoric/swingset-vat/tools/manual-timer.js';
 import { TimeMath } from '@agoric/time';
-import { makeScalarMapStore } from '@agoric/vat-data/src/index.js';
+import { makeScalarMapStore } from '@agoric/vat-data';
 import {
   makeRatio,
   makeRatioFromAmounts,
@@ -126,6 +126,7 @@ export const setupServices = async (t, params = defaultParams) => {
 
   void E(reserveCF).addIssuer(collateral.issuer, 'Collateral');
 
+  /** @type {import('@agoric/swingset-liveslots').Baggage} */
   const paBaggage = makeScalarMapStore();
   const { priceAuthority, adminFacet: registry } =
     providePriceAuthorityRegistry(paBaggage);

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -1,7 +1,6 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
-import '@agoric/vats/src/core/types-ambient.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { E } from '@endo/far';
 import { NonNullish } from '@agoric/assert';

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 92.26
+    "atLeast": 92.28
   }
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -68,6 +68,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 90.04
+    "atLeast": 89.97
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -67,6 +67,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 86.97
+    "atLeast": 86.91
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -67,6 +67,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 86.91
+    "atLeast": 94.07
   }
 }

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -11,7 +11,6 @@ import {
   makeBoard,
 } from '@agoric/vats/src/core/basic-behaviors.js';
 import { setupClientManager } from '@agoric/vats/src/core/chain-behaviors.js';
-import '@agoric/vats/src/core/types-ambient.js';
 import { buildRootObject as boardRoot } from '@agoric/vats/src/vat-board.js';
 import { buildRootObject as mintsRoot } from '@agoric/vats/src/vat-mints.js';
 import { makeFakeBankKit } from '@agoric/vats/tools/bank-utils.js';

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -6,8 +6,6 @@ import { E } from '@endo/far';
 import path from 'path';
 import { makeMockTestSpace } from './supports.js';
 
-import '@agoric/vats/src/core/types-ambient.js';
-
 /** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -11,8 +11,6 @@ import {
   topicPath,
 } from './supports.js';
 
-import '@agoric/vats/src/core/types-ambient.js';
-
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
 const test = anyTest;
 

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -78,6 +78,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 68.59
+    "atLeast": 68.72
   }
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -49,6 +49,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 75.52
+    "atLeast": 76.1
   }
 }

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -65,6 +65,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 71.48
+    "atLeast": 75.1
   }
 }

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -45,6 +45,6 @@
     "node": ">=14.15.0"
   },
   "typeCoverage": {
-    "atLeast": 98.23
+    "atLeast": 99.19
   }
 }

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -1,7 +1,6 @@
 import { M } from '@agoric/store';
 import '@agoric/store/exported.js';
 import { E } from '@endo/far';
-import './core/types-ambient.js';
 
 const { Fail, details: X } = assert;
 

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -135,6 +135,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 81.5
+    "atLeast": 84.82
   }
 }

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -54,6 +54,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 96.33
+    "atLeast": 96.68
   }
 }


### PR DESCRIPTION
refs: #8144 

## Description

#8144 made an empty module declaration for `@agoric/store`. It was to stop a `noImplicitAny` error, but it did so by creating an explicit any. The net effect was "any" for imports from that package. This cost type coverage, e.g. 7% of smart-wallet. (The last commit shows some packages went down a smidge with this, I suspect because it now resolves more types, which themselves lack coverage. IOW it's not a smaller numerator but a larger denominator.)

This PR removes the declaration and makes a couple tweaks to get it passing. It also refreshes the type coverage metrics and makes a drive-by cleanup of types-ambient imports that are no longer necessary.

### Security Considerations

--
### Scaling Considerations

--


### Documentation Considerations

--

### Testing Considerations

CI

### Upgrade Considerations

--
