### PR TITLE
feat(xsnap): Build sensitivity to presence of build toolchain

### DIFF
--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "repl": "node src/xsrepl.js",
     "build:bin": "if test -d ./test; then node src/build.js; else yarn build:from-env; fi",
-    "build:env": "test -d ./test && node src/build.js --show-env > build.env",
+    "build:env": "node src/build.js --show-env > build.env",
     "build:from-env": "{ cat build.env; echo node src/build.js; } | xargs env",
     "build": "yarn build:bin && yarn build:env",
     "postinstall": "yarn build:from-env",

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -50,7 +50,14 @@
     "LICENSE*",
     "api.js",
     "build.env",
-    "src"
+    "moddable/modules/data",
+    "moddable/xs/includes",
+    "moddable/xs/makefiles",
+    "moddable/xs/platforms/*.h",
+    "moddable/xs/sources",
+    "src",
+    "xsnap-native/xsnap/makefiles",
+    "xsnap-native/xsnap/sources"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/xsnap/scripts/test-package.sh
+++ b/packages/xsnap/scripts/test-package.sh
@@ -14,8 +14,8 @@ yarn pack -f "$TEMP/package.tar"
   cd "$TEMP"
   tar xvf package.tar
   cd package
-  yarn
-  time yarn build
-  time yarn build
-  time yarn build
+  time yarn
+  time yarn
+  time yarn
+  time yarn
 )

--- a/packages/xsnap/scripts/test-package.sh
+++ b/packages/xsnap/scripts/test-package.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Verifies that files in package.json covers everything xsnap needs to compile
+# from sources out of an npm package.
+set -xueo pipefail
+
+TEMP=$(mktemp -d)
+# function cleanup() {
+#   rm -rf "$TEMP"
+# }
+# trap cleanup EXIT
+
+yarn pack -f "$TEMP/package.tar"
+(
+  cd "$TEMP"
+  tar xvf package.tar
+  cd package
+  yarn
+  time yarn build
+  time yarn build
+  time yarn build
+)

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -326,7 +326,7 @@ async function main(args, { env, stdout, spawn, fs, os }) {
     hasSource = true;
   }
 
-  if (hasSource) {
+  if (hasSource && !showEnv) {
     await makeXsnap({ spawn, fs, os });
   } else if (!hasBin) {
     throw new Error(

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -313,8 +313,8 @@ async function main(args, { env, stdout, spawn, fs, os }) {
   const hasBin = fs.existsSync(
     asset(`../xsnap-native/xsnap/build/bin/${platform}/release/xsnap-worker`),
   );
-  let hasSource = fs.existsSync(asset('moddable/xs/includes/xs.h'));
-  const hasGit = fs.existsSync(asset('moddable/.git'));
+  let hasSource = fs.existsSync(asset('../moddable/xs/includes/xs.h'));
+  const hasGit = fs.existsSync(asset('../moddable/.git'));
   const isWorkingCopy = hasGit || (!hasSource && !hasBin);
   const showEnv = args.includes('--show-env');
 

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -326,12 +326,14 @@ async function main(args, { env, stdout, spawn, fs, os }) {
     hasSource = true;
   }
 
-  if (hasSource && !showEnv) {
-    await makeXsnap({ spawn, fs, os });
-  } else if (!hasBin) {
-    throw new Error(
-      'XSnap has neither sources nor a pre-built binary. Docker? .dockerignore? npm files?',
-    );
+  if (!showEnv) {
+    if (hasSource) {
+      await makeXsnap({ spawn, fs, os });
+    } else if (!hasBin) {
+      throw new Error(
+        'XSnap has neither sources nor a pre-built binary. Docker? .dockerignore? npm files?',
+      );
+    }
   }
 }
 

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -139,7 +139,7 @@ const makeSubmodule = (path, repoUrl, { git }) => {
 };
 
 /**
- * @param {string[]} args
+ * @param {boolean} showEnv
  * @param {{
  *   env: Record<string, string | undefined>,
  *   stdout: typeof process.stdout,
@@ -151,7 +151,7 @@ const makeSubmodule = (path, repoUrl, { git }) => {
  *   },
  * }} io
  */
-const updateSubmodules = async (args, { env, stdout, spawn, fs }) => {
+const updateSubmodules = async (showEnv, { env, stdout, spawn, fs }) => {
   const git = makeCLI('git', { spawn });
 
   // When changing/adding entries here, make sure to search the whole project
@@ -173,7 +173,7 @@ const updateSubmodules = async (args, { env, stdout, spawn, fs }) => {
   ];
 
   await null;
-  if (args.includes('--show-env')) {
+  if (showEnv) {
     for (const submodule of submodules) {
       const { path, envPrefix, commitHash } = submodule;
       if (!commitHash) {
@@ -316,9 +316,13 @@ async function main(args, { env, stdout, spawn, fs, os }) {
   let hasSource = fs.existsSync(asset('moddable/xs/includes/xs.h'));
   const hasGit = fs.existsSync(asset('moddable/.git'));
   const isWorkingCopy = hasGit || (!hasSource && !hasBin);
+  const showEnv = args.includes('--show-env');
 
-  if (isWorkingCopy || args.includes('--show-env')) {
-    await updateSubmodules(args, { env, stdout, spawn, fs });
+  if (isWorkingCopy || showEnv) {
+    if (showEnv && !isWorkingCopy) {
+      throw new Error('XSnap requires a working copy and git to --show-env');
+    }
+    await updateSubmodules(showEnv, { env, stdout, spawn, fs });
     hasSource = true;
   }
 

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -98,7 +98,7 @@ export async function xsnap(options) {
   const platform = {
     Linux: 'lin',
     Darwin: 'mac',
-    Windows_NT: 'win',
+    // Windows_NT: 'win', // One can dream.
   }[os];
 
   if (platform === undefined) {


### PR DESCRIPTION
<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #8536

## Description

For those just tuning in, @warner [took a run](https://github.com/Agoric/agoric-sdk/compare/release-getting-started...warner/8536-xsnap-without-git) at making `yarn` build `xsnap` just once when it’s initially installed. I then took a run at [landing](https://github.com/Agoric/agoric-sdk/pull/9113) the [described fix](https://github.com/Agoric/agoric-sdk/issues/8536) and discovered a problem with building in Docker and reverted.

The changes you see before you unrevert the revert and go on to address the issue with Docker. Except, we do not update `.dockerignore`. We do not do anything special for the `Docker` environment because the new `Dockerfile.sdk` doesn’t require accommodation. We *might* in some future change make the `postinstall` script gracefully handle a Docker environment that has a binary but no sources, and we’ve laid some groundwork, but that case is still not supported.

Elaborating on the original plan, it also turns out to be insufficient to assume the presence of a `moddable` directory implies the existence of checked-out files under some circumstances (Documentation CI). So, we must be more specific about a file that would have been checked out. I chose the `xs.h` header arbitrarily.

This attempt otherwise resembles #9113 and ensures the C sources get published to `npm` so the recipient doesn’t have to `git` update submodules and this _presumably_ is why `make` remembers where it left off when you `yarn` again later.

Documentation integration PR (this regressed last time) https://github.com/Agoric/documentation/pull/1050

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
