### PR TITLE
fix(vats): include index.js in NPM package

### DIFF
--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -55,9 +55,8 @@
     "src/",
     "scripts/",
     "tools/",
-    "*.json",
-    "globals.d.ts",
-    "exported.js"
+    "index.*",
+    "exported.*"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
closes: #8809

## Description

Add missing file to NPM package

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Our test coverage is abysmal here, but out of scope.

I have manually verified that the package now contains all expected files
```term
$ tar -tvzf agoric-vats-v0.15.1.tgz | head -n 9
drwxr-xr-x 0/0               0 2024-01-25 18:30 package
-rw-r--r-- 0/0           69166 2024-01-25 18:17 package/CHANGELOG.md
-rw-r--r-- 0/0              69 2024-01-25 18:17 package/README.md
-rw-r--r-- 0/0              49 2024-01-25 18:30 package/exported.d.ts
-rw-r--r-- 0/0             103 2024-01-25 18:30 package/exported.d.ts.map
-rw-r--r-- 0/0              38 2024-01-25 18:17 package/exported.js
-rw-r--r-- 0/0             259 2024-01-25 18:30 package/index.d.ts
-rw-r--r-- 0/0              97 2024-01-25 18:30 package/index.d.ts.map
-rw-r--r-- 0/0             376 2024-01-25 18:17 package/index.js
```

### Upgrade Considerations

Must be included in release branch to be published. Verified that the same change is needed there