### PR TITLE
slogSender using positions in file instead of mmap

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,9 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier'],
   extends: ['@agoric', 'plugin:ava/recommended'],
   rules: {
+    // UNTIL on Endo with https://github.com/endojs/endo/pull/2032
+    '@endo/no-nullish-coalescing': 'off',
+
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
     '@typescript-eslint/no-floating-promises': 'error',
     // so that floating-promises can be explicitly permitted with void operator

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -37,7 +37,6 @@
     "@opentelemetry/semantic-conventions": "~1.9.0",
     "anylogger": "^0.21.0",
     "better-sqlite3": "^9.1.1",
-    "bufferfromfile": "agoric-labs/BufferFromFile#Agoric-built",
     "tmp": "^0.2.1"
   },
   "devDependencies": {
@@ -64,6 +63,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 87.55
+    "atLeast": 87.14
   }
 }

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -1,3 +1,4 @@
+// @ts-check
 /// <reference types="ses" />
 
 // https://github.com/Agoric/agoric-sdk/issues/3742#issuecomment-1028451575
@@ -70,6 +71,13 @@ const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
   return arenaSize;
 };
 
+/**
+ * @param {{
+ *   circularBufferSize?: number,
+ *   stateDir?: string,
+ *   circularBufferFilename?: string
+ * }} opts
+ */
 export const makeMemoryMappedCircularBuffer = async ({
   circularBufferSize = DEFAULT_CBUF_SIZE,
   stateDir = '/tmp',
@@ -227,6 +235,11 @@ export const makeMemoryMappedCircularBuffer = async ({
   return { readCircBuf, writeCircBuf, writeJSON };
 };
 
+/**
+ * Loaded dynamically by makeSlogSender()
+ *
+ * @type {import('./index.js').MakeSlogSender}
+ */
 export const makeSlogSender = async opts => {
   const { writeJSON } = await makeMemoryMappedCircularBuffer(opts);
   return Object.assign(writeJSON, {

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -32,10 +32,14 @@ const I_ARENA_START = 4 * BigUint64Array.BYTES_PER_ELEMENT;
 
 const RECORD_HEADER_SIZE = BigUint64Array.BYTES_PER_ELEMENT;
 
+/**
+ * Initializes a circular buffer with the given size, creating the buffer file if it doesn't exist or is not large enough.
+ *
+ * @param {string} bufferFile - the file path for the circular buffer
+ * @param {number} circularBufferSize - the size of the circular buffer
+ * @returns {Promise<bigint>} the size of the initialized circular buffer
+ */
 const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
-  if (!circularBufferSize) {
-    return undefined;
-  }
   // If the file doesn't exist, or is not large enough, create it.
   const stbuf = await fsp.stat(bufferFile).catch(e => {
     if (e.code === 'ENOENT') {

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -14,8 +14,8 @@
 // no coherency problem, and the speed is unaffected by disk write speeds.
 
 import BufferFromFile from 'bufferfromfile';
-import { promises as fsPromises } from 'fs';
-import path from 'path';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
 import { serializeSlogObj } from './serialize-slog-obj.js';
 
 const { Fail } = assert;
@@ -37,7 +37,7 @@ const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
     return undefined;
   }
   // If the file doesn't exist, or is not large enough, create it.
-  const stbuf = await fsPromises.stat(bufferFile).catch(e => {
+  const stbuf = await fsp.stat(bufferFile).catch(e => {
     if (e.code === 'ENOENT') {
       return undefined;
     }
@@ -58,8 +58,8 @@ const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
   header.setBigUint64(I_CIRC_START, 0n);
   header.setBigUint64(I_CIRC_END, 0n);
 
-  await fsPromises.mkdir(path.dirname(bufferFile), { recursive: true });
-  await fsPromises.writeFile(bufferFile, headerBuf);
+  await fsp.mkdir(path.dirname(bufferFile), { recursive: true });
+  await fsp.writeFile(bufferFile, headerBuf);
 
   if (stbuf && stbuf.size >= circularBufferSize) {
     // File is big enough.
@@ -67,7 +67,7 @@ const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
   }
 
   // Increase the file size.
-  await fsPromises.truncate(bufferFile, circularBufferSize);
+  await fsp.truncate(bufferFile, circularBufferSize);
   return arenaSize;
 };
 

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -392,6 +392,6 @@ export const makeSlogSenderFromBuffer = ({ writeCircBuf }) => {
  * @type {import('./index.js').MakeSlogSender}
  */
 export const makeSlogSender = async opts => {
-  const { writeCircBuf } = await makeMemoryMappedCircularBuffer(opts);
+  const { writeCircBuf } = await makeSimpleCircularBuffer(opts);
   return makeSlogSenderFromBuffer({ writeCircBuf });
 };

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -5,7 +5,7 @@
 
 import '@endo/init';
 
-import { makeMemoryMappedCircularBuffer } from './flight-recorder.js';
+import { makeSimpleCircularBuffer } from './flight-recorder.js';
 
 const main = async () => {
   const files = process.argv.slice(2);
@@ -14,7 +14,7 @@ const main = async () => {
   }
 
   for await (const file of files) {
-    const { readCircBuf } = await makeMemoryMappedCircularBuffer({
+    const { readCircBuf } = await makeSimpleCircularBuffer({
       circularBufferFilename: file,
       circularBufferSize: 0,
     });

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -14,6 +14,9 @@ export * from './make-slog-sender.js';
  * }} SlogSender
  */
 /**
+ * @typedef {(opts: import('./index.js').MakeSlogSenderOptions) => SlogSender | undefined} MakeSlogSender
+ */
+/**
  * @typedef {MakeSlogSenderCommonOptions & Record<string, unknown>} MakeSlogSenderOptions
  * @typedef {object} MakeSlogSenderCommonOptions
  * @property {Record<string, string | undefined>} [env]

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -34,9 +34,9 @@ export const tryFlushSlogSender = async (
   await Promise.resolve(slogSender?.forceFlush?.()).catch(err => {
     log?.('Failed to flush slog sender', err);
     if (err.errors) {
-      err.errors.forEach(error => {
+      for (const error of err.errors) {
         log?.('nested error:', error);
-      });
+      }
     }
     if (env.SLOGSENDER_FAIL_ON_ERROR) {
       throw err;
@@ -67,12 +67,12 @@ export const getResourceAttributes = ({
   }
   if (OTEL_RESOURCE_ATTRIBUTES) {
     // Allow overriding resource attributes.
-    OTEL_RESOURCE_ATTRIBUTES.split(',').forEach(kv => {
+    for (const kv of OTEL_RESOURCE_ATTRIBUTES.split(',')) {
       const match = kv.match(/^([^=]*)=(.*)$/);
       if (match) {
         resourceAttributes[match[1]] = match[2];
       }
-    });
+    }
   }
   return resourceAttributes;
 };

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -74,7 +74,7 @@ async function run() {
     if (!flush) {
       return;
     }
-    await slogSender.forceFlush();
+    await slogSender.forceFlush?.();
     fs.writeFileSync(progressFileName, JSON.stringify(progress));
   };
 

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -19,7 +19,7 @@ export const DEFAULT_SLOGSENDER_AGENT = 'self';
 const filterTruthy = arr => /** @type {any[]} */ (arr.filter(Boolean));
 
 /**
- * @param {import('./index.js').MakeSlogSenderOptions} opts
+ * @type {import('./index.js').MakeSlogSender}
  */
 export const makeSlogSender = async (opts = {}) => {
   const { env = {}, stateDir: stateDirOption, ...otherOpts } = opts;
@@ -88,7 +88,7 @@ export const makeSlogSender = async (opts = {}) => {
     slogSenderModules.map(async moduleIdentifier =>
       import(moduleIdentifier)
         .then(
-          /** @param {{makeSlogSender: (opts: {}) => Promise<SlogSender | undefined>}} module */ ({
+          /** @param {{makeSlogSender: import('./index.js').MakeSlogSender}} module */ ({
             makeSlogSender: maker,
           }) => {
             if (typeof maker !== 'function') {

--- a/packages/telemetry/src/otel-and-flight-recorder.js
+++ b/packages/telemetry/src/otel-and-flight-recorder.js
@@ -1,6 +1,9 @@
 import { NonNullish } from '@agoric/assert';
 import { makeSlogSender as makeSlogSenderFromEnv } from './make-slog-sender.js';
 
+/**
+ * @param {import('./index.js').MakeSlogSenderOptions} opts
+ */
 export const makeSlogSender = async opts => {
   const { SLOGFILE: _1, SLOGSENDER: _2, ...otherEnv } = opts.env || {};
 

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -54,9 +54,9 @@ const serializeInto = (value, prefix, target = {}, depth = 3) => {
       } else {
         const proto = Object.getPrototypeOf(value);
         if (proto == null || proto === Object.prototype) {
-          Object.entries(value).forEach(([key, nested]) =>
-            serializeInto(nested, `${prefix}.${key}`, target, depth),
-          );
+          for (const [key, nested] of Object.entries(value)) {
+            serializeInto(nested, `${prefix}.${key}`, target, depth);
+          }
           return target;
         }
       }

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -1,56 +1,82 @@
+import fs from 'node:fs';
 import tmp from 'tmp';
 import { test } from './prepare-test-env-ava.js';
 
 import {
   makeMemoryMappedCircularBuffer,
+  makeSimpleCircularBuffer,
   makeSlogSenderFromBuffer,
 } from '../src/flight-recorder.js';
 
-test('flight-recorder sanity', async t => {
-  const { name: tmpFile, removeCallback } = tmp.fileSync();
-  const { readCircBuf, writeCircBuf } = await makeMemoryMappedCircularBuffer({
-    circularBufferSize: 512,
-    circularBufferFilename: tmpFile,
-  });
-  const slogSender = makeSlogSenderFromBuffer({ writeCircBuf });
-  slogSender({ type: 'start' });
+const bufferTests = test.macro(
+  /**
+   *
+   * @param {*} t
+   * @param {{makeBuffer: Function}} input
+   */
+  async (t, input) => {
+    const BUFFER_SIZE = 512;
 
-  const len0 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
-  const { done: done0 } = readCircBuf(len0);
-  t.false(done0, 'readCircBuf should not be done');
-  const dv0 = new DataView(len0.buffer);
-  const buf0 = new Uint8Array(Number(dv0.getBigUint64(0)));
-  const { done: done0b } = readCircBuf(buf0, len0.byteLength);
-  t.false(done0b, 'readCircBuf should not be done');
-  const buf0Str = new TextDecoder().decode(buf0);
-  t.is(buf0Str, `\n{"type":"start"}`, `start compare failed`);
+    const { name: tmpFile, removeCallback } = tmp.fileSync();
+    const { readCircBuf, writeCircBuf } = await input.makeBuffer({
+      circularBufferSize: BUFFER_SIZE,
+      circularBufferFilename: tmpFile,
+    });
+    const slogSender = makeSlogSenderFromBuffer({ writeCircBuf });
+    slogSender({ type: 'start' });
+    await slogSender.forceFlush();
+    t.is(fs.readFileSync(tmpFile, { encoding: 'utf8' }).length, BUFFER_SIZE);
 
-  const last = 500;
-  for (let i = 0; i < last; i += 1) {
-    slogSender({ type: 'iteration', iteration: i });
-  }
+    const len0 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
+    const { done: done0 } = readCircBuf(len0);
+    t.false(done0, 'readCircBuf should not be done');
+    const dv0 = new DataView(len0.buffer);
+    const buf0 = new Uint8Array(Number(dv0.getBigUint64(0)));
+    const { done: done0b } = readCircBuf(buf0, len0.byteLength);
+    t.false(done0b, 'readCircBuf should not be done');
+    const buf0Str = new TextDecoder().decode(buf0);
+    t.is(buf0Str, `\n{"type":"start"}`, `start compare failed`);
 
-  let offset = 0;
-  const len1 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
-  for (let i = 490; i < last; i += 1) {
-    const { done: done1 } = readCircBuf(len1, offset);
-    offset += len1.byteLength;
-    t.false(done1, `readCircBuf ${i} should not be done`);
-    const dv1 = new DataView(len1.buffer);
-    const buf1 = new Uint8Array(Number(dv1.getBigUint64(0)));
-    const { done: done1b } = readCircBuf(buf1, offset);
-    offset += buf1.byteLength;
-    t.false(done1b, `readCircBuf ${i} should not be done`);
-    const buf1Str = new TextDecoder().decode(buf1);
-    t.is(
-      buf1Str,
-      `\n{"type":"iteration","iteration":${i}}`,
-      `iteration ${i} compare failed`,
-    );
-  }
+    const last = 500;
+    for (let i = 0; i < last; i += 1) {
+      slogSender({ type: 'iteration', iteration: i });
+      await slogSender.forceFlush();
+      t.is(
+        fs.readFileSync(tmpFile, { encoding: 'utf8' }).length,
+        BUFFER_SIZE,
+        `iteration ${i} length mismatch`,
+      );
+    }
 
-  const { done: done2 } = readCircBuf(len1, offset);
-  t.assert(done2, `readCircBuf ${last} should be done`);
-  // console.log({ tmpFile });
-  removeCallback();
+    let offset = 0;
+    const len1 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
+    for (let i = 490; i < last; i += 1) {
+      const { done: done1 } = readCircBuf(len1, offset);
+      offset += len1.byteLength;
+      t.false(done1, `readCircBuf ${i} should not be done`);
+      const dv1 = new DataView(len1.buffer);
+      const buf1 = new Uint8Array(Number(dv1.getBigUint64(0)));
+      const { done: done1b } = readCircBuf(buf1, offset);
+      offset += buf1.byteLength;
+      t.false(done1b, `readCircBuf ${i} should not be done`);
+      const buf1Str = new TextDecoder().decode(buf1);
+      t.is(
+        buf1Str,
+        `\n{"type":"iteration","iteration":${i}}`,
+        `iteration ${i} compare failed`,
+      );
+    }
+
+    const { done: done2 } = readCircBuf(len1, offset);
+    t.assert(done2, `readCircBuf ${last} should be done`);
+    // console.log({ tmpFile });
+    removeCallback();
+  },
+);
+
+test('memory mapped', bufferTests, {
+  makeBuffer: makeMemoryMappedCircularBuffer,
+});
+test('simple', bufferTests, {
+  makeBuffer: makeSimpleCircularBuffer,
 });

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -69,6 +69,10 @@ const bufferTests = test.macro(
 
     const { done: done2 } = readCircBuf(len1, offset);
     t.assert(done2, `readCircBuf ${last} should be done`);
+
+    slogSender(null, 'PRE-SERIALIZED');
+    await slogSender.forceFlush();
+    t.truthy(fs.readFileSync(tmpFile).includes('PRE-SERIALIZED'));
     // console.log({ tmpFile });
     removeCallback();
   },

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -3,11 +3,11 @@ import tmp from 'tmp';
 import { test } from './prepare-test-env-ava.js';
 
 import {
-  makeMemoryMappedCircularBuffer,
   makeSimpleCircularBuffer,
   makeSlogSenderFromBuffer,
 } from '../src/flight-recorder.js';
 
+// Factored this way to support multiple implementations, which at one point there were
 const bufferTests = test.macro(
   /**
    *
@@ -78,9 +78,6 @@ const bufferTests = test.macro(
   },
 );
 
-test('memory mapped', bufferTests, {
-  makeBuffer: makeMemoryMappedCircularBuffer,
-});
 test('simple', bufferTests, {
   makeBuffer: makeSimpleCircularBuffer,
 });

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -1,15 +1,18 @@
 import tmp from 'tmp';
 import { test } from './prepare-test-env-ava.js';
 
-import { makeMemoryMappedCircularBuffer } from '../src/flight-recorder.js';
+import {
+  makeMemoryMappedCircularBuffer,
+  makeSlogSenderFromBuffer,
+} from '../src/flight-recorder.js';
 
 test('flight-recorder sanity', async t => {
   const { name: tmpFile, removeCallback } = tmp.fileSync();
-  const { writeJSON: slogSender, readCircBuf } =
-    await makeMemoryMappedCircularBuffer({
-      circularBufferSize: 512,
-      circularBufferFilename: tmpFile,
-    });
+  const { readCircBuf, writeCircBuf } = await makeMemoryMappedCircularBuffer({
+    circularBufferSize: 512,
+    circularBufferFilename: tmpFile,
+  });
+  const slogSender = makeSlogSenderFromBuffer({ writeCircBuf });
   slogSender({ type: 'start' });
 
   const len0 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);

--- a/patches/bufferfromfile+0.4.377.patch
+++ b/patches/bufferfromfile+0.4.377.patch
@@ -1,9 +1,0 @@
-diff --git a/node_modules/bufferfromfile/proto/wtools/amid/bufferFromFile/Main.js b/node_modules/bufferfromfile/proto/wtools/amid/bufferFromFile/Main.js
-index 4c4c41b..9b88d11 100644
---- a/node_modules/bufferfromfile/proto/wtools/amid/bufferFromFile/Main.js
-+++ b/node_modules/bufferfromfile/proto/wtools/amid/bufferFromFile/Main.js
-@@ -1,3 +1,4 @@
-+// @ts-nocheck
- ( function _BufferFromFile_js_()
- { //
- 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,21 +1624,6 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@mapbox/node-pre-gyp@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz#09a8781a3a036151cdebbe8719d6f8b25d4058bc"
-  integrity sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==
-  dependencies:
-    detect-libc "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.1.0"
-    node-fetch "^2.6.7"
-    nopt "^5.0.0"
-    npmlog "^5.0.1"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.11"
-
 "@noble/hashes@^1", "@noble/hashes@^1.0.0":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
@@ -2883,14 +2868,6 @@ are-docs-informative@^0.0.2:
   resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
   integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
 
-are-we-there-yet@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
-  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
-
 are-we-there-yet@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz#679df222b278c64f2cdba1175cdc00b0d96164bd"
@@ -3299,14 +3276,6 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bufferfromfile@agoric-labs/BufferFromFile#Agoric-built:
-  version "0.4.377"
-  resolved "https://codeload.github.com/agoric-labs/BufferFromFile/tar.gz/691031035856fadba2603e52f4411160d7f34ed6"
-  dependencies:
-    "@mapbox/node-pre-gyp" "1.0.9"
-    node-gyp "^9.3.1"
-    wbasenodejscpp latest
-
 builtin-modules@^3.1.0, builtin-modules@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
@@ -3647,7 +3616,7 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color-support@^1.1.2, color-support@^1.1.3:
+color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
@@ -3768,7 +3737,7 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
-console-control-strings@^1.0.0, console-control-strings@^1.1.0:
+console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
@@ -5253,21 +5222,6 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.2.tgz#98d93991c39da9361f8e50b337c4f6e41f120e21"
   integrity sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==
 
-gauge@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
-  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
-  dependencies:
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.2"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.1"
-    object-assign "^4.1.1"
-    signal-exit "^3.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.2"
-
 gauge@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce"
@@ -6681,7 +6635,7 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.1.0:
+make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -7422,7 +7376,7 @@ node-gyp-build@^4.3.0, node-gyp-build@^4.4.0, node-gyp-build@^4.5.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
   integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
-node-gyp@^9.0.0, node-gyp@^9.3.1:
+node-gyp@^9.0.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.0.tgz#2a7a91c7cba4eccfd95e949369f27c9ba704f369"
   integrity sha512-dMXsYP6gc9rRbejLXmTbVRYjAHw7ppswsKyMxuxJxxOHzluIO1rGp9TOQgjFJ+2MCqcOcQTOPB/8Xwhr+7s4Eg==
@@ -7610,16 +7564,6 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-npmlog@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
-  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
-  dependencies:
-    are-we-there-yet "^2.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^3.0.0"
-    set-blocking "^2.0.0"
-
 npmlog@^6.0.0, npmlog@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830"
@@ -7680,11 +7624,6 @@ nx@15.9.4, "nx@>=14.8.1 < 16":
     "@nrwl/nx-linux-x64-musl" "15.9.4"
     "@nrwl/nx-win32-arm64-msvc" "15.9.4"
     "@nrwl/nx-win32-x64-msvc" "15.9.4"
-
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-hash@^1.3.1:
   version "1.3.1"
@@ -8937,7 +8876,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -9877,11 +9816,6 @@ walk-up-path@^1.0.0:
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-1.0.0.tgz#d4745e893dd5fd0dbb58dd0a4c6a33d9c9fec53e"
   integrity sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==
 
-wbasenodejscpp@latest:
-  version "0.3.134"
-  resolved "https://registry.yarnpkg.com/wbasenodejscpp/-/wbasenodejscpp-0.3.134.tgz#c23c06bd8c3e170afe59084cfa6e7d41c07b0ffa"
-  integrity sha512-B3cyJ14XNKe7gfu+pQPdCkDKTMu4DiFS/iKWE+1AhroChj+hLiNYCcoUuvsjEocQtBPItjb57mbhdKCJ80pjCA==
-
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -9944,7 +9878,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.2, wide-align@^1.1.5:
+wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==


### PR DESCRIPTION
refs: #8636

## Description

On the path to Node 20 compatibility, we need to drop the `bufferfromfile` dependency.  (It doesn't work in Node 20 and fixing it is prohibitive: https://github.com/agoric-labs/BufferFromFile/pull/2). We decided to give on on mmap and just use file offsets.

This refactors `flight-recorder.js` to abstract the file IO and implements an alternate IO using sync FS methods.

Then it changes the code using the mmap-ed IO to use the fs IO.

Finally it removes the mmap-ed version. The factoring could be simplified more after that but imo it helps to have the separate concerns in separate functions.

### Security Considerations

n/a

### Scaling Considerations

Writes are async. Clients can `forceFlush` when it matters. The tests do this to ensure they're reading after the writes.

### Documentation Considerations

Nothing relevant.

### Testing Considerations

I think the existing test coverage is enough.

### Upgrade Considerations

n/a