### PR TITLE
ci: restore core proposal in upgrade test

### DIFF
--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -8,7 +8,7 @@
         "test": "echo Use synthetic-chain to test proposal images"
     },
     "dependencies": {
-        "@agoric/synthetic-chain": "^0.0.2",
+        "@agoric/synthetic-chain": "^0.0.3",
         "tsx": "^4.7.0"
     },
     "license": "Apache-2.0"

--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -3,7 +3,11 @@
     "releaseNotes": "TBD",
     "sdkImageTag": "latest",
     "planName": "UNRELEASED_UPGRADE",
-    "upgradeInfo": {},
+    "upgradeInfo": {
+      "coreProposals": [
+        "@agoric/builders/scripts/vats/init-network.js"
+      ]
+    },
     "type": "Software Upgrade Proposal"
   },
   "type": "module",

--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -3,12 +3,13 @@
     "releaseNotes": "TBD",
     "sdkImageTag": "latest",
     "planName": "UNRELEASED_UPGRADE",
+    "upgradeInfo": {},
     "type": "Software Upgrade Proposal"
   },
   "type": "module",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agoric/synthetic-chain": "^0.0.2-0",
+    "@agoric/synthetic-chain": "^0.0.3",
     "ava": "^5.3.1",
     "better-sqlite3": "^9.2.2",
     "execa": "^7.2.0"

--- a/a3p-integration/proposals/a:upgrade-next/post.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/post.test.js
@@ -1,0 +1,8 @@
+import test from 'ava';
+
+import { getIncarnation } from '@agoric/synthetic-chain/src/lib/vat-status.js';
+
+test(`Ensure Network Vat was installed`, async t => {
+  const incarnation = await getIncarnation('network');
+  t.is(incarnation, 0);
+});

--- a/a3p-integration/proposals/a:upgrade-next/yarn.lock
+++ b/a3p-integration/proposals/a:upgrade-next/yarn.lock
@@ -5,16 +5,16 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@agoric/synthetic-chain@npm:^0.0.2-0":
-  version: 0.0.2-0
-  resolution: "@agoric/synthetic-chain@npm:0.0.2-0"
+"@agoric/synthetic-chain@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@agoric/synthetic-chain@npm:0.0.3"
   dependencies:
     better-sqlite3: "npm:^9.2.2"
     tsx: "npm:^3.12.8"
     typescript: "npm:^5.3.3"
   bin:
     synthetic-chain: cli.ts
-  checksum: c046c56bd3977f7877abbc1ae077c0db44142399593da7ff1aaab1e3c46860b817d2a76b8521f687a8d9ae18461a4734bda584e4a9e1490980f7120553ea16ac
+  checksum: 72e5196f1697649eb63eae0041b6e59395fd22c69b1be9a2339a861c397d0b7aba868c4d44052c515c1afa63fb192ec3778997567728836a0456e62747462374
   languageName: node
   linkType: hard
 
@@ -2066,7 +2066,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@agoric/synthetic-chain": "npm:^0.0.2-0"
+    "@agoric/synthetic-chain": "npm:^0.0.3"
     ava: "npm:^5.3.1"
     better-sqlite3: "npm:^9.2.2"
     execa: "npm:^7.2.0"

--- a/a3p-integration/yarn.lock
+++ b/a3p-integration/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@agoric/synthetic-chain@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@agoric/synthetic-chain/-/synthetic-chain-0.0.2.tgz#c23f77c88fde0e050d62ff59684f1120586fdb4f"
-  integrity sha512-azAcU6o1OZvlCtnflrTsbwFaYp7uak6S4lZicsrlErvuA24U7oyORO0O4W47LqPkzxAullJZiQCwHpT5Ac3v2Q==
+"@agoric/synthetic-chain@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@agoric/synthetic-chain/-/synthetic-chain-0.0.3.tgz#eaa9ea9429a950686e5cc31200f1e30cf7acedfd"
+  integrity sha512-C+2cb3IPoiCKSRNyVAE8mt+BLeZB2AKzAnW0TJK5SgVSBlX+wgcrNMZHpSlrWScFzlsEQJWzqRdzpV2YdVtESg==
   dependencies:
     better-sqlite3 "^9.2.2"
     tsx "^3.12.8"


### PR DESCRIPTION
refs: #8635

## Description

As noted in https://github.com/Agoric/agoric-sdk/pull/8635/files#r1452459188, the new a3p based tests no longer simulate a core proposal of installing the network components. With https://github.com/Agoric/agoric-3-proposals/pull/63 implemented, this PR restores that test.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Restores removed test

### Upgrade Considerations

This changing test code of upgrade related features