### PR TITLE
fix getting-started

### DIFF
--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -1,6 +1,10 @@
 // @jessie-check
 
 /// <reference types="ses"/>
+/**
+ * @import {Passable} from '@endo/pass-style')
+ * @import {CopySet, Key} from '@endo/patterns')
+ */
 
 /**
  * @template {AssetKind} [K=AssetKind]

--- a/packages/builders/scripts/inter-protocol/deploy-contracts.js
+++ b/packages/builders/scripts/inter-protocol/deploy-contracts.js
@@ -3,6 +3,7 @@ import url from 'url';
 import { makeHelpers } from '@agoric/deploy-script-support';
 import { E } from '@endo/eventual-send';
 import { getCopyMapEntries, makeCopyMap } from '@agoric/store';
+/** @import {CopyMap} from '@endo/patterns' */
 
 // TODO: CLI options to choose contracts
 const contractRefs = [

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -4,6 +4,7 @@ import { matches, makeScalarMapStore } from '@agoric/store';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { untilTrue } from '@agoric/internal';
 import { withGroundState, makeState } from './state.js';
+/** @import {Passable} from '@endo/pass-style' */
 
 /**
  * @param {(obj: unknown) => unknown} [sanitize]

--- a/packages/cache/src/types.js
+++ b/packages/cache/src/types.js
@@ -7,7 +7,10 @@ import '@agoric/store/exported.js';
 // Ensure this is a module.
 export {};
 
-/** @import { ERef } from '@endo/far' */
+/**
+ * @import { ERef } from '@endo/far'
+ * @import {Passable} from '@endo/pass-style'
+ */
 
 /**
  * @typedef {object} Updater

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -20,11 +20,8 @@ export const SECONDS_PER_HOUR = 60n * 60n;
 export const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
 export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 
-/**
- * @typedef {import('../vaultFactory/vaultFactory.js').VaultFactoryContract['publicFacet']} VaultFactoryPublicFacet
- * @import {AuctioneerPublicFacet} from '../auction/auctioneer.js'
- * @import {AuctioneerCreatorFacet} from '../auction/auctioneer.js'
- */
+/** @import {start as VFStart} from '../vaultFactory/vaultFactory.js' */
+/** @typedef {Awaited<ReturnType<VFStart>>['publicFacet']} VaultFactoryPublicFacet */
 
 /**
  * @typedef {object} PSMKit
@@ -63,9 +60,7 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
  *   reserveKit: GovernanceFacetKit<
  *     import('../reserve/assetReserve.js')['start']
  *   >;
- *   vaultFactoryKit: GovernanceFacetKit<
- *     import('../vaultFactory/vaultFactory.js')['start']
- *   >;
+ *   vaultFactoryKit: GovernanceFacetKit<VFStart>;
  *   auctioneerKit: AuctioneerKit;
  *   minInitialDebt: NatValue;
  * }>} EconomyBootstrapSpace

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -2,6 +2,8 @@ import { WalletName } from '@agoric/internal';
 import { getCopyMapEntries, makeCopyMap } from '@agoric/store';
 import { E } from '@endo/far';
 
+/** @import {CopyMap} from '@endo/patterns') */
+
 const { Fail } = assert;
 
 /**

--- a/packages/internal/src/config.js
+++ b/packages/internal/src/config.js
@@ -22,6 +22,7 @@ export const BridgeId = {
   PROVISION: 'provision',
   PROVISION_SMART_WALLET: 'provisionWallet',
   VLOCALCHAIN: 'vlocalchain',
+  VTRANSFER: 'vtransfer',
   WALLET: 'wallet',
 };
 harden(BridgeId);

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -1406,6 +1406,7 @@ export function prepareLoopbackProtocolHandler(zone, { watch, allVows }) {
     },
   );
 
+  /** @param {string} [instancePrefix] */
   const makeLoopbackProtocolHandler = instancePrefix => {
     const { protocolHandler } = makeLoopbackProtocolHandlerKit(instancePrefix);
     return harden(protocolHandler);

--- a/packages/store/exported.d.ts
+++ b/packages/store/exported.d.ts
@@ -1,0 +1,35 @@
+/* eslint-disable -- doesn't understand .d.ts */
+/**
+ * @file re-export types into global namespace, for consumers that expect these
+ *   to be ambient
+ */
+import {
+  LegacyMap as _LegacyMap,
+  LegacyWeakMap as _LegacyWeakMap,
+  MapStore as _MapStore,
+  SetStore as _SetStore,
+  StoreOptions as _StoreOptions,
+  WeakMapStore as _WeakMapStore,
+  WeakSetStore as _WeakSetStore,
+} from './src/types.js';
+import { Pattern as _Pattern } from '@endo/patterns';
+
+// export everything
+export * from './src/types.js';
+
+// re-export types into global namespace, for consumers that expect these to be
+//  ambient
+declare global {
+  export {
+    _LegacyMap as LegacyMap,
+    _LegacyMap as LegacyMap,
+    _LegacyWeakMap as LegacyWeakMap,
+    _MapStore as MapStore,
+    _SetStore as SetStore,
+    _StoreOptions as StoreOptions,
+    _WeakMapStore as WeakMapStore,
+    _WeakSetStore as WeakSetStore,
+    // other packages
+    _Pattern as Pattern,
+  };
+}

--- a/packages/store/exported.js
+++ b/packages/store/exported.js
@@ -1,1 +1,1 @@
-import './src/types.js';
+// Dummy file for .d.ts twin to declare ambients

--- a/packages/store/src/stores/scalarMapStore.js
+++ b/packages/store/src/stores/scalarMapStore.js
@@ -18,6 +18,11 @@ import { makeCurrentKeysKit } from './store-utils.js';
 const { quote: q } = assert;
 
 /**
+ * @import {Passable} from '@endo/pass-style')
+ * @import {Key} from '@endo/patterns')
+ */
+
+/**
  * @template {Key} K
  * @template {Passable} V
  * @param {Map<K, V>} jsmap

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -8,6 +8,8 @@ import {
 
 const { quote: q, Fail } = assert;
 
+/** @import {WeakSetStore} from '@agoric/store/exported.js'; */
+
 /**
  * @template K
  * @param {WeakSet<K & object>} jsset

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -1,21 +1,14 @@
 /// <reference types="ses"/>
 
+// Ensure this is a module.
+export {};
+
 /**
  * Note TODO https://github.com/endojs/endo/issues/1488
  *
  * @import {Passable} from '@endo/pass-style'
- */
-/** @import {CopyTagged} from '@endo/pass-style' */
-/** @import {Pattern} from '@endo/patterns' */
-/** @import {Key} from '@endo/patterns' */
-/**
- * @template {Key} [K=Key]
- * @typedef {import('@endo/patterns').CopySet<K>} CopySet
- */
-/**
- * @template {Key} [K=Key]
- * @template {Passable} [V=Passable]
- * @typedef {import('@endo/patterns').CopyMap<K, V>} CopyMap
+ * @import {CopySet, CopyMap, Pattern} from '@endo/patterns'
+ * @import {Key} from '@endo/patterns'
  */
 
 /**

--- a/packages/store/test/perf-patterns.js
+++ b/packages/store/test/perf-patterns.js
@@ -17,6 +17,7 @@ import {
   ProposalShape,
 } from './borrow-guards.js';
 import '../src/types.js';
+/** @import {Passable} from '@endo/pass-style' */
 
 const gcAndFinalize = makeGcAndFinalize(engineGC);
 

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -3,7 +3,9 @@
 import { Fail } from '@agoric/assert';
 import { provideLazy } from '@agoric/store';
 
-/** @type {import('@agoric/swingset-liveslots').VatData} */
+/** @import {Baggage, PickFacet, VatData} from '@agoric/swingset-liveslots' */
+
+/** @type {VatData} */
 let VatDataGlobal;
 if ('VatData' in globalThis) {
   globalThis.VatData || Fail`VatData defined in global as null or undefined`;
@@ -62,7 +64,7 @@ export const {
  *
  *     const makeFoo = pickFacet(makeFooBase, 'self');
  *
- * @type {import('@agoric/swingset-liveslots').PickFacet}
+ * @type {PickFacet}
  */
 export const pickFacet =
   (maker, facetName) =>
@@ -83,33 +85,8 @@ export const partialAssign = (target, source) => {
 };
 harden(partialAssign);
 
-// XXX copied from @agoric/store types
-// UNTIL https://github.com/Agoric/agoric-sdk/issues/4560
-/**
- * @typedef {object} StoreOptions
- * Of the dimensions on which KeyedStores can differ, we only represent a few
- * of them as standard options. A given store maker should document which
- * options it supports, as well as its positions on dimensions for which it
- * does not support options.
- * @property {boolean} [longLived=true] Which way to optimize a weak store. True means
- * that we expect this weak store to outlive most of its keys, in which
- * case we internally may use a JavaScript `WeakMap`. Otherwise we internally
- * may use a JavaScript `Map`.
- * Defaults to true, so please mark short lived stores explicitly.
- * @property {boolean} [durable=false]  The contents of this store survive termination
- *   of its containing process, allowing for restart or upgrade but at the cost
- *   of forbidding storage of references to ephemeral data.  Defaults to false.
- * @property {boolean} [fakeDurable=false]  This store pretends to be a durable store
- *   but does not enforce that the things stored in it actually be themselves
- *   durable (whereas an actual durable store would forbid storage of such
- *   items).  This is in service of allowing incremental transition to use of
- *   durable stores, to enable normal operation and testing when some stuff
- *   intended to eventually be durable has not yet been made durable.  A store
- *   marked as fakeDurable will appear to operate normally but any attempt to
- *   upgrade its containing vat will fail with an error.
- * @property {import('@agoric/swingset-liveslots').Pattern} [keyShape]
- * @property {import('@agoric/swingset-liveslots').Pattern} [valueShape]
- */
+/** @import {StoreOptions} from '@agoric/store/exported.js' */
+
 /**
  * Unlike `provideLazy`, `provide` should be called at most once
  * within any vat incarnation with a given `baggage`,`key` pair.
@@ -138,12 +115,12 @@ harden(partialAssign);
 
 export const provide =
   // XXX cast because provideLazy is `any` due to broken type import
-  /** @type {<K, V>(baggage: import('@agoric/swingset-liveslots').Baggage, key: K, makeValue: (key: K) => V) => V} */ (
+  /** @type {<K, V>(baggage: Baggage, key: K, makeValue: (key: K) => V) => V} */ (
     provideLazy
   );
 
 // TODO: Find a good home for this function used by @agoric/vat-data and testing code
-/** @param {import('@agoric/swingset-liveslots').VatData} VatData */
+/** @param {VatData} VatData */
 export const makeStoreUtils = VatData => {
   const {
     // eslint-disable-next-line no-shadow -- these literally do shadow the globals
@@ -157,7 +134,7 @@ export const makeStoreUtils = VatData => {
   } = VatData;
 
   /**
-   * @param {import('@agoric/swingset-liveslots').Baggage} baggage
+   * @param {Baggage} baggage
    * @param {string} name
    * @param {Omit<StoreOptions, 'durable'>} options
    */
@@ -168,7 +145,7 @@ export const makeStoreUtils = VatData => {
   harden(provideDurableMapStore);
 
   /**
-   * @param {import('@agoric/swingset-liveslots').Baggage} baggage
+   * @param {Baggage} baggage
    * @param {string} name
    * @param {Omit<StoreOptions, 'durable'>} options
    */
@@ -179,7 +156,7 @@ export const makeStoreUtils = VatData => {
   harden(provideDurableWeakMapStore);
 
   /**
-   * @param {import('@agoric/swingset-liveslots').Baggage} baggage
+   * @param {Baggage} baggage
    * @param {string} name
    * @param {Omit<StoreOptions, 'durable'>} options
    */
@@ -190,7 +167,7 @@ export const makeStoreUtils = VatData => {
   harden(provideDurableSetStore);
 
   /**
-   * @param {import('@agoric/swingset-liveslots').Baggage} baggage
+   * @param {Baggage} baggage
    * @param {string} name
    * @param {Omit<StoreOptions, 'durable'>} options
    */

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -15,6 +15,8 @@ import { makeMarshal } from '@endo/marshal';
 
 import { crc6 } from './crc.js';
 
+/** @import {Key} from '@endo/patterns') */
+
 export const DEFAULT_CRC_DIGITS = 2;
 export const DEFAULT_PREFIX = 'board0';
 

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -2,6 +2,8 @@
 
 import { M } from '@endo/patterns';
 
+/** @import {MapStore} from '@agoric/store/src/types.js' */
+
 const VowShape = M.tagged(
   'Vow',
   harden({

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -3,6 +3,9 @@ import { assert, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
 import '../internal-types.js';
+/**
+ * @import {MapStore} from '@agoric/store/exported.js'
+ */
 
 /**
  * Iterate over the amounts and sum, storing the sums in a

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -32,7 +32,9 @@ import {
 } from '../contractSupport/ratio.js';
 
 /// <reference path="../../../ERTP/exported.js" />
-
+/**
+ * @import {LegacyMap} from '@agoric/store/exported.js'
+ */
 /** @typedef {bigint | number | string} ParsableNumber */
 /**
  * @typedef {Readonly<ParsableNumber | { data: ParsableNumber }>} OraclePriceSubmission

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -1,4 +1,8 @@
 #! /bin/bash
+# When debugging this locally, you'll want to delete all the local tags it
+# generates, here and in your Endo checkout:
+#   git tag -d $(git tag -l)
+# That also deletes the remotes, but they will be restored on next fetch.
 
 thisdir=$(cd -- "$(dirname "$0")" >/dev/null && pwd)
 


### PR DESCRIPTION
continuation of https://github.com/Agoric/agoric-sdk/pull/9170

## Description

There's still a failure in getting-started https://github.com/Agoric/agoric-sdk/actions/runs/8485932550/job/23251589935

This whacks some more moles. This passes for me locally with, `REGISTRY_PUBLISH_WORKSPACES="/opt/agoric/endo" scripts/registry.sh bg-publish registry/yarn`, but so does master. So I'll test this with a workflow trigger.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
none
### Scaling Considerations
none
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

none

### Testing Considerations


- [x] [Integration tests](https://github.com/Agoric/agoric-sdk/actions/runs/8511278339) triggered for https://github.com/Agoric/agoric-sdk/pull/9178/commits/bc686da818c7fd56a21e7eb3c33822d123003089

### Upgrade Considerations

none