### PR TITLE
fix: update name of agd fee granter flag

### DIFF
--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -161,7 +161,7 @@ export async function connectToChain(
   );
 
   // The helper address may not have a token balance, and instead uses a
-  // separate fee account, set up with something like:
+  // separate fee granter account, set up with something like:
   //
   // agd tx feegrant grant --period=5 --period-limit=200000uist \
   // $(cat cosmos-fee-account) $(cat ag-cosmos-helper-address)
@@ -653,7 +653,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
 
       // Use the feeAccount for any fees.
       if (feeAccountAddr) {
-        txArgs.push(`--fee-account=${feeAccountAddr}`);
+        txArgs.push(`--fee-granter=${feeAccountAddr}`);
       }
 
       // We just try a single delivery per block.


### PR DESCRIPTION
closes: #9196

## Description

The `--fee-account` flag was renamed to `--fee-granter` in cosmos-sdk 0.46.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A - searched for mention of removed flag and found none.

### Testing Considerations

The code in question appears to not be under CI test. However, it's not part of the product, and the code addresses a corner case.

### Upgrade Considerations

N/A
