### PR TITLE
adopt eslint-env directive

### DIFF
--- a/golang/cosmos/index.cjs
+++ b/golang/cosmos/index.cjs
@@ -1,2 +1,2 @@
-/* global module require */
+/* eslint-env node */
 module.exports = require('bindings')('agcosmosdaemon.node');

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/SwingSet/test/worker-protocol.test.js
+++ b/packages/SwingSet/test/worker-protocol.test.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* eslint-env node */
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 

--- a/packages/agoric-cli/scripts/get-sdk-package-names.js
+++ b/packages/agoric-cli/scripts/get-sdk-package-names.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-/* global process, Buffer */
+/* eslint-env node */
 import { spawn } from 'child_process';
 import { basename } from 'path';
 

--- a/packages/agoric-cli/src/anylogger-agoric.js
+++ b/packages/agoric-cli/src/anylogger-agoric.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import {
   getEnvironmentOption,
   getEnvironmentOptionsList,

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
+/* eslint-env node */
 // @ts-check
 // @jessie-check
-
-/* global fetch, setTimeout */
 
 import '@endo/init/pre.js';
 

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -1,14 +1,15 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global fetch, setTimeout, process */
+/* eslint-env node */
+import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
+import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
 import { Fail } from '@endo/errors';
 import { Nat } from '@endo/nat';
-import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { Command } from 'commander';
 import * as cp from 'child_process';
+import { Command } from 'commander';
 import { inspect } from 'util';
-import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
 import { normalizeAddressWithOptions } from '../lib/chain.js';
+import { bigintReplacer } from '../lib/format.js';
 import { getNetworkConfig, makeRpcUtils, storageHelper } from '../lib/rpc.js';
 import {
   getCurrent,
@@ -17,7 +18,6 @@ import {
   sendAction,
   sendHint,
 } from '../lib/wallet.js';
-import { bigintReplacer } from '../lib/format.js';
 
 /** @import {PriceAuthority, PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js'; */
 

--- a/packages/agoric-cli/src/commands/perf.js
+++ b/packages/agoric-cli/src/commands/perf.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global process */
+/* eslint-env node */
 import {
   iterateEach,
   makeCastingSpec,

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global fetch, process */
+/* eslint-env node */
 import { Command } from 'commander';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { asPercent } from '../lib/format.js';

--- a/packages/agoric-cli/src/commands/reserve.js
+++ b/packages/agoric-cli/src/commands/reserve.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global fetch, process */
+/* eslint-env node */
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { Command } from 'commander';
 import { makeRpcUtils } from '../lib/rpc.js';

--- a/packages/agoric-cli/src/commands/test-upgrade.js
+++ b/packages/agoric-cli/src/commands/test-upgrade.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process */
+/* eslint-env node */
 import { Fail } from '@endo/errors';
 import { CommanderError } from 'commander';
 import { normalizeAddressWithOptions } from '../lib/chain.js';

--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global fetch, process */
+/* eslint-env node */
 import { Command } from 'commander';
 import {
   lookupOfferIdForVault,

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global fetch, process */
+/* eslint-env node */
 import {
   iterateLatest,
   makeCastingSpec,

--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process setTimeout setInterval clearInterval */
+/* eslint-env node */
 
 import { X } from '@endo/errors';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
+/* eslint-env node */
 // @jessie-check
-
-/* global process */
 
 import '@endo/init/pre.js';
 import 'esm';

--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 // @ts-check
 
 /** @import { ChildProcess } from 'child_process' */

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -1,4 +1,4 @@
-/* global process Buffer */
+/* eslint-env node */
 import path from 'path';
 import chalk from 'chalk';
 import { makePspawn } from './helpers.js';

--- a/packages/agoric-cli/src/lib/bundles.js
+++ b/packages/agoric-cli/src/lib/bundles.js
@@ -1,6 +1,5 @@
 // @ts-check
-
-/* global Buffer */
+/* eslint-env node */
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process */
+/* eslint-env node */
 import { normalizeBech32 } from '@cosmjs/encoding';
 import { execFileSync as execFileSyncAmbient } from 'child_process';
 

--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global Buffer, fetch, process */
+/* eslint-env node */
 
 import { NonNullish } from '@agoric/internal';
 import {

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process */
+/* eslint-env node */
 
 import { Fail } from '@endo/errors';
 import { iterateReverse } from '@agoric/casting';

--- a/packages/agoric-cli/src/main-publish.js
+++ b/packages/agoric-cli/src/main-publish.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 // @ts-check
 
 import path from 'path';

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import { Command } from 'commander';
 import path from 'path';
 import url from 'url';

--- a/packages/agoric-cli/src/open.js
+++ b/packages/agoric-cli/src/open.js
@@ -1,4 +1,4 @@
-/* global process setInterval clearInterval */
+/* eslint-env node */
 import opener from 'opener';
 import { assert, X } from '@endo/errors';
 import { getAccessToken } from '@agoric/access-token';

--- a/packages/agoric-cli/src/scripts.js
+++ b/packages/agoric-cli/src/scripts.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process */
+/* eslint-env node */
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/captp';
 import { search as readContainingPackageDescriptor } from '@endo/compartment-mapper';

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -1,4 +1,4 @@
-/* global process setTimeout */
+/* eslint-env node */
 import chalk from 'chalk';
 import { createHash } from 'crypto';
 import path from 'path';

--- a/packages/agoric-cli/test/inter-cli.test.js
+++ b/packages/agoric-cli/test/inter-cli.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global Buffer */
+/* eslint-env node */
 import '@endo/init';
 import test from 'ava';
 import { createCommand, CommanderError } from 'commander';

--- a/packages/agoric-cli/test/upgrade-contract/propose-buggy-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/propose-buggy-contract.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 
 import { makeHelpers } from '@agoric/deploy-script-support';
 

--- a/packages/agoric-cli/test/upgrade-contract/propose-upgrade-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/propose-upgrade-contract.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 
 import { makeHelpers } from '@agoric/deploy-script-support';
 

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process setTimeout setInterval clearInterval Buffer */
+/* eslint-env node */
 
 import fs from 'fs';
 import path from 'path';

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jsdoc/require-param, @jessie.js/safe-await-separator */
-/* global process */
+/* eslint-env node */
 
 import childProcessAmbient from 'child_process';
 import { promises as fsAmbientPromises } from 'fs';

--- a/packages/builders/scripts/inter-protocol/add-collateral-core.js
+++ b/packages/builders/scripts/inter-protocol/add-collateral-core.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import { makeHelpers } from '@agoric/deploy-script-support';
 
 import { getManifestForAddAssetToVault } from '@agoric/inter-protocol/src/proposals/addAssetToVault.js';

--- a/packages/builders/scripts/inter-protocol/init-core.js
+++ b/packages/builders/scripts/inter-protocol/init-core.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 /**
  * @file can be run with `agoric deploy` after a chain is running (depends on
  *   chain state) Only works with "local" chain and not sim-chain b/c it needs

--- a/packages/builders/scripts/inter-protocol/invite-committee-core.js
+++ b/packages/builders/scripts/inter-protocol/invite-committee-core.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import { makeHelpers } from '@agoric/deploy-script-support';
 
 import { getManifestForInviteCommittee } from '@agoric/inter-protocol/src/proposals/committee-proposal.js';

--- a/packages/builders/scripts/inter-protocol/price-feed-core.js
+++ b/packages/builders/scripts/inter-protocol/price-feed-core.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import { makeHelpers } from '@agoric/deploy-script-support';
 
 export const DEFAULT_CONTRACT_TERMS = {

--- a/packages/cosmic-swingset/check-validator.cjs
+++ b/packages/cosmic-swingset/check-validator.cjs
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
+/* eslint-env node */
 // @jessie-check
 
-/* global process require Buffer */
 // check-validator - Find if there is a validator that matches the current ag-chain-cosmos
 // Michael FIG <mfig@agoric.com>, 2021-06-25
 const oper = process.argv[2];

--- a/packages/cosmic-swingset/scripts/clean-core-eval.js
+++ b/packages/cosmic-swingset/scripts/clean-core-eval.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 /* global globalThis */
-
+/* eslint-env node */
 import '@endo/init/debug.js';
 import * as farExports from '@endo/far';
 import { isEntrypoint } from '../src/helpers/is-entrypoint.js';
@@ -63,7 +63,6 @@ export const main = async (argv, { readFile, stdout }) => {
 };
 
 if (isEntrypoint(import.meta.url)) {
-  /* global process */
   void farExports.E.when(import('fs/promises'), fsp =>
     main([...process.argv], {
       readFile: fsp.readFile,

--- a/packages/cosmic-swingset/src/anylogger-agoric.js
+++ b/packages/cosmic-swingset/src/anylogger-agoric.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import {
   getEnvironmentOptionsList,
   getEnvironmentOption,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process */
+/* eslint-env node */
 
 // XXX the JSON configs specify that launching the chain requires @agoric/builders,
 // so let the JS tooling know about it by importing it here.

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -1,4 +1,4 @@
-/* global process setTimeout clearTimeout */
+/* eslint-env node */
 import path from 'path';
 import fs from 'fs';
 import { Fail } from '@endo/errors';

--- a/packages/deployment/scripts/crunch.mjs
+++ b/packages/deployment/scripts/crunch.mjs
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
+/* eslint-env node */
 // crunch.mjs - crunch a kvstore trace file's writes into TSV
-
-/* global process,Buffer */
 
 import fs from 'fs';
 import ReadlineTransform from 'readline-transform';

--- a/packages/deployment/scripts/docker-deployment.cjs
+++ b/packages/deployment/scripts/docker-deployment.cjs
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-/* global process */
+/* eslint-env node */
 // Get a deployment.json for a 2-node docker setup.
 
 const DEFAULT_NUM_VALIDATORS = 2;

--- a/packages/deployment/src/entrypoint.js
+++ b/packages/deployment/src/entrypoint.js
@@ -1,6 +1,5 @@
 #! /usr/bin/env node
 /* eslint-env node */
-
 import '@endo/init';
 
 import fs from 'fs';

--- a/packages/internal/src/lib-nodejs/worker-protocol.js
+++ b/packages/internal/src/lib-nodejs/worker-protocol.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* eslint-env node */
 import { Transform } from 'stream';
 
 // Transform objects which convert from hardened Arrays of JSON-serializable

--- a/packages/internal/src/netstring.js
+++ b/packages/internal/src/netstring.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* eslint-env node */
 import { Fail } from '@endo/errors';
 
 // adapted from 'netstring-stream', https://github.com/tlivings/netstring-stream/

--- a/packages/internal/src/node/buffer-line-transform.js
+++ b/packages/internal/src/node/buffer-line-transform.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* eslint-env node */
 /* eslint-disable no-underscore-dangle */
 
 import { Transform } from 'node:stream';

--- a/packages/internal/src/node/createBundles.js
+++ b/packages/internal/src/node/createBundles.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 // Use modules not prefixed with `node:` since some deploy scripts may
 // still be running in esm emulation
 import path from 'path';

--- a/packages/internal/test/netstring.test.js
+++ b/packages/internal/test/netstring.test.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* eslint-env node */
 import test from 'ava';
 
 import {

--- a/packages/solo/src/init-basedir.js
+++ b/packages/solo/src/init-basedir.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process */
+/* eslint-env node */
 import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';

--- a/packages/solo/src/outbound.js
+++ b/packages/solo/src/outbound.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import anylogger from 'anylogger';
 
 import { Fail } from '@endo/errors';

--- a/packages/solo/src/pipe-entrypoint.js
+++ b/packages/solo/src/pipe-entrypoint.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 // @ts-check
 import '@endo/init/pre-bundle-source.js';
 import '@endo/init/unsafe-fast.js';

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global process setTimeout */
+/* eslint-env node */
 import fs from 'fs';
 import url from 'url';
 import path from 'path';

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -1,4 +1,4 @@
-/* global process setTimeout */
+/* eslint-env node */
 import { spawn } from 'child_process';
 import WebSocket from 'ws';
 import { makeCapTP, E } from '@endo/captp';

--- a/packages/solo/test/home.test.js
+++ b/packages/solo/test/home.test.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 

--- a/packages/stat-logger/src/statGraph.js
+++ b/packages/stat-logger/src/statGraph.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global Buffer */
+/* eslint-env node */
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/packages/swingset-liveslots/test/virtual-objects/set-debug-label-instances.js
+++ b/packages/swingset-liveslots/test/virtual-objects/set-debug-label-instances.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 
 // put this in a separate module, so we can make it happen before
 // importing virtualObjectManager.js

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import { KERNEL_STATS_METRICS } from '@agoric/swingset-vat/src/kernel/metrics.js';
 import { spawnSync } from 'child_process';
 import fs from 'fs';

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global Buffer */
+/* eslint-env node */
 /// <reference types="ses" />
 
 import fs from 'node:fs';

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-/* global process */
+/* eslint-env node */
 // frcat - print out the contents of a flight recorder
 // NOTE: this only works on inactive recorder files where the writer has terminated
 

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-/* global setTimeout */
+/* eslint-env node */
 import '@endo/init';
 
 import fs from 'fs';

--- a/packages/telemetry/src/slog-sender-pipe-entrypoint.js
+++ b/packages/telemetry/src/slog-sender-pipe-entrypoint.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 import '@endo/init';
 
 import anylogger from 'anylogger';

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* global process */
+/* eslint-env node */
 import * as childProcessTop from 'child_process';
 import { fileURLToPath } from 'url';
 import fsTop from 'fs';

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -326,7 +326,7 @@ export async function main(
   await replayXSnap(options, folders, { readdirSync, readFileSync });
 }
 
-/* global process */
+/* eslint-env node */
 if (process.argv[1] === fileURLToPath(new URL(import.meta.url))) {
   main([...process.argv.slice(2)], {
     spawn: childProcessPowers.spawn,

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 /* eslint no-await-in-loop: ["off"] */
 
 import { finished } from 'stream/promises';

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -1,4 +1,4 @@
-/* global process */
+/* eslint-env node */
 /* We make exceptions for test code. This is a test utility. */
 /* eslint no-await-in-loop: ["off"] */
 

--- a/packages/xsnap/test/replay.test.js
+++ b/packages/xsnap/test/replay.test.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* eslint-env node */
 
 import test from 'ava';
 

--- a/scripts/report-globals.mts
+++ b/scripts/report-globals.mts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+/* eslint-disable -- hacky script for irregular reports */
+
+/**
+ * @file Report Globals
+ *
+ * Detect modules using globals and report them to stdout.
+ *
+ * Scripts are exempt because they are all entrypoints.
+ */
+
+// When this was run on 2023-12-30, the output was:
+import execa from 'execa';
+import fs from 'node:fs';
+
+const lastRun = {
+  big: 2,
+  Buffer: 65,
+  clearInterval: 5,
+  clearTimeout: 6,
+  document: 22,
+  E: 15,
+  fetch: 21,
+  globalThis: 50,
+  localStorage: 3,
+  process: 134,
+  setImmediate: 19,
+  setInterval: 4,
+  setTimeout: 25,
+  startPSM: 2,
+  VatData: 18,
+  walletFrame: 2,
+  window: 10,
+};
+
+// exempt files with shebangs bc they are entrypoints
+const SHEBANG = '#!';
+
+/**
+ * Remove all eslint directives from all files
+ * @param str
+ */
+const disableLintDirective = (str: 'global' | 'eslint-env') => {
+  const cmd = `git grep --extended-regexp --files-with-matches  '\\/\\* ${str} ' packages | xargs grep -L '${SHEBANG}' |xargs sed -i '' "s/\\/\\* ${str} /\\/\\* ~${str} /"`;
+  execa.sync(cmd, { shell: true });
+};
+
+const runEslint = () => {
+  // XXX leaves these around. just git reset --hard to clean up.
+  disableLintDirective('global');
+  disableLintDirective('eslint-env');
+
+  execa.sync(
+    // true to succeed despite eslint failures
+    'npm run --silent lint:eslint --if-present --workspaces > eslintOutput.txt || true',
+    { shell: true },
+  );
+};
+
+const report = () => {
+  const eslintOutput = fs.readFileSync('eslintOutput.txt', 'utf8');
+
+  const LINE_RE = /error {2}'(\w+)' is not defined/;
+  const instances = eslintOutput
+    .split('\n')
+    .map(line => {
+      let m;
+      if ((m = line.match(LINE_RE))) {
+        return m[1];
+      }
+    })
+    .filter(Boolean);
+
+  const counts = instances.reduce((acc, cur) => {
+    acc[cur] = (acc[cur] || 0) + 1;
+    return acc;
+  }, {});
+
+  console.log(counts);
+};
+
+// Feel free to disable this while debugging
+runEslint();
+report();
+console.log(
+  'Done. Copy and commit the output into this file. Then git reset hard the rest of the repo.',
+);


### PR DESCRIPTION
## Description

Make our `lint-fix` script use report-unused-disable-directives and run that to remove them. (This requires `yarn format` after because for some reason it puts spaces in front of the Jessie directive.)

Replace many `global` directives with `eslint-env node`. I think those all are to be run in Node. If some are to be run under XS, maybe we should contribute an eslint-env for it: https://eslint.org/docs/latest/use/configure/language-options

### Security Considerations

Arguably reduces visibility of ambient authority. For that I created a script that interested parties can use any time to report on it.

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

nothing special

### Upgrade Considerations

n/a