### PR TITLE
docs: prune out-date node version in favor of LTS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We support MacOS, Linux, and Windows Subsystem for Linux (WSL).
 
 For many of the packages here, JavaScript development tools suffice:
 
- - [node](https://nodejs.org/) 14.15.0 or higher
+ - [node](https://nodejs.org/) LTS
  - [yarn](https://classic.yarnpkg.com/en/docs/install) (`npm install -g yarn`)
 
 But to ensure contributions are compatible with all packages, you will


### PR DESCRIPTION
## Description

prune out-date node version in favor of LTS

### Security / Scaling / Testing Considerations

n/a

### Documentation / Testing / Upgrade Considerations

I think "we support node LTS" is our goal. Due to issues such as #8599, docs on [Platform Requirements](https://docs.agoric.com/guides/getting-started/#platform-requirements) currently cite v18.16.0 specifically. In that case, @kbennett2000 regularly tests the getting started docs to be sure it works. I don't think we have a corresponding maintenance trigger for CONTRIBUTING, so "LTS" is probably better.

ci tests 18.x and 20.x, which are the 2 current LTS versions according to the [node release schedule](https://nodejs.org/en/about/previous-releases):

```yml
      matrix:
        node-version: ['18.x', '20.x']
```
-- https://github.com/Agoric/agoric-sdk/blob/master/.github/workflows/test-all-packages.yml
