### PR TITLE
feat(ertp): purse amountStore abstraction

### DIFF
--- a/packages/ERTP/src/amountStore.js
+++ b/packages/ERTP/src/amountStore.js
@@ -1,0 +1,33 @@
+import { AmountMath } from './amountMath.js';
+
+/**
+ * @template {AssetKind} [K=AssetKind]
+ * @typedef {object} AmountStore
+ * @property {() => Amount<K>} getAmount
+ * @property {(delta: Amount<K>) => void} increment
+ * @property {(delta: Amount<K>) => boolean} decrement
+ */
+
+/**
+ * @template {AssetKind} [K=AssetKind]
+ * @param {object} state
+ * @param {string} key
+ * @returns {AmountStore<K>}
+ */
+export const makeAmountStore = (state, key) => {
+  /** @type {AmountStore<K>} */
+  return harden({
+    getAmount: () => state[key],
+    increment: delta => {
+      state[key] = AmountMath.add(state[key], delta);
+    },
+    decrement: delta => {
+      if (AmountMath.isGTE(state[key], delta)) {
+        state[key] = AmountMath.subtract(state[key], delta);
+        return true;
+      }
+      return false;
+    },
+  });
+};
+harden(makeAmountStore);

--- a/packages/ERTP/src/amountStore.js
+++ b/packages/ERTP/src/amountStore.js
@@ -15,7 +15,6 @@ import { AmountMath } from './amountMath.js';
  * @returns {AmountStore<K>}
  */
 export const makeAmountStore = (state, key) => {
-  /** @type {AmountStore<K>} */
   return harden({
     getAmount: () => state[key],
     increment: delta => {

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -277,11 +277,11 @@ export const preparePaymentLedger = (
   const withdrawInternal = (balanceStore, amount, recoverySet) => {
     amount = coerce(amount);
     const payment = makePayment();
+    // COMMIT POINT Move the withdrawn assets from this purse into
+    // payment. Total assets must remain conserved.
+    balanceStore.decrement(amount) ||
+      Fail`Withdrawal of ${amount} failed because the purse only contained ${balanceStore.getAmount()}`;
     try {
-      // COMMIT POINT Move the withdrawn assets from this purse into
-      // payment. Total assets must remain conserved.
-      balanceStore.decrement(amount) ||
-        Fail`Withdrawal of ${amount} failed because the purse only contained ${balanceStore.getAmount()}`;
       initPayment(payment, amount, recoverySet);
     } catch (err) {
       shutdownLedgerWithFailure(err);


### PR DESCRIPTION
closes: #XXXX
refs: #8862

## Description

Abstract the purse's internal storage of its currentBalance into something that encapsulates the actual implementation, and enables that implementation to be, for example, a MapStore implementation of a copyBag amount kind. Currently does not actually change the representation. Just sets us up to do so.

We currently kludge to avoid any upgrade sensitivity, where the actual balance representation is still `state.currentBalance: Amount`. We don't gain anything until we change that representation. But how should we upgrade old representation instances to use the new store representation?

Also, we don't gain anything until we notify of balance changes rather than new balances. This change by its nature cannot be encapsulated. How do we make that transition?


### Security Considerations

none

### Scaling Considerations

The whole point is the scaling benefits of changing this internal representation to a store, when warranted. This is an experiment that has yet to actually demonstrate net benefit. This PR only sets the stage, and the mild cost of a few extra heap allocations and function calls. Beyond that, this PR should have no effect on scaling.

### Documentation Considerations

Once we do it, will need to document the shift from notifying of new balances to notifying of balance changes.

### Testing Considerations

First, do no harm. Until this has observable changes no tests should need to change.

### Upgrade Considerations

We need to cope with the external change from balance notifications to balance change notifications.

We will need to upgrade from a `state.currentBalance: Amount` representation to one using store.

Both will need design.

Another worry is that there are currently 118 occurrences of `getCurrentAmount()` in agoric-sdk outside of the ERTP package. Any of these that are requests of a store-based-purse will get more expensive, since the purse will need to re-synthesize it from its encapsulated store.
