### PR TITLE
build(golang): Support faster local iteration and align better with upstream

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -61,10 +61,10 @@ node-compile-gyp:
 		npm run build:gyp; \
 	fi
 
-compile-agd: go-mod-cache
+compile-agd: go.sum
 	go build -v $(MOD_READONLY) $(BUILD_FLAGS) -buildmode=exe -o build/agd ./cmd/agd
 
-install-agd: go-mod-cache
+install-agd: go.sum
 	go install -v $(MOD_READONLY) $(BUILD_FLAGS) -buildmode=exe ./cmd/agd
 
 # Only run from the package.json build:gyp script.
@@ -73,17 +73,18 @@ compile-gyp:
 	node-gyp configure build $(GYP_DEBUG) || { status=$$?; rm -f binding.gyp; exit $$status; }
 	rm -f binding.gyp
 
-compile-libdaemon: go-mod-cache
+compile-libdaemon: go.sum
 	go build -v $(MOD_READONLY) $(SHARED_BUILD_FLAGS) -buildmode=c-shared \
 		-o build/libagcosmosdaemon.so ./cmd/libdaemon/main.go
 
-go-mod-cache: go.sum
-	@echo "--> Download go modules to local cache"
-	@go mod download
-
 go.sum: go.mod
-	@echo "--> Ensure dependencies have not been modified"
+	@echo "--> Ensure dependencies have not been modified unless suppressed by SKIP_MOD_VERIFY ..."
+ifndef SKIP_MOD_VERIFY
 	GO111MODULE=on go mod verify
+endif
+	GO111MODULE=on go mod tidy
+	@echo "--> Download go modules to local cache"
+	go mod download
 
 ###############################################################################
 ###                           Protobuf                                    ###

--- a/packages/cosmic-proto/update-protos.sh
+++ b/packages/cosmic-proto/update-protos.sh
@@ -7,7 +7,7 @@ AG_SDK=$(readlink -f "$(dirname -- "$(readlink -f -- "$0")")/../..")
 
 # go ensure fresh build
 cd "$AG_SDK"/golang/cosmos
-make go-mod-cache
+SKIP_MOD_VERIFY=1 make go.sum
 COSMOS_SDK=$(go list -m -f '{{ .Dir }}' github.com/cosmos/cosmos-sdk)
 IBC_GO=$(go list -m -f '{{ .Dir }}' github.com/cosmos/ibc-go/v6)
 cd -


### PR DESCRIPTION
## Description

* Replace synthetic "go-mod-cache" Makefile target with direct dependence upon go.sum ([as upstream](https://github.com/cosmos/cosmos-sdk/blob/1f0c68d08f669c6813f9759fcc254a72855a577c/Makefile#L173-L176)).
* Introduce support for `make SKIP_MOD_VERIFY=1` to avoid unnecessary expensive scans when e.g. tweaking referents of local-directory `replace $modulePath => ../path/to/module` directives in go.mod.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

There is no formal place to document the new make variable, so it is instead directly mentioned in make output.

### Testing Considerations

Manually verified expected behavior in various scenarios (e.g., running `make` without `go.mod` changes).

### Upgrade Considerations

n/a