### PR TITLE
fix(xsnap): Address Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,12 @@ packages/stat-logger
 **/_agstate
 .vagrant
 endo-sha.txt
+# We avoid copying these into a docker build context, because we're
+# also not copying the .git directories. If someone runs "docker
+# build" from a non-clean agoric-sdk tree, the build context would
+# have moddable/ source files but no moddable/.git, and that would be
+# confused with an unpacked NPM tarball. See
+# packages/xsnap/src/build.js for details.
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
 packages/xsnap/moddable

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,13 +22,7 @@ packages/stat-logger
 **/_agstate
 .vagrant
 endo-sha.txt
-# We avoid copying these into a docker build context, because we're
-# also not copying the .git directories. If someone runs "docker
-# build" from a non-clean agoric-sdk tree, the build context would
-# have moddable/ source files but no moddable/.git, and that would be
-# confused with an unpacked NPM tarball. See
-# packages/xsnap/src/build.js for details.
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
-packages/xsnap/moddable
-packages/xsnap/xsnap-native
+packages/xsnap/moddable/.git
+packages/xsnap/xsnap-native/.git

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -45,7 +45,7 @@ WORKDIR /usr/src/agoric-sdk
 COPY . .
 
 # add retry for qemu arm64 network fetching and mui issues with qemu
-RUN bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
+RUN XSNAP_IS_IN_DOCKER=1 bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
 
 # Need to build the Node.js node extension that uses our above Golang shared library.
 COPY --from=cosmos-go /usr/src/agoric-sdk/golang/cosmos/build golang/cosmos/build/
@@ -61,7 +61,7 @@ RUN \
   bin/agd build
 
 # Remove dev dependencies.
-RUN rm -rf packages/xsnap/moddable packages/xsnap/xsnap-native/build/tmp
+RUN rm -rf packages/xsnap/moddable packages/xsnap/xsnap-native/xsnap/build/tmp
 RUN mkdir golang/tmp && \
   mv golang/cosmos/package.json golang/cosmos/build golang/cosmos/index.cjs golang/tmp/ && \
   rm -rf golang/cosmos && mv golang/tmp golang/cosmos

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -290,9 +290,10 @@ async function main(args, { env, stdout, spawn, fs, os }) {
   //
   // We short-circuit after a single stat if moddable/.git exists because that
   // implies that moddable/ exists.
+  const isDocker = env.XSNAP_IS_IN_DOCKER;
   const isWorkingCopy =
     fs.existsSync('moddable/.git') || !fs.existsSync('moddable');
-  if (isWorkingCopy) {
+  if (isWorkingCopy && !isDocker) {
     await updateSubmodules(args, { env, stdout, spawn, fs });
   }
   await makeXsnap({ spawn, fs, os });

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -288,7 +288,7 @@ async function main(args, { env, stdout, spawn, fs, os }) {
   // | EXISTS    | ABSENT        | NO           |
   // | EXISTS    | EXISTS        | YES          |
   //
-  if (!env.XSNAP_IN_DOCKER) {
+  if (!env.XSNAP_IS_IN_DOCKER) {
     // We short-circuit after a single stat if moddable/.git exists because that
     // implies that moddable/ exists.
     const isWorkingCopy =

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -288,15 +288,16 @@ async function main(args, { env, stdout, spawn, fs, os }) {
   // | EXISTS    | ABSENT        | NO           |
   // | EXISTS    | EXISTS        | YES          |
   //
-  // We short-circuit after a single stat if moddable/.git exists because that
-  // implies that moddable/ exists.
-  const isDocker = env.XSNAP_IS_IN_DOCKER;
-  const isWorkingCopy =
-    fs.existsSync('moddable/.git') || !fs.existsSync('moddable');
-  if (isWorkingCopy && !isDocker) {
-    await updateSubmodules(args, { env, stdout, spawn, fs });
+  if (!env.XSNAP_IN_DOCKER) {
+    // We short-circuit after a single stat if moddable/.git exists because that
+    // implies that moddable/ exists.
+    const isWorkingCopy =
+      fs.existsSync('moddable/.git') || !fs.existsSync('moddable');
+    if (isWorkingCopy) {
+      await updateSubmodules(args, { env, stdout, spawn, fs });
+    }
+    await makeXsnap({ spawn, fs, os });
   }
-  await makeXsnap({ spawn, fs, os });
 }
 
 const run = () =>


### PR DESCRIPTION
closes: #9121

## Description

This adds an accommodation for Docker in the xsnap build process so that in the presence of an environment variable introduced by the Docker config it will not attempt to install git submodules.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
