### PR TITLE
fix Zoe Invitation types

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -100,6 +100,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 75.03
+    "atLeast": 75.02
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -98,6 +98,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 77.17
+    "atLeast": 77.12
   }
 }

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -37,6 +37,6 @@
     "readline-transform": "^1.0.0"
   },
   "typeCoverage": {
-    "atLeast": 51.3
+    "atLeast": 50.87
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -83,6 +83,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 95.77
+    "atLeast": 95.9
   }
 }

--- a/packages/inter-protocol/src/reserve/assetReserveKit.js
+++ b/packages/inter-protocol/src/reserve/assetReserveKit.js
@@ -143,8 +143,10 @@ export const prepareAssetReserveKit = async (
           trace('burnFeesToReduceShortfall', reduction);
           reduction = AmountMath.coerce(feeKit.brand, reduction);
           const feeKeyword = state.keywordForBrand.get(feeKit.brand);
-          const feeBalance =
-            state.collateralSeat.getAmountAllocated(feeKeyword);
+          const feeBalance = state.collateralSeat.getAmountAllocated(
+            feeKeyword,
+            feeKit.brand,
+          );
           const amountToBurn = AmountMath.min(reduction, feeBalance);
           if (AmountMath.isEmpty(amountToBurn)) {
             return;

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -87,7 +87,7 @@ const validTransitions = {
  * @typedef {object} VaultManager
  * @property {() => Subscriber<import('./vaultManager.js').AssetState>} getAssetSubscriber
  * @property {(collateralAmount: Amount) => Amount<'nat'>} maxDebtFor
- * @property {() => Brand} getCollateralBrand
+ * @property {() => Brand<'nat'>} getCollateralBrand
  * @property {(base: string) => string} scopeDescription
  * @property {() => Brand<'nat'>} getDebtBrand
  * @property {MintAndTransfer} mintAndTransfer

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -776,7 +776,7 @@ export const prepareVault = (baggage, makeRecorderKit, zcf) => {
           );
         },
 
-        /** @returns {Promise<Invitation>} */
+        /** @returns {Promise<Invitation<VaultKit>>} */
         makeTransferInvitation() {
           const { state, facets } = this;
           const { outerUpdater } = state;

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -51,6 +51,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 92.83
+    "atLeast": 93.01
   }
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -70,6 +70,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 90.79
+    "atLeast": 91.05
   }
 }

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -35,6 +35,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 62.06
+    "atLeast": 63.21
   }
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -49,6 +49,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 76.27
+    "atLeast": 76.3
   }
 }

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -59,6 +59,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 54.98
+    "atLeast": 55.46
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -75,6 +75,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 89.52
+    "atLeast": 89.69
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -139,6 +139,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 84.82
+    "atLeast": 84.88
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -139,6 +139,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 84.73
+    "atLeast": 84.82
   }
 }

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -6,13 +6,6 @@ type IssuerOptionsRecord = import('@agoric/ertp').IssuerOptionsRecord;
 type Completion = any;
 type ZCFMakeEmptySeatKit = (exit?: ExitRule | undefined) => ZcfSeatKit;
 
-type MakeInvitation = <Result>(
-  offerHandler: OfferHandler<Result>,
-  description: string,
-  customDetails?: object,
-  proposalShape?: Pattern,
-) => Promise<Invitation<R, A>>;
-
 /**
  * Zoe Contract Facet
  *
@@ -60,7 +53,12 @@ type ZCF<CT extends unknown = Record<string, unknown>> = {
    * getting in the `customDetails`. `customDetails` will be
    * placed in the details of the invitation.
    */
-  makeInvitation: MakeInvitation;
+  makeInvitation: <R>(
+    offerHandler: OfferHandler<R>,
+    description: string,
+    customDetails?: object,
+    proposalShape?: Pattern,
+  ) => Promise<Invitation<R, A>>;
   shutdown: (completion: Completion) => void;
   shutdownWithFailure: ShutdownWithFailure;
   getZoeService: () => ERef<ZoeService>;
@@ -164,21 +162,20 @@ type ZCFMint<K extends AssetKind = AssetKind> = {
  * normally an instanceof Error.
  */
 type ZCFSeatFail = (reason: unknown) => Error;
-/**
- * The brand is used for filling in an empty amount if the `keyword`
- * is not present in the allocation
- */
-type ZCFGetAmountAllocated = (
-  keyword: Keyword,
-  brand?: Brand<AssetKind> | undefined,
-) => Amount<any>;
 type ZCFSeat = {
   exit: (completion?: Completion) => void;
   fail: ZCFSeatFail;
   getSubscriber: () => Promise<Subscriber<Allocation>>;
   hasExited: () => boolean;
   getProposal: () => ProposalRecord;
-  getAmountAllocated: ZCFGetAmountAllocated;
+  /**
+   * @param brand used for filling in an empty amount if the `keyword`
+   * is not present in the allocation
+   */
+  getAmountAllocated: (
+    keyword: Keyword,
+    brand?: Brand<AssetKind> | undefined,
+  ) => Amount;
   getCurrentAllocation: () => Allocation;
   /**
    * @deprecated Use atomicRearrange instead

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -172,10 +172,10 @@ type ZCFSeat = {
    * @param brand used for filling in an empty amount if the `keyword`
    * is not present in the allocation
    */
-  getAmountAllocated: (
+  getAmountAllocated: <B extends Brand>(
     keyword: Keyword,
-    brand?: Brand<AssetKind> | undefined,
-  ) => Amount;
+    brand?: B,
+  ) => B extends Brand<infer K> ? Amount<K> : Amount;
   getCurrentAllocation: () => Allocation;
   /**
    * @deprecated Use atomicRearrange instead

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -53,8 +53,8 @@ type ZCF<CT extends unknown = Record<string, unknown>> = {
    * getting in the `customDetails`. `customDetails` will be
    * placed in the details of the invitation.
    */
-  makeInvitation: <R>(
-    offerHandler: OfferHandler<R>,
+  makeInvitation: <R, A = undefined>(
+    offerHandler: OfferHandler<ERef<R>, A>,
     description: string,
     customDetails?: object,
     proposalShape?: Pattern,
@@ -207,14 +207,14 @@ type ZcfSeatKit = {
   zcfSeat: ZCFSeat;
   userSeat: ERef<UserSeat>;
 };
-type HandleOffer<OR extends unknown> = (
+type HandleOffer<OR extends unknown, OA> = (
   seat: ZCFSeat,
-  offerArgs?: object,
+  offerArgs?: OA,
 ) => OR;
-type OfferHandler<OR extends unknown = unknown> =
-  | HandleOffer<OR>
+type OfferHandler<OR extends unknown = unknown, OA = never> =
+  | HandleOffer<OR, OA>
   | {
-      handle: HandleOffer<OR>;
+      handle: HandleOffer<OR, OA>;
     };
 type ContractMeta = {
   customTermsShape?: CopyRecord<any> | undefined;
@@ -243,3 +243,11 @@ type ContractStartFnResult<PF, CF> = {
 };
 type ContractOf<S> = import('../zoeService/utils').ContractOf<S>;
 type AdminFacet = import('../zoeService/utils').AdminFacet<any>;
+
+declare const OfferReturn: unique symbol;
+declare const OfferArgs: unique symbol;
+type Invitation<R = unknown, A = undefined> = Payment<'set'> & {
+  // because TS is structural, without this the generic is ignored
+  [OfferReturn]?: R;
+  [OfferArgs]?: A;
+};

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -189,15 +189,22 @@ export const createSeatManager = (
         return hasExited(self);
       },
 
+      /**
+       * @type {ZCFSeat['getAmountAllocated']}
+       */
       getAmountAllocated(keyword, brand) {
         const { self } = this;
         assertActive(self);
         const currentAllocation = getCurrentAllocation(self);
         if (currentAllocation[keyword] !== undefined) {
+          // @ts-expect-error cast
           return currentAllocation[keyword];
         }
-        brand || Fail`A brand must be supplied when the keyword is not defined`;
+        if (!brand) {
+          throw Fail`A brand must be supplied when the keyword is not defined`;
+        }
         const assetKind = getAssetKindByBrand(brand);
+        // @ts-expect-error cast
         return AmountMath.makeEmpty(brand, assetKind);
       },
       getCurrentAllocation() {

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -321,7 +321,8 @@ export const makeZCFZygote = async (
         customDetails,
         proposalShape,
       );
-      return invitationP;
+      // rely on the ZCF type signature
+      return /** @type {any} */ (invitationP);
     },
     // Shutdown the entire vat and give payouts
     shutdown: completion => {

--- a/packages/zoe/src/contractSupport/prepare-ownable.js
+++ b/packages/zoe/src/contractSupport/prepare-ownable.js
@@ -20,7 +20,7 @@ const TransferProposalShape = M.splitRecord({
 /**
  * @template {(string | symbol)[]} MN Method names
  * @param {import('@agoric/base-zone').Zone} zone
- * @param {MakeInvitation} makeInvitation
+ * @param {ZCF['makeInvitation']} makeInvitation
  *   A function with the same behavior as `zcf.makeInvitation`.
  *   A contract will normally just extract it from its own zcf using the
  *   argument expression

--- a/packages/zoe/src/contractSupport/prepare-ownable.js
+++ b/packages/zoe/src/contractSupport/prepare-ownable.js
@@ -34,7 +34,7 @@ const TransferProposalShape = M.splitRecord({
  *   The method names of the underlying exo class that should be represented
  *   by transparently-forwarding methods of the wrapping ownable object.
  * @param {OwnableOptions} [options]
- * @returns {<U>(underlying: U) => Pick<U, MN[number]> & {makeTransferInvitation: () => Invitation}}
+ * @returns {<U>(underlying: U) => Pick<U, MN[number]> & {makeTransferInvitation: () => Invitation<U>}}
  */
 export const prepareOwnable = (
   zone,

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -176,12 +176,11 @@ export const depositToSeatSuccessMsg = `Deposit and reallocation successful.`;
  * The `amounts` and `payments` records must have corresponding
  * keywords.
  *
- * @template {object} [OR=unknown]
  * @param {ZCF} zcf
  * @param {ZCFSeat} recipientSeat
  * @param {AmountKeywordRecord} amounts
  * @param {PaymentPKeywordRecord} payments
- * @returns {Promise<OR>} `Deposit and reallocation successful.`
+ * @returns {Promise<string>} `Deposit and reallocation successful.`
  */
 export const depositToSeat = async (zcf, recipientSeat, amounts, payments) => {
   !recipientSeat.hasExited() || Fail`The recipientSeat cannot have exited.`;

--- a/packages/zoe/src/contracts/auction/firstPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/firstPriceLogic.js
@@ -22,7 +22,6 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   for (const bidSeat of bidSeats) {
     if (!bidSeat.hasExited()) {
       activeBidsCount += 1n;
-      /** @type {Amount<'nat'>} */
       const bid = bidSeat.getAmountAllocated('Bid', bidBrand);
       // bidSeat is added in time order, in case of a tie, we privilege the earlier.
       // So the later bidder will need a strictly greater bid to win the auction.

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -23,7 +23,6 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   bidSeats.forEach(bidSeat => {
     if (!bidSeat.hasExited()) {
       activeBidsCount += 1n;
-      /** @type {Amount<'nat'>} */
       const bid = bidSeat.getAmountAllocated('Bid', bidBrand);
       // If the bid is greater than the highestBid, it's the new highestBid
       if (AmountMath.isGTE(bid, highestBid, bidBrand)) {

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -37,7 +37,10 @@ export const makeBorrowInvitation = (zcf, config) => {
       want: { Loan: null },
     });
 
-    const collateralGiven = borrowerSeat.getAmountAllocated('Collateral');
+    const collateralGiven = borrowerSeat.getAmountAllocated(
+      'Collateral',
+      borrowerSeat.getProposal().give.Collateral.brand,
+    );
     const loanWanted = borrowerSeat.getProposal().want.Loan;
     const loanBrand = zcf.getTerms().brands.Loan;
 

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -43,9 +43,3 @@
  *
  * @typedef {AmountKeywordRecord} Allocation
  */
-
-/**
- * @template {object} [R=unknown] Offer result
- * @template {object} [A=never] Offer args
- * @typedef {Payment<'set'>} Invitation
- */

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -108,7 +108,7 @@
 
 /**
  * @callback GetInvitationDetails
- * @param {ERef<Invitation>} invitation
+ * @param {ERef<Invitation<any, any>>} invitation
  * @returns {Promise<InvitationDetails>}
  */
 
@@ -148,7 +148,7 @@
  */
 
 /**
- * @typedef {<Args, Result>(
+ * @typedef {<Result, Args = undefined>(
  *   invitation: ERef<Invitation<Result, Args>>,
  *   proposal?: Proposal,
  *   paymentKeywordRecord?: PaymentPKeywordRecord,

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -5,7 +5,7 @@
  * https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html
  */
 import { E } from '@endo/eventual-send';
-import { expectType } from 'tsd';
+import { expectNotType, expectType } from 'tsd';
 
 // 'prepare' is deprecated but still supported
 import type { prepare as scaledPriceAuthorityStart } from '../src/contracts/scaledPriceAuthority.js';
@@ -66,4 +66,16 @@ import type { prepare as scaledPriceAuthorityStart } from '../src/contracts/scal
   //   // @ts-expect-error
   //   'invalid privateArgs',
   // );
+}
+
+{
+  const zcf = {} as ZCF;
+  const zoe = {} as ZoeService;
+  const invitation = await zcf.makeInvitation(() => 1n, 'invitation');
+  expectType<Invitation<bigint>>(invitation);
+  const userSeat = E(zoe).offer(invitation);
+  const result = await E(userSeat).getOfferResult();
+  // @ts-expect-error
+  result.notInResult;
+  expectType<bigint>(result);
 }


### PR DESCRIPTION
## Description

I noticed `makeInvitation` was returning an `any` invitation and I went down a bit of a rabbit hole to fix it. But it's done. See `packages/zoe/test/types.test-d.ts` for the tests.

The `chore(types)` commits don't affect runtime and the `fix(types)` commit does. The first coverage commit resets the baseline so only the second shows the effect of these changes.

### Security Considerations
n/a
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations
n/a
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
n/a
<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations
CI
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

Backwards compatible changes