### PR TITLE
docs(zoe): subsume zoe-api from docs.agoric.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "clean": "yarn lerna run --no-bail clean",
     "check-dependencies": "node ./scripts/check-mismatched-dependencies.cjs",
-    "docs": "typedoc --tsconfig tsconfig.build.json",
+    "docs": "typedoc --tsconfig tsconfig.build.json --excludeInternal",
     "docs:markdown-for-agoric-documentation-repo": "typedoc --plugin typedoc-plugin-markdown --tsconfig tsconfig.build.json",
     "lerna": "lerna",
     "link-cli": "yarn run create-agoric-cli",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier-plugin-sh": "^0.14.0",
     "type-coverage": "^2.27.1",
     "typedoc": "^0.25.12",
-    "typedoc-plugin-markdown": "^3.17.1",
+    "typedoc-plugin-markdown": "^4.0.0-next.54",
     "typescript": "^5.5.0-dev.20240327",
     "typescript-eslint": "^7.3.1"
   },

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -47,8 +47,8 @@ export {};
  */
 
 /**
- * @typedef {'nat' | 'set' | 'copySet' | 'copyBag'} AssetKind See doc-comment
- *   for `AmountValue`.
+ * @typedef {'nat' | 'set' | 'copySet' | 'copyBag'} AssetKind See
+ *   {@link AmountValue}.
  */
 
 /**

--- a/packages/ERTP/typedoc.json
+++ b/packages/ERTP/typedoc.json
@@ -3,7 +3,8 @@
         "../../typedoc.base.json"
     ],
     "entryPoints": [
-        "src/index.js"
+        "src/index.js",
+        "src/types-ambient.js"
     ],
     "validation": {
         "notExported": false,

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -1,5 +1,3 @@
-type CopyRecord<T> = import('@endo/pass-style').CopyRecord<T>;
-type IssuerOptionsRecord = import('@agoric/ertp').IssuerOptionsRecord;
 /**
  * Any passable non-thenable. Often an explanatory string.
  */
@@ -71,7 +69,7 @@ type ZCF<CT extends unknown = Record<string, unknown>> = {
     keyword: Keyword,
     assetKind?: K_2 | undefined,
     displayInfo?: AdditionalDisplayInfo,
-    options?: IssuerOptionsRecord,
+    options?: import('@agoric/ertp').IssuerOptionsRecord,
   ) => Promise<ZCFMint<K_2>>;
   registerFeeMint: ZCFRegisterFeeMint;
   makeEmptySeatKit: ZCFMakeEmptySeatKit;
@@ -217,8 +215,8 @@ type OfferHandler<OR extends unknown = unknown, OA = never> =
       handle: HandleOffer<OR, OA>;
     };
 type ContractMeta = {
-  customTermsShape?: CopyRecord<any> | undefined;
-  privateArgsShape?: CopyRecord<any> | undefined;
+  customTermsShape?: import('@endo/pass-style').CopyRecord<any> | undefined;
+  privateArgsShape?: import('@endo/pass-style').CopyRecord<any> | undefined;
   upgradability?: 'none' | 'canBeUpgraded' | 'canUpgrade' | undefined;
 };
 /**

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -152,7 +152,7 @@ export const makeZCFZygote = async (
     return makeZcMint(keyword, zoeMint);
   };
 
-  /** @type {ZCFRegisterFeeMint} */
+  /** @type {ZCF['registerFeeMint']} */
   const registerFeeMint = async (keyword, feeMintAccess) => {
     getInstanceRecHolder().assertUniqueKeyword(keyword);
 
@@ -354,7 +354,7 @@ export const makeZCFZygote = async (
     getBrandForIssuer,
     getIssuerForBrand,
     getAssetKind: getAssetKindByBrand,
-    /** @type {SetTestJig} */
+    /** @type {ZCF['setTestJig']} */
     setTestJig: (testFn = () => ({})) => {
       if (testJigSetter) {
         testJigSetter({ ...testFn(), zcf });

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -272,7 +272,7 @@
 /**
  * @typedef {object} ZcfSeatManager
  * @property {MakeZCFSeat} makeZCFSeat
- * @property {Reallocate} reallocate
+ * @property {ZCF['reallocate']} reallocate
  * @property {DropAllReferences} dropAllReferences
  */
 

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -67,7 +67,7 @@ export const makeInstallationStorage = (getBundleCapForID, zoeBaggage) => {
    * an instance is started.
    */
 
-  /** @type {InstallBundle} */
+  /** @type {ZoeService['install']} */
   const installSourceBundle = async (bundle, bundleLabel) => {
     typeof bundle === 'object' || Fail`a bundle must be provided`;
     /** @type {Installation} */

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -127,16 +127,16 @@
  * @property {GetAssetKindByBrand} getAssetKindByBrand
  * @property {DepositPayments} depositPayments
  * @property {Issuer<'set'>} invitationIssuer
- * @property {InstallBundle} installBundle
- * @property {InstallBundleID} installBundleID
- * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
+ * @property {ZoeService['install']} installBundle
+ * @property {ZoeService['installBundleID']} installBundleID
+ * @property {ZoeService['getBundleIDFromInstallation']} getBundleIDFromInstallation
  * @property {import('./utils.js').GetPublicFacet} getPublicFacet
- * @property {GetBrands} getBrands
- * @property {GetIssuers} getIssuers
+ * @property {ZoeService['getBrands']} getBrands
+ * @property {ZoeService['getIssuers']} getIssuers
  * @property {import('./utils.js').GetTerms} getTerms
- * @property {GetOfferFilter} getOfferFilter
- * @property {SetOfferFilter} setOfferFilter
- * @property {GetInstallationForInstance} getInstallationForInstance
+ * @property {ZoeService['getOfferFilter']} getOfferFilter
+ * @property {(instance: Instance, strings: string[]) => void} setOfferFilter
+ * @property {ZoeService['getInstallationForInstance']} getInstallationForInstance
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation
  * @property {GetProposalShapeForInvitation} getProposalShapeForInvitation

--- a/packages/zoe/src/zoeService/invitationQueries.js
+++ b/packages/zoe/src/zoeService/invitationQueries.js
@@ -4,7 +4,7 @@ import { assert, details as X, Fail, quote as q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 
 export const makeInvitationQueryFns = invitationIssuer => {
-  /** @type {GetInvitationDetails} */
+  /** @type {ZoeService['getInvitationDetails']} */
   const getInvitationDetails = async invitationP => {
     const onRejected = reason => {
       const err = assert.error(
@@ -21,11 +21,11 @@ export const makeInvitationQueryFns = invitationIssuer => {
     return invAmount.value[0];
   };
 
-  /** @type {GetInstance} */
+  /** @type {ZoeService['getInstance']} */
   const getInstance = invitation =>
     E.get(getInvitationDetails(invitation)).instance;
 
-  /** @type {GetInstallation} */
+  /** @type {ZoeService['getInstallation']} */
   const getInstallation = invitation =>
     E.get(getInvitationDetails(invitation)).installation;
 

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -15,7 +15,7 @@ import '../internal-types.js';
 const { quote: q, Fail } = assert;
 
 export const makeOfferMethod = offerDataAccess => {
-  /** @type {Offer} */
+  /** @type {ZoeService['offer']} */
   const offer = async (
     invitation,
     uncleanProposal = harden({}),

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -1,6 +1,10 @@
 // @jessie-check
 
 /// <reference types="ses"/>
+/**
+ * @import { Installation } from './utils.js'
+ * @import { InstallationStart } from './utils.js'
+ */
 
 /**
  * @typedef {object} ZoeService
@@ -271,7 +275,7 @@
  */
 
 /**
- * @typedef {import('./utils.js').Instance<any>} Instance
+ * @import { Instance } from './utils.js'
  */
 
 /**
@@ -299,16 +303,6 @@
  * @property {InvitationHandle} handle
  * @property {string} description
  * @property {Record<string, any>} [customDetails]
- */
-
-/**
- * @template [SF=any] contract start function
- * @typedef {import('./utils.js').Installation<SF>} Installation
- */
-
-/**
- * @template {Installation} I
- * @typedef {import('./utils.js').InstallationStart<I>} InstallationStart
  */
 
 /**

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -15,13 +15,13 @@ type ContractFacet<T extends {} = {}> = {
  * Installation of a contract, typed by its start function.
  */
 declare const StartFunction: unique symbol;
-export type Installation<SF> = {
+export type Installation<SF = any> = {
   getBundle: () => SourceBundle;
   getBundleLabel: () => string;
   // because TS is structural, without this the generic is ignored
   [StartFunction]: SF;
 };
-export type Instance<SF> = Handle<'Instance'> & {
+export type Instance<SF = any> = Handle<'Instance'> & {
   // because TS is structural, without this the generic is ignored
   [StartFunction]: SF;
 };

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -35,7 +35,7 @@ type ContractStartFunction = (
   baggage?: Baggage,
 ) => ERef<{ creatorFacet?: {}; publicFacet?: {} }>;
 
-export type AdminFacet<SF extends ContractStartFunction> = {
+export interface AdminFacet<SF extends ContractStartFunction> {
   // Completion, which is currently any
   getVatShutdownPromise: () => Promise<any>;
   upgradeContract: Parameters<SF>[1] extends undefined
@@ -47,7 +47,7 @@ export type AdminFacet<SF extends ContractStartFunction> = {
   restartContract: Parameters<SF>[1] extends undefined
     ? () => Promise<VatUpgradeResults>
     : (newPrivateArgs: Parameters<SF>[1]) => Promise<VatUpgradeResults>;
-};
+}
 
 type StartParams<SF> = SF extends ContractStartFunction
   ? Parameters<SF>[1] extends undefined

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -77,7 +77,7 @@ type StartContractInstance<C> = (
 ) => Promise<{
   creatorFacet: C['creatorFacet'];
   publicFacet: C['publicFacet'];
-  instance: Instance;
+  instance: Instance<C>;
   creatorInvitation: C['creatorInvitation'];
   adminFacet: AdminFacet<any>;
 }>;

--- a/packages/zoe/typedoc.json
+++ b/packages/zoe/typedoc.json
@@ -3,7 +3,7 @@
         "../../typedoc.base.json"
     ],
     "entryPoints": [
-        "src/contractFacet/internal-types.js",
+        "src/contractFacet/internal-types.d.ts",
         "src/contractFacet/types-ambient.d.ts",
         "src/contractSupport/index.js",
         "src/contractSupport/types.js",


### PR DESCRIPTION
DRAFT. goal:
closes: #4291

## Description / Documentation Considerations

ensure JSDoc in @agoric/ertp subsumes https://docs.agoric.com/reference/zoe-api/

 - [ ] Zoe Service
 - [ ] UserSeat
 - [ ] ZCF
 - [ ] ZCFSeat
 - [x] ZCFMint
 - [ ] ZoeHelper
 - [ ] Ratio Math
 - [ ] Zoe Data Types

### Security / Scaling / Testing / Upgrade Considerations

n/a
