### PR TITLE
refactor(internal): Doing a TODO for UpgradeDisconnectionShape

### DIFF
--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -60,7 +60,7 @@ export {};
  * @typedef { import('@agoric/swingset-liveslots').Message } Message
  *
  * @typedef { 'none' | 'ignore' | 'logAlways' | 'logFailure' | 'panic' } ResolutionPolicy
- * @typedef {import('@agoric/internal/src/upgrade-api.js').DisconnectionObject} DisconnectionObject
+ * @typedef {import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} UpgradeDisconnection
  *
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryObject } VatDeliveryObject
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryResult } VatDeliveryResult

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -60,7 +60,6 @@ export {};
  * @typedef { import('@agoric/swingset-liveslots').Message } Message
  *
  * @typedef { 'none' | 'ignore' | 'logAlways' | 'logFailure' | 'panic' } ResolutionPolicy
- * @typedef {import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} UpgradeDisconnection
  *
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryObject } VatDeliveryObject
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryResult } VatDeliveryResult

--- a/packages/internal/src/upgrade-api.js
+++ b/packages/internal/src/upgrade-api.js
@@ -1,18 +1,34 @@
 // @ts-check
 // @jessie-check
-import { isObject } from '@endo/marshal';
+
+import { M, matches } from '@endo/patterns';
+
+const { isFrozen } = Object;
 
 /**
- * @typedef {{ name: string, upgradeMessage: string, incarnationNumber: number }} DisconnectionObject
+ * An Error-like object for use as the rejection reason of promises
+ * abandoned by upgrade.
+ *
+ * @typedef {{
+ *   name: string,
+ *   upgradeMessage: string,
+ *   incarnationNumber: number
+ * }} UpgradeDisconnection
  */
 
+export const UpgradeDisconnectionShape = harden({
+  name: 'vatUpgraded',
+  upgradeMessage: M.string(),
+  incarnationNumber: M.number(),
+});
+
 /**
- * Makes an Error-like object for use as the rejection value of promises
+ * Makes an Error-like object for use as the rejection reason of promises
  * abandoned by upgrade.
  *
  * @param {string} upgradeMessage
  * @param {number} toIncarnationNumber
- * @returns {DisconnectionObject}
+ * @returns {UpgradeDisconnection}
  */
 export const makeUpgradeDisconnection = (upgradeMessage, toIncarnationNumber) =>
   harden({
@@ -22,20 +38,12 @@ export const makeUpgradeDisconnection = (upgradeMessage, toIncarnationNumber) =>
   });
 harden(makeUpgradeDisconnection);
 
-// TODO: Simplify once we have @endo/patterns (or just export the shape).
-// const upgradeDisconnectionShape = harden({
-//   name: 'vatUpgraded',
-//   upgradeMessage: M.string(),
-//   incarnationNumber: M.number(),
-// });
-// const isUpgradeDisconnection = err => matches(err, upgradeDisconnectionShape);
 /**
- * @param {any} err
- * @returns {err is DisconnectionObject}
+ * @param {any} reason
+ *   If `reason` is not frozen, it cannot be an UpgradeDisconnection,
+ *   so returns false without even checking against the shape.
+ * @returns {reason is UpgradeDisconnection}
  */
-export const isUpgradeDisconnection = err =>
-  isObject(err) &&
-  err.name === 'vatUpgraded' &&
-  typeof err.upgradeMessage === 'string' &&
-  typeof err.incarnationNumber === 'number';
+export const isUpgradeDisconnection = reason =>
+  isFrozen(reason) && matches(reason, UpgradeDisconnectionShape);
 harden(isUpgradeDisconnection);

--- a/packages/internal/src/upgrade-api.js
+++ b/packages/internal/src/upgrade-api.js
@@ -10,7 +10,7 @@ const { isFrozen } = Object;
  * abandoned by upgrade.
  *
  * @typedef {{
- *   name: string,
+ *   name: 'vatUpgraded',
  *   upgradeMessage: string,
  *   incarnationNumber: number
  * }} UpgradeDisconnection


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #8742 #7401 

## Description

Happened to run across this TODO from #7401 while reviewing #8742. Looking, at the #7401 review, I see at https://github.com/Agoric/agoric-sdk/pull/7401/files#diff-0bf8845b178624f94f798671028604656a8848e55e1f41784fa4b37b5236ee96

> My first attempt didn't quite work, so I'm deferring this until we've got a little more time to spend on it.

So I thought I'd give it a trivial try and see what CI has to say about it.
As a result: It seems the problem is that `isUpgradeDisconnection` was sometimes applied to non-frozen non-UpgradeDisconnection objects, such as errors thrown by the platform or by a raw `throw *Error(...);`. So added an early `isFrozen` conjunct.

Also
- since the UpgradeDisconnection is not and error, but is to be used as a promise-rejection-reason, changed terminology from `err` to `reason`.
- given the rest of the API, IMO the type should be named `UpgradeDisconnection`. So I did that rename. 


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
