### PR TITLE
fix: guard for getGovernedParams

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -302,7 +302,7 @@ const prepareVaultDirector = (
           SubscriberShape,
         ),
         getElectorateSubscription: M.call().returns(SubscriberShape),
-        getGovernedParams: M.call({ collateralBrand: BrandShape }).returns(
+        getGovernedParams: M.callWhen({ collateralBrand: BrandShape }).returns(
           M.record(),
         ),
         getInvitationAmount: M.call(M.string()).returns(AmountShape),
@@ -464,7 +464,12 @@ const prepareVaultDirector = (
         getElectorateSubscription() {
           return directorParamManager.getSubscription();
         },
-        /** @param {{ collateralBrand: Brand }} selector */
+        /**
+         * Note this works only for a collateral manager. For the director use,
+         * `getElectorateSubscription`
+         *
+         * @param {{ collateralBrand: Brand }} selector
+         */
         getGovernedParams({ collateralBrand }) {
           // TODO use named getters of TypedParamManager
           return vaultParamManagers.get(collateralBrand).getParams();

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2015,15 +2015,22 @@ test('governance publisher', async t => {
   ({
     value: { current },
   } = await managerGovNotifier.getUpdateSince());
-  // can't deepEqual because of non-literal objects so check keys and then partial shapes
-  t.deepEqual(Object.keys(current), [
-    'DebtLimit',
-    'InterestRate',
-    'LiquidationMargin',
-    'LiquidationPadding',
-    'LiquidationPenalty',
-    'MintFee',
-  ]);
+  t.deepEqual(
+    current,
+    await E(vfPublic).getGovernedParams({ collateralBrand: aeth.brand }),
+  );
+  t.deepEqual(
+    Object.keys(current),
+    [
+      'DebtLimit',
+      'InterestRate',
+      'LiquidationMargin',
+      'LiquidationPadding',
+      'LiquidationPenalty',
+      'MintFee',
+    ],
+    'param keys differ',
+  );
   t.like(current, {
     DebtLimit: { type: 'amount' },
     InterestRate: { type: 'ratio' },


### PR DESCRIPTION

## Description

Fixes a bug with an incorrect guard for `getGovernedParams`.  Includes regression test.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

Should be included whenever VaultFactory is upgraded. Does not complicate upgrade because nothing was relying on the previous buggy behavior.

A work-around until this is deployed is to read from the subscription.