### PR TITLE
fix(agoric-cli): handle another vstorage error variation

### DIFF
--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -148,12 +148,13 @@ export const makeVStorage = (powers, config = networkConfig) => {
           // console.debug('readAt returned', { blockHeight });
         } catch (err) {
           if (
-            // CosmosSDK ErrNotFound; there is no data at the path
-            (err.codespace === 'sdk' && err.code === 38) ||
-            // CosmosSDK ErrUnknownRequest; misrepresentation of the same until
-            // https://github.com/Agoric/agoric-sdk/commit/dafc7c1708977aaa55e245dc09a73859cf1df192
-            // TODO remove after upgrade-12
-            err.message.match(/unknown request/)
+            // CosmosSDK ErrInvalidRequest with particular message text;
+            // misrepresentation of pruned data
+            // TODO replace after incorporating a fix to
+            // https://github.com/cosmos/cosmos-sdk/issues/19992
+            err.codespace === 'sdk' &&
+            err.code === 18 &&
+            err.message.match(/pruned/)
           ) {
             // console.error(err);
             break;


### PR DESCRIPTION
fixes #9033

avoid:

```
Error#1: error code 18 reading data of published.wallet.agoric1l...: failed to load state at height 14007...; version mismatch on immutable IAVL tree; version does not exist. Version has either been pruned, or is for a future block height (latest height: 14026...): invalid request

  at packages/agoric-cli/src/lib/rpc.js:83:23
  at async Object.readAt (packages/agoric-cli/src/lib/rpc.js:122:19)
  at async Object.readFully (packages/agoric-cli/src/lib/rpc.js:144:38)
  at async storedWalletState (packages/agoric-cli/src/lib/wallet.js:228:21)
  at async Promise.all (index 1)
  at async
  Command.<anonymous> (packages/agoric-cli/src/commands/inter.js:566:34)
```

## Description

When exploring the history of data at a vstorage key, `err.codespace === 'sdk' && err.code === 38` is sort of the first-class signal for "there is no more" (_according to what? I'm not sure_). But we don't seem to always get that sort of error. We have also accepted any error whose message matches `/unknown request/`. With this change, we also take `/pruned/` as such a signal.

DRAFT until:

 - [ ] is there a spec for these errors that we could / should cite in this code?
 - [ ] given the cost of a test, is it OK to land this without one?
 - [ ] to fully address #9033, is there something on the chain side that we should fix? or is this enough? That is: should I change "closes" to "refs"?

### Security / Scaling Considerations

n / a

### Documentation Considerations

If this fix is to-spec, then there are none. Otherwise, perhaps some disclaimer is in order, at least as a code comment.

### Testing Considerations

A fix normally comes with a test. A unit test would be nice. But this testing CLI code isn't factored to facilitate unit testing. It kinda needs a whole running blockchain. So a test is probably more trouble than it's worth for a ~1 line fix.

### Upgrade Considerations

The change that introduced the symptoms of #9033 was evidently missing some upgrade considerations.
