### PR TITLE
refactor(network): rename `bind` to `bindPort`

### DIFF
--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -13,7 +13,7 @@ import { V as E } from '@agoric/vat-data/vow.js';
  */
 export const start = async (zcf, privateArgs, _baggage) => {
   const { address, networkVat } = privateArgs;
-  const myPort = await E(networkVat).bind(address);
+  const myPort = await E(networkVat).bindPort(address);
 
   const { log } = console;
   let connP;

--- a/packages/boot/test/bootstrapTests/ibcServerMock.js
+++ b/packages/boot/test/bootstrapTests/ibcServerMock.js
@@ -19,7 +19,7 @@ const { log } = console;
 export const start = async (zcf, privateArgs, _baggage) => {
   const { address, networkVat } = privateArgs;
 
-  const boundPort = await E(networkVat).bind(address);
+  const boundPort = await E(networkVat).bindPort(address);
 
   /** @type {Array<[label: string, resolve: (value: any) => void, reject: (reason: any) => void]>} */
   const queue = [];

--- a/packages/inter-protocol/test/smartWallet/boot-test-utils.js
+++ b/packages/inter-protocol/test/smartWallet/boot-test-utils.js
@@ -58,7 +58,7 @@ export const makeMock = log =>
 
       network: Far('network', {
         registerProtocolHandler: noop,
-        bind: () => harden({ addListener: noop }),
+        bindPort: () => harden({ addListener: noop }),
       }),
     },
   });

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -57,15 +57,15 @@ E(home.ibcport[0]).connect(remoteEndpoint, connectionHandler)
 
 The other side of `connect()` is a "listening port". These ports are waiting for inbound connections to be established.
 
-To get a listening port, you need a `NetworkInterface` object (such as the one on your `ag-solo` under `home.network`) and ask it to `bind()` to an endpoint. You can either provide a specific port name, or allow the API to allocate a random one for you. The endpoint specifies the type of connection that this port will be able to accept (IBC, TCP, etc), and some properties of that connection. `bind()` uses a "multiaddress" to encode this information.
+To get a listening port, you need a `NetworkInterface` object (such as the one on your `ag-solo` under `home.network`) and ask it to `bindPort()` to an endpoint. You can either provide a specific port name, or allow the API to allocate a random one for you. The endpoint specifies the type of connection that this port will be able to accept (IBC, TCP, etc), and some properties of that connection. `bindPort()` uses a "multiaddress" to encode this information.
 
 ```js
 // ask for a random allocation - ends with a slash
-E(home.network).bind('/ibc-port/')
+E(home.network).bindPort('/ibc-port/')
   .then(port => usePort(port));
 
 // or ask for a specific port name
-E(home.network).bind('/ibc-port/my-cool-port-name')
+E(home.network).bindPort('/ibc-port/my-cool-port-name')
   .then(port => usePort(port));
 ```
 
@@ -147,7 +147,7 @@ Note that if you want to listen on this port again, you can just call `port.addL
 
 ### Closing the Port Entirely
 
-Removing a listener doesn't release the port address to make it available for other `bind()` requests.  You can call:
+Removing a listener doesn't release the port address to make it available for other `bindPort()` requests.  You can call:
 
 ```js
 port.revoke();

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -652,7 +652,7 @@ const prepareBinder = (zone, powers) => {
     {
       protocolImpl: Shape.ProtocolImplI,
       binder: M.interface('Binder', {
-        bind: M.callWhen(Shape.Endpoint).returns(Shape.Vow$(Shape.Port)),
+        bindPort: M.callWhen(Shape.Endpoint).returns(Shape.Vow$(Shape.Port)),
       }),
       binderInboundInstantiateWatcher: M.interface(
         'BinderInboundInstantiateWatcher',
@@ -840,13 +840,13 @@ const prepareBinder = (zone, powers) => {
             localAddr,
           });
         },
-        async bind(localAddr) {
-          return this.facets.binder.bind(localAddr);
+        async bindPort(localAddr) {
+          return this.facets.binder.bindPort(localAddr);
         },
       },
       binder: {
         /** @param {string} localAddr */
-        async bind(localAddr) {
+        async bindPort(localAddr) {
           const { protocolHandler } = this.state;
 
           // Check if we are underspecified (ends in slash)

--- a/packages/network/src/router.js
+++ b/packages/network/src/router.js
@@ -93,7 +93,7 @@ export const prepareRouter = zone => {
 
 /**
  * @typedef {object} RouterProtocol
- * @property {(prefix: string) => PromiseVow<Port>} bind
+ * @property {(prefix: string) => PromiseVow<Port>} bindPort
  * @property {(paths: string[], protocolHandler: ProtocolHandler) => void} registerProtocolHandler
  * @property {(prefix: string, protocolHandler: ProtocolHandler) => void} unregisterProtocolHandler
  */
@@ -119,7 +119,7 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
         M.remotable(),
       ).returns(),
       unregisterProtocolHandler: M.call(M.string(), M.remotable()).returns(),
-      bind: M.callWhen(Shape.Endpoint).returns(Shape.Vow$(Shape.Port)),
+      bindPort: M.callWhen(Shape.Endpoint).returns(Shape.Vow$(Shape.Port)),
     }),
     () => {
       /** @type {Router<Protocol>} */
@@ -169,10 +169,10 @@ export const prepareRouterProtocol = (zone, powers, E = defaultE) => {
         this.state.protocolHandlers.delete(prefix);
       },
       /** @param {Endpoint} localAddr */
-      async bind(localAddr) {
+      async bindPort(localAddr) {
         const [route] = this.state.router.getRoutes(localAddr);
         route !== undefined || Fail`No registered router for ${localAddr}`;
-        return E(route[1]).bind(localAddr);
+        return E(route[1]).bindPort(localAddr);
       },
     },
   );

--- a/packages/network/src/shapes.js
+++ b/packages/network/src/shapes.js
@@ -178,7 +178,7 @@ export const Shape = /** @type {const} */ harden({
   },
 
   ProtocolImplI: M.interface('ProtocolImpl', {
-    bind: M.callWhen(Shape2.Endpoint).returns(Shape2.Vow$(Shape2.Port)),
+    bindPort: M.callWhen(Shape2.Endpoint).returns(Shape2.Vow$(Shape2.Port)),
     inbound: M.callWhen(Shape2.Endpoint, Shape2.Endpoint).returns(
       Shape2.Vow$(Shape2.InboundAttempt),
     ),

--- a/packages/network/src/types.js
+++ b/packages/network/src/types.js
@@ -33,7 +33,7 @@
 
 /**
  * @typedef {object} Protocol The network Protocol
- * @property {(prefix: Endpoint) => PromiseVow<Port>} bind Claim a port, or if
+ * @property {(prefix: Endpoint) => PromiseVow<Port>} bindPort Claim a port, or if
  *   ending in ENDPOINT_SEPARATOR, a fresh name
  */
 
@@ -182,7 +182,7 @@
  * @property {() => PromiseVow<void>} close Abort the attempt
  *
  * @typedef {object} ProtocolImpl Things the protocol can do for us
- * @property {(prefix: Endpoint) => PromiseVow<Remote<Port>>} bind Claim a port, or if
+ * @property {(prefix: Endpoint) => PromiseVow<Remote<Port>>} bindPort Claim a port, or if
  *   ending in ENDPOINT_SEPARATOR, a fresh name
  * @property {(
  *   listenAddr: Endpoint,

--- a/packages/network/test/test-network-misc.js
+++ b/packages/network/test/test-network-misc.js
@@ -128,7 +128,7 @@ test('handled protocol', async t => {
   );
   const protocol = makeNetworkProtocol(makeProtocolHandler());
 
-  const port = await when(protocol.bind('/ibc/*/ordered'));
+  const port = await when(protocol.bindPort('/ibc/*/ordered'));
 
   const { vow, resolver } = makeVowKit();
 
@@ -181,7 +181,9 @@ test('protocol connection listen', async t => {
   );
   const protocol = makeNetworkProtocol(makeProtocolHandler());
 
-  const port = await when(protocol.bind('/net/ordered/ordered/some-portname'));
+  const port = await when(
+    protocol.bindPort('/net/ordered/ordered/some-portname'),
+  );
   const { vow, resolver } = makeVowKit();
 
   const prepareConnectionHandler = () => {
@@ -272,7 +274,7 @@ test('protocol connection listen', async t => {
 
   await port.addListener(listener);
 
-  const port2 = await when(protocol.bind('/net/ordered'));
+  const port2 = await when(protocol.bindPort('/net/ordered'));
   const { handler } = makeEchoConnectionHandler();
 
   const prepareHandlerWithOpen = () => {
@@ -320,7 +322,7 @@ test('loopback protocol', async t => {
   const protocol = makeNetworkProtocol(makeLoopbackProtocolHandler());
   const { vow, resolver } = makeVowKit();
 
-  const port = await when(protocol.bind('/loopback/foo'));
+  const port = await when(protocol.bindPort('/loopback/foo'));
 
   const prepareConnectionHandler = () => {
     const makeConnectionHandler = zone.exoClass(
@@ -358,7 +360,7 @@ test('loopback protocol', async t => {
   const listener = makeListenHandler();
   await when(port.addListener(listener));
 
-  const port2 = await when(protocol.bind('/loopback/bar'));
+  const port2 = await when(protocol.bindPort('/loopback/bar'));
   const prepareOpener = () => {
     const openerHandler = zone.exoClass(
       'opener',

--- a/packages/orchestration/src/orchestration.js
+++ b/packages/orchestration/src/orchestration.js
@@ -209,7 +209,7 @@ const prepareOrchestration = (zone, createChainAccount) =>
       self: {
         async bindPort() {
           const network = getPower(this.state.powers, 'network');
-          const port = await E(network).bind(
+          const port = await E(network).bindPort(
             `/ibc-port/icacontroller-${this.state.icaControllerNonce}`,
           );
           this.state.icaControllerNonce += 1;

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -49,8 +49,8 @@ export const setupOrchestrationVat = async (
   /** @type {AttenuatedNetwork} */
   const network = Far('Attenuated Network', {
     /** @param {string} localAddr */
-    async bind(localAddr) {
-      return E(networkVat).bind(localAddr);
+    async bindPort(localAddr) {
+      return E(networkVat).bindPort(localAddr);
     },
   });
 

--- a/packages/orchestration/src/types.d.ts
+++ b/packages/orchestration/src/types.d.ts
@@ -1,6 +1,6 @@
 import type { RouterProtocol } from '@agoric/network/src/router';
 
-export type AttenuatedNetwork = Pick<RouterProtocol, 'bind'>;
+export type AttenuatedNetwork = Pick<RouterProtocol, 'bindPort'>;
 
 export type * from './orchestration.js';
 export type * from './vat-orchestration.js';

--- a/packages/pegasus/src/proposals/core-proposal.js
+++ b/packages/pegasus/src/proposals/core-proposal.js
@@ -104,7 +104,7 @@ export const listenPegasus = async ({
   pegasusConnectionsAdmin.resolve(nameAdmin);
 
   const pegasus = await E(zoe).getPublicFacet(pegasusInstance);
-  const port = await E(networkVat).bind('/ibc-port/pegasus');
+  const port = await E(networkVat).bindPort('/ibc-port/pegasus');
   return addPegasusTransferPort(port, pegasus, pegasusNameAdmin);
 };
 harden(listenPegasus);

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -95,7 +95,9 @@ async function testRemotePeg(t) {
   const makeNetworkProtocol = prepareNetworkProtocol(zone, powers);
   const network = makeNetworkProtocol(makeLoopbackHandler());
 
-  const portP = when(E(network).bind('/ibc-channel/chanabc/ibc-port/portdef'));
+  const portP = when(
+    E(network).bindPort('/ibc-channel/chanabc/ibc-port/portdef'),
+  );
   const portName = await E(portP).getLocalAddress();
 
   /**

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -61,8 +61,8 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  * space.
  *
  * The `networkVat` is CLOSELY HELD in the core space, where later, we claim
- * ports using `E(networkVat).bind(_path_)`. As discussed in `ProtocolHandler`
- * docs, _path_ is:
+ * ports using `E(networkVat).bindPort(_path_)`. As discussed in
+ * `ProtocolHandler` docs, _path_ is:
  *
  * - /ibc-port/NAME for an IBC port with a known name or,
  * - /ibc-port/ for an IBC port with a fresh name.
@@ -72,8 +72,8 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  *
  * Testing facilities include:
  *
- * - loopback ports: `E(networkVat).bind('/local/')`
- * - an echo port: `E(vats.network).bind('/ibc-port/echo')`
+ * - loopback ports: `E(networkVat).bindPort('/local/')`
+ * - an echo port: `E(vats.network).bindPort('/ibc-port/echo')`
  *
  * @param {BootstrapPowers & {
  *   consume: { loadCriticalVat: VatLoader<any> };
@@ -140,7 +140,7 @@ export const setupNetworkProtocols = async (
         lastICAPort += 1;
         bindAddr += `${INTERCHAIN_ACCOUNT_CONTROLLER_PORT_PREFIX}${lastICAPort}`;
       }
-      const port = when(E(vats.network).bind(bindAddr));
+      const port = when(E(vats.network).bindPort(bindAddr));
       ibcportP.push(port);
     }
     return Promise.all(ibcportP);
@@ -152,7 +152,7 @@ export const setupNetworkProtocols = async (
   await registerNetworkProtocols(vats, dibcBridgeManager);
 
   // Add an echo listener on our ibc-port network (whether real or virtual).
-  const echoPort = await when(E(vats.network).bind('/ibc-port/echo'));
+  const echoPort = await when(E(vats.network).bindPort('/ibc-port/echo'));
   const { listener } = await E(vats.network).makeEchoConnectionKit();
   await when(E(echoPort).addListener(listener));
   return E(client).assignBundle([_a => ({ ibcport: makePorts() })]);

--- a/packages/vats/src/vat-network.js
+++ b/packages/vats/src/vat-network.js
@@ -35,7 +35,7 @@ export function buildRootObject(_vatPowers, _args, baggage) {
     /** @param {Parameters<typeof protocol.unregisterProtocolHandler>} args */
     unregisterProtocolHandler: (...args) =>
       protocol.unregisterProtocolHandler(...args),
-    /** @param {Parameters<typeof protocol.bind>} args */
-    bind: (...args) => protocol.bind(...args),
+    /** @param {Parameters<typeof protocol.bindPort>} args */
+    bindPort: (...args) => protocol.bindPort(...args),
   });
 }

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -128,7 +128,7 @@ test('network - ibc', async t => {
   // Actually test the ibc port binding.
   // TODO: Do more tests on the returned Port object.
   t.log('Opening a Listening Port');
-  const p = await when(E(networkVat).bind('/ibc-port/'));
+  const p = await when(E(networkVat).bindPort('/ibc-port/'));
   const ev1 = await events.next();
   t.assert(!ev1.done);
   t.deepEqual(ev1.value, ['bindPort', { packet: { source_port: 'port-1' } }]);

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -74,7 +74,7 @@ export const makeMock = log =>
       network: Far('network', {
         registerProtocolHandler: noop,
         makeLoopbackProtocolHandler: noop,
-        bind: () => Far('network - listener', { addListener: noop }),
+        bindPort: () => Far('network - listener', { addListener: noop }),
       }),
     },
   });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

In `@agoric/network`, the current syntax to bind a port is `E(networkVat).bind(address)`. This change renames it to `E(networkVat).bindPort()`, so it's not confused with `.bind(this)`

Motivating discussion: https://github.com/Agoric/agoric-sdk/pull/9195#discussion_r1556403021

closes: #XXXX
refs: #8881

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
