### PR TITLE
more robust repairWalletForIncarnation2

### DIFF
--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -19,7 +19,7 @@ import { AmountMath } from '@agoric/ertp/src/amountMath.js';
  * @param {ERef<any>} walletAdmin - an internal type of the
  * wallet, not defined here
  * @param {ERef<ZoeService>} zoe
- * @param {ERef<Purse>} zoeInvitationPurse
+ * @param {ERef<Purse<'set'>>} zoeInvitationPurse
  */
 export const makeOfferAndFindInvitationAmount = (
   walletAdmin,
@@ -28,7 +28,7 @@ export const makeOfferAndFindInvitationAmount = (
 ) => {
   /**
    * @param {Record<string, any>} invitationDetailsCriteria
-   * @returns {Promise<Amount>} invitationAmount
+   * @returns {Promise<Amount<'set'>>} invitationAmount
    */
   const findInvitationAmount = async invitationDetailsCriteria => {
     const invitationAmount = await E(zoeInvitationPurse).getCurrentAmount();

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -104,17 +104,29 @@ const offerWatcherGuard = harden({
   }),
 });
 
+/**
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ */
 export const prepareOfferWatcher = baggage => {
   return prepareExoClassKit(
     baggage,
     'OfferWatcher',
     offerWatcherGuard,
-    (walletHelper, deposit, offerSpec, address, iAmount, seatRef) => ({
+    /**
+     *
+     * @param {*} walletHelper
+     * @param {*} deposit
+     * @param {import('./offers.js').OfferSpec} offerSpec
+     * @param {string} address
+     * @param {Amount<'set'>} invitationAmount
+     * @param {UserSeat} seatRef
+     */
+    (walletHelper, deposit, offerSpec, address, invitationAmount, seatRef) => ({
       walletHelper,
       deposit,
       status: offerSpec,
       address,
-      invitationAmount: iAmount,
+      invitationAmount,
       seatRef,
     }),
     {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -1102,9 +1102,9 @@ export const prepareSmartWallet = (baggage, shared) => {
             },
           });
         },
+        // TODO remove this and repairUnwatchedSeats once the repair has taken place.
         /**
-         * one-time use function. Remove this and repairUnwatchedSeats once the
-         * repair has taken place.
+         * To be called once ever per wallet.
          *
          * @param {object} key
          */
@@ -1115,8 +1115,12 @@ export const prepareSmartWallet = (baggage, shared) => {
             return;
           }
 
-          void facets.helper.repairUnwatchedSeats();
-          void facets.helper.repairUnwatchedPurses();
+          facets.helper.repairUnwatchedSeats().catch(e => {
+            console.error('repairUnwatchedSeats rejection', e);
+          });
+          facets.helper.repairUnwatchedPurses().catch(e => {
+            console.error('repairUnwatchedPurses rejection', e);
+          });
           trace(`repaired wallet ${state.address}`);
         },
       },

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -173,7 +173,7 @@ const trace = makeTracer('SmrtWlt');
  *   paymentQueues: MapStore<Brand, Array<Payment>>,
  *   offerToInvitationMakers: MapStore<string, import('./types.js').InvitationMakers>,
  *   offerToPublicSubscriberPaths: MapStore<string, Record<string, string>>,
- *   offerToUsedInvitation: MapStore<string, Amount>,
+ *   offerToUsedInvitation: MapStore<string, Amount<'set'>>,
  *   purseBalances: MapStore<Purse, Amount>,
  *   updateRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<UpdateRecord>,
  *   currentRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<CurrentWalletRecord>,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -643,24 +643,24 @@ export const prepareSmartWallet = (baggage, shared) => {
             const offerSpec = liveOffers.get(seatId);
             const seat = liveOfferSeats.get(seatId);
 
-            const invitation = invitationFromSpec(offerSpec.invitationSpec);
-            watcherPromises.push(
-              E.when(
-                E(invitationIssuer).getAmountOf(invitation),
-                invitationAmount => {
-                  const watcher = makeOfferWatcher(
-                    facets.helper,
-                    facets.deposit,
-                    offerSpec,
-                    address,
-                    invitationAmount,
-                    seat,
-                  );
-                  return watchOfferOutcomes(watcher, seat);
-                },
-              ),
-            );
+            const watchOutcome = (async () => {
+              // To infer the invitation amount for the offer
+              const invitation = invitationFromSpec(offerSpec.invitationSpec);
+              const invitationAmount =
+                await E(invitationIssuer).getAmountOf(invitation);
+              const watcher = makeOfferWatcher(
+                facets.helper,
+                facets.deposit,
+                offerSpec,
+                address,
+                invitationAmount,
+                seat,
+              );
+              void E(invitationIssuer).burn(invitation);
+              return watchOfferOutcomes(watcher, seat);
+            })();
             trace(`Repaired seat ${seatId} for wallet ${address}`);
+            watcherPromises.push(watchOutcome);
           }
 
           await Promise.all(watcherPromises);

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -644,10 +644,29 @@ export const prepareSmartWallet = (baggage, shared) => {
             const seat = liveOfferSeats.get(seatId);
 
             const watchOutcome = (async () => {
-              // To infer the invitation amount for the offer
-              const invitation = invitationFromSpec(offerSpec.invitationSpec);
-              const invitationAmount =
-                await E(invitationIssuer).getAmountOf(invitation);
+              await null;
+              let invitationAmount = state.offerToUsedInvitation.get(
+                // @ts-expect-error older type allowed number
+                offerSpec.id,
+              );
+              if (invitationAmount) {
+                facets.helper.logWalletInfo(
+                  'recovered invitation amount for offer',
+                  offerSpec.id,
+                );
+              } else {
+                facets.helper.logWalletInfo(
+                  'inferring invitation amount for offer',
+                  offerSpec.id,
+                );
+                const tempInvitation = invitationFromSpec(
+                  offerSpec.invitationSpec,
+                );
+                invitationAmount =
+                  await E(invitationIssuer).getAmountOf(tempInvitation);
+                void E(invitationIssuer).burn(tempInvitation);
+              }
+
               const watcher = makeOfferWatcher(
                 facets.helper,
                 facets.deposit,
@@ -656,7 +675,6 @@ export const prepareSmartWallet = (baggage, shared) => {
                 invitationAmount,
                 seat,
               );
-              void E(invitationIssuer).burn(invitation);
               return watchOfferOutcomes(watcher, seat);
             })();
             trace(`Repaired seat ${seatId} for wallet ${address}`);


### PR DESCRIPTION
## Description

In testing with production state we noticed new log messages that hadn't appeared in synthetic tests. And the investigation of making invitations revealed that they were never burned.

This addresses those by:
1. explicitly logging the rejections in `repairWalletForIncarnation2`
2. burning the invitations that are made just to infer amounts
3. pulling amounts from state when possible

It also includes some type coverage improvements made while navigating the code above.

### Security Considerations

none

### Scaling Considerations

Prevents some wasted retention of unused invitations

### Documentation Considerations

n/a

### Testing Considerations

we should see the new log messages in upgrade-14 testing

### Upgrade Considerations

To be included in `dev-upgrade-14` cc @mhofman 