### PR TITLE
feat(zoe): getInvitationDetails enforces singleton invitation

### DIFF
--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -58,6 +58,7 @@
     "@endo/common": "^1.1.0",
     "@endo/captp": "^4.0.4",
     "@endo/eventual-send": "^1.1.2",
+    "@endo/exo": "^1.2.1",
     "@endo/far": "^1.0.4",
     "@endo/import-bundle": "^1.0.4",
     "@endo/marshal": "^1.3.0",

--- a/packages/zoe/src/zoeService/invitationQueries.js
+++ b/packages/zoe/src/zoeService/invitationQueries.js
@@ -17,7 +17,7 @@ export const makeInvitationQueryFns = invitationIssuer => {
       .getAmountOf(invitationP)
       .catch(onRejected);
     (Array.isArray(invAmount.value) && invAmount.value.length === 1) ||
-      Fail`Expected exactly one invitation, not ${q(invAmount.value.length)}`;
+      Fail`Expected exactly 1 invitation, not ${q(invAmount.value.length)}`;
     return invAmount.value[0];
   };
 

--- a/packages/zoe/src/zoeService/invitationQueries.js
+++ b/packages/zoe/src/zoeService/invitationQueries.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import { assert, details as X } from '@agoric/assert';
+import { assert, details as X, Fail, quote as q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 
 export const makeInvitationQueryFns = invitationIssuer => {
@@ -13,10 +13,12 @@ export const makeInvitationQueryFns = invitationIssuer => {
       assert.note(err, X`Due to ${reason}`);
       throw err;
     };
-    return E.get(
-      E.get(E(invitationIssuer).getAmountOf(invitationP).catch(onRejected))
-        .value,
-    )[0];
+    const invAmount = await E(invitationIssuer)
+      .getAmountOf(invitationP)
+      .catch(onRejected);
+    (Array.isArray(invAmount.value) && invAmount.value.length === 1) ||
+      Fail`Expected exactly one invitation, not ${q(invAmount.value.length)}`;
+    return invAmount.value[0];
   };
 
   /** @type {GetInstance} */

--- a/packages/zoe/test/unitTests/contracts/test-invitation-details.js
+++ b/packages/zoe/test/unitTests/contracts/test-invitation-details.js
@@ -1,0 +1,88 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import path from 'path';
+
+import bundleSource from '@endo/bundle-source';
+import { E } from '@endo/eventual-send';
+import { AmountMath } from '@agoric/ertp';
+
+import { makeZoeForTest } from '../../../tools/setup-zoe.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const root = `${dirname}/two-invitations.js`;
+
+test('plural invitation details', async t => {
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
+  const zoe = makeZoeForTest(fakeVatAdmin);
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+
+  // Pack the contract.
+  const bundle = await bundleSource(root);
+  vatAdminState.installBundle('a1-two-invitations', bundle);
+  const installation = await E(zoe).installBundleID('a1-two-invitations');
+
+  const { creatorFacet: twoInvitations } = await E(zoe).startInstance(
+    installation,
+    undefined,
+    undefined,
+    undefined,
+    'a1-two-invitations',
+  );
+
+  const i1 = await E(twoInvitations).get1();
+  const i2 = await E(twoInvitations).get2();
+
+  const i1Amount = await E(invitationIssuer).getAmountOf(i1);
+  const i2Amount = await E(invitationIssuer).getAmountOf(i2);
+  const bothAmount = AmountMath.add(i1Amount, i2Amount);
+
+  const i1Detail = await E(zoe).getInvitationDetails(i1);
+  const i2Detail = await E(zoe).getInvitationDetails(i2);
+
+  t.deepEqual(i1Detail, {
+    ...i1Detail,
+    description: 'invite1',
+    customDetails: {
+      i: 1,
+    },
+  });
+
+  t.deepEqual(i2Detail, {
+    ...i2Detail,
+    description: 'invite2',
+    customDetails: {
+      i: 2,
+    },
+  });
+
+  const invitePurse = E(invitationIssuer).makeEmptyPurse();
+  t.true(await E(invitationIssuer).isLive(i1));
+  t.true(await E(invitationIssuer).isLive(i2));
+
+  await E(invitePurse).deposit(i1);
+  await E(invitePurse).deposit(i2);
+
+  t.false(await E(invitationIssuer).isLive(i1));
+  t.false(await E(invitationIssuer).isLive(i2));
+
+  const bothPayment = await E(invitePurse).withdraw(bothAmount);
+
+  const bothDetails = await E(zoe).getInvitationDetails(bothPayment);
+
+  // This demonstrates the bug that
+  // https://github.com/Agoric/agoric-sdk/pull/8780 fixes.
+  // `bothPayment` is a valid payment that carries the rights to two
+  // invitations. However, this violates the singleton assumption of
+  // `getInvitationDetails`, which just returns one of them,
+  // silently dropping the other.
+  t.deepEqual(bothDetails, {
+    ...i1Detail,
+    description: 'invite2',
+    customDetails: {
+      i: 2,
+    },
+  });
+});

--- a/packages/zoe/test/unitTests/contracts/test-invitation-details.js
+++ b/packages/zoe/test/unitTests/contracts/test-invitation-details.js
@@ -71,6 +71,6 @@ test('plural invitation details', async t => {
   const bothPayment = await E(invitePurse).withdraw(bothAmount);
 
   await t.throwsAsync(() => E(zoe).getInvitationDetails(bothPayment), {
-    message: 'Expected exactly one invitation, not 2',
+    message: 'Expected exactly 1 invitation, not 2',
   });
 });

--- a/packages/zoe/test/unitTests/contracts/test-invitation-details.js
+++ b/packages/zoe/test/unitTests/contracts/test-invitation-details.js
@@ -70,19 +70,7 @@ test('plural invitation details', async t => {
 
   const bothPayment = await E(invitePurse).withdraw(bothAmount);
 
-  const bothDetails = await E(zoe).getInvitationDetails(bothPayment);
-
-  // This demonstrates the bug that
-  // https://github.com/Agoric/agoric-sdk/pull/8780 fixes.
-  // `bothPayment` is a valid payment that carries the rights to two
-  // invitations. However, this violates the singleton assumption of
-  // `getInvitationDetails`, which just returns one of them,
-  // silently dropping the other.
-  t.deepEqual(bothDetails, {
-    ...i1Detail,
-    description: 'invite2',
-    customDetails: {
-      i: 2,
-    },
+  await t.throwsAsync(() => E(zoe).getInvitationDetails(bothPayment), {
+    message: 'Expected exactly one invitation, not 2',
   });
 });

--- a/packages/zoe/test/unitTests/contracts/two-invitations.js
+++ b/packages/zoe/test/unitTests/contracts/two-invitations.js
@@ -1,0 +1,29 @@
+import { M } from '@endo/patterns';
+import { makeExo } from '@endo/exo';
+
+/**
+ * This contract just provides two invitations to support the test in
+ * test-invitation-details.js
+ *
+ * @type {ContractStartFn}
+ */
+export const start = zcf => {
+  return harden({
+    creatorFacet: makeExo(
+      'TwoInvitations',
+      M.interface('TwoInvitations', {
+        get1: M.callWhen().returns(M.remotable('Invitation')),
+        get2: M.callWhen().returns(M.remotable('Invitation')),
+      }),
+      {
+        get1() {
+          return zcf.makeInvitation(() => null, 'invite1', harden({ i: 1 }));
+        },
+        get2() {
+          return zcf.makeInvitation(() => null, 'invite2', harden({ i: 2 }));
+        },
+      },
+    ),
+  });
+};
+harden(start);


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/issues/8358 , https://github.com/Agoric/agoric-sdk/pull/9090

## Description

This PR doesn't close https://github.com/Agoric/agoric-sdk/issues/8358 , but does effectively do an important special case: Callers of `getInvitationDetails(invitationPayment)` invariably assume our normal case of representing an invitation as a payment carrying that one invitation. However, as an ERTP non-fungble `'set'`-style asset, the payment's amount carries a set of invitation descriptions, meaning that the payment itself carries any number of invitations as the transferable assets.

We believe we never use that flexibility, and only even use invitation payments carrying exactly one invitation. However, this assumption is not checked. This PR adds this check specifically to `getInvitationDetails` that is widely used to get an invitation's details. But it is not universally used everywhere we make this assumption, so even after this PR we may have other places where we assume this without checking.

### Security Considerations

The point. This unchecked assumption raises the possibility of confusion attacks, where, let's say, Alice somehow leads Bob into forming a payment carrying multiple invitations, where our code then *silently* processes only one of these and drops the other on the floor. With this PR, some of these confusion attacks will now fail with a diagnostic, so at least the potential vulnerability can be fixed. If this failure happens "soon enough", it may also fail safe, preventing Bob from losing an invitation asset.

### Scaling Considerations
none
### Documentation Considerations
We always should have documented this restriction on our normal use of payments as invitations. This PR reminds us of this need.
### Testing Considerations

At https://github.com/Agoric/agoric-sdk/pull/9090 the first commit ran to completion in CI with all successes. It only adds a test case that, as of that first commit by itself, demonstrates the bug.

The second commit both fixes the bug, and fixes the test to pass again, thereby demonstrating the change in behavior caused by this fix.

### Upgrade Considerations

In theory it is possible that there is some working code making use of payments carrying multiple invitation descriptions, and correctly accessing only the zeroth by using `getInvitationDetails`. This PR would break such currently-correct code. More likely, any code broken by this PR was already incorrect, and breaking it would be better than allowing to continue silently doing the wrong thing.

Note that CI is green with this PR and no other changes, so at least the existing CI tests never violate the assumption where this PR would enforce it.