### PR TITLE
Default to unreleased docker tag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -228,7 +228,7 @@ jobs:
           df -h
       - uses: actions/checkout@v3
       - name: docker build (sdk)
-        # Produces ghcr.io/agoric/agoric-sdk:latest used in the following upgrade test.
+        # Produces ghcr.io/agoric/agoric-sdk:unreleased used in the following upgrade test.
         # run: cd packages/deployment && ./scripts/test-docker-build.sh | $TEST_COLLECT
         # XXX skip TAP test output and collection for now; it hides the output from the logs
         run: make docker-build-sdk

--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -1,7 +1,7 @@
 {
   "agoricProposal": {
     "releaseNotes": "TBD",
-    "sdkImageTag": "latest",
+    "sdkImageTag": "unreleased",
     "planName": "UNRELEASED_UPGRADE",
     "upgradeInfo": {
       "coreProposals": [

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -2,7 +2,7 @@ REPOSITORY = ghcr.io/agoric/cosmic-swingset
 REPOSITORY_SDK = ghcr.io/agoric/agoric-sdk
 SS := ../cosmic-swingset/
 
-TAG := latest
+TAG := unreleased
 GIT_REVISION := $(shell hash=$$(git rev-parse --short HEAD); \
 	dirty=`git diff --quiet 2>/dev/null || echo -dirty`; \
 	echo "$$hash$$dirty")

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -1,19 +1,11 @@
 REPOSITORY = ghcr.io/agoric/cosmic-swingset
 REPOSITORY_SDK = ghcr.io/agoric/agoric-sdk
 SS := ../cosmic-swingset/
-VERSION := $(shell node -e 'console.log(require("../../package.json").version??"")' 2>/dev/null)
 
-TAG := $(if $(VERSION),$(VERSION),latest)
+TAG := latest
 GIT_REVISION := $(shell hash=$$(git rev-parse --short HEAD); \
 	dirty=`git diff --quiet 2>/dev/null || echo -dirty`; \
 	echo "$$hash$$dirty")
-
-# Don't push alpha tags as ":$(TAG)".
-ifeq ($(TAG),latest)
-DONT_PUSH_LATEST := :
-else
-DONT_PUSH_LATEST := $(if $(findstring -,$(TAG)),:,)
-endif
 
 default: docker-build
 
@@ -42,32 +34,6 @@ docker-build-ssh-node:
 	docker build --build-arg=TAG=$(TAG)  -t ghcr.io/agoric/ssh-node:$(TAG) --file=Dockerfile.ssh-node ./docker
 	docker tag ghcr.io/agoric/ssh-node:$(TAG) ghcr.io/agoric/ssh-node:latest
 
-# Just push $(TAG)
-docker-push-only:
-	$(MAKE) docker-push DONT_PUSH_LATEST=: TAG=$(TAG)
-
-docker-push: docker-push-base docker-push-solo docker-push-setup \
-	docker-push-ibc-alpha docker-push-ssh-node
-
 # ./docker is an emptyish directory.
 docker-build-ibc-alpha:
 	docker build --build-arg=SDK_TAG=$(TAG) -t $(REPOSITORY_SDK):ibc-alpha --file=Dockerfile.ibc-alpha ./docker
-
-docker-push-ibc-alpha: docker-build-ibc-alpha
-	docker push $(REPOSITORY_SDK):ibc-alpha
-
-docker-push-setup:
-	$(DONT_PUSH_LATEST) docker push $(REPOSITORY)-setup:latest
-	docker push $(REPOSITORY)-setup:$(TAG)
-
-docker-push-base:
-	$(DONT_PUSH_LATEST) docker push $(REPOSITORY_SDK):latest
-	docker push $(REPOSITORY_SDK):$(TAG)
-
-docker-push-solo:
-	$(DONT_PUSH_LATEST) docker push $(REPOSITORY)-solo:latest
-	docker push $(REPOSITORY)-solo:$(TAG)
-
-docker-push-ssh-node:
-	$(DONT_PUSH_LATEST) docker push ghcr.io/agoric/ssh-node:latest
-	docker push ghcr.io/agoric/ssh-node:$(TAG)


### PR DESCRIPTION

## Description

While reviewing #8743 we realized that the reliance on the `latest` docker image could be confusing, as it is actually expecting a locally built image of the sdk, not the latest released version of the sdk.

This removes some no longer used docker push logic from the deployment makefile, and uses an `unreleased` tag by default when building locally, which is in turn used as the image tag by the a3p integration test

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Maybe?

### Testing Considerations

Relying on existing CI to catch any breakage

### Upgrade Considerations

None