### PR TITLE
end runtime imports of other packages for types

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -85,6 +85,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 90.56
+    "atLeast": 90.61
   }
 }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -100,6 +100,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 75.05
+    "atLeast": 75.03
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -98,6 +98,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 76.93
+    "atLeast": 77.17
   }
 }

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -87,6 +87,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 87.83
+    "atLeast": 87.57
   }
 }

--- a/packages/builders/index.js
+++ b/packages/builders/index.js
@@ -1,2 +1,0 @@
-// Ambient types
-import '@agoric/network/exported.js';

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@agoric/ertp": "^0.16.2",
     "@agoric/internal": "^0.3.2",
-    "@agoric/network": "^0.1.0",
     "@agoric/notifier": "^0.6.2",
     "@agoric/smart-wallet": "^0.5.3",
     "@agoric/vat-data": "^0.5.2",

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -79,6 +79,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 73.62
+    "atLeast": 73.8
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -47,6 +47,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 86.81
+    "atLeast": 90.97
   }
 }

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -60,6 +60,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 89.58
+    "atLeast": 89.6
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -68,6 +68,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 79.84
+    "atLeast": 80.49
   }
 }

--- a/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
+++ b/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
@@ -8,10 +8,6 @@ import {
 } from '@agoric/vats/src/core/utils.js';
 import { makeCoreProposalBehavior } from '../../src/coreProposalBehavior.js';
 
-// TODO remove this stubborn case
-// https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/vats/src/core/types-ambient.js';
-
 // TODO: we need to rewrite writeCoreProposal.js to produce BundleIDs,
 // although this test doesn't exercise that.
 

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 82.1
+    "atLeast": 94.73
   }
 }

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -1,5 +1,3 @@
-import '@agoric/vats/src/core/types-ambient.js';
-
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { NonNullish } from '@agoric/assert';

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -68,6 +68,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 76.57
+    "atLeast": 91.68
   }
 }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -76,6 +76,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 89.74
+    "atLeast": 89.76
   }
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -70,6 +70,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 89.97
+    "atLeast": 90.79
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -67,6 +67,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.75
+    "atLeast": 93.76
   }
 }

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -4,9 +4,6 @@ import { InvitationHandleShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/far';
 import { shape } from './typeGuards.js';
 
-// Ambient types. Needed only for dev but this does a runtime import.
-import '@agoric/zoe/exported.js';
-
 const { Fail } = assert;
 
 // A safety limit

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -78,6 +78,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 68.76
+    "atLeast": 73.13
   }
 }

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -62,6 +62,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 50
+    "atLeast": 55.05
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -58,6 +58,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 85.75
+    "atLeast": 86.12
   }
 }

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -67,6 +67,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 75.2
+    "atLeast": 75.22
   }
 }

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -59,6 +59,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 53.18
+    "atLeast": 54.98
   }
 }

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -48,6 +48,6 @@
     "node": ">=14.15.0"
   },
   "typeCoverage": {
-    "atLeast": 98.78
+    "atLeast": 98.79
   }
 }

--- a/packages/vats/index.js
+++ b/packages/vats/index.js
@@ -1,5 +1,4 @@
 // Ambient types
-import '@agoric/zoe/exported.js';
 import './src/core/types-ambient.js';
 
 // eslint-disable-next-line import/export -- no named exports

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -75,6 +75,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.05
+    "atLeast": 89.52
   }
 }

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -7,6 +7,8 @@ import { keyEQ } from '@agoric/store';
 import { makeNameHubKit } from '../nameHub.js';
 import { makeLogHooks, makePromiseSpace } from './promise-space.js';
 
+import './types-ambient.js';
+
 const { entries, fromEntries, keys } = Object;
 const { Fail, quote: q } = assert;
 

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 87.51
+    "atLeast": 88.27
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -138,6 +138,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 84.72
+    "atLeast": 84.73
   }
 }


### PR DESCRIPTION
closes: #6512

## Description

@dckc proposed [another trick](https://github.com/Agoric/agoric-sdk/issues/6512#issuecomment-1991853031) : making a file that's picked up by tsconfig's glob but not ever imported itself. Whatever ambient types that file imports get picked up by the type checker.  This only works for the particular tsconfig, but I thought it was worth seeing how it would help with #6512.

Turns out that since that was filed the repo has improved such that we don't need any ambient imports of other packages. (Found by `agoric/.*types` regexp in `.js` files) There's one case with a test relying on `@agoric/vats/src/core/utils.js` not getting the types that entails, but simply having that module import the types solves that problem.



### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

Make sure there's no reduction in type coverage. I ran `update-type-coverage.sh` before the changes and committed that. After all the changes I ran again and nothing change.

### Upgrade Considerations

none
