### PR TITLE
chore(ci): use synthetic-chain build config

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -237,7 +237,7 @@ jobs:
         run: yarn install
         working-directory: a3p-integration
       - name: build proposals tests
-        run: yarn synthetic-chain append
+        run: yarn synthetic-chain build
         working-directory: a3p-integration
       - name: run proposals tests
         run: yarn synthetic-chain test

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -1,11 +1,14 @@
 {
     "private": true,
+    "agoricSyntheticChain": {
+        "fromTag": "main"
+    },
     "scripts": {
         "build": "echo Use synthetic-chain to build proposal images",
         "test": "echo Use synthetic-chain to test proposal images"
     },
     "dependencies": {
-        "@agoric/synthetic-chain": "^0.0.2-0",
+        "@agoric/synthetic-chain": "^0.0.2",
         "tsx": "^4.7.0"
     },
     "license": "Apache-2.0"

--- a/a3p-integration/yarn.lock
+++ b/a3p-integration/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@agoric/synthetic-chain@^0.0.2-0":
-  version "0.0.2-0"
-  resolved "https://registry.yarnpkg.com/@agoric/synthetic-chain/-/synthetic-chain-0.0.2-0.tgz#8658321a7c4bf3026096129f9053f1a0f9247bd7"
-  integrity sha512-VFZE7kbMqEuicqAiShJFa0cHBgNRb/Wmq/gndZ7/ynuPR5RJs5cssvAuj7lvbfMvzir2WgYybxnd4srJ9hSu6A==
+"@agoric/synthetic-chain@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@agoric/synthetic-chain/-/synthetic-chain-0.0.2.tgz#c23f77c88fde0e050d62ff59684f1120586fdb4f"
+  integrity sha512-azAcU6o1OZvlCtnflrTsbwFaYp7uak6S4lZicsrlErvuA24U7oyORO0O4W47LqPkzxAullJZiQCwHpT5Ac3v2Q==
   dependencies:
     better-sqlite3 "^9.2.2"
     tsx "^3.12.8"


### PR DESCRIPTION
refs: #8635
refs: #8605

## Description

Use the new `package.json` build config introduced in https://github.com/Agoric/agoric-3-proposals/pull/58 to avoid having to modify the command in GitHub Actions workflows in the release branches which use a fixed base image.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

This makes the base image more explicit and discoverable

### Testing Considerations

Manually tested, integration tests will verify

### Upgrade Considerations

Here I explicitly specify the base tag to highlight the difference between master and release.