### PR TITLE
restore 'builders' typecheck

### DIFF
--- a/packages/builders/scripts/inter-protocol/add-collateral-core.js
+++ b/packages/builders/scripts/inter-protocol/add-collateral-core.js
@@ -112,6 +112,7 @@ export default async (homeP, endowments) => {
 
   await writeCoreProposal('gov-add-collateral', defaultProposalBuilder);
   await writeCoreProposal('gov-start-psm', opts =>
+    // @ts-expect-error XXX makeInstallCache types
     psmProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
   );
 };

--- a/packages/builders/scripts/inter-protocol/init-core.js
+++ b/packages/builders/scripts/inter-protocol/init-core.js
@@ -192,9 +192,11 @@ export default async (homeP, endowments) => {
   });
   await Promise.all([
     writeCoreProposal('gov-econ-committee', opts =>
+      // @ts-expect-error XXX makeInstallCache types
       committeeProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
     ),
     writeCoreProposal('gov-amm-vaults-etc', opts =>
+      // @ts-expect-error XXX makeInstallCache types
       mainProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
     ),
   ]);

--- a/packages/builders/scripts/smart-wallet/build-game1-start.js
+++ b/packages/builders/scripts/smart-wallet/build-game1-start.js
@@ -27,7 +27,6 @@ export const game1ProposalBuilder = async ({ publishRef, install }) => {
   });
 };
 
-/** @type {DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('start-game1', game1ProposalBuilder);

--- a/packages/builders/scripts/smart-wallet/build-wallet-factory2-upgrade.js
+++ b/packages/builders/scripts/smart-wallet/build-wallet-factory2-upgrade.js
@@ -16,7 +16,6 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
       'getManifestForUpgradeWallet',
       {
         walletRef: publishRef(
-          // @ts-expect-error eslint is confused. The call is correct.
           install('@agoric/smart-wallet/src/walletFactory.js'),
         ),
       },

--- a/packages/builders/scripts/smart-wallet/build-walletFactory-upgrade.js
+++ b/packages/builders/scripts/smart-wallet/build-walletFactory-upgrade.js
@@ -28,7 +28,6 @@ export const defaultProposalBuilder = async ({ publishRef, install }) => {
   });
 };
 
-/** @type {DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('upgrade-walletFactory', defaultProposalBuilder);

--- a/packages/builders/scripts/vats/set-core-proposal-env.js
+++ b/packages/builders/scripts/vats/set-core-proposal-env.js
@@ -10,7 +10,7 @@ if (!spec) {
 }
 
 const vatConfigFile = require.resolve(spec);
-const configJson = fs.readFileSync(vatConfigFile);
+const configJson = fs.readFileSync(vatConfigFile, 'utf-8');
 const config = JSON.parse(configJson);
 
 const envs = new Map();

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "checkJs": false,
+    "allowSyntheticDefaultImports": true,
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 2,
   },
   "include": [
     "*.js",

--- a/packages/deploy-script-support/src/endo-pieces-contract.js
+++ b/packages/deploy-script-support/src/endo-pieces-contract.js
@@ -18,6 +18,9 @@ export const start = () => {
     });
   };
 
+  /**
+   * @param {{ zoe: ERef<ZoeService> }} opts
+   */
   const makeBundler = ({ zoe }) => {
     /** @type { Map<string, [string, Uint8Array]>} */
     const nameToContent = new Map();

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -16,7 +16,7 @@ export {};
  */
 
 /**
- * @typedef {{ bundleName: string } | { bundleID: string} } ManifestBundleRef
+ * @typedef {{fileName?: string} & ({ bundleName: string } | { bundleID: string}) } ManifestBundleRef
  */
 
 /**
@@ -26,10 +26,10 @@ export {};
  */
 
 /**
- * @callback InstallBundle
+ * @callback InstallEntrypoint
  * @param {string} srcSpec
- * @param {string} bundlePath
- * @param {any} [opts]
+ * @param {string} [bundlePath]
+ * @param {unknown} [opts]
  * @returns {Promise<ManifestBundleRef>}
  */
 
@@ -37,8 +37,8 @@ export {};
  * @callback ProposalBuilder
  * @param {{
  *   publishRef: PublishBundleRef,
- *   install: InstallBundle,
- *   wrapInstall?: <T>(f: T) => T }
+ *   install: InstallEntrypoint,
+ *   wrapInstall?: <T extends InstallEntrypoint>(f: T) => T }
  * } powers
  * @param {...any} args
  * @returns {Promise<ProposalResult>}

--- a/packages/deploy-script-support/src/getBundlerMaker.js
+++ b/packages/deploy-script-support/src/getBundlerMaker.js
@@ -14,6 +14,7 @@ import { E } from '@endo/far';
 import url from 'url';
 
 /** @typedef {ReturnType<import('./endo-pieces-contract.js')['start']>['publicFacet']} BundleMaker */
+/** @typedef {ReturnType<BundleMaker['makeBundler']>} Bundler */
 
 export const makeGetBundlerMaker =
   (homeP, { lookup, bundleSource }) =>

--- a/packages/deploy-script-support/src/writeCoreProposal.js
+++ b/packages/deploy-script-support/src/writeCoreProposal.js
@@ -39,6 +39,7 @@ export const makeWriteCoreProposal = (
   const { bundleSource, pathResolve } = endowments;
 
   let bundlerCache;
+  /** @returns {import('./getBundlerMaker.js').Bundler} */
   const getBundler = () => {
     if (!bundlerCache) {
       bundlerCache = E(getBundlerMaker()).makeBundler({
@@ -120,6 +121,7 @@ export const makeWriteCoreProposal = (
 
     // Await a reference then publish to the board.
     const cmds = [];
+    /** @param {Promise<import('./externalTypes.js').ManifestBundleRef>} refP */
     const publishRef = async refP => {
       const { fileName, ...ref } = await refP;
       if (fileName) {

--- a/packages/deploy-script-support/test/unitTests/test-installInPieces.js
+++ b/packages/deploy-script-support/test/unitTests/test-installInPieces.js
@@ -27,6 +27,7 @@ test('installInPieces', async t => {
     },
   };
 
+  // @ts-expect-error fake Zoe
   const bundler = E(publicFacet).makeBundler({ zoe });
 
   const installation = await installInPieces(endoPieces, bundler, {


### PR DESCRIPTION
## Description

Typechecking of `deploy-script-support` was lost at some point.  https://github.com/Agoric/agoric-sdk/pull/8747#discussion_r1458353153

This restores the checking and resolves the errors encountered.

I punted on solving the `makeInstallCache` types.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
