### PR TITLE
chore: Update comments referencing core eval handling

### DIFF
--- a/golang/cosmos/proto/agoric/swingset/swingset.proto
+++ b/golang/cosmos/proto/agoric/swingset/swingset.proto
@@ -8,7 +8,7 @@ option go_package = "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types
 
 // CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
 // core.
-// See `agoric-sdk/packages/vats/src/core/eval.js`.
+// See `bridgeCoreEval` in agoric-sdk packages/vats/src/core/chain-behaviors.js.
 message CoreEvalProposal {
   option (gogoproto.goproto_getters) = false;
 

--- a/golang/cosmos/x/swingset/types/swingset.pb.go
+++ b/golang/cosmos/x/swingset/types/swingset.pb.go
@@ -27,7 +27,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
 // core.
-// See `agoric-sdk/packages/vats/src/core/eval.js`.
+// See `bridgeCoreEval` in agoric-sdk packages/vats/src/core/chain-behaviors.js.
 type CoreEvalProposal struct {
 	Title       string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`

--- a/packages/cosmic-proto/proto/agoric/swingset/swingset.proto
+++ b/packages/cosmic-proto/proto/agoric/swingset/swingset.proto
@@ -8,7 +8,7 @@ option go_package = "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types
 
 // CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
 // core.
-// See `agoric-sdk/packages/vats/src/core/eval.js`.
+// See `bridgeCoreEval` in agoric-sdk packages/vats/src/core/chain-behaviors.js.
 message CoreEvalProposal {
   option (gogoproto.goproto_getters) = false;
 

--- a/packages/cosmic-proto/src/codegen/agoric/swingset/swingset.ts
+++ b/packages/cosmic-proto/src/codegen/agoric/swingset/swingset.ts
@@ -9,7 +9,7 @@ import { isSet, bytesFromBase64, base64FromBytes } from '../../helpers.js';
 /**
  * CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
  * core.
- * See `agoric-sdk/packages/vats/src/core/eval.js`.
+ * See `bridgeCoreEval` in agoric-sdk packages/vats/src/core/chain-behaviors.js.
  */
 export interface CoreEvalProposal {
   title: string;
@@ -27,7 +27,7 @@ export interface CoreEvalProposalProtoMsg {
 /**
  * CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
  * core.
- * See `agoric-sdk/packages/vats/src/core/eval.js`.
+ * See `bridgeCoreEval` in agoric-sdk packages/vats/src/core/chain-behaviors.js.
  */
 export interface CoreEvalProposalAmino {
   title?: string;
@@ -45,7 +45,7 @@ export interface CoreEvalProposalAminoMsg {
 /**
  * CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
  * core.
- * See `agoric-sdk/packages/vats/src/core/eval.js`.
+ * See `bridgeCoreEval` in agoric-sdk packages/vats/src/core/chain-behaviors.js.
  */
 export interface CoreEvalProposalSDKType {
   title: string;

--- a/packages/vats/src/core/README.md
+++ b/packages/vats/src/core/README.md
@@ -1,7 +1,7 @@
 # Core vats and supports
 
 This directory contains modules that build vats that boot other vats. If that's all it did, it could terminate but it also has persistent responsibilities:
-- hold the `CORE_EVAL` bridge handler
+- hold the `CORE_EVAL` bridge handler (see `bridgeCoreEval` in [chain-behaviors.js](./chain-behaviors.js)
 - hold a PrioritySenderManager handed out to some contracts
 
 Bootstrap vats must not hold precious state (see https://github.com/Agoric/agoric-sdk/issues/4548). These state aren't _precious_ because they can be reconstructed.


### PR DESCRIPTION
Fixes #9054

## Description

Replaces references to the nonexistent **packages/vats/src/core/eval.js** with references to **packages/vats/src/core/chain-behaviors.js**.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

I'm open to suggestions of an even better target.

### Testing Considerations

n/a

### Upgrade Considerations

n/a