### PR TITLE
bump GH runner versions

### DIFF
--- a/.github/actions/get-latest-check/action.yml
+++ b/.github/actions/get-latest-check/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Attach integration-test-result check
       id: attach-check
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         CREATE_IF_NEEDED: '${{ inputs.create-if-needed }}'
       with:

--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: set default environment variables
       run: echo GOPATH="$HOME/go" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: ${{ inputs.path }}
         clean: 'false'

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -45,7 +45,7 @@ runs:
     # the published NPM packages.
     - name: Get the appropriate Endo branch
       id: endo-branch
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         result-encoding: string
         script: |-

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -116,7 +116,7 @@ runs:
       id: system-info
     - name: restore built files
       id: built
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}
         key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-node-${{ inputs.node-version }}-built-${{ inputs.xsnap-random-init }}-${{ github.sha }}-${{ steps.endo-sha.outputs.sha }}

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Reconfigure git to use HTTP authentication
       run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
       shell: bash
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: yarn

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: set default environment variables
       run: echo ESM_DISABLE_CACHE=true >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         clean: false
         submodules: 'true'
@@ -78,7 +78,7 @@ runs:
       if: steps.endo-branch.outputs.result != 'NOPE'
     - name: check out Endo if necessary
       id: endo-checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: agoric/endo
         path: ./replacement-endo

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -31,7 +31,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -11,7 +11,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -48,7 +48,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/[[INSERT_DAPP_NAME]]
           path: dapp

--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: ['18.x', '20.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-node
@@ -41,7 +41,7 @@ jobs:
         # note: only use one node-version
         node-version: ['18.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -100,7 +100,7 @@ jobs:
         node-version: ['18.x']
     if: ${{github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -144,7 +144,7 @@ jobs:
         node-version: ['18.x']
     if: ${{github.event_name == 'push'}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '18.x'
     - name: cache node modules

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version: '18.x'
     - name: cache node modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
         node-version: '18.x'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,7 +18,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: '18.x'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
           - linux/amd64
           - linux/arm64/v8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Save BUILD_TAG
         run: |
           ARCH=$(echo '${{ matrix.platform }}' | tr / _)
@@ -195,7 +195,7 @@ jobs:
       packages: write
     if: ${{ needs.docker-sdk.outputs.tag }} != dev
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Save SDK_TAG
         run: echo "SDK_TAG=${{ needs.snapshot.outputs.tag }}" >> $GITHUB_ENV
       - name: Prefix tags
@@ -245,7 +245,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Save SDK_TAG
         run: echo "SDK_TAG=${{ needs.snapshot.outputs.tag }}" >> $GITHUB_ENV
       - name: Prefix tags

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         mode: [no-failure]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.20'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,7 +65,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -133,7 +133,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate loadgen branch
         id: get-loadgen-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -302,7 +302,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Final integration-test-result
         if: always()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const previousSuccess = ${{ needs.pre_check.outputs.previous_success }};

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
         cli: [link-cli/yarn, registry/yarn, registry/npm, registry/npx]
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
@@ -109,7 +109,7 @@ jobs:
 
     runs-on: ubuntu-22.04 # jammy (LTS)
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -150,7 +150,7 @@ jobs:
             return branch;
 
       - name: Check out loadgen
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/testnet-load-generator
           path: ./testnet-load-generator
@@ -227,7 +227,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "=== After cleanup:"
           df -h
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: docker build (sdk)
         # Produces ghcr.io/agoric/agoric-sdk:unreleased used in the following upgrade test.
         # run: cd packages/deployment && ./scripts/test-docker-build.sh | $TEST_COLLECT
@@ -299,7 +299,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Final integration-test-result
         if: always()
         uses: actions/github-script@v6

--- a/.github/workflows/manage-integration-check.yml
+++ b/.github/workflows/manage-integration-check.yml
@@ -11,7 +11,7 @@ jobs:
       check_id: ${{ steps.create-check.outputs.result }}
     steps:
       - name: Create check
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: create-check
         if: ${{ github.event.action == 'requested' || github.event.action == 'in_progress' }}
         with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update check result
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ github.event.action == 'completed' }}
         with:
           result-encoding: string

--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -53,7 +53,7 @@ jobs:
       ) &&
       !contains(github.event.pull_request.labels.*.name, 'bypass:linear-history')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - shell: bash

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: technote-space/get-diff-action@v4
@@ -28,7 +28,7 @@ jobs:
   breakage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: technote-space/get-diff-action@v4

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         node-version: ['18.x', '20.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-node
@@ -44,7 +44,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install graphviz
         run: sudo apt install -y graphviz
 
@@ -61,7 +61,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: '18.x'
@@ -81,7 +81,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: '18.x'
@@ -107,7 +107,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -200,7 +200,7 @@ jobs:
           echo "node-version=${{ matrix.engine == 'xs' && '18.x' || matrix.engine }}" >> $GITHUB_OUTPUT
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -320,7 +320,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -361,7 +361,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -405,7 +405,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -445,7 +445,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -486,7 +486,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -528,7 +528,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -579,7 +579,7 @@ jobs:
           echo "node-version=${{ matrix.engine == 'xs' && '18.x' || matrix.engine }}" >> $GITHUB_OUTPUT
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -620,7 +620,7 @@ jobs:
           echo "node-version=${{ matrix.engine == 'xs' && '18.x' || matrix.engine }}" >> $GITHUB_OUTPUT
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -664,7 +664,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs-unit' || 'test:unit' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
         # BEGIN-TEST-BOILERPLATE
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -706,7 +706,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs-worker' || 'test:swingset' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
         # BEGIN-TEST-BOILERPLATE
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -37,7 +37,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -54,7 +54,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/dapp-card-store
           path: dapp

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -37,7 +37,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -54,7 +54,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/dapp-otc
           path: dapp

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -54,7 +54,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/dapp-pegasus
           path: dapp

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -37,7 +37,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -54,7 +54,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/dapp-simple-exchange
           path: dapp

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -37,7 +37,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -17,7 +17,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -54,7 +54,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/dapp-treasury
           path: dapp

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -37,7 +37,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -37,7 +37,7 @@ jobs:
       # The default is 'main'
       - name: Get the appropriate dapp branch
         id: get-branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: ['18.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -54,7 +54,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/documentation
           path: dapp

--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -15,7 +15,7 @@ jobs:
   gotest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-golang
         with:
           go-version: '1.20'

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -11,5 +11,5 @@ jobs:
   run-scripts-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: scripts/test/test.sh

--- a/.github/workflows/update-hackathon-branch.yml.DISABLED
+++ b/.github/workflows/update-hackathon-branch.yml.DISABLED
@@ -11,7 +11,7 @@ jobs:
   update-hackathon:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |


### PR DESCRIPTION
no ticket

## Description

https://github.com/Agoric/agoric-sdk/actions/runs/8088946803?pr=9011 warns,
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/github-script@v6, actions/setup-node@v3, kenchan0130/actions-system-info@master, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This bumps all the version numbers. `actions-system-info` always pulls from master so will be solved when https://github.com/kenchan0130/actions-system-info/pull/152 lands.

### Security Considerations

n/a
### Scaling Considerations
n/a

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
n/a

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations
CI
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations
n/a

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
