### PR TITLE
ZCF, ZCFMint API docs - subsume docs site content (WIP)

### DIFF
--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -47,8 +47,8 @@ export {};
  */
 
 /**
- * @typedef {'nat' | 'set' | 'copySet' | 'copyBag'} AssetKind See doc-comment
- *   for `AmountValue`.
+ * @typedef {'nat' | 'set' | 'copySet' | 'copyBag'} AssetKind See
+ *   {@link AmountValue}.
  */
 
 /**

--- a/packages/ERTP/typedoc.json
+++ b/packages/ERTP/typedoc.json
@@ -3,7 +3,8 @@
         "../../typedoc.base.json"
     ],
     "entryPoints": [
-        "src/index.js"
+        "src/index.js",
+        "src/types-ambient.js"
     ],
     "validation": {
         "notExported": false,

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -4,7 +4,6 @@ type IssuerOptionsRecord = import('@agoric/ertp').IssuerOptionsRecord;
  * Any passable non-thenable. Often an explanatory string.
  */
 type Completion = any;
-type ZCFMakeEmptySeatKit = (exit?: ExitRule | undefined) => ZcfSeatKit;
 
 /**
  * Zoe Contract Facet
@@ -14,17 +13,62 @@ type ZCFMakeEmptySeatKit = (exit?: ExitRule | undefined) => ZcfSeatKit;
  * the Zoe state for that instance. The Zoe Contract Facet is accessed
  * synchronously from within the contract, and usually is referred to
  * in code as zcf.
+ *
+ * @template CT type of custom terms of the contract
  */
-type ZCF<CT extends unknown = Record<string, unknown>> = {
+interface ZCF<CT extends unknown = Record<string, unknown>> {
   /**
-   * - atomically reallocate amounts among seats.
+   * Rearrange the allocations according to the transfer descriptions.
+   * This is a set of changes to allocations that must satisfy several
+   * constraints. If these constraints are all met, then the reallocation
+   * happens atomically. Otherwise, it does not happen at all.
+   *
+   * The conditions
+   *    * All the mentioned seats are still live,
+   *    * No outstanding stagings for any of the mentioned seats. Stagings
+   *      have been deprecated in favor or atomicRearrange. To prevent
+   *      confusion, for each reallocation, it can only be expressed in
+   *      the old way or the new way, but not a mixture.
+   *    * Offer safety
+   *    * Overall conservation
+   *
+   * The overall transfer is expressed as an array of `TransferPart`. Each
+   * individual `TransferPart` is one of
+   * - A transfer from a `fromSeat` to a `toSeat`. Specify both toAmount
+   *     and fromAmount to change keywords, otherwise only fromAmount is required.
+   * - A taking from a `fromSeat`'s allocation. See the {@link fromOnly} helper.
+   * - A giving into a `toSeat`'s allocation. See the {@link toOnly} helper.
+   *
    */
   atomicRearrange: (transfers: TransferPart[]) => void;
   /**
-   * - reallocate amounts among seats.
    * @deprecated Use atomicRearrange instead.
+   *
+   * The contract can reallocate over seats, which commits the staged
+   * allocation for each seat. On commit, the staged allocation becomes
+   * the current allocation and the staged allocation is deleted.
+   *
+   * The reallocation will only succeed if the reallocation 1) conserves
+   * rights (the amounts specified have the same total value as the
+   * current total amount), and 2) is 'offer-safe' for all parties
+   * involved. All seats that have staged allocations must be included
+   * as arguments to `reallocate`, or an error is thrown. Additionally,
+   * an error is thrown if any seats included in `reallocate` do not
+   * have a staged allocation.
+   *
+   * The reallocation is partial, meaning that it applies only to the
+   * seats passed in as arguments. By induction, if rights conservation
+   * and offer safety hold before, they will hold after a safe
+   * reallocation, even though we only re-validate for the seats whose
+   * allocations will change. Since rights are conserved for the change,
+   * overall rights will be unchanged, and a reallocation can only
+   * effect offer safety for seats whose allocations change.
    */
-  reallocate: Reallocate;
+  reallocate: (
+    seat1: ZCFSeat,
+    seat2: ZCFSeat,
+    ...seatRest: Array<ZCFSeat>
+  ) => void;
   /**
    * - check
    * whether a keyword is valid and unique and could be added in
@@ -66,47 +110,65 @@ type ZCF<CT extends unknown = Record<string, unknown>> = {
   getTerms: () => StandardTerms & CT;
   getBrandForIssuer: <K extends AssetKind>(issuer: Issuer<K>) => Brand<K>;
   getIssuerForBrand: <K_1 extends AssetKind>(brand: Brand<K_1>) => Issuer<K_1>;
-  getAssetKind: GetAssetKindByBrand;
+  /**
+   * Get the assetKind for a brand known by Zoe
+   *
+   * To be deleted when brands have a property for assetKind
+   */
+  getAssetKind: (brand: Brand) => AssetKind;
+  /**
+   * Creates a {@link ZCFMint}, which provides synchronous methods to and reallocate assets.
+   *
+   * **Note**: The call to make the {@link ZCFMint} is asynchronous, but
+   * calls to the resulting {@link ZCFMint} are synchronous.
+   *
+   * @example
+   * const syncMint = await zcf.makeZCFMint('MyToken', AssetKind.COPY_SET);
+   * const { brand, issuer } = syncMint.getIssuerRecord();
+   * syncMint.mintGains({ myKeyword: amount }, seat);
+   *
+   * @param displayInfo see {@link DisplayInfo}
+   * @returns
+   */
   makeZCFMint: <K_2 extends AssetKind = 'nat'>(
     keyword: Keyword,
     assetKind?: K_2 | undefined,
     displayInfo?: AdditionalDisplayInfo,
     options?: IssuerOptionsRecord,
   ) => Promise<ZCFMint<K_2>>;
-  registerFeeMint: ZCFRegisterFeeMint;
-  makeEmptySeatKit: ZCFMakeEmptySeatKit;
-  setTestJig: SetTestJig;
+  registerFeeMint: (
+    keyword: Keyword,
+    allegedFeeMintAccess: FeeMintAccess,
+  ) => Promise<ZCFMint<'nat'>>;
+  makeEmptySeatKit: (exit?: ExitRule | undefined) => ZcfSeatKit;
+  /**
+   * Provide a jig object for testing purposes only.
+   *
+   * The contract code provides a callback whose return result will
+   * be made available to the test that started this contract. The
+   * supplied callback will only be called in a testing context,
+   * never in production; i.e., it is only called if `testJigSetter`
+   * was supplied.
+   *
+   * If no, `testFn` is supplied, then an empty jig will be used.
+   * An additional `zcf` property set to the current ContractFacet
+   * will be appended to the returned jig object (overriding any
+   * provided by the `testFn`).
+   */
+  setTestJig: (testFn: () => Record<string, unknown>) => void;
   stopAcceptingOffers: () => Promise<void>;
   setOfferFilter: (strings: Array<string>) => Promise<void>;
   getOfferFilter: () => Promise<Array<string>>;
   getInstance: () => Instance;
-};
+}
+
 /**
- * The contract can reallocate over seats, which commits the staged
- * allocation for each seat. On commit, the staged allocation becomes
- * the current allocation and the staged allocation is deleted.
- *
- * The reallocation will only succeed if the reallocation 1) conserves
- * rights (the amounts specified have the same total value as the
- * current total amount), and 2) is 'offer-safe' for all parties
- * involved. All seats that have staged allocations must be included
- * as arguments to `reallocate`, or an error is thrown. Additionally,
- * an error is thrown if any seats included in `reallocate` do not
- * have a staged allocation.
- *
- * The reallocation is partial, meaning that it applies only to the
- * seats passed in as arguments. By induction, if rights conservation
- * and offer safety hold before, they will hold after a safe
- * reallocation, even though we only re-validate for the seats whose
- * allocations will change. Since rights are conserved for the change,
- * overall rights will be unchanged, and a reallocation can only
- * effect offer safety for seats whose allocations change.
+ * Each `TransferPart` is one of
+ * - A transfer from a `fromSeat` to a `toSeat`. Specify both toAmount
+ *     and fromAmount to change keywords, otherwise only fromAmount is required.
+ * - A taking from a `fromSeat`'s allocation. See the {@link fromOnly} helper.
+ * - A giving into a `toSeat`'s allocation. See the {@link toOnly} helper.
  */
-type Reallocate = (
-  seat1: ZCFSeat,
-  seat2: ZCFSeat,
-  ...seatRest: Array<ZCFSeat>
-) => void;
 type TransferPart = [
   fromSeat?: ZCFSeat,
   toSeat?: ZCFSeat,
@@ -114,26 +176,19 @@ type TransferPart = [
   toAmounts?: AmountKeywordRecord,
 ];
 
-type ZCFRegisterFeeMint = (
-  keyword: Keyword,
-  allegedFeeMintAccess: FeeMintAccess,
-) => Promise<ZCFMint<'nat'>>;
 /**
- * Provide a jig object for testing purposes only.
+ * Synchronous methods for minting assets.
  *
- * The contract code provides a callback whose return result will
- * be made available to the test that started this contract. The
- * supplied callback will only be called in a testing context,
- * never in production; i.e., it is only called if `testJigSetter`
- * was supplied.
+ * @see {ZCF['makeZCFMint']}
  *
- * If no, `testFn` is supplied, then an empty jig will be used.
- * An additional `zcf` property set to the current ContractFacet
- * will be appended to the returned jig object (overriding any
- * provided by the `testFn`).
  */
-type SetTestJig = (testFn: () => Record<string, unknown>) => void;
-type ZCFMint<K extends AssetKind = AssetKind> = {
+interface ZCFMint<K extends AssetKind = AssetKind> {
+  /**
+   * Get the issuer, brand, etc. associated with a {@link ZCFMint}
+   *
+   * While {@link ZCFMint} is a distinct interface from {@link Mint},
+   * the {@link Issuer} and {@link Brand} interfaces are un-changed from ERTP.
+   */
   getIssuerRecord: () => IssuerRecord<K>;
   /**
    * All the amounts in gains must be of this ZCFMint's brand.
@@ -156,7 +211,8 @@ type ZCFMint<K extends AssetKind = AssetKind> = {
    * Burn that amount of assets from the pooled purse.
    */
   burnLosses: (losses: AmountKeywordRecord, zcfSeat: ZCFSeat) => void;
-};
+}
+
 /**
  * fail called with the reason for this failure, where reason is
  * normally an instanceof Error.

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -1,5 +1,3 @@
-type CopyRecord<T> = import('@endo/pass-style').CopyRecord<T>;
-type IssuerOptionsRecord = import('@agoric/ertp').IssuerOptionsRecord;
 /**
  * Any passable non-thenable. Often an explanatory string.
  */
@@ -134,7 +132,7 @@ interface ZCF<CT extends unknown = Record<string, unknown>> {
     keyword: Keyword,
     assetKind?: K_2 | undefined,
     displayInfo?: AdditionalDisplayInfo,
-    options?: IssuerOptionsRecord,
+    options?: import('@agoric/ertp').IssuerOptionsRecord,
   ) => Promise<ZCFMint<K_2>>;
   registerFeeMint: (
     keyword: Keyword,
@@ -273,8 +271,8 @@ type OfferHandler<OR extends unknown = unknown, OA = never> =
       handle: HandleOffer<OR, OA>;
     };
 type ContractMeta = {
-  customTermsShape?: CopyRecord<any> | undefined;
-  privateArgsShape?: CopyRecord<any> | undefined;
+  customTermsShape?: import('@endo/pass-style').CopyRecord<any> | undefined;
+  privateArgsShape?: import('@endo/pass-style').CopyRecord<any> | undefined;
   upgradability?: 'none' | 'canBeUpgraded' | 'canUpgrade' | undefined;
 };
 /**

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -152,7 +152,7 @@ export const makeZCFZygote = async (
     return makeZcMint(keyword, zoeMint);
   };
 
-  /** @type {ZCFRegisterFeeMint} */
+  /** @type {ZCF['registerFeeMint']} */
   const registerFeeMint = async (keyword, feeMintAccess) => {
     getInstanceRecHolder().assertUniqueKeyword(keyword);
 
@@ -354,7 +354,7 @@ export const makeZCFZygote = async (
     getBrandForIssuer,
     getIssuerForBrand,
     getAssetKind: getAssetKindByBrand,
-    /** @type {SetTestJig} */
+    /** @type {ZCF['setTestJig']} */
     setTestJig: (testFn = () => ({})) => {
       if (testJigSetter) {
         testJigSetter({ ...testFn(), zcf });

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -272,7 +272,7 @@
 /**
  * @typedef {object} ZcfSeatManager
  * @property {MakeZCFSeat} makeZCFSeat
- * @property {Reallocate} reallocate
+ * @property {ZCF['reallocate']} reallocate
  * @property {DropAllReferences} dropAllReferences
  */
 

--- a/packages/zoe/typedoc.json
+++ b/packages/zoe/typedoc.json
@@ -3,7 +3,7 @@
         "../../typedoc.base.json"
     ],
     "entryPoints": [
-        "src/contractFacet/internal-types.js",
+        "src/contractFacet/internal-types.d.ts",
         "src/contractFacet/types-ambient.d.ts",
         "src/contractSupport/index.js",
         "src/contractSupport/types.js",


### PR DESCRIPTION
_I started writing this up before I realized that not all the ZCF stuff is done: makeInvitation, ProposalShapes, ..._

refs: #4291

## Description

 - type -> interface, which gets better navigation (and seems better for such things anyway)
 - inline method types rather than `getAssetKind: GetAssetKindByBrand`

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
