### PR TITLE
docs(time): docs for types are in .d.ts

### DIFF
--- a/packages/time/typedoc.json
+++ b/packages/time/typedoc.json
@@ -4,6 +4,6 @@
     ],
     "entryPoints": [
         "src/timeMath.js",
-        "src/types.js"
+        "src/types.d.ts"
     ]
 }


### PR DESCRIPTION
refs:

 - https://github.com/Agoric/documentation/issues/1031
 - https://github.com/Agoric/documentation/issues/948

### Documentation Considerations

fix typedoc config to find the bulk of the @agoric/time docs