### PR TITLE
adopt EReturn type

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -36,6 +36,10 @@ import { makeStartXSnap } from './startXSnap.js';
 import { makeStartSubprocessWorkerNode } from './startNodeSubprocess.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
  * @typedef { import('../types-internal.js').VatID } VatID
  */
 
@@ -494,7 +498,7 @@ export async function makeSwingsetController(
 
   return controller;
 }
-/** @typedef {Awaited<ReturnType<typeof makeSwingsetController>>} SwingsetController */
+/** @typedef {EReturn<typeof makeSwingsetController>} SwingsetController */
 
 /**
  * NB: To be used only in tests. An app with this may not survive a reboot.

--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -79,7 +79,7 @@ const makeConfigFromPaths = (bootstrapVatPath, options = {}) => {
  * Refcount incrementing should be manual,
  * see https://github.com/Agoric/agoric-sdk/issues/7213
  * @returns {Promise<{
- *   controller: Awaited<ReturnType<typeof makeSwingsetController>>,
+ *   controller: EReturn<typeof makeSwingsetController>,
  *   kvStore: KVStore,
  *   messageToVat: (vatName: string, method: string, ...args: unknown[]) => Promise<unknown>,
  *   messageToVatAndRetain: (vatName: string, method: string, ...args: unknown[]) => Promise<unknown>,

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -1,6 +1,10 @@
 import { makeNodeBundleCache as wrappedMaker } from '@endo/bundle-source/cache.js';
 import styles from 'ansi-styles'; // less authority than 'chalk'
 
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
 /** @type {typeof wrappedMaker} */
 export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
   const log = (...args) => {
@@ -17,7 +21,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
   };
   return wrappedMaker(dest, { log, ...options }, loadModule, pid);
 };
-/** @typedef {Awaited<ReturnType<typeof makeNodeBundleCache>>} BundleCache */
+/** @typedef {EReturn<typeof makeNodeBundleCache>} BundleCache */
 
 /** @type {Map<string, Promise<BundleCache>>} */
 const providedCaches = new Map();

--- a/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
+++ b/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
@@ -1,4 +1,5 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
 import type { TestFn } from 'ava';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import {

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -1,5 +1,6 @@
 /** @file upgrade network / IBC vat at many points in state machine */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
 import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 import type { TestFn } from 'ava';
 import { createRequire } from 'module';

--- a/packages/boot/test/bootstrapTests/upgradeAPI.test.ts
+++ b/packages/boot/test/bootstrapTests/upgradeAPI.test.ts
@@ -1,4 +1,5 @@
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
 import type { TestFn } from 'ava';
 import path from 'path';
 import bundleSource from '@endo/bundle-source';

--- a/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
+++ b/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
@@ -1,7 +1,6 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import type { TestFn } from 'ava';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,

--- a/packages/boot/test/upgrading/upgrade-contracts.test.js
+++ b/packages/boot/test/upgrading/upgrade-contracts.test.js
@@ -2,8 +2,9 @@
  * @file cribbed from
  *   packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
  */
-import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { buildVatController } from '@agoric/swingset-vat';
 
 /**

--- a/packages/casting/test/interpose-net-access.test.js
+++ b/packages/casting/test/interpose-net-access.test.js
@@ -15,7 +15,11 @@ import {
 import { makeTendermintRpcClient } from '../src/makeHttpClient.js';
 import { captureIO, replayIO, web1, web2 } from './net-access-fixture.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/** @type {import('ava').TestFn<EReturn<typeof makeTestContext>>} */
 const test = /** @type {any} */ (anyTest);
 
 const RECORDING = false;

--- a/packages/client-utils/src/smart-wallet-kit.js
+++ b/packages/client-utils/src/smart-wallet-kit.js
@@ -4,6 +4,7 @@ import { makeStargateClient } from './rpc.js';
 import { makeAgoricNames, makeVstorageKit } from './vstorage-kit.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {Amount, Brand} from '@agoric/ertp/src/types.js'
  * @import {CurrentWalletRecord, UpdateRecord} from '@agoric/smart-wallet/src/smartWallet.js';
  * @import {MinimalNetworkConfig} from './network-config.js';
@@ -110,4 +111,4 @@ export const makeSmartWalletKit = async ({ fetch, delay }, networkConfig) => {
     pollOffer,
   };
 };
-/** @typedef {Awaited<ReturnType<typeof makeSmartWalletKit>>} SmartWalletKit */
+/** @typedef {EReturn<typeof makeSmartWalletKit>} SmartWalletKit */

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -55,6 +55,10 @@ import {
   validateImporterOptions,
 } from './import-kernel-db.js';
 
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
 const ignore = () => {};
 
 // eslint-disable-next-line no-unused-vars
@@ -581,7 +585,7 @@ export default async function main(
     return blockingSendSpy;
   }
 
-  /** @type {Awaited<ReturnType<typeof launch>>['blockingSend'] | undefined} */
+  /** @type {EReturn<typeof launch>['blockingSend'] | undefined} */
   let blockingSend;
 
   async function handleSwingStoreExport(blockHeight, request, requestArgs) {

--- a/packages/fast-usdc/test/cli/lp-commands.test.ts
+++ b/packages/fast-usdc/test/cli/lp-commands.test.ts
@@ -1,10 +1,11 @@
+import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
+import type { EReturn } from '@endo/far';
 import { Far, makeMarshal } from '@endo/marshal';
 import anyTest, { type TestFn } from 'ava';
 import { Command } from 'commander';
-import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
+import { addLPCommands } from '../../src/cli/lp-commands.js';
 import { flags } from '../../tools/cli-tools.js';
 import { mockStream } from '../../tools/mock-io.js';
-import { addLPCommands } from '../../src/cli/lp-commands.js';
 
 const makeTestContext = () => {
   const program = new Command();
@@ -54,7 +55,7 @@ const makeTestContext = () => {
   return { program, marshaller, out, err, USDC, FastLP, now };
 };
 
-const test = anyTest as TestFn<Awaited<ReturnType<typeof makeTestContext>>>;
+const test = anyTest as TestFn<EReturn<typeof makeTestContext>>;
 test.beforeEach(async t => (t.context = await makeTestContext()));
 
 test('fast-usdc deposit command', async t => {

--- a/packages/fast-usdc/test/exos/advancer.test.ts
+++ b/packages/fast-usdc/test/exos/advancer.test.ts
@@ -5,15 +5,16 @@ import {
   encodeAddressHook,
 } from '@agoric/cosmic-proto/address-hooks.js';
 import type { NatAmount } from '@agoric/ertp';
+import { makeTracer } from '@agoric/internal';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { ChainAddressShape, denomHash } from '@agoric/orchestration';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { type ZoeTools } from '@agoric/orchestration/src/utils/zoe-tools.js';
 import { q } from '@endo/errors';
+import type { EReturn } from '@endo/far';
 import { Far } from '@endo/pass-style';
-import type { TestFn } from 'ava';
-import { makeTracer } from '@agoric/internal';
 import { M, mustMatch } from '@endo/patterns';
+import type { TestFn } from 'ava';
 import { PendingTxStatus } from '../../src/constants.js';
 import { prepareAdvancer, stateShape } from '../../src/exos/advancer.js';
 import {
@@ -21,12 +22,13 @@ import {
   type SettlerKit,
 } from '../../src/exos/settler.js';
 import { prepareStatusManager } from '../../src/exos/status-manager.js';
+import { CctpTxEvidenceShape } from '../../src/type-guards.js';
 import type { LiquidityPoolKit } from '../../src/types.js';
 import { makeFeeTools } from '../../src/utils/fees.js';
 import {
+  intermediateRecipient,
   MockCctpTxEvidences,
   settlementAddress,
-  intermediateRecipient,
 } from '../fixtures.js';
 import {
   makeTestFeeConfig,
@@ -34,7 +36,6 @@ import {
   prepareMockOrchAccounts,
 } from '../mocks.js';
 import { commonSetup } from '../supports.js';
-import { CctpTxEvidenceShape } from '../../src/type-guards.js';
 
 const trace = makeTracer('AdvancerTest', false);
 
@@ -44,7 +45,7 @@ const LOCAL_DENOM = `ibc/${denomHash({
     fetchedChainInfo.agoric.connections['noble-1'].transferChannel.channelId,
 })}`;
 
-type CommonSetup = Awaited<ReturnType<typeof commonSetup>>;
+type CommonSetup = EReturn<typeof commonSetup>;
 
 const createTestExtensions = (t, common: CommonSetup) => {
   const {

--- a/packages/fast-usdc/test/exos/settler.test.ts
+++ b/packages/fast-usdc/test/exos/settler.test.ts
@@ -10,6 +10,7 @@ import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import type { Zone } from '@agoric/zone';
+import type { EReturn } from '@endo/far';
 import { PendingTxStatus, TxStatus } from '../../src/constants.js';
 import {
   prepareSettler,
@@ -215,7 +216,7 @@ const makeTestContext = async t => {
   };
 };
 
-const test = anyTest as TestFn<Awaited<ReturnType<typeof makeTestContext>>>;
+const test = anyTest as TestFn<EReturn<typeof makeTestContext>>;
 
 test.beforeEach(async t => (t.context = await makeTestContext(t)));
 

--- a/packages/fast-usdc/test/exos/status-manager.test.ts
+++ b/packages/fast-usdc/test/exos/status-manager.test.ts
@@ -1,19 +1,20 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import type { TestFn } from 'ava';
 
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { defaultMarshaller } from '@agoric/internal/src/storage-test-utils.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import type { EReturn } from '@endo/far';
 import { PendingTxStatus } from '../../src/constants.js';
 import {
   prepareStatusManager,
   stateShape,
   type StatusManager,
 } from '../../src/exos/status-manager.js';
-import { commonSetup, provideDurableZone } from '../supports.js';
-import { MockCctpTxEvidences } from '../fixtures.js';
 import type { CctpTxEvidence } from '../../src/types.js';
+import { MockCctpTxEvidences } from '../fixtures.js';
+import { commonSetup, provideDurableZone } from '../supports.js';
 
-type Common = Awaited<ReturnType<typeof commonSetup>>;
+type Common = EReturn<typeof commonSetup>;
 type TestContext = {
   statusManager: StatusManager;
   storage: Common['bootstrap']['storage'];

--- a/packages/fast-usdc/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc/test/fast-usdc.contract.test.ts
@@ -28,7 +28,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E } from '@endo/far';
+import { E, type EReturn } from '@endo/far';
 import { matches } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
 import path from 'path';
@@ -61,7 +61,7 @@ const getInvitationProperties = async (
 // Spec for Mainnet. Other values are covered in unit tests of TransactionFeed.
 const operatorQty = 3;
 
-type CommonSetup = Awaited<ReturnType<typeof commonSetup>>;
+type CommonSetup = EReturn<typeof commonSetup>;
 const startContract = async (
   common: Pick<CommonSetup, 'brands' | 'commonPrivateArgs' | 'utils'>,
 ) => {
@@ -124,7 +124,7 @@ const makeTestContext = async (t: ExecutionContext) => {
   });
 
   const sync = {
-    ocw: makePromiseKit<Awaited<ReturnType<typeof makeOracleOperator>>[]>(),
+    ocw: makePromiseKit<EReturn<typeof makeOracleOperator>[]>(),
     lp: makePromiseKit<Record<string, ReturnType<typeof makeLP>>>(),
   };
 
@@ -171,7 +171,7 @@ const makeTestContext = async (t: ExecutionContext) => {
   };
 };
 
-type FucContext = Awaited<ReturnType<typeof makeTestContext>>;
+type FucContext = EReturn<typeof makeTestContext>;
 const test = anyTest as TestFn<FucContext>;
 test.before(async t => (t.context = await makeTestContext(t)));
 

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -17,7 +17,8 @@ import {
 import { ClosingRuleShape, ParamChangesSpecShape } from './typeGuards.js';
 
 /**
- * @import {VoteCounterCreatorFacet, VoteCounterPublicFacet, QuestionSpec, OutcomeRecord, AddQuestion, AddQuestionReturn, ClosingRule, GovernableStartFn, LimitedCF, PoserFacet, VoteOnApiInvocation, VoteOnOfferFilter, VoteOnParamChanges} from './types.js';
+ * @import {EReturn} from '@endo/far';
+ * @import {ClosingRule, GovernableStartFn, LimitedCF, PoserFacet, VoteOnApiInvocation, VoteOnOfferFilter, VoteOnParamChanges} from './types.js';
  */
 
 const trace = makeTracer('CGK', false);
@@ -72,7 +73,7 @@ export const prepareContractGovernorKit = (baggage, powers) => {
   let filterGovernance;
   /** @type {ReturnType<typeof setupParamGovernance>} */
   let paramGovernance;
-  /** @type {Awaited<ReturnType<typeof setupApiGovernance>>} */
+  /** @type {EReturn<typeof setupApiGovernance>} */
   let apiGovernance;
 
   /** @type {any} */
@@ -277,4 +278,4 @@ export const prepareContractGovernorKit = (baggage, powers) => {
   return makeContractGovernorKit;
 };
 
-/** @typedef {ReturnType<ReturnType<typeof prepareContractGovernorKit>>} ContractGovernorKit */
+/** @typedef {EReturn<EReturn<typeof prepareContractGovernorKit>>} ContractGovernorKit */

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
@@ -11,6 +11,10 @@ import {
 } from '../../../src/index.js';
 import { MALLEABLE_NUMBER } from './governedContract.js';
 
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
 const build = async (log, zoe) => {
   return Far('voter', {
     createVoter: async (name, invitation) => {
@@ -105,7 +109,7 @@ const build = async (log, zoe) => {
 };
 
 /**
- * @typedef {ReturnType<Awaited<ReturnType<typeof build>>['createVoter']>} EVatVoter
+ * @typedef {ReturnType<EReturn<typeof build>['createVoter']>} EVatVoter
  */
 
 /** @type {import('@agoric/swingset-vat/src/kernel/vat-loader/types.js').BuildRootObjectForTestVat} */

--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -28,6 +28,7 @@ import {
 } from './util.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {Baggage} from '@agoric/vat-data';
  * @import {PriceAuthority} from '@agoric/zoe/tools/types.js';
  * @import {TypedPattern} from '@agoric/internal';
@@ -790,4 +791,4 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
 };
 harden(prepareAuctionBook);
 
-/** @typedef {ReturnType<ReturnType<typeof prepareAuctionBook>>} AuctionBook */
+/** @typedef {EReturn<EReturn<typeof prepareAuctionBook>>} AuctionBook */

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -19,6 +19,7 @@ import { prepareOracleAdminKit } from './priceOracleKit.js';
 import { prepareRoundsManagerKit } from './roundsManager.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {TypedPattern} from '@agoric/internal';
  * @import {PriceAuthority, PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
  */
@@ -371,4 +372,4 @@ export const prepareFluxAggregatorKit = async (
   return makeFluxAggregatorKit;
 };
 harden(prepareFluxAggregatorKit);
-/** @typedef {ReturnType<Awaited<ReturnType<typeof prepareFluxAggregatorKit>>>} FluxAggregatorKit */
+/** @typedef {EReturn<EReturn<typeof prepareFluxAggregatorKit>>} FluxAggregatorKit */

--- a/packages/inter-protocol/src/price/priceOracleKit.js
+++ b/packages/inter-protocol/src/price/priceOracleKit.js
@@ -7,6 +7,10 @@ const trace = makeTracer('OrKit', true);
 export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
 /**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
  * @typedef {{
  *   oracleId: string;
  *   roundPowers: {
@@ -122,4 +126,4 @@ export const prepareOracleAdminKit = baggage =>
     },
   );
 
-/** @typedef {ReturnType<ReturnType<typeof prepareOracleAdminKit>>} OracleKit */
+/** @typedef {EReturn<EReturn<typeof prepareOracleAdminKit>>} OracleKit */

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -44,6 +44,10 @@ import { makeNatAmountShape } from '../contractSupport.js';
  */
 
 /**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
  * @typedef {object} MetricsNotification Metrics naming scheme is that nouns are
  *   present values and past-participles are accumulative.
  * @property {Amount<'nat'>} anchorPoolBalance amount of Anchor token available
@@ -442,4 +446,4 @@ export const start = async (zcf, privateArgs, baggage) => {
 };
 harden(start);
 
-/** @typedef {Awaited<ReturnType<typeof start>>['publicFacet']} PsmPublicFacet */
+/** @typedef {EReturn<typeof start>['publicFacet']} PsmPublicFacet */

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -8,6 +8,10 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { prepareAssetReserveKit } from './assetReserveKit.js';
 
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
 const trace = makeTracer('AR', true);
 
 /** @type {ContractMeta<typeof start>} */
@@ -118,8 +122,8 @@ harden(start);
  * @property {() => Promise<Invitation<ShortfallReporter>>} makeShortfallReportingInvitation
  */
 
-/** @typedef {Awaited<ReturnType<typeof start>>['publicFacet']} AssetReservePublicFacet */
+/** @typedef {EReturn<typeof start>['publicFacet']} AssetReservePublicFacet */
 /**
- * @typedef {Awaited<ReturnType<typeof start>>['creatorFacet']} AssetReserveCreatorFacet
+ * @typedef {EReturn<typeof start>['creatorFacet']} AssetReserveCreatorFacet
  *   the creator facet for the governor
  */

--- a/packages/inter-protocol/src/reserve/assetReserveKit.js
+++ b/packages/inter-protocol/src/reserve/assetReserveKit.js
@@ -14,6 +14,7 @@ import { UnguardedHelperI } from '@agoric/internal/src/typeGuards.js';
 const trace = makeTracer('ReserveKit', true);
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {TypedPattern} from '@agoric/internal';
  */
 
@@ -288,4 +289,4 @@ export const prepareAssetReserveKit = async (
   return makeAssetReserveKit;
 };
 harden(prepareAssetReserveKit);
-/** @typedef {ReturnType<Awaited<ReturnType<typeof prepareAssetReserveKit>>>} AssetReserveKit */
+/** @typedef {EReturn<EReturn<typeof prepareAssetReserveKit>>} AssetReserveKit */

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -17,6 +17,7 @@ import { prepareVaultKit } from './vaultKit.js';
 const trace = makeTracer('Vault', true);
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {Brand} from '@agoric/ertp/src/types.js';
  * @import {NormalizedDebt} from './storeUtils.js';
  */
@@ -874,4 +875,4 @@ export const prepareVault = (baggage, makeRecorderKit, zcf) => {
   return maker;
 };
 
-/** @typedef {ReturnType<ReturnType<typeof prepareVault>>['self']} Vault */
+/** @typedef {EReturn<EReturn<typeof prepareVault>>['self']} Vault */

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -40,6 +40,7 @@ import {
 } from './vaultManager.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {TypedPattern} from '@agoric/internal';
  */
 
@@ -545,13 +546,14 @@ const prepareVaultDirector = (
   return makeVaultDirector;
 };
 harden(prepareVaultDirector);
+/** @typedef {EReturn<EReturn<typeof prepareVaultDirector>>} VaultDirector */
 
 /**
  * Prepare the VaultDirector kind, get or make the singleton
  *
  * @type {(
  *   ...pvdArgs: Parameters<typeof prepareVaultDirector>
- * ) => ReturnType<ReturnType<typeof prepareVaultDirector>>}
+ * ) => VaultDirector}
  */
 export const provideDirector = (...args) => {
   const makeVaultDirector = prepareVaultDirector(...args);

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -8,6 +8,10 @@ import { prepareVaultHolder } from './vaultHolder.js';
 const trace = makeTracer('VK', true);
 
 /**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
  * Wrap the VaultHolder duration object in a record suitable for the result of
  * an invitation.
  *
@@ -44,4 +48,4 @@ export const prepareVaultKit = (baggage, makeRecorderKit) => {
   return makeVaultKit;
 };
 
-/** @typedef {ReturnType<ReturnType<typeof prepareVaultKit>>} VaultKit */
+/** @typedef {EReturn<EReturn<typeof prepareVaultKit>>} VaultKit */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -66,7 +66,7 @@ import { calculateDistributionPlan } from './proceeds.js';
 import { AuctionPFShape } from '../auction/auctioneer.js';
 
 /**
- * @import {Baggage} from '@agoric/vat-data';
+ * @import {EReturn} from '@endo/far';
  * @import {PriceAuthority, PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
  */
 
@@ -1306,7 +1306,7 @@ export const prepareVaultManagerKit = (
   return makeVaultManagerKit;
 };
 
-/** @typedef {Awaited<ReturnType<ReturnType<typeof prepareVaultManagerKit>>>} VaultManagerKit */
+/** @typedef {EReturn<EReturn<typeof prepareVaultManagerKit>>} VaultManagerKit */
 /**
  * @typedef {VaultManagerKit['self']} VaultManager Each VaultManager manages a
  *   single collateral type.

--- a/packages/inter-protocol/test/price/fluxAggregatorKit.test.js
+++ b/packages/inter-protocol/test/price/fluxAggregatorKit.test.js
@@ -20,7 +20,11 @@ import { makePriceQuoteIssuer } from '@agoric/zoe/src/contractSupport/priceQuote
 import { prepareFluxAggregatorKit } from '../../src/price/fluxAggregatorKit.js';
 import { topicPath } from '../supports.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeContext>>>} */
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/** @type {import('ava').TestFn<EReturn<typeof makeContext>>} */
 const test = unknownTest;
 
 const defaultConfig = {

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -28,6 +28,7 @@ import {
 } from './supports.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {Bank} from '@agoric/vats/src/vat-bank.js'
  * @import {SmartWallet} from '@agoric/smart-wallet/src/smartWallet.js'
  * @import {WalletReviver} from '@agoric/smart-wallet/src/walletFactory.js'
@@ -133,7 +134,7 @@ test.before(async t => {
   t.context = await makeTestContext();
 });
 
-/** @param {Awaited<ReturnType<typeof makeTestContext>>} context */
+/** @param {EReturn<typeof makeTestContext>} context */
 const tools = context => {
   const { zoe, anchor, installs, storageRoot } = context;
   // @ts-expect-error missing mint

--- a/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
@@ -19,10 +19,13 @@ import {
   voteForOpenQuestion,
 } from './contexts.js';
 
-/** @import {ZoeManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
+/**
+ * @import {ZoeManualTimer} from '@agoric/zoe/tools/manualTimer.js';
+ * @import {EReturn} from '@endo/far';
+ */
 
 /**
- * @typedef {Awaited<ReturnType<typeof makeDefaultTestContext>> & {
+ * @typedef {EReturn<typeof makeDefaultTestContext> & {
  *   consume: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume'];
  * }} TestContext
  */

--- a/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
+++ b/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
@@ -38,6 +38,7 @@ import {
 import { defaultParamValues } from './vaultFactoryUtils.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {VaultFactoryContract as VFC} from '../../src/vaultFactory/vaultFactory.js';
  * @import {AmountUtils} from '@agoric/zoe/tools/test-utils.js';
  */
@@ -46,7 +47,7 @@ import { defaultParamValues } from './vaultFactoryUtils.js';
  * @typedef {Record<string, any> & {
  *   aeth: IssuerKit & AmountUtils;
  *   run: IssuerKit & AmountUtils;
- *   bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>;
+ *   bundleCache: EReturn<typeof unsafeMakeBundleCache>;
  *   rates: VaultManagerParamValues;
  *   interestTiming: InterestTiming;
  *   zoe: ZoeService;

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -43,7 +43,8 @@ import {
 } from './vaultFactoryUtils.js';
 
 /**
- * @import {PriceAuthority, PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
+ * @import {EReturn} from '@endo/far';
+ * @import {PriceAuthority} from '@agoric/zoe/tools/types.js';
  * @import {VaultFactoryContract as VFC} from '../../src/vaultFactory/vaultFactory.js'
  * @import {AmountUtils} from '@agoric/zoe/tools/test-utils.js';
  */
@@ -52,7 +53,7 @@ import {
  * @typedef {Record<string, any> & {
  *   aeth: IssuerKit & AmountUtils;
  *   run: IssuerKit & AmountUtils;
- *   bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>;
+ *   bundleCache: EReturn<typeof unsafeMakeBundleCache>;
  *   rates: VaultManagerParamValues;
  *   interestTiming: InterestTiming;
  *   zoe: ZoeService;

--- a/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
@@ -45,13 +45,14 @@ import {
 /**
  * @import {VaultFactoryContract as VFC} from '../../src/vaultFactory/vaultFactory.js';
  * @import {AmountUtils} from '@agoric/zoe/tools/test-utils.js';
+ * @import {EReturn} from '@endo/far';
  */
 
 /**
  * @typedef {Record<string, any> & {
  *   aeth: IssuerKit & AmountUtils;
  *   run: IssuerKit & AmountUtils;
- *   bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>;
+ *   bundleCache: EReturn<typeof unsafeMakeBundleCache>;
  *   rates: VaultManagerParamValues;
  *   interestTiming: InterestTiming;
  *   zoe: ZoeService;

--- a/packages/orchestration/src/utils/time.js
+++ b/packages/orchestration/src/utils/time.js
@@ -4,6 +4,7 @@ import { TimeMath } from '@agoric/time';
 /**
  * @import {RelativeTimeRecord, TimerBrand, TimerService} from '@agoric/time';
  * @import {Remote} from '@agoric/internal';
+ * @import {EReturn} from '@endo/far';
  */
 
 export const SECONDS_PER_MINUTE = 60n;
@@ -45,4 +46,4 @@ export function makeTimestampHelper(timer) {
   });
 }
 
-/** @typedef {Awaited<ReturnType<typeof makeTimestampHelper>>} TimestampHelper */
+/** @typedef {EReturn<typeof makeTimestampHelper>} TimestampHelper */

--- a/packages/orchestration/test/examples/basic-flows.contract.test.ts
+++ b/packages/orchestration/test/examples/basic-flows.contract.test.ts
@@ -2,7 +2,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import type { TestFn } from 'ava';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
-import { E, getInterfaceOf } from '@endo/far';
+import { E, getInterfaceOf, type EReturn } from '@endo/far';
 import path from 'path';
 import { makeIssuerKit } from '@agoric/ertp';
 import {
@@ -18,10 +18,10 @@ const contractFile = `${dirname}/../../src/examples/${contractName}.contract.js`
 type StartFn =
   typeof import('../../src/examples/basic-flows.contract.js').start;
 
-type TestContext = Awaited<ReturnType<typeof commonSetup>> & {
+type TestContext = EReturn<typeof commonSetup> & {
   zoe: ZoeService;
   instance: Instance<StartFn>;
-  brands: Awaited<ReturnType<typeof commonSetup>>['brands'] & {
+  brands: EReturn<typeof commonSetup>['brands'] & {
     moolah: AmountUtils;
   };
 };

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -1,13 +1,3 @@
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import type { TestFn } from 'ava';
-import { heapVowE as E } from '@agoric/vow/vat.js';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import type { IBCMethod } from '@agoric/vats';
-import {
-  MsgTransfer,
-  MsgTransferResponse,
-} from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
-import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import {
   QueryAllBalancesRequest,
   QueryAllBalancesResponse,
@@ -20,38 +10,50 @@ import {
 } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
 import { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import {
-  QueryDelegationRequest,
-  QueryDelegatorDelegationsRequest,
-  QueryUnbondingDelegationRequest,
-  QueryDelegatorUnbondingDelegationsRequest,
-  QueryRedelegationsRequest,
-  QueryDelegationResponse,
-  QueryDelegatorDelegationsResponse,
-  QueryUnbondingDelegationResponse,
-  QueryDelegatorUnbondingDelegationsResponse,
-  QueryRedelegationsResponse,
-} from '@agoric/cosmic-proto/cosmos/staking/v1beta1/query.js';
-import {
   QueryDelegationRewardsRequest,
-  QueryDelegationTotalRewardsRequest,
   QueryDelegationRewardsResponse,
+  QueryDelegationTotalRewardsRequest,
   QueryDelegationTotalRewardsResponse,
 } from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/query.js';
-import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
+import {
+  QueryDelegationRequest,
+  QueryDelegationResponse,
+  QueryDelegatorDelegationsRequest,
+  QueryDelegatorDelegationsResponse,
+  QueryDelegatorUnbondingDelegationsRequest,
+  QueryDelegatorUnbondingDelegationsResponse,
+  QueryRedelegationsRequest,
+  QueryRedelegationsResponse,
+  QueryUnbondingDelegationRequest,
+  QueryUnbondingDelegationResponse,
+} from '@agoric/cosmic-proto/cosmos/staking/v1beta1/query.js';
 import {
   MsgDelegate,
   MsgDelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
-import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
+import {
+  MsgTransfer,
+  MsgTransferResponse,
+} from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
 import { makeIssuerKit } from '@agoric/ertp';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import type { IBCMethod } from '@agoric/vats';
+import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { decodeBase64 } from '@endo/base64';
-import { commonSetup } from '../supports.js';
+import type { EReturn } from '@endo/far';
+import type { TestFn } from 'ava';
+import type { CosmosValidatorAddress } from '../../src/cosmos-api.js';
+import fetchedChainInfo from '../../src/fetched-chain-info.js';
 import type {
   AmountArg,
   ChainAddress,
   Denom,
 } from '../../src/orchestration-api.js';
-import { prepareMakeTestCOAKit } from './make-test-coa-kit.js';
+import { assetOn } from '../../src/utils/asset.js';
 import {
   buildMsgResponseString,
   buildQueryPacketString,
@@ -59,12 +61,11 @@ import {
   buildTxPacketString,
   parseOutgoingTxPacket,
 } from '../../tools/ibc-mocks.js';
-import type { CosmosValidatorAddress } from '../../src/cosmos-api.js';
 import { protoMsgMocks } from '../ibc-mocks.js';
-import fetchedChainInfo from '../../src/fetched-chain-info.js';
-import { assetOn } from '../../src/utils/asset.js';
+import { commonSetup } from '../supports.js';
+import { prepareMakeTestCOAKit } from './make-test-coa-kit.js';
 
-type TestContext = Awaited<ReturnType<typeof commonSetup>>;
+type TestContext = EReturn<typeof commonSetup>;
 
 const test = anyTest as TestFn<TestContext>;
 

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -1,3 +1,5 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
 import {
   QueryAllBalancesRequest,
   QueryAllBalancesResponse,
@@ -41,7 +43,6 @@ import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import type { IBCMethod } from '@agoric/vats';
 import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import { heapVowE as E } from '@agoric/vow/vat.js';
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { decodeBase64 } from '@endo/base64';
 import type { EReturn } from '@endo/far';

--- a/packages/orchestration/test/exos/make-test-coa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-coa-kit.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/require-param -- ts types */
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { Far } from '@endo/far';
+import { Far, type EReturn } from '@endo/far';
 import type { ExecutionContext } from 'ava';
 import { prepareCosmosOrchestrationAccount } from '../../src/exos/cosmos-orchestration-account.js';
 import { commonSetup } from '../supports.js';
@@ -22,7 +22,7 @@ export const prepareMakeTestCOAKit = (
     commonPrivateArgs: { marshaller },
     facadeServices,
     utils,
-  }: Awaited<ReturnType<typeof commonSetup>>,
+  }: EReturn<typeof commonSetup>,
   { zcf = Far('MockZCF', {}) } = {},
 ) => {
   t.log('exo setup - prepareCosmosOrchestrationAccount');

--- a/packages/orchestration/test/exos/make-test-loa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-loa-kit.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/require-param -- ts types */
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { Far } from '@endo/far';
+import { Far, type EReturn } from '@endo/far';
 import type { ExecutionContext } from 'ava';
 import { prepareLocalOrchestrationAccountKit } from '../../src/exos/local-orchestration-account.js';
 import { commonSetup } from '../supports.js';
@@ -21,7 +21,7 @@ export const prepareMakeTestLOAKit = (
     commonPrivateArgs: { marshaller },
     facadeServices: { chainHub },
     utils,
-  }: Awaited<ReturnType<typeof commonSetup>>,
+  }: EReturn<typeof commonSetup>,
   { zcf = Far('MockZCF', {}) } = {},
 ) => {
   const { timer, localchain, rootZone, vowTools } = bootstrap;

--- a/packages/orchestration/test/fixtures/query-flows.contract.test.ts
+++ b/packages/orchestration/test/fixtures/query-flows.contract.test.ts
@@ -2,7 +2,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import type { TestFn } from 'ava';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
-import { E } from '@endo/far';
+import { E, type EReturn } from '@endo/far';
 import path from 'path';
 import {
   type JsonSafe,
@@ -35,7 +35,7 @@ const contractFile = `${dirname}/../../src/fixtures/query-flows.contract.js`;
 type StartFn =
   typeof import('../../src/fixtures/query-flows.contract.js').start;
 
-type TestContext = Awaited<ReturnType<typeof commonSetup>> & {
+type TestContext = EReturn<typeof commonSetup> & {
   zoe: ZoeService;
   instance: Instance<StartFn>;
 };

--- a/packages/orchestration/test/utils/zcf-tools.test.ts
+++ b/packages/orchestration/test/utils/zcf-tools.test.ts
@@ -6,7 +6,7 @@ import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { makeHeapZone } from '@agoric/zone';
 import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
-import { E, Far } from '@endo/far';
+import { E, Far, type EReturn } from '@endo/far';
 import type { TestFn } from 'ava';
 import { createRequire } from 'node:module';
 import { makeZcfTools } from '../../src/utils/zcf-tools.js';
@@ -40,7 +40,7 @@ const makeTestContext = async () => {
   return { zoe, zcf, zcfTools, vt };
 };
 
-type TestContext = Awaited<ReturnType<typeof makeTestContext>>;
+type TestContext = EReturn<typeof makeTestContext>;
 
 const test = anyTest as TestFn<TestContext>;
 

--- a/packages/orchestration/test/utils/zoe-tools.test.ts
+++ b/packages/orchestration/test/utils/zoe-tools.test.ts
@@ -9,7 +9,7 @@ import {
   withAmountUtils,
 } from '@agoric/zoe/tools/test-utils.js';
 import type { Issuer } from '@agoric/ertp/src/types.js';
-import { E } from '@endo/far';
+import { E, type EReturn } from '@endo/far';
 import {
   LOCALCHAIN_DEFAULT_ADDRESS,
   SIMULATED_ERRORS,
@@ -22,8 +22,8 @@ const contractName = 'zoeTools';
 const contractFile = `${dirname}/../../test/fixtures/zoe-tools.contract.js`;
 type StartFn = typeof import('../../test/fixtures/zoe-tools.contract.js').start;
 
-type TestContext = Awaited<ReturnType<typeof commonSetup>> & {
-  brands: Awaited<ReturnType<typeof commonSetup>>['brands'] & {
+type TestContext = EReturn<typeof commonSetup> & {
+  brands: EReturn<typeof commonSetup>['brands'] & {
     moolah: AmountUtils;
   };
   zoe: ZoeService;

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -47,6 +47,7 @@ import { prepareOfferWatcher, makeWatchOfferOutcomes } from './offerWatcher.js';
 
 /**
  * @import {WeakMapStore, MapStore} from '@agoric/store'
+ * @import {EReturn} from '@endo/far';
  * @import {OfferId, OfferStatus} from './offers.js';
  */
 
@@ -1141,5 +1142,4 @@ export const prepareSmartWallet = (baggage, shared) => {
   return makeSmartWallet;
 };
 harden(prepareSmartWallet);
-
-/** @typedef {Awaited<ReturnType<ReturnType<typeof prepareSmartWallet>>>} SmartWallet */
+/** @typedef {EReturn<EReturn<typeof prepareSmartWallet>>} SmartWallet */

--- a/packages/smart-wallet/test/startWalletFactory.test.js
+++ b/packages/smart-wallet/test/startWalletFactory.test.js
@@ -7,9 +7,11 @@ import path from 'path';
 import { makeMockTestSpace } from './supports.js';
 
 /**
- * @type {import('ava').TestFn<
- *   Awaited<ReturnType<typeof makeTestContext>>
- * >}
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
+ * @type {import('ava').TestFn<EReturn<typeof makeTestContext>>}
  */
 const test = anyTest;
 

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -8,6 +8,10 @@ import path from 'node:path';
 import { Fail } from '@endo/errors';
 import { serializeSlogObj } from './serialize-slog-obj.js';
 
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
 export const DEFAULT_CBUF_SIZE = 100 * 1024 * 1024;
 export const DEFAULT_CBUF_FILE = 'flight-recorder.bin';
 export const SLOG_MAGIC = 0x41472d534c4f4721n; // 'AG-SLOG!'
@@ -63,7 +67,7 @@ const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
   return arenaSize;
 };
 
-/** @typedef {Awaited<ReturnType<typeof makeSimpleCircularBuffer>>} CircularBuffer */
+/** @typedef {EReturn<typeof makeSimpleCircularBuffer>} CircularBuffer */
 
 /**
  *
@@ -270,7 +274,7 @@ export const makeSimpleCircularBuffer = async ({
 
 /**
  *
- * @param {Pick<Awaited<ReturnType<typeof makeSimpleCircularBuffer>>, 'writeCircBuf'>} circBuf
+ * @param {Pick<EReturn<typeof makeSimpleCircularBuffer>, 'writeCircBuf'>} circBuf
  */
 export const makeSlogSenderFromBuffer = ({ writeCircBuf }) => {
   /** @type {Promise<void>} */

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -9,6 +9,10 @@ import {
 import { makePromiseSpace } from './promise-space.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
  * @typedef {true
  *   | string
  *   | { [key: string]: BootstrapManifestPermit | undefined }} BootstrapManifestPermit
@@ -217,4 +221,4 @@ export const makeBootstrap = (
     //#endregion
   });
 };
-/** @typedef {Awaited<ReturnType<typeof makeBootstrap>>} BootstrapRootObject */
+/** @typedef {EReturn<typeof makeBootstrap>} BootstrapRootObject */

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -12,6 +12,10 @@ import {
   slotToBoardRemote,
 } from '../../tools/board-utils.js';
 
+/**
+ * @import {EReturn} from '@endo/far';
+ */
+
 const trace = makeTracer('StartWF');
 
 /**
@@ -21,7 +25,7 @@ const trace = makeTracer('StartWF');
  * >} inst
  *
  *
- * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
+ * @typedef {EReturn<typeof startFactoryInstance>} WalletFactoryStartResult
  */
 // eslint-disable-next-line no-unused-vars
 const startFactoryInstance = (zoe, inst) => E(zoe).startInstance(inst);

--- a/packages/vats/src/localchain.js
+++ b/packages/vats/src/localchain.js
@@ -13,6 +13,7 @@ import { Shape as NetworkShape } from '@agoric/network';
 const { Vow$ } = NetworkShape;
 
 /**
+ * @import {EReturn} from '@endo/far';
  * @import {TypedJson, ResponseTo, JsonSafe} from '@agoric/cosmic-proto';
  * @import {PromiseVow, VowTools} from '@agoric/vow';
  * @import {TargetApp, TargetRegistration} from './bridge-target.js';
@@ -215,6 +216,7 @@ export const prepareLocalChainAccountKit = (zone, { watch }) =>
       },
     },
   );
+/** @typedef {EReturn<EReturn<typeof prepareLocalChain>>} LocalChain */
 
 /**
  * @typedef {Awaited<
@@ -337,6 +339,4 @@ export const prepareLocalChainTools = (zone, vowTools) => {
   return harden({ makeLocalChain });
 };
 harden(prepareLocalChainTools);
-
 /** @typedef {ReturnType<typeof prepareLocalChainTools>} LocalChainTools */
-/** @typedef {ReturnType<LocalChainTools['makeLocalChain']>} LocalChain */

--- a/packages/vats/src/proposals/transfer-proposal.js
+++ b/packages/vats/src/proposals/transfer-proposal.js
@@ -5,6 +5,10 @@ import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import { makeScopedBridge } from '../bridge.js';
 
 /**
+ * @import {EReturn} from '@endo/far';
+ */
+
+/**
  * @param {BootstrapPowers & {
  *   consume: {
  *     bridgeManager: import('../types').BridgeManager;
@@ -66,7 +70,7 @@ export const setupTransferMiddleware = async (
       VTRANSFER_IBC_EVENT,
       interceptorFactory,
     );
-  /** @type {Awaited<ReturnType<typeof provideBridgeTargetKit>>} */
+  /** @type {EReturn<typeof provideBridgeTargetKit>} */
   let bridgeTargetKit;
   try {
     const vtransferBridge = await makeScopedBridge(bridgeManager, vtransferID);


### PR DESCRIPTION
## Description

While working on another PR, I had to type out `ReturnType<Awaited<ReturnType<` again and I wished for a utility type.

This PR first made an `ExoObj` type but has changed to use `EReturn` now available in Endo.
- https://github.com/endojs/endo/pull/2659

### Security Considerations
n/a
### Scaling Considerations

n/a

### Documentation Considerations

Not necessary

### Testing Considerations

CI

### Upgrade Considerations

n/a
