### PR TITLE
ci(restore-node): preserve `package.json` timestamp

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -131,21 +131,23 @@ runs:
           sudo apt-get update
           sudo apt-get install libbsd-dev
         fi
+
+        # Preserve the original package.json to restore it after Endo replacements.
+        cp -a package.json package.json.orig
+
         # Replace the Endo packages with the ones built from the checked-out branch.
         if test -e ~/endo; then
           scripts/get-packed-versions.sh ~/endo | scripts/resolve-versions.sh
         fi
         yarn install
 
-        if ! cmp -s <(git cat-file blob HEAD:package.json) package.json; then
-          # In the event that the package.json has been modified by Endo
-          # replacements, we need to have a yarn-installed.sum that matches
-          # the unmodified package.json.  As long as we don't explicitly `yarn
-          # install` anywhere other than in this action and in the bin/agd
-          # script, we should be able to reuse even Endo-overridden built caches
-          # successfully.
-          git checkout HEAD -- package.json
-        fi
+        # In the event that the package.json has been modified by Endo
+        # replacements, we need to have a yarn-installed timestamp that
+        # corresponds to the unmodified package.json.  As long as we don't
+        # explicitly `yarn install` anywhere other than in this action and in
+        # the bin/agd script, we should be able to reuse even Endo-overridden
+        # built caches successfully.
+        mv package.json.orig package.json
 
         if test -e ~/endo; then
           # Stage the redirected `yarn install` consequences.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #9232
refs: #6432

## Description

The `restore-node` Github action was updating the timestamp on `package.json` if there was an `#endo-branch: XXX` setting on the PR.  This caused `agd-builder.sh` to rebuild the cached build artifacts unnecessarily, including using incorrect `@endo/*` package versions (the ones in the PR's `package.json`s, not the ones from branch `XXX`).

Now the `package.json` is copied (preserving its timestamp), and moved back into place after installing any replaced packages.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

n/a

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

With this PR, shorter CI runs.

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

n/a

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

n/a

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

n/a

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
