### PR TITLE
feat: repair KREAd contract on zoe upgrade

### DIFF
--- a/a3p-integration/proposals/a:upgrade-14/create-kread-item-test.sh
+++ b/a3p-integration/proposals/a:upgrade-14/create-kread-item-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+source /usr/src/upgrade-test-scripts/env_setup.sh
+
+OFFER=$(mktemp -t agops.XXX)
+agops vaults open --wantMinted 6.00 --giveCollateral 9.0 >|"$OFFER"
+agoric wallet send --offer "$OFFER" --from gov1 --keyring-backend="test"
+
+
+govamount="200000000ubld"
+provisionSmartWallet $GOV1ADDR $govamount
+
+KREAD_ITEM_OFFER=$(mktemp -t kreadItem.XXX)
+node ./generate-kread-item-request.mjs > $KREAD_ITEM_OFFER
+agops perf satisfaction --from $GOV1ADDR --executeOffer $KREAD_ITEM_OFFER --keyring-backend=test
+
+agd query vstorage data published.wallet.$GOV1ADDR.current  -o json >& gov1.out
+name=`jq '.value | fromjson | .values[2] | fromjson | .body[1:] | fromjson | .purses[1].balance.value.payload[0][0].name ' gov1.out`
+test_val $name \"ephemeral_Ace\" "found KREAd character"

--- a/a3p-integration/proposals/a:upgrade-14/generate-kread-item-request.mjs
+++ b/a3p-integration/proposals/a:upgrade-14/generate-kread-item-request.mjs
@@ -1,0 +1,76 @@
+/* global process */
+import assert from 'assert';
+import { execFile } from 'child_process';
+
+const ISTunit = 1_000_000n; // aka displayInfo: { decimalPlaces: 6 }
+
+const id = `KREAd-test-${Date.now()}`;
+
+// poor-man's zx
+const $ = cmd => {
+  const [file, ...args] = cmd.split(' ');
+
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { encoding: 'utf8' }, (err, out) => {
+      if (err) return reject(err);
+      resolve(out);
+    });
+  });
+};
+
+const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
+
+const fromSmallCapsEntries = txt => {
+  const { body, slots } = JSON.parse(txt);
+  const theEntries = zip(JSON.parse(body.slice(1)), slots).map(
+    ([[name, ref], boardID]) => {
+      const iface = ref.replace(/^\$\d+\./, '');
+      return [name, { iface, boardID }];
+    },
+  );
+  return Object.fromEntries(theEntries);
+};
+
+const brand = fromSmallCapsEntries(
+  await $('agoric follow -lF :published.agoricNames.brand -o text'),
+);
+assert(brand.IST);
+
+const slots = []; // XXX global mutable state
+
+const smallCaps = {
+  Nat: n => `+${n}`,
+  // XXX mutates obj
+  ref: obj => {
+    if (obj.ix) return obj.ix;
+    const ix = slots.length;
+    slots.push(obj.boardID);
+    obj.ix = `$${ix}.Alleged: ${obj.iface}`;
+    return obj.ix;
+  },
+};
+
+const body = {
+  method: 'executeOffer',
+  offer: {
+    id,
+    invitationSpec: {
+      source: 'agoricContract',
+      instancePath: ['kread'],
+      callPipe: [['makeMintCharacterInvitation', []]],
+    },
+    offerArgs: { name: 'ephemeral_Ace' },
+    proposal: {
+      give: {
+        Price: {
+          brand: smallCaps.ref(brand.IST),
+          value: smallCaps.Nat(5n * ISTunit) }
+      },
+    },
+  },
+};
+
+const capData = { body: `#${JSON.stringify(body)}`, slots };
+const action = JSON.stringify(capData);
+
+console.log(action);

--- a/a3p-integration/proposals/a:upgrade-14/test.sh
+++ b/a3p-integration/proposals/a:upgrade-14/test.sh
@@ -4,3 +4,5 @@
 # The effects of this step are not persisted in further proposal layers.
 
 yarn ava
+
+./create-kread-item-test.sh

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -849,6 +849,8 @@ func upgrade14Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgr
 			vm.CoreProposalStepForModules("@agoric/vats/scripts/build-wallet-factory2-upgrade.js"),
 			// Then, upgrade Zoe and ZCF
 			vm.CoreProposalStepForModules("@agoric/vats/scripts/replace-zoe.js"),
+			// Next revive KREAd characters
+			vm.CoreProposalStepForModules("@agoric/vats/scripts/revive-kread.js"),
 		}
 
 		app.upgradeDetails = &upgradeDetails{

--- a/packages/vats/scripts/revive-kread.js
+++ b/packages/vats/scripts/revive-kread.js
@@ -1,0 +1,13 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async () =>
+  harden({
+    sourceSpec: '@agoric/vats/src/proposals/kread-proposal.js',
+    getManifestCall: ['getManifestForKread'],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('revive-kread', defaultProposalBuilder);
+};

--- a/packages/vats/src/proposals/kread-proposal.js
+++ b/packages/vats/src/proposals/kread-proposal.js
@@ -1,0 +1,24 @@
+import { E } from '@endo/far';
+
+/**
+ * @param {BootstrapPowers & {
+ *   consume: { kreadKit: KreadKit };
+ * }} powers
+ */
+export const repairKread = async ({ consume: { kreadKit: kreadKitP } }) => {
+  console.log('repairSubscribers');
+
+  const kreadKit = await kreadKitP;
+  const creatorFacet = kreadKit.creatorFacet;
+  console.log(`KREAd creatorFacet`, creatorFacet);
+  await E(creatorFacet).reviveMarketExitSubscribers();
+  console.log('KREAd subscribers were revived!');
+};
+
+export const getManifestForKread = _powers => ({
+  manifest: {
+    [repairKread.name]: {
+      consume: { kreadKit: true },
+    },
+  },
+});


### PR DESCRIPTION
closes: #8837

## Description

Invoke KREAd's revive

### Security Considerations

negligible

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Needs to be tested. I think doing any KREAd transaction after the upgrade demonstrates success.

### Upgrade Considerations

#8714 showed that a Zoe upgrade would break promises that the KREAd contract depends on. We expect `creatorFacet.reviveMarketExitSubscribers();` to reconnect to the relevant promises.