### PR TITLE
feat: upgrade interchain stack to ibc6

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -100,7 +100,7 @@ proto-check-breaking: proto-tools
 
 GOGO_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/gogo/protobuf)
 # GOOGLE_API_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/googleapis/googleapis)/google/api
-IBC_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/ibc-go/v5)/proto/ibc/core
+IBC_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/ibc-go/v6)/proto/ibc/core
 COSMOS_PROTO_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/cosmos-proto)/proto/cosmos_proto
 COSMOS_SDK_PROTO_URL := file://$(shell go list -m -f '{{ .Dir }}' github.com/cosmos/cosmos-sdk)/proto/cosmos
 

--- a/golang/cosmos/ante/ante.go
+++ b/golang/cosmos/ante/ante.go
@@ -4,8 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-	ibcante "github.com/cosmos/ibc-go/v5/modules/core/ante"
-	ibckeeper "github.com/cosmos/ibc-go/v5/modules/core/keeper"
+	ibcante "github.com/cosmos/ibc-go/v6/modules/core/ante"
+	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -606,10 +606,10 @@ func NewAgoricApp(
 			app.BaseApp.DeliverTx,
 			encodingConfig.TxConfig,
 		),
-		// REVIEWER: using innerAk here instead of app.AccountKeeper
+		// NOTE: using innerAk here instead of app.AccountKeeper
 		// since migration method doesn't know how to unwrap the account keeper.
 		// Needs access to some struct fields.
-		// Alternative is to add accessor methods to the AccountKeeper interface.
+		// (Alternative is to add accessor methods to the AccountKeeper interface.)
 		auth.NewAppModule(appCodec, innerAk, nil),
 		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
-        nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
+	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -81,22 +81,22 @@ import (
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	ica "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts"
+	ica "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts"
 
-	icahost "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/host"
-	icahostkeeper "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/host/keeper"
-	icahosttypes "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/host/types"
-	icatypes "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/types"
-	"github.com/cosmos/ibc-go/v5/modules/apps/transfer"
-	ibctransferkeeper "github.com/cosmos/ibc-go/v5/modules/apps/transfer/keeper"
-	ibctransfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
-	ibc "github.com/cosmos/ibc-go/v5/modules/core"
-	ibcclient "github.com/cosmos/ibc-go/v5/modules/core/02-client"
-	ibcclientclient "github.com/cosmos/ibc-go/v5/modules/core/02-client/client"
-	ibcclienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
-	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"
-	ibchost "github.com/cosmos/ibc-go/v5/modules/core/24-host"
-	ibckeeper "github.com/cosmos/ibc-go/v5/modules/core/keeper"
+	icahost "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/host"
+	icahostkeeper "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/host/keeper"
+	icahosttypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/types"
+	"github.com/cosmos/ibc-go/v6/modules/apps/transfer"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v6/modules/apps/transfer/keeper"
+	ibctransfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	ibc "github.com/cosmos/ibc-go/v6/modules/core"
+	ibcclient "github.com/cosmos/ibc-go/v6/modules/core/02-client"
+	ibcclientclient "github.com/cosmos/ibc-go/v6/modules/core/02-client/client"
+	ibcclienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	porttypes "github.com/cosmos/ibc-go/v6/modules/core/05-port/types"
+	ibchost "github.com/cosmos/ibc-go/v6/modules/core/24-host"
+	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
@@ -1151,8 +1151,8 @@ func (app *GaiaApp) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APICo
 	// Register new tendermint queries routes from grpc-gateway.
 	tmservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
-        // Register node gRPC service for grpc-gateway.
-        nodeservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
+	// Register node gRPC service for grpc-gateway.
+	nodeservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
 	// Register grpc-gateway routes for all modules.
 	ModuleBasics.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/math v1.0.0-rc.0
 	github.com/armon/go-metrics v0.4.1
 	github.com/cosmos/cosmos-sdk v0.46.16
-	github.com/cosmos/ibc-go/v5 v5.3.2
+	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/mux v1.8.0

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -378,8 +378,8 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.6 h1:XY78yEeNPrEYyNCKlqr9chrwoeSDJ0bV2VjocTk//OU=
 github.com/cosmos/iavl v0.19.6/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/cosmos/ibc-go/v5 v5.3.2 h1:PPSs5hNAjYd8jVfHvXsqfnCYd/r9C7wpu+O2A4TOO5g=
-github.com/cosmos/ibc-go/v5 v5.3.2/go.mod h1:Q2W1rjtwR738fqFQhE66dZ0frsLlr+Wiezlwei0TMGo=
+github.com/cosmos/ibc-go/v6 v6.2.1 h1:NiaDXTRhKwf3n9kELD4VRIe5zby1yk1jBvaz9tXTQ6k=
+github.com/cosmos/ibc-go/v6 v6.2.1/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/cosmos/ledger-cosmos-go v0.12.4 h1:drvWt+GJP7Aiw550yeb3ON/zsrgW0jgh5saFCr7pDnw=

--- a/golang/cosmos/third_party/proto/ibc/core/channel/v1/channel.proto
+++ b/golang/cosmos/third_party/proto/ibc/core/channel/v1/channel.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";

--- a/golang/cosmos/third_party/proto/ibc/core/client/v1/client.proto
+++ b/golang/cosmos/third_party/proto/ibc/core/client/v1/client.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v5/modules/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v6/modules/core/02-client/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";

--- a/golang/cosmos/x/vibc/ibc.go
+++ b/golang/cosmos/x/vibc/ibc.go
@@ -8,11 +8,11 @@ import (
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capability "github.com/cosmos/cosmos-sdk/x/capability/types"
-	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
-	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"
-	host "github.com/cosmos/ibc-go/v5/modules/core/24-host"
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v6/modules/core/05-port/types"
+	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+	"github.com/cosmos/ibc-go/v6/modules/core/exported"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -81,29 +81,28 @@ func (ch IBCModule) Receive(cctx context.Context, str string) (ret string, err e
 
 	switch msg.Method {
 	case "sendPacket":
-		seq, ok := keeper.GetNextSequenceSend(
-			ctx,
-			msg.Packet.SourcePort,
-			msg.Packet.SourceChannel,
-		)
-		if !ok {
-			return "", fmt.Errorf("unknown sequence number")
-		}
-
 		timeoutTimestamp := msg.Packet.TimeoutTimestamp
 		if msg.Packet.TimeoutHeight.IsZero() && msg.Packet.TimeoutTimestamp == 0 {
 			// Use the relative timeout if no absolute timeout is specifiied.
 			timeoutTimestamp = uint64(ctx.BlockTime().UnixNano()) + msg.RelativeTimeoutNs
 		}
 
-		packet := channeltypes.NewPacket(
-			msg.Packet.Data, seq,
-			msg.Packet.SourcePort, msg.Packet.SourceChannel,
-			msg.Packet.DestinationPort, msg.Packet.DestinationChannel,
-			msg.Packet.TimeoutHeight, timeoutTimestamp,
+		seq, err := keeper.SendPacket(
+			ctx,
+			msg.Packet.SourcePort,
+			msg.Packet.SourceChannel,
+			msg.Packet.TimeoutHeight,
+			timeoutTimestamp,
+			msg.Packet.Data,
 		)
-		err = keeper.SendPacket(ctx, packet)
 		if err == nil {
+			// synthesize the sent packet
+			packet := channeltypes.NewPacket(
+				msg.Packet.Data, seq,
+				msg.Packet.SourcePort, msg.Packet.SourceChannel,
+				msg.Packet.DestinationPort, msg.Packet.DestinationChannel,
+				msg.Packet.TimeoutHeight, timeoutTimestamp,
+			)
 			bytes, err := json.Marshal(&packet)
 			if err == nil {
 				ret = string(bytes)

--- a/golang/cosmos/x/vibc/keeper/keeper.go
+++ b/golang/cosmos/x/vibc/keeper/keeper.go
@@ -10,10 +10,11 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capability "github.com/cosmos/cosmos-sdk/x/capability/types"
-	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
-	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"
-	host "github.com/cosmos/ibc-go/v5/modules/core/24-host"
-	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v6/modules/core/05-port/types"
+	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
+	ibcexported "github.com/cosmos/ibc-go/v6/modules/core/exported"
 
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
@@ -58,12 +59,6 @@ func (k Keeper) GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) s
 	return k.bankKeeper.GetBalance(ctx, addr, denom)
 }
 
-// GetNextSequenceSend defines a wrapper function for the channel Keeper's function
-// in order to expose it to the vibc IBC handler.
-func (k Keeper) GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool) {
-	return k.channelKeeper.GetNextSequenceSend(ctx, portID, channelID)
-}
-
 // GetChannel defines a wrapper function for the channel Keeper's function
 // in order to expose it to the vibc IBC handler.
 func (k Keeper) GetChannel(ctx sdk.Context, portID, channelID string) (channeltypes.Channel, bool) {
@@ -99,15 +94,20 @@ func (k Keeper) ChanOpenInit(ctx sdk.Context, order channeltypes.Order, connecti
 
 // SendPacket defines a wrapper function for the channel Keeper's function
 // in order to expose it to the vibc IBC handler.
-func (k Keeper) SendPacket(ctx sdk.Context, packet ibcexported.PacketI) error {
-	portID := packet.GetSourcePort()
-	channelID := packet.GetSourceChannel()
-	capName := host.ChannelCapabilityPath(portID, channelID)
+func (k Keeper) SendPacket(
+	ctx sdk.Context,
+	sourcePort string,
+	sourceChannel string,
+	timeoutHeight clienttypes.Height,
+	timeoutTimestamp uint64,
+	data []byte,
+) (uint64, error) {
+	capName := host.ChannelCapabilityPath(sourcePort, sourceChannel)
 	chanCap, ok := k.GetCapability(ctx, capName)
 	if !ok {
-		return sdkerrors.Wrapf(channeltypes.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
+		return 0, sdkerrors.Wrapf(channeltypes.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
-	return k.channelKeeper.SendPacket(ctx, chanCap, packet)
+	return k.channelKeeper.SendPacket(ctx, chanCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
 }
 
 var _ ibcexported.Acknowledgement = (*rawAcknowledgement)(nil)

--- a/golang/cosmos/x/vibc/types/expected_keepers.go
+++ b/golang/cosmos/x/vibc/types/expected_keepers.go
@@ -3,16 +3,24 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capability "github.com/cosmos/cosmos-sdk/x/capability/types"
-	connection "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
-	channel "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
-	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	connection "github.com/cosmos/ibc-go/v6/modules/core/03-connection/types"
+	channel "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v6/modules/core/exported"
 )
 
 // ChannelKeeper defines the expected IBC channel keeper
 type ChannelKeeper interface {
 	GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channel.Channel, found bool)
-	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
-	SendPacket(ctx sdk.Context, channelCap *capability.Capability, packet ibcexported.PacketI) error
+	SendPacket(
+		ctx sdk.Context,
+		channelCap *capability.Capability,
+		sourcePort string,
+		sourceChannel string,
+		timeoutHeight clienttypes.Height,
+		timeoutTimestamp uint64,
+		data []byte,
+	) (uint64, error)
 	WriteAcknowledgement(ctx sdk.Context, channelCap *capability.Capability, packet ibcexported.PacketI, acknowledgement ibcexported.Acknowledgement) error
 	ChanOpenInit(ctx sdk.Context, order channel.Order, connectionHops []string, portID string,
 		portCap *capability.Capability, counterparty channel.Counterparty, version string) (string, *capability.Capability, error)

--- a/golang/cosmos/x/vibc/types/msgs.go
+++ b/golang/cosmos/x/vibc/types/msgs.go
@@ -4,7 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	chanTypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
+	chanTypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
 )
 
 const RouterKey = ModuleName // this was defined in your key.go file

--- a/golang/cosmos/x/vibc/types/msgs.pb.go
+++ b/golang/cosmos/x/vibc/types/msgs.pb.go
@@ -7,7 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
+	types "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
 	_ "github.com/gogo/protobuf/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"
 	proto "github.com/gogo/protobuf/proto"


### PR DESCRIPTION
closes: #8224

## Description

Upgrade ibc-go from v5 to v6.

Reviewers, please see the [ibc-go 5-to-6 migration guide](https://github.com/cosmos/ibc-go/blob/v6.2.1/docs/migrations/v5-to-v6.md).

### Security Considerations

Careful code review is required.

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

IBC connection construction and usage must be tested in integration tests.

### Upgrade Considerations

(From previous PR which upgraded cosmos-sdk to v0.46, there a new IAVL index is built on upgrade:

> The first time the chain is started after the upgrade, the aforementioned index is created. The creation process might take time and depends on the size of the latest state of the chain. For example, Osmosis takes around 15 minutes to rebuild the index.
> 
> While the index is being created, node operators can observe the following in the logs: "Upgrading IAVL storage for faster queries + execution on the live state. This may take a while". The store key is appended to the message. The message is printed for every module that has a non-transient store. As a result, it gives a good indication of the progress of the upgrade.
> 

See "IAVL" section of the [cosmos-sdk v0.46 upgrade guide](https://github.com/cosmos/cosmos-sdk/blob/v0.46.16/UPGRADING.md).)
