### PR TITLE
feat(cosmos): Handle multiple upgrades of the same version

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -789,7 +789,6 @@ func NewAgoricApp(
 	app.SetEndBlocker(app.EndBlocker)
 
 	for name := range upgradeNamesOfThisVersion {
-
 		app.UpgradeKeeper.SetUpgradeHandler(
 			name,
 			upgrade14Handler(app, name),
@@ -853,6 +852,8 @@ func upgrade14Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgr
 
 		CoreProposalSteps := []vm.CoreProposalStep{}
 
+		// These CoreProposalSteps are not idempotent and should only be executed
+		// as part of the first upgrade-14 on any given chain.
 		if isFirstTimeUpgradeOfThisVersion(app, ctx) {
 			// Each CoreProposalStep runs sequentially, and can be constructed from
 			// one or more modules executing in parallel within the step.

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -832,8 +832,9 @@ func NewAgoricApp(
 }
 
 var upgradeNamesOfThisVersion = map[string]bool{
-	"agoric-upgrade-14":     true,
-	"agorictest-upgrade-14": true,
+	"agoric-upgrade-14":         true,
+	"agorictest-upgrade-14":     true,
+	"agorictest-upgrade-14-rc1": true,
 }
 
 func isFirstTimeUpgradeOfThisVersion(app *GaiaApp, ctx sdk.Context) bool {

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -831,9 +831,9 @@ func NewAgoricApp(
 }
 
 var upgradeNamesOfThisVersion = map[string]bool{
-	"agoric-upgrade-14":         true,
-	"agorictest-upgrade-14":     true,
-	"agorictest-upgrade-14-rc1": true,
+	"agoric-upgrade-14":       true,
+	"agorictest-upgrade-14":   true,
+	"agorictest-upgrade-14-2": true,
 }
 
 func isFirstTimeUpgradeOfThisVersion(app *GaiaApp, ctx sdk.Context) bool {

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -788,25 +788,19 @@ func NewAgoricApp(
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
 
-	const (
-		upgradeName     = "agoric-upgrade-14"
-		upgradeNameTest = "agorictest-upgrade-14"
-	)
+	for name := range upgradeNamesOfThisVersion {
 
-	app.UpgradeKeeper.SetUpgradeHandler(
-		upgradeName,
-		upgrade14Handler(app, upgradeName),
-	)
-	app.UpgradeKeeper.SetUpgradeHandler(
-		upgradeNameTest,
-		upgrade14Handler(app, upgradeNameTest),
-	)
+		app.UpgradeKeeper.SetUpgradeHandler(
+			name,
+			upgrade14Handler(app, name),
+		)
+	}
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(err)
 	}
-	if (upgradeInfo.Name == upgradeName || upgradeInfo.Name == upgradeNameTest) && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name != "" && upgradeNamesOfThisVersion[upgradeInfo.Name] && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Deleted: []string{
 				crisistypes.ModuleName, // The SDK discontinued the crisis module in v0.51.0
@@ -837,20 +831,38 @@ func NewAgoricApp(
 	return app
 }
 
+var upgradeNamesOfThisVersion = map[string]bool{
+	"agoric-upgrade-14":     true,
+	"agorictest-upgrade-14": true,
+}
+
+func isFirstTimeUpgradeOfThisVersion(app *GaiaApp, ctx sdk.Context) bool {
+	for name := range upgradeNamesOfThisVersion {
+		if app.UpgradeKeeper.GetDoneHeight(ctx, name) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // upgrade14Handler performs standard upgrade actions plus custom actions for upgrade-14.
 func upgrade14Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
 		app.CheckControllerInited(false)
 
-		// Each CoreProposalStep runs sequentially, and can be constructed from
-		// one or more modules executing in parallel within the step.
-		CoreProposalSteps := []vm.CoreProposalStep{
-			// First, upgrade wallet factory
-			vm.CoreProposalStepForModules("@agoric/vats/scripts/build-wallet-factory2-upgrade.js"),
-			// Then, upgrade Zoe and ZCF
-			vm.CoreProposalStepForModules("@agoric/vats/scripts/replace-zoe.js"),
-			// Next revive KREAd characters
-			vm.CoreProposalStepForModules("@agoric/vats/scripts/revive-kread.js"),
+		CoreProposalSteps := []vm.CoreProposalStep{}
+
+		if isFirstTimeUpgradeOfThisVersion(app, ctx) {
+			// Each CoreProposalStep runs sequentially, and can be constructed from
+			// one or more modules executing in parallel within the step.
+			CoreProposalSteps = []vm.CoreProposalStep{
+				// First, upgrade wallet factory
+				vm.CoreProposalStepForModules("@agoric/vats/scripts/build-wallet-factory2-upgrade.js"),
+				// Then, upgrade Zoe and ZCF
+				vm.CoreProposalStepForModules("@agoric/vats/scripts/replace-zoe.js"),
+				// Next revive KREAd characters
+				vm.CoreProposalStepForModules("@agoric/vats/scripts/revive-kread.js"),
+			}
 		}
 
 		app.upgradeDetails = &upgradeDetails{

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -799,7 +799,7 @@ func NewAgoricApp(
 	if err != nil {
 		panic(err)
 	}
-	if upgradeInfo.Name != "" && upgradeNamesOfThisVersion[upgradeInfo.Name] && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeNamesOfThisVersion[upgradeInfo.Name] && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Deleted: []string{
 				crisistypes.ModuleName, // The SDK discontinued the crisis module in v0.51.0

--- a/scripts/gen-upgrade-proposal.sh
+++ b/scripts/gen-upgrade-proposal.sh
@@ -20,7 +20,7 @@ curl -L "$ZIPURL" -o "$zipfile"
 echo "Generating SHA-256 checksum..." 1>&2
 checksum=sha256:$(shasum -a 256 "$zipfile" | cut -d' ' -f1)
 
-info="{\"binaries\":{\"any\":\"$ZIPURL?checksum=$checksum\"}}"
+info="{\"binaries\":{\"any\":\"$ZIPURL//agoric-sdk-$COMMIT_ID?checksum=$checksum\"},\"source\":\"$ZIPURL?checksum=$checksum\"}"
 
 cat <<EOF 1>&2
 ------------------------------------------------------------


### PR DESCRIPTION
fixes: #9047

## Description

Refactors how upgradeNames are registered and only add core proposal on the first upgrade of the version.

This is to avoid re-executing core proposals which are currently not version tracked nor idempotent. 

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Will create a test in agoric-3-proposals that simulates this sequential upgrade that is expected on emerynet.

Existing a3p-integration test will exercise the flow without sequential upgrades.

### Upgrade Considerations

In preparation of new RC being cut for upgrade-14