### PR TITLE
refactor(smart-wallet): test UpgradeDisconnection correctly

### DIFF
--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -1002,19 +1002,19 @@ export const prepareSmartWallet = (baggage, shared) => {
 
             // await so that any errors are caught and handled below
             await watchOfferOutcomes(watcher, seatRef);
-          } catch (err) {
+          } catch (reason) {
             // This block only runs if the block above fails during one vat incarnation.
-            facets.helper.logWalletError('IMMEDIATE OFFER ERROR:', err);
+            facets.helper.logWalletError('IMMEDIATE OFFER ERROR:', reason);
 
             // Update status to observers
-            if (err.upgradeMessage === 'vat upgraded') {
+            if (isUpgradeDisconnection(reason)) {
               // The offer watchers will reconnect. Don't reclaim or exit
               return;
             } else if (watcher) {
               // The watcher's onRejected will updateStatus()
             } else {
               facets.helper.updateStatus({
-                error: err.toString(),
+                error: reason.toString(),
                 ...offerSpec,
               });
             }
@@ -1033,7 +1033,7 @@ export const prepareSmartWallet = (baggage, shared) => {
 
             // XXX tests rely on throwing immediate errors, not covering the
             // error handling in the event the failure is after an upgrade
-            throw err;
+            throw reason;
           }
         },
         /**


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8998#pullrequestreview-1902399201

## Description

The current smartWallet code, in one place, tests whether an object is an UpgradeDisconnection by `err.upgradeMessage === 'vat upgraded'`. But the official test tests only the contents of `err.name`. Thus, this test can make errors of both inclusion and exclusion. This PR replaces that with the official predicate.

Despite the seemingly significant change, I classify this PR as a refactor because I manually looked for all occurrences of `'vatUpgraded'`, `'vat upgraded'`, `makeUpgradeDisconnection`, and `isUpgradeDisconnection`, and verified that the change made by this PR is unlikely to actually have any observable effect on anything. Rather, it is protection against cases that may arise in the future.

### Security Considerations

The wrong test might possible open a security vulnerability on our current system, but probably not. It is hard to image.
After this PR, we won't need to worry about this discrepancy even in theory, or wrt future code.

### Scaling Considerations

none
### Documentation Considerations
none

### Testing Considerations

To the degree this is a pure refactoring, there's nothing to test. We could test for behavior under the discrepancy we're fixing here. But this PR does not do so. Reviewers, are you ok without that test?

### Upgrade Considerations

Should be none. Hard to imagine otherwise. Reviewers, am I possibly missing anything?