### PR TITLE
Fix cosmic-proto generate and rebuild

### DIFF
--- a/packages/cosmic-proto/MAINTAINERS.md
+++ b/packages/cosmic-proto/MAINTAINERS.md
@@ -28,6 +28,7 @@ mkdir -p proto
 cd proto
 ln -s ../../../golang/cosmos/proto/agoric .
 ln -s ../../../golang/cosmos/third_party/proto/gogoproto .
+ln -s ../../../golang/cosmos/third_party/proto/cosmos_proto .
 ln -s ../node_modules/protobufjs/google .
 ```
 

--- a/packages/cosmic-proto/dist/agoric/swingset/swingset.d.ts
+++ b/packages/cosmic-proto/dist/agoric/swingset/swingset.d.ts
@@ -111,8 +111,13 @@ export interface Egress {
   /** TODO: Remove these power flags as they are deprecated and have no effect. */
   powerFlags: string[];
 }
-/** The payload messages used by swingset state-sync */
-export interface ExtensionSnapshotterArtifactPayload {
+/**
+ * SwingStoreArtifact encodes an artifact of a swing-store export.
+ * Artifacts may be stored or transmitted in any order. Most handlers do
+ * maintain the artifact order from their original source as an effect of how
+ * they handle the artifacts.
+ */
+export interface SwingStoreArtifact {
   name: string;
   data: Uint8Array;
 }
@@ -514,17 +519,11 @@ export declare const Egress: {
     object: I,
   ): Egress;
 };
-export declare const ExtensionSnapshotterArtifactPayload: {
-  encode(
-    message: ExtensionSnapshotterArtifactPayload,
-    writer?: _m0.Writer,
-  ): _m0.Writer;
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number,
-  ): ExtensionSnapshotterArtifactPayload;
-  fromJSON(object: any): ExtensionSnapshotterArtifactPayload;
-  toJSON(message: ExtensionSnapshotterArtifactPayload): unknown;
+export declare const SwingStoreArtifact: {
+  encode(message: SwingStoreArtifact, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): SwingStoreArtifact;
+  fromJSON(object: any): SwingStoreArtifact;
+  toJSON(message: SwingStoreArtifact): unknown;
   fromPartial<
     I extends {
       name?: string | undefined;
@@ -532,12 +531,10 @@ export declare const ExtensionSnapshotterArtifactPayload: {
     } & {
       name?: string | undefined;
       data?: Uint8Array | undefined;
-    } & {
-      [K in Exclude<keyof I, keyof ExtensionSnapshotterArtifactPayload>]: never;
-    },
+    } & { [K in Exclude<keyof I, keyof SwingStoreArtifact>]: never },
   >(
     object: I,
-  ): ExtensionSnapshotterArtifactPayload;
+  ): SwingStoreArtifact;
 };
 type Builtin =
   | Date

--- a/packages/cosmic-proto/dist/agoric/swingset/swingset.js
+++ b/packages/cosmic-proto/dist/agoric/swingset/swingset.js
@@ -538,10 +538,10 @@ export const Egress = {
     return message;
   },
 };
-function createBaseExtensionSnapshotterArtifactPayload() {
+function createBaseSwingStoreArtifact() {
   return { name: '', data: new Uint8Array() };
 }
-export const ExtensionSnapshotterArtifactPayload = {
+export const SwingStoreArtifact = {
   encode(message, writer = _m0.Writer.create()) {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -554,7 +554,7 @@ export const ExtensionSnapshotterArtifactPayload = {
   decode(input, length) {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseExtensionSnapshotterArtifactPayload();
+    const message = createBaseSwingStoreArtifact();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -589,7 +589,7 @@ export const ExtensionSnapshotterArtifactPayload = {
     return obj;
   },
   fromPartial(object) {
-    const message = createBaseExtensionSnapshotterArtifactPayload();
+    const message = createBaseSwingStoreArtifact();
     message.name = object.name ?? '';
     message.data = object.data ?? new Uint8Array();
     return message;

--- a/packages/cosmic-proto/dist/agoric/vstorage/query.d.ts
+++ b/packages/cosmic-proto/dist/agoric/vstorage/query.d.ts
@@ -13,6 +13,39 @@ export interface QueryDataRequest {
 export interface QueryDataResponse {
   value: string;
 }
+/** QueryCapDataRequest contains a path and formatting configuration. */
+export interface QueryCapDataRequest {
+  path: string;
+  /**
+   * mediaType must be an actual media type in the registry at
+   * https://www.iana.org/assignments/media-types/media-types.xhtml
+   * or a special value that does not conflict with the media type syntax.
+   * The only valid value is "JSON Lines", which is also the default.
+   */
+  mediaType: string;
+  /**
+   * itemFormat, if present, must be the special value "flat" to indicate that
+   * the deep structure of each item should be flattened into a single level
+   * with kebab-case keys (e.g., `{ "metrics": { "min": 0, "max": 88 } }` as
+   * `{ "metrics-min": 0, "metrics-max": 88 }`).
+   */
+  itemFormat: string;
+  /**
+   * remotableValueFormat indicates how to transform references to opaque but
+   * distinguishable Remotables into readable embedded representations.
+   * * "object" represents each Remotable as an `{ id, allegedName }` object, e.g. `{ "id": "board007", "allegedName": "IST brand" }`.
+   * * "string" represents each Remotable as a string with bracket-wrapped contents including its alleged name and id, e.g. "[Alleged: IST brand <board007>]".
+   */
+  remotableValueFormat: string;
+}
+/**
+ * QueryCapDataResponse represents the result with the requested formatting,
+ * reserving space for future metadata such as media type.
+ */
+export interface QueryCapDataResponse {
+  blockHeight: string;
+  value: string;
+}
 /** QueryChildrenRequest is the vstorage path children query. */
 export interface QueryChildrenRequest {
   path: string;
@@ -52,6 +85,44 @@ export declare const QueryDataResponse: {
   >(
     object: I,
   ): QueryDataResponse;
+};
+export declare const QueryCapDataRequest: {
+  encode(message: QueryCapDataRequest, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryCapDataRequest;
+  fromJSON(object: any): QueryCapDataRequest;
+  toJSON(message: QueryCapDataRequest): unknown;
+  fromPartial<
+    I extends {
+      path?: string | undefined;
+      mediaType?: string | undefined;
+      itemFormat?: string | undefined;
+      remotableValueFormat?: string | undefined;
+    } & {
+      path?: string | undefined;
+      mediaType?: string | undefined;
+      itemFormat?: string | undefined;
+      remotableValueFormat?: string | undefined;
+    } & { [K in Exclude<keyof I, keyof QueryCapDataRequest>]: never },
+  >(
+    object: I,
+  ): QueryCapDataRequest;
+};
+export declare const QueryCapDataResponse: {
+  encode(message: QueryCapDataResponse, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryCapDataResponse;
+  fromJSON(object: any): QueryCapDataResponse;
+  toJSON(message: QueryCapDataResponse): unknown;
+  fromPartial<
+    I extends {
+      blockHeight?: string | undefined;
+      value?: string | undefined;
+    } & {
+      blockHeight?: string | undefined;
+      value?: string | undefined;
+    } & { [K in Exclude<keyof I, keyof QueryCapDataResponse>]: never },
+  >(
+    object: I,
+  ): QueryCapDataResponse;
 };
 export declare const QueryChildrenRequest: {
   encode(message: QueryChildrenRequest, writer?: _m0.Writer): _m0.Writer;
@@ -382,8 +453,13 @@ export declare const QueryChildrenResponse: {
 };
 /** Query defines the gRPC querier service */
 export interface Query {
-  /** Return an arbitrary vstorage datum. */
+  /** Return the raw string value of an arbitrary vstorage datum. */
   Data(request: QueryDataRequest): Promise<QueryDataResponse>;
+  /**
+   * Return a formatted representation of a vstorage datum that must be
+   * a valid StreamCell with CapData values, or standalone CapData.
+   */
+  CapData(request: QueryCapDataRequest): Promise<QueryCapDataResponse>;
   /** Return the children of a given vstorage path. */
   Children(request: QueryChildrenRequest): Promise<QueryChildrenResponse>;
 }
@@ -397,6 +473,7 @@ export declare class QueryClientImpl implements Query {
     },
   );
   Data(request: QueryDataRequest): Promise<QueryDataResponse>;
+  CapData(request: QueryCapDataRequest): Promise<QueryCapDataResponse>;
   Children(request: QueryChildrenRequest): Promise<QueryChildrenResponse>;
 }
 interface Rpc {

--- a/packages/cosmic-proto/dist/agoric/vstorage/query.js
+++ b/packages/cosmic-proto/dist/agoric/vstorage/query.js
@@ -88,6 +88,132 @@ export const QueryDataResponse = {
     return message;
   },
 };
+function createBaseQueryCapDataRequest() {
+  return { path: '', mediaType: '', itemFormat: '', remotableValueFormat: '' };
+}
+export const QueryCapDataRequest = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.path !== '') {
+      writer.uint32(10).string(message.path);
+    }
+    if (message.mediaType !== '') {
+      writer.uint32(18).string(message.mediaType);
+    }
+    if (message.itemFormat !== '') {
+      writer.uint32(26).string(message.itemFormat);
+    }
+    if (message.remotableValueFormat !== '') {
+      writer.uint32(82).string(message.remotableValueFormat);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCapDataRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.path = reader.string();
+          break;
+        case 2:
+          message.mediaType = reader.string();
+          break;
+        case 3:
+          message.itemFormat = reader.string();
+          break;
+        case 10:
+          message.remotableValueFormat = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      path: isSet(object.path) ? String(object.path) : '',
+      mediaType: isSet(object.mediaType) ? String(object.mediaType) : '',
+      itemFormat: isSet(object.itemFormat) ? String(object.itemFormat) : '',
+      remotableValueFormat: isSet(object.remotableValueFormat)
+        ? String(object.remotableValueFormat)
+        : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.path !== undefined && (obj.path = message.path);
+    message.mediaType !== undefined && (obj.mediaType = message.mediaType);
+    message.itemFormat !== undefined && (obj.itemFormat = message.itemFormat);
+    message.remotableValueFormat !== undefined &&
+      (obj.remotableValueFormat = message.remotableValueFormat);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryCapDataRequest();
+    message.path = object.path ?? '';
+    message.mediaType = object.mediaType ?? '';
+    message.itemFormat = object.itemFormat ?? '';
+    message.remotableValueFormat = object.remotableValueFormat ?? '';
+    return message;
+  },
+};
+function createBaseQueryCapDataResponse() {
+  return { blockHeight: '', value: '' };
+}
+export const QueryCapDataResponse = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.blockHeight !== '') {
+      writer.uint32(10).string(message.blockHeight);
+    }
+    if (message.value !== '') {
+      writer.uint32(82).string(message.value);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCapDataResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.blockHeight = reader.string();
+          break;
+        case 10:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      blockHeight: isSet(object.blockHeight) ? String(object.blockHeight) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.blockHeight !== undefined &&
+      (obj.blockHeight = message.blockHeight);
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryCapDataResponse();
+    message.blockHeight = object.blockHeight ?? '';
+    message.value = object.value ?? '';
+    return message;
+  },
+};
 function createBaseQueryChildrenRequest() {
   return { path: '', pagination: undefined };
 }
@@ -224,12 +350,20 @@ export class QueryClientImpl {
     this.service = opts?.service || 'agoric.vstorage.Query';
     this.rpc = rpc;
     this.Data = this.Data.bind(this);
+    this.CapData = this.CapData.bind(this);
     this.Children = this.Children.bind(this);
   }
   Data(request) {
     const data = QueryDataRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Data', data);
     return promise.then(data => QueryDataResponse.decode(new _m0.Reader(data)));
+  }
+  CapData(request) {
+    const data = QueryCapDataRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, 'CapData', data);
+    return promise.then(data =>
+      QueryCapDataResponse.decode(new _m0.Reader(data)),
+    );
   }
   Children(request) {
     const data = QueryChildrenRequest.encode(request).finish();

--- a/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.d.ts
+++ b/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.d.ts
@@ -35,7 +35,11 @@ export interface PageRequest {
      * is set.
      */
     countTotal: boolean;
-    /** reverse is set to true if results are to be returned in the descending order. */
+    /**
+     * reverse is set to true if results are to be returned in the descending order.
+     *
+     * Since: cosmos-sdk 0.43
+     */
     reverse: boolean;
 }
 /**
@@ -50,7 +54,8 @@ export interface PageRequest {
 export interface PageResponse {
     /**
      * next_key is the key to be passed to PageRequest.key to
-     * query the next page most efficiently
+     * query the next page most efficiently. It will be empty if
+     * there are no more results.
      */
     nextKey: Uint8Array;
     /**

--- a/packages/cosmic-proto/proto/cosmos_proto
+++ b/packages/cosmic-proto/proto/cosmos_proto
@@ -1,0 +1,1 @@
+../../../golang/cosmos/third_party/proto/cosmos_proto


### PR DESCRIPTION
refs: #8791

## Description

The IBC upgrade PR started relying on `cosmos_proto` but did not update `cosmic-proto` to make this dependency excplicit.
This fixes that, and regenerates the JS protos.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

This would have been caught if we had #8131

### Upgrade Considerations

Will pick up in upgrade-14 and rebuild there (along #7950)
