### PR TITLE
fix: When setting a new zcfBundleCap, store it in baggage

### DIFF
--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -180,9 +180,10 @@ const makeDurableZoeKit = ({
         getZcfBundleCap({ id: bundleId }, vatAdminSvc),
         bundleCap => {
           zcfBundleCap = bundleCap;
+          zoeBaggage.set('zcfBundleCap', zcfBundleCap);
         },
         e => {
-          console.error(`'🚨 unable to update ZCF Bundle: `, e);
+          console.error('🚨 unable to update ZCF Bundle: ', e);
           throw e;
         },
       );

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -57,13 +57,18 @@ const makeDurableZoeKit = ({
   let zcfBundleCap;
 
   const saveBundleCap = () => {
-    E.when(
+    void E.when(
       Promise.all([vatAdminSvc, getZcfBundleCap(zcfSpec, vatAdminSvc)]),
       ([vatAdminService, bundleCap]) => {
         zcfBundleCap = bundleCap;
 
-        zoeBaggage.init('vatAdminSvc', vatAdminService);
-        zoeBaggage.init('zcfBundleCap', zcfBundleCap);
+        if (!zoeBaggage.has('vatAdminSvc')) {
+          zoeBaggage.init('vatAdminSvc', vatAdminService);
+          zoeBaggage.init('zcfBundleCap', zcfBundleCap);
+        } else {
+          zoeBaggage.set('vatAdminSvc', vatAdminService);
+          zoeBaggage.set('zcfBundleCap', zcfBundleCap);
+        }
       },
     );
   };
@@ -176,7 +181,7 @@ const makeDurableZoeKit = ({
 
   const zoeConfigFacet = prepareExo(zoeBaggage, 'ZoeConfigFacet', ZoeConfigI, {
     updateZcfBundleId(bundleId) {
-      E.when(
+      void E.when(
         getZcfBundleCap({ id: bundleId }, vatAdminSvc),
         bundleCap => {
           zcfBundleCap = bundleCap;


### PR DESCRIPTION
refs: #8806

## Description

Copy of #8806 for the upgrade-15 release branch

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

As we're testing zoe upgrades in a3p, verify that the newly set value survives zoe upgrade.

### Upgrade Considerations

Prep it for upgrade.