### PR TITLE
chore(cosmic-swingset): Propagate errors from `main` in clean-core-eval.js

### DIFF
--- a/packages/cosmic-swingset/scripts/clean-core-eval.js
+++ b/packages/cosmic-swingset/scripts/clean-core-eval.js
@@ -62,16 +62,13 @@ export const main = async (argv, { readFile, stdout }) => {
 
 if (isEntrypoint(import.meta.url)) {
   /* global process */
-  void farExports.E.when(
-    import('fs/promises'),
-    fsp =>
-      main([...process.argv], {
-        readFile: fsp.readFile,
-        stdout: process.stdout,
-      }),
-    err => {
-      process.exitCode = 1;
-      console.error(err);
-    },
-  );
+  void farExports.E.when(import('fs/promises'), fsp =>
+    main([...process.argv], {
+      readFile: fsp.readFile,
+      stdout: process.stdout,
+    }),
+  ).catch(err => {
+    process.exitCode = 1;
+    console.error(err);
+  });
 }


### PR DESCRIPTION
Mistakenly changed by https://github.com/Agoric/agoric-sdk/pull/7870 .
Ref 94c6b3c83a5326594f1e2886ae01d6a703a7a68f

## Description

`E.when(…, onResolve, onReject)` does not send errors from `onResolve` to `onReject`. To preserve the intent of the original code, we want `E.when(…, onResolve).catch(onReject)`.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a

### Upgrade Considerations

n/a