### PR TITLE
Add missing dispatch events to kernel metrics counters

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -549,16 +549,16 @@ export default function buildKernel(
     const { vatID, kpid } = message;
     insistVatID(vatID);
     insistKernelType('promise', kpid);
-    kernelKeeper.incStat('dispatches');
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
       kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
+    kernelKeeper.incStat('dispatches');
+    kernelKeeper.incStat('dispatchNotify');
     const { meterID } = vatInfo;
 
     const p = kernelKeeper.getKernelPromise(kpid);
-    kernelKeeper.incStat('dispatchNotify');
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     p.state !== 'unresolved' || Fail`spurious notification ${kpid}`;
     /** @type { KernelDeliveryOneNotify[] } */
@@ -599,6 +599,8 @@ export default function buildKernel(
     if (!vatWarehouse.lookup(vatID)) {
       return NO_DELIVERY_CRANK_RESULTS; // can't collect from the dead
     }
+    kernelKeeper.incStat('dispatches');
+    kernelKeeper.incStat('dispatchGCMessage');
     /** @type { KernelDeliveryDropExports | KernelDeliveryRetireExports | KernelDeliveryRetireImports } */
     const kd = harden([type, krefs]);
     if (type === 'retireExports') {
@@ -626,6 +628,8 @@ export default function buildKernel(
     if (!vatWarehouse.lookup(vatID)) {
       return NO_DELIVERY_CRANK_RESULTS; // can't collect from the dead
     }
+    kernelKeeper.incStat('dispatches');
+    kernelKeeper.incStat('dispatchBOYD');
     /** @type { KernelDeliveryBringOutYourDead } */
     const kd = harden([type]);
     const vd = vatWarehouse.kernelDeliveryToVatDelivery(vatID, kd);
@@ -659,6 +663,8 @@ export default function buildKernel(
       kdebug(`vat ${vatID} terminated before startVat delivered`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
+    kernelKeeper.incStat('dispatches');
+    kernelKeeper.incStat('dispatchStartVat');
     const { meterID } = vatInfo;
     /** @type { KernelDeliveryStartVat } */
     const kd = harden(['startVat', vatParameters]);
@@ -761,6 +767,8 @@ export default function buildKernel(
     if (!vatWarehouse.lookup(vatID)) {
       return NO_DELIVERY_CRANK_RESULTS; // vat is dead, ignore
     }
+    kernelKeeper.incStat('dispatches');
+    kernelKeeper.incStat('dispatchChangeVatOptions');
 
     /** @type { Record<string, unknown> } */
     const optionsForVat = {};
@@ -812,6 +820,8 @@ export default function buildKernel(
     if (!vatInfo) {
       return NO_DELIVERY_CRANK_RESULTS; // vat terminated already
     }
+    kernelKeeper.incStat('dispatches');
+    kernelKeeper.incStat('dispatchUpgradeVat');
     const { meterID } = vatInfo;
     let computrons;
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);

--- a/packages/SwingSet/src/kernel/metrics.js
+++ b/packages/SwingSet/src/kernel/metrics.js
@@ -80,6 +80,31 @@ export const KERNEL_STATS_SUM_METRICS = /** @type {const} */ ([
     name: 'swingset_dispatch_notify_total',
     description: 'Total number of SwingSet vat promise notifications',
   },
+  {
+    key: 'dispatchGCMessage',
+    name: 'swingset_dispatch_gc_total',
+    description: 'Total number of SwingSet vat GC message deliveries',
+  },
+  {
+    key: 'dispatchBOYD',
+    name: 'swingset_dispatch_boyd_total',
+    description: 'Total number of SwingSet vat BOYD deliveries',
+  },
+  {
+    key: 'dispatchStartVat',
+    name: 'swingset_dispatch_startvat_total',
+    description: 'Total number of SwingSet vat startVat deliveries',
+  },
+  {
+    key: 'dispatchChangeVatOptions',
+    name: 'swingset_dispatch_changevatoptions_total',
+    description: 'Total number of SwingSet vat changeVatOptions deliveries',
+  },
+  {
+    key: 'dispatchUpgradeVat',
+    name: 'swingset_dispatch_upgradevat_total',
+    description: 'Total number of SwingSet vat upgradeVat deliveries',
+  },
 ]);
 
 export const KERNEL_STATS_UPDOWN_METRICS = /** @type {const} */ ([


### PR DESCRIPTION
Adds metric counters for GC messages, bringOutYourDead, startVat, changeVatOptions, and upgradeVat, which never got added when these dispatch types did.

Fixes #8655
