### PR TITLE
feat(vow): VowShape, isVow

### DIFF
--- a/packages/swingset-liveslots/src/watchedPromises.js
+++ b/packages/swingset-liveslots/src/watchedPromises.js
@@ -2,9 +2,10 @@
 // no-lonely-if is a stupid rule that really should be disabled globally
 /* eslint-disable no-lonely-if */
 
+import { Fail } from '@endo/errors';
+import { E } from '@endo/eventual-send';
 import { assert } from '@agoric/assert';
 import { initEmpty, M } from '@agoric/store';
-import { E } from '@endo/eventual-send';
 import { parseVatSlot } from './parseVatSlots.js';
 
 /**
@@ -198,7 +199,10 @@ export function makeWatchedPromiseManager({
       const watcherVref = convertValToSlot(watcher);
       assert(watcherVref, 'invalid watcher');
       const { virtual, durable } = parseVatSlot(watcherVref);
-      assert(virtual || durable, 'promise watcher must be a virtual object');
+      virtual ||
+        durable ||
+        // separate line so easy to breakpoint on
+        Fail`promise watcher must be a virtual object`;
       if (watcher.onFulfilled) {
         assert.typeof(watcher.onFulfilled, 'function');
       }

--- a/packages/vow/src/index.js
+++ b/packages/vow/src/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 export * from './tools.js';
 export { default as makeE } from './E.js';
+export { VowShape } from './vow-utils.js';
 
 // eslint-disable-next-line import/export
 export * from './types.js';

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -122,3 +122,11 @@ export {};
  * @template [T=any]
  * @typedef {import('./types.js').ERef<T | import('./types.js').Vow<T>>} Specimen
  */
+
+/**
+ * @typedef {object} VowTools
+ * // TODO type according to prepareWatch returns
+ * @property {(specimenP:any, watcher?:any, watcherContext?:any) => Vow} watch
+ * @property {(specimenP:any, onFulfilled?:any, onRejected?:any) => Promise} when
+ * @property {() => VowKit} makeVowKit
+ */

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -126,7 +126,7 @@ export {};
 /**
  * @typedef {object} VowTools
  * // TODO type according to prepareWatch returns
- * @property {(specimenP:any, watcher?:any, watcherContext?:any) => Vow} watch
- * @property {(specimenP:any, onFulfilled?:any, onRejected?:any) => Promise} when
- * @property {() => VowKit} makeVowKit
+ * @property {import('./watch.js').Watch} watch
+ * @property {import('./when.js').When} when
+ * @property {<T = any>() => VowKit<T>} makeVowKit
  */

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -125,7 +125,6 @@ export {};
 
 /**
  * @typedef {object} VowTools
- * // TODO type according to prepareWatch returns
  * @property {import('./watch.js').Watch} watch
  * @property {import('./when.js').When} when
  * @property {<T = any>() => VowKit<T>} makeVowKit

--- a/packages/vow/src/vow-utils.js
+++ b/packages/vow/src/vow-utils.js
@@ -1,11 +1,20 @@
 // @ts-check
 import { E as basicE } from '@endo/eventual-send';
-import { getTag, passStyleOf } from '@endo/pass-style';
-
-// TODO: `isPassable` should come from @endo/pass-style
-import { isPassable } from '@agoric/base-zone';
+import { isPassable } from '@endo/pass-style';
+import { M, matches } from '@endo/patterns';
 
 export { basicE };
+
+export const VowShape = M.tagged(
+  'Vow',
+  M.splitRecord({
+    vowV0: M.remotable('VowV0'),
+  }),
+);
+
+export const isVow = specimen =>
+  isPassable(specimen) && matches(specimen, VowShape);
+harden(isVow);
 
 /**
  * A vow is a passable tagged as 'Vow'.  Its payload is a record with
@@ -19,11 +28,7 @@ export { basicE };
  * @returns {import('./types').VowPayload<T> | undefined} undefined if specimen is not a vow, otherwise the vow's payload.
  */
 export const getVowPayload = specimen => {
-  const isVow =
-    isPassable(specimen) &&
-    passStyleOf(specimen) === 'tagged' &&
-    getTag(specimen) === 'Vow';
-  if (!isVow) {
+  if (!isVow(specimen)) {
     return undefined;
   }
 
@@ -32,3 +37,4 @@ export const getVowPayload = specimen => {
   );
   return vow.payload;
 };
+harden(getVowPayload);


### PR DESCRIPTION
closes: #XXXX
refs: #9097 #9153

## Description

Initially extracted from #9097. 

Introduces an explicit `VowShape` --- a pattern for recognizing vows --- and an `isVow` predicate that uses that shape. Tightens `getPayload` so it only applies to vows that satisfy these conditions.

Also exports a new `VowTools` type.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

none
### Upgrade Considerations

The pattern is currently too specific to what vows look like in the current implementation of vow. The vow representation was explicitly designed to enable other vow representations in the future. It is unclear if the `VowShape` pattern should be loosened to accommodate that, at the risk of accepting non-vows, or if the `VowShape` pattern should evolve as vow representations evolve.

The current `VowShape` in this PR does already use `M.splitRecord` which should be adequate to anticipate the most likely evolutions of vow representations.