### PR TITLE
fix: update protobuf download and generation for ibc-go v4

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -98,17 +98,12 @@ proto-lint: proto-tools
 proto-check-breaking: proto-tools
 	${BIN}/buf breaking --against $(PR_TARGET_REPO)#branch=$(PR_TARGET_BRANCH),subdir=golang/cosmos
 
-TMVER := $(shell go list -m all | sed -ne 's!^github\.com/tendermint/tendermint \(.*\)!\1!p')
-COSMOSVER = $(shell go list -m all | sed -ne 's!^github\.com/cosmos/cosmos-sdk \(.*\)!\1!p')
-IBCVER = 832044782f10
-t:
-	echo "X$(COSMOSVER)X"
-
-TM_URL           := file://$(shell go list -m -f '{{ .Dir }}' github.com/tendermint/tendermint)/proto/tendermint
 GOGO_PROTO_URL   := file://$(shell go list -m -f '{{ .Dir }}' github.com/gogo/protobuf)
 IBC_PROTO_URL    := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/ibc-go/v4)/proto/ibc/core
+COSMOS_PROTO_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/regen-network/cosmos-proto)
 COSMOS_SDK_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/cosmos-sdk)/proto/cosmos
 
+COSMOS_PROTO_TYPES = third_party/proto/cosmos_proto
 GOGO_PROTO_TYPES  = third_party/proto/gogoproto
 IBC_CHANNEL_TYPES = third_party/proto/ibc/core/channel/v1
 IBC_CLIENT_TYPES = third_party/proto/ibc/core/client/v1
@@ -116,6 +111,9 @@ SDK_QUERY_TYPES  	= third_party/proto/cosmos/base/query/v1beta1
 SDK_UPGRADE_TYPES = third_party/proto/cosmos/upgrade/v1beta1
 
 proto-update-deps:
+	mkdir -p $(COSMOS_PROTO_TYPES)
+	curl -sSL $(COSMOS_PROTO_PROTO_URL)/cosmos.proto > $(COSMOS_PROTO_TYPES)/cosmos.proto
+
 	mkdir -p $(GOGO_PROTO_TYPES)
 	curl -sSL $(GOGO_PROTO_URL)/gogoproto/gogo.proto > $(GOGO_PROTO_TYPES)/gogo.proto
 

--- a/golang/cosmos/scripts/protocgen.sh
+++ b/golang/cosmos/scripts/protocgen.sh
@@ -2,6 +2,17 @@
 
 set -eo pipefail
 
+protoc_gen_gocosmos() {
+  if ! grep "github.com/gogo/protobuf => github.com/regen-network/protobuf" go.mod &>/dev/null ; then
+    echo -e "\tPlease run this command from somewhere inside the ibc-go folder."
+    return 1
+  fi
+
+  go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
+}
+
+protoc_gen_gocosmos
+
 proto_dirs=$(find . -path ./third_party -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   # NOTE: when migrating to grpc-gateway v2, we will need to remove the

--- a/golang/cosmos/third_party/proto/cosmos/base/query/v1beta1/pagination.proto
+++ b/golang/cosmos/third_party/proto/cosmos/base/query/v1beta1/pagination.proto
@@ -32,6 +32,8 @@ message PageRequest {
   bool count_total = 4;
 
   // reverse is set to true if results are to be returned in the descending order.
+  //
+  // Since: cosmos-sdk 0.43
   bool reverse = 5;
 }
 

--- a/golang/cosmos/third_party/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/golang/cosmos/third_party/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -64,6 +64,8 @@ message CancelSoftwareUpgradeProposal {
 }
 
 // ModuleVersion specifies a module and its consensus version.
+//
+// Since: cosmos-sdk 0.43
 message ModuleVersion {
   option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = true;

--- a/golang/cosmos/third_party/proto/cosmos_proto/cosmos.proto
+++ b/golang/cosmos/third_party/proto/cosmos_proto/cosmos.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package cosmos_proto;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/regen-network/cosmos-proto";
+
+extend google.protobuf.MessageOptions {
+    string interface_type = 93001;
+
+    string implements_interface = 93002;
+}
+
+extend google.protobuf.FieldOptions {
+    string accepts_interface = 93001;
+}

--- a/golang/cosmos/third_party/proto/ibc/core/channel/v1/channel.proto
+++ b/golang/cosmos/third_party/proto/ibc/core/channel/v1/channel.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";
@@ -130,6 +130,20 @@ message PacketState {
   uint64 sequence = 3;
   // embedded data that represents packet state.
   bytes data = 4;
+}
+
+// PacketId is an identifer for a unique Packet
+// Source chains refer to packets by source port/channel
+// Destination chains refer to packets by destination port/channel
+message PacketId {
+  option (gogoproto.goproto_getters) = false;
+
+  // channel port identifier
+  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  // channel unique identifier
+  string channel_id = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // packet sequence
+  uint64 sequence = 3;
 }
 
 // Acknowledgement is the recommended acknowledgement format to be used by

--- a/golang/cosmos/third_party/proto/ibc/core/client/v1/client.proto
+++ b/golang/cosmos/third_party/proto/ibc/core/client/v1/client.proto
@@ -2,11 +2,12 @@ syntax = "proto3";
 
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v4/modules/core/02-client/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "cosmos/upgrade/v1beta1/upgrade.proto";
+import "cosmos_proto/cosmos.proto";
 
 // IdentifiedClientState defines a client state with an additional client
 // identifier field.
@@ -23,7 +24,7 @@ message ConsensusStateWithHeight {
   // consensus state height
   Height height = 1 [(gogoproto.nullable) = false];
   // consensus state
-  google.protobuf.Any consensus_state = 2 [(gogoproto.moretags) = "yaml\"consensus_state\""];
+  google.protobuf.Any consensus_state = 2 [(gogoproto.moretags) = "yaml:\"consensus_state\""];
 }
 
 // ClientConsensusStates defines all the stored consensus states for a given
@@ -41,7 +42,8 @@ message ClientConsensusStates {
 // handler may fail if the subject and the substitute do not match in client and
 // chain parameters (with exception to latest height, frozen height, and chain-id).
 message ClientUpdateProposal {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)         = false;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
   // the title of the update proposal
   string title = 1;
   // the description of the proposal
@@ -56,9 +58,10 @@ message ClientUpdateProposal {
 // UpgradeProposal is a gov Content type for initiating an IBC breaking
 // upgrade.
 message UpgradeProposal {
-  option (gogoproto.goproto_getters)  = false;
-  option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.goproto_stringer)        = false;
+  option (gogoproto.equal)                   = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
   string                      title       = 1;
   string                      description = 2;


### PR DESCRIPTION

closes: #8767

## Description

Update our proto dependency fetching for new dependencies.

Update some generation details to match ibc-go machinery.

Update dependencies and regenerate `.pb.go` files. No change in these files, but previously hand-edited code is not generated correctly.

Clean up unused junk in `Makefile`.

### Security Considerations

New dependency, but only for proto files.

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

N/A

### Upgrade Considerations

N/A
