### PR TITLE
TypeScript 5.5 with @import tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "type-coverage": "^2.27.1",
     "typedoc": "^0.25.12",
     "typedoc-plugin-markdown": "^3.17.1",
-    "typescript": "^5.4.3",
+    "typescript": "^5.5.0-dev.20240327",
     "typescript-eslint": "^7.3.1"
   },
   "resolutions": {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -33,12 +33,7 @@ import { makeDeviceTranslators } from './deviceTranslator.js';
 import { notifyTermination } from './notifyTermination.js';
 import { makeVatAdminHooks } from './vat-admin-hooks.js';
 
-/**
- * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject
- * @typedef {import('@agoric/swingset-liveslots').VatDeliveryResult} VatDeliveryResult
- * @typedef {import('@agoric/swingset-liveslots').VatSyscallObject} VatSyscallObject
- * @typedef {import('@agoric/swingset-liveslots').VatSyscallResult} VatSyscallResult
- */
+/** @import * as liveslots from '@agoric/swingset-liveslots' */
 
 function abbreviateReplacer(_, arg) {
   if (typeof arg === 'bigint') {
@@ -390,7 +385,7 @@ export default function buildKernel(
    *
    * @param {VatID} vatID
    * @param {KernelDeliveryObject} kd
-   * @param {VatDeliveryObject} vd
+   * @param {liveslots.VatDeliveryObject} vd
    */
   async function deliverAndLogToVat(vatID, kd, vd) {
     vatRequestedTermination = undefined;
@@ -400,7 +395,7 @@ export default function buildKernel(
     const vs = kernelSlog.provideVatSlogger(vatID).vatSlog;
     await null;
     try {
-      /** @type { VatDeliveryResult } */
+      /** @type { liveslots.VatDeliveryResult } */
       const deliveryResult = await vatWarehouse.deliverToVat(vatID, kd, vd, vs);
       insistVatDeliveryResult(deliveryResult);
       // const [ ok, problem, usage ] = deliveryResult;
@@ -1447,8 +1442,8 @@ export default function buildKernel(
     // not
     /**
      *
-     * @param {VatSyscallObject} vatSyscallObject
-     * @returns {VatSyscallResult}
+     * @param {liveslots.VatSyscallObject} vatSyscallObject
+     * @returns {liveslots.VatSyscallResult}
      */
     function vatSyscallHandler(vatSyscallObject) {
       if (!vatWarehouse.lookup(vatID)) {
@@ -1463,7 +1458,7 @@ export default function buildKernel(
       let ksc;
       /** @type { KernelSyscallResult } */
       let kres = harden(['error', 'incomplete']);
-      /** @type { VatSyscallResult } */
+      /** @type { liveslots.VatSyscallResult } */
       let vres = harden(['error', 'incomplete']);
 
       try {

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -1,3 +1,5 @@
+/** @import { ERef } from '@endo/far' */
+
 export {};
 
 /* This file defines types that part of the external API of swingset. That
@@ -353,10 +355,10 @@ export {};
  * @property {VatAdminFacet} adminNode
  *
  * @typedef {object} VatAdminSvc
- * @property {(id: BundleID) => import('@endo/far').ERef<BundleCap>} waitForBundleCap
- * @property {(id: BundleID) => import('@endo/far').ERef<BundleCap>} getBundleCap
- * @property {(name: string) => import('@endo/far').ERef<BundleCap>} getNamedBundleCap
- * @property {(name: string) => import('@endo/far').ERef<BundleID>} getBundleIDByName
- * @property {(bundleCap: BundleCap, options?: DynamicVatOptions) => import('@endo/far').ERef<CreateVatResults>} createVat
+ * @property {(id: BundleID) => ERef<BundleCap>} waitForBundleCap
+ * @property {(id: BundleID) => ERef<BundleCap>} getBundleCap
+ * @property {(name: string) => ERef<BundleCap>} getNamedBundleCap
+ * @property {(name: string) => ERef<BundleID>} getBundleIDByName
+ * @property {(bundleCap: BundleCap, options?: DynamicVatOptions) => ERef<CreateVatResults>} createVat
  *
  */

--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -2,6 +2,8 @@ import { Fail, q } from '@agoric/assert';
 import { kunser } from '@agoric/kmarshal';
 import { makeQueue } from '@endo/stream';
 
+/** @import { ERef } from '@endo/far' */
+
 /**
  * @param {import('../src/controller/controller.js').SwingsetController} controller
  */
@@ -15,7 +17,7 @@ export const makeRunUtils = controller => {
    * Wait for exclusive access to the controller, then before relinquishing that access,
    * enqueue and process a delivery and return the result.
    *
-   * @param {() => import('@endo/far').ERef<void | ReturnType<controller['queueToVatObject']>>} deliveryThunk
+   * @param {() => ERef<void | ReturnType<controller['queueToVatObject']>>} deliveryThunk
    * function for enqueueing a delivery and returning the result kpid (if any)
    * @param {boolean} [voidResult] whether to ignore the result
    * @returns {Promise<any>}

--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -1,7 +1,7 @@
 /* global process */
 // @ts-check
 
-/** @typedef {import('child_process').ChildProcess} ChildProcess */
+/** @import { ChildProcess } from 'child_process' */
 
 export const getSDKBinaries = ({
   jsPfx = '../..',

--- a/packages/agoric-cli/test/test-inter-cli.js
+++ b/packages/agoric-cli/test/test-inter-cli.js
@@ -12,8 +12,10 @@ import { fmtBid, makeInterCommand } from '../src/commands/inter.js';
 
 const { entries } = Object;
 
-/** @typedef {import('commander').Command} Command */
-/** @typedef {import('@agoric/vats/tools/board-utils.js').BoardRemote} BoardRemote */
+/**
+ * @import { Command } from 'commander';
+ * @import { BoardRemote } from '@agoric/vats/tools/board-utils.js';
+ */
 
 /**
  * @param {{ boardId: string, iface: string }} detail

--- a/packages/cache/src/types.js
+++ b/packages/cache/src/types.js
@@ -7,7 +7,7 @@ import '@agoric/store/exported.js';
 // Ensure this is a module.
 export {};
 
-/** @template T @typedef {import('@endo/far').ERef<T>} ERef */
+/** @import { ERef } from '@endo/far' */
 
 /**
  * @typedef {object} Updater

--- a/packages/casting/src/types.js
+++ b/packages/casting/src/types.js
@@ -5,7 +5,7 @@ import '@agoric/notifier';
 
 export {};
 
-/** @template T @typedef {import('@endo/far').ERef<T>} ERef */
+/** @import { ERef } from '@endo/far' */
 
 /**
  * @typedef {object} LeaderOptions

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -70,7 +70,7 @@
     "publish-scripts": "0.1.0",
     "rimraf": "^5.0.0",
     "tsimp": "^2.0.11",
-    "typescript": "^5.4.3"
+    "typescript": "^5.5.0-dev.20240327"
   },
   "dependencies": {
     "@cosmjs/amino": "^0.32.3",

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -3,6 +3,8 @@ import { E } from '@endo/far';
 import { isObject, isPassableSymbol } from '@endo/marshal';
 import { getInterfaceMethodKeys } from '@endo/patterns';
 
+/** @import { ERef } from '@endo/far' */
+
 const { Fail, quote: q } = assert;
 
 const { fromEntries } = Object;
@@ -101,9 +103,9 @@ harden(makeSyncFunctionCallback);
  * Create a callback from a potentially far function.
  *
  * @template {(...args: unknown[]) => any} I
- * @template {import('@endo/far').ERef<
+ * @template {ERef<
  *   (...args: [...B, ...Parameters<I>]) => ReturnType<I>
- * >} [T=import('@endo/far').ERef<I>]
+ * >} [T=ERef<I>]
  * @template {unknown[]} [B=[]]
  * @param {T} target
  * @param {B} bound
@@ -149,9 +151,9 @@ harden(makeSyncMethodCallback);
  *
  * @template {(...args: unknown[]) => any} I
  * @template {PropertyKey} P
- * @template {import('@endo/far').ERef<{
+ * @template {ERef<{
  *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>
- * }>} [T=import('@endo/far').ERef<{ [x in P]: I }>]
+ * }>} [T=ERef<{ [x in P]: I }>]
  * @template {unknown[]} [B=[]]
  * @param {T} target
  * @param {P} methodName

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -5,6 +5,8 @@ import { M } from '@endo/patterns';
 import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import * as cb from './callback.js';
 
+/** @import { ERef } from '@endo/far' */
+
 const { Fail } = assert;
 
 /** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
@@ -248,7 +250,7 @@ const makeNullStorageNode = () => {
  * falling back to an inert object with the correct interface (but incomplete
  * behavior) when that is unavailable.
  *
- * @param {import('@endo/far').ERef<StorageNode?>} storageNodeRef
+ * @param {ERef<StorageNode?>} storageNodeRef
  * @param {string} childName
  * @returns {Promise<StorageNode>}
  */
@@ -261,8 +263,8 @@ harden(makeStorageNodeChild);
 
 // TODO find a better module for this
 /**
- * @param {import('@endo/far').ERef<StorageNode>} storageNode
- * @param {import('@endo/far').ERef<Marshaller>} marshaller
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  * @returns {(value: unknown) => Promise<void>}
  */
 export const makeSerializeToStorage = (storageNode, marshaller) => {

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -12,7 +12,7 @@ const { quote: q, Fail } = assert;
 
 export const BASIS_POINTS = 10_000n;
 
-/** @template T @typedef {import('@endo/eventual-send').ERef<T>} ERef<T> */
+/** @import { ERef } from '@endo/far' */
 
 /**
  * @template T

--- a/packages/kmarshal/src/kmarshal.js
+++ b/packages/kmarshal/src/kmarshal.js
@@ -2,6 +2,8 @@ import { Far, passStyleOf } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import { assert, Fail } from '@agoric/assert';
 
+/** @import { ERef } from '@endo/far' */
+
 // Simple wrapper for serializing and unserializing marshalled values inside the
 // kernel, where we don't actually want to use clists nor actually allocate real
 // objects, but instead to stay entirely within the domain of krefs.  This is
@@ -98,7 +100,7 @@ harden(makeStandinPromise);
 /**
  * @param {string} kref
  * @param {string} [iface]
- * @returns {import('@endo/eventual-send').ERef<KCap>}
+ * @returns {ERef<KCap>}
  */
 export const kslot = (kref, iface = 'undefined') => {
   assert.typeof(kref, 'string');

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -1,9 +1,6 @@
 // @jessie-check
 
-/**
- * @template T
- * @typedef {import('@endo/far').ERef<T>} ERef
- */
+/** @import { ERef } from '@endo/far' */
 
 /**
  * @template T

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -21,9 +21,10 @@ export const delayByTurns = async turnCount => {
   }
 };
 
-/** @typedef {import('@endo/marshal').Passable} Passable */
-
-/** @typedef {import('ava').Assertions} Assertions */
+/**
+ * @import { Passable } from '@endo/marshal'
+ * @import { Assertions} from 'ava'
+ */
 
 const obj = harden({});
 const unresP = new Promise(_ => {});

--- a/patches/eslint-plugin-jsdoc+47.0.2.patch
+++ b/patches/eslint-plugin-jsdoc+47.0.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/eslint-plugin-jsdoc/dist/tagNames.js b/node_modules/eslint-plugin-jsdoc/dist/tagNames.js
+index 4d27508..2d9aeb5 100644
+--- a/node_modules/eslint-plugin-jsdoc/dist/tagNames.js
++++ b/node_modules/eslint-plugin-jsdoc/dist/tagNames.js
+@@ -102,6 +102,8 @@ const jsdocTags = exports.jsdocTags = {
+  */
+ const typeScriptTags = exports.typeScriptTags = {
+   ...jsdocTags,
++  // https://github.com/microsoft/TypeScript/issues/22160
++  import: [],
+   // https://www.typescriptlang.org/tsconfig/#stripInternal
+   internal: [],
+   // https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#overload-support-in-jsdoc

--- a/yarn.lock
+++ b/yarn.lock
@@ -11606,7 +11606,12 @@ typescript-eslint@^7.3.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^5.4.3, typescript@~5.4.2:
+typescript@^5.5.0-dev.20240327:
+  version "5.5.0-dev.20240327"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240327.tgz#bd5aa22496947a32eef83f2339b04c51cccaebaf"
+  integrity sha512-8nAu1p3cwPDGwuJ2XyLonUMdWYtHIyFRi/3qA0FYNmArajdxYW15fh9szcDlLF1nPz/3kM7sbT1q8K7GLTPvxA==
+
+typescript@~5.4.2:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
   integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==


### PR DESCRIPTION
_no ticket_

## Description

Adopts the 5.5 nightly to get the `@import` tag. T [release plan](https://github.com/microsoft/TypeScript/issues/57475) says there will be a beta release on Apr 16. Reviewers, please evaluate whether it's worth using this pinned nightly until then.

Includes a patch for https://github.com/gajus/eslint-plugin-jsdoc/issues/1218

Also demonstrates a few instances of adopting the new syntax. I propose we get the capability into trunk first and separately adopt it. I think I could mostly automate it with a regex but I'd want to make that a short-lived PR to avoid merge conflicts.

### Security Considerations

n/a, build only

### Scaling Considerations

n/a, build only

### Documentation Considerations

Once adopted we'll need to update our TypeScript style guide.

### Testing Considerations

CI and also local dev. E.g. IDEs must be configured to use the workspace TypeScript version instead of what's built in. I've tested with VS Code. Maybe @Chris-Hibbert can test with JetBrains.

### Upgrade Considerations

Should not affect runtime.
