### PR TITLE
refactor: slightly better marshal identification for diagnostics

### DIFF
--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -210,7 +210,7 @@ export async function initializeKernel(config, kernelStorage, options = {}) {
       serializeBodyFormat: 'smallcaps',
       // TODO Temporary hack.
       // See https://github.com/Agoric/agoric-sdk/issues/2780
-      errorIdNum: 60000,
+      errorIdNum: 60_000,
     });
     const args = kunser(m.serialize(harden([vatObj0s, deviceObj0s])));
     const rootKref = exportRootObject(kernelKeeper, bootstrapVatID);

--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -74,11 +74,11 @@ export function buildSerializationTools(syscall, deviceName) {
   }
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
-    marshalName: `device:${deviceName}`,
+    marshalName: `deviceTools:${deviceName}`,
     serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
-    errorIdNum: 60000,
+    errorIdNum: 40_000,
   });
 
   // for invoke(), these will unserialize the arguments, and serialize the

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -107,7 +107,7 @@ export function makeDeviceSlots(
     serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
-    errorIdNum: 50000,
+    errorIdNum: 50_000,
   });
 
   function PresenceHandler(importSlot) {

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -564,7 +564,7 @@ function build(
     serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
-    errorIdNum: 70000,
+    errorIdNum: 70_000,
     marshalSaveError: err =>
       // By sending this to `console.warn`, under cosmic-swingset this is
       // controlled by the `console` option given to makeLiveSlots.

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -242,6 +242,9 @@ export function makeFakeLiveSlotsStuff(options = {}) {
 
   const marshal = makeMarshal(convertValToSlot, convertSlotToVal, {
     serializeBodyFormat: 'smallcaps',
+    marshalName: 'fakeLiveSlots',
+    errorIdNum: 80_000,
+    marshalSaveError: _err => {},
   });
 
   function registerEntry(baseRef, val, valIsCohort) {

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -340,7 +340,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       marshalName: 'hydration',
       // TODO Temporary hack.
       // See https://github.com/Agoric/agoric-sdk/issues/2780
-      errorIdNum: 30000,
+      errorIdNum: 30_000,
       serializeBodyFormat: 'smallcaps',
     },
   );


### PR DESCRIPTION

closes: #XXXX
refs: #9097 #9154 

## Description

Staged on #9154 to enable #9097 to be easily restaged on both.

Originally extracted from #9097. Motivated by the lack of self-identification of the marshal in `fakeVirtualSupport.js`. But as long as I was looking at that, made each of our existing marshal self-identifications a bit clearer. Gave each a unique prefix name and a distinct starting number.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
nothing for testing per se.

Helps slightly with debugging.
### Upgrade Considerations
these identifications do not show up in any durable data, so none.