### PR TITLE
feat: create chain account (ica)

### DIFF
--- a/packages/boot/test/bootstrapTests/test-vat-orchestration.ts
+++ b/packages/boot/test/bootstrapTests/test-vat-orchestration.ts
@@ -1,0 +1,89 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import type { ExecutionContext, TestFn } from 'ava';
+import { M, matches } from '@endo/patterns';
+import { makeWalletFactoryContext } from './walletFactory.ts';
+
+const makeTestContext = async (t: ExecutionContext) =>
+  makeWalletFactoryContext(t);
+
+type DefaultTestContext = Awaited<ReturnType<typeof makeTestContext>>;
+const test: TestFn<DefaultTestContext> = anyTest;
+
+test.before(async t => {
+  t.context = await makeTestContext(t);
+
+  async function setupDeps() {
+    const {
+      buildProposal,
+      evalProposal,
+      runUtils: { EV },
+    } = t.context;
+    /** ensure network, ibc, and orchestration are available */
+    await evalProposal(
+      buildProposal('@agoric/builders/scripts/vats/init-network.js'),
+    );
+    await evalProposal(
+      buildProposal('@agoric/builders/scripts/vats/init-orchestration.js'),
+    );
+    const vatStore = await EV.vat('bootstrap').consumeItem('vatStore');
+    t.true(await EV(vatStore).has('ibc'), 'ibc');
+    t.true(await EV(vatStore).has('network'), 'network');
+    t.true(await EV(vatStore).has('orchestration'), 'orchestration');
+  }
+
+  await setupDeps();
+});
+
+test.after.always(t => t.context.shutdown?.());
+
+test('createAccount returns an ICA connection', async t => {
+  const {
+    runUtils: { EV },
+  } = t.context;
+
+  const orchestration = await EV.vat('bootstrap').consumeItem('orchestration');
+
+  const account = await EV(orchestration).createAccount(
+    'connection-0',
+    'connection-0',
+  );
+  t.truthy(account, 'createAccount returns an account');
+  t.truthy(
+    matches(account, M.remotable('ChainAccount')),
+    'account is a remotable',
+  );
+  const [remoteAddress, localAddress, accountAddress, port] = await Promise.all(
+    [
+      EV(account).getRemoteAddress(),
+      EV(account).getLocalAddress(),
+      EV(account).getAccountAddress(),
+      EV(account).getPort(),
+    ],
+  );
+  t.regex(remoteAddress, /icahost/);
+  t.regex(localAddress, /icacontroller/);
+  t.regex(accountAddress, /osmo1/);
+  t.truthy(matches(port, M.remotable('Port')));
+  t.log('ICA Account Addresses', {
+    remoteAddress,
+    localAddress,
+    accountAddress,
+  });
+});
+
+test('ICA connection can be closed', async t => {
+  const {
+    runUtils: { EV },
+  } = t.context;
+
+  const orchestration = await EV.vat('bootstrap').consumeItem('orchestration');
+
+  const account = await EV(orchestration).createAccount(
+    'connection-0',
+    'connection-0',
+  );
+  t.truthy(account, 'createAccount returns an account');
+
+  const res = await EV(account).close();
+  t.is(res, 'Connection closed');
+});

--- a/packages/boot/tools/ibc/README.md
+++ b/packages/boot/tools/ibc/README.md
@@ -1,0 +1,113 @@
+
+# ICS-27 Interchain Accounts
+
+Sequence diagrams for Interchain Accounts based on [ics-027-interchain-accounts/README.md#9ffb1d2](https://github.com/cosmos/ibc/blob/9ffb1d26d3018b6efda546189ec7e43d56d23da3/spec/app/ics-027-interchain-accounts/README.md).
+
+### IBC Connection Creation
+
+_Prerequisite to creating a channel._
+
+```mermaid
+sequenceDiagram
+    participant CC as Chain A
+    participant R as Relayer
+    participant HC as Chain B
+
+    CC->>R: ConnOpenInit(ClientId, CounterpartyClientId, Version)
+    R->>HC: ConnOpenTry(ClientId, CounterpartyClientId, Version, CounterpartyVersion)
+    HC-->>R: ConnOpenTry(Version)
+    R->>CC: ConnOpenAck(ConnectionId, Version)
+    CC-->>R: ConnOpenAck
+    R->>HC: ConnOpenConfirm(ConnectionId)
+```
+
+Mock Testing: 
+ - on `ConnOpenInit`, return `ConnOpenAck`
+
+### ICA Channel Creation
+
+```mermaid
+sequenceDiagram
+    participant CC as Controller Chain
+    participant R as Relayer
+    participant HC as Host Chain
+
+    CC->>CC: RegisterInterchainAccount()
+    CC->>R: ChannelOpenInit(Order, ConnectionHops, PortIdentifier, ChannelIdentifier, Version)
+    R->>HC: ChannelOpenTry(Order, ConnectionHops, PortIdentifier, ChannelIdentifier, Version)
+    HC->>HC: RegisterInterchainAccount(CounterpartyPortIdentifier)
+    HC-->>R: ChannelOpenTry(Version)
+    R->>CC: ChannelOpenAck(PortIdentifier, ChannelIdentifier, CounterpartyVersion)
+    CC->>CC: SetInterchainAccountAddress(PortID, Address)
+    CC->>CC: SetActiveChannelID(PortIdentifier, ConnectionID, ChannelIdentifier)
+    CC-->>R: ChannelOpenAck
+    R->>HC: ChannelOpenConfirm(PortIdentifier, ChannelIdentifier)
+    HC->>HC: SetActiveChannelID(CounterpartyPortIdentifier, ConnectionID, ChannelIdentifier)
+```
+
+Mock Testing: 
+ - on `ChannelOpenInit`, return `ChannelOpenAck`
+
+### ICA Transaction
+
+```mermaid
+sequenceDiagram
+    participant CC as Controller Chain
+    participant R as Relayer
+    participant HC as Host Chain
+
+    CC->>R: SendPacket(PacketData)
+    R->>HC: onRecvPacket(Packet)
+    HC->>HC: Deserialize and validate packet data
+    alt Successful deserialization and validation
+        HC->>HC: AuthenticateTx(msgs)
+        HC->>HC: ExecuteTx(msgs)
+        HC-->>R: Acknowledgement(result)
+    else Error
+        HC-->>R: ErrorAcknowledgement(error)
+    end
+    R->>CC: onAcknowledgePacket(Packet, Acknowledgement)
+    CC->>CC: Handle acknowledgement
+```
+
+Mock Testing: 
+ - on `SendPacket`, return `onAcknowledgePacket`
+
+
+### ICA Channel Reactivation
+
+```mermaid
+sequenceDiagram
+    participant CC as Controller Chain
+    participant R as Relayer
+    participant HC as Host Chain
+
+    Note over CC,HC: Existing ICA channel expires or closes
+    CC->>CC: Channel closes or times out
+    CC->>R: ChannelOpenInit(Order, ConnectionHops, PortIdentifier, ChannelIdentifier, Version)
+    Note right of CC: Reusing the same PortIdentifier and ConnectionID
+    R->>HC: ChannelOpenTry(Order, ConnectionHops, PortIdentifier, ChannelIdentifier, Version)
+    HC->>HC: Verify PortIdentifier and ConnectionID match the previous active channel
+    HC->>HC: Verify the channel is in CLOSED state
+    HC->>HC: Verify the new channel has the same order and version as the previous channel
+    HC-->>R: ChannelOpenTry(Version)
+    R->>CC: ChannelOpenAck(PortIdentifier, ChannelIdentifier, CounterpartyVersion)
+    CC->>CC: Verify the CounterpartyVersion matches the previous active channel
+    CC->>CC: SetActiveChannelID(PortIdentifier, ConnectionID, ChannelIdentifier)
+    CC-->>R: ChannelOpenAck
+    R->>HC: ChannelOpenConfirm(PortIdentifier, ChannelIdentifier)
+    HC->>HC: SetActiveChannelID(CounterpartyPortIdentifier, ConnectionID, ChannelIdentifier)
+```
+
+Mock Testing: 
+ - on `ChannelOpenInit`, return `ChannelOpenAck`
+    - n.b. testing should verify `SetActiveChannelID` flow on CC side
+
+
+### Testing Mocks Summary
+
+ - IBC Connection Creation: on ConnOpenInit, return ConnOpenAck
+ - ICA Channel Creation: on ChannelOpenInit, return ChannelOpenAck
+ - ICA Transaction: on SendPacket, return onAcknowledgePacket
+ - ICA Channel Reactivation: on ChannelOpenInit, return ChannelOpenAck
+    - testing should verify SetActiveChannelID flow on CC side

--- a/packages/boot/tools/ibc/mocks.js
+++ b/packages/boot/tools/ibc/mocks.js
@@ -1,0 +1,28 @@
+/**
+ * mock bridgeInbound events for ICA (ICS-27) flow
+ * see [./ics27-1.md](./ics27-1.md) for more details
+ *
+ * sourced from [@agoric/vats/test/test-network.js](https://github.com/Agoric/agoric-sdk/blob/4601a1ab65a0c36fbfbfcc1fa59e83ee10a1c996/packages/vats/test/test-network.js)
+ * and end e2e testing with sim chains (v16: IBC fromBridge logs)
+ */
+export const icaMocks = {
+  startChannelOpenInit: {
+    // ICA Channel Creation
+    channelOpenAck: obj => ({
+      type: 'IBC_EVENT',
+      blockHeight: 99,
+      blockTime: 1711571357,
+      event: 'channelOpenAck',
+      portID: obj.packet.source_port,
+      channelID: 'channel-0',
+      counterparty: {
+        port_id: obj.packet.destination_port,
+        channel_id: 'channel-1',
+      },
+      counterpartyVersion:
+        '{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-0","address":"osmo1234","encoding":"proto3","txType":"sdk_multi_msg"}',
+      connectionHops: obj.hops,
+    }),
+    // XXX channelOpenAckFailure
+  },
+};

--- a/packages/builders/scripts/orchestration/init-stakeAtom.js
+++ b/packages/builders/scripts/orchestration/init-stakeAtom.js
@@ -1,0 +1,34 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async (
+  { publishRef, install },
+  options = {},
+) => {
+  const {
+    hostConnectionId = 'connection-1',
+    controllerConnectionId = 'connection-0',
+  } = options;
+  return harden({
+    sourceSpec: '@agoric/orchestration/src/proposals/start-stakeAtom.js',
+    getManifestCall: [
+      'getManifestForStakeAtom',
+      {
+        installKeys: {
+          stakeAtom: publishRef(
+            install(
+              '@agoric/orchestration/src/contracts/stakeAtom.contract.js',
+            ),
+          ),
+        },
+        hostConnectionId,
+        controllerConnectionId,
+      },
+    ],
+  });
+};
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('start-stakeAtom', defaultProposalBuilder);
+};

--- a/packages/builders/scripts/vats/init-orchestration.js
+++ b/packages/builders/scripts/vats/init-orchestration.js
@@ -1,0 +1,20 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    sourceSpec: '@agoric/orchestration/src/proposals/orchestration-proposal.js',
+    getManifestCall: [
+      'getManifestForOrchestration',
+      {
+        orchestrationRef: publishRef(
+          install('@agoric/orchestration/src/vat-orchestration.js'),
+        ),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('gov-orchestration', defaultProposalBuilder);
+};

--- a/packages/orchestration/index.js
+++ b/packages/orchestration/index.js
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/export
 export * from './src/types.js';
 export * from './src/utils/address.js';
+export * from './src/orchestration.js';

--- a/packages/orchestration/index.js
+++ b/packages/orchestration/index.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/export
 export * from './src/types.js';
+export * from './src/utils/address.js';

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -29,9 +29,12 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
+    "@agoric/assert": "^0.6.0",
     "@agoric/ertp": "^0.16.2",
     "@agoric/internal": "^0.3.2",
+    "@agoric/network": "^0.1.0",
     "@agoric/notifier": "^0.6.2",
+    "@agoric/store": "^0.9.2",
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
     "@agoric/zoe": "^0.26.2",
@@ -41,9 +44,10 @@
     "@endo/patterns": "^1.3.0"
   },
   "devDependencies": {
+    "@endo/ses-ava": "^1.2.0",
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
-    "ava": "^5.3.0",
+    "ava": "^5.3.1",
     "cosmjs-types": "^0.9.0"
   },
   "ava": {

--- a/packages/orchestration/src/contracts/stakeAtom.contract.js
+++ b/packages/orchestration/src/contracts/stakeAtom.contract.js
@@ -1,0 +1,52 @@
+// @ts-check
+/**
+ * @file Example contract that uses orchestration
+ */
+
+import { makeDurableZone } from '@agoric/zone/durable.js';
+import { V as E } from '@agoric/vat-data/vow.js';
+import { M } from '@endo/patterns';
+
+/**
+ * @import * as orchestration from '../types'
+ * @import * as vatData from '@agoric/vat-data'
+ */
+
+/**
+ * @typedef {{
+ *  hostConnectionId: orchestration.ConnectionId;
+ *  controllerConnectionId: orchestration.ConnectionId;
+ * }} StakeAtomTerms
+ */
+
+/**
+ *
+ * @param {ZCF<StakeAtomTerms>} zcf
+ * @param {{
+ *   orchestration: orchestration.Orchestration;
+ * }} privateArgs
+ * @param {vatData.Baggage} baggage
+ */
+export const start = async (zcf, privateArgs, baggage) => {
+  const { hostConnectionId, controllerConnectionId } = zcf.getTerms();
+  const { orchestration } = privateArgs;
+
+  const zone = makeDurableZone(baggage);
+
+  const publicFacet = zone.exo(
+    'StakeAtom',
+    M.interface('StakeAtomI', {
+      createAccount: M.callWhen().returns(M.remotable('ChainAccount')),
+    }),
+    {
+      async createAccount() {
+        return E(orchestration).createAccount(
+          hostConnectionId,
+          controllerConnectionId,
+        );
+      },
+    },
+  );
+
+  return { publicFacet };
+};

--- a/packages/orchestration/src/orchestration.js
+++ b/packages/orchestration/src/orchestration.js
@@ -1,0 +1,236 @@
+// @ts-check
+/** @file Orchestration service */
+import { NonNullish } from '@agoric/assert';
+import { makeTracer } from '@agoric/internal';
+import { V as E } from '@agoric/vat-data/vow.js';
+import { M } from '@endo/patterns';
+import { makeICAConnectionAddress, parseAddress } from './utils/address.js';
+import '@agoric/network/exported.js';
+
+const { Fail, bare } = assert;
+const trace = makeTracer('Orchestration');
+
+// TODO improve me
+/** @typedef {string} ChainAddress */
+
+/**
+ * @typedef {object} OrchestrationPowers
+ * @property {ERef<
+ *   import('@agoric/orchestration/src/types').AttenuatedNetwork
+ * >} network
+ */
+
+/**
+ * PowerStore is used so additional powers can be added on upgrade. See
+ * [#7337](https://github.com/Agoric/agoric-sdk/issues/7337) for tracking on Exo
+ * state migrations.
+ *
+ * @typedef {MapStore<
+ *   keyof OrchestrationPowers,
+ *   OrchestrationPowers[keyof OrchestrationPowers]
+ * >} PowerStore
+ */
+
+/**
+ * @template {keyof OrchestrationPowers} K
+ * @param {PowerStore} powers
+ * @param {K} name
+ */
+const getPower = (powers, name) => {
+  powers.has(name) || Fail`need powers.${bare(name)} for this method`;
+  return /** @type {OrchestrationPowers[K]} */ (powers.get(name));
+};
+
+export const ChainAccountI = M.interface('ChainAccount', {
+  getAccountAddress: M.call().returns(M.string()),
+  getLocalAddress: M.call().returns(M.string()),
+  getRemoteAddress: M.call().returns(M.string()),
+  getPort: M.call().returns(M.remotable('Port')),
+  close: M.callWhen().returns(M.string()),
+});
+
+export const ConnectionHandlerI = M.interface('ConnectionHandler', {
+  onOpen: M.callWhen(M.any(), M.string(), M.string(), M.any()).returns(M.any()),
+  onClose: M.callWhen(M.any(), M.any(), M.any()).returns(M.any()),
+  onReceive: M.callWhen(M.any(), M.string()).returns(M.any()),
+});
+
+/** @param {import('@agoric/base-zone').Zone} zone */
+const prepareChainAccount = zone =>
+  zone.exoClassKit(
+    'ChainAccount',
+    { account: ChainAccountI, connectionHandler: ConnectionHandlerI },
+    /**
+     * @param {Port} port
+     * @param {string} requestedRemoteAddress
+     */
+    (port, requestedRemoteAddress) =>
+      /**
+       * @type {{
+       *   port: Port;
+       *   connection: Connection | undefined;
+       *   localAddress: string | undefined;
+       *   requestedRemoteAddress: string;
+       *   remoteAddress: string | undefined;
+       *   accountAddress: ChainAddress | undefined;
+       * }}
+       */ (
+        harden({
+          port,
+          connection: undefined,
+          requestedRemoteAddress,
+          remoteAddress: undefined,
+          accountAddress: undefined,
+          localAddress: undefined,
+        })
+      ),
+    {
+      account: {
+        getAccountAddress() {
+          return NonNullish(
+            this.state.accountAddress,
+            'Error parsing account address from remote address',
+          );
+        },
+        getLocalAddress() {
+          return NonNullish(
+            this.state.localAddress,
+            'local address not available',
+          );
+        },
+        getRemoteAddress() {
+          return NonNullish(
+            this.state.remoteAddress,
+            'remote address not available',
+          );
+        },
+        getPort() {
+          return this.state.port;
+        },
+        async close() {
+          /// XXX what should the behavior be here? and `onClose`?
+          // - retrieve assets?
+          // - revoke the port?
+          const { connection } = this.state;
+          if (!connection) throw Fail`connection not available`;
+          await null;
+          try {
+            await E(connection).close();
+          } catch (e) {
+            throw Fail`Failed to close connection: ${e}`;
+          }
+          return 'Connection closed';
+        },
+      },
+      connectionHandler: {
+        /**
+         * @param {Connection} connection
+         * @param {string} localAddr
+         * @param {string} remoteAddr
+         * @param {ConnectionHandler} _connectionHandler
+         */
+        async onOpen(connection, localAddr, remoteAddr, _connectionHandler) {
+          trace(`ICA Channel Opened for ${localAddr} at ${remoteAddr}`);
+          this.state.connection = connection;
+          this.state.remoteAddress = remoteAddr;
+          this.state.localAddress = localAddr;
+          // XXX parseAddress currently throws, should it return '' instead?
+          this.state.accountAddress = parseAddress(remoteAddr);
+        },
+        async onClose(_connection, reason, _connectionHandler) {
+          trace(`ICA Channel closed. Reason: ${reason}`);
+          // XXX handle connection closing
+          // XXX is there a scenario where a connection will unexpectedly close? _I think yes_
+        },
+        async onReceive(connection, bytes) {
+          trace(`ICA Channel onReceive`, connection, bytes);
+          return '';
+        },
+      },
+    },
+  );
+
+export const OrchestrationI = M.interface('Orchestration', {
+  createAccount: M.callWhen(M.string(), M.string()).returns(
+    M.remotable('ChainAccount'),
+  ),
+});
+
+/**
+ * @param {import('@agoric/base-zone').Zone} zone
+ * @param {ReturnType<typeof prepareChainAccount>} createChainAccount
+ */
+const prepareOrchestration = (zone, createChainAccount) =>
+  zone.exoClassKit(
+    'Orchestration',
+    {
+      self: M.interface('OrchestrationSelf', {
+        bindPort: M.callWhen().returns(M.remotable()),
+      }),
+      public: OrchestrationI,
+    },
+    /** @param {Partial<OrchestrationPowers>} [initialPowers] */
+    initialPowers => {
+      /** @type {PowerStore} */
+      const powers = zone.detached().mapStore('PowerStore');
+      if (initialPowers) {
+        for (const [name, power] of Object.entries(initialPowers)) {
+          powers.init(/** @type {keyof OrchestrationPowers} */ (name), power);
+        }
+      }
+      return { powers, icaControllerNonce: 0 };
+    },
+    {
+      self: {
+        async bindPort() {
+          const network = getPower(this.state.powers, 'network');
+          const port = await E(network)
+            .bind(`/ibc-port/icacontroller-${this.state.icaControllerNonce}`)
+            .catch(e => Fail`Failed to bind port: ${e}`);
+          this.state.icaControllerNonce += 1;
+          return port;
+        },
+      },
+      public: {
+        /**
+         * @param {import('@agoric/orchestration').ConnectionId} hostConnectionId
+         *   the counterparty connection_id
+         * @param {import('@agoric/orchestration').ConnectionId} controllerConnectionId
+         *   self connection_id
+         * @returns {Promise<ChainAccount>}
+         */
+        async createAccount(hostConnectionId, controllerConnectionId) {
+          const port = await this.facets.self.bindPort();
+
+          const remoteConnAddr = makeICAConnectionAddress(
+            hostConnectionId,
+            controllerConnectionId,
+          );
+          const chainAccount = createChainAccount(port, remoteConnAddr);
+
+          // await so we do not return a ChainAccount before it successfully instantiates
+          await E(port)
+            .connect(remoteConnAddr, chainAccount.connectionHandler)
+            // XXX if we fail, should we close the port (if it was created in this flow)?
+            .catch(e => Fail`Failed to create ICA connection: ${bare(e)}`);
+
+          return chainAccount.account;
+        },
+      },
+    },
+  );
+
+/** @param {import('@agoric/base-zone').Zone} zone */
+export const prepareOrchestrationTools = zone => {
+  const createChainAccount = prepareChainAccount(zone);
+  const makeOrchestration = prepareOrchestration(zone, createChainAccount);
+
+  return harden({ makeOrchestration });
+};
+harden(prepareOrchestrationTools);
+
+/** @typedef {ReturnType<ReturnType<typeof prepareChainAccount>>} ChainAccountKit */
+/** @typedef {ChainAccountKit['account']} ChainAccount */
+/** @typedef {ReturnType<typeof prepareOrchestrationTools>} OrchestrationTools */
+/** @typedef {ReturnType<OrchestrationTools['makeOrchestration']>} OrchestrationKit */
+/** @typedef {OrchestrationKit['public']} Orchestration */

--- a/packages/orchestration/src/orchestration.js
+++ b/packages/orchestration/src/orchestration.js
@@ -7,6 +7,11 @@ import { M } from '@endo/patterns';
 import { makeICAConnectionAddress, parseAddress } from './utils/address.js';
 import '@agoric/network/exported.js';
 
+/**
+ * @import { ConnectionId } from './types';
+ * @import { Zone } from '@agoric/base-zone';
+ */
+
 const { Fail, bare } = assert;
 const trace = makeTracer('Orchestration');
 
@@ -55,7 +60,7 @@ export const ConnectionHandlerI = M.interface('ConnectionHandler', {
   onReceive: M.callWhen(M.any(), M.string()).returns(M.any()),
 });
 
-/** @param {import('@agoric/base-zone').Zone} zone */
+/** @param {Zone} zone */
 const prepareChainAccount = zone =>
   zone.exoClassKit(
     'ChainAccount',
@@ -127,9 +132,8 @@ const prepareChainAccount = zone =>
          * @param {Connection} connection
          * @param {string} localAddr
          * @param {string} remoteAddr
-         * @param {ConnectionHandler} _connectionHandler
          */
-        async onOpen(connection, localAddr, remoteAddr, _connectionHandler) {
+        async onOpen(connection, localAddr, remoteAddr) {
           trace(`ICA Channel Opened for ${localAddr} at ${remoteAddr}`);
           this.state.connection = connection;
           this.state.remoteAddress = remoteAddr;
@@ -137,7 +141,7 @@ const prepareChainAccount = zone =>
           // XXX parseAddress currently throws, should it return '' instead?
           this.state.accountAddress = parseAddress(remoteAddr);
         },
-        async onClose(_connection, reason, _connectionHandler) {
+        async onClose(_connection, reason) {
           trace(`ICA Channel closed. Reason: ${reason}`);
           // XXX handle connection closing
           // XXX is there a scenario where a connection will unexpectedly close? _I think yes_
@@ -157,7 +161,7 @@ export const OrchestrationI = M.interface('Orchestration', {
 });
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
+ * @param {Zone} zone
  * @param {ReturnType<typeof prepareChainAccount>} createChainAccount
  */
 const prepareOrchestration = (zone, createChainAccount) =>
@@ -193,9 +197,9 @@ const prepareOrchestration = (zone, createChainAccount) =>
       },
       public: {
         /**
-         * @param {import('@agoric/orchestration').ConnectionId} hostConnectionId
+         * @param {ConnectionId} hostConnectionId
          *   the counterparty connection_id
-         * @param {import('@agoric/orchestration').ConnectionId} controllerConnectionId
+         * @param {ConnectionId} controllerConnectionId
          *   self connection_id
          * @returns {Promise<ChainAccount>}
          */
@@ -220,7 +224,7 @@ const prepareOrchestration = (zone, createChainAccount) =>
     },
   );
 
-/** @param {import('@agoric/base-zone').Zone} zone */
+/** @param {Zone} zone */
 export const prepareOrchestrationTools = zone => {
   const createChainAccount = prepareChainAccount(zone);
   const makeOrchestration = prepareOrchestration(zone, createChainAccount);

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -1,0 +1,99 @@
+// @ts-check
+import { V as E } from '@agoric/vat-data/vow.js';
+import { Far } from '@endo/far';
+
+/** @import { AttenuatedNetwork, Orchestration, OrchestrationVat } from '../types' */
+
+/**
+ * @param {BootstrapPowers & {
+ *   consume: {
+ *     loadCriticalVat: VatLoader<any>;
+ *     networkVat: NetworkVat;
+ *   };
+ *   produce: {
+ *     orchestration: Producer<any>;
+ *     orchestrationKit: Producer<any>;
+ *     orchestrationVat: Producer<any>;
+ *   };
+ * }} powers
+ * @param {object} options
+ * @param {{ orchestrationRef: VatSourceRef }} options.options
+ *
+ * @typedef {{
+ *   orchestration: ERef<OrchestrationVat>;
+ * }} OrchestrationVats
+ */
+export const setupOrchestrationVat = async (
+  {
+    consume: { loadCriticalVat, networkVat },
+    produce: {
+      orchestrationVat,
+      orchestration,
+      orchestrationKit: orchestrationKitP,
+    },
+  },
+  options,
+) => {
+  const { orchestrationRef } = options.options;
+  /** @type {OrchestrationVats} */
+  const vats = {
+    orchestration: E(loadCriticalVat)('orchestration', orchestrationRef),
+  };
+  // don't proceed if loadCriticalVat fails
+  await Promise.all(Object.values(vats));
+
+  orchestrationVat.reset();
+  orchestrationVat.resolve(vats.orchestration);
+
+  await networkVat;
+  /** @type {AttenuatedNetwork} */
+  const network = Far('Attenuated Network', {
+    /** @param {string} localAddr */
+    async bind(localAddr) {
+      return E(networkVat).bind(localAddr);
+    },
+  });
+
+  const newOrchestrationKit = await E(vats.orchestration).makeOrchestration({
+    network,
+  });
+
+  orchestration.reset();
+  orchestration.resolve(newOrchestrationKit.public);
+  orchestrationKitP.reset();
+  orchestrationKitP.resolve(newOrchestrationKit);
+};
+
+/**
+ * @param {BootstrapPowers & {
+ *   consume: {
+ *     orchestration: Orchestration;
+ *   };
+ * }} powers
+ * @param {object} _options
+ */
+export const addOrchestrationToClient = async (
+  { consume: { client, orchestration } },
+  _options,
+) => {
+  return E(client).assignBundle([_a => ({ orchestration })]);
+};
+
+export const getManifestForOrchestration = (_powers, { orchestrationRef }) => ({
+  manifest: {
+    [setupOrchestrationVat.name]: {
+      consume: {
+        loadCriticalVat: true,
+        networkVat: true,
+      },
+      produce: {
+        orchestration: 'orchestration',
+        orchestrationKit: 'orchestration',
+        orchestrationVat: 'orchestration',
+      },
+    },
+  },
+  options: {
+    orchestrationRef,
+  },
+});

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -1,0 +1,68 @@
+// @ts-check
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+
+const trace = makeTracer('StartStakeAtom', true);
+
+/**
+ * @param {BootstrapPowers & { installation: {consume: {stakeAtom: Installation<import('../contracts/stakeAtom.contract.js').start>}}}} powers
+ * @param {{options: import('../contracts/stakeAtom.contract.js').StakeAtomTerms}} options
+ */
+export const startStakeAtom = async (
+  {
+    consume: { orchestration, startUpgradable },
+    installation: {
+      consume: { stakeAtom },
+    },
+    instance: {
+      produce: { stakeAtom: produceInstance },
+    },
+  },
+  { options: { hostConnectionId, controllerConnectionId } },
+) => {
+  trace('startStakeAtom', { hostConnectionId, controllerConnectionId });
+  await null;
+
+  /** @type {StartUpgradableOpts<import('../contracts/stakeAtom.contract.js').start>} */
+  const startOpts = {
+    label: 'stakeAtom',
+    installation: stakeAtom,
+    terms: {
+      hostConnectionId,
+      controllerConnectionId,
+    },
+    privateArgs: {
+      orchestration: await orchestration,
+    },
+  };
+
+  const { instance } = await E(startUpgradable)(startOpts);
+  produceInstance.resolve(instance);
+};
+harden(startStakeAtom);
+
+export const getManifestForStakeAtom = (
+  { restoreRef },
+  { installKeys, ...options },
+) => {
+  return {
+    manifest: {
+      [startStakeAtom.name]: {
+        consume: {
+          orchestration: true,
+          startUpgradable: true,
+        },
+        installation: {
+          consume: { stakeAtom: true },
+        },
+        instance: {
+          produce: { stakeAtom: true },
+        },
+      },
+    },
+    installations: {
+      stakeAtom: restoreRef(installKeys.stakeAtom),
+    },
+    options,
+  };
+};

--- a/packages/orchestration/src/types.d.ts
+++ b/packages/orchestration/src/types.d.ts
@@ -1,0 +1,1 @@
+export type ConnectionId = `connection-${number}`;

--- a/packages/orchestration/src/types.d.ts
+++ b/packages/orchestration/src/types.d.ts
@@ -1,1 +1,8 @@
+import type { RouterProtocol } from '@agoric/network/src/router';
+
 export type ConnectionId = `connection-${number}`;
+
+export type AttenuatedNetwork = Pick<RouterProtocol, 'bind'>;
+
+export type * from './orchestration.js';
+export type * from './vat-orchestration.js';

--- a/packages/orchestration/src/types.js
+++ b/packages/orchestration/src/types.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '@agoric/network/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/zoe/exported.js';
 

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -1,0 +1,54 @@
+// @ts-check
+import { Fail } from '@agoric/assert';
+
+/** @import { ConnectionId } from '../types'; */
+
+/**
+ * @param {ConnectionId} hostConnectionId Counterpart Connection ID
+ * @param {ConnectionId} controllerConnectionId Self Connection ID
+ * @param {object} [opts]
+ * @param {string} [opts.encoding] - message encoding format for the channel. default is `proto3`
+ * @param {'ordered' | 'unordered'} [opts.ordering] - channel ordering. currently only `ordered` is supported for ics27-1
+ * @param {string} [opts.txType] - default is `sdk_multi_msg`
+ * @param {string} [opts.version] - default is `ics27-1`
+ */
+export const makeICAConnectionAddress = (
+  hostConnectionId,
+  controllerConnectionId,
+  {
+    version = 'ics27-1',
+    encoding = 'proto3',
+    ordering = 'ordered',
+    txType = 'sdk_multi_msg',
+  } = {},
+) => {
+  hostConnectionId || Fail`hostConnectionId is required`;
+  controllerConnectionId || Fail`controllerConnectionId is required`;
+  const connString = JSON.stringify({
+    version,
+    controllerConnectionId,
+    hostConnectionId,
+    address: '', // will be provided by the counterparty after channelOpenAck
+    encoding,
+    txType,
+  });
+  return `/ibc-hop/${controllerConnectionId}/ibc-port/icahost/${ordering}/${connString}`;
+};
+
+/**
+ * Parse a chain address from a remote address string.
+ * Assumes the address string is in a JSON format and contains an "address" field.
+ * This function is designed to be safe against malformed inputs and unexpected data types, and will return `undefined` in those cases.
+ * @param {string} remoteAddressString - remote address string, including version
+ * @returns {string | undefined} returns undefined on error
+ */
+export const parseAddress = remoteAddressString => {
+  try {
+    // Extract JSON version string assuming it's always surrounded by {}
+    const jsonStr = remoteAddressString?.match(/{.*?}/)?.[0];
+    const jsonObj = jsonStr ? JSON.parse(jsonStr) : undefined;
+    return jsonObj?.address ?? undefined;
+  } catch (error) {
+    return undefined;
+  }
+};

--- a/packages/orchestration/src/vat-orchestration.js
+++ b/packages/orchestration/src/vat-orchestration.js
@@ -1,0 +1,22 @@
+// @ts-check
+import { Far } from '@endo/far';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+import { prepareOrchestrationTools } from './orchestration.js';
+
+/** @import { OrchestrationPowers } from './types.js' */
+
+export const buildRootObject = (_vatPowers, _args, baggage) => {
+  const zone = makeDurableZone(baggage);
+  const { makeOrchestration } = prepareOrchestrationTools(
+    zone.subZone('orchestration'),
+  );
+
+  return Far('OrchestrationVat', {
+    /** @param {Partial<OrchestrationPowers>} [initialPowers] */
+    makeOrchestration(initialPowers = {}) {
+      return makeOrchestration(initialPowers);
+    },
+  });
+};
+
+/** @typedef {ReturnType<typeof buildRootObject>} OrchestrationVat */

--- a/packages/orchestration/test/utils/address.test.js
+++ b/packages/orchestration/test/utils/address.test.js
@@ -1,0 +1,69 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+import {
+  makeICAConnectionAddress,
+  parseAddress,
+} from '../../src/utils/address.js';
+
+test('makeICAConnectionAddress', t => {
+  t.throws(() => makeICAConnectionAddress(), {
+    message: 'hostConnectionId is required',
+  });
+  t.throws(() => makeICAConnectionAddress('connection-0'), {
+    message: 'controllerConnectionId is required',
+  });
+  t.is(
+    makeICAConnectionAddress('connection-1', 'connection-0'),
+    '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    'returns connection string when controllerConnectionId and hostConnectionId are provided',
+  );
+  t.is(
+    makeICAConnectionAddress('connection-1', 'connection-0', {
+      version: 'ics27-0',
+    }),
+    '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-0","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    'accepts custom version',
+  );
+  t.is(
+    makeICAConnectionAddress('connection-1', 'connection-0', {
+      encoding: 'test',
+    }),
+    '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"test","txType":"sdk_multi_msg"}',
+    'accepts custom encoding',
+  );
+  t.is(
+    makeICAConnectionAddress('connection-1', 'connection-0', {
+      ordering: 'unordered',
+    }),
+    '/ibc-hop/connection-0/ibc-port/icahost/unordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    'accepts custom ordering',
+  );
+});
+
+test('parseAddress', t => {
+  t.is(
+    parseAddress('/ibc-hop/'),
+    undefined,
+    'returns undefined when version json is missing',
+  );
+  t.is(
+    parseAddress(
+      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    ),
+    '',
+    'returns empty string if address is an empty string',
+  );
+  t.is(
+    parseAddress(
+      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","txType":"sdk_multi_msg"}',
+    ),
+    'osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq',
+    'returns address',
+  );
+  t.is(
+    parseAddress(
+      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controller_connection_id":"connection-0","host_connection_id":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","tx_type":"sdk_multi_msg"}/ibc-channel/channel-1',
+    ),
+    'osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq',
+    'returns address when localAddrr is appended to version string',
+  );
+});

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -179,6 +179,7 @@ type WellKnownName = {
     | 'reserve'
     | 'psm'
     | 'scaledPriceAuthority'
+    | 'stakeAtom' // test contract
     | 'stakeBld' // test contract
     | 'econCommitteeCharter'
     | 'priceAggregator';
@@ -193,6 +194,7 @@ type WellKnownName = {
     | 'provisionPool'
     | 'reserve'
     | 'reserveGovernor'
+    | 'stakeAtom' // test contract
     | 'stakeBld' // test contract
     | 'Pegasus';
   oracleBrand: 'USD';
@@ -341,9 +343,12 @@ type ChainBootstrapSpaceT = {
    * Vault Factory. ONLY FOR DISASTER RECOVERY
    */
   instancePrivateArgs: Map<Instance, unknown>;
+  localchain: import('@agoric/vats/src/localchain.js').LocalChain;
   mints?: MintsVat;
   namesByAddress: import('../types.js').NameHub;
   namesByAddressAdmin: import('../types.js').NamesByAddressAdmin;
+  networkVat: NetworkVat;
+  orchestration: import('@agoric/orchestration/src/orchestration.js').Orchestration;
   pegasusConnections: import('@agoric/vats').NameHubKit;
   pegasusConnectionsAdmin: import('@agoric/vats').NameAdmin;
   priceAuthorityVat: Awaited<PriceAuthorityVat>;

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -56,6 +56,7 @@ export const agoricNamesReserved = harden({
     econCommitteeCharter: 'Charter for Econ Governance questions',
     priceAggregator: 'simple price aggregator',
     scaledPriceAuthority: 'scaled price authority',
+    stakeAtom: 'example ATOM staking contract',
     stakeBld: 'example BLD staking contract',
   },
   instance: {
@@ -70,6 +71,7 @@ export const agoricNamesReserved = harden({
     econCommitteeCharter: 'Charter for Econ Governance questions',
     provisionPool: 'Account Provision Pool',
     walletFactory: 'Smart Wallet Factory',
+    stakeAtom: 'example ATOM staking contract',
     stakeBld: 'example BLD staking contract',
   },
   oracleBrand: {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #9064
refs: #9042
## Description


1. `vat-orchestration` - which just has a `createAccount()` method to start to request an ICA account on a remote chain
2. `E(chainAccount).getAccountAddress()` returns a chain account address (as well as `.getRemoteAddress()` and `.getLocalAddress()`)
3. Example `stakeAtom.contract.js`, that creates an ICA on a remote chain.
   - expect a 2nd PR for 9042  to send a delegate message
5. Working towards the spec here: https://github.com/agoric-labs/orchestration-api-spec/blob/main/src/index.d.ts


### Outstanding Items
- [x] fix ` @agoric/orchestration -> @agoric/vats -> @agoric/orchestration` dependency cycles
- [x] `getRemoteAddress()` returns a stale value - it should match what is logged in "IBC onConnect"
   - see #9186
- [x] testing - there's a bootstrap test that's not able to verify the full flow. Interested to get feedback on the approach. I think we may need to build out more network mocking for remote connections.
- [x] proto3json - note to self to test if any remote chains currently accept proto3json 
    - unfortunately, `json` | `proto3-json` are not valid for the osmo image i am using ([attempt](https://github.com/Agoric/agoric-sdk/pull/9114#discussion_r1548250202)). Tangentially, Hermes does not propagate an error when the negotiating fails (it stops when simulate_tx fails), so the `createAccount` promise hangs. MF suggests filing a bug.
- [x] ~~`delegate()` - protobuf encoding, so we can a message that doesn't throw an error~~
   - tackling this in a follow up PR
- [x] ~~`e2e` - check in a3p-style test with starship~~
   -  tackling this in a follow up PR
   
### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

The `Port` object is highly authoritative. The Port ID and Connection ID are used by host chains to determine the account address and recover closed channels.

There should be a single source allocating ports, and networkVat should ensure ports are not reused unless someone has a reference to the original port.

See #9165 where this is tracked.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->

