### PR TITLE
build(agd): more careful `stamp.sum` handling

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -150,12 +150,12 @@ runs:
         function diffsha1() {
           stamp=$1
           shift
-          find ${1+"$@"} -exec sha1sum {} \; | sort +1 > "$stamp.new" || true
-          if test ! -s "$stamp.new"; then
+          find ${1+"$@"} -exec sha1sum {} \; | sort +1 > "$stamp.files" || true
+          if test ! -s "$stamp.files"; then
             echo "No new dependencies found for $stamp" 1>&2
             return 0
           fi
-          diff -u "$stamp" "$stamp.new" || return 1
+          diff -u "$stamp" "$stamp.files" || return 1
           return 0
         }
 
@@ -171,9 +171,9 @@ runs:
         mkdir -p "$STAMPS"
         sum="$STAMPS/yarn-installed.sum"
         diffsha1 "$sum" "${files[@]}" || {
-          mv "$sum.new" "$sum"
+          mv "$sum.files" "$sum"
         }
-        rm -f "$sum.new"
+        rm -f "$sum.files"
 
         if test -e ~/endo; then
           # Stage the redirected `yarn install` consequences.

--- a/bin/agd
+++ b/bin/agd
@@ -28,7 +28,7 @@ done
 
 # diffsha1 stamp_name find_args...
 # executes find(1) with the given arguments and saves the resulting file list,
-# then runs $DIGEST_CMD on the file list, saves the digest to file stamp_name.new,
+# then runs $DIGEST_CMD on the file list, saves the digest to file stamp_name.files,
 # and compares to the saved digest in the file stamp_name.
 # Returns success (0) if it cannot write to the temporary files, if the find results are empty,
 # or if the computed digest is the same as the saved digest.
@@ -36,19 +36,19 @@ done
 function diffsha1() {
   stamp=$1
   shift
-  find ${1+"$@"} > "$stamp.new.$$"
-  if test ! -s "$stamp.new.$$"; then
+  find ${1+"$@"} > "$stamp.files.$$"
+  if test ! -s "$stamp.files.$$"; then
     # echo "No new dependencies found for $stamp" 1>&2
-    rm -f "$stamp.new.$$"
+    rm -f "$stamp.files.$$"
     return 0
   fi
-  xargs $DIGEST_CMD <"$stamp.new.$$" | sort +1 > "$stamp.new" || true
-  rm -f "$stamp.new.$$"
-  if test ! -s "$stamp.new"; then
-    rm -f "$stamp.new"
+  xargs $DIGEST_CMD <"$stamp.files.$$" | sort +1 > "$stamp.files" || true
+  rm -f "$stamp.files.$$"
+  if test ! -s "$stamp.files"; then
+    rm -f "$stamp.files"
     return 0
   fi
-  diff -u "$stamp" "$stamp.new" || return 1
+  diff -u "$stamp" "$stamp.files" || return 1
   return 0
 }
 
@@ -177,8 +177,8 @@ ${NO_BUILD:-false} || (
       fi
     )
   }
-  test -f "$sum" || mv -f "$sum.new" "$sum"
-  rm -f "$sum.new"
+  test -f "$sum" || mv -f "$sum.files" "$sum"
+  rm -f "$sum.files"
 
   if $need_nodejs; then
     lazy_yarn() {
@@ -204,9 +204,9 @@ ${NO_BUILD:-false} || (
     diffsha1 "$sum" "${files[@]}" || { echo "$sum has changed"; $do_not_build; } || {
       rm -f "$sum" "$STAMPS/yarn-built"
       lazy_yarn install
-      mv "$sum.new" "$sum"
+      mv "$sum.files" "$sum"
     }
-    rm -f "$sum.new"
+    rm -f "$sum.files"
 
     stamp=$STAMPS/yarn-built
     test -e "$stamp" || {

--- a/bin/agd
+++ b/bin/agd
@@ -26,21 +26,28 @@ for cmd in sha1sum shasum sha1sum; do
   command -v $DIGEST_CMD &>/dev/null && break
 done
 
+# diffsha1 stamp_name find_args...
+# executes find(1) with the given arguments and saves the resulting file list,
+# then runs $DIGEST_CMD on the file list, saves the digest to file stamp_name.new,
+# and compares to the saved digest in the file stamp_name.
+# Returns success (0) if it cannot write to the temporary files, if the find results are empty,
+# or if the computed digest is the same as the saved digest.
+# Returns failure (1) if the computed digest is different.
 function diffsha1() {
   stamp=$1
   shift
-  if ! (true > "$stamp.new") 2>/dev/null; then
-    # echo "Cannot write to $stamp.new" 1>&2
-    return 0
-  fi
-  find ${1+"$@"} > "$stamp.new.files"
-  if test ! -s "$stamp.new.files"; then
+  find ${1+"$@"} > "$stamp.new.$$"
+  if test ! -s "$stamp.new.$$"; then
     # echo "No new dependencies found for $stamp" 1>&2
-    rm -f "$stamp.new.files"
+    rm -f "$stamp.new.$$"
     return 0
   fi
-  xargs $DIGEST_CMD <"$stamp.new.files" | sort +1 > "$stamp.new" || true
-  rm -f "$stamp.new.files"
+  xargs $DIGEST_CMD <"$stamp.new.$$" | sort +1 > "$stamp.new" || true
+  rm -f "$stamp.new.$$"
+  if test ! -s "$stamp.new"; then
+    rm -f "$stamp.new"
+    return 0
+  fi
   diff -u "$stamp" "$stamp.new" || return 1
   return 0
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #8996

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

If there's a missing file, rebuild `agd`, but not if creating the stamps lacks permission.
### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
