### PR TITLE
feat(base-zone): alt revocable api using amplifier

### DIFF
--- a/packages/base-zone/src/prepare-revocable.js
+++ b/packages/base-zone/src/prepare-revocable.js
@@ -4,7 +4,7 @@ import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 const { Fail, quote: q } = assert;
 
 /**
- * @template {any} [U=any]
+ * @template [U=any]
  * @typedef {object} RevocableMakerKit
  * @property {(revocable: U) => boolean} revoke
  * @property {(underlying: U) => U} makeRevocable
@@ -17,7 +17,7 @@ const { Fail, quote: q } = assert;
  */
 
 /**
- * @template {any} [U=any]
+ * @template [U=any]
  * @typedef {object} RevocableKit
  * @property {RevokerFacet} revoker
  * @property {U} revocable
@@ -32,7 +32,7 @@ const { Fail, quote: q } = assert;
  */
 
 /**
- * @template {any} [U=any]
+ * @template [U=any]
  * @typedef {object} RevocableKitOptions
  * @property {string} [uInterfaceName]
  *   The `interfaceName` of the underlying interface guard.
@@ -57,7 +57,7 @@ const { Fail, quote: q } = assert;
  * where the wrapper is a revocable forwarder.
  *
  * @deprecated Change to `prepareRevocableMakerKit` once #8977 happens
- * @template {any} [U=any]
+ * @template [U=any]
  * @param {import('@agoric/base-zone').Zone} zone
  * @param {string} uKindName
  *   The `kindName` of the underlying exo class

--- a/packages/base-zone/src/prepare-revocable.js
+++ b/packages/base-zone/src/prepare-revocable.js
@@ -13,7 +13,7 @@ const { Fail, quote: q } = assert;
 
 /**
  * @typedef {object} RevokerFacet
- * @property {() => boolean} revokeOne
+ * @property {() => boolean} revoke
  */
 
 /**
@@ -56,7 +56,6 @@ const { Fail, quote: q } = assert;
  * Make an exo class kit for wrapping an underlying exo class,
  * where the wrapper is a revocable forwarder.
  *
- * @deprecated Change to `prepareRevocableMakerKit` once #8977 happens
  * @template [U=any]
  * @param {import('@agoric/base-zone').Zone} zone
  * @param {string} uKindName
@@ -80,7 +79,7 @@ export const prepareRevocableMakerKit = (
   } = options;
   const RevocableIKit = harden({
     revoker: M.interface(`${uInterfaceName}_revoker`, {
-      revokeOne: M.call().returns(M.boolean()),
+      revoke: M.call().returns(M.boolean()),
     }),
     revocable: M.interface(
       `${uInterfaceName}_revocable`,
@@ -105,7 +104,7 @@ export const prepareRevocableMakerKit = (
     }),
     {
       revoker: {
-        revokeOne() {
+        revoke() {
           const { state } = this;
           if (state.underlying === undefined) {
             return false;
@@ -162,7 +161,7 @@ export const prepareRevocableMakerKit = (
     if (facets === undefined) {
       return false;
     }
-    return facets.revoker.revokeOne();
+    return facets.revoker.revoke();
   };
 
   return harden({


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8779 https://github.com/Agoric/agoric-sdk/pull/8965

## Description

An alternative to https://github.com/Agoric/agoric-sdk/pull/8965 by using the amplifier provided by endo for heap zones and by https://github.com/Agoric/agoric-sdk/pull/8779 for virtual and durable zones. 

In this alternative, rather than expose the per-cohort revoker facet, instead we return a kit one level earlier in the making hierarchy. This kit is `{ revoke, makeRevocable }`, where the `makeRevocable` itself just returns the revocable, not a kit, and the `revoke` function will revoke any revocable made by that `makeRevocable` function.

Diffing this PR against https://github.com/Agoric/agoric-sdk/pull/8965 should demonstrate that this alternate API is no harder to use for the uses we originally had and tested. An upcoming PR staged on this will make use of this alternate API, whereas it would have been difficult for it to use the revocability API of https://github.com/Agoric/agoric-sdk/pull/8965

### Security Considerations

The returned `revoke` function now applies to all revocables make by that `makeRevocable` function, and so is more powerful that the revoker of https://github.com/Agoric/agoric-sdk/pull/8965, which only revokes its own cohort. Therefore it is more dangerous to leak. But the API encourages it to simply be used in the creation lexical scope and not given out from there.

### Scaling Considerations

none so far. But for some uses, without https://github.com/Agoric/agoric-sdk/pull/8779 we would often be lead to creating a new weakStore to do our own amplification from the revocable to the revoker. This PR avoids that need.

### Documentation Considerations

- [ ] I need to write doccomments for the new API, so typedoc can generate typedoc pages explaining how to use it.

### Testing Considerations

Aside from the testing changes already in this PR, none.

### Upgrade Considerations

For upgrading durable state, none.

For API compat, if this https://github.com/Agoric/agoric-sdk/pull/8965 is never merged separately from this PR, then no one who still imports it from its old home in @agoric/zoe could be disrupted by the change in API. The one known user, prepare-ownable.js in @agoric/zoe, is upgraded by this PR to use the new API.