### PR TITLE
test(ansible): Improve failure output

### DIFF
--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -79,7 +79,7 @@ while [[ ${#rpcAddrs[@]} -gt 0 ]]; do
       fi
       txfile="/tmp/faucet.$$.json"
       signedtxfile="/tmp/faucet.$$.signed.json"
-      trap 'rm -f "$txfile"' EXIT
+      trap 'rm -f "$txfile" "$signedtxfile"' EXIT
       echo "$body0" | jq ".body.messages += $msg1" > "$txfile"
       if $TX sign "$txfile" | tee "$signedtxfile" | $TX broadcast --broadcast-mode=block - | tee /dev/stderr | grep -q '^code: 0'; then
         status=0

--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -78,14 +78,14 @@ while [[ ${#rpcAddrs[@]} -gt 0 ]]; do
         msg1='[]'
       fi
       txfile="/tmp/faucet.$$.json"
+      signedtxfile="/tmp/faucet.$$.signed.json"
       trap 'rm -f "$txfile"' EXIT
       echo "$body0" | jq ".body.messages += $msg1" > "$txfile"
-      if $TX sign "$txfile" | $TX broadcast --broadcast-mode=block - | tee /dev/stderr | grep -q '^code: 0'; then
+      if $TX sign "$txfile" | tee "$signedtxfile" | $TX broadcast --broadcast-mode=block - | tee /dev/stderr | grep -q '^code: 0'; then
         status=0
       else
         status=$?
-        echo "Failed to append $msg1" 1>&2
-        echo "to $body0" 1>&2
+        printf 'tx broadcast failure!\n''unsigned payload: %s\n''signed payload: %s\n' "$(cat "$txfile")" "$(cat "$signedtxfile")" 1>&2
       fi
       exit $status
       ;;


### PR DESCRIPTION
Fixes #9060
Ref d13427ce59618b9dafcdd490a8d57db24df075e4

## Description

Improves the error output of packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Further improvements may be warranted, but this covers the confusing failures we've seen so far.

### Upgrade Considerations

n/a