### PR TITLE
7918 upgrade15 update zoe zcf

### DIFF
--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -10,6 +10,9 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
 
   if (zoeBaggage.has(BUILD_PARAMS_KEY)) {
     const { feeIssuerConfig, zcfSpec } = zoeBaggage.get(BUILD_PARAMS_KEY);
+    // The return value is `{ zoeService, zoeConfigFacet, feeMintAccess }`. This
+    // call only needs zoeConfigFacet because the others have been returned.
+    // zoeConfigFacet was added after the first release of Zoe on-chain.
     ({ zoeConfigFacet } = makeDurableZoeKit({
       // For now Zoe will rewire vatAdminSvc on its own
       shutdownZoeVat,

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -6,15 +6,17 @@ const BUILD_PARAMS_KEY = 'buildZoeParams';
 export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
   const shutdownZoeVat = vatPowers.exitVatWithFailure;
 
+  let zoeConfigFacet;
+
   if (zoeBaggage.has(BUILD_PARAMS_KEY)) {
     const { feeIssuerConfig, zcfSpec } = zoeBaggage.get(BUILD_PARAMS_KEY);
-    makeDurableZoeKit({
+    ({ zoeConfigFacet } = makeDurableZoeKit({
       // For now Zoe will rewire vatAdminSvc on its own
       shutdownZoeVat,
       feeIssuerConfig,
       zcfSpec,
       zoeBaggage,
-    });
+    }));
   }
 
   return Far('root', {
@@ -44,5 +46,6 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
         feeMintAccess,
       });
     },
+    getZoeConfigFacet: () => zoeConfigFacet,
   });
 }

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -182,7 +182,8 @@ const makeDurableZoeKit = ({
           zcfBundleCap = bundleCap;
         },
         e => {
-          console.warn(`unable to update ZCF Bundle: `, e);
+          console.error(`'🚨 unable to update ZCF Bundle: `, e);
+          throw e;
         },
       );
     },

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -1,5 +1,10 @@
 import { E } from '@endo/far';
-import { AssetKind, makeDurableIssuerKit, AmountMath } from '@agoric/ertp';
+import {
+  AssetKind,
+  makeDurableIssuerKit,
+  AmountMath,
+  prepareIssuerKit,
+} from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
@@ -117,7 +122,7 @@ export const makeZoeStorageManager = (
     'zoeMintBaggageSet',
   );
   for (const issuerBaggage of zoeMintBaggageSet.values()) {
-    zoeMintBaggageSet(issuerBaggage);
+    prepareIssuerKit(issuerBaggage);
   }
 
   const makeZoeMint = prepareExoClass(


### PR DESCRIPTION
refs: #7918 
refs: #7918
refs: #6678
refs: #7946

## Description

Add to the release branch the code to allow updating the version of ZCF to be used on contract upgrades. (https://github.com/Agoric/agoric-sdk/pull/7918)

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Has been tested in swingSetTests, and in docker. Once the release branch is ready, we'll add a3p-integration tests, too.

### Upgrade Considerations

Allows contract vats to be upgraded.
