### PR TITLE
A3p test zcf bundle cap

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,6 +39,7 @@ module.exports = {
       './packages/*/tsconfig.json',
       './packages/*/tsconfig.json',
       './packages/wallet/*/tsconfig.json',
+      './a3p-integration/proposals/*/tsconfig.json',
       './tsconfig.json',
     ],
     tsconfigRootDir: __dirname,

--- a/a3p-integration/.gitignore
+++ b/a3p-integration/.gitignore
@@ -2,6 +2,7 @@
 Dockerfile
 docker-bake.*
 upgrade-test-scripts
+*submission/
 
 # Yarn (https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
 .pnp.*

--- a/a3p-integration/.gitignore
+++ b/a3p-integration/.gitignore
@@ -14,8 +14,8 @@ upgrade-test-scripts
 # same for each proposal, an independent project
 proposals/*/.pnp.*
 proposals/*/.yarn/*
-proposals/*/!.yarn/patches
-proposals/*/!.yarn/plugins
-proposals/*/!.yarn/releases
-proposals/*/!.yarn/sdks
-proposals/*/!.yarn/versions
+!proposals/*/.yarn/patches
+!proposals/*/.yarn/plugins
+!proposals/*/.yarn/releases
+!proposals/*/.yarn/sdks
+!proposals/*/.yarn/versions

--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -17,6 +17,7 @@
   "ava": {
     "concurrency": 1,
     "serial": true,
+    "timeout": "1m",
     "files": [
       "!submission"
     ]

--- a/a3p-integration/proposals/a:upgrade-next/probeZcfBundleCap.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/probeZcfBundleCap.test.js
@@ -1,0 +1,36 @@
+import test from 'ava';
+
+import {
+  evalBundles,
+  getIncarnation,
+  getVatDetails,
+} from '@agoric/synthetic-chain';
+
+const SUBMISSION_DIR = 'probe-submission';
+
+test('upgrade Zoe to verify ZcfBundleCap endures', async t => {
+  await null;
+  t.assert((await getIncarnation('zoe')) === 1, 'zoe incarnation must be one');
+
+  // Before the test, the Wallet Factory should be using the legacy ZCF
+  const detailsBefore = await getVatDetails('walletFactory');
+  t.true(detailsBefore.incarnation >= 2, 'wf incarnation must be >= 2');
+
+  await evalBundles(SUBMISSION_DIR);
+
+  const detailsAfter = await getVatDetails('walletFactory');
+  t.is(
+    detailsAfter.incarnation,
+    detailsBefore.incarnation + 2,
+    'wf incarnation must increase by 2',
+  );
+
+  // The test restarts the WalletFactory, so it'll use the recently assigned
+  // ZCF bundle. It then restarts Zoe, so it'll revert to whichever ZCF bundle
+  // made it to persistent store. We then restart the Wallet Factory and see if
+  // it's gone back to the ZCF that Zoe initially knew about. If we could get the
+  // ZCF bundleID here from the probe, we'd explicitly check for that. Instead,
+  // we have to be content that it did indeed use the newly assigned bundle in
+  // manual tests.
+  t.not(detailsAfter.bundleID, detailsBefore.bundleID);
+});

--- a/a3p-integration/proposals/a:upgrade-next/test.sh
+++ b/a3p-integration/proposals/a:upgrade-next/test.sh
@@ -3,4 +3,6 @@
 # Place here any test that should be executed using the executed proposal.
 # The effects of this step are not persisted in further proposal layers.
 
-yarn ava
+yarn ava post.test.js
+GLOBIGNORE=post.test.js
+yarn ava *.test.js

--- a/packages/builders/scripts/vats/probe-zcf-bundle.js
+++ b/packages/builders/scripts/vats/probe-zcf-bundle.js
@@ -1,0 +1,22 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    sourceSpec: '@agoric/vats/src/proposals/probeZcfBundle.js',
+    getManifestCall: [
+      'getManifestForProbeZcfBundleCap',
+      {
+        zoeRef: publishRef(install('@agoric/vats/src/vat-zoe.js')),
+        zcfRef: publishRef(install('@agoric/zoe/src/contractFacet/vatRoot.js')),
+        walletRef: publishRef(
+          install('@agoric/smart-wallet/src/walletFactory.js'),
+        ),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('probeZcfBundle', defaultProposalBuilder);
+};

--- a/packages/vats/src/proposals/probeZcfBundle.js
+++ b/packages/vats/src/proposals/probeZcfBundle.js
@@ -1,0 +1,72 @@
+import { E } from '@endo/far';
+import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
+
+// verify that Zoe remembers the zcfBundleCap across upgrades
+export const probeZcfBundleCap = async (
+  {
+    consume: {
+      vatAdminSvc,
+      walletFactoryStartResult,
+      provisionPoolStartResult,
+      chainStorage,
+      walletBridgeManager: walletBridgeManagerP,
+      vatStore,
+    },
+  },
+  options,
+) => {
+  const { zoeRef, zcfRef, walletRef } = options.options;
+
+  const { adminNode, root: zoeRoot } = await E(vatStore).get('zoe');
+  const zoeConfigFacet = await E(zoeRoot).getZoeConfigFacet();
+
+  // STEP 1: restart WF; it'll use the newest ZCF known to Zoe ////////////////
+
+  const WALLET_STORAGE_PATH_SEGMENT = 'wallet';
+  const [walletBridgeManager, walletStorageNode, ppFacets] = await Promise.all([
+    walletBridgeManagerP,
+    makeStorageNodeChild(chainStorage, WALLET_STORAGE_PATH_SEGMENT),
+    provisionPoolStartResult,
+  ]);
+  const walletReviver = await E(ppFacets.creatorFacet).getWalletReviver();
+  const privateArgs = {
+    storageNode: walletStorageNode,
+    walletBridgeManager,
+    walletReviver,
+  };
+
+  const { adminFacet: walletAdminFacet } = await walletFactoryStartResult;
+  await E(walletAdminFacet).upgradeContract(walletRef.bundleID, privateArgs);
+
+  // STEP 2: Set the ZCF bundle ////////////////////////
+  await E(zoeConfigFacet).updateZcfBundleId(zcfRef.bundleID);
+
+  // STEP 3: Upgrade Zoe again ////////////////////////
+  // //////  See if Zoe forgets ZcfBundleCap //////////
+
+  const zoeBundleCap = await E(vatAdminSvc).getBundleCap(zoeRef.bundleID);
+  await E(adminNode).upgrade(zoeBundleCap, {});
+
+  // STEP 4: restart WF ////////////////////////
+  await E(walletAdminFacet).restartContract(privateArgs);
+
+  // //////  See which zcf bundle was used //////////
+};
+harden(probeZcfBundleCap);
+
+export const getManifestForProbeZcfBundleCap = (_powers, options) => ({
+  manifest: {
+    [probeZcfBundleCap.name]: {
+      consume: {
+        vatAdminSvc: true,
+        vatStore: true,
+        walletBridgeManager: true,
+        walletFactoryStartResult: true,
+        provisionPoolStartResult: true,
+        chainStorage: true,
+      },
+    },
+  },
+  options,
+});
+harden(getManifestForProbeZcfBundleCap);

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -469,8 +469,12 @@ export const makeZCFZygote = async (
 
       await null;
       if (!zcfBaggage.has('repairedContractCompletionWatcher')) {
-        await E(zoeInstanceAdmin).repairContractCompletionWatcher();
-        console.log(`Repaired contract completion watcher`);
+        // We don't wait because it's a cross-vat call (to Zoe) that can't be
+        // completed during this vat's start-up
+        E(zoeInstanceAdmin)
+          .repairContractCompletionWatcher()
+          .catch(() => {});
+
         zcfBaggage.init('repairedContractCompletionWatcher', true);
       }
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -266,6 +266,7 @@ export const makeStartInstance = (
           contractBundleCap: newContractBundleCap,
           privateArgs: newPrivateArgs,
         };
+        state.contractBundleCap = newContractBundleCap;
         return E.when(getFreshZcfBundleCap(), bCap =>
           E(state.adminNode).upgrade(bCap, { vatParameters }),
         );

--- a/scripts/generate-a3p-submission.sh
+++ b/scripts/generate-a3p-submission.sh
@@ -8,13 +8,17 @@ cd "$sdkroot"
 buildSubmission() {
   proposalName=$1
   a3pProposal=$2
+  output=${3:-$proposalName}
+  submissionName=${4:-submission}
 
   yarn agoric run "packages/builders/scripts/vats/$proposalName.js"
 
-  submissionDir="a3p-integration/proposals/$a3pProposal/submission"
+
+  submissionDir="a3p-integration/proposals/$a3pProposal/$submissionName"
   mkdir -p "$submissionDir"
-  cp $(grep -oh '/.*b1-.*.json' "$proposalName"*) "$submissionDir"
-  mv "$proposalName"* "$submissionDir"
+  cp $(grep -oh '/.*b1-.*.json' "$output"*) "$submissionDir"
+  mv "$output"* "$submissionDir"
 }
 
+buildSubmission probe-zcf-bundle "a:upgrade-next" probeZcfBundle probe-submission
 buildSubmission test-localchain "b:localchain"


### PR DESCRIPTION
refs: #8868

## Description

An a3p-integration test for #8807.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing/Upgrade Considerations

This is a test that a bug fix had the appropriate effect.

The test takes advantage of the fact that the `vatInfo` held in swingstore (and returned by `getVatDetails()` in synthetic-chain) gives the bundleId of the ZCF in a contract vat rather than the bundleID of the contract itself.
