### PR TITLE
adopt ESM in tsconfig

### DIFF
--- a/packages/ERTP/exported.d.ts
+++ b/packages/ERTP/exported.d.ts
@@ -8,7 +8,9 @@
 export * from './src/types.js';
 
 // XXX re-export types into global namespace, for consumers that expect these to
-//  be ambient
+//  be ambient. Why the _ prefix? Because without it TS gets confused between the
+//  import and export symbols. h/t https://stackoverflow.com/a/66588974
+//  Note one big downside vs ambients is that these types will appear to be on `globalThis`.
 import {
   Amount as _Amount,
   Brand as _Brand,

--- a/packages/ERTP/exported.d.ts
+++ b/packages/ERTP/exported.d.ts
@@ -1,0 +1,41 @@
+/* eslint-disable -- doesn't understand .d.ts */
+/**
+ * @file re-export types into global namespace, for consumers that expect these
+ *   to be ambient
+ */
+
+// export everything
+export * from './src/types.js';
+
+// XXX re-export types into global namespace, for consumers that expect these to
+//  be ambient
+import {
+  Amount as _Amount,
+  Brand as _Brand,
+  Issuer as _Issuer,
+  IssuerKit as _IssuerKit,
+  Mint as _Mint,
+  AssetKind as _AssetKind,
+  SetValue as _SetValue,
+  NatValue as _NatValue,
+  DisplayInfo as _DisplayInfo,
+  AdditionalDisplayInfo as _AdditionalDisplayInfo,
+  Payment as _Payment,
+  Purse as _Purse,
+} from './src/types.js';
+declare global {
+  export {
+    _Amount as Amount,
+    _Brand as Brand,
+    _Issuer as Issuer,
+    _IssuerKit as IssuerKit,
+    _Mint as Mint,
+    _AssetKind as AssetKind,
+    _SetValue as SetValue,
+    _NatValue as NatValue,
+    _DisplayInfo as DisplayInfo,
+    _AdditionalDisplayInfo as AdditionalDisplayInfo,
+    _Payment as Payment,
+    _Purse as Purse,
+  };
+}

--- a/packages/ERTP/exported.js
+++ b/packages/ERTP/exported.js
@@ -1,1 +1,1 @@
-import './src/types-ambient.js';
+// Dummy file for .d.ts twin to declare ambients

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "echo \"export {}; \" | cat - src/types-ambient.js > src/types.js && tsc --build --clean tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*' src/types.js",
+    "prepack": "tsc --build tsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava",
     "test:xs": "yarn test:xs-unit && yarn test:xs-worker",
@@ -61,7 +61,8 @@
   "files": [
     "src",
     "NEWS.md",
-    "exported.js"
+    "exported.js",
+    "exported.d.ts"
   ],
   "ava-xs": {
     "exclude": [

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -6,6 +6,8 @@ import { setMathHelpers } from './mathHelpers/setMathHelpers.js';
 import { copySetMathHelpers } from './mathHelpers/copySetMathHelpers.js';
 import { copyBagMathHelpers } from './mathHelpers/copyBagMathHelpers.js';
 
+/** @import {Amount, AssetKind, AmountValue, AssetKindForValue, AssetValueForKind, Brand, MathHelpers} from './types.js' */
+
 const { quote: q, Fail } = assert;
 
 /**

--- a/packages/ERTP/src/amountStore.js
+++ b/packages/ERTP/src/amountStore.js
@@ -1,5 +1,7 @@
 import { AmountMath } from './amountMath.js';
 
+/** @import {Amount, AssetKind, AmountValue, AssetKindForValue, AssetValueForKind, Brand, MathHelpers} from './types.js' */
+
 /**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} AmountStore

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -5,6 +5,8 @@ import { mustMatch } from '@agoric/store';
 
 import { DisplayInfoShape } from './typeGuards.js';
 
+/** @import {AdditionalDisplayInfo, AssetKind, DisplayInfo} from './types.js' */
+
 /**
  * @param {AdditionalDisplayInfo} allegedDisplayInfo
  * @param {AssetKind} assetKind

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -9,7 +9,8 @@ import { AssetKind, assertAssetKind } from './amountMath.js';
 import { coerceDisplayInfo } from './displayInfo.js';
 import { preparePaymentLedger } from './paymentLedger.js';
 
-import './types-ambient.js';
+/** @import {AdditionalDisplayInfo, RecoverySetsOption, IssuerKit, PaymentLedger} from './types.js' */
+/** @import {ShutdownWithFailure} from '@agoric/swingset-vat' */
 
 /**
  * @template {AssetKind} K
@@ -58,7 +59,7 @@ const setupIssuerKit = (
 
   // Attenuate the powerful authority to mint and change balances
   /** @type {PaymentLedger<K>} */
-  // @ts-expect-error could be instantiated with different subtype of AssetKind
+  // @ts-expect-error could be instantiated with a different subtype
   const { issuer, mint, brand, mintRecoveryPurse } = preparePaymentLedger(
     issuerZone,
     name,

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -4,6 +4,8 @@ import { mustMatch } from '@agoric/store';
 import { E } from '@endo/far';
 import { AmountMath } from './amountMath.js';
 
+/** @import {Amount, AssetKind, AmountValue, AssetKindForValue, Payment, Brand, Purse} from './types.js' */
+
 const { Fail } = assert;
 
 /**

--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -10,7 +10,8 @@ import {
   bagUnion,
   bagDisjointSubtract,
 } from '@agoric/store';
-import '../types-ambient.js';
+
+/** @import {MathHelpers} from '../types.js' */
 
 /** @type {import('@endo/patterns').CopyBag} */
 const empty = makeCopyBag([]);

--- a/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
@@ -10,7 +10,11 @@ import {
   setDisjointUnion,
   setDisjointSubtract,
 } from '@agoric/store';
-import '../types-ambient.js';
+
+/**
+ * @import {MathHelpers} from '../types.js'
+ * @import {CopySet} from '@endo/patterns'
+ */
 
 /** @type {CopySet} */
 const empty = makeCopySet([]);

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -2,7 +2,7 @@
 
 import { Nat, isNat } from '@endo/nat';
 
-import '../types-ambient.js';
+/** @import {MathHelpers, NatValue} from '../types.js' */
 
 const { Fail } = assert;
 const empty = 0n;

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -9,7 +9,8 @@ import {
   coerceToElements,
   elementsCompare,
 } from '@agoric/store';
-import '../types-ambient.js';
+
+/** @import {MathHelpers, SetValue} from '../types.js' */
 
 // Operations for arrays with unique objects identifying and providing
 // information about digital assets. Used for Zoe invites.

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -2,6 +2,8 @@
 
 import { initEmpty } from '@agoric/store';
 
+/** @import {AssetKind, Brand, Payment} from './types.js' */
+
 // TODO Type InterfaceGuard better than InterfaceGuard<any>
 /**
  * @template {AssetKind} K

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -10,6 +10,11 @@ import { preparePurseKind } from './purse.js';
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
+/**
+ * @import {Amount, AssetKind, DisplayInfo, PaymentLedger, Payment, Brand, RecoverySetsOption, Purse, Issuer, Mint} from './types.js'
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat'
+ */
+
 const { details: X, quote: q, Fail } = assert;
 
 /**

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -3,6 +3,8 @@ import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 import { makeAmountStore } from './amountStore.js';
 
+/** @import {Amount, AssetKind, AmountValue, AssetKindForValue, RecoverySetsOption, Brand, Payment} from './types.js' */
+
 const { Fail } = assert;
 
 const EMPTY_COPY_SET = makeCopySet([]);

--- a/packages/ERTP/src/transientNotifier.js
+++ b/packages/ERTP/src/transientNotifier.js
@@ -4,6 +4,8 @@ import { makeScalarBigWeakMapStore } from '@agoric/vat-data';
 import { provideLazy } from '@agoric/store';
 import { makeNotifierKit } from '@agoric/notifier';
 
+/** @import {Purse} from './types.js' */
+
 // Note: Virtual for high cardinality, but *not* durable, and so
 // broken across an upgrade.
 export const makeTransientNotifierKit = () => {

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,6 +1,7 @@
 // @jessie-check
 
 import { M, matches, getInterfaceGuardPayload } from '@endo/patterns';
+/** @import {AmountValue, AssetKindForValue, AssetValueForKind, Brand, MathHelpers} from './types.js' */
 
 export const BrandShape = M.remotable('Brand');
 export const IssuerShape = M.remotable('Issuer');

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -1,5 +1,8 @@
 // @jessie-check
 
+// Ensure this is a module.
+export {};
+
 /// <reference types="ses"/>
 /**
  * @import {Passable} from '@endo/pass-style')
@@ -209,8 +212,6 @@
  *   anti-pattern.
  * @property {AssetKind} [assetKind]
  */
-
-/** @import {ShutdownWithFailure} from '@agoric/swingset-vat') */
 
 /**
  * @template {AssetKind} [K=AssetKind]

--- a/packages/ERTP/test/types.test-d.ts
+++ b/packages/ERTP/test/types.test-d.ts
@@ -2,8 +2,12 @@ import { Far } from '@endo/marshal';
 import { expectType } from 'tsd';
 
 import { AmountMath, AssetKind } from '../src/index.js';
-
-import '../src/types-ambient.js';
+import type {
+  Amount,
+  AssetValueForKind,
+  Brand,
+  SetValue,
+} from '../src/types.js';
 
 {
   const brand: Brand<'nat'> = Far('natbrand');

--- a/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
@@ -1,6 +1,8 @@
 import { Far } from '@endo/marshal';
 import { AssetKind } from '../../../src/index.js';
 
+/** @import {Brand} from '../../../src/types.js'; */
+
 /** @type {Brand<AssetKind>} */
 export const mockBrand = Far('brand', {
   // eslint-disable-next-line no-unused-vars

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
@@ -4,6 +4,8 @@ import { getCopySetKeys, makeCopySet } from '@agoric/store';
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
 import { mockBrand } from './mockBrand.js';
 
+/** @import {CopySet} from '@endo/patterns' */
+
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled
 // correctly.

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -5,6 +5,8 @@ import { Far } from '@endo/marshal';
 import { AssetKind, makeIssuerKit, AmountMath } from '../../src/index.js';
 import { claim, combine } from '../../src/legacy-payment-helpers.js';
 
+/** @import {Amount, Issuer} from '../../src/types.js' */
+
 test('makeIssuerKit bad allegedName', async t => {
   // @ts-expect-error Intentional wrong type for testing
   t.throws(() => makeIssuerKit(harden({})), { message: `{} must be a string` });

--- a/packages/ERTP/tsconfig.json
+++ b/packages/ERTP/tsconfig.json
@@ -5,7 +5,8 @@
     "maxNodeModuleJsDepth": 1,
   },
   "include": [
-    "exported.js",
+    // omit exported.js because 1) it's empty and would overwrite exported.d.ts
+    // and 2) because it's only for consumption in other packages
     "src/**/*.js",
     "src/**/*.ts",
     "test"

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -93,7 +93,7 @@ export default function makeDeviceManager(
       /** @type { DeviceInvocationResult } */
       const deviceResults = dispatch.invoke(target, method, args);
       // common error: raw devices returning capdata instead of ['ok', capdata]
-      assert.equal(deviceResults.length, 2, deviceResults);
+      assert.equal(deviceResults.length, 2, JSON.stringify(deviceResults));
       if (deviceResults[0] === 'ok') {
         insistCapData(deviceResults[1]);
       } else {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -272,7 +272,7 @@ export function makeXsSubprocessFactory({
       ]);
       await closeP;
 
-      /** @type {Partial<import('@agoric/swing-store/src/snapStore.js').SnapshotInfo>} */
+      /** @type {Partial<import('@agoric/swing-store').SnapshotInfo>} */
       const reloadSnapshotInfo = {
         snapPos,
         hash: snapshotResults.hash,

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -138,7 +138,7 @@ const coerceBid = (offerStatus, agoricNames, warn) => {
  *
  * @param {import('@agoric/smart-wallet/src/offers.js').OfferStatus &
  *         { offerArgs: BidSpec}} bid
- * @param {import('agoric/src/lib/format.js').AssetDescriptor[]} assets
+ * @param {import('../lib/format.js').AssetDescriptor[]} assets
  */
 export const fmtBid = (bid, assets) => {
   const fmt = makeFormatters(assets);

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -96,7 +96,7 @@ harden(execSwingsetTransaction);
 /**
  *
  * @param {import('./rpc.js').MinimalNetworkConfig} net
- * @returns {Promise<import('@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset').Params>}
+ * @returns {Promise<import('@agoric/cosmic-proto/swingset/swingset.js').Params>}
  */
 export const fetchSwingsetParams = async net => {
   const { rpcAddrs } = net;

--- a/packages/agoric-cli/test/test-inter-cli.js
+++ b/packages/agoric-cli/test/test-inter-cli.js
@@ -39,7 +39,7 @@ const agoricNames = harden({
     auctioneer: makeBoardRemote({ boardId: 'board434', iface: 'Instance' }),
   },
 
-  /** @type {Record<string,import('agoric/src/lib/format.js').AssetDescriptor>} */
+  /** @type {Record<string,import('../src/lib/format.js').AssetDescriptor>} */
   vbankAsset: {
     ubld: {
       denom: 'ubld',

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -20,11 +20,9 @@
 // but we need to import it here as well.
 /// <reference path="./types.js" />
 
-/** @import {Checker} from '@endo/marshal' */
-
 const { freeze } = Object;
 
-/** @type {Assert} */
+/** @type {import("ses").Assert} */
 const globalAssert = globalThis.assert;
 
 if (globalAssert === undefined) {

--- a/packages/base-zone/src/exports.d.ts
+++ b/packages/base-zone/src/exports.d.ts
@@ -5,5 +5,4 @@
 //   Types exposed from modules.
 //
 
-// @ts-expect-error TS1383: Only named exports may use 'export type'.
 export type * from './types.js';

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -26,7 +26,7 @@ import {
 import type { ExecutionContext as AvaT } from 'ava';
 
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
-import type { CoreEvalSDKType } from '@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset';
+import type { CoreEvalSDKType } from '@agoric/cosmic-proto/swingset/swingset.js';
 import type { BridgeHandler } from '@agoric/vats';
 
 const trace = makeTracer('BSTSupport', false);

--- a/packages/cosmic-swingset/src/params.js
+++ b/packages/cosmic-swingset/src/params.js
@@ -31,7 +31,7 @@ export const encodeQueueSizes = queueSizes =>
 
 /**
  * Map the SwingSet parameters to a deterministic data structure.
- * @param {import('@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset.js').ParamsSDKType} params
+ * @param {import('@agoric/cosmic-proto/swingset/swingset.js').ParamsSDKType} params
  */
 export const parseParams = params => {
   const {

--- a/packages/cosmic-swingset/src/sim-params.js
+++ b/packages/cosmic-swingset/src/sim-params.js
@@ -63,7 +63,7 @@ export const defaultBeansPerUnit = [
 const defaultBootstrapVatConfig =
   '@agoric/vm-config/decentral-demo-config.json';
 
-/** @type {import('@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset.js').PowerFlagFeeSDKType[]} */
+/** @type {import('@agoric/cosmic-proto/swingset/swingset.js').PowerFlagFeeSDKType[]} */
 export const defaultPowerFlagFees = [
   { power_flag: 'SMART_WALLET', fee: [makeCoin('ubld', 10_000_000n)] },
 ];
@@ -77,7 +77,7 @@ export const defaultQueueMax = [
 ];
 
 /**
- * @type {import('@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset.js').ParamsSDKType}
+ * @type {import('@agoric/cosmic-proto/swingset/swingset.js').ParamsSDKType}
  */
 export const DEFAULT_SIM_SWINGSET_PARAMS = {
   beans_per_unit: defaultBeansPerUnit,

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -47,7 +47,7 @@
     "@endo/marshal": "^1.4.0",
     "@endo/nat": "^5.0.5",
     "@endo/promise-kit": "^1.1.0",
-    "jessie.js": "^0.3.2"
+    "jessie.js": "^0.3.4"
   },
   "devDependencies": {
     "@agoric/smart-wallet": "^0.5.3",

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -267,7 +267,11 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
       return periodicCollector;
     },
 
-    /** @param {import('@endo/far').EOnly<DepositFacet>} depositFacet */
+    /**
+     * @param {import('@endo/far').EOnly<
+     *   import('@agoric/ertp/exported.js').DepositFacet
+     * >} depositFacet
+     */
     makeDepositFacetDestination: depositFacet => {
       return Far(`DepositFacetDestination`, {
         pushPayment: async (payment, _issuer) => {

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -1,6 +1,5 @@
 // @jessie-check
 
-// @ts-expect-error FIXME Jessie.js exports
 import { makeMap } from 'jessie.js';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -1,5 +1,6 @@
 // @jessie-check
 
+// @ts-expect-error FIXME Jessie.js exports
 import { makeMap } from 'jessie.js';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -24,6 +24,11 @@ import { Far, deeplyFulfilled } from '@endo/marshal';
 const { details: X, quote: q, Fail } = assert;
 
 /**
+ * @import {ERef} from '@endo/far'
+ * @import {Amount} from '@agoric/ertp/src/types.js'
+ */
+
+/**
  * @typedef {import('@agoric/zoe/src/zoeService/utils.js').Instance<
  *   import('@agoric/inter-protocol/src/psm/psm.js').start
  * >} PsmInstance
@@ -136,7 +141,7 @@ export const prepareProvisionPoolKit = (
     /**
      * @param {object} opts
      * @param {Purse<'nat'>} opts.fundPurse
-     * @param {Brand} opts.poolBrand
+     * @param {Brand<'nat'>} opts.poolBrand
      * @param {StorageNode} opts.metricsNode
      */
     ({ fundPurse, poolBrand, metricsNode }) => {
@@ -440,7 +445,7 @@ export const prepareProvisionPoolKit = (
    * Prepare synchronous values before passing to real Exo maker
    *
    * @param {object} opts
-   * @param {Brand} opts.poolBrand
+   * @param {Brand<'nat'>} opts.poolBrand
    * @param {ERef<StorageNode>} opts.storageNode
    */
   const makeProvisionPoolKit = async ({ poolBrand, storageNode }) => {

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -30,7 +30,7 @@
     "@endo/promise-kit": "^1.1.0",
     "@endo/stream": "^1.2.0",
     "anylogger": "^0.21.0",
-    "jessie.js": "^0.3.2"
+    "jessie.js": "^0.3.4"
   },
   "devDependencies": {
     "@endo/init": "^1.1.0",

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -16,8 +16,8 @@ const ownKeys =
   );
 
 /**
- * @template {import('@endo/exo/src/exo-makers.js').Methods} T
- * @typedef {(...args: Parameters<ReturnType<prepareAttenuator>>) => import('@endo/exo/src/exo-makers.js').Farable<T>} MakeAttenuator
+ * @template {import('@endo/exo').Methods} T
+ * @typedef {(...args: Parameters<ReturnType<prepareAttenuator>>) => import('@endo/exo').Farable<T>} MakeAttenuator
  */
 
 /**

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -4,6 +4,8 @@
 import { deeplyFulfilled, isObject } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeQueue } from '@endo/stream';
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore FIXME Jessie.js exports
 import { asyncGenerate } from 'jessie.js';
 
 const { fromEntries, keys, values } = Object;

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -4,8 +4,6 @@
 import { deeplyFulfilled, isObject } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeQueue } from '@endo/stream';
-// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-// @ts-ignore FIXME Jessie.js exports
 import { asyncGenerate } from 'jessie.js';
 
 const { fromEntries, keys, values } = Object;

--- a/packages/network/src/types.js
+++ b/packages/network/src/types.js
@@ -11,9 +11,9 @@
  */
 
 /**
- * @template {import('@endo/exo/src/exo-makers').Methods} M
+ * @template {import('@endo/exo').Methods} M
  * @template {(...args: any[]) => any} I
- * @typedef {M & ThisType<{ self: import('@endo/exo/src/exo-makers').Guarded<M>, state: ReturnType<I> }>} ExoClassMethods
+ * @typedef {M & ThisType<{ self: import('@endo/exo').Guarded<M>, state: ReturnType<I> }>} ExoClassMethods
  * Rearrange the exo types to make a cast of the methods (M) and init function (I) to a specific type.
  */
 

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -7,6 +7,10 @@ import { E, Far } from '@endo/far';
 import { makeOncePromiseKit } from './once-promise-kit.js';
 
 /**
+ * @import {DepositFacet} from '@agoric/ertp/exported.js'
+ */
+
+/**
  * Create or return an existing courier promise kit.
  *
  * @template K

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -9,7 +9,7 @@
 
 /**
  * @typedef {object} PacketParts
- * @property {AmountValue} value
+ * @property {import("@agoric/ertp/exported.js").AmountValue} value
  * @property {Denom} remoteDenom
  * @property {DepositAddress} depositAddress
  * @property {string} memo

--- a/packages/store/exported.d.ts
+++ b/packages/store/exported.d.ts
@@ -3,6 +3,13 @@
  * @file re-export types into global namespace, for consumers that expect these
  *   to be ambient
  */
+// export everything
+export * from './src/types.js';
+
+// XXX re-export types into global namespace, for consumers that expect these to
+//  be ambient. Why the _ prefix? Because without it TS gets confused between the
+//  import and export symbols. h/t https://stackoverflow.com/a/66588974
+//  Note one big downside vs ambients is that these types will appear to be on `globalThis`.
 import {
   LegacyMap as _LegacyMap,
   LegacyWeakMap as _LegacyWeakMap,
@@ -13,12 +20,6 @@ import {
   WeakSetStore as _WeakSetStore,
 } from './src/types.js';
 import { Pattern as _Pattern } from '@endo/patterns';
-
-// export everything
-export * from './src/types.js';
-
-// re-export types into global namespace, for consumers that expect these to be
-//  ambient
 declare global {
   export {
     _LegacyMap as LegacyMap,

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -23,8 +23,7 @@ import {
 /**
  * @import {DurableKindHandle} from '@agoric/swingset-liveslots'
  * @import {DefineKindOptions} from '@agoric/swingset-liveslots'
- * @import {ClassContextProvider} from '@endo/exo/src/exo-tools.js'
- * @import {KitContextProvider} from '@endo/exo/src/exo-tools.js'
+ * @import {ClassContextProvider, KitContextProvider} from '@endo/exo/tools.js'
  */
 
 const {

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -94,7 +94,7 @@ export const makeExoUtils = VatData => {
    *   self: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').Guarded<T>}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo').Guarded<T>}
    */
   const defineVirtualExoClass = (tag, interfaceGuard, init, methods, options) =>
     // @ts-expect-error cast
@@ -112,14 +112,14 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
-   *   facets: import('@endo/exo/src/exo-makers.js').GuardedKit<T>,
+   *   facets: import('@endo/exo').GuardedKit<T>,
    *   state: ReturnType<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').GuardedKit<T>}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo').GuardedKit<T>}
    */
   const defineVirtualExoClassKit = (
     tag,
@@ -150,7 +150,7 @@ export const makeExoUtils = VatData => {
    *   self: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').Guarded<T>}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo').Guarded<T>}
    */
   const defineDurableExoClass = (
     kindHandle,
@@ -174,14 +174,14 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
-   *   facets: import('@endo/exo/src/exo-makers.js').GuardedKit<T>,
+   *   facets: import('@endo/exo').GuardedKit<T>,
    *   state: ReturnType<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').GuardedKit<T>}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo').GuardedKit<T>}
    */
   const defineDurableExoClassKit = (
     kindHandle,
@@ -213,7 +213,7 @@ export const makeExoUtils = VatData => {
    *   self: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').Guarded<T>}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo').Guarded<T>}
    */
   const prepareExoClass = (
     baggage,
@@ -240,14 +240,14 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
-   *   facets: import('@endo/exo/src/exo-makers.js').GuardedKit<T>,
+   *   facets: import('@endo/exo').GuardedKit<T>,
    *   state: ReturnType<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
    *   state: ReturnType<I>
    * }>} [options]
-   * @returns {(...args: Parameters<I>) => import('@endo/exo/src/exo-makers.js').GuardedKit<T>}
+   * @returns {(...args: Parameters<I>) => import('@endo/exo').GuardedKit<T>}
    */
   const prepareExoClassKit = (
     baggage,
@@ -273,7 +273,7 @@ export const makeExoUtils = VatData => {
    * @param {InterfaceGuard | undefined} interfaceGuard
    * @param {M} methods
    * @param {DefineKindOptions<{ self: M }>} [options]
-   * @returns {import('@endo/exo/src/exo-makers.js').Guarded<M>}
+   * @returns {import('@endo/exo').Guarded<M>}
    */
   const prepareExo = (
     baggage,
@@ -302,7 +302,7 @@ export const makeExoUtils = VatData => {
    * @param {string} kindName
    * @param {M} methods
    * @param {DefineKindOptions<{ self: M }>} [options]
-   * @returns {import('@endo/exo/src/exo-makers.js').Guarded<M>}
+   * @returns {import('@endo/exo').Guarded<M>}
    */
   const prepareSingleton = (baggage, kindName, methods, options = undefined) =>
     prepareExo(baggage, kindName, undefined, methods, options);

--- a/packages/vat-data/test/test-amplify-virtual-class-kits.js
+++ b/packages/vat-data/test/test-amplify-virtual-class-kits.js
@@ -43,7 +43,7 @@ test('test amplify defineVirtualExoClass fails', t => {
 });
 
 test('test amplify defineVirtualExoClassKit', t => {
-  /** @type {import('@endo/exo/src/exo-makers.js').Amplify} */
+  /** @type {import('@endo/exo').Amplify} */
   let amp;
   const makeCounterKit = defineVirtualExoClassKit(
     'Counter',

--- a/packages/vat-data/test/test-is-instance-virtual-class-kits.js
+++ b/packages/vat-data/test/test-is-instance-virtual-class-kits.js
@@ -18,7 +18,7 @@ const DownCounterI = M.interface('DownCounter', {
 });
 
 test('test isInstance defineVirtualExoClass', t => {
-  /** @type {import('@endo/exo/src/exo-makers.js').IsInstance} */
+  /** @type {import('@endo/exo').IsInstance} */
   let isInstance;
   const makeUpCounter = defineVirtualExoClass(
     'UpCounter',
@@ -59,7 +59,7 @@ test('test isInstance defineVirtualExoClass', t => {
 });
 
 test('test isInstance defineVirtualExoClassKit', t => {
-  /** @type {import('@endo/exo/src/exo-makers.js').IsInstance} */
+  /** @type {import('@endo/exo').IsInstance} */
   let isInstance;
   const makeCounterKit = defineVirtualExoClassKit(
     'Counter',

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -41,7 +41,7 @@
     "@endo/patterns": "^1.3.0",
     "@endo/promise-kit": "^1.1.0",
     "import-meta-resolve": "^2.2.1",
-    "jessie.js": "^0.3.2"
+    "jessie.js": "^0.3.4"
   },
   "devDependencies": {
     "@agoric/swingset-liveslots": "^0.10.2",

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -57,7 +57,7 @@ export const bridgeCoreEval = async allPowers => {
     async fromBridge(obj) {
       switch (obj.type) {
         case 'CORE_EVAL': {
-          /** @type {import('@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset.js').CoreEvalProposalSDKType} */
+          /** @type {import('@agoric/cosmic-proto/swingset/swingset.js').CoreEvalProposalSDKType} */
           const { evals } = obj;
           return Promise.all(
             evals.map(({ json_permits: jsonPermit, js_code: code }) =>

--- a/packages/vats/src/core/promise-space.js
+++ b/packages/vats/src/core/promise-space.js
@@ -31,7 +31,7 @@ export const makeLogHooks = log =>
  * Note: caller is responsible for synchronization in case of onResolve() called
  * with a promise.
  *
- * @param {MapStore<string, Passable>} store
+ * @param {MapStore<string, import('@endo/marshal').Passable>} store
  * @param {typeof console.log} [log]
  * @returns {PromiseSpaceHooks}
  */

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -1,3 +1,4 @@
+// @ts-expect-error FIXME Jessie.js exports
 import { makeMap } from 'jessie.js';
 import { E, Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -1,4 +1,3 @@
-// @ts-expect-error FIXME Jessie.js exports
 import { makeMap } from 'jessie.js';
 import { E, Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -626,7 +626,11 @@ const prepareBankManager = (
       /**
        * @param {string} denom
        * @param {AssetIssuerKit} feeKit
-       * @returns {ERef<import('@endo/far').EOnly<DepositFacet>>}
+       * @returns {ERef<
+       *   import('@endo/far').EOnly<
+       *     import('@agoric/ertp/exported.js').DepositFacet
+       *   >
+       * >}
        */
       getRewardDistributorDepositFacet(denom, feeKit) {
         const { bankChannel } = this.state;

--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -15,7 +15,7 @@
 
 /**
  * @typedef {object} PurseActions
- * @property {(receiverP: ERef<{ receive: (payment: Payment) => void }>, valueToSend: AmountValue) => Promise<void>} send
+ * @property {(receiverP: ERef<{ receive: (payment: Payment) => void }>, valueToSend: import('@agoric/ertp/exported.js').AmountValue) => Promise<void>} send
  * @property {(payment: Payment) => Promise<Amount>} receive
  * @property {(payment: Payment, amount?: Amount) => Promise<Amount>} deposit
  */
@@ -82,7 +82,7 @@
  * @property {string} [issuerBoardId]
  *
  * @typedef {object} PaymentActions
- * @property {(purseOrPetname?: (Purse | Petname)) => Promise<AmountValue>} deposit
+ * @property {(purseOrPetname?: (Purse | Petname)) => Promise<import('@agoric/ertp/exported.js').AmountValue>} deposit
  * @property {() => Promise<boolean>} refresh
  * @property {() => Promise<boolean>} getAmountOf
  */

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -76,7 +76,7 @@ export const makeZCFZygote = async (
     instantiate: instantiateIssuerStorage,
   } = provideIssuerStorage(zcfBaggage);
 
-  /** @type {ShutdownWithFailure} */
+  /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
   const shutdownWithFailure = reason => {
     E(zoeInstanceAdmin).failAllSeats(reason);
     seatManager.dropAllReferences();

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -37,7 +37,7 @@ export const doLiquidation = async (
     zcf.shutdown('your loan had to be liquidated');
   };
 
-  /** @type {ShutdownWithFailure} */
+  /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
   const closeWithFailure = err => {
     lenderSeat.fail(err);
     collateralSeat.fail(err);

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -56,7 +56,7 @@
  * @typedef {object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {ZoeSeatAdminExit} exit
- * @property {ShutdownWithFailure} fail called with the reason
+ * @property {import('@agoric/swingset-vat').ShutdownWithFailure} fail called with the reason
  * for calling fail on this seat, where reason is normally an instanceof Error.
  * @property {() => Subscriber<AmountKeywordRecord>} getExitSubscriber
  */
@@ -92,7 +92,7 @@
  * @property {() => string[]} getOfferFilter
  * @property {() => Installation} getInstallation
  * @property {(completion: Completion) => void} exitAllSeats
- * @property {ShutdownWithFailure} failAllSeats
+ * @property {import('@agoric/swingset-vat').ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  * @property {(string: string) => boolean} isBlocked
  * @property {(handleOfferObj: HandleOfferObj, publicFacet: unknown) => void} initDelayedState
@@ -130,7 +130,7 @@
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
  * @property {(completion: Completion) => void} exitAllSeats
- * @property {ShutdownWithFailure} failAllSeats
+ * @property {import('@agoric/swingset-vat').ShutdownWithFailure} failAllSeats
  * @property {(seatHandle: SeatHandle, completion: Completion) => void} exitSeat
  * @property {(seatHandle: SeatHandle, reason: Error) => void} failSeat
  * @property {() => void} stopAcceptingOffers
@@ -289,7 +289,7 @@
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {ShutdownWithFailure} shutdownWithFailure
+ * @param {import('@agoric/swingset-vat').ShutdownWithFailure} shutdownWithFailure
  * @param {import('@agoric/vat-data').Baggage} zcfBaggage
  * @returns {{ seatManager: ZcfSeatManager, zcfMintReallocator: ZcfMintReallocator }}
  */

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -29,7 +29,7 @@ export const defaultFeeIssuerConfig = harden(
 /**
  * @param {import('@agoric/vat-data').Baggage} zoeBaggage
  * @param {FeeIssuerConfig} feeIssuerConfig
- * @param {ShutdownWithFailure} shutdownZoeVat
+ * @param {import('@agoric/swingset-vat').ShutdownWithFailure} shutdownZoeVat
  */
 const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const mintBaggage = provideDurableMapStore(zoeBaggage, 'mintBaggage');

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -12,7 +12,7 @@ const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
 
 /**
  * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {ShutdownWithFailure | undefined} shutdownZoeVat
+ * @param {import('@agoric/swingset-vat').ShutdownWithFailure | undefined} shutdownZoeVat
  */
 export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
   const invitationKitBaggage = provideDurableMapStore(

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -40,7 +40,7 @@ const { Fail } = assert;
  * @param {Promise<VatAdminSvc> | VatAdminSvc} [options.vatAdminSvc] - The vatAdmin Service, which carries the
  * power to create a new vat. If it's not available when makeZoe() is called, it
  * must be provided later using setVatAdminService().
- * @param {ShutdownWithFailure} [options.shutdownZoeVat] - a function to
+ * @param {import('@agoric/swingset-vat').ShutdownWithFailure} [options.shutdownZoeVat] - a function to
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} [options.feeIssuerConfig]
@@ -268,7 +268,7 @@ const makeDurableZoeKit = ({
  * @param {Promise<VatAdminSvc> | VatAdminSvc} [vatAdminSvc] - The vatAdmin Service, which carries the
  * power to create a new vat. If it's not available when makeZoe() is called, it
  * must be provided later using setVatAdminService().
- * @param {ShutdownWithFailure} [shutdownZoeVat] - a function to
+ * @param {import('@agoric/swingset-vat').ShutdownWithFailure} [shutdownZoeVat] - a function to
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} [feeIssuerConfig]

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -46,7 +46,7 @@ const { ownKeys } = Reflect;
  * @param {CreateZCFVat} createZCFVat - the ability to create a new
  * ZCF Vat
  * @param {GetBundleCapForID} getBundleCapForID
- * @param {ShutdownWithFailure} shutdownZoeVat
+ * @param {import('@agoric/swingset-vat').ShutdownWithFailure} shutdownZoeVat
  * @param {{
  *    getFeeIssuerKit: GetFeeIssuerKit,
  *    getFeeIssuer: () => Issuer,

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -58,7 +58,7 @@ const start = zcf => {
   };
 
   const zcfShutdown = completion => zcf.shutdown(completion);
-  /** @type {ShutdownWithFailure} */
+  /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
   const zcfShutdownWithFailure = reason => zcf.shutdownWithFailure(reason);
 
   const makeSwapInvitation = () =>

--- a/packages/zone/src/exports.d.ts
+++ b/packages/zone/src/exports.d.ts
@@ -3,4 +3,4 @@
 //   Types exposed from modules.
 //
 
-export type { ExoZone, Stores, Zone } from '@agoric/base-zone/src/exports.js';
+export type * from '@agoric/base-zone';

--- a/patches/@endo+exo+1.3.0.patch
+++ b/patches/@endo+exo+1.3.0.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/@endo/exo/index.d.ts b/node_modules/@endo/exo/index.d.ts
+index bd4c7ed..463ae5e 100644
+--- a/node_modules/@endo/exo/index.d.ts
++++ b/node_modules/@endo/exo/index.d.ts
+@@ -1,3 +1,3 @@
+ export { GET_INTERFACE_GUARD } from "./src/get-interface.js";
+-export { initEmpty, defineExoClass, defineExoClassKit, makeExo } from "./src/exo-makers.js";
++export * from "./src/exo-makers.js";
+ //# sourceMappingURL=index.d.ts.map
+diff --git a/node_modules/@endo/exo/index.js b/node_modules/@endo/exo/index.js
+index 0936e29..3924dd4 100644
+--- a/node_modules/@endo/exo/index.js
++++ b/node_modules/@endo/exo/index.js
+@@ -1,8 +1,3 @@
+-export {
+-  initEmpty,
+-  defineExoClass,
+-  defineExoClassKit,
+-  makeExo,
+-} from './src/exo-makers.js';
++export * from './src/exo-makers.js';
+ 
+ export { GET_INTERFACE_GUARD } from './src/get-interface.js';
+diff --git a/node_modules/@endo/exo/tools.d.ts b/node_modules/@endo/exo/tools.d.ts
+index 0537b0b..be5d131 100644
+--- a/node_modules/@endo/exo/tools.d.ts
++++ b/node_modules/@endo/exo/tools.d.ts
+@@ -1,2 +1,2 @@
+-export { defendPrototype, defendPrototypeKit } from "./src/exo-tools.js";
++export * from "./src/exo-tools.js";
+ //# sourceMappingURL=tools.d.ts.map
+diff --git a/node_modules/@endo/exo/tools.js b/node_modules/@endo/exo/tools.js
+index e8db521..072ff15 100644
+--- a/node_modules/@endo/exo/tools.js
++++ b/node_modules/@endo/exo/tools.js
+@@ -1 +1 @@
+-export { defendPrototype, defendPrototypeKit } from './src/exo-tools.js';
++export * from './src/exo-tools.js';

--- a/patches/jessie.js+0.3.4.patch
+++ b/patches/jessie.js+0.3.4.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/jessie.js/package.json b/node_modules/jessie.js/package.json
+index 24f0881..da02cf8 100644
+--- a/node_modules/jessie.js/package.json
++++ b/node_modules/jessie.js/package.json
+@@ -16,10 +16,6 @@
+   },
+   "main": "./src/main.js",
+   "types": "./types/main.d.ts",
+-  "exports": {
+-    "./package.json": "./package.json",
+-    ".": "./src/main.js"
+-  },
+   "scripts": {
+     "build": "yarn build:types",
+     "build:types": "tsc -p jsconfig.build.json --outDir types",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "allowJs": true,
     "checkJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,11 +1512,6 @@
     "@endo/zip" "^1.0.3"
     ses "^1.4.0"
 
-"@endo/env-options@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-0.1.4.tgz#e516bc3864f00b154944e444fb8996a9a0c23a45"
-  integrity sha512-Ol8ct0aW8VK1ZaqntnUJfrYT59P6Xn36XPbHzkqQhsYkpudKDn5ILYEwGmSO/Ff+XJjv/pReNI0lhOyyrDa9mg==
-
 "@endo/env-options@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-1.1.2.tgz#38cb86effbdcc2879bb5a4f50650b129000c37c2"
@@ -1550,13 +1545,6 @@
     "@babel/traverse" "^7.23.6"
     source-map "0.7.4"
 
-"@endo/eventual-send@^0.17.6":
-  version "0.17.6"
-  resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-0.17.6.tgz#86719e4e3ff76991c49f6680309dc77dff65fe55"
-  integrity sha512-73cKY2uiWdzMJn7i284NJyD3K0UKjpksBg/EA2GT8YJa0TgeBczFQIm81vC08itK5gHuDDH2vC5COSGR6hxKIg==
-  dependencies:
-    "@endo/env-options" "^0.1.4"
-
 "@endo/eventual-send@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-1.2.0.tgz#e882c0b9807da397100ce9aab6e18941559903e5"
@@ -1577,15 +1565,7 @@
     "@endo/pass-style" "^1.3.0"
     "@endo/patterns" "^1.3.0"
 
-"@endo/far@^0.2.3":
-  version "0.2.22"
-  resolved "https://registry.yarnpkg.com/@endo/far/-/far-0.2.22.tgz#fda187289a903ee3f9d6dcc5664ee7fef1994b1f"
-  integrity sha512-LFOicqyHslKOSk/H5EfGOcw347ftDSwYHARPasnrG4UJOEkcU1ZG5bN/BmfONtcidB776gWZKrV/tNl4WLIlyw==
-  dependencies:
-    "@endo/eventual-send" "^0.17.6"
-    "@endo/pass-style" "^0.1.7"
-
-"@endo/far@^1.1.0":
+"@endo/far@^1.0.0", "@endo/far@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@endo/far/-/far-1.1.0.tgz#aeb86dc43447d58fd3bc62249f9e7e776c9c93ea"
   integrity sha512-phpwBCkoFuzmjWUTXlf8ry7t4H7k/FTdXBTIWJjREmPEEdK+ZPxM3nTAmq3faf17/aSTAaKrdWDC6PNiMCxqNg==
@@ -1649,14 +1629,6 @@
     "@endo/stream" "^1.2.0"
     ses "^1.4.0"
 
-"@endo/pass-style@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@endo/pass-style/-/pass-style-0.1.7.tgz#ea22568e8b86fb2d1a14a5fc042374cc0d8e310b"
-  integrity sha512-dlB62Ptjcy/+iachy7qzAdgIwaU60rE+XLummLRpE2tDSJF2jSFJlVwa/QuGw1KKO7Rt4vog/51sKev3EbJZQg==
-  dependencies:
-    "@endo/promise-kit" "^0.2.60"
-    "@fast-check/ava" "^1.1.5"
-
 "@endo/pass-style@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@endo/pass-style/-/pass-style-1.3.0.tgz#9d119487df3a53ad7a1b04bd1634f12c25521acb"
@@ -1678,13 +1650,6 @@
     "@endo/eventual-send" "^1.2.0"
     "@endo/marshal" "^1.4.0"
     "@endo/promise-kit" "^1.1.0"
-
-"@endo/promise-kit@^0.2.60":
-  version "0.2.60"
-  resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.60.tgz#8012ada06970c7eaf965cd856563b34a1790e163"
-  integrity sha512-6Zp9BqBbc3ywaG+iLRrQRmO/VLKrMnvsbgOKKPMpjEC3sUlksYA09uaH3GrKZgoGChF8m9bXK8eFW39z7wJNUw==
-  dependencies:
-    ses "^0.18.8"
 
 "@endo/promise-kit@^1.1.0":
   version "1.1.0"
@@ -7697,12 +7662,12 @@ jake@^10.8.5:
     filelist "^1.0.4"
     minimatch "^3.1.2"
 
-jessie.js@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/jessie.js/-/jessie.js-0.3.2.tgz#68159e1097f86fa56a3136668313ea38e96fc9f2"
-  integrity sha512-Gpa2iZhl/hPZGT3HWEURfYIV5kFjeHZmQLZuRF6A5czuezmEOlnDYH3w7rohaaEWwxJiXprUWj4r6lh1JIkXAA==
+jessie.js@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/jessie.js/-/jessie.js-0.3.4.tgz#7e35dadc91cf4740d2ddc8a58b6cd0a99eb64a08"
+  integrity sha512-JYJm6nXuFIO/X6OWLBatorgqmFVYbenqnFP0UDalO2OQ6sn58VeJ3cKtMQ0l0TM0JnCx4wKhyO4BQQ/ilxjd6g==
   dependencies:
-    "@endo/far" "^0.2.3"
+    "@endo/far" "^1.0.0"
 
 jest-diff@^29.0.3:
   version "29.5.0"
@@ -10607,13 +10572,6 @@ serve-static@1.15.0:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.18.0"
-
-ses@^0.18.8:
-  version "0.18.8"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.18.8.tgz#88036511ac3b3c07e4d82dd8cfc6e5f3788205b6"
-  integrity sha512-kOH1AhJc6gWDXKURKeU1w7iFUdImAegAljVvBg5EUBgNqjH4bxcEsGVUadVEPtA2PVRMyQp1fiSMDwEZkQNj1g==
-  dependencies:
-    "@endo/env-options" "^0.1.4"
 
 ses@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
closes: #9184

## Description

In the course of https://github.com/Agoric/agoric-sdk/pull/9111 I've run continually run into problems with module resolution. Endo expects ESM but agoric-sdk is configured with a mixture of ESM and CommonJS.

This PR changes the tsconfig to `bundler` so that we can use export maps from packages. Then it has a slew of changes to accomodate that.

### Security Considerations

n/a
### Scaling Considerations

n/a

### Documentation Considerations

Perhaps note the `globalThis` type

### Testing Considerations

CI

### Upgrade Considerations

Should not have a chain impact
