### PR TITLE
test(boot): remove some unused imports

### DIFF
--- a/packages/boot/test/bootstrapTests/test-zcf-upgrade.ts
+++ b/packages/boot/test/bootstrapTests/test-zcf-upgrade.ts
@@ -42,7 +42,7 @@ export const makeZoeTestContext = async t => {
     configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
   });
 
-  const { controller, runUtils } = swingsetTestKit;
+  const { runUtils } = swingsetTestKit;
   console.timeLog('DefaultTestContext', 'swingsetTestKit');
   const { EV } = runUtils;
 
@@ -66,7 +66,6 @@ export const makeZoeTestContext = async t => {
 
   return {
     ...swingsetTestKit,
-    controller,
     agoricNamesRemotes,
     zoeDriver,
   };

--- a/packages/boot/test/bootstrapTests/test-zcf-upgrade.ts
+++ b/packages/boot/test/bootstrapTests/test-zcf-upgrade.ts
@@ -4,18 +4,11 @@ import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import bundleSource from '@endo/bundle-source';
 
-import processAmbient from 'child_process';
-import { promises as fsAmbientPromises } from 'fs';
 import path from 'path';
 
-import { BridgeHandler } from '@agoric/vats';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
 import { TestFn } from 'ava';
-import {
-  matchAmount,
-  makeProposalExtractor,
-  makeSwingsetTestKit,
-} from '../../tools/supports.ts';
+import { matchAmount, makeSwingsetTestKit } from '../../tools/supports.ts';
 import { makeZoeDriver } from '../../tools/drivers.ts';
 
 const filename = new URL(import.meta.url).pathname;


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

minor fix for a minor irritation noticed while looking at this file. I don't know why `yarn lint` doesn't complain about these unused imports, not why `yarn lint-fix` does not remove them.

No implications under the uninvestigated assumption that none of these importings themselves perform any relevant side-effects.

And a drive-by simplification (`controller`) that must be observationally equivalent.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
none
### Upgrade Considerations
none