### PR TITLE
feat(repl): deal with Vows

### DIFF
--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -1,5 +1,7 @@
 import { isPromise } from '@endo/promise-kit';
-import { E, Far } from '@endo/far';
+import { Far } from '@endo/far';
+import { V as E } from '@agoric/vat-data/vow.js';
+import * as vowExports from '@agoric/vat-data/vow.js';
 import * as farExports from '@endo/far';
 
 import { Nat } from '@endo/nat';
@@ -190,6 +192,8 @@ export function getReplHandler(replObjects, send) {
 
   const endowments = {
     ...farExports,
+    ...vowExports,
+    E,
     assert,
     console: replConsole,
     commands,

--- a/packages/vats/test/test-repl.js
+++ b/packages/vats/test/test-repl.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { getReplHandler } from '../src/repl.js';
 
 function make() {
@@ -52,8 +53,7 @@ test('repl: basic eval, eventual promise resolution', async t => {
   t.is(m.histnum, 1);
   t.is(m.display, 'unresolved Promise');
   t.deepEqual(sentMessages, []);
-  await Promise.resolve();
-  await Promise.resolve(); // I don't know why two stalls are needed
+  await eventLoopIteration();
   m = sentMessages.shift();
   t.is(m.type, 'updateHistory');
   t.is(m.histnum, 1);
@@ -194,9 +194,7 @@ test('repl: eventual send', async t => {
   t.is(m.histnum, 1);
   t.is(m.display, 'unresolved Promise');
 
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve(); // I don't know why three stalls are needed
+  await eventLoopIteration();
 
   m = sentMessages.shift();
   t.is(m.type, 'updateHistory');


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Improves the `ag-solo` REPL's handling of vows by using the Vow-aware `E` implementation.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations
n/a

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations
n/a

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

n/a
<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

n/a
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

n/a
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
