### PR TITLE
refactor(liveslots): minor improvements to prepare for upcoming changes

### DIFF
--- a/packages/swingset-liveslots/src/cache.js
+++ b/packages/swingset-liveslots/src/cache.js
@@ -4,7 +4,7 @@ import { Fail } from '@agoric/assert';
  * @template V
  * @callback CacheGet
  * @param {string} key
- * @returns {V}
+ * @returns {V | undefined}
  */
 
 /**
@@ -17,7 +17,7 @@ import { Fail } from '@agoric/assert';
 /**
  * @callback CacheDelete
  * @param {string} key
- * @returns {void}
+ * @returns {boolean}
  *
  * @callback CacheFlush
  * @returns {void}
@@ -62,6 +62,7 @@ import { Fail } from '@agoric/assert';
 export function makeCache(readBacking, writeBacking, deleteBacking) {
   const stash = new Map();
   const dirtyKeys = new Set();
+  /** @type {Cache<V>} */
   const cache = {
     get: key => {
       assert.typeof(key, 'string');
@@ -82,8 +83,9 @@ export function makeCache(readBacking, writeBacking, deleteBacking) {
     },
     delete: key => {
       assert.typeof(key, 'string');
-      stash.delete(key);
+      const result = stash.delete(key);
       dirtyKeys.add(key);
+      return result;
     },
     flush: () => {
       const keys = [...dirtyKeys.keys()];

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -255,7 +255,11 @@ export function makeCollectionManager(
     const kindInfo = storeKindInfo[kindName];
     kindInfo || Fail`unknown collection kind ${kindName}`;
     const { hasWeakKeys, durable } = kindInfo;
-    const getSchema = () => schemaCache.get(collectionID);
+    const getSchema = () => {
+      const result = schemaCache.get(collectionID);
+      assert(result !== undefined);
+      return result;
+    };
     const dbKeyPrefix = `vc.${collectionID}.`;
     let currentGenerationNumber = 0;
 
@@ -749,7 +753,9 @@ export function makeCollectionManager(
     const collection = summonCollectionInternal(false, collectionID, kindName);
 
     let doMoreGC = collection.clearInternal(true);
-    const { schemataCapData } = schemaCache.get(collectionID);
+    const record = schemaCache.get(collectionID);
+    assert(record !== undefined);
+    const { schemataCapData } = record;
     doMoreGC =
       schemataCapData.slots.map(vrm.removeReachableVref).some(b => b) ||
       doMoreGC;

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -13,12 +13,12 @@ import type {
   WeakMapStore,
   WeakSetStore,
 } from '@agoric/store';
+import type { StateShape } from '@endo/exo';
 import type { makeWatchedPromiseManager } from './watchedPromises.js';
 
 // TODO should be moved into @endo/patterns and eventually imported here
 // instead of this local definition.
 export type InterfaceGuardKit = Record<string, InterfaceGuard>;
-
 export type { MapStore, Pattern };
 
 // This needs `any` values.  If they were `unknown`, code that uses Baggage
@@ -88,7 +88,7 @@ export type DefineKindOptions<C> = {
    * If provided, it describes the shape of all state records of instances
    * of this kind.
    */
-  stateShape?: { [name: string]: Pattern };
+  stateShape?: StateShape;
 
   /**
    * Intended for internal use only.

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -17,7 +17,7 @@ import {
 /** @template T @typedef {import('@agoric/vat-data').DefineKindOptions<T>} DefineKindOptions */
 
 /**
- * @typedef {import('@endo/exo/src/exo-tools.js').ContextProvider } ContextProvider
+ * @typedef {import('@endo/exo/src/exo-tools.js').ClassContextProvider } ClassContextProvider
  */
 
 /**
@@ -995,7 +995,7 @@ export const makeVirtualObjectManager = (
         interfaceGuardKit,
       );
     } else {
-      /** @type {ContextProvider} */
+      /** @type {ClassContextProvider} */
       const contextProvider = rep => {
         const slot = getSlotForVal(rep);
         assert(slot !== undefined);

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -16,7 +16,16 @@ import {
 
 /** @template T @typedef {import('@agoric/vat-data').DefineKindOptions<T>} DefineKindOptions */
 
-const { hasOwn, defineProperty, getOwnPropertyNames, entries } = Object;
+/**
+ * @typedef {import('@endo/exo/src/exo-tools.js').ContextProvider } ContextProvider
+ */
+
+/**
+ * @typedef {import('@endo/exo/src/exo-tools.js').KitContextProvider } KitContextProvider
+ */
+
+const { hasOwn, defineProperty, getOwnPropertyNames, entries, fromEntries } =
+  Object;
 const { ownKeys } = Reflect;
 const { quote: q } = assert;
 
@@ -139,39 +148,6 @@ const makeContextCache = (makeState, makeContext) => {
   const writeBacking = _baseRef => Fail`never called`;
   const deleteBacking = _baseRef => Fail`never called`;
   return makeCache(readBacking, writeBacking, deleteBacking);
-};
-
-/**
- * @typedef {import('@endo/exo/src/exo-tools.js').ContextProvider } ContextProvider
- */
-
-/**
- * @param {*} contextCache
- * @param {*} getSlotForVal
- * @returns {ContextProvider}
- */
-const makeContextProvider = (contextCache, getSlotForVal) =>
-  harden(rep => contextCache.get(getSlotForVal(rep)));
-
-const makeContextProviderKit = (contextCache, getSlotForVal, facetNames) => {
-  /** @type { Record<string, any> } */
-  const contextProviderKit = {};
-  for (const [index, name] of facetNames.entries()) {
-    contextProviderKit[name] = rep => {
-      const vref = getSlotForVal(rep);
-      const { baseRef, facet } = parseVatSlot(vref);
-
-      // Without this check, an attacker (with access to both cohort1.facetA
-      // and cohort2.facetB) could effectively forge access to cohort1.facetB
-      // and cohort2.facetA. They could not forge the identity of those two
-      // objects, but they could invoke all their equivalent methods, by using
-      // e.g. cohort1.facetA.foo.apply(cohort2.facetB, [...args])
-      Number(facet) === index || Fail`illegal cross-facet access`;
-
-      return harden(contextCache.get(baseRef));
-    };
-  }
-  return harden(contextProviderKit);
 };
 
 // The management of single Representatives (i.e. defineKind) is very similar
@@ -891,7 +867,9 @@ export const makeVirtualObjectManager = (
       return harden({
         get() {
           const baseRef = getBaseRef(this);
-          const { valueMap, capdatas } = dataCache.get(baseRef);
+          const record = dataCache.get(baseRef);
+          assert(record !== undefined);
+          const { valueMap, capdatas } = record;
           if (!valueMap.has(prop)) {
             const value = harden(unserialize(capdatas[prop]));
             checkStatePropertyValue(value, prop);
@@ -908,6 +886,7 @@ export const makeVirtualObjectManager = (
             insistDurableCapdata(vrm, prop, capdata, true);
           }
           const record = dataCache.get(baseRef); // mutable
+          assert(record !== undefined);
           const oldSlots = record.capdatas[prop].slots;
           const newSlots = capdata.slots;
           vrm.updateReferenceCounts(oldSlots, newSlots);
@@ -931,7 +910,9 @@ export const makeVirtualObjectManager = (
     const makeState = baseRef => {
       const state = { __proto__: statePrototype };
       if (stateShape === undefined) {
-        for (const prop of ownKeys(dataCache.get(baseRef).capdatas)) {
+        const record = dataCache.get(baseRef);
+        assert(record !== undefined);
+        for (const prop of ownKeys(record.capdatas)) {
           assert(typeof prop === 'string');
           checkStateProperty(prop);
           defineProperty(state, prop, makeFieldDescriptor(prop));
@@ -982,17 +963,47 @@ export const makeVirtualObjectManager = (
 
     let proto;
     if (multifaceted) {
+      /** @type { Record<string, KitContextProvider> } */
+      const contextProviderKit = fromEntries(
+        facetNames.map((name, index) => [
+          name,
+          rep => {
+            const vref = getSlotForVal(rep);
+            assert(vref !== undefined);
+            const { baseRef, facet } = parseVatSlot(vref);
+
+            // Without this check, an attacker (with access to both
+            // cohort1.facetA and cohort2.facetB)
+            // could effectively forge access to
+            // cohort1.facetB and cohort2.facetA.
+            // They could not forge the identity of those two
+            // objects, but they could invoke all their equivalent methods,
+            // by using e.g.
+            // cohort1.facetA.foo.apply(cohort2.facetB, [...args])
+            Number(facet) === index || Fail`illegal cross-facet access`;
+
+            return harden(contextCache.get(baseRef));
+          },
+        ]),
+      );
+
       proto = defendPrototypeKit(
         tag,
-        makeContextProviderKit(contextCache, getSlotForVal, facetNames),
+        harden(contextProviderKit),
         behavior,
         thisfulMethods,
         interfaceGuardKit,
       );
     } else {
+      /** @type {ContextProvider} */
+      const contextProvider = rep => {
+        const slot = getSlotForVal(rep);
+        assert(slot !== undefined);
+        return harden(contextCache.get(slot));
+      };
       proto = defendPrototype(
         tag,
-        makeContextProvider(contextCache, getSlotForVal),
+        harden(contextProvider),
         behavior,
         thisfulMethods,
         interfaceGuard,
@@ -1014,6 +1025,7 @@ export const makeVirtualObjectManager = (
     const deleteStoredVO = baseRef => {
       let doMoreGC = false;
       const record = dataCache.get(baseRef);
+      assert(record !== undefined);
       for (const valueCD of Object.values(record.capdatas)) {
         for (const vref of valueCD.slots) {
           doMoreGC = vrm.removeReachableVref(vref) || doMoreGC;
@@ -1072,7 +1084,7 @@ export const makeVirtualObjectManager = (
         val = makeRepresentative(proto, baseRef);
       }
       registerValue(baseRef, val, multifaceted);
-      finish?.(contextCache.get(baseRef));
+      finish && finish(contextCache.get(baseRef));
       return val;
     };
 

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -17,11 +17,27 @@ import {
 /** @template T @typedef {import('@agoric/vat-data').DefineKindOptions<T>} DefineKindOptions */
 
 /**
- * @typedef {import('@endo/exo/src/exo-tools.js').ClassContextProvider } ClassContextProvider
+ * @typedef {(
+ *   representative: any
+ * ) => import('@endo/exo/src/exo-tools.js').ClassContext | undefined} ClassContextProvider
+ * Definition only temporarily copied from exo-tools.js to here.
+ * TODO Once agoric-sdk is upgraded to depend on an `@endo/exo` incorporating
+ * https://github.com/endojs/endo/pull/1966
+ * then replace with the following (fixing the implied "@")
+ *
+ * at-typedef {import('@endo/exo/src/exo-tools.js').ClassContextProvider } ClassContextProvider
+ *
+ * @typedef {(facet: any) => import('@endo/exo/src/exo-tools.js').KitContext | undefined} KitContextProvider
+ * Definition only temporarily copied from exo-tools.js to here.
+ * TODO Once agoric-sdk is upgraded to depend on an `@endo/exo` incorporating
+ * https://github.com/endojs/endo/pull/1966
+ * then replace with the following (fixing the implied "@")
+ *
+ * at-typedef {import('@endo/exo/src/exo-tools.js').KitContextProvider } KitContextProvider
  */
 
 /**
- * @typedef {import('@endo/exo/src/exo-tools.js').KitContextProvider } KitContextProvider
+ *
  */
 
 const { hasOwn, defineProperty, getOwnPropertyNames, entries, fromEntries } =
@@ -989,6 +1005,15 @@ export const makeVirtualObjectManager = (
 
       proto = defendPrototypeKit(
         tag,
+        // TODO Once agoric-sdk is upgraded to depend on an `@endo/exo`
+        // incorporating https://github.com/endojs/endo/pull/1966
+        // Then the following at-ts-ignore will no longer be needed.
+        // However, it is an at-ts-ignore rather than an
+        // at-ts-expect-error to be compat with endo both before and
+        // after, until we're safely across the transition.
+        //
+        // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+        // @ts-ignore
         harden(contextProviderKit),
         behavior,
         thisfulMethods,
@@ -1003,6 +1028,15 @@ export const makeVirtualObjectManager = (
       };
       proto = defendPrototype(
         tag,
+        // TODO Once agoric-sdk is upgraded to depend on an `@endo/exo`
+        // incorporating https://github.com/endojs/endo/pull/1966
+        // Then the following at-ts-ignore will no longer be needed.
+        // However, it is an at-ts-ignore rather than an
+        // at-ts-expect-error to be compat with endo both before and
+        // after, until we're safely across the transition.
+        //
+        // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+        // @ts-ignore
         harden(contextProvider),
         behavior,
         thisfulMethods,


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/endojs/endo/pull/1964 https://github.com/endojs/endo/pull/1966

## Description

Minor refactors to prepare for upcoming changes.

Some minor typing improvements. Mostly being explicit that `cache.get(key)` can return an answer or `undefined`, and then adding explicit `assert(thing !== undefined);` statements as suggested by the type checker. I believe in all cases where I added these, the `undefined` case would have caused an early enough error anyway, so the only behavioral change would be to make the error a bit clearer. 

***Reviewers, please look at all these potential behavioral changes to be sure my added assertions would not cause any buggy behavior.*** Also, are some of these cases that should always have handled the `undefined` case differently than just throwing an error?

As previously discussed with @FUDCo, `cache.delete(key)` now returns a boolean to say whether it actually deleted anything. The motivation for this was `receiveRevoker` which is disappearing https://github.com/endojs/endo/pull/1964 , but this seems like a good change anyway. It is more consistent with other `collection.delete(key)` APIs.

The most significant are the simplifications of deleting `makeContextProvider` and `makeContextProviderKit`, and putting their context provider making code inline.


### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

none

### Upgrade Considerations

none