### PR TITLE
ci: merge integration branch before endo checkout

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -58,6 +58,18 @@ runs:
           }
           console.log(branch);
           return branch;
+    - name: merge endo integration branch
+      id: endo-integration-merge
+      run: |-
+        set -e
+        git ls-remote --exit-code --heads origin "refs/heads/integration-endo-${{ steps.endo-branch.outputs.result }}" || exit 0
+        git fetch --unshallow origin integration-endo-${{ steps.endo-branch.outputs.result }}
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git merge --commit --no-edit origin/integration-endo-${{ steps.endo-branch.outputs.result }}
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      if: steps.endo-branch.outputs.result != 'NOPE'
     - name: check out Endo if necessary
       id: endo-checkout
       uses: actions/checkout@v3
@@ -84,18 +96,6 @@ runs:
         echo "$sha" > endo-sha.txt
         git add endo-sha.txt
       shell: bash
-    - name: merge endo integration branch
-      id: endo-integration-merge
-      run: |-
-        set -e
-        git ls-remote --exit-code --heads origin "refs/heads/integration-endo-${{ steps.endo-branch.outputs.result }}" || exit 0
-        git fetch --unshallow origin integration-endo-${{ steps.endo-branch.outputs.result }}
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git merge --commit --no-edit origin/integration-endo-${{ steps.endo-branch.outputs.result }}
-      shell: bash
-      working-directory: ${{ inputs.path }}
-      if: steps.endo-branch.outputs.result != 'NOPE'
     - name: Reconfigure git to use HTTP authentication
       run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
       shell: bash


### PR DESCRIPTION
refs: #8715
refs: https://github.com/Agoric/agoric-sdk/actions/runs/7868048310/job/21464643015

## Description

#8715 staged a new `endo-sha.txt` when running with an integration against endo, but didn't take in consideration that an integration branch may be merged in those cases. This re-orders the steps taken to merge the integration branch before checking out endo, and more importantly, before staging the endo tracking file, which would prevent the merge.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Reproduced the steps locally. Also triggering in CI with the following:

```
#endo-branch: master
```

### Upgrade Considerations

CI only change that should be cherry-picked into the release branch when release sync occurs.
