### PR TITLE
speed up sdk rebuild

### DIFF
--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -19,8 +19,7 @@
   },
   "ava": {
     "concurrency": 1,
-    "serial": true,
-    "timeout": "1m",
+    "timeout": "2m",
     "files": [
       "!submission"
     ]

--- a/a3p-integration/proposals/a:upgrade-next/priceFeed.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/priceFeed.test.js
@@ -120,19 +120,23 @@ const getPriceQuote = async price => {
 
 test.serial('push prices', async t => {
   // There are no old prices for the other currencies.
+  t.log('awaiting ATOM price pre');
   const atomOutPre = await getPriceQuote('ATOM');
   t.is(atomOutPre, '+12010000');
 
+  t.log('adding oracle for each brand');
   await addOraclesForBrand('ATOM');
   await addOraclesForBrand('stATOM');
   await addOraclesForBrand('stTIA');
   await addOraclesForBrand('stOSMO');
 
+  t.log('pushing new prices');
   await pushPrices(11.2, 'ATOM');
   await pushPrices(11.3, 'stTIA');
   await pushPrices(11.4, 'stATOM');
   await pushPrices(11.5, 'stOSMO');
 
+  t.log('awaiting new quotes');
   // agd query -o json  vstorage data published.priceFeed.stOSMO-USD_price_feed |&
   //   jq '.value | fromjson | .values[0] | fromjson | .body[1:] | fromjson | .amountOut.value'
   const atomOut = await getPriceQuote('ATOM');

--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": "^18.12 || ^20.9"
   },
+  "packageManager": "yarn@1.22.19",
   "scripts": {
     "test": "exit 0",
     "build:all": "make",

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -78,7 +78,8 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y vim jq less 
 WORKDIR /usr/src
 COPY --from=build-js /usr/src/agoric-sdk agoric-sdk
 COPY --from=otel /otelcol-contrib /usr/local/bin/
-RUN ln -s /usr/src/agoric-sdk/bin/agd /usr/local/bin/
+# use the naked binary of agd instead of the wrapper script that rebuilds sometimes
+RUN ln -s /usr/src/agoric-sdk/golang/cosmos/build/agd /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/solo/bin/ag-solo /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/agoric-cli/bin/agoric /usr/local/bin/

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -8,9 +8,11 @@ RUN go mod download
 
 COPY golang/cosmos ./
 
+# Optional, set in workflow push the SDK image but not in builds for test
 ARG GIT_COMMIT
 ARG GIT_REVISION
-RUN make GIT_COMMIT="$GIT_COMMIT" GIT_REVISION="$GIT_REVISION" MOD_READONLY= compile-go
+ENV GOCACHE=/root/.cache/go-build
+RUN --mount=type=cache,target=$GOCACHE make GIT_COMMIT="$GIT_COMMIT" GIT_REVISION="$GIT_REVISION" MOD_READONLY= compile-go
 
 ###############################
 # OTEL fetch
@@ -29,10 +31,28 @@ RUN set -eux; \
   echo "${otelHash} otel.tgz" | sha256sum -c -; \
   tar -C / -xzf otel.tgz
 
+###############################
+# @agoric/cosmos package
+FROM node:18-bullseye AS cosmos-package
+ENV YARN_CACHE_FOLDER=/root/.yarn
+
+WORKDIR /usr/src/agoric-sdk/golang/cosmos
+COPY --from=cosmos-go --link /usr/src/agoric-sdk/golang/cosmos .
+
+RUN corepack enable
+RUN yarn install --frozen-lockfile
+RUN yarn build:gyp
+
+# Remove dev dependencies.
+WORKDIR /usr/src/agoric-sdk/
+RUN mkdir golang/tmp && \
+  mv golang/cosmos/package.json golang/cosmos/build golang/cosmos/index.cjs golang/tmp/ && \
+  rm -rf golang/cosmos && mv golang/tmp golang/cosmos
 
 ###############################
-# The js build container
-FROM node:18-bullseye AS build-js
+# @agoric/xsnap package
+FROM node:18-bullseye AS xsnap-package
+ENV YARN_CACHE_FOLDER=/root/.yarn
 
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
@@ -42,14 +62,9 @@ ARG XSNAP_NATIVE_COMMIT_HASH
 ARG XSNAP_NATIVE_URL
 
 WORKDIR /usr/src/agoric-sdk
-COPY . .
+COPY --link packages/xsnap packages/xsnap
 
-# add retry for qemu arm64 network fetching and mui issues with qemu
-RUN bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
-
-# Need to build the Node.js node extension that uses our above Golang shared library.
-COPY --from=cosmos-go /usr/src/agoric-sdk/golang/cosmos/build golang/cosmos/build/
-
+WORKDIR /usr/src/agoric-sdk/packages/xsnap
 # Check out the specified submodule versions.
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
@@ -58,15 +73,32 @@ RUN \
   MODDABLE_URL="$MODDABLE_URL" \
   XSNAP_NATIVE_COMMIT_HASH="$XSNAP_NATIVE_COMMIT_HASH" \
   XSNAP_NATIVE_URL="$XSNAP_NATIVE_URL" \
-  bin/agd build
+  yarn build
 
 # Remove dev dependencies.
+WORKDIR /usr/src/agoric-sdk
 RUN rm -rf packages/xsnap/moddable packages/xsnap/xsnap-native/build/tmp
-RUN mkdir golang/tmp && \
-  mv golang/cosmos/package.json golang/cosmos/build golang/cosmos/index.cjs golang/tmp/ && \
-  rm -rf golang/cosmos && mv golang/tmp golang/cosmos
-# FIXME: This causes bundling differences.  https://github.com/endojs/endo/issues/919
-# RUN yarn install --frozen-lockfile --production --network-timeout 100000
+
+###############################
+# The js build container
+FROM node:18-bullseye AS build-js
+ENV YARN_CACHE_FOLDER=/root/.yarn
+
+WORKDIR /usr/src/agoric-sdk
+
+# Minimal to build SDK (exclude docs, a3p-integration, etc)
+COPY --link lerna.json package.json repoconfig.sh tsconfig.json yarn.lock ./
+COPY --link bin bin
+COPY --link packages packages
+COPY --link patches patches
+COPY --from=cosmos-package --link /usr/src/agoric-sdk/golang golang
+COPY --from=xsnap-package --link /usr/src/agoric-sdk/packages/xsnap packages/xsnap
+
+RUN --mount=type=cache,target=$YARN_CACHE_FOLDER yarn install --frozen-lockfile
+
+# build everything except xsnap, built above. 'cosmos' was also built above but
+# it's safe to include here because its package "build" script is "exit 0".
+RUN yarn lerna run --ignore "@agoric/xsnap" build
 
 ###############################
 # The install container.
@@ -76,14 +108,14 @@ FROM node:18-bullseye AS install
 RUN apt-get --allow-releaseinfo-change update && apt-get install -y vim jq less && apt-get clean -y
 
 WORKDIR /usr/src
-COPY --from=build-js /usr/src/agoric-sdk agoric-sdk
-COPY --from=otel /otelcol-contrib /usr/local/bin/
+COPY --from=build-js --link /usr/src/agoric-sdk agoric-sdk
+COPY --from=otel --link /otelcol-contrib /usr/local/bin/
 # use the naked binary of agd instead of the wrapper script that rebuilds sometimes
 RUN ln -s /usr/src/agoric-sdk/golang/cosmos/build/agd /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/solo/bin/ag-solo /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/agoric-cli/bin/agoric /usr/local/bin/
-COPY . lib/ag-solo/
+COPY --link . lib/ag-solo/
 
 ARG GIT_REVISION=unknown
 RUN echo "$GIT_REVISION" > /usr/src/agoric-sdk/packages/solo/public/git-revision.txt
@@ -93,6 +125,7 @@ RUN ln -sf /data /agoric
 RUN ln -sf /data/solo /usr/src/agoric-sdk/packages/cosmic-swingset/solo
 RUN ln -sf /data/chains /usr/src/agoric-sdk/packages/cosmic-swingset/chains
 
+COPY --link scripts agoric-sdk/scripts
 RUN /usr/src/agoric-sdk/scripts/smoketest-binaries.sh
 
 # By default, run the daemon with specified arguments.

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -3,9 +3,6 @@ REPOSITORY_SDK = ghcr.io/agoric/agoric-sdk
 SS := ../cosmic-swingset/
 
 TAG := unreleased
-GIT_REVISION := $(shell hash=$$(git rev-parse --short HEAD); \
-	dirty=`git diff --quiet 2>/dev/null || echo -dirty`; \
-	echo "$$hash$$dirty")
 
 default: docker-build
 
@@ -18,7 +15,7 @@ docker-build: docker-build-sdk docker-build-solo \
 
 docker-build-sdk:
 	bargs=`node ../xsnap/src/build.js --show-env | sed -e 's/^/ --build-arg=/'`; \
-	docker build $$bargs --build-arg=GIT_REVISION=$(GIT_REVISION) \
+	docker build $$bargs \
 		-t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
 	docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 


### PR DESCRIPTION
closes: #8848

## Description

Cuts a couple minutes wait off re-builds when JS changed and removes the 1min cost for commits.

Benchmarking with `yarn build:sdk` in a3p-integration after `docker system prune`.

Step | master (sec) | PR (sec)
-- | -- | --
Prune + build | `149.2` | `155.5`
Rebuild | `   .7` | `   .6`
Modify vat + build | `177.0` | ` 73.0`
Rebuild | `   .9` | `   .9`
Commit change + build | ` 70.7` | `   .7`
Rebuild | `   .8` | `   .5`

That 73s after changing a vat is because Yarn classic is being dumb about "building fresh packages" for 48s. That will go away with,
- https://github.com/Agoric/agoric-sdk/issues/451

### Security Considerations

n/a, local

### Scaling Considerations

n/a, local

### Documentation Considerations

should be transparent


### Testing Considerations

Tested locally

### Upgrade Considerations

n/a