### PR TITLE
fix(scripts): Add go-getter subdirectory unwrapping to generated `agd tx submit-proposal`s

### DIFF
--- a/scripts/gen-upgrade-proposal.sh
+++ b/scripts/gen-upgrade-proposal.sh
@@ -20,7 +20,7 @@ curl -L "$ZIPURL" -o "$zipfile"
 echo "Generating SHA-256 checksum..." 1>&2
 checksum=sha256:$(shasum -a 256 "$zipfile" | cut -d' ' -f1)
 
-info="{\"binaries\":{\"any\":\"$ZIPURL?checksum=$checksum\"}}"
+info="{\"binaries\":{\"any\":\"$ZIPURL//agoric-sdk-$COMMIT_ID?checksum=$checksum\"},\"source\":\"$ZIPURL?checksum=$checksum\"}"
 
 cat <<EOF 1>&2
 ------------------------------------------------------------


### PR DESCRIPTION
Closes #9105

## Description

Updates URLs in `upgrade-info` generated by gen-upgrade-proposal.sh to include [go-getter directory unwrapping](https://github.com/hashicorp/go-getter?tab=readme-ov-file#subdirectories) as added to upgrade-14 by https://github.com/Agoric/agoric-sdk/commit/32bff4b84a382dd4897870a04063bcad5e489a33#diff-212b769d9a514d2e7813277e574999c609023d1d27de8d7b11244b879a81db3e . Later changes are expected for #8784, but this syncs back code from that side branch.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Nothing beyond the original fix.

### Upgrade Considerations

Nothing beyond the original fix.