### PR TITLE
chore: clean up dead code for legacy REST methods

### DIFF
--- a/golang/cosmos/x/swingset/module.go
+++ b/golang/cosmos/x/swingset/module.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
@@ -58,10 +57,6 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	}
 	// Once json successfully marshalled, passes along to genesis.go
 	return ValidateGenesis(&data)
-}
-
-// Register rest routes
-func (AppModuleBasic) RegisterRESTRoutes(ctx client.Context, rtr *mux.Router) {
 }
 
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {

--- a/golang/cosmos/x/vbank/module.go
+++ b/golang/cosmos/x/vbank/module.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	stdlog "log"
 
-	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
@@ -58,10 +57,6 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 		return err
 	}
 	return ValidateGenesis(&data)
-}
-
-// Register rest routes
-func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Router) {
 }
 
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {

--- a/golang/cosmos/x/vibc/module.go
+++ b/golang/cosmos/x/vibc/module.go
@@ -3,7 +3,6 @@ package vibc
 import (
 	"encoding/json"
 
-	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
@@ -51,10 +50,6 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	return nil
 }
 
-// Register rest routes
-func (AppModuleBasic) RegisterRESTRoutes(ctx client.Context, rtr *mux.Router) {
-}
-
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(_ client.Context, _ *runtime.ServeMux) {
 }
 
@@ -70,7 +65,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 
 type AppModule struct {
 	AppModuleBasic
-	keeper Keeper
+	keeper     Keeper
 	bankKeeper types.BankKeeper
 }
 
@@ -79,7 +74,7 @@ func NewAppModule(k Keeper, bankKeeper types.BankKeeper) AppModule {
 	am := AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         k,
-		bankKeeper:		 bankKeeper,
+		bankKeeper:     bankKeeper,
 	}
 	return am
 }

--- a/golang/cosmos/x/vstorage/module.go
+++ b/golang/cosmos/x/vstorage/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
@@ -55,10 +54,6 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	}
 	// Once json successfully marshalled, passes along to genesis.go
 	return ValidateGenesis(&data)
-}
-
-// Register rest routes
-func (AppModuleBasic) RegisterRESTRoutes(ctx client.Context, rtr *mux.Router) {
 }
 
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {


### PR DESCRIPTION
refs: #8803

## Description

Cosmos-SDK 0.46 removed the "legacy REST" interface in cosmos/cosmos-sdk#9594. The supporting `RegisterRESTRoutes()` method was left in the `AppModuleBasic` interface for "compatibility" (?), but was finally removed in cosmos/cosmos-sdk#11797.

We have several no-op implementations of this method that are no longer required for compilation. Cleaning them up reduces clutter.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

None.

### Upgrade Considerations

None.
