### PR TITLE
test(boot): Add pause functionality to the mock IBC server

### DIFF
--- a/packages/boot/test/bootstrapTests/ibcServerMock.js
+++ b/packages/boot/test/bootstrapTests/ibcServerMock.js
@@ -1,6 +1,10 @@
 /** @file Mock IBC Server */
 // @ts-check
 import { E, Far } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+
+const { quote: q, Fail } = assert;
+const { log } = console;
 
 /**
  *
@@ -13,7 +17,8 @@ import { E, Far } from '@endo/far';
 export const start = async (zcf, privateArgs, baggage) => {
   const { boundPort } = privateArgs;
 
-  const { log } = console;
+  /** @type {Array<[label: string, resolve: () => void, reject: () => void]>} */
+  const queue = [];
 
   /** @type {ListenHandler} */
   const listener = Far('L', {
@@ -21,19 +26,52 @@ export const start = async (zcf, privateArgs, baggage) => {
       const ch = Far('CH', {
         async onReceive(_c, packetBytes) {
           log('Receiving Data', packetBytes);
+          assert.typeof(packetBytes, 'string');
+          const { promise, resolve, reject } = makePromiseKit();
+          queue.push([
+            'onReceive',
+            () => resolve(`got ${packetBytes}`),
+            reject,
+          ]);
+          return promise;
         },
         async onOpen(_c, localAddr, remoteAddr, _connectionHandler) {
           log('onOpen', { localAddr, remoteAddr });
+          const { promise, resolve, reject } = makePromiseKit();
+          queue.push(['onOpen', resolve, reject]);
+          return promise;
         },
       });
-      return ch;
+      const { promise, resolve, reject } = makePromiseKit();
+      queue.push(['onAccept', () => resolve(ch), reject]);
+      return promise;
     },
     async onListen(port, _listenHandler) {
       console.debug(`listening on echo port: ${port}`);
+      const { promise, resolve, reject } = makePromiseKit();
+      queue.push(['onListen', resolve, reject]);
+      return promise;
     },
   });
 
   const creatorFacet = Far('CF', {
+    /**
+     * Assert that the next pending operation has the expected label and release it.
+     *
+     * @param {string} expectedLabel
+     * @returns {Promise<void>}
+     */
+    dequeue: async expectedLabel => {
+      queue.length > 0 ||
+        Fail`got empty queue when expecting ${q(expectedLabel)}`;
+      const [label, resolve, reject] = /** @type {any} */ (queue.shift());
+      if (label === expectedLabel) {
+        resolve();
+        return;
+      }
+      reject(Error(`expecting to dequeue ${expectedLabel} but saw ${label}`));
+      Fail`expecting to dequeue ${q(expectedLabel)} but saw ${q(label)}`;
+    },
     listen: async () => {
       await E(boundPort).addListener(listener);
     },


### PR DESCRIPTION
For testing upgrades while an operation is pending (i.e., before it is `dequeue`d)