### PR TITLE
feat(vow): fix issues revealed by new `Remote<T>` type

### DIFF
--- a/packages/network/src/bytes.js
+++ b/packages/network/src/bytes.js
@@ -1,24 +1,41 @@
+// @ts-check
 /// <reference path="./types.js" />
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 
-/* eslint-disable no-bitwise */
+/** @typedef {Data | Buffer | Uint8Array | Iterable<number>} SourceData */
+
 /**
- * Convert some data to bytes.
+ * @param {SourceData} contents
+ */
+const coerceToByteArray = contents => {
+  if (typeof contents === 'string') {
+    contents = contents.split('').map(c => c.charCodeAt(0));
+  }
+  if (contents instanceof Uint8Array) {
+    // Reconstruct to ensure we have a Uint8Array and not a Buffer.
+    return new Uint8Array(
+      contents.buffer,
+      contents.byteOffset,
+      contents.byteLength,
+    );
+  }
+  return new Uint8Array(contents);
+};
+
+/**
+ * Convert some data to bytes.  We can use a local Iterable as a source for data
+ * bytes, but we need to call `toBytes(it)` to obtain a passable value.
  *
- * @param {Data} data
+ * NOTE: Passing a Uint8Array without calling this function is not yet supported
+ * by `@endo/marshal`.
+ *
+ * @param {SourceData} data
  * @returns {Bytes}
  */
 export function toBytes(data) {
-  /** @type {Data | number[]} */
-  let bytes = data;
-  // TODO: We really need marshallable TypedArrays.
-  if (typeof bytes === 'string') {
-    bytes = bytes.split('').map(c => c.charCodeAt(0));
-  }
-
   // We return the raw characters in the lower half of
   // the String's representation.
-  const buf = new Uint8Array(bytes);
+  const buf = coerceToByteArray(data);
   return String.fromCharCode.apply(null, buf);
 }
 
@@ -35,25 +52,16 @@ export function bytesToString(bytes) {
 /**
  * Base64, as specified in https://tools.ietf.org/html/rfc4648#section-4
  *
- * @param {Data} data
+ * @param {SourceData} data
  * @returns {string} base64 encoding
  */
 export function dataToBase64(data) {
-  /** @type {Uint8Array} */
-  let bytes;
-  if (typeof data === 'string') {
-    bytes = new Uint8Array(data.length);
-    for (let i = 0; i < data.length; i += 1) {
-      bytes[i] = data.charCodeAt(i);
-    }
-  } else {
-    bytes = new Uint8Array(data);
-  }
+  const bytes = coerceToByteArray(data);
   return encodeBase64(bytes);
 }
 
 /**
- * Decodes a string into base64.
+ * Decodes a base64 string into bytes.
  *
  * @param {string} string Base64-encoded string
  * @returns {Bytes} decoded bytes

--- a/packages/network/src/index.js
+++ b/packages/network/src/index.js
@@ -1,4 +1,5 @@
 export * from './network.js';
+export * from './shapes.js';
 export { prepareRouter, prepareRouterProtocol } from './router.js';
 export * from './multiaddr.js';
 export * from './bytes.js';

--- a/packages/network/src/router.js
+++ b/packages/network/src/router.js
@@ -2,11 +2,8 @@
 import { E as defaultE } from '@endo/far';
 import { M } from '@endo/patterns';
 import { Fail } from '@agoric/assert';
-import {
-  ENDPOINT_SEPARATOR,
-  Shape,
-  prepareNetworkProtocol,
-} from './network.js';
+import { ENDPOINT_SEPARATOR, prepareNetworkProtocol } from './network.js';
+import { Shape } from './shapes.js';
 
 import '@agoric/store/exported.js';
 /// <reference path="./types.js" />
@@ -59,7 +56,7 @@ export const prepareRouter = zone => {
             ret.push([prefix, this.state.prefixToRoute.get(prefix)]);
           }
           // Trim off the last value (after the slash).
-          const defaultPrefix = prefix.substr(
+          const defaultPrefix = prefix.slice(
             0,
             prefix.lastIndexOf(ENDPOINT_SEPARATOR) + 1,
           );
@@ -131,7 +128,7 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
       /** @type {MapStore<string, Protocol>} */
       const protocols = detached.mapStore('prefix');
 
-      /** @type {MapStore<string, ProtocolHandler>} */
+      /** @type {MapStore<string, Remote<ProtocolHandler>>} */
       const protocolHandlers = detached.mapStore('prefix');
 
       return {
@@ -143,7 +140,7 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
     {
       /**
        * @param {string[]} paths
-       * @param {ProtocolHandler} protocolHandler
+       * @param {Remote<ProtocolHandler>} protocolHandler
        */
       registerProtocolHandler(paths, protocolHandler) {
         const protocol = makeNetworkProtocol(protocolHandler);
@@ -157,13 +154,13 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
       // Needs to account for multiple paths.
       /**
        * @param {string} prefix
-       * @param {ProtocolHandler} protocolHandler
+       * @param {Remote<ProtocolHandler>} protocolHandler
        */
       unregisterProtocolHandler(prefix, protocolHandler) {
         const ph = this.state.protocolHandlers.get(prefix);
         ph === protocolHandler ||
           Fail`Protocol handler is not registered at prefix ${prefix}`;
-        // TODO: unmap protocol hanlders to their corresponding protocol
+        // TODO: unmap protocol handlers to their corresponding protocol
         // e.g. using a map
         // before unregistering
         // @ts-expect-error note FIXME above

--- a/packages/network/src/shapes.js
+++ b/packages/network/src/shapes.js
@@ -1,0 +1,123 @@
+// @ts-check
+import { M } from '@endo/patterns';
+
+const Shape1 = /** @type {const} */ ({
+  /**
+   * Data is string | Buffer | ArrayBuffer
+   * but only string is passable
+   */
+  Data: M.string(),
+  Bytes: M.string(),
+  Endpoint: M.string(),
+  Opts: M.recordOf(M.string(), M.any()),
+  Vow: M.tagged(
+    'Vow',
+    M.splitRecord({
+      vowV0: M.remotable('VowV0'), // basic version 0 support
+    }),
+  ),
+  Vow$: shape => M.or(shape, Shape1.Vow),
+  ConnectionHandler: M.remotable('ConnectionHandler'),
+  Connection: M.remotable('Connection'),
+  InboundAttempt: M.remotable('InboundAttempt'),
+  Listener: M.remotable('Listener'),
+  ListenHandler: M.remotable('ListenHandler'),
+  Port: M.remotable('Port'),
+  ProtocolHandler: M.remotable('ProtocolHandler'),
+  ProtocolImpl: M.remotable('ProtocolImpl'),
+});
+
+const Shape2 = /** @type {const} */ ({
+  ...Shape1,
+  AttemptDescription: M.splitRecord(
+    { handler: Shape1.ConnectionHandler },
+    { remoteAddress: Shape1.Endpoint, localAddress: Shape1.Endpoint },
+  ),
+  ConnectionI: M.interface('Connection', {
+    send: M.callWhen(Shape1.Data)
+      .optional(Shape1.Opts)
+      .returns(Shape1.Vow$(Shape1.Bytes)),
+    close: M.callWhen().returns(Shape1.Vow$(M.undefined())),
+    getLocalAddress: M.call().returns(Shape1.Endpoint),
+    getRemoteAddress: M.call().returns(Shape1.Endpoint),
+  }),
+  PortI: M.interface('Port', {
+    getLocalAddress: M.call().returns(Shape1.Endpoint),
+    addListener: M.callWhen(Shape1.Listener).returns(
+      Shape1.Vow$(M.undefined()),
+    ),
+    connect: M.callWhen(Shape1.Endpoint)
+      .optional(Shape1.ConnectionHandler)
+      .returns(Shape1.Vow$(Shape1.Connection)),
+    removeListener: M.callWhen(Shape1.Listener).returns(
+      Shape1.Vow$(M.undefined()),
+    ),
+    revoke: M.callWhen().returns(M.undefined()),
+  }),
+  ProtocolHandlerI: M.interface('ProtocolHandler', {
+    onCreate: M.callWhen(M.remotable(), Shape1.ProtocolHandler).returns(
+      Shape1.Vow$(M.undefined()),
+    ),
+    generatePortID: M.callWhen(Shape1.Endpoint, Shape1.ProtocolHandler).returns(
+      Shape1.Vow$(M.string()),
+    ),
+    onBind: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.ProtocolHandler,
+    ).returns(Shape1.Vow$(M.undefined())),
+    onListen: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.ListenHandler,
+      Shape1.ProtocolHandler,
+    ).returns(Shape1.Vow$(M.undefined())),
+    onListenRemove: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.ListenHandler,
+      Shape1.ProtocolHandler,
+    ).returns(Shape1.Vow$(M.undefined())),
+    onInstantiate: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.Endpoint,
+      Shape1.ProtocolHandler,
+    ).returns(Shape1.Vow$(Shape1.Endpoint)),
+    onConnect: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.Endpoint,
+      Shape1.ConnectionHandler,
+      Shape1.ProtocolHandler,
+    ).returns(Shape1.Vow$(Shape1.AttemptDescription)),
+    onRevoke: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.ProtocolHandler,
+    ).returns(Shape1.Vow$(M.undefined())),
+  }),
+  ProtocolImplI: M.interface('ProtocolImpl', {
+    bind: M.callWhen(Shape1.Endpoint).returns(Shape1.Vow$(Shape1.Port)),
+    inbound: M.callWhen(Shape1.Endpoint, Shape1.Endpoint).returns(
+      Shape1.Vow$(Shape1.InboundAttempt),
+    ),
+    outbound: M.callWhen(
+      Shape1.Port,
+      Shape1.Endpoint,
+      Shape1.ConnectionHandler,
+    ).returns(Shape1.Vow$(Shape1.Connection)),
+  }),
+});
+
+export const Shape = /** @type {const} */ harden({
+  ...Shape2,
+  InboundAttemptI: M.interface('InboundAttempt', {
+    accept: M.callWhen(Shape2.AttemptDescription).returns(
+      Shape2.Vow$(Shape2.Connection),
+    ),
+    getLocalAddress: M.call().returns(Shape2.Endpoint),
+    getRemoteAddress: M.call().returns(Shape2.Endpoint),
+    close: M.callWhen().returns(Shape2.Vow$(M.undefined())),
+  }),
+});

--- a/packages/network/test/test-network-misc.js
+++ b/packages/network/test/test-network-misc.js
@@ -348,9 +348,6 @@ test('loopback protocol', async t => {
         async onAccept(_p, _localAddr, _remoteAddr, _listenHandler) {
           return makeConnectionHandler();
         },
-        async onRemove(p, _listenHandler) {
-          console.log('onRemove', p);
-        },
       },
     );
 

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -33,15 +33,15 @@ export const getCourierPK = (key, keyToCourierPK) => {
  *
  * @typedef {object} CourierArgs
  * @property {ZCF} zcf
- * @property {ERef<BoardDepositFacet>} board
- * @property {ERef<NameHub>} namesByAddress
+ * @property {Remote<BoardDepositFacet>} board
+ * @property {Remote<NameHub>} namesByAddress
  * @property {Denom} sendDenom
  * @property {Brand} localBrand
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
- * @property {ERef<TransferProtocol>} transferProtocol
+ * @property {Remote<TransferProtocol>} transferProtocol
  * @property {ReturnType<import('@agoric/vow').prepareVowTools>['when']} when
- * @param {ERef<Connection>} connection
+ * @param {Remote<Connection>} connection
  * @returns {(args: CourierArgs) => Courier}
  */
 export const makeCourierMaker =

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -31,8 +31,8 @@ const TRANSFER_PROPOSAL_SHAPE = {
  *
  * @param {object} powers
  * @param {ZCF} powers.zcf the Zoe Contract Facet
- * @param {ERef<BoardDepositFacet>} powers.board where to find depositFacets by boardID
- * @param {ERef<NameHub>} powers.namesByAddress where to find depositFacets by bech32
+ * @param {Remote<BoardDepositFacet>} powers.board where to find depositFacets by boardID
+ * @param {Remote<NameHub>} powers.namesByAddress where to find depositFacets by bech32
  * @param {ReturnType<import('@agoric/vow').prepareVowTools>['when']} powers.when
  *
  * @typedef {import('@agoric/vats').NameHub} NameHub
@@ -62,7 +62,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
   };
 
   /**
-   * @type {LegacyWeakMap<Peg, LocalDenomState>}
+   * @type {LegacyWeakMap<Remote<Peg>, LocalDenomState>}
    */
   // Legacy because Mappings mix functions and data
   const pegToDenomState = makeLegacyWeakMap('Peg');
@@ -105,8 +105,8 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
    * @param {object} param0
    * @param {ReturnType<typeof makeCourierMaker>} param0.makeCourier
    * @param {LocalDenomState} param0.localDenomState
-   * @param {ERef<TransferProtocol>} param0.transferProtocol
-   * @param {ERef<DenomTransformer>} param0.denomTransformer
+   * @param {Remote<TransferProtocol>} param0.transferProtocol
+   * @param {Remote<DenomTransformer>} param0.denomTransformer
    * @returns {PegasusConnectionActions}
    */
   const makePegasusConnectionActions = ({
@@ -319,8 +319,8 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
     /**
      * Return a handler that can be used with the Network API.
      *
-     * @param {ERef<TransferProtocol>} [transferProtocol]
-     * @param {ERef<DenomTransformer>} [denomTransformer]
+     * @param {Remote<TransferProtocol>} [transferProtocol]
+     * @param {Remote<DenomTransformer>} [denomTransformer]
      * @returns {PegasusConnectionKit}
      */
     makePegasusConnectionKit(
@@ -328,7 +328,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
       denomTransformer = DEFAULT_DENOM_TRANSFORMER,
     ) {
       /**
-       * @type {LegacyWeakMap<Connection, LocalDenomState>}
+       * @type {LegacyWeakMap<Remote<Connection>, LocalDenomState>}
        */
       // Legacy because the value contains a JS Set
       const connectionToLocalDenomState = makeLegacyWeakMap('Connection');
@@ -458,7 +458,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
     /**
      * Create a Zoe invitation to transfer assets over network to a deposit address.
      *
-     * @param {ERef<Peg>} pegP the peg over which to transfer
+     * @param {Remote<Peg>} pegP the peg over which to transfer
      * @param {DepositAddress} depositAddress the remote receiver's address
      * @param {string} [memo] the memo to attach to ics transfer packet
      * @param {SenderOptions} [opts] additional sender options

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -12,8 +12,8 @@ import '@agoric/network/exported.js';
 // empty acknowledgements as distinct from unacknowledged packets.
 const DEFAULT_ACKNOWLEDGEMENT = '\x00';
 
-// Default timeout after 10 minutes.
-const DEFAULT_PACKET_TIMEOUT_NS = 10n * 60n * 1_000_000_000n;
+// Default timeout after 60 minutes.
+const DEFAULT_PACKET_TIMEOUT_NS = 60n * 60n * 1_000_000_000n;
 
 /** @typedef {import('./types.js').BridgeHandler} BridgeHandler */
 
@@ -220,13 +220,18 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
     'IBCProtocolHandler',
     undefined,
     ibcdev => {
-      /** @type {MapStore<string, Connection>} */
+      /** @type {MapStore<string, import('@agoric/vow').Remote<Connection>>} */
       const channelKeyToConnP = detached.mapStore('channelKeyToConnP');
 
       /** @type {MapStore<string, ConnectingInfo>} */
       const channelKeyToInfo = detached.mapStore('channelKeyToInfo');
 
-      /** @type {MapStore<string, InboundAttempt>} */
+      /**
+       * @type {MapStore<
+       *   string,
+       *   import('@agoric/vow').Remote<InboundAttempt>
+       * >}
+       */
       const channelKeyToAttempt = detached.mapStore('channelKeyToAttempt');
 
       /** @type {MapStore<string, Outbound[]>} */
@@ -256,8 +261,9 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
         srcPortToOutbounds,
         channelKeyToSeqAck,
         portToPendingConns,
-        lastPortID: 0, // Nonce for creating port identifiers.
-        /** @type {ProtocolImpl | undefined} */ protocolImpl: undefined,
+        lastPortID: 0n, // Nonce for creating port identifiers.
+        /** @type {import('@agoric/vow').Remote<ProtocolImpl> | null} */
+        protocolImpl: null,
       };
     },
     {
@@ -271,7 +277,7 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
           return '';
         },
         async generatePortID(_localAddr, _protocolHandler) {
-          this.state.lastPortID += 1;
+          this.state.lastPortID += 1n;
           return `port-${this.state.lastPortID}`;
         },
         async onBind(port, localAddr, _protocolHandler) {
@@ -341,7 +347,10 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
             onConnectP: kit,
             localAddr,
           };
-          if (!srcPortToOutbounds.has(portID)) {
+          if (srcPortToOutbounds.has(portID)) {
+            const outbounds = srcPortToOutbounds.get(portID);
+            srcPortToOutbounds.set(portID, harden([...outbounds, ob]));
+          } else {
             srcPortToOutbounds.init(portID, harden([ob]));
           }
 
@@ -422,11 +431,9 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
               //     e => console.warn('Manual packet', e, 'failed:', e),
               //   );
 
+              assert(protocolImpl);
               const attempt = await when(
-                /** @type {ProtocolImpl} */ (protocolImpl).inbound(
-                  localAddr,
-                  remoteAddr,
-                ),
+                E(protocolImpl).inbound(localAddr, remoteAddr),
               );
 
               // Tell what version string we negotiated.
@@ -579,7 +586,7 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
               const conn = channelKeyToConnP.get(channelKey);
               const data = base64ToBytes(data64);
 
-              watch(conn.send(data), makeAckWatcher(util, packet));
+              watch(E(conn).send(data), makeAckWatcher(util, packet));
               break;
             }
 
@@ -614,7 +621,7 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
               if (channelKeyToConnP.has(channelKey)) {
                 const conn = channelKeyToConnP.get(channelKey);
                 channelKeyToConnP.delete(channelKey);
-                void conn.close();
+                void E(conn).close();
               }
               break;
             }
@@ -686,7 +693,7 @@ export const prepareIBCProtocol = (zone, { makeVowKit, watch, when }) => {
             return seqToAck.get(sequence);
           }
           const kit = makeVowKit();
-          seqToAck.init(sequence, harden(kit));
+          seqToAck.init(sequence, kit);
           return kit;
         },
       },

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -205,7 +205,7 @@ test('network - ibc', async t => {
           source_channel: 'channel-1',
           source_port: 'port-1',
         },
-        relativeTimeoutNs: 600_000_000_000n, // 10 minutes in nanoseconds.
+        relativeTimeoutNs: 3_600_000_000_000n, // 60 minutes in nanoseconds.
       },
     ]);
 

--- a/packages/vow/src/E.js
+++ b/packages/vow/src/E.js
@@ -263,10 +263,10 @@ const makeE = (
          * unwrapped(x).then(onfulfilled, onrejected)
          *
          * @template T
-         * @template [TResult1=Unwrap<T>]
+         * @template [TResult1=import('./types.js').Unwrap<T>]
          * @template [TResult2=never]
          * @param {ERef<T>} x value to convert to a handled promise
-         * @param {(value: Unwrap<T>) => ERef<TResult1>} [onfulfilled]
+         * @param {(value: import('./types.js').Unwrap<T>) => ERef<TResult1>} [onfulfilled]
          * @param {(reason: any) => ERef<TResult2>} [onrejected]
          * @returns {Promise<TResult1 | TResult2>}
          * @readonly
@@ -307,9 +307,7 @@ export default makeE;
 /**
  * @template {Callable} T
  * @typedef {(
- *   ReturnType<T> extends PromiseLike<infer U>                       // if function returns a promise
- *     ? T                                                            // return the function
- *     : (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>  // make it return a promise
+ *   (...args: Parameters<T>) => Promise<import('./types.js').Unwrap<ReturnType<T>>>
  * )} ECallable
  */
 
@@ -399,7 +397,7 @@ export default makeE;
  *     ? PickCallable<R>                                              // then return the callable properties of R
  *     : Awaited<T> extends import('@endo/eventual-send').RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
  *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends import('./types').Vow<infer U>
+ *     : Awaited<T> extends import('./types.js').Vow<infer U>
  *     ? RemoteFunctions<U>                                           // then extract the remotable functions of U
  *     : T extends PromiseLike<infer U>                               // otherwise, if T is a promise
  *     ? Awaited<T>                                                   // then return resolved value T
@@ -409,19 +407,12 @@ export default makeE;
 
 /**
  * @template T
- * @typedef {T extends PromiseLike<infer U> ? Unwrap<U> :
- *   T extends import('./types').Vow<infer U> ? Unwrap<U> :
- *   T} Unwrap
- */
-
-/**
- * @template T
  * @typedef {(
  *   T extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>
  *     ? L
  *     : Awaited<T> extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>
  *     ? L
- *     : Awaited<T> extends import('./types').Vow<infer U>
+ *     : Awaited<T> extends import('./types.js').Vow<infer U>
  *     ? LocalRecord<U>
  *     : T extends PromiseLike<infer U>
  *     ? Awaited<T>

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -1,23 +1,64 @@
 // @ts-check
 export {};
 
+/** @typedef {(...args: any[]) => any} Callable */
+
 /**
  * @template T
- * @typedef {PromiseLike<T | Vow<T>>} PromiseVow
+ * @typedef {Promise<T | Vow<T>>} PromiseVow Return type of a function that may
+ * return a promise or a vow.
  */
 
 /**
  * @template T
- * @typedef {import('./E').ERef<T>} ERef
+ * @typedef {T | PromiseLike<T>} ERef
  */
 
 /**
- * Creates a type that accepts both near and marshalled references that were
- * returned from `Remotable` or `Far`, and also promises for such references.
- *
+ * @template T
+ * @typedef {(
+ *   T extends bigint ? true :
+ *   T extends boolean ? true :
+ *   T extends null ? true :
+ *   T extends number ? true :
+ *   T extends string ? true :
+ *   T extends symbol ? true :
+ *   T extends undefined ? true :
+ *   false
+ * )} IsPrimitive Whether T is a primitive type.
+ */
+
+/**
+ * @template T
+ * @typedef {(
+ *   IsPrimitive<T> extends true ? T :
+ *   T extends Callable ? never :
+ *   { [P in keyof T as T[P] extends Callable ? never : P]: DataOnly<T[P]> }
+ * )} DataOnly Recursively extract the non-callable properties of T.
+ */
+
+/**
+ * Follow the chain of vow shortening to the end, returning the final value.
+ * This is used within E, so we must narrow the type to its remote form.
+ * @template T
+ * @typedef {(
+ *   T extends PromiseLike<infer U> ? Unwrap<U> :
+ *   T extends import('./types').Vow<infer U> ? Unwrap<U> :
+ *   IsPrimitive<T> extends true ? T :
+ *   T extends import('@endo/eventual-send').RemotableBrand<infer Local, infer Primary> ? Local & T :
+ *   T
+ * )} Unwrap
+ */
+
+/**
+ * A type that accepts both near and marshalled references that were
+ * returned from `Remotable` or `Far`.
  * @template Primary The type of the primary reference.
- * @template [Local=import('./E').DataOnly<Primary>] The local properties of the object.
- * @typedef {ERef<Local & import('@endo/eventual-send').RemotableBrand<Local, Primary>>} FarRef
+ * @template [Local=DataOnly<Primary>] The local properties of the object.
+ * @typedef {Primary |
+ *   import('@endo/eventual-send').RemotableBrand<Local, Primary>
+ * } Remote A type that doesn't assume its parameter is local, but is
+ * satisfied with both local and remote references.
  */
 
 /**
@@ -36,7 +77,7 @@ export {};
 /**
  * @template [T=any]
  * @typedef {object} VowPayload
- * @property {import('@endo/eventual-send').FarRef<VowV0<T>>} vowV0
+ * @property {Remote<VowV0<T>>} vowV0
  */
 
 /**

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -8,18 +8,17 @@ export const makeWhen = (isRetryableReason = () => false) => {
   /**
    * Shorten `specimenP` until we achieve a final result.
    *
-   * @template [T=any]
-   * @template [TResult1=import('./E.js').Unwrap<T>]
+   * @template T
+   * @template [TResult1=import('./types.js').Unwrap<T>]
    * @template [TResult2=never]
    * @param {T} specimenP value to unwrap
-   * @param {(value: import('./E.js').Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
+   * @param {(value: import('./types.js').Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
    * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
    * @returns {Promise<TResult1 | TResult2>}
    */
   const when = async (specimenP, onFulfilled, onRejected) => {
     // Ensure we don't run until a subsequent turn.
     await null;
-    Promise.prototype.then;
 
     // Ensure we have a presence that won't be disconnected later.
     let result = await specimenP;
@@ -38,7 +37,7 @@ export const makeWhen = (isRetryableReason = () => false) => {
       payload = getVowPayload(result);
     }
 
-    const unwrapped = /** @type {import('./E.js').Unwrap<T>} */ (result);
+    const unwrapped = /** @type {import('./types.js').Unwrap<T>} */ (result);
 
     // We've extracted the final result.
     if (onFulfilled == null && onRejected == null) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #9027
refs: #8444

## Description

This PR creates a new `Remote<T>` type to use in code that does not assume that `T` is local, and thus must be manipulated using something like the `E` eventual send operator.  Its definition is significantly more straightforward than `FarRef`, and more effective than `ERef`.

Using the associated `Unwrap<T>` in `packages/vow`, and applying `Remote<T>` to the latest `packages/network` and `packages/vat/src/ibc.js`, I was able to surface some untypable code that indicated misuse of vows or a missing `E`.  Satisfyingly, resolving these errors led to clearer, more correct code.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Improved correctness.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
No runtime cost.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
Waiting until this is migrated to Endo and replaces `FarRef`, with full adoption before documenting.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Failures are a compile-time error, but only manual testing and code linting/typechecking has been done so far.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
Compile-time types are erased; the definition of these types does not affect the actual code to be evaluated.
