### PR TITLE
docs(pegasus): Remote<T> -> ERef<T> for board, namesByAddress

### DIFF
--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -33,8 +33,8 @@ export const getCourierPK = (key, keyToCourierPK) => {
  *
  * @typedef {object} CourierArgs
  * @property {ZCF} zcf
- * @property {Remote<BoardDepositFacet>} board
- * @property {Remote<NameHub>} namesByAddress
+ * @property {ERef<BoardDepositFacet>} board
+ * @property {ERef<NameHub>} namesByAddress
  * @property {Denom} sendDenom
  * @property {Brand} localBrand
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -31,8 +31,8 @@ const TRANSFER_PROPOSAL_SHAPE = {
  *
  * @param {object} powers
  * @param {ZCF} powers.zcf the Zoe Contract Facet
- * @param {Remote<BoardDepositFacet>} powers.board where to find depositFacets by boardID
- * @param {Remote<NameHub>} powers.namesByAddress where to find depositFacets by bech32
+ * @param {ERef<BoardDepositFacet>} powers.board where to find depositFacets by boardID
+ * @param {ERef<NameHub>} powers.namesByAddress where to find depositFacets by bech32
  * @param {ReturnType<import('@agoric/vow').prepareVowTools>['when']} powers.when
  *
  * @typedef {import('@agoric/vats').NameHub} NameHub


### PR DESCRIPTION
refs: #9027, #8852 , https://github.com/Agoric/documentation/issues/1031

## Description / Documentation Considerations

`yarn build-ts` was reporting type errors; that interferes with work on reference docs.

It's not clear to me nor to @turadg why `yarn lint` was not reporting errors.

### Security / Scaling / Testing / Upgrade Considerations

I looked for any reason `namesByAddress` or `board` couldn't be a promise; for example, if they were in an exo state and hence in durable storage. I didn't see any.
