### PR TITLE
allow non-vat builders

### DIFF
--- a/a3p-integration/proposals/a:upgrade-next/package.json
+++ b/a3p-integration/proposals/a:upgrade-next/package.json
@@ -7,7 +7,7 @@
       "coreProposals": []
     },
     "sdk-generate": [
-      "probe-zcf-bundle probe-submission"
+      "vats/probe-zcf-bundle.js probe-submission"
     ],
     "type": "Software Upgrade Proposal"
   },

--- a/a3p-integration/proposals/b:localchain/package.json
+++ b/a3p-integration/proposals/b:localchain/package.json
@@ -3,7 +3,7 @@
     "type": "/agoric.swingset.CoreEvalProposal",
     "source": "subdir",
     "sdk-generate": [
-      "test-localchain"
+      "vats/test-localchain.js"
     ]
   },
   "type": "module",

--- a/a3p-integration/scripts/generate-a3p-submission.sh
+++ b/a3p-integration/scripts/generate-a3p-submission.sh
@@ -6,11 +6,11 @@ sdkroot=$(git rev-parse --show-toplevel)
 cd "$sdkroot"
 
 a3pProposalDir=$1
-proposalName=$2
+builderScript=$2
 submissionDirName=${3:-submission}
 submissionDir="./a3p-integration/$a3pProposalDir/$submissionDirName"
 
-yarn agoric run "packages/builders/scripts/vats/$proposalName.js"
+yarn agoric run "packages/builders/scripts/$builderScript"
 mkdir -p "$submissionDir"
 
 plans=*-plan.json


### PR DESCRIPTION
## Description

Lets proposals specify build scripts other than in `vats`.

Makes them responsible for the `.js` extension to make it more obvious when reading that the string specifies a filename.

### Other Considerations
can't impact production