### PR TITLE
feat(vow): fix issues revealed by new `Remote<T>` type

### DIFF
--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -7,7 +7,7 @@ import { V as E } from '@agoric/vat-data/vow.js';
  * @param {ZCF} zcf
  * @param {{
  *   address: string,
- *   networkVat: any
+ *   networkVat: ERef<ReturnType<typeof import('@agoric/vats/src/vat-network').buildRootObject>>;
  * }} privateArgs
  * @param {import("@agoric/vat-data").Baggage} _baggage
  */

--- a/packages/boot/test/bootstrapTests/ibcServerMock.js
+++ b/packages/boot/test/bootstrapTests/ibcServerMock.js
@@ -12,7 +12,7 @@ const { log } = console;
  * @param {ZCF} zcf
  * @param {{
  *   address: string,
- *   networkVat: any
+ *   networkVat: ERef<ReturnType<typeof import('@agoric/vats/src/vat-network').buildRootObject>>;
  * }} privateArgs
  * @param {import("@agoric/vat-data").Baggage} _baggage
  */

--- a/packages/network/src/bytes.js
+++ b/packages/network/src/bytes.js
@@ -1,23 +1,41 @@
+// @ts-check
 /// <reference path="./types.js" />
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 
+/** @typedef {Data | Buffer | Uint8Array | Iterable<number>} SourceData */
+
 /**
- * Convert some data to bytes.
+ * @param {SourceData} contents
+ */
+const coerceToByteArray = contents => {
+  if (typeof contents === 'string') {
+    contents = contents.split('').map(c => c.charCodeAt(0));
+  }
+  if (contents instanceof Uint8Array) {
+    // Reconstruct to ensure we have a Uint8Array and not a Buffer.
+    return new Uint8Array(
+      contents.buffer,
+      contents.byteOffset,
+      contents.byteLength,
+    );
+  }
+  return new Uint8Array(contents);
+};
+
+/**
+ * Convert some data to bytes.  We can use a local Iterable as a source for data
+ * bytes, but we need to call `toBytes(it)` to obtain a passable value.
  *
- * @param {Data} data
+ * NOTE: Passing a Uint8Array without calling this function is not yet supported
+ * by `@endo/marshal`.
+ *
+ * @param {SourceData} data
  * @returns {Bytes}
  */
 export function toBytes(data) {
-  /** @type {Data | number[]} */
-  let bytes = data;
-  // TODO: We really need marshallable TypedArrays.
-  if (typeof bytes === 'string') {
-    bytes = bytes.split('').map(c => c.charCodeAt(0));
-  }
-
   // We return the raw characters in the lower half of
   // the String's representation.
-  const buf = new Uint8Array(bytes);
+  const buf = coerceToByteArray(data);
   return String.fromCharCode.apply(null, buf);
 }
 
@@ -34,25 +52,16 @@ export function bytesToString(bytes) {
 /**
  * Base64, as specified in https://tools.ietf.org/html/rfc4648#section-4
  *
- * @param {Data} data
+ * @param {SourceData} data
  * @returns {string} base64 encoding
  */
 export function dataToBase64(data) {
-  /** @type {Uint8Array} */
-  let bytes;
-  if (typeof data === 'string') {
-    bytes = new Uint8Array(data.length);
-    for (let i = 0; i < data.length; i += 1) {
-      bytes[i] = data.charCodeAt(i);
-    }
-  } else {
-    bytes = new Uint8Array(data);
-  }
+  const bytes = coerceToByteArray(data);
   return encodeBase64(bytes);
 }
 
 /**
- * Decodes a string into base64.
+ * Decodes a base64 string into bytes.
  *
  * @param {string} string Base64-encoded string
  * @returns {Bytes} decoded bytes

--- a/packages/network/src/bytes.js
+++ b/packages/network/src/bytes.js
@@ -3,10 +3,10 @@
 import { Fail } from '@agoric/assert';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 
-/** @typedef {Data | Buffer | Uint8Array | Iterable<number>} SourceData */
+/** @typedef {Bytes | Buffer | Uint8Array | Iterable<number>} ByteSource */
 
 /**
- * @param {SourceData} contents
+ * @param {ByteSource} contents
  */
 const coerceToByteArray = contents => {
   if (typeof contents === 'string') {
@@ -30,13 +30,13 @@ const coerceToByteArray = contents => {
  * Convert a Uint8Array or other sequence of octets to a string representation
  * that `@endo/marshal` accepts as Passable.
  *
- * @param {SourceData} data
+ * @param {ByteSource} byteSource
  * @returns {Bytes}
  */
-export function toBytes(data) {
+export function toBytes(byteSource) {
   // We return the raw characters in the lower half of
   // the String's representation.
-  const buf = coerceToByteArray(data);
+  const buf = coerceToByteArray(byteSource);
   return String.fromCharCode(...buf);
 }
 
@@ -53,11 +53,11 @@ export function bytesToString(bytes) {
 /**
  * Base64, as specified in https://tools.ietf.org/html/rfc4648#section-4
  *
- * @param {SourceData} data
+ * @param {ByteSource} byteSource
  * @returns {string} base64 encoding
  */
-export function dataToBase64(data) {
-  const bytes = coerceToByteArray(data);
+export function dataToBase64(byteSource) {
+  const bytes = coerceToByteArray(byteSource);
   return encodeBase64(bytes);
 }
 

--- a/packages/network/src/index.js
+++ b/packages/network/src/index.js
@@ -1,4 +1,5 @@
 export * from './network.js';
+export * from './shapes.js';
 export { prepareRouter, prepareRouterProtocol } from './router.js';
 export * from './multiaddr.js';
 export * from './bytes.js';

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -87,7 +87,7 @@ const prepareHalfConnection = (zone, { watch }) => {
           const { addrs, r } = this.state;
           return addrs[r];
         },
-        /** @param {Data} packetBytes */
+        /** @param {Bytes} packetBytes */
         async send(packetBytes) {
           const { closed, handlers, r, conns } = this.state;
           if (closed) {

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -4,6 +4,7 @@ import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { Fail } from '@agoric/assert';
 import { toBytes } from './bytes.js';
+import { Shape } from './shapes.js';
 
 import '@agoric/store/exported.js';
 /// <reference path="./types.js" />
@@ -14,202 +15,13 @@ import '@agoric/store/exported.js';
  */
 export const ENDPOINT_SEPARATOR = '/';
 
-const Shape1 = /** @type {const} */ ({
-  /**
-   * Data is string | Buffer | ArrayBuffer
-   * but only string is passable
-   */
-  Data: M.string(),
-  Bytes: M.string(),
-  Endpoint: M.string(),
-  Vow: M.tagged(
-    'Vow',
-    harden({
-      vowV0: M.remotable('VowV0'),
-    }),
-  ),
-  ConnectionHandler: M.remotable('ConnectionHandler'),
-  Connection: M.remotable('Connection'),
-  InboundAttempt: M.remotable('InboundAttempt'),
-  Listener: M.remotable('Listener'),
-  ListenHandler: M.remotable('ListenHandler'),
-  Port: M.remotable('Port'),
-  ProtocolHandler: M.remotable('ProtocolHandler'),
-  ProtocolImpl: M.remotable('ProtocolImpl'),
-});
-
-const Shape2 = /** @type {const} */ ({
-  ...Shape1,
-  Vow$: shape => M.or(shape, Shape1.Vow),
-  AttemptDescription: M.splitRecord(
-    { handler: Shape1.ConnectionHandler },
-    { remoteAddress: Shape1.Endpoint, localAddress: Shape1.Endpoint },
-  ),
-  Opts: M.recordOf(M.string(), M.any()),
-});
-
-export const Shape = /** @type {const} */ harden({
-  ...Shape2,
-  ConnectionI: {
-    connection: M.interface('Connection', {
-      send: M.callWhen(Shape2.Data)
-        .optional(Shape2.Opts)
-        .returns(Shape2.Vow$(Shape2.Bytes)),
-      close: M.callWhen().returns(Shape2.Vow$(M.undefined())),
-      getLocalAddress: M.call().returns(Shape2.Endpoint),
-      getRemoteAddress: M.call().returns(Shape2.Endpoint),
-    }),
-    openConnectionAckWatcher: M.interface('OpenConnectionAckWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
-      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    sinkWatcher: M.interface('SinkWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
-    }),
-  },
-  InboundAttemptI: {
-    inboundAttempt: M.interface('InboundAttempt', {
-      accept: M.callWhen(Shape2.AttemptDescription).returns(
-        Shape2.Vow$(Shape2.Connection),
-      ),
-      getLocalAddress: M.call().returns(Shape2.Endpoint),
-      getRemoteAddress: M.call().returns(Shape2.Endpoint),
-      close: M.callWhen().returns(Shape2.Vow$(M.undefined())),
-    }),
-    inboundAttemptAcceptWatcher: M.interface('InboundAttemptAcceptWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
-      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    sinkWatcher: M.interface('SinkWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
-    }),
-  },
-  PortI: {
-    port: M.interface('Port', {
-      getLocalAddress: M.call().returns(Shape2.Endpoint),
-      addListener: M.callWhen(Shape2.Listener).returns(
-        Shape2.Vow$(M.undefined()),
-      ),
-      connect: M.callWhen(Shape2.Endpoint)
-        .optional(Shape2.ConnectionHandler)
-        .returns(Shape2.Vow$(Shape2.Connection)),
-      removeListener: M.callWhen(Shape2.Listener).returns(
-        Shape2.Vow$(M.undefined()),
-      ),
-      revoke: M.callWhen().returns(Shape2.Vow$(M.undefined())),
-    }),
-    portAddListenerWatcher: M.interface('PortAddListenerWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    portRemoveListenerWatcher: M.interface('PortRemoveListenerWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    portConnectWatcher: M.interface('PortConnectWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    portRevokeWatcher: M.interface('PortRevokeWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    portRevokeCleanupWatcher: M.interface('PortRevokeCleanupWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
-      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-    sinkWatcher: M.interface('SinkWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
-      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-  },
-  ProtocolHandlerI: {
-    protocolHandler: M.interface('ProtocolHandler', {
-      onCreate: M.callWhen(M.remotable(), Shape2.ProtocolHandler).returns(
-        Shape2.Vow$(M.undefined()),
-      ),
-      generatePortID: M.callWhen(
-        Shape2.Endpoint,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(M.string())),
-      onBind: M.callWhen(
-        Shape2.Port,
-        Shape2.Endpoint,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(M.undefined())),
-      onListen: M.callWhen(
-        Shape2.Port,
-        Shape2.Endpoint,
-        Shape2.ListenHandler,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(M.undefined())),
-      onListenRemove: M.callWhen(
-        Shape2.Port,
-        Shape2.Endpoint,
-        Shape2.ListenHandler,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(M.undefined())),
-      onInstantiate: M.callWhen(
-        Shape2.Port,
-        Shape2.Endpoint,
-        Shape2.Endpoint,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(Shape2.Endpoint)),
-      onConnect: M.callWhen(
-        Shape2.Port,
-        Shape2.Endpoint,
-        Shape2.Endpoint,
-        Shape2.ConnectionHandler,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(Shape2.AttemptDescription)),
-      onRevoke: M.callWhen(
-        Shape2.Port,
-        Shape2.Endpoint,
-        Shape2.ProtocolHandler,
-      ).returns(Shape2.Vow$(M.undefined())),
-    }),
-    protocolHandlerAcceptWatcher: M.interface('ProtocolHandlerAcceptWatcher', {
-      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
-    }),
-    protocolHandlerInstantiateWatcher: M.interface(
-      'ProtocolHandlerInstantiateWatcher',
-      {
-        onFulfilled: M.call(M.any()).rest(M.any()).returns(),
-      },
-    ),
-    protocolHandlerConnectWatcher: M.interface(
-      'ProtocolHandlerConnectWatcher',
-      {
-        onFulfilled: M.call(M.any()).rest(M.any()).returns(),
-      },
-    ),
-    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
-      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
-    }),
-  },
-
-  ProtocolImplI: M.interface('ProtocolImpl', {
-    bind: M.callWhen(Shape2.Endpoint).returns(Shape2.Vow$(Shape2.Port)),
-    inbound: M.callWhen(Shape2.Endpoint, Shape2.Endpoint).returns(
-      Shape2.Vow$(Shape2.InboundAttempt),
-    ),
-    outbound: M.callWhen(
-      Shape2.Port,
-      Shape2.Endpoint,
-      Shape2.ConnectionHandler,
-    ).returns(Shape2.Vow$(Shape2.Connection)),
-  }),
-});
-
 /** @param {unknown} err */
 export const rethrowUnlessMissing = err => {
   // Ugly hack rather than being able to determine if the function
   // exists.
   if (
     !(err instanceof TypeError) ||
-    !err.message.match(/target has no method|is not a function$/)
+    !String(err.message).match(/target has no method|is not a function$/)
   ) {
     throw err;
   }
@@ -237,7 +49,7 @@ export function getPrefixes(addr) {
 /**
  * @typedef {object} ConnectionOpts
  * @property {Endpoint[]} addrs
- * @property {ConnectionHandler[]} handlers
+ * @property {import('@agoric/vow').Remote<Required<ConnectionHandler>>[]} handlers
  * @property {MapStore<number, Connection>} conns
  * @property {WeakSetStore<Closable>} current
  * @property {0|1} l
@@ -254,9 +66,6 @@ const prepareHalfConnection = (zone, { watch }) => {
     Shape.ConnectionI,
     /** @param {ConnectionOpts} opts */
     ({ addrs, handlers, conns, current, l, r }) => {
-      /** @type {string | undefined} */
-      let closed;
-
       return {
         addrs,
         handlers,
@@ -264,7 +73,8 @@ const prepareHalfConnection = (zone, { watch }) => {
         current,
         l,
         r,
-        closed,
+        /** @type {string | undefined} */
+        closed: undefined,
       };
     },
     {
@@ -281,7 +91,7 @@ const prepareHalfConnection = (zone, { watch }) => {
         async send(packetBytes) {
           const { closed, handlers, r, conns } = this.state;
           if (closed) {
-            throw closed;
+            throw Error(closed);
           }
 
           const innerVow = watch(
@@ -348,12 +158,12 @@ const prepareHalfConnection = (zone, { watch }) => {
 
 /**
  * @param {import('@agoric/zone').Zone} zone
- * @param {ConnectionHandler} handler0
+ * @param {import('@agoric/vow').Remote<Required<ConnectionHandler>>} handler0
  * @param {Endpoint} addr0
- * @param {ConnectionHandler} handler1
+ * @param {import('@agoric/vow').Remote<Required<ConnectionHandler>>} handler1
  * @param {Endpoint} addr1
  * @param {(opts: ConnectionOpts) => Connection} makeConnection
- * @param {WeakSetStore<Closable>} current
+ * @param {WeakSetStore<Closable>} [current]
  */
 export const crossoverConnection = (
   zone,
@@ -369,7 +179,7 @@ export const crossoverConnection = (
   /** @type {MapStore<number, Connection>} */
   const conns = detached.mapStore('addrToConnections');
 
-  /** @type {ConnectionHandler[]} */
+  /** @type {import('@agoric/vow').Remote<Required<ConnectionHandler>>[]} */
   const handlers = harden([handler0, handler1]);
   /** @type {Endpoint[]} */
   const addrs = harden([addr0, addr1]);
@@ -415,9 +225,9 @@ const prepareInboundAttempt = (zone, makeConnection, { watch }) => {
      * @param {object} opts
      * @param {string} opts.localAddr
      * @param {string} opts.remoteAddr
-     * @param { MapStore<Port, SetStore<Closable>> } opts.currentConnections
+     * @param {MapStore<Port, SetStore<Closable>>} opts.currentConnections
      * @param {string} opts.listenPrefix
-     * @param {MapStore<Endpoint, [Port, ListenHandler]>} opts.listening
+     * @param {MapStore<Endpoint, [Port, import('@agoric/vow').Remote<Required<ListenHandler>>]>} opts.listening
      */
     ({
       localAddr,
@@ -472,7 +282,7 @@ const prepareInboundAttempt = (zone, makeConnection, { watch }) => {
          * @param {object} opts
          * @param {string} [opts.localAddress]
          * @param {string} [opts.remoteAddress]
-         * @param {ConnectionHandler} opts.handler
+         * @param {import('@agoric/vow').Remote<ConnectionHandler>} opts.handler
          */
         async accept({ localAddress, remoteAddress, handler: rchandler }) {
           const { consummated, localAddr, remoteAddr } = this.state;
@@ -514,9 +324,13 @@ const prepareInboundAttempt = (zone, makeConnection, { watch }) => {
 
           return crossoverConnection(
             zone,
-            lchandler,
+            /** @type {import('@agoric/vow').Remote<Required<ConnectionHandler>>} */ (
+              lchandler
+            ),
             localAddress,
-            rchandler,
+            /** @type {import('@agoric/vow').Remote<Required<ConnectionHandler>>} */ (
+              rchandler
+            ),
             remoteAddress,
             makeConnection,
             current,
@@ -573,217 +387,213 @@ const preparePort = (zone, powers) => {
 
   const { watch, allVows } = powers;
 
-  const makePortKit = zone.exoClassKit(
-    'Port',
-    Shape.PortI,
-    /**
-     * @param {object} opts
-     * @param {Endpoint} opts.localAddr
-     * @param {MapStore<Endpoint, [Port, ListenHandler]>} opts.listening
-     * @param {SetStore<Connection>} opts.openConnections
-     * @param {MapStore<Port, SetStore<Closable>>} opts.currentConnections
-     * @param {MapStore<string, Port>} opts.boundPorts
-     * @param {ProtocolHandler} opts.protocolHandler
-     * @param {ProtocolImpl} opts.protocolImpl
-     */
-    ({
-      localAddr,
+  /**
+   * @param {object} opts
+   * @param {Endpoint} opts.localAddr
+   * @param {MapStore<Endpoint, [Port, import('@agoric/vow').Remote<Required<ListenHandler>>]>} opts.listening
+   * @param {SetStore<import('@agoric/vow').Remote<Connection>>} opts.openConnections
+   * @param {MapStore<Port, SetStore<Closable>>} opts.currentConnections
+   * @param {MapStore<string, Port>} opts.boundPorts
+   * @param {import('@agoric/vow').Remote<ProtocolHandler>} opts.protocolHandler
+   * @param {Remote<ProtocolImpl>} opts.protocolImpl
+   */
+  const initPort = ({
+    localAddr,
+    listening,
+    openConnections,
+    currentConnections,
+    boundPorts,
+    protocolHandler,
+    protocolImpl,
+  }) => {
+    return {
       listening,
       openConnections,
       currentConnections,
       boundPorts,
+      localAddr,
       protocolHandler,
       protocolImpl,
-    }) => {
-      return {
-        listening,
-        openConnections,
-        currentConnections,
-        boundPorts,
-        localAddr,
-        protocolHandler,
-        protocolImpl,
-        /** @type {RevokeState | undefined} */
-        revoked: undefined,
-      };
-    },
-    {
-      port: {
-        getLocalAddress() {
-          // Works even after revoke().
-          return this.state.localAddr;
-        },
-        /** @param {ListenHandler} listenHandler */
-        async addListener(listenHandler) {
-          const { revoked, listening, localAddr, protocolHandler } = this.state;
+      /** @type {RevokeState | undefined} */
+      revoked: undefined,
+    };
+  };
 
-          !revoked || Fail`Port ${this.state.localAddr} is revoked`;
-          listenHandler || Fail`listenHandler is not defined`;
+  const makePortKit = zone.exoClassKit('Port', Shape.PortI, initPort, {
+    port: {
+      getLocalAddress() {
+        // Works even after revoke().
+        return this.state.localAddr;
+      },
+      /** @param {import('@agoric/vow').Remote<Required<ListenHandler>>} listenHandler */
+      async addListener(listenHandler) {
+        const { revoked, listening, localAddr, protocolHandler } = this.state;
 
-          if (listening.has(localAddr)) {
-            // Last one wins.
-            const [lport, lhandler] = listening.get(localAddr);
-            if (lhandler === listenHandler) {
-              return;
-            }
-            listening.set(localAddr, [this.facets.port, listenHandler]);
-            E(lhandler).onRemove(lport, lhandler).catch(rethrowUnlessMissing);
-          } else {
-            listening.init(
-              localAddr,
-              harden([this.facets.port, listenHandler]),
-            );
+        !revoked || Fail`Port ${this.state.localAddr} is revoked`;
+        listenHandler || Fail`listenHandler is not defined`;
+
+        if (listening.has(localAddr)) {
+          // Last one wins.
+          const [lport, lhandler] = listening.get(localAddr);
+          if (lhandler === listenHandler) {
+            return;
           }
+          listening.set(localAddr, [this.facets.port, listenHandler]);
+          E(lhandler).onRemove(lport, lhandler).catch(rethrowUnlessMissing);
+        } else {
+          listening.init(localAddr, harden([this.facets.port, listenHandler]));
+        }
 
-          // ASSUME: that the listener defines onAccept.
+        // ASSUME: that the listener defines onAccept.
 
-          const innerVow = watch(
-            E(protocolHandler).onListen(
-              this.facets.port,
-              localAddr,
-              listenHandler,
-              protocolHandler,
-            ),
-            this.facets.portAddListenerWatcher,
-            { listenHandler },
-          );
-          return watch(innerVow, this.facets.rethrowUnlessMissingWatcher);
-        },
-        /** @param {ListenHandler} listenHandler */
-        async removeListener(listenHandler) {
-          const { listening, localAddr, protocolHandler } = this.state;
-          listening.has(localAddr) || Fail`Port ${localAddr} is not listening`;
-          listening.get(localAddr)[1] === listenHandler ||
-            Fail`Port ${localAddr} handler to remove is not listening`;
-          listening.delete(localAddr);
-
-          const innerVow = watch(
-            E(protocolHandler).onListenRemove(
-              this.facets.port,
-              localAddr,
-              listenHandler,
-              protocolHandler,
-            ),
-            this.facets.portRemoveListenerWatcher,
-            { listenHandler },
-          );
-          return watch(innerVow, this.facets.rethrowUnlessMissingWatcher);
-        },
-        /**
-         * @param {Endpoint} remotePort
-         * @param {ConnectionHandler} connectionHandler
-         */
-        async connect(
-          remotePort,
-          connectionHandler = /** @type {any} */ (makeIncapable()),
-        ) {
-          const { revoked, localAddr, protocolImpl } = this.state;
-
-          !revoked || Fail`Port ${localAddr} is revoked`;
-          /** @type {Endpoint} */
-          const dst = harden(remotePort);
-          return watch(
-            protocolImpl.outbound(this.facets.port, dst, connectionHandler),
-            this.facets.portConnectWatcher,
-            { revoked },
-          );
-        },
-        async revoke() {
-          const { revoked, localAddr } = this.state;
-          const { protocolHandler } = this.state;
-
-          revoked !== RevokeState.REVOKED ||
-            Fail`Port ${localAddr} is already revoked`;
-
-          this.state.revoked = RevokeState.REVOKING;
-
-          const revokeVow = watch(
-            E(protocolHandler).onRevoke(
-              this.facets.port,
-              localAddr,
-              protocolHandler,
-            ),
-            this.facets.portRevokeWatcher,
-          );
-
-          return watch(revokeVow, this.facets.portRevokeCleanupWatcher);
-        },
+        const innerVow = watch(
+          E(protocolHandler).onListen(
+            this.facets.port,
+            localAddr,
+            listenHandler,
+            protocolHandler,
+          ),
+          this.facets.portAddListenerWatcher,
+          { listenHandler },
+        );
+        return watch(innerVow, this.facets.rethrowUnlessMissingWatcher);
       },
-      portAddListenerWatcher: {
-        onFulfilled(_value, watcherContext) {
-          const { listenHandler } = watcherContext;
-          return E(listenHandler).onListen(this.facets.port, listenHandler);
-        },
+      /** @param {Remote<Required<ListenHandler>>} listenHandler */
+      async removeListener(listenHandler) {
+        const { listening, localAddr, protocolHandler } = this.state;
+        listening.has(localAddr) || Fail`Port ${localAddr} is not listening`;
+        listening.get(localAddr)[1] === listenHandler ||
+          Fail`Port ${localAddr} handler to remove is not listening`;
+        listening.delete(localAddr);
+
+        const innerVow = watch(
+          E(protocolHandler).onListenRemove(
+            this.facets.port,
+            localAddr,
+            listenHandler,
+            protocolHandler,
+          ),
+          this.facets.portRemoveListenerWatcher,
+          { listenHandler },
+        );
+        return watch(innerVow, this.facets.rethrowUnlessMissingWatcher);
       },
-      portRemoveListenerWatcher: {
-        onFulfilled(_value, watcherContext) {
-          const { listenHandler } = watcherContext;
-          return E(listenHandler).onRemove(this.facets.port, listenHandler);
-        },
+      /**
+       * @param {Endpoint} remotePort
+       * @param {Remote<ConnectionHandler>} [connectionHandler]
+       */
+      async connect(
+        remotePort,
+        connectionHandler = /** @type {Remote<ConnectionHandler>} */ (
+          makeIncapable()
+        ),
+      ) {
+        const { revoked, localAddr, protocolImpl } = this.state;
+
+        !revoked || Fail`Port ${localAddr} is revoked`;
+        /** @type {Endpoint} */
+        const dst = harden(remotePort);
+        return watch(
+          E(protocolImpl).outbound(this.facets.port, dst, connectionHandler),
+          this.facets.portConnectWatcher,
+          { revoked },
+        );
       },
-      portConnectWatcher: {
-        onFulfilled(conn, watchContext) {
-          const { revoked } = watchContext;
-          const { openConnections } = this.state;
+      async revoke() {
+        const { revoked, localAddr } = this.state;
+        const { protocolHandler } = this.state;
 
-          if (revoked) {
-            void E(conn).close();
-          } else {
-            openConnections.add(conn);
-          }
-          return conn;
-        },
-      },
-      portRevokeWatcher: {
-        onFulfilled(_value) {
-          const { currentConnections, listening, localAddr } = this.state;
-          const port = this.facets.port;
+        revoked !== RevokeState.REVOKED ||
+          Fail`Port ${localAddr} is already revoked`;
 
-          // Clean up everything we did.
-          const values = [...currentConnections.get(port).values()];
+        this.state.revoked = RevokeState.REVOKING;
 
-          /** @type {import('@agoric/vow').Specimen[]} */
-          const ps = [];
+        const revokeVow = watch(
+          E(protocolHandler).onRevoke(
+            this.facets.port,
+            localAddr,
+            protocolHandler,
+          ),
+          this.facets.portRevokeWatcher,
+        );
 
-          ps.push(
-            ...values.map(conn =>
-              watch(E(conn).close(), this.facets.sinkWatcher),
-            ),
-          );
-
-          if (listening.has(localAddr)) {
-            const listener = listening.get(localAddr)[1];
-            ps.push(port.removeListener(listener));
-          }
-
-          return watch(allVows(ps), this.facets.rethrowUnlessMissingWatcher);
-        },
-      },
-      sinkWatcher: {
-        onFulfilled() {
-          return undefined;
-        },
-        onRejected() {
-          return undefined;
-        },
-      },
-      portRevokeCleanupWatcher: {
-        onFulfilled(_value) {
-          const { currentConnections, boundPorts, localAddr } = this.state;
-
-          this.state.revoked = RevokeState.REVOKED;
-
-          currentConnections.delete(this.facets.port);
-          boundPorts.delete(localAddr);
-        },
-      },
-      rethrowUnlessMissingWatcher: {
-        onRejected(e) {
-          rethrowUnlessMissing(e);
-        },
+        return watch(revokeVow, this.facets.portRevokeCleanupWatcher);
       },
     },
-  );
+    portAddListenerWatcher: {
+      onFulfilled(_value, watcherContext) {
+        const { listenHandler } = watcherContext;
+        return E(listenHandler).onListen(this.facets.port, listenHandler);
+      },
+    },
+    portRemoveListenerWatcher: {
+      onFulfilled(_value, watcherContext) {
+        const { listenHandler } = watcherContext;
+        return E(listenHandler).onRemove(this.facets.port, listenHandler);
+      },
+    },
+    portConnectWatcher: {
+      onFulfilled(conn, watchContext) {
+        const { revoked } = watchContext;
+        const { openConnections } = this.state;
+
+        if (revoked) {
+          void E(conn).close();
+        } else {
+          openConnections.add(conn);
+        }
+        return conn;
+      },
+    },
+    portRevokeWatcher: {
+      onFulfilled(_value) {
+        const { currentConnections, listening, localAddr } = this.state;
+        const port = this.facets.port;
+
+        // Clean up everything we did.
+        const values = [...currentConnections.get(port).values()];
+
+        /** @type {import('@agoric/vow').Specimen[]} */
+        const ps = [];
+
+        ps.push(
+          ...values.map(conn =>
+            watch(E(conn).close(), this.facets.sinkWatcher),
+          ),
+        );
+
+        if (listening.has(localAddr)) {
+          const listener = listening.get(localAddr)[1];
+          ps.push(port.removeListener(listener));
+        }
+
+        return watch(allVows(ps), this.facets.rethrowUnlessMissingWatcher);
+      },
+    },
+    sinkWatcher: {
+      onFulfilled() {
+        return undefined;
+      },
+      onRejected() {
+        return undefined;
+      },
+    },
+    portRevokeCleanupWatcher: {
+      onFulfilled(_value) {
+        const { currentConnections, boundPorts, localAddr } = this.state;
+
+        this.state.revoked = RevokeState.REVOKED;
+
+        currentConnections.delete(this.facets.port);
+        boundPorts.delete(localAddr);
+      },
+    },
+    rethrowUnlessMissingWatcher: {
+      onRejected(e) {
+        rethrowUnlessMissing(e);
+      },
+    },
+  });
 
   const makePort = ({
     localAddr,
@@ -889,10 +699,10 @@ const prepareBinder = (zone, powers) => {
     },
     /**
      * @param {object} opts
-     * @param { MapStore<Port, SetStore<Closable>> } opts.currentConnections
+     * @param {MapStore<Port, SetStore<Closable>>} opts.currentConnections
      * @param {MapStore<string, Port>} opts.boundPorts
-     * @param {MapStore<Endpoint, [Port, ListenHandler]>} opts.listening
-     * @param {ProtocolHandler} opts.protocolHandler
+     * @param {MapStore<Endpoint, [Port, Remote<Required<ListenHandler>>]>} opts.listening
+     * @param {Remote<Required<ProtocolHandler>>} opts.protocolHandler
      */
     ({ currentConnections, boundPorts, listening, protocolHandler }) => {
       /** @type {SetStore<Connection>} */
@@ -1150,9 +960,13 @@ const prepareBinder = (zone, powers) => {
 
           return crossoverConnection(
             zone,
-            lchandler,
+            /** @type {import('@agoric/vow').Remote<Required<ConnectionHandler>>} */ (
+              lchandler
+            ),
             localAddr,
-            rchandler,
+            /** @type {import('@agoric/vow').Remote<Required<ConnectionHandler>>} */ (
+              rchandler
+            ),
             remoteAddr,
             makeConnection,
             current,
@@ -1210,7 +1024,7 @@ const prepareBinder = (zone, powers) => {
       binderOutboundAcceptWatcher: {
         onFulfilled(attempt, watchContext) {
           const { handler } = watchContext;
-          return attempt.accept({ handler });
+          return E(attempt).accept({ handler });
         },
       },
       binderBindGeneratePortWatcher: {
@@ -1238,7 +1052,7 @@ const prepareBinder = (zone, powers) => {
           const { port, localAddr } = watchContext;
           const { boundPorts, currentConnections } = this.state;
 
-          boundPorts.init(localAddr, harden(port));
+          boundPorts.init(localAddr, port);
           currentConnections.init(
             port,
             zone.detached().setStore('connections'),
@@ -1313,7 +1127,7 @@ export const prepareNetworkProtocol = (zone, powers) => {
   const makeBinderKit = prepareBinder(zone, powers);
 
   /**
-   * @param {ProtocolHandler} protocolHandler
+   * @param {Remote<ProtocolHandler>} protocolHandler
    * @returns {Protocol}
    */
   const makeNetworkProtocol = protocolHandler => {
@@ -1325,7 +1139,7 @@ export const prepareNetworkProtocol = (zone, powers) => {
     /** @type {MapStore<string, Port>} */
     const boundPorts = detached.mapStore('addrToPort');
 
-    /** @type {MapStore<Endpoint, [Port, ListenHandler]>} */
+    /** @type {MapStore<Endpoint, [Port, Remote<Required<ListenHandler>>]>} */
     const listening = detached.mapStore('listening');
 
     const { binder, protocolImpl } = makeBinderKit({
@@ -1354,14 +1168,14 @@ export const prepareEchoConnectionKit = zone => {
     {
       handler: M.interface('ConnectionHandler', {
         onReceive: M.callWhen(
-          Shape2.Connection,
-          Shape2.Bytes,
-          Shape2.ConnectionHandler,
+          Shape.Connection,
+          Shape.Bytes,
+          Shape.ConnectionHandler,
         )
-          .optional(Shape2.Opts)
-          .returns(Shape2.Data),
-        onClose: M.callWhen(Shape2.Connection)
-          .optional(M.any(), Shape2.ConnectionHandler)
+          .optional(Shape.Opts)
+          .returns(Shape.Data),
+        onClose: M.callWhen(Shape.Connection)
+          .optional(M.any(), Shape.ConnectionHandler)
           .returns(M.undefined()),
       }),
       listener: M.interface('Listener', {
@@ -1377,10 +1191,9 @@ export const prepareEchoConnectionKit = zone => {
       }),
     },
     () => {
-      /** @type {string | undefined} */
-      let closed;
       return {
-        closed,
+        /** @type {string | undefined} */
+        closed: undefined,
       };
     },
     {
@@ -1394,7 +1207,7 @@ export const prepareEchoConnectionKit = zone => {
           const { closed } = this.state;
 
           if (closed) {
-            throw closed;
+            throw Error(closed);
           }
           return bytes;
         },
@@ -1415,7 +1228,7 @@ export const prepareEchoConnectionKit = zone => {
       },
       listener: {
         async onAccept(_port, _localAddr, _remoteAddr, _listenHandler) {
-          return harden(this.facets.handler);
+          return this.facets.handler;
         },
         async onListen(port, _listenHandler) {
           console.debug(`listening on echo port: ${port}`);
@@ -1436,21 +1249,24 @@ export const prepareEchoConnectionKit = zone => {
 export function prepareLoopbackProtocolHandler(zone, { watch }) {
   const detached = zone.detached();
 
+  /** @param {string} [instancePrefix] */
+  const initHandler = (instancePrefix = 'nonce/') => {
+    /** @type {MapStore<string, [Remote<Port>, Remote<Required<ListenHandler>>]>} */
+    const listeners = detached.mapStore('localAddr');
+
+    return {
+      listeners,
+      portNonce: 0n,
+      instancePrefix,
+      instanceNonce: 0n,
+    };
+  };
+
   const makeLoopbackProtocolHandlerKit = zone.exoClassKit(
     'ProtocolHandler',
     Shape.ProtocolHandlerI,
     /** @param {string} [instancePrefix] */
-    (instancePrefix = 'nonce/') => {
-      /** @type {MapStore<string, [Port, ListenHandler]>} */
-      const listeners = detached.mapStore('localAddr');
-
-      return {
-        listeners,
-        portNonce: 0n,
-        instancePrefix,
-        instanceNonce: 0n,
-      };
-    },
+    initHandler,
     {
       protocolHandler: {
         async onCreate(_impl, _protocolHandler) {
@@ -1463,13 +1279,7 @@ export function prepareLoopbackProtocolHandler(zone, { watch }) {
         async onBind(_port, _localAddr, _protocolHandler) {
           // noop, for now; Maybe handle a bind?
         },
-        async onConnect(
-          _port,
-          localAddr,
-          remoteAddr,
-          _chandler,
-          protocolHandler,
-        ) {
+        async onConnect(_port, localAddr, remoteAddr) {
           const { listeners } = this.state;
           const [lport, lhandler] = listeners.get(remoteAddr);
 
@@ -1479,11 +1289,11 @@ export function prepareLoopbackProtocolHandler(zone, { watch }) {
           );
 
           const instantiateInnerVow = watch(
-            E(protocolHandler).onInstantiate(
+            E(this.facets.protocolHandler).onInstantiate(
               lport,
               remoteAddr,
               localAddr,
-              protocolHandler,
+              this.facets.protocolHandler,
             ),
             this.facets.protocolHandlerInstantiateWatcher,
           );
@@ -1510,16 +1320,30 @@ export function prepareLoopbackProtocolHandler(zone, { watch }) {
           if (listeners.has(localAddr)) {
             const lhandler = listeners.get(localAddr)[1];
             if (lhandler !== listenHandler) {
-              listeners.set(localAddr, [port, listenHandler]);
+              listeners.set(
+                localAddr,
+                harden([
+                  port,
+                  /** @type {Remote<Required<ListenHandler>>} */ (
+                    listenHandler
+                  ),
+                ]),
+              );
             }
           } else {
-            listeners.init(localAddr, harden([port, listenHandler]));
+            listeners.init(
+              localAddr,
+              harden([
+                port,
+                /** @type {Remote<Required<ListenHandler>>} */ (listenHandler),
+              ]),
+            );
           }
         },
         /**
          * @param {Port} port
          * @param {Endpoint} localAddr
-         * @param {ListenHandler} listenHandler
+         * @param {Remote<Required<ListenHandler>>} listenHandler
          * @param {*} _protocolHandler
          */
         async onListenRemove(port, localAddr, listenHandler, _protocolHandler) {

--- a/packages/network/src/router.js
+++ b/packages/network/src/router.js
@@ -2,11 +2,8 @@
 import { E as defaultE } from '@endo/far';
 import { M } from '@endo/patterns';
 import { Fail } from '@agoric/assert';
-import {
-  ENDPOINT_SEPARATOR,
-  Shape,
-  prepareNetworkProtocol,
-} from './network.js';
+import { ENDPOINT_SEPARATOR, prepareNetworkProtocol } from './network.js';
+import { Shape } from './shapes.js';
 
 import '@agoric/store/exported.js';
 /// <reference path="./types.js" />
@@ -59,7 +56,7 @@ export const prepareRouter = zone => {
             ret.push([prefix, this.state.prefixToRoute.get(prefix)]);
           }
           // Trim off the last value (after the slash).
-          const defaultPrefix = prefix.substr(
+          const defaultPrefix = prefix.slice(
             0,
             prefix.lastIndexOf(ENDPOINT_SEPARATOR) + 1,
           );
@@ -131,7 +128,7 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
       /** @type {MapStore<string, Protocol>} */
       const protocols = detached.mapStore('prefix');
 
-      /** @type {MapStore<string, ProtocolHandler>} */
+      /** @type {MapStore<string, Remote<ProtocolHandler>>} */
       const protocolHandlers = detached.mapStore('prefix');
 
       return {
@@ -143,7 +140,7 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
     {
       /**
        * @param {string[]} paths
-       * @param {ProtocolHandler} protocolHandler
+       * @param {Remote<ProtocolHandler>} protocolHandler
        */
       registerProtocolHandler(paths, protocolHandler) {
         const protocol = makeNetworkProtocol(protocolHandler);
@@ -157,13 +154,13 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
       // Needs to account for multiple paths.
       /**
        * @param {string} prefix
-       * @param {ProtocolHandler} protocolHandler
+       * @param {Remote<ProtocolHandler>} protocolHandler
        */
       unregisterProtocolHandler(prefix, protocolHandler) {
         const ph = this.state.protocolHandlers.get(prefix);
         ph === protocolHandler ||
           Fail`Protocol handler is not registered at prefix ${prefix}`;
-        // TODO: unmap protocol hanlders to their corresponding protocol
+        // TODO: unmap protocol handlers to their corresponding protocol
         // e.g. using a map
         // before unregistering
         // @ts-expect-error note FIXME above

--- a/packages/network/src/shapes.js
+++ b/packages/network/src/shapes.js
@@ -1,0 +1,191 @@
+// @ts-check
+import { M } from '@endo/patterns';
+
+const Shape1 = /** @type {const} */ ({
+  /**
+   * Data is string | Buffer | ArrayBuffer
+   * but only string is passable
+   */
+  Data: M.string(),
+  Bytes: M.string(),
+  Endpoint: M.string(),
+  Vow: M.tagged(
+    'Vow',
+    harden({
+      vowV0: M.remotable('VowV0'),
+    }),
+  ),
+  ConnectionHandler: M.remotable('ConnectionHandler'),
+  Connection: M.remotable('Connection'),
+  InboundAttempt: M.remotable('InboundAttempt'),
+  Listener: M.remotable('Listener'),
+  ListenHandler: M.remotable('ListenHandler'),
+  Port: M.remotable('Port'),
+  ProtocolHandler: M.remotable('ProtocolHandler'),
+  ProtocolImpl: M.remotable('ProtocolImpl'),
+});
+
+const Shape2 = /** @type {const} */ ({
+  ...Shape1,
+  Vow$: shape => M.or(shape, Shape1.Vow),
+  AttemptDescription: M.splitRecord(
+    { handler: Shape1.ConnectionHandler },
+    { remoteAddress: Shape1.Endpoint, localAddress: Shape1.Endpoint },
+  ),
+  Opts: M.recordOf(M.string(), M.any()),
+});
+
+export const Shape = /** @type {const} */ harden({
+  ...Shape2,
+  ConnectionI: {
+    connection: M.interface('Connection', {
+      send: M.callWhen(Shape2.Data)
+        .optional(Shape2.Opts)
+        .returns(Shape2.Vow$(Shape2.Bytes)),
+      close: M.callWhen().returns(Shape2.Vow$(M.undefined())),
+      getLocalAddress: M.call().returns(Shape2.Endpoint),
+      getRemoteAddress: M.call().returns(Shape2.Endpoint),
+    }),
+    openConnectionAckWatcher: M.interface('OpenConnectionAckWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
+      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    sinkWatcher: M.interface('SinkWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
+    }),
+  },
+  InboundAttemptI: {
+    inboundAttempt: M.interface('InboundAttempt', {
+      accept: M.callWhen(Shape2.AttemptDescription).returns(
+        Shape2.Vow$(Shape2.Connection),
+      ),
+      getLocalAddress: M.call().returns(Shape2.Endpoint),
+      getRemoteAddress: M.call().returns(Shape2.Endpoint),
+      close: M.callWhen().returns(Shape2.Vow$(M.undefined())),
+    }),
+    inboundAttemptAcceptWatcher: M.interface('InboundAttemptAcceptWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
+      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    sinkWatcher: M.interface('SinkWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
+    }),
+  },
+  PortI: {
+    port: M.interface('Port', {
+      getLocalAddress: M.call().returns(Shape2.Endpoint),
+      addListener: M.callWhen(Shape2.Listener).returns(
+        Shape2.Vow$(M.undefined()),
+      ),
+      connect: M.callWhen(Shape2.Endpoint)
+        .optional(Shape2.ConnectionHandler)
+        .returns(Shape2.Vow$(Shape2.Connection)),
+      removeListener: M.callWhen(Shape2.Listener).returns(
+        Shape2.Vow$(M.undefined()),
+      ),
+      revoke: M.callWhen().returns(Shape2.Vow$(M.undefined())),
+    }),
+    portAddListenerWatcher: M.interface('PortAddListenerWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    portRemoveListenerWatcher: M.interface('PortRemoveListenerWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    portConnectWatcher: M.interface('PortConnectWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    portRevokeWatcher: M.interface('PortRevokeWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    portRevokeCleanupWatcher: M.interface('PortRevokeCleanupWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
+      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+    sinkWatcher: M.interface('SinkWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
+      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+  },
+  ProtocolHandlerI: {
+    protocolHandler: M.interface('ProtocolHandler', {
+      onCreate: M.callWhen(M.remotable(), Shape2.ProtocolHandler).returns(
+        Shape2.Vow$(M.undefined()),
+      ),
+      generatePortID: M.callWhen(
+        Shape2.Endpoint,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(M.string())),
+      onBind: M.callWhen(
+        Shape2.Port,
+        Shape2.Endpoint,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(M.undefined())),
+      onListen: M.callWhen(
+        Shape2.Port,
+        Shape2.Endpoint,
+        Shape2.ListenHandler,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(M.undefined())),
+      onListenRemove: M.callWhen(
+        Shape2.Port,
+        Shape2.Endpoint,
+        Shape2.ListenHandler,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(M.undefined())),
+      onInstantiate: M.callWhen(
+        Shape2.Port,
+        Shape2.Endpoint,
+        Shape2.Endpoint,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(Shape2.Endpoint)),
+      onConnect: M.callWhen(
+        Shape2.Port,
+        Shape2.Endpoint,
+        Shape2.Endpoint,
+        Shape2.ConnectionHandler,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(Shape2.AttemptDescription)),
+      onRevoke: M.callWhen(
+        Shape2.Port,
+        Shape2.Endpoint,
+        Shape2.ProtocolHandler,
+      ).returns(Shape2.Vow$(M.undefined())),
+    }),
+    protocolHandlerAcceptWatcher: M.interface('ProtocolHandlerAcceptWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(),
+    }),
+    protocolHandlerInstantiateWatcher: M.interface(
+      'ProtocolHandlerInstantiateWatcher',
+      {
+        onFulfilled: M.call(M.any()).rest(M.any()).returns(),
+      },
+    ),
+    protocolHandlerConnectWatcher: M.interface(
+      'ProtocolHandlerConnectWatcher',
+      {
+        onFulfilled: M.call(M.any()).rest(M.any()).returns(),
+      },
+    ),
+    rethrowUnlessMissingWatcher: M.interface('RethrowUnlessMissingWatcher', {
+      onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
+    }),
+  },
+
+  ProtocolImplI: M.interface('ProtocolImpl', {
+    bind: M.callWhen(Shape2.Endpoint).returns(Shape2.Vow$(Shape2.Port)),
+    inbound: M.callWhen(Shape2.Endpoint, Shape2.Endpoint).returns(
+      Shape2.Vow$(Shape2.InboundAttempt),
+    ),
+    outbound: M.callWhen(
+      Shape2.Port,
+      Shape2.Endpoint,
+      Shape2.ConnectionHandler,
+    ).returns(Shape2.Vow$(Shape2.Connection)),
+  }),
+});

--- a/packages/network/src/types.js
+++ b/packages/network/src/types.js
@@ -42,14 +42,14 @@
  * @typedef {object} Port A port that has been bound to a protocol
  * @property {() => Endpoint} getLocalAddress Get the locally bound name of this
  *   port
- * @property {(acceptHandler: Remote<Required<ListenHandler>>) => PromiseVow<void>} addListener
+ * @property {(acceptHandler: Remote<ListenHandler>) => PromiseVow<void>} addListener
  *   Begin accepting incoming connections
  * @property {(
  *   remote: Endpoint,
  *   connectionHandler?: Remote<ConnectionHandler>,
  * ) => PromiseVow<Connection>} connect
  *   Make an outbound connection
- * @property {(acceptHandler: Remote<Required<ListenHandler>>) => PromiseVow<void>} removeListener
+ * @property {(acceptHandler: Remote<ListenHandler>) => PromiseVow<void>} removeListener
  *   Remove the currently-bound listener
  * @property {() => PromiseVow<void>} revoke Deallocate the port entirely, removing all
  *   listeners and closing all active connections

--- a/packages/network/src/types.js
+++ b/packages/network/src/types.js
@@ -18,7 +18,6 @@
  */
 
 /**
- * @typedef {string | number[]} Data Eventually should allow passable Uint8Array
  * @typedef {string} Bytes Each character code carries 8-bit octets.  Eventually we want to use passable Uint8Arrays.
  */
 
@@ -81,7 +80,7 @@
 /**
  * @typedef {object} Connection
  * @property {(
- *   packetBytes: Data,
+ *   packetBytes: Bytes,
  *   opts?: Record<string, any>,
  * ) => PromiseVow<Bytes>} send
  *   Send a packet on the connection
@@ -105,7 +104,7 @@
  *   ack: Bytes,
  *   c: Remote<ConnectionHandler>,
  *   opts?: Record<string, any>,
- * ) => PromiseVow<Data>} [onReceive]
+ * ) => PromiseVow<Bytes>} [onReceive]
  *   The connection received a packet
  * @property {(
  *   connection: Remote<Connection>,

--- a/packages/network/src/types.js
+++ b/packages/network/src/types.js
@@ -2,13 +2,24 @@
 
 /**
  * @template T
- * @typedef {Promise<T | import('@agoric/vow').Vow<T>>} PromiseVow
+ * @typedef {import('@agoric/vow').PromiseVow<T>} PromiseVow
  */
 
 /**
- * @typedef {string | Buffer | ArrayBuffer} Data
- *
- * @typedef {string} Bytes
+ * @template T
+ * @typedef {import('@agoric/vow').Remote<T>} Remote
+ */
+
+/**
+ * @template {import('@endo/exo/src/exo-makers').Methods} M
+ * @template {(...args: any[]) => any} I
+ * @typedef {M & ThisType<{ self: import('@endo/exo/src/exo-makers').Guarded<M>, state: ReturnType<I> }>} ExoClassMethods
+ * Rearrange the exo types to make a cast of the methods (M) and init function (I) to a specific type.
+ */
+
+/**
+ * @typedef {string | number[]} Data Eventually should allow passable Uint8Array
+ * @typedef {string} Bytes Each character code carries 8-bit octets.  Eventually we want to use passable Uint8Arrays.
  */
 
 /**
@@ -31,14 +42,14 @@
  * @typedef {object} Port A port that has been bound to a protocol
  * @property {() => Endpoint} getLocalAddress Get the locally bound name of this
  *   port
- * @property {(acceptHandler: ListenHandler) => PromiseVow<void>} addListener
+ * @property {(acceptHandler: Remote<Required<ListenHandler>>) => PromiseVow<void>} addListener
  *   Begin accepting incoming connections
  * @property {(
  *   remote: Endpoint,
- *   connectionHandler?: ConnectionHandler,
+ *   connectionHandler?: Remote<ConnectionHandler>,
  * ) => PromiseVow<Connection>} connect
  *   Make an outbound connection
- * @property {(acceptHandler: ListenHandler) => PromiseVow<void>} removeListener
+ * @property {(acceptHandler: Remote<Required<ListenHandler>>) => PromiseVow<void>} removeListener
  *   Remove the currently-bound listener
  * @property {() => PromiseVow<void>} revoke Deallocate the port entirely, removing all
  *   listeners and closing all active connections
@@ -46,25 +57,24 @@
 
 /**
  * @typedef {object} ListenHandler A handler for incoming connections
- * @property {(port: Port, l: ListenHandler) => PromiseVow<void>} [onListen] The
- *   listener has been registered
+ * @property {(port: Remote<Port>, l: Remote<ListenHandler>) => PromiseVow<void>} [onListen] The listener has been registered
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
  *   remoteAddr: Endpoint,
- *   l: ListenHandler,
- * ) => PromiseVow<ConnectionHandler>} onAccept
+ *   l: Remote<ListenHandler>,
+ * ) => PromiseVow<Remote<ConnectionHandler>>} onAccept
  *   A new connection is incoming
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
  *   remoteAddr: Endpoint,
- *   l: ListenHandler,
+ *   l: Remote<ListenHandler>,
  * ) => PromiseVow<void>} [onReject]
  *   The connection was rejected
- * @property {(port: Port, rej: any, l: ListenHandler) => PromiseVow<void>} [onError]
+ * @property {(port: Remote<Port>, rej: any, l: Remote<ListenHandler>) => PromiseVow<void>} [onError]
  *   There was an error while listening
- * @property {(port: Port, l: ListenHandler) => PromiseVow<void>} [onRemove] The
+ * @property {(port: Remote<Port>, l: Remote<ListenHandler>) => PromiseVow<void>} [onRemove] The
  *   listener has been removed
  */
 
@@ -84,23 +94,23 @@
 /**
  * @typedef {object} ConnectionHandler A handler for a given Connection
  * @property {(
- *   connection: Connection,
+ *   connection: Remote<Connection>,
  *   localAddr: Endpoint,
  *   remoteAddr: Endpoint,
- *   c: ConnectionHandler,
+ *   c: Remote<ConnectionHandler>,
  * ) => PromiseVow<void>} [onOpen]
  *   The connection has been opened
  * @property {(
- *   connection: Connection,
+ *   connection: Remote<Connection>,
  *   ack: Bytes,
- *   c: ConnectionHandler,
+ *   c: Remote<ConnectionHandler>,
  *   opts?: Record<string, any>,
  * ) => PromiseVow<Data>} [onReceive]
  *   The connection received a packet
  * @property {(
- *   connection: Connection,
+ *   connection: Remote<Connection>,
  *   reason?: CloseReason,
- *   c?: ConnectionHandler,
+ *   c?: Remote<ConnectionHandler>,
  * ) => PromiseVow<void>} [onClose]
  *   The connection has been closed
  *
@@ -109,7 +119,7 @@
 
 /**
  * @typedef {object} AttemptDescription
- * @property {ConnectionHandler} handler
+ * @property {Remote<ConnectionHandler>} handler
  * @property {Endpoint} [remoteAddress]
  * @property {Endpoint} [localAddress]
  */
@@ -117,49 +127,49 @@
 /**
  * @typedef {object} ProtocolHandler A handler for things the protocol
  *   implementation will invoke
- * @property {(protocol: ProtocolImpl, p: ProtocolHandler) => PromiseVow<void>} onCreate
+ * @property {(protocol: Remote<ProtocolImpl>, p: Remote<ProtocolHandler>) => PromiseVow<void>} onCreate
  *   This protocol is created
- * @property {(localAddr: Endpoint, p: ProtocolHandler) => PromiseVow<string>} generatePortID
+ * @property {(localAddr: Endpoint, p: Remote<ProtocolHandler>) => PromiseVow<string>} generatePortID
  *   Create a fresh port identifier for this protocol
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
- *   p: ProtocolHandler,
+ *   p: Remote<ProtocolHandler>,
  * ) => PromiseVow<void>} onBind
  *   A port will be bound
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
- *   listenHandler: ListenHandler,
- *   p: ProtocolHandler,
+ *   listenHandler: Remote<ListenHandler>,
+ *   p: Remote<ProtocolHandler>,
  * ) => PromiseVow<void>} onListen
  *   A port was listening
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
- *   listenHandler: ListenHandler,
- *   p: ProtocolHandler,
+ *   listenHandler: Remote<ListenHandler>,
+ *   p: Remote<ProtocolHandler>,
  * ) => PromiseVow<void>} onListenRemove
  *   A port listener has been reset
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
  *   remote: Endpoint,
- *   p: ProtocolHandler,
+ *   p: Remote<ProtocolHandler>,
  * ) => PromiseVow<Endpoint>} [onInstantiate]
  *   Return unique suffix for local address
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
  *   remote: Endpoint,
- *   c: ConnectionHandler,
- *   p: ProtocolHandler,
+ *   c: Remote<ConnectionHandler>,
+ *   p: Remote<ProtocolHandler>,
  * ) => PromiseVow<AttemptDescription>} onConnect
  *   A port initiates an outbound connection
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   localAddr: Endpoint,
- *   p: ProtocolHandler,
+ *   p: Remote<ProtocolHandler>,
  * ) => PromiseVow<void>} onRevoke
  *   The port is being completely destroyed
  *
@@ -173,7 +183,7 @@
  * @property {() => PromiseVow<void>} close Abort the attempt
  *
  * @typedef {object} ProtocolImpl Things the protocol can do for us
- * @property {(prefix: Endpoint) => PromiseVow<Port>} bind Claim a port, or if
+ * @property {(prefix: Endpoint) => PromiseVow<Remote<Port>>} bind Claim a port, or if
  *   ending in ENDPOINT_SEPARATOR, a fresh name
  * @property {(
  *   listenAddr: Endpoint,
@@ -181,9 +191,9 @@
  * ) => PromiseVow<InboundAttempt>} inbound
  *   Make an attempt to connect into this protocol
  * @property {(
- *   port: Port,
+ *   port: Remote<Port>,
  *   remoteAddr: Endpoint,
- *   connectionHandler: ConnectionHandler,
+ *   connectionHandler: Remote<ConnectionHandler>,
  * ) => PromiseVow<Connection>} outbound
  *   Create an outbound connection
  */

--- a/packages/network/test/test-network-misc.js
+++ b/packages/network/test/test-network-misc.js
@@ -348,9 +348,6 @@ test('loopback protocol', async t => {
         async onAccept(_p, _localAddr, _remoteAddr, _listenHandler) {
           return makeConnectionHandler();
         },
-        async onRemove(p, _listenHandler) {
-          console.log('onRemove', p);
-        },
       },
     );
 

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -33,15 +33,15 @@ export const getCourierPK = (key, keyToCourierPK) => {
  *
  * @typedef {object} CourierArgs
  * @property {ZCF} zcf
- * @property {ERef<BoardDepositFacet>} board
- * @property {ERef<NameHub>} namesByAddress
+ * @property {Remote<BoardDepositFacet>} board
+ * @property {Remote<NameHub>} namesByAddress
  * @property {Denom} sendDenom
  * @property {Brand} localBrand
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
- * @property {ERef<TransferProtocol>} transferProtocol
+ * @property {Remote<TransferProtocol>} transferProtocol
  * @property {ReturnType<import('@agoric/vow').prepareVowTools>['when']} when
- * @param {ERef<Connection>} connection
+ * @param {Remote<Connection>} connection
  * @returns {(args: CourierArgs) => Courier}
  */
 export const makeCourierMaker =

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -31,8 +31,8 @@ const TRANSFER_PROPOSAL_SHAPE = {
  *
  * @param {object} powers
  * @param {ZCF} powers.zcf the Zoe Contract Facet
- * @param {ERef<BoardDepositFacet>} powers.board where to find depositFacets by boardID
- * @param {ERef<NameHub>} powers.namesByAddress where to find depositFacets by bech32
+ * @param {Remote<BoardDepositFacet>} powers.board where to find depositFacets by boardID
+ * @param {Remote<NameHub>} powers.namesByAddress where to find depositFacets by bech32
  * @param {ReturnType<import('@agoric/vow').prepareVowTools>['when']} powers.when
  *
  * @typedef {import('@agoric/vats').NameHub} NameHub
@@ -62,7 +62,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
   };
 
   /**
-   * @type {LegacyWeakMap<Peg, LocalDenomState>}
+   * @type {LegacyWeakMap<Remote<Peg>, LocalDenomState>}
    */
   // Legacy because Mappings mix functions and data
   const pegToDenomState = makeLegacyWeakMap('Peg');
@@ -105,8 +105,8 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
    * @param {object} param0
    * @param {ReturnType<typeof makeCourierMaker>} param0.makeCourier
    * @param {LocalDenomState} param0.localDenomState
-   * @param {ERef<TransferProtocol>} param0.transferProtocol
-   * @param {ERef<DenomTransformer>} param0.denomTransformer
+   * @param {Remote<TransferProtocol>} param0.transferProtocol
+   * @param {Remote<DenomTransformer>} param0.denomTransformer
    * @returns {PegasusConnectionActions}
    */
   const makePegasusConnectionActions = ({
@@ -319,8 +319,8 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
     /**
      * Return a handler that can be used with the Network API.
      *
-     * @param {ERef<TransferProtocol>} [transferProtocol]
-     * @param {ERef<DenomTransformer>} [denomTransformer]
+     * @param {Remote<TransferProtocol>} [transferProtocol]
+     * @param {Remote<DenomTransformer>} [denomTransformer]
      * @returns {PegasusConnectionKit}
      */
     makePegasusConnectionKit(
@@ -328,7 +328,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
       denomTransformer = DEFAULT_DENOM_TRANSFORMER,
     ) {
       /**
-       * @type {LegacyWeakMap<Connection, LocalDenomState>}
+       * @type {LegacyWeakMap<Remote<Connection>, LocalDenomState>}
        */
       // Legacy because the value contains a JS Set
       const connectionToLocalDenomState = makeLegacyWeakMap('Connection');
@@ -458,7 +458,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
     /**
      * Create a Zoe invitation to transfer assets over network to a deposit address.
      *
-     * @param {ERef<Peg>} pegP the peg over which to transfer
+     * @param {Remote<Peg>} pegP the peg over which to transfer
      * @param {DepositAddress} depositAddress the remote receiver's address
      * @param {string} [memo] the memo to attach to ics transfer packet
      * @param {SenderOptions} [opts] additional sender options

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -4,9 +4,12 @@
  */
 import { E } from '@endo/far';
 import { BridgeId as BRIDGE_ID } from '@agoric/internal';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
-import { makeHeapZone } from '@agoric/zone';
+
 import { makeScalarBigMapStore } from '@agoric/vat-data';
+
+// Heap-based vow resolution is used for this module because the
+// bootstrap vat can't yet be upgraded.
+import { when } from '@agoric/vat-data/vow.js';
 
 const NUM_IBC_PORTS_PER_CLIENT = 3;
 const INTERCHAIN_ACCOUNT_CONTROLLER_PORT_PREFIX = 'icacontroller-';
@@ -16,9 +19,12 @@ const INTERCHAIN_ACCOUNT_CONTROLLER_PORT_PREFIX = 'icacontroller-';
  * @param {ERef<import('../types.js').ScopedBridgeManager>} [dibcBridgeManager]
  */
 export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
+  /** @type {Promise<void>[]} */
   const ps = [];
 
-  const loopbackHandler = await E(vats.network).makeLoopbackProtocolHandler();
+  const loopbackHandler = /** @type {Remote<ProtocolHandler>} */ (
+    await E(vats.network).makeLoopbackProtocolHandler()
+  );
   // Every vat has a loopback device.
   ps.push(E(vats.network).registerProtocolHandler(['/local'], loopbackHandler));
 
@@ -42,8 +48,8 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
         ),
     );
   } else {
-    const loHandler = await E(vats.network).makeLoopbackProtocolHandler(
-      'ibc-channel/channel-',
+    const loHandler = /** @type {Remote<ProtocolHandler>} */ (
+      await E(vats.network).makeLoopbackProtocolHandler('ibc-channel/channel-')
     );
     ps.push(E(vats.network).registerProtocolHandler(['/ibc-port'], loHandler));
   }
@@ -134,7 +140,7 @@ export const setupNetworkProtocols = async (
         lastICAPort += 1;
         bindAddr += `${INTERCHAIN_ACCOUNT_CONTROLLER_PORT_PREFIX}${lastICAPort}`;
       }
-      const port = E(vats.network).bind(bindAddr);
+      const port = when(E(vats.network).bind(bindAddr));
       ibcportP.push(port);
     }
     return Promise.all(ibcportP);
@@ -145,15 +151,10 @@ export const setupNetworkProtocols = async (
   // ibc-port etc.
   await registerNetworkProtocols(vats, dibcBridgeManager);
 
-  // Heap-based vow resolution is used for this module because the
-  // bootstrap vat can't yet be upgraded.
-  const powers = prepareVowTools(makeHeapZone());
-
-  const { when } = powers;
   // Add an echo listener on our ibc-port network (whether real or virtual).
   const echoPort = await when(E(vats.network).bind('/ibc-port/echo'));
   const { listener } = await E(vats.network).makeEchoConnectionKit();
-  await E(echoPort).addListener(listener);
+  await when(E(echoPort).addListener(listener));
   return E(client).assignBundle([_a => ({ ibcport: makePorts() })]);
 };
 

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -205,7 +205,7 @@ test('network - ibc', async t => {
           source_channel: 'channel-1',
           source_port: 'port-1',
         },
-        relativeTimeoutNs: 600_000_000_000n, // 10 minutes in nanoseconds.
+        relativeTimeoutNs: 3_600_000_000_000n, // 60 minutes in nanoseconds.
       },
     ]);
 

--- a/packages/vow/src/E.js
+++ b/packages/vow/src/E.js
@@ -263,10 +263,10 @@ const makeE = (
          * unwrapped(x).then(onfulfilled, onrejected)
          *
          * @template T
-         * @template [TResult1=Unwrap<T>]
+         * @template [TResult1=import('./types.js').Unwrap<T>]
          * @template [TResult2=never]
          * @param {ERef<T>} x value to convert to a handled promise
-         * @param {(value: Unwrap<T>) => ERef<TResult1>} [onfulfilled]
+         * @param {(value: import('./types.js').Unwrap<T>) => ERef<TResult1>} [onfulfilled]
          * @param {(reason: any) => ERef<TResult2>} [onrejected]
          * @returns {Promise<TResult1 | TResult2>}
          * @readonly
@@ -307,9 +307,7 @@ export default makeE;
 /**
  * @template {Callable} T
  * @typedef {(
- *   ReturnType<T> extends PromiseLike<infer U>                       // if function returns a promise
- *     ? T                                                            // return the function
- *     : (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>  // make it return a promise
+ *   (...args: Parameters<T>) => Promise<import('./types.js').Unwrap<ReturnType<T>>>
  * )} ECallable
  */
 
@@ -399,7 +397,7 @@ export default makeE;
  *     ? PickCallable<R>                                              // then return the callable properties of R
  *     : Awaited<T> extends import('@endo/eventual-send').RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
  *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends import('./types').Vow<infer U>
+ *     : Awaited<T> extends import('./types.js').Vow<infer U>
  *     ? RemoteFunctions<U>                                           // then extract the remotable functions of U
  *     : T extends PromiseLike<infer U>                               // otherwise, if T is a promise
  *     ? Awaited<T>                                                   // then return resolved value T
@@ -409,19 +407,12 @@ export default makeE;
 
 /**
  * @template T
- * @typedef {T extends PromiseLike<infer U> ? Unwrap<U> :
- *   T extends import('./types').Vow<infer U> ? Unwrap<U> :
- *   T} Unwrap
- */
-
-/**
- * @template T
  * @typedef {(
  *   T extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>
  *     ? L
  *     : Awaited<T> extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>
  *     ? L
- *     : Awaited<T> extends import('./types').Vow<infer U>
+ *     : Awaited<T> extends import('./types.js').Vow<infer U>
  *     ? LocalRecord<U>
  *     : T extends PromiseLike<infer U>
  *     ? Awaited<T>

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -1,23 +1,64 @@
 // @ts-check
 export {};
 
+/** @typedef {(...args: any[]) => any} Callable */
+
 /**
  * @template T
- * @typedef {PromiseLike<T | Vow<T>>} PromiseVow
+ * @typedef {Promise<T | Vow<T>>} PromiseVow Return type of a function that may
+ * return a promise or a vow.
  */
 
 /**
  * @template T
- * @typedef {import('./E').ERef<T>} ERef
+ * @typedef {T | PromiseLike<T>} ERef
  */
 
 /**
- * Creates a type that accepts both near and marshalled references that were
- * returned from `Remotable` or `Far`, and also promises for such references.
- *
+ * @template T
+ * @typedef {(
+ *   T extends bigint ? true :
+ *   T extends boolean ? true :
+ *   T extends null ? true :
+ *   T extends number ? true :
+ *   T extends string ? true :
+ *   T extends symbol ? true :
+ *   T extends undefined ? true :
+ *   false
+ * )} IsPrimitive Whether T is a primitive type.
+ */
+
+/**
+ * @template T
+ * @typedef {(
+ *   IsPrimitive<T> extends true ? T :
+ *   T extends Callable ? never :
+ *   { [P in keyof T as T[P] extends Callable ? never : P]: DataOnly<T[P]> }
+ * )} DataOnly Recursively extract the non-callable properties of T.
+ */
+
+/**
+ * Follow the chain of vow shortening to the end, returning the final value.
+ * This is used within E, so we must narrow the type to its remote form.
+ * @template T
+ * @typedef {(
+ *   T extends PromiseLike<infer U> ? Unwrap<U> :
+ *   T extends import('./types').Vow<infer U> ? Unwrap<U> :
+ *   IsPrimitive<T> extends true ? T :
+ *   T extends import('@endo/eventual-send').RemotableBrand<infer Local, infer Primary> ? Local & T :
+ *   T
+ * )} Unwrap
+ */
+
+/**
+ * A type that accepts both near and marshalled references that were
+ * returned from `Remotable` or `Far`.
  * @template Primary The type of the primary reference.
- * @template [Local=import('./E').DataOnly<Primary>] The local properties of the object.
- * @typedef {ERef<Local & import('@endo/eventual-send').RemotableBrand<Local, Primary>>} FarRef
+ * @template [Local=DataOnly<Primary>] The local properties of the object.
+ * @typedef {Primary |
+ *   import('@endo/eventual-send').RemotableBrand<Local, Primary>
+ * } Remote A type that doesn't assume its parameter is local, but is
+ * satisfied with both local and remote references.
  */
 
 /**
@@ -36,7 +77,7 @@ export {};
 /**
  * @template [T=any]
  * @typedef {object} VowPayload
- * @property {import('@endo/eventual-send').FarRef<VowV0<T>>} vowV0
+ * @property {Remote<VowV0<T>>} vowV0
  */
 
 /**

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -8,18 +8,17 @@ export const makeWhen = (isRetryableReason = () => false) => {
   /**
    * Shorten `specimenP` until we achieve a final result.
    *
-   * @template [T=any]
-   * @template [TResult1=import('./E.js').Unwrap<T>]
+   * @template T
+   * @template [TResult1=import('./types.js').Unwrap<T>]
    * @template [TResult2=never]
    * @param {T} specimenP value to unwrap
-   * @param {(value: import('./E.js').Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
+   * @param {(value: import('./types.js').Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
    * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
    * @returns {Promise<TResult1 | TResult2>}
    */
   const when = async (specimenP, onFulfilled, onRejected) => {
     // Ensure we don't run until a subsequent turn.
     await null;
-    Promise.prototype.then;
 
     // Ensure we have a presence that won't be disconnected later.
     let result = await specimenP;
@@ -38,7 +37,7 @@ export const makeWhen = (isRetryableReason = () => false) => {
       payload = getVowPayload(result);
     }
 
-    const unwrapped = /** @type {import('./E.js').Unwrap<T>} */ (result);
+    const unwrapped = /** @type {import('./types.js').Unwrap<T>} */ (result);
 
     // We've extracted the final result.
     if (onFulfilled == null && onRejected == null) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #9027
refs: #8444

## Description

This PR creates a new `Remote<T>` type to use in code that does not assume that `T` is local, and thus must be manipulated using something like the `E` eventual send operator.  Its definition is significantly more straightforward than `FarRef`, and more effective than `ERef`.

Using the associated `Unwrap<T>` in `packages/vow`, and applying `Remote<T>` to the latest `packages/network` and `packages/vat/src/ibc.js`, I was able to surface some untypable code that indicated misuse of vows or a missing `E`.  Satisfyingly, resolving these errors led to clearer, more correct code.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Improved correctness.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
No runtime cost.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
Waiting until this is migrated to Endo and replaces `FarRef`, with full adoption before documenting.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Failures are a compile-time error, but only manual testing and code linting/typechecking has been done so far.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
Compile-time types are erased; the definition of these types does not affect the actual code to be evaluated.
