### PR TITLE
README in generated markdown docs - update plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier-plugin-sh": "^0.14.0",
     "type-coverage": "^2.27.1",
     "typedoc": "^0.25.12",
-    "typedoc-plugin-markdown": "^3.17.1",
+    "typedoc-plugin-markdown": "^4.0.0-next.54",
     "typescript": "^5.5.0-dev.20240327",
     "typescript-eslint": "^7.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11565,12 +11565,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc-plugin-markdown@^3.17.1:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz#c33f42363c185adf842f4699166015f7fe0ed02b"
-  integrity sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==
-  dependencies:
-    handlebars "^4.7.7"
+typedoc-plugin-markdown@^4.0.0-next.54:
+  version "4.0.0-next.55"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.0.0-next.55.tgz#624ea848b7b73b093fbb3905b28effb885805dea"
+  integrity sha512-bwEEBkAP0kHnjE10QzPBXAri5yHYmgb+vZP+xn9GirBLCk3lt7SMUiUx0fj7lEtTmbgIH0rv20f3xP+JWxCPHg==
 
 typedoc@^0.25.12:
   version "0.25.12"


### PR DESCRIPTION
refs:
 - https://github.com/Agoric/documentation/issues/1056

## Description / Documentation Considerations

update typedoc markdown plugin to -next version to get fix for

 - https://github.com/tgreyuk/typedoc-plugin-markdown/issues/383

DRAFT until
 - [ ] .md extension lacking from generated README - fix? rename after?

### Security Considerations

supply chain: OK to rely on pre-release version of this dev tool?
