### PR TITLE
Make Recovery sets optional

### DIFF
--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -173,8 +173,9 @@
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} PaymentLedger
  * @property {Mint<K>} mint
- * @property {Purse<K>} mintRecoveryPurse Useful only to get the recovery set
- *   associated with minted payments that are still live.
+ * @property {Purse<K>} mintRecoveryPurse Externally useful only if this issuer
+ *   uses recovery sets. Can be used to get the recovery set associated with
+ *   minted payments that are still live.
  * @property {Issuer<K>} issuer
  * @property {Brand<K>} brand
  */
@@ -183,8 +184,9 @@
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} IssuerKit
  * @property {Mint<K>} mint
- * @property {Purse<K>} mintRecoveryPurse Useful only to get the recovery set
- *   associated with minted payments that are still live.
+ * @property {Purse<K>} mintRecoveryPurse Externally useful only if this issuer
+ *   uses recovery sets. Can be used to get the recovery set associated with
+ *   minted payments that are still live.
  * @property {Issuer<K>} issuer
  * @property {Brand<K>} brand
  * @property {DisplayInfo} displayInfo
@@ -213,6 +215,23 @@
  * @property {() => Issuer<K>} getIssuer Gets the Issuer for this mint.
  * @property {(newAmount: Amount<K>) => Payment<K>} mintPayment Creates a new
  *   Payment containing newly minted amount.
+ */
+
+// /////////////////////////// Purse / Payment /////////////////////////////////
+
+/**
+ * Issuers first became durable with mandatory recovery sets. Later they were
+ * made optional, but there is no support for converting from one state to the
+ * other. Thus, absence of a `RecoverySetsOption` state is equivalent to
+ * `'hasRecoverySets'`. In the absence of a `recoverySetsOption` parameter,
+ * upgradeIssuerKit defaults to the predecessor's `RecoverySetsOption` state, or
+ * `'hasRecoverySets'` if none.
+ *
+ * At this time, a `'noRecoverySets'` predecessor cannot be upgraded to a
+ * `'hasRecoverySets'` successor. If it turns out this transition is needed, it
+ * can likely be supported in a future upgrade.
+ *
+ * @typedef {'hasRecoverySets' | 'noRecoverySets'} RecoverySetsOption
  */
 
 // /////////////////////////// Purse / Payment /////////////////////////////////
@@ -276,10 +295,14 @@
  *   can spend the assets at stake on other things. Afterwards, if the recipient
  *   of the original check finally gets around to depositing it, their deposit
  *   fails.
+ *
+ *   Returns an empty set if this issuer does not support recovery sets.
  * @property {() => Amount<K>} recoverAll For use in emergencies, such as coming
  *   back from a traumatic crash and upgrade. This deposits all the payments in
  *   this purse's recovery set into the purse itself, returning the total amount
  *   of assets recovered.
+ *
+ *   Returns an empty amount if this issuer does not support recovery sets.
  */
 
 /**

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -227,9 +227,10 @@
  * upgradeIssuerKit defaults to the predecessor's `RecoverySetsOption` state, or
  * `'hasRecoverySets'` if none.
  *
- * At this time, a `'noRecoverySets'` predecessor cannot be upgraded to a
- * `'hasRecoverySets'` successor. If it turns out this transition is needed, it
- * can likely be supported in a future upgrade.
+ * At this time, issuers started in one of the states (`'noRecoverySets'`, or
+ * `'hasRecoverySets'`) cannot be converted to the other on upgrade. If this
+ * transition is needed, it can likely be supported in a future upgrade. File an
+ * issue on github and explain what you need and why.
  *
  * @typedef {'hasRecoverySets' | 'noRecoverySets'} RecoverySetsOption
  */

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -74,6 +74,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     'set',
     undefined,
     undefined,
+    { recoverySetsOption: 'noRecoverySets' },
   );
 
   const {

--- a/packages/zoe/src/contractSupport/priceAuthorityQuoteMint.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityQuoteMint.js
@@ -17,6 +17,7 @@ export const provideQuoteMint = baggage => {
     AssetKind.SET,
     undefined,
     undefined,
+    { recoverySetsOption: 'noRecoverySets' },
   );
   return issuerKit.mint;
 };


### PR DESCRIPTION
refs: #8400
closes: #8498
closes: #8418
refs: #8928

## Description

This change makes it possible, when creating an issuer, to decline to use recover sets. It also converts priceAuthority and fluxAggregator to do so. This only affects new instances of these contracts. The existing instances hold large numbers of old no-longer-used quote-payments which are currently uncollectible.

This PR was based on #8498 (itself based on #8418) which would have gradually removed quote-payments from the recoverySet. We aren't taking that approach because those vats are not upgradeable. #8418 would have released all the unneeded quote-payments at once, which would likely have overwhelmed the GC system.

#8400 talks about the general problem. #8928 talks about one possible long-term fix cleaning up the retained garbage.

### Security Considerations

N/A

### Scaling Considerations

It's all about reducing the impact of large quantities of unneeded quotes. This PR will stop us from accumulating more quotes.

### Documentation Considerations

N/A

### Testing Considerations

We will validate in a chain environment.

### Upgrade Considerations

This introduces new code for the priceAuthority and fluxAggregator contracts, which will be used to create new instances which will be more performant. The existing vats will be addressed later.