### PR TITLE
fix(zoe): Fix OfferHandlerI.handle returns guard

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -176,11 +176,12 @@ export const depositToSeatSuccessMsg = `Deposit and reallocation successful.`;
  * The `amounts` and `payments` records must have corresponding
  * keywords.
  *
+ * @template {object} [OR=unknown]
  * @param {ZCF} zcf
  * @param {ZCFSeat} recipientSeat
  * @param {AmountKeywordRecord} amounts
  * @param {PaymentPKeywordRecord} payments
- * @returns {Promise<string>} `Deposit and reallocation successful.`
+ * @returns {Promise<OR>} `Deposit and reallocation successful.`
  */
 export const depositToSeat = async (zcf, recipientSeat, amounts, payments) => {
   !recipientSeat.hasExited() || Fail`The recipientSeat cannot have exited.`;

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -127,7 +127,7 @@ export const InvitationElementShape = M.splitRecord({
 });
 
 export const OfferHandlerI = M.interface('OfferHandler', {
-  handle: M.call(SeatShape).optional(M.any()).returns(M.string()),
+  handle: M.call(SeatShape).optional(M.any()).returns(M.any()),
 });
 
 export const SeatHandleAllocationsShape = M.arrayOf(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #8745 

## Description

At https://github.com/Agoric/agoric-sdk/pull/8745#discussion_r1451054595 @dckc suggests extracting this one fix into a separate change. This PR is that.

An _OfferResult_ is the value returned by a offer handler. `E(userSeat).getOfferResult()` returns a promise for an OfferResult.

By design, an OfferResult can be any `Passable`. Indeed, its static type is often the `OR` of
```js
 * @template {object} [OR=unknown]
```
which is the type parameter of `UserSeat`.

However, the OfferResult is so often a string, that the incorrect assumption that it is a string has crept into our code in at least the two places fixed by this PR. One is an incorrect `returns` guard. The other is an incorrect promise type parameter.

### Security Considerations

More accurate types help security review. The too-narrow results guard would only cause inappropriate failures, which at least usually preserve integrity while sacrificing availability. The incorrect promise type arg is unsound in a way that might cause a reviewer to miss a loss of integrity: The `@returns {Promise<string>}` statically makes a claim that might silently be violated by runtime behavior. (Note though that neither has yet resulted in any known such problem.)

### Scaling Considerations

None.

### Documentation Considerations

The documentation at https://docs.agoric.com/reference/zoe-api/user-seat.html#e-userseat-getofferresult is already correct. This brings the code into agreement with the existing docs.

More accurate types will also help generate more accurate docs.

### Testing Considerations

None.

### Upgrade Considerations

None, I think.