### PR TITLE
refactor(base-zone,store): prepare for migration to endo repo

### DIFF
--- a/packages/base-zone/README.md
+++ b/packages/base-zone/README.md
@@ -7,3 +7,7 @@ the JS heap (ephemeral), pageable out to disk (virtual) or can be revived after
 a vat upgrade (durable).
 
 This library is used internally by [@agoric/zone](../zone/README.md); refer to it for more details.  Unless you are an author of a new Zone backing store type, or want to use `makeHeapZone` without introducing build dependencies on [@agoric/vat-data](../vat-data/README.md), you should instead use [@agoric/zone](../zone/README.md).
+
+---
+
+Be aware that both this package `@agoric/base-zone` and `@agoric/store` will move from the agoric-sdk repository to the endo repository and likely renamed `@endo/zone` and `@endo/store`. At that time, we will first deprecate the versions here, then replace them with deprecated stubs that reexport from their new home. We hope to eventually remove even these stubs, depending on the compat cost at that time.

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -22,36 +22,6 @@ Store adds some additional functionality on top of Map.
 
 See `makeScalarWeakMapStore` for the wrapper around JavaScript's WeakMap abstraction.
 
-# External Store
+---
 
-An External Store is defined by its maker function, and provides abstractions
-that are compatible with large, synchronous secondary storage that can be paged
-in and out of local memory.
-
-```js
-import { makeExternalStore } from '@agoric/store';
-
-// Here is us defining an instance store for 'hello' objects.
-const estore = makeExternalStore((msg = 'Hello') => ({
-  hello(nickname) {
-    return `${msg}, ${nickname}!`;
-  },
-}));
-
-const h = estore.makeInstance('Hi');
-h.hello('friend') === 'Hi, friend!';
-const wm = estore.makeWeakMap('Hello object');
-wm.init(h, 'data');
-// ... time passes and h is paged out and reloaded.
-wm.get(h) === 'data';
-wm.set(h, 'new-data');
-// ... time passes and h is paged out and reloaded.
-map.delete(h);
-```
-
-Note that when you import and use the `makeExternalStore` function, the platform
-you are running on may rewrite your code to use a more scalable implementation
-of that function.  If it is not rewritten, then `makeExternalStore` will use
-`makeMemoryExternalStore`, a full-featured, though in-memory-only
-implementation.  If you don't desire rewriting, then use
-`makeMemoryExternalStore` directly.
+Be aware that both `@agoric/base-zone` and this package `@agoric/store` will move from the agoric-sdk repository to the endo repository and likely renamed `@endo/zone` and `@endo/store`. At that time, we will first deprecate the versions here, then replace them with deprecated stubs that reexport from their new home. We hope to eventually remove even these stubs, depending on the compat cost at that time.

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -30,14 +30,12 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/assert": "^0.6.0",
     "@endo/exo": "^1.1.0",
     "@endo/marshal": "^1.1.0",
     "@endo/pass-style": "^1.1.0",
     "@endo/patterns": "^1.1.0"
   },
   "devDependencies": {
-    "@agoric/time": "^0.3.2",
     "@endo/init": "^1.0.2",
     "@endo/ses-ava": "^1.1.0",
     "ava": "^5.3.0"

--- a/packages/store/src/legacy/legacyMap.js
+++ b/packages/store/src/legacy/legacyMap.js
@@ -1,6 +1,7 @@
-import { q, Fail } from '@agoric/assert';
-
 import '../types.js';
+
+// TODO, once migrated to endo, import from @endo/errors instead
+const { Fail, quote: q } = assert;
 
 /**
  * This module and its fraternal sibling legacyWeakMap exist only to ease a

--- a/packages/store/src/legacy/legacyWeakMap.js
+++ b/packages/store/src/legacy/legacyWeakMap.js
@@ -1,5 +1,7 @@
-import { q, Fail } from '@agoric/assert';
 import '../types.js';
+
+// TODO, once migrated to endo, import from @endo/errors instead
+const { Fail, quote: q } = assert;
 
 /**
  * See doccomment in the closely related `legacyMap.js` module.

--- a/packages/store/test/borrow-guards.js
+++ b/packages/store/test/borrow-guards.js
@@ -1,5 +1,4 @@
 import { M } from '@endo/patterns';
-import { TimestampShape } from '@agoric/time';
 
 // The purpose of this module is to provide snapshotted (and possibly stale)
 // copies of various patterns and guards from packages that this package
@@ -22,6 +21,14 @@ export const AmountShape = harden({
 
 const AmountKeywordRecordShape = M.recordOf(M.string(), AmountShape);
 const AmountPatternKeywordRecordShape = M.recordOf(M.string(), M.pattern());
+
+const TimerBrandShape = M.remotable('TimerBrand');
+const TimestampValueShape = M.nat();
+const TimestampRecordShape = harden({
+  timerBrand: TimerBrandShape,
+  absValue: TimestampValueShape,
+});
+const TimestampShape = M.or(TimestampRecordShape, TimestampValueShape);
 
 export const FullProposalShape = harden({
   want: AmountPatternKeywordRecordShape,


### PR DESCRIPTION
closes: #XXXX
refs: #8745 

## Description

By removing dependencies from this pair to anything else in agoric-sdk, we prepare to move this pair of packages from the agoric-sdk repo to the endo repo.

From internal discussions, it is clear that the agoric-sdk repository and the endo repository will remain separate at least for the immediate future, and possibly forever. However, for the current boundary between the two to make sense, there remain two misplaced packages: `@agoric/base-zone` and `@agoric/store`. This PR just prepares them to make the migration, but does nothing else.

Additional motivation (that finally pushed me to start this) is @dckc's comment at https://github.com/Agoric/agoric-sdk/pull/8745#discussion_r1451053080 . Once prepare-revocable.js is refactored to depend on zones, it will no longer be limited to durable objects, but can be used with any zone. At that point, it should live in the endo repo. (The rest of #8745 , which is about ownables, should remain in agoric-sdk because it uses zoe concepts.)

### Security Considerations

For this PR itself, none. For the migration it prepared for, likely none as well, but we'll be explicit about that then.

### Scaling Considerations

For this PR itself, none. For the migration it prepared for, likely none as well, but we'll be explicit about that then.

### Documentation Considerations

For this PR itself, mostly none. For the migration it prepared for, likely none as well, but we'll be explicit about that then.

I did add a note to the README of both packages explaining that these will be migrated to the endo repo.

### Testing Considerations

For this PR itself, none. For the migration it prepared for, likely none as well, but we'll be explicit about that then.

### Upgrade Considerations

For this PR itself, none. For the migration it prepared for, likely none as well, but we'll be explicit about that then.

@ivanlei , I added you as a reviewer to judge when this PR could be merged without being too disruptive.
