### PR TITLE
fix(agoric-cli): Remove conflicting AggregateError declaration comment

### DIFF
--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -1,4 +1,4 @@
-/* global process AggregateError Buffer */
+/* global process Buffer */
 import path from 'path';
 import chalk from 'chalk';
 import { makePspawn } from './helpers.js';


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/endojs/endo/pull/2042#discussion_r1486748971 https://github.com/Agoric/agoric-sdk/pull/7937

## Description

`AggregateError` has been part of standard JS for a long time. But endo's permits list does not yet list it, causing it to be omitted from SES. https://github.com/endojs/endo/pull/2042 will support `AggregateError` together with the long delayed `Promise.any`, `error.cause`, and `error.errors`.

Trying both https://github.com/Agoric/agoric-sdk/pull/7937 with the https://github.com/endojs/endo/pull/2042 fork, we find one integration failure from line
```js
/* global process AggregateError Buffer */
```
Deleting the `AggregateError` from this comment works with the https://github.com/endojs/endo/pull/2042 fork according to #7937 CI, and works with the endo that agoric-sdk currently depends on, according to this PR's CI. Thus, we can delete the declaration now without breaking anything, and avoid breaking once agoric-sdk is synced with an endo incorporating https://github.com/endojs/endo/pull/2042

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
We originally did the https://github.com/Agoric/agoric-sdk/pull/7937 in order to see if #2042 is compat with XS. It did not detect any such problems, but did detect this instead.

I'd say this corroborates the case that endo CI should at least run agoric-sdk CI lint jobs. Not all integration problems would have been caught be this, of course. But a surprising number would have. 
### Upgrade Considerations
none