### PR TITLE
move priceAuthorityRegistry with its vat

### DIFF
--- a/packages/SwingSet/src/kernel/state/storageHelper.js
+++ b/packages/SwingSet/src/kernel/state/storageHelper.js
@@ -26,7 +26,10 @@ export function* enumeratePrefixedKeys(kvStore, prefix, exclusiveEnd) {
   }
 }
 
-// NOTE: awkward naming: the thing that returns a stream of keys is named
+/**
+ * @param {KVStore} kvStore
+ * @param {string} prefix
+ */ // NOTE: awkward naming: the thing that returns a stream of keys is named
 // "enumerate..." while the thing that returns a stream of values is named
 // "get..."
 function* enumerateNumericPrefixedKeys(kvStore, prefix) {
@@ -43,12 +46,20 @@ function* enumerateNumericPrefixedKeys(kvStore, prefix) {
   }
 }
 
+/**
+ * @param {KVStore} kvStore
+ * @param {string} prefix
+ */
 export function* getPrefixedValues(kvStore, prefix) {
   for (const key of enumerateNumericPrefixedKeys(kvStore, prefix)) {
     yield kvStore.get(key) || Fail`enumerate ensures get`;
   }
 }
 
+/**
+ * @param {KVStore} kvStore
+ * @param {string} prefix
+ */
 export function deletePrefixedKeys(kvStore, prefix) {
   // this is kind of like a deleteRange() would be, but can be implemented
   // efficiently without backend DB support because it only looks at numeric

--- a/packages/boot/test/upgrading/test-upgrade-vats.js
+++ b/packages/boot/test/upgrading/test-upgrade-vats.js
@@ -424,7 +424,7 @@ test('upgrade vat-priceAuthority', async t => {
     priceAuthorityVatConfig,
   );
 
-  /** @type {import('@agoric/zoe/tools/priceAuthorityRegistry.js').PriceAuthorityRegistry} */
+  /** @type {import('@agoric/vats/src/priceAuthorityRegistry.js').PriceAuthorityRegistry} */
   const registry = await EV(priceAuthorityRoot).getRegistry();
 
   // Ideally we'd also test registering a PA and verifying the same one comes out the def end.

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -16,7 +16,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
-import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
+import { providePriceAuthorityRegistry } from '@agoric/vats/src/priceAuthorityRegistry.js';
 import { E } from '@endo/eventual-send';
 import { NonNullish } from '@agoric/assert';
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -16,7 +16,7 @@ import { deeplyFulfilled } from '@endo/marshal';
 
 import { NonNullish } from '@agoric/assert';
 import { eventLoopIteration } from '@agoric/notifier/tools/testSupports.js';
-import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
+import { providePriceAuthorityRegistry } from '@agoric/vats/src/priceAuthorityRegistry.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data/src/index.js';
 
 import {

--- a/packages/inter-protocol/test/vaultFactory/test-replacePriceAuthority.js
+++ b/packages/inter-protocol/test/vaultFactory/test-replacePriceAuthority.js
@@ -10,7 +10,7 @@ import { buildManualTimer } from '@agoric/swingset-vat/tools/manual-timer.js';
 import { E } from '@endo/eventual-send';
 import { deeplyFulfilled } from '@endo/marshal';
 import { TimeMath } from '@agoric/time';
-import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
+import { providePriceAuthorityRegistry } from '@agoric/vats/src/priceAuthorityRegistry.js';
 import { makeScalarMapStore } from '@agoric/vat-data/src/index.js';
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
 import { makeNotifierFromAsyncIterable, subscribeEach } from '@agoric/notifier';

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -5,7 +5,7 @@ import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data/src/index.js';
-import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
+import { providePriceAuthorityRegistry } from '@agoric/vats/src/priceAuthorityRegistry.js';
 
 import { makeScriptedPriceAuthority } from '@agoric/zoe/tools/scriptedPriceAuthority.js';
 import { E } from '@endo/eventual-send';

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -348,7 +348,7 @@ type ChainBootstrapSpaceT = {
   pegasusConnectionsAdmin: import('@agoric/vats').NameAdmin;
   priceAuthorityVat: Awaited<PriceAuthorityVat>;
   priceAuthority: PriceAuthority;
-  priceAuthorityAdmin: import('@agoric/zoe/tools/priceAuthorityRegistry').PriceAuthorityRegistryAdmin;
+  priceAuthorityAdmin: import('@agoric/vats/src/priceAuthorityRegistry').PriceAuthorityRegistryAdmin;
   provisioning: Awaited<ProvisioningVat> | undefined;
   provisionBridgeManager: import('../types.js').ScopedBridgeManager | undefined;
   provisionWalletBridgeManager:

--- a/packages/vats/src/priceAuthorityRegistry.js
+++ b/packages/vats/src/priceAuthorityRegistry.js
@@ -6,9 +6,9 @@ import {
   provideDurableMapStore,
 } from '@agoric/vat-data';
 import { provideLazy } from '@agoric/store';
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import { Far } from '@endo/marshal';
-import { PriceAuthorityI } from '../src/contractSupport/priceAuthority.js';
+import { PriceAuthorityI } from '@agoric/zoe/src/contractSupport/priceAuthority.js';
 
 const { Fail } = assert;
 
@@ -19,17 +19,19 @@ const { Fail } = assert;
 
 /**
  * @typedef {object} PriceAuthorityRegistryAdmin
- * @property {(pa: ERef<PriceAuthority>,
- *             brandIn: Brand,
- *             brandOut: Brand,
- *             force?: boolean) => Promise<Deleter>} registerPriceAuthority
- * Add a unique price authority for a given pair
+ * @property {(
+ *   pa: ERef<PriceAuthority>,
+ *   brandIn: Brand,
+ *   brandOut: Brand,
+ *   force?: boolean,
+ * ) => Promise<Deleter>} registerPriceAuthority
+ *   Add a unique price authority for a given pair
  */
 
 /**
  * @typedef {object} PriceAuthorityRegistry A price authority that is a facade
- * for other backing price authorities registered for a given asset and price
- * brand
+ *   for other backing price authorities registered for a given asset and price
+ *   brand
  * @property {PriceAuthority} priceAuthority
  * @property {PriceAuthorityRegistryAdmin} adminFacet
  */
@@ -43,10 +45,10 @@ const { Fail } = assert;
 export const providePriceAuthorityRegistry = baggage => {
   /**
    * @typedef {object} PriceAuthorityRecord A record indicating a registered
-   * price authority.  We put a box around the priceAuthority to ensure the
-   * deleter doesn't delete the wrong thing.
+   *   price authority. We put a box around the priceAuthority to ensure the
+   *   deleter doesn't delete the wrong thing.
    * @property {ERef<PriceAuthority>} priceAuthority the sub-authority for a
-   * given input and output brand pair
+   *   given input and output brand pair
    */
 
   /** @type {MapStore<Brand, MapStore<Brand, PriceAuthorityRecord>>} */
@@ -74,10 +76,12 @@ export const providePriceAuthorityRegistry = baggage => {
     /**
      * Return a quote when relation is true of the arguments.
      *
-     * @param {Amount<'nat'>} amountIn monitor the amountOut corresponding to this amountIn
-     * @param {Amount<'nat'>} amountOutLimit the value to compare with the monitored amountOut
+     * @param {Amount<'nat'>} amountIn monitor the amountOut corresponding to
+     *   this amountIn
+     * @param {Amount<'nat'>} amountOutLimit the value to compare with the
+     *   monitored amountOut
      * @returns {Promise<PriceQuote>} resolve with a quote when `amountOut
-     * relation amountOutLimit` is true
+     *   relation amountOutLimit` is true
      */
     async (amountIn, amountOutLimit) => {
       const pa = paFor(amountIn.brand, amountOutLimit.brand);
@@ -94,10 +98,12 @@ export const providePriceAuthorityRegistry = baggage => {
     /**
      * Return a mutable quote when relation is true of the arguments.
      *
-     * @param {Amount} amountIn monitor the amountOut corresponding to this amountIn
-     * @param {Amount} amountOutLimit the value to compare with the monitored amountOut
+     * @param {Amount} amountIn monitor the amountOut corresponding to this
+     *   amountIn
+     * @param {Amount} amountOutLimit the value to compare with the monitored
+     *   amountOut
      * @returns {Promise<MutableQuote>} resolve with a quote when `amountOut
-     * relation amountOutLimit` is true
+     *   relation amountOutLimit` is true
      */
     async (amountIn, amountOutLimit) => {
       const pa = paFor(amountIn.brand, amountOutLimit.brand);

--- a/packages/vats/src/vat-priceAuthority.js
+++ b/packages/vats/src/vat-priceAuthority.js
@@ -1,5 +1,5 @@
-import { providePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry.js';
 import { Far } from '@endo/marshal';
+import { providePriceAuthorityRegistry } from './priceAuthorityRegistry.js';
 
 /**
  * Vat holding the canonical PriceAuthorityRegistry for looking up prices on any

--- a/packages/vats/test/test-priceAuthorityRegistry.js
+++ b/packages/vats/test/test-priceAuthorityRegistry.js
@@ -1,10 +1,11 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
+
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { buildManualTimer } from '@agoric/swingset-vat/tools/manual-timer.js';
-import { E } from '@endo/eventual-send';
-import { providePriceAuthorityRegistry } from '../../../tools/priceAuthorityRegistry.js';
-import { makeFakePriceAuthority } from '../../../tools/fakePriceAuthority.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority.js';
+import { E } from '@endo/far';
+import { providePriceAuthorityRegistry } from '../src/priceAuthorityRegistry.js';
 
 test('price authority confused stores', async t => {
   const baggage = makeScalarBigMapStore('test baggage');


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/pull/7399#issuecomment-1796735087

## Description

priceAuthorityRegistry is in the Zoe package but it's the implementation of `vat-priceAuthorityRegistry`. This moves it adjacent to the latter.

It also has a misc typedef improvement that happened to be on my working branch.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

This removes a file from the `@agoric/zoe` package, but it's in `tools` which is not part of the package API. So I didn't call it a breaking change. Also if I had used conventional commits to mark it a breaking change, it would have been called a breaking change to `@agoric/vats` too, which would be erroneous. One more reason to stop using conventional commits, imo.