### PR TITLE
refactor(internal): remove unused functions migrating to endo

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -88,16 +88,3 @@ function an(str) {
 }
 freeze(an);
 export { an };
-
-/**
- * In the `assertFoo`/`isFoo`/`checkFoo` pattern, `checkFoo` has a `check`
- * parameter of type `Checker`. `assertFoo` calls `checkFoo` passes
- * `assertChecker` as the `check` argument. `isFoo` passes `identChecker`
- * as the `check` argument. `identChecker` acts precisely like an
- * identity function, but is typed as a `Checker` to indicate its
- * intended use.
- *
- * @type {Checker}
- */
-export const identChecker = (cond, _details) => cond;
-harden(identChecker);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #XXXX

## Description

Remove exports that are both unused within agoric-sdk and migrating to endo anyway.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Fewer copies of code are fewer copies to potentially get out of sync, and fewer copies that potentially need to be tested. Though in this case, there were no agoric-sdk tests of these functions as implemented in agoric-sdk

### Upgrade Considerations

One of these functions (`assertChecker`) is exported from the @agoric/assert package, and so is a legitimate import by others outside of agoric-sdk. All the others are from @agoric/internal, which no code outside of agoric-sdk is supposed to import from.