### PR TITLE
refactor(golang/cosmos/ante): Align with upstream DeductFeeDecorator

### DIFF
--- a/golang/cosmos/ante/ante.go
+++ b/golang/cosmos/ante/ante.go
@@ -45,9 +45,6 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(),
 		ante.NewExtensionOptionsDecorator(nil), // reject all extensions
-		// former ante.NewMempoolFeeDecorator()
-		// replaced as in https://github.com/provenance-io/provenance/pull/1016
-		// ante.NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, nil),
 		NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),

--- a/golang/cosmos/ante/ante.go
+++ b/golang/cosmos/ante/ante.go
@@ -45,13 +45,17 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(),
 		ante.NewExtensionOptionsDecorator(nil), // reject all extensions
-		NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(opts.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(opts.AccountKeeper),
 		NewInboundDecorator(opts.SwingsetKeeper),
-		NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, opts.FeeCollectorName),
+
+		// We use a custom fee-deduction decorator
+		// to support a dynamically-configurable collector destination.
+		// [cosmos-sdk v0.46.16] NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
+		NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, opts.FeeCollectorName, opts.TxFeeChecker),
+
 		// SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewSetPubKeyDecorator(opts.AccountKeeper),
 		ante.NewValidateSigCountDecorator(opts.AccountKeeper),

--- a/golang/cosmos/ante/ante.go
+++ b/golang/cosmos/ante/ante.go
@@ -47,7 +47,8 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewExtensionOptionsDecorator(nil), // reject all extensions
 		// former ante.NewMempoolFeeDecorator()
 		// replaced as in https://github.com/provenance-io/provenance/pull/1016
-		ante.NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, nil),
+		// ante.NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, nil),
+		NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(opts.AccountKeeper),

--- a/golang/cosmos/ante/fee.go
+++ b/golang/cosmos/ante/fee.go
@@ -9,6 +9,54 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
+// TODO: Keep in sync with cosmos-sdk/x/auth/ante/fee.go
+
+// MempoolFeeDecorator will check if the transaction's fee is at least as large
+// as the local validator's minimum gasFee (defined in validator config).
+// If fee is too low, decorator returns error and tx is rejected from mempool.
+// Note this only applies when ctx.CheckTx = true
+// If fee is high enough or not CheckTx, then call next AnteHandler
+// CONTRACT: Tx must implement FeeTx to use MempoolFeeDecorator
+type MempoolFeeDecorator struct{}
+
+func NewMempoolFeeDecorator() MempoolFeeDecorator {
+	return MempoolFeeDecorator{}
+}
+
+func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, sdkioerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feeCoins := feeTx.GetFee()
+	gas := feeTx.GetGas()
+
+	// Ensure that the provided fees meet a minimum threshold for the validator,
+	// if this is a CheckTx. This is only for local mempool purposes, and thus
+	// is only ran on check tx.
+	if ctx.IsCheckTx() && !simulate {
+		minGasPrices := ctx.MinGasPrices()
+		if !minGasPrices.IsZero() {
+			requiredFees := make(sdk.Coins, len(minGasPrices))
+
+			// Determine the required fees by multiplying each required minimum gas
+			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+			glDec := sdk.NewDec(int64(gas))
+			for i, gp := range minGasPrices {
+				fee := gp.Amount.Mul(glDec)
+				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
+			}
+
+			if !feeCoins.IsAnyGTE(requiredFees) {
+				return ctx, sdkioerrors.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, requiredFees)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
 // DeductFeeDecorator deducts fees from the first signer of the tx
 // If the first signer does not have the funds to pay for the fees, return with InsufficientFunds error
 // Call next AnteHandler if fees successfully deducted

--- a/golang/cosmos/ante/fee_test.go
+++ b/golang/cosmos/ante/fee_test.go
@@ -1,0 +1,103 @@
+package ante
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+
+	// "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/gogo/protobuf/proto"
+)
+
+const (
+	addr1 = "cosmos1uupflqrldlpkktssnzgp3r03ff6kz4u4kzd92pjgsfddye7grrlqt9rmmt"
+)
+
+var (
+	c = sdk.NewCoins
+)
+
+func ubld(amt int64) sdk.Coin {
+	return sdk.NewInt64Coin("ubld", amt)
+}
+
+func makeTestFeeTx(msgs ...proto.Message) *tx.Tx {
+	wrappedMsgs := make([]*types.Any, len(msgs))
+	for i, m := range msgs {
+		any, err := types.NewAnyWithValue(m)
+		if err != nil {
+			panic(err)
+		}
+		wrappedMsgs[i] = any
+	}
+	return &tx.Tx{
+		AuthInfo: &tx.AuthInfo{
+			Fee: &tx.Fee{},
+		},
+		Body: &tx.TxBody{
+			Messages: wrappedMsgs,
+		},
+	}
+}
+
+type mockFeegrantKeeper struct{}
+
+var _ FeegrantKeeper = mockFeegrantKeeper{}
+
+func (mfk mockFeegrantKeeper) UseGrantedFees(ctx sdk.Context, granter, grantee sdk.AccAddress, fee sdk.Coins, msgs []sdk.Msg) error {
+	return nil
+}
+
+func TestDoubleFee(t *testing.T) {
+	feeCollector := "fee collector"
+	ak := mockAccountKeeper{}
+	bk := newMockBankKeeper()
+	fk := mockFeegrantKeeper{}
+	handler := sdk.ChainAnteDecorators(
+		// ante.NewDeductFeeDecorator(ak, bk, fk, nil),
+		NewMempoolFeeDecorator(),
+		NewDeductFeeDecorator(ak, bk, fk, feeCollector),
+	)
+
+	checkTx := false
+	eventManager := sdk.NewEventManager()
+	ctx := sdk.Context{}.WithContext(context.Background()).WithIsCheckTx(checkTx).WithEventManager(eventManager)
+	tx := makeTestFeeTx(&banktypes.MsgSend{})
+	fee := c(ubld(1000))
+	tx.AuthInfo.Fee.Amount = fee
+	tx.AuthInfo.Fee.GasLimit = 64000
+	tx.AuthInfo.Fee.Payer = addr1
+
+	simulate := false
+	errMsg := ""
+
+	bk.balances[addr1] = c(ubld(9000))
+
+	newCtx, err := handler(ctx, tx, simulate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(newCtx, ctx) {
+		t.Errorf("want ctx %v, got %v", ctx, newCtx)
+	}
+	if err != nil {
+		if errMsg == "" {
+			t.Errorf("want no error, got %s", err.Error())
+		} else if err.Error() != errMsg {
+			t.Errorf("want error %s, got %s", errMsg, err.Error())
+		}
+	} else if errMsg != "" {
+		t.Errorf("want error %s, got none", errMsg)
+	}
+	if !bk.balances[addr1].IsEqual(c(ubld(8000))) {
+		t.Errorf("want sender balance %s, got %s", c(ubld(8000)), bk.balances[addr1])
+	}
+	if !bk.balances[feeCollector].IsEqual(fee) {
+		t.Errorf("want fee collector balance %s, got %s", fee, bk.balances[feeCollector])
+	}
+}

--- a/golang/cosmos/ante/fee_test.go
+++ b/golang/cosmos/ante/fee_test.go
@@ -60,8 +60,7 @@ func TestDoubleFee(t *testing.T) {
 	fk := mockFeegrantKeeper{}
 	handler := sdk.ChainAnteDecorators(
 		// ante.NewDeductFeeDecorator(ak, bk, fk, nil),
-		NewMempoolFeeDecorator(),
-		NewDeductFeeDecorator(ak, bk, fk, feeCollector),
+		NewDeductFeeDecorator(ak, bk, fk, feeCollector, nil),
 	)
 
 	checkTx := false

--- a/golang/cosmos/ante/test_helpers.go
+++ b/golang/cosmos/ante/test_helpers.go
@@ -1,0 +1,156 @@
+package ante
+
+import (
+	"fmt"
+
+	sdkmath "cosmossdk.io/math"
+	swingtypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/gogo/protobuf/proto"
+)
+
+func makeTestTx(msgs ...proto.Message) sdk.Tx {
+	wrappedMsgs := make([]*types.Any, len(msgs))
+	for i, m := range msgs {
+		any, err := types.NewAnyWithValue(m)
+		if err != nil {
+			panic(err)
+		}
+		wrappedMsgs[i] = any
+	}
+	return &tx.Tx{
+		Body: &tx.TxBody{
+			Messages: wrappedMsgs,
+		},
+	}
+}
+
+func nilAnteHandler(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
+	return ctx, nil
+}
+
+type mockAccountKeeper struct{}
+
+var _ ante.AccountKeeper = mockAccountKeeper{}
+
+func (mak mockAccountKeeper) GetParams(ctx sdk.Context) (params authtypes.Params) {
+	return authtypes.Params{}
+}
+
+func (mak mockAccountKeeper) GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI {
+	return authtypes.NewBaseAccountWithAddress(addr)
+}
+
+func (mak mockAccountKeeper) SetAccount(ctx sdk.Context, acc authtypes.AccountI) {
+
+}
+
+func (mak mockAccountKeeper) GetModuleAddress(moduleName string) sdk.AccAddress {
+	return []byte{}
+}
+
+type mockBankKeeper struct {
+	balances map[string]sdk.Coins
+}
+
+var _ authtypes.BankKeeper = &mockBankKeeper{}
+
+func newMockBankKeeper() *mockBankKeeper {
+	return &mockBankKeeper{
+		balances: map[string]sdk.Coins{},
+	}
+}
+
+func (mbk *mockBankKeeper) sendCoinsInternal(from, to string, amt sdk.Coins) error {
+	fromBalance := mbk.balances[from]
+	if !fromBalance.IsAllGTE(amt) {
+		return fmt.Errorf("insufficient balance for [%s] want %s, have %s", from, amt, fromBalance)
+	}
+	mbk.balances[from] = fromBalance.Sub(amt...)
+	toBalance := mbk.balances[to]
+	mbk.balances[to] = toBalance.Add(amt...)
+	return nil
+}
+
+func (mbk *mockBankKeeper) SendCoins(ctx sdk.Context, from, to sdk.AccAddress, amt sdk.Coins) error {
+	return mbk.sendCoinsInternal(from.String(), to.String(), amt)
+}
+
+func (mbk *mockBankKeeper) SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
+	return mbk.sendCoinsInternal(senderAddr.String(), recipientModule, amt)
+}
+
+type mockSignModeHandler struct{}
+
+var _ authsigning.SignModeHandler = mockSignModeHandler{}
+
+// DefaultMode is the default mode that is to be used with this handler if no
+// other mode is specified. This can be useful for testing and CLI usage
+func (msmh mockSignModeHandler) DefaultMode() signing.SignMode {
+	return signing.SignMode_SIGN_MODE_DIRECT
+}
+
+// Modes is the list of modes supporting by this handler
+func (msmh mockSignModeHandler) Modes() []signing.SignMode {
+	return []signing.SignMode{signing.SignMode_SIGN_MODE_DIRECT}
+}
+
+// GetSignBytes returns the sign bytes for the provided SignMode, SignerData and Tx,
+// or an error
+func (msmh mockSignModeHandler) GetSignBytes(mode signing.SignMode, data authsigning.SignerData, tx sdk.Tx) ([]byte, error) {
+	return []byte{}, nil
+}
+
+type mockSwingsetKeeper struct {
+	inboundQueueLength    int32
+	inboundQueueLengthErr error
+	inboundLimit          int32
+	mempoolLimit          int32
+	emptyQueueAllowed     bool
+	isHighPriorityOwner   bool
+}
+
+var _ SwingsetKeeper = mockSwingsetKeeper{}
+var _ swingtypes.SwingSetKeeper = mockSwingsetKeeper{}
+
+func (msk mockSwingsetKeeper) InboundQueueLength(ctx sdk.Context) (int32, error) {
+	return msk.inboundQueueLength, msk.inboundQueueLengthErr
+}
+
+func (msk mockSwingsetKeeper) GetState(ctx sdk.Context) swingtypes.State {
+	if msk.emptyQueueAllowed {
+		return swingtypes.State{}
+	}
+	return swingtypes.State{
+		QueueAllowed: []swingtypes.QueueSize{
+			swingtypes.NewQueueSize(swingtypes.QueueInbound, msk.inboundLimit),
+			swingtypes.NewQueueSize(swingtypes.QueueInboundMempool, msk.mempoolLimit),
+		},
+	}
+}
+
+func (msk mockSwingsetKeeper) IsHighPriorityAddress(ctx sdk.Context, addr sdk.AccAddress) (bool, error) {
+	return msk.isHighPriorityOwner, nil
+}
+
+func (msk mockSwingsetKeeper) GetBeansPerUnit(ctx sdk.Context) map[string]sdkmath.Uint {
+	return nil
+}
+
+func (msk mockSwingsetKeeper) ChargeBeans(ctx sdk.Context, addr sdk.AccAddress, beans sdkmath.Uint) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (msk mockSwingsetKeeper) GetSmartWalletState(ctx sdk.Context, addr sdk.AccAddress) swingtypes.SmartWalletState {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (msk mockSwingsetKeeper) ChargeForSmartWallet(ctx sdk.Context, addr sdk.AccAddress) error {
+	return fmt.Errorf("not implemented")
+}

--- a/golang/cosmos/ante/validator_tx_fee.go
+++ b/golang/cosmos/ante/validator_tx_fee.go
@@ -1,0 +1,68 @@
+// This file clones cosmos-sdk x/auth/ante/validator_tx_fee.go as of v0.46.16,
+// and should be kept up-to-date with upstream changes.
+
+package ante
+
+import (
+	"math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// checkTxFeeWithValidatorMinGasPrices implements the default fee logic, where the minimum price per
+// unit of gas is fixed and set by each validator, can the tx priority is computed from the gas price.
+func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return nil, 0, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feeCoins := feeTx.GetFee()
+	gas := feeTx.GetGas()
+
+	// Ensure that the provided fees meet a minimum threshold for the validator,
+	// if this is a CheckTx. This is only for local mempool purposes, and thus
+	// is only ran on check tx.
+	if ctx.IsCheckTx() {
+		minGasPrices := ctx.MinGasPrices()
+		if !minGasPrices.IsZero() {
+			requiredFees := make(sdk.Coins, len(minGasPrices))
+
+			// Determine the required fees by multiplying each required minimum gas
+			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+			glDec := sdk.NewDec(int64(gas))
+			for i, gp := range minGasPrices {
+				fee := gp.Amount.Mul(glDec)
+				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
+			}
+
+			if !feeCoins.IsAnyGTE(requiredFees) {
+				return nil, 0, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, requiredFees)
+			}
+		}
+	}
+
+	priority := getTxPriority(feeCoins, int64(gas))
+	return feeCoins, priority, nil
+}
+
+// getTxPriority returns a naive tx priority based on the amount of the smallest denomination of the gas price
+// provided in a transaction.
+// NOTE: This implementation should be used with a great consideration as it opens potential attack vectors
+// where txs with multiple coins could not be prioritize as expected.
+func getTxPriority(fee sdk.Coins, gas int64) int64 {
+	var priority int64
+	for _, c := range fee {
+		p := int64(math.MaxInt64)
+		gasPrice := c.Amount.QuoRaw(gas)
+		if gasPrice.IsInt64() {
+			p = gasPrice.Int64()
+		}
+		if priority == 0 || p < priority {
+			priority = p
+		}
+	}
+
+	return priority
+}


### PR DESCRIPTION
closes: #9036

## Description

An alternative extension to #9045 as suggested in https://github.com/Agoric/agoric-sdk/pull/9045#pullrequestreview-1922842993 (cloning upstream DeductFeeDecorator and extending it to support a `feeCollectorName` argument.

### Security Considerations

Nothing in particular.

### Scaling Considerations

n/a

### Documentation Considerations

The code should hopefully be clear about its provenance.

### Testing Considerations

@JimLarson suggests an additional test for behavior formerly handled by MempoolFeeDecorator, which I could use help with.

### Upgrade Considerations

Should preserve previous behavior and minimize burden to incorporate future upstream changes.
