### PR TITLE
smart wallet report rejections of durable promises

### DIFF
--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -227,15 +227,15 @@ export const prepareOfferWatcher = baggage => {
         /**
          * If promise disconnected, watch again. Or if there's an Error, handle it.
          *
-         * @param {Error} err
+         * @param {Error | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
          * @param {UserSeat} seat
          */
-        onRejected(err, seat) {
+        onRejected(reason, seat) {
           const { facets } = this;
-          if (isUpgradeDisconnection(err)) {
+          if (isUpgradeDisconnection(reason)) {
             void watchForPayout(facets, seat);
           } else {
-            facets.helper.handleError(err);
+            facets.helper.handleError(reason);
           }
         },
       },
@@ -249,15 +249,15 @@ export const prepareOfferWatcher = baggage => {
         /**
          * If promise disconnected, watch again. Or if there's an Error, handle it.
          *
-         * @param {Error} err
+         * @param {Error | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
          * @param {UserSeat} seat
          */
-        onRejected(err, seat) {
+        onRejected(reason, seat) {
           const { facets } = this;
-          if (isUpgradeDisconnection(err)) {
+          if (isUpgradeDisconnection(reason)) {
             void watchForOfferResult(facets, seat);
           } else {
-            facets.helper.handleError(err);
+            facets.helper.handleError(reason);
           }
         },
       },
@@ -276,12 +276,12 @@ export const prepareOfferWatcher = baggage => {
          * and getPayouts() settle the same (they await the same promise and
          * then synchronously return a local value).
          *
-         * @param {Error} err
+         * @param {Error | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
          * @param {UserSeat} seat
          */
-        onRejected(err, seat) {
+        onRejected(reason, seat) {
           const { facets } = this;
-          if (isUpgradeDisconnection(err)) {
+          if (isUpgradeDisconnection(reason)) {
             void watchForNumWants(facets, seat);
           }
         },

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -153,6 +153,7 @@ export const prepareOfferWatcher = baggage => {
           );
         },
 
+        /** @param {unknown} result */
         publishResult(result) {
           const { state, facets } = this;
 
@@ -169,6 +170,7 @@ export const prepareOfferWatcher = baggage => {
               facets.helper.updateStatus({ result });
               break;
             case 'copyRecord':
+              // @ts-expect-error narrowed by passStyle
               if ('invitationMakers' in result) {
                 // save for continuing invitation offer
 
@@ -176,6 +178,7 @@ export const prepareOfferWatcher = baggage => {
                   String(state.status.id),
                   state.invitationAmount,
                   result.invitationMakers,
+                  // @ts-expect-error narrowed by passStyle
                   result.publicSubscribers,
                 );
               }

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -854,6 +854,10 @@ export const prepareSmartWallet = (baggage, shared) => {
 
       payments: {
         /**
+         * Withdraw the offered amount from the appropriate purse of this wallet.
+         *
+         * Save its amount in liveOfferPayments in case we need to reclaim the payment.
+         *
          * @param {AmountKeywordRecord} give
          * @param {OfferId} offerId
          * @returns {PaymentPKeywordRecord}
@@ -869,8 +873,8 @@ export const prepareSmartWallet = (baggage, shared) => {
             .getLiveOfferPayments()
             .init(offerId, brandPaymentRecord);
 
-          // Add each payment to liveOfferPayments as it is withdrawn. If
-          // there's an error partway through, we can recover the withdrawals.
+          // Add each payment amount to brandPaymentRecord as it is withdrawn. If
+          // there's an error later, we can use it to redeposit the correct amount.
           return objectMap(give, amount => {
             /** @type {Promise<Purse>} */
             const purseP = facets.helper.purseForBrand(amount.brand);
@@ -891,19 +895,27 @@ export const prepareSmartWallet = (baggage, shared) => {
           });
         },
 
+        /**
+         * Find the live payments for the offer and deposit them back in the appropriate purses.
+         *
+         * @param {OfferId} offerId
+         * @returns {Promise<void>}
+         */
         async tryReclaimingWithdrawnPayments(offerId) {
           const { facets } = this;
+
+          await null;
 
           const liveOfferPayments = facets.helper.getLiveOfferPayments();
           if (liveOfferPayments.has(offerId)) {
             const brandPaymentRecord = liveOfferPayments.get(offerId);
             if (!brandPaymentRecord) {
-              return Promise.resolve(undefined);
+              return;
             }
             // Use allSettled to ensure we attempt all the deposits, regardless of
             // individual rejections.
-            return Promise.allSettled(
-              Array.from(brandPaymentRecord.entries()).map(async ([b, p]) => {
+            await Promise.allSettled(
+              Array.from(brandPaymentRecord.entries()).map(([b, p]) => {
                 // Wait for the withdrawal to complete.  This protects against a
                 // race when updating paymentToPurse.
                 const purseP = facets.helper.purseForBrand(b);


### PR DESCRIPTION
closes: #8997

## Description

This moves the error handling into an onRejected callback of the durable promise watcher for the offer result. The other two watchers are for particular values from Zoe after that promise resolves. Those are synchronous and don't need their own error handling.

It doesn't move `tryReclaimingWithdrawnPayments` because that would require heavier refactoring and in our analysis its a very unlikely scenario. I've commented with why it's there. I also changed its return type to `Promise<void>`, instead of all the settlements. Since that value was never read, it's not changing behavior and I called it a refactor.

### Security Considerations

No change.

### Scaling Considerations

No change.

### Documentation Considerations

It would help if Zoe documented in its code which methods' promises settle together.

### Testing Considerations

Ideally there'd be a new test for this fix but there isn't.

### Upgrade Considerations

To be included in u14 upgrade of smartWallet.