### PR TITLE
fix: "x" parameter in many tests is optional

### DIFF
--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -33,7 +33,7 @@ test('test defineDurableExoClass', t => {
   const makeUpCounter = defineDurableExoClass(
     upCounterKind,
     UpCounterI,
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
@@ -69,7 +69,7 @@ test('test defineDurableExoClassKit', t => {
   const makeCounterKit = defineDurableExoClassKit(
     counterKindHandle,
     { up: UpCounterI, down: DownCounterI },
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       up: {
@@ -124,7 +124,7 @@ test('finish option', t => {
     UpCounterI,
     /**
      * @param {string} name
-     * @param {number} x
+     * @param {number} [x]
      */
     (name, x = 0) => ({ name, x }),
     {

--- a/packages/vat-data/test/test-prepare.js
+++ b/packages/vat-data/test/test-prepare.js
@@ -32,7 +32,7 @@ test('test prepareExoClass', t => {
     baggage,
     'UpCounter',
     UpCounterI,
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
@@ -66,7 +66,7 @@ test('test prepareExoClassKit', t => {
     baggage,
     'Counter',
     { up: UpCounterI, down: DownCounterI },
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -27,7 +27,7 @@ test('test defineVirtualExoClass', t => {
   const makeUpCounter = defineVirtualExoClass(
     'UpCounter',
     UpCounterI,
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
@@ -58,7 +58,7 @@ test('test defineVirtualExoClassKit', t => {
   const makeCounterKit = defineVirtualExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       up: {


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8745

## Description

At https://github.com/Agoric/agoric-sdk/pull/8745#discussion_r1451052306 @dckc noticed that an optional `x` parameter should have been declared optional but was not. Turns out that I had copy-paste-modify that mistaken declaration to other tests. 

This PR fixes the ones in agoric-sdk. https://github.com/endojs/endo/pull/1965 the ones in endo.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

none

### Upgrade Considerations

none