### PR TITLE
chore(cosmos): state-sync improvements

### DIFF
--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -15,7 +15,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
+	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/snapshots"
@@ -126,9 +128,15 @@ func initRootCmd(sender Sender, rootCmd *cobra.Command, encodingConfig params.En
 	cfg := sdk.GetConfig()
 	cfg.Seal()
 
+	ac := appCreator{
+		encCfg: encodingConfig,
+		sender: sender,
+	}
+
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(gaia.ModuleBasics, gaia.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, gaia.DefaultNodeHome),
+		genutilcli.MigrateGenesisCmd(),
 		genutilcli.GenTxCmd(gaia.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, gaia.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(gaia.ModuleBasics),
 		AddGenesisAccountCmd(encodingConfig.Marshaler, gaia.DefaultNodeHome),
@@ -136,12 +144,10 @@ func initRootCmd(sender Sender, rootCmd *cobra.Command, encodingConfig params.En
 		testnetCmd(gaia.ModuleBasics, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),
 		config.Cmd(),
+		pruning.Cmd(ac.newApp, gaia.DefaultNodeHome),
+		snapshot.Cmd(ac.newApp),
 	)
 
-	ac := appCreator{
-		encCfg: encodingConfig,
-		sender: sender,
-	}
 	server.AddCommands(rootCmd, gaia.DefaultNodeHome, ac.newApp, ac.appExport, addModuleInitFlags)
 
 	for _, command := range rootCmd.Commands() {
@@ -231,6 +237,7 @@ func txCommand() *cobra.Command {
 		authcmd.GetBroadcastCommand(),
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
+		authcmd.GetAuxToFeeCommand(),
 		flags.LineBreak,
 		vestingcli.GetTxCmd(),
 	)

--- a/golang/cosmos/x/swingset/keeper/swing_store_exports_handler.go
+++ b/golang/cosmos/x/swingset/keeper/swing_store_exports_handler.go
@@ -751,10 +751,14 @@ func (exportsHandler SwingStoreExportsHandler) RestoreExport(provider SwingStore
 	}
 	defer os.RemoveAll(exportDir)
 
+	exportsHandler.logger.Info("creating swing-store restore", "exportDir", exportDir, "height", blockHeight)
+
 	err = WriteSwingStoreExportToDirectory(provider, exportDir)
 	if err != nil {
 		return err
 	}
+
+	exportsHandler.logger.Info("restoring swing-store", "exportDir", exportDir, "height", blockHeight)
 
 	action := &swingStoreRestoreExportAction{
 		Type:        swingStoreExportActionType,
@@ -772,7 +776,7 @@ func (exportsHandler SwingStoreExportsHandler) RestoreExport(provider SwingStore
 		return err
 	}
 
-	exportsHandler.logger.Info("restored swing-store export", "exportDir", exportDir, "height", blockHeight)
+	exportsHandler.logger.Info("restored swing-store", "exportDir", exportDir, "height", blockHeight)
 
 	return nil
 }


### PR DESCRIPTION
refs: #8888

## Description

Adds simple logging to know when we're starting each step of the state-sync restore.

A test of the [upcoming upgrade-14 on mainfork](https://github.com/Agoric/agoric-sdk/issues/8875) took almost 3 hours to restore, which is a big regression (approx 50%) from earlier versions, and the lack of logging makes it hard to pin-point where this regressions is.

This is not a fix for 8888, only some surface logging that could be easily added without enabling the more verbose option that would spamming stdout.

This also syncs up the commands that are in upstream `cosmos-sdk/simapp/simd/cmd/root.go`, in particular the new `snapshot` command which allows to manage the local snapshot DB and perform all snapshot operations triggered by the command line! See https://github.com/cosmos/cosmos-sdk/pull/16067

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually tested that snapshots list / dump / load works as expected
`snapshots export` does not work because the way our extension integrates with the snapshot mechanism is not compatible (will file an issue)
I did manage to verify `snapshots restore` works, with some necessary shenanigans due to discrepancy between tendermint and cosmos heights.

### Upgrade Considerations

Would like to include in upgrade-14