### PR TITLE
test(zone,vow): is this a watch revival bug?

### DIFF
--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -33,8 +33,11 @@
     "@endo/pass-style": "^1.2.0"
   },
   "devDependencies": {
+    "@agoric/internal": "^0.3.2",
     "@agoric/swingset-liveslots": "^0.10.2",
+    "@agoric/vow": "^0.1.0",
     "@endo/patterns": "^1.2.0",
+    "@endo/promise-kit": "^1.0.4",
     "ava": "^5.3.0"
   },
   "publishConfig": {

--- a/packages/zone/test/test-upgrade-watch.js
+++ b/packages/zone/test/test-upgrade-watch.js
@@ -1,0 +1,101 @@
+// eslint-disable-next-line import/order
+import {
+  test,
+  getBaggage,
+  annihilate,
+  nextLife,
+} from './prepare-test-env-ava.js';
+
+import { Fail } from '@endo/errors';
+import { passStyleOf } from '@endo/pass-style';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { PromiseWatcherI } from '@agoric/vow/src/watch-promise.js';
+import { makePromiseKit } from '@endo/promise-kit';
+// import { prepareVowTools } from '@agoric/vow';
+import { prepareVowTools as prepareWatchableVowTools } from '@agoric/vat-data/vow.js';
+
+// import { makeHeapZone } from '../heap.js';
+// import { makeVirtualZone } from '../virtual.js';
+import { makeDurableZone } from '../durable.js';
+
+/**
+ * @param {any} t
+ * @param {import('@agoric/base-zone').Zone} zone
+ * @param {any} vowTools
+ */
+const testFirstPlay = async (t, zone, vowTools) => {
+  const { watch, makeVowKit } = vowTools;
+
+  const rupertGiles = zone.exo('RupertGiles', PromiseWatcherI, {
+    onFulfilled(fulfillment) {
+      console.log('should not wake yet', fulfillment);
+    },
+    onRejected(reason) {
+      console.log('should not startle yet', reason);
+    },
+  });
+  const { vow: v1 } = zone.makeOnce('v1', () => makeVowKit());
+  t.is(passStyleOf(v1), 'tagged');
+
+  watch(v1, rupertGiles);
+};
+
+/**
+ * @param {any} t
+ * @param {import('@agoric/base-zone').Zone} zone
+ * @param {any} _vowTools
+ */
+const testReplay = async (t, zone, _vowTools) => {
+  const { promise, resolve, reject } = makePromiseKit();
+
+  zone.exo('RupertGiles', PromiseWatcherI, {
+    onFulfilled(fulfillment) {
+      console.log('woken', fulfillment);
+      resolve(fulfillment);
+    },
+    onRejected(reason) {
+      console.log('startled', reason);
+      reject(reason);
+    },
+  });
+
+  const { vow: v1, resolver: r1 } =
+    /** @type {import('@agoric/vow').VowKit} */ (
+      zone.makeOnce('v1', () => Fail`v1 expected`)
+    );
+  t.is(passStyleOf(v1), 'tagged');
+  console.log('ask to awaken');
+  r1.resolve('wake up');
+  const f = await promise;
+  // BUG? We never get here
+  console.log('fulfilled', f);
+};
+
+// await test.serial('test heap async-flow', async t => {
+//   const zone = makeHeapZone('heapRoot');
+//   const vowTools = prepareVowTools(zone);
+//   return testFirstPlay(t, zone, vowTools);
+// });
+
+// await test.serial('test virtual async-flow', async t => {
+//   annihilate();
+//   const zone = makeVirtualZone('virtualRoot');
+//   const vowTools = prepareVowTools(zone);
+//   return testFirstPlay(t, zone, vowTools);
+// });
+
+await test.serial('test durable async-flow', async t => {
+  annihilate();
+
+  nextLife();
+  const zone1 = makeDurableZone(getBaggage(), 'durableRoot');
+  const vowTools1 = prepareWatchableVowTools(zone1);
+  await testFirstPlay(t, zone1, vowTools1);
+
+  await eventLoopIteration();
+
+  nextLife();
+  const zone2 = makeDurableZone(getBaggage(), 'durableRoot');
+  const vowTools2 = prepareWatchableVowTools(zone2);
+  return testReplay(t, zone2, vowTools2);
+});


### PR DESCRIPTION

closes: #XXXX
refs: #9097 

## Description

Isolates the bug that #9097 is stuck on. As isolated, the problem does reproduce.

I'm following the general testing pattern used in #9097, especially in test-async-flow.js, which is where I'm having this problem. There, see https://github.com/Agoric/agoric-sdk/blob/9a00502ec871ee623b88b1781b74d80abd25fdc5/packages/zone/test/async-flow/test-async-flow.js#L181-L182
I shouldn't need the `asyncFlow.wake()` call. But if I remove it I get the same symptom isolated here:

If I `watch` with an unresolved durable vow and durable watcher in the first incarnation, and then I resolve that durable vow in the second incarnation, the durable watcher that was watching that vow should now wake up. It doesn't.

@michaelfig , is this a bug in watching durable vows across incarnations?

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
