### PR TITLE
DO NOT MERGE test #8752 against current endo master

### DIFF
--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -133,6 +133,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../../tools/bootstrap-relay.js', {
     defaultManagerType,


### PR DESCRIPTION
#endo-branch: master

There is some type juggling to get #8752 to type check both 
- on the endo that agoric-sdk currently depends on, and 
- on an endo incorporating https://github.com/endojs/endo/pull/1966 , which is already merged into endo master.

The first is tested by #8752 , which passes and is already approved.

This PR is a throw away, purely to test the second condition


closes: #XXXX
refs: #8752 https://github.com/endojs/endo/pull/1966

