### PR TITLE
feat(xsnap): Dispense with git when in node_modules

### DIFF
--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -13,10 +13,10 @@
   "scripts": {
     "repl": "node src/xsrepl.js",
     "build:bin": "if test -d ./test; then node src/build.js; else yarn build:from-env; fi",
-    "build:env": "test -d ./test && node src/build.js --show-env > build.env",
+    "build:env": "if test -d ./test; then node src/build.js --show-env > build.env; fi",
     "build:from-env": "{ cat build.env; echo node src/build.js; } | xargs env",
     "build": "yarn build:bin && yarn build:env",
-    "postinstall": "yarn build:from-env",
+    "postinstall": "node src/build.js",
     "clean": "rm -rf xsnap-native/xsnap/build",
     "lint": "run-s --continue-on-error lint:*",
     "lint:js": "eslint 'src/**/*.js' 'test/**/*.js' api.js",
@@ -50,7 +50,14 @@
     "LICENSE*",
     "api.js",
     "build.env",
-    "src"
+    "moddable/modules/data",
+    "moddable/xs/includes",
+    "moddable/xs/makefiles",
+    "moddable/xs/platforms/*.h",
+    "moddable/xs/sources",
+    "src",
+    "xsnap-native/xsnap/makefiles",
+    "xsnap-native/xsnap/sources"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/xsnap/scripts/test-package.sh
+++ b/packages/xsnap/scripts/test-package.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Verifies that files in package.json covers everything xsnap needs to compile
+# from sources out of an npm package.
+set -xueo pipefail
+
+TEMP=$(mktemp -d)
+# function cleanup() {
+#   rm -rf "$TEMP"
+# }
+# trap cleanup EXIT
+
+yarn pack -f "$TEMP/package.tar"
+(
+  cd "$TEMP"
+  tar xvf package.tar
+  cd package
+  yarn
+  time yarn build
+  time yarn build
+  time yarn build
+)

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -149,12 +149,9 @@ const makeSubmodule = (path, repoUrl, { git }) => {
  *     rmdirSync: typeof import('fs').rmdirSync,
  *     readFile: typeof import('fs').promises.readFile,
  *   },
- *   os: {
- *     type: typeof import('os').type,
- *   }
  * }} io
  */
-async function main(args, { env, stdout, spawn, fs, os }) {
+const updateSubmodules = async (args, { env, stdout, spawn, fs }) => {
   const git = makeCLI('git', { spawn });
 
   // When changing/adding entries here, make sure to search the whole project
@@ -214,7 +211,22 @@ async function main(args, { env, stdout, spawn, fs, os }) {
       await submodule.init();
     }
   }
+};
 
+/**
+ * @param {{
+ *   spawn: typeof import('child_process').spawn,
+ *   fs: {
+ *     existsSync: typeof import('fs').existsSync,
+ *     rmdirSync: typeof import('fs').rmdirSync,
+ *     readFile: typeof import('fs').promises.readFile,
+ *   },
+ *   os: {
+ *     type: typeof import('os').type,
+ *   }
+ * }} io
+ */
+const makeXsnap = async ({ spawn, fs, os }) => {
   const pjson = await fs.readFile(asset('../package.json'), 'utf-8');
   const pkg = JSON.parse(pjson);
 
@@ -239,6 +251,51 @@ async function main(args, { env, stdout, spawn, fs, os }) {
       },
     );
   }
+};
+
+/**
+ * @param {string[]} args
+ * @param {{
+ *   env: Record<string, string | undefined>,
+ *   stdout: typeof process.stdout,
+ *   spawn: typeof import('child_process').spawn,
+ *   fs: {
+ *     existsSync: typeof import('fs').existsSync,
+ *     rmdirSync: typeof import('fs').rmdirSync,
+ *     readFile: typeof import('fs').promises.readFile,
+ *   },
+ *   os: {
+ *     type: typeof import('os').type,
+ *   }
+ * }} io
+ */
+async function main(args, { env, stdout, spawn, fs, os }) {
+  // I solemnly swear I will do no synchronous work followed by a variable
+  // number turns of the event loop.
+  await null;
+
+  // If this is a working copy of xsnap in a checkout of agoric-sdk, we need to
+  // either clone or update submodules.
+  // Otherwise, we are running from an extracted npm tarball in a dependent
+  // package's node_modules, in which case we should just `make` with the
+  // `moddable` directory provided by npm.
+  // This will avoid rebuilding native xsnap in the common case for end users.
+  //
+  // | moddable/ | moddable/.git | working copy |
+  // | --------- | ------------- | ------------ |
+  // | ABSENT    | ABSENT        | YES          |
+  // | ABSENT    | EXISTS        | *            |
+  // | EXISTS    | ABSENT        | NO           |
+  // | EXISTS    | EXISTS        | YES          |
+  //
+  // We short-circuit after a single stat if moddable/.git exists because that
+  // implies that moddable/ exists.
+  const isWorkingCopy =
+    fs.existsSync('moddable/.git') || !fs.existsSync('moddable');
+  if (isWorkingCopy) {
+    await updateSubmodules(args, { env, stdout, spawn, fs });
+  }
+  await makeXsnap({ spawn, fs, os });
 }
 
 const run = () =>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #8536 
refs: #8383

## Description

This creates a fast path for building xsnap when it’s installed into node_modules instead of the working copy, by distributing the relevant xsnap-native and moddable submodules in the published artifact and dispensing with git submodules entirely in that case. This ensures that rebuilding the package in place will be near instantaneous after the first installation.

This does not attempt to distribute precompiled binaries for the target architecture and platform. We leave cross-compiling and distributing platform-specific alternatives as an ongoing exercise under #8383.

### Security Considerations

Negligible improvement in software supply chain security. This removes `git` from the supply chain of system dependencies necessary for building `xsnap`. The package still requires a postinstall script and is consequently worth a close audit before granting `allow-scripts`.

### Scaling Considerations

For dapp developers, this should save a large chunk of time when they run `yarn` during development.

### Documentation Considerations

Should be a transparent win.

### Testing Considerations

I’ve included a script for manually testing the published build process and run it locally. It takes a fair chunk of time to run every time. It could conceivably be included in the regression suite somewhere.

### Upgrade Considerations

Should have no impact on upgrade.