### PR TITLE
feat(smart-wallet): tryExitOffer also tries to reclaim

### DIFF
--- a/a3p-integration/proposals/a:upgrade-next/exit-reclaim.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/exit-reclaim.test.js
@@ -1,0 +1,36 @@
+import test from 'ava';
+import { $ } from 'execa';
+import { execFileSync } from 'node:child_process';
+import { makeAgd, waitForBlock } from './synthetic-chain-excerpt.js';
+
+const offerId = 'bad-invitation-15'; // cf. prepare.sh
+const from = 'gov1';
+
+test('exitOffer tool reclaims stuck payment', async t => {
+  const showAndExec = (file, args, opts) => {
+    console.log('$', file, ...args);
+    return execFileSync(file, args, opts);
+  };
+  const agd = makeAgd({ execFileSync: showAndExec }).withOpts({
+    keyringBackend: 'test',
+  });
+
+  const addr = await agd.lookup(from);
+  t.log(from, 'addr', addr);
+
+  const getBalance = async target => {
+    const { balances } = await agd.query(['bank', 'balances', addr]);
+    const { amount } = balances.find(({ denom }) => denom === target);
+    return Number(amount);
+  };
+
+  const before = await getBalance('uist');
+  t.log('uist balance before:', before);
+
+  await $`node ./exitOffer.js --id ${offerId} --from ${from}`;
+
+  await waitForBlock(2);
+  const after = await getBalance('uist');
+  t.log('uist balance after:', after);
+  t.true(after > before);
+});

--- a/a3p-integration/proposals/a:upgrade-next/exitOffer.js
+++ b/a3p-integration/proposals/a:upgrade-next/exitOffer.js
@@ -1,0 +1,97 @@
+// Note: limit imports to node modules for portability
+import { parseArgs, promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const options = /** @type {const} */ ({
+  id: { type: 'string' },
+  from: { type: 'string' },
+  bin: { type: 'string', default: '/usr/src/agoric-sdk/node_modules/.bin' },
+});
+
+const Usage = `
+Try to exit an offer, reclaiming any associated payments.
+
+  node exitOffer.js --id ID --from FROM [--bin PATH]
+
+Options:
+  --id <offer id>
+  --from <address or key name>
+
+  --bin <path to agoric and agd> default: ${options.bin.default}
+`;
+
+const badUsage = () => {
+  const reason = new Error(Usage);
+  reason.name = 'USAGE';
+  throw reason;
+};
+
+const { stringify: q } = JSON;
+// limited to JSON data: no remotables/promises; no undefined.
+const toCapData = data => ({ body: `#${q(data)}`, slots: [] });
+
+const { entries } = Object;
+/**
+ * @param {Record<string, string>} obj - e.g. { color: 'blue' }
+ * @returns {string[]} - e.g. ['--color', 'blue']
+ */
+const flags = obj =>
+  entries(obj)
+    .map(([k, v]) => [`--${k}`, v])
+    .flat();
+
+const execP = promisify(execFile);
+
+const showAndRun = (file, args) => {
+  console.log('$', file, ...args);
+  return execP(file, args);
+};
+
+const withTempFile = async (tail, fn) => {
+  const tmpDir = await mkdtemp('offers-');
+  const tmpFile = join(tmpDir, tail);
+  try {
+    const result = await fn(tmpFile);
+    return result;
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(err =>
+      console.error(err),
+    );
+  }
+};
+
+const doAction = async (action, from) => {
+  await withTempFile('offer.json', async tmpOffer => {
+    await writeFile(tmpOffer, q(toCapData(action)));
+
+    const out = await showAndRun('agoric', [
+      'wallet',
+      ...flags({ 'keyring-backend': 'test' }),
+      'send',
+      ...flags({ offer: tmpOffer, from }),
+    ]);
+    return out.stdout;
+  });
+};
+
+const main = async (argv, env) => {
+  const { values } = parseArgs({ args: argv.slice(2), options });
+  const { id: offerId, from, bin } = values;
+  (offerId && from) || badUsage();
+
+  env.PATH = `${bin}:${env.PATH}`;
+  const action = { method: 'tryExitOffer', offerId };
+  const out = await doAction(action, from);
+  console.log(out);
+};
+
+main(process.argv, process.env).catch(e => {
+  if (e.name === 'USAGE' || e.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION') {
+    console.error(e.message);
+  } else {
+    console.error(e);
+  }
+  process.exit(1);
+});

--- a/a3p-integration/proposals/a:upgrade-next/initial.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/initial.test.js
@@ -6,7 +6,7 @@ const vats = {
   network: { incarnation: 0 },
   ibc: { incarnation: 0 },
   localchain: { incarnation: 0 },
-  walletFactory: { incarnation: 2 },
+  walletFactory: { incarnation: 3 },
   zoe: { incarnation: 1 },
 };
 

--- a/a3p-integration/proposals/a:upgrade-next/prepare.sh
+++ b/a3p-integration/proposals/a:upgrade-next/prepare.sh
@@ -1,9 +1,29 @@
 #!/bin/bash
 
 # Exit when any command fails
-set -e
+set -uxeo pipefail
 
 # Place here any actions that should happen before the upgrade is proposed. The
 # actions are executed in the previous chain software, and the effects are
 # persisted so they can be used in the steps after the upgrade is complete,
 # such as in the "use" or "test" steps, or further proposal layers.
+
+printISTBalance() {
+  addr=$(agd keys show -a "$1" --keyring-backend=test)
+  agd query bank balances "$addr" -o json \
+    | jq -c '.balances[] | select(.denom=="uist")'
+
+}
+
+echo TEST: Offer with bad invitation
+printISTBalance gov1
+
+badInvitationOffer=$(mktemp)
+cat > "$badInvitationOffer" << 'EOF'
+{"body":"#{\"method\":\"executeOffer\",\"offer\":{\"id\":\"bad-invitation-15\",\"invitationSpec\":{\"callPipe\":[[\"badMethodName\"]],\"instancePath\":[\"reserve\"],\"source\":\"agoricContract\"},\"proposal\":{\"give\":{\"Collateral\":{\"brand\":\"$0.Alleged: IST brand\",\"value\":\"+15000\"}}}}}","slots":["board0257"]}
+EOF
+
+PATH=/usr/src/agoric-sdk/node_modules/.bin:$PATH
+agops perf satisfaction --keyring-backend=test send --executeOffer "$badInvitationOffer" --from gov1 || true
+
+printISTBalance gov1

--- a/a3p-integration/proposals/a:upgrade-next/synthetic-chain-excerpt.js
+++ b/a3p-integration/proposals/a:upgrade-next/synthetic-chain-excerpt.js
@@ -1,0 +1,166 @@
+/**
+ * @file work-around: importing @agoric/synthetic-chain hangs XXX
+ */
+// @ts-check
+import { $ } from 'execa';
+
+const waitForBootstrap = async () => {
+  const endpoint = 'localhost';
+  while (true) {
+    const { stdout: json } = await $({
+      reject: false,
+    })`curl -s --fail -m 15 ${`${endpoint}:26657/status`}`;
+
+    if (json.length === 0) {
+      continue;
+    }
+
+    const data = JSON.parse(json);
+
+    if (data.jsonrpc !== '2.0') {
+      continue;
+    }
+
+    const lastHeight = data.result.sync_info.latest_block_height;
+
+    if (lastHeight !== '1') {
+      return lastHeight;
+    }
+
+    await new Promise(r => setTimeout(r, 2000));
+  }
+};
+
+export const waitForBlock = async (times = 1) => {
+  console.log(times);
+  let time = 0;
+  while (time < times) {
+    const block1 = await waitForBootstrap();
+    while (true) {
+      const block2 = await waitForBootstrap();
+
+      if (block1 !== block2) {
+        console.log('block produced');
+        break;
+      }
+
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    time += 1;
+  }
+};
+
+const { freeze } = Object;
+
+const agdBinary = 'agd';
+
+/**
+ * @param {{execFileSync: typeof import('child_process').execFileSync }} io
+ * @returns
+ */
+export const makeAgd = ({ execFileSync }) => {
+  /**
+   * @param {{
+   *   home?: string;
+   *   keyringBackend?: string;
+   *   rpcAddrs?: string[];
+   * }} opts
+   */
+  const make = ({ home, keyringBackend, rpcAddrs } = {}) => {
+    const keyringArgs = [
+      ...(home ? ['--home', home] : []),
+      ...(keyringBackend ? [`--keyring-backend`, keyringBackend] : []),
+    ];
+    if (rpcAddrs) {
+      assert.equal(
+        rpcAddrs.length,
+        1,
+        'XXX rpcAddrs must contain only one entry',
+      );
+    }
+    const nodeArgs = [...(rpcAddrs ? [`--node`, rpcAddrs[0]] : [])];
+
+    const exec = (args, opts) => execFileSync(agdBinary, args, opts).toString();
+
+    const outJson = ['--output', 'json'];
+
+    const ro = freeze({
+      status: async () => JSON.parse(exec([...nodeArgs, 'status'])),
+      query: async qArgs => {
+        const out = exec(['query', ...qArgs, ...nodeArgs, ...outJson], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+
+        try {
+          return JSON.parse(out);
+        } catch (e) {
+          console.error(e);
+          console.info('output:', out);
+        }
+      },
+    });
+    const nameHub = freeze({
+      /**
+       * NOTE: synchronous I/O
+       */
+      lookup: (...path) => {
+        if (!Array.isArray(path)) {
+          // TODO: use COND || Fail``
+          throw TypeError();
+        }
+        if (path.length !== 1) {
+          throw Error(`path length limited to 1: ${path.length}`);
+        }
+        const [name] = path;
+        const txt = exec(['keys', 'show', `--address`, name, ...keyringArgs]);
+        return txt.trim();
+      },
+    });
+    const rw = freeze({
+      /**
+       * @param {string[]} txArgs
+       * @param {{ chainId: string, from: string, yes?: boolean }} opts
+       */
+      tx: async (txArgs, { chainId, from, yes }) => {
+        const yesArg = yes ? ['--yes'] : [];
+        const args = [
+          ...nodeArgs,
+          ...[`--chain-id`, chainId],
+          ...keyringArgs,
+          ...[`--from`, from],
+          'tx',
+          ...['--broadcast-mode', 'block'],
+          ...['--gas', 'auto'],
+          ...['--gas-adjustment', '1.3'],
+          ...txArgs,
+          ...yesArg,
+          ...outJson,
+        ];
+        const out = exec(args);
+        try {
+          return JSON.parse(out);
+        } catch (e) {
+          console.error(e);
+          console.info('output:', out);
+        }
+      },
+      ...ro,
+      ...nameHub,
+      readOnly: () => ro,
+      nameHub: () => nameHub,
+      keys: {
+        add: (name, mnemonic) => {
+          return execFileSync(
+            agdBinary,
+            [...keyringArgs, 'keys', 'add', name, '--recover'],
+            { input: mnemonic },
+          ).toString();
+        },
+      },
+      withOpts: opts => make({ home, keyringBackend, rpcAddrs, ...opts }),
+    });
+    return rw;
+  };
+  return make();
+};

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -898,6 +898,8 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 				/* upgrade-15 evals */
 				// Upgrade ZCF only
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/upgrade-zcf.js"),
+				// Upgrade walletFactory
+				vm.CoreProposalStepForModules("@agoric/builders/scripts/smart-wallet/build-wallet-factory2-upgrade.js"),
 				// upgrade the provisioning vat
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/replace-provisioning.js"),
 				// Enable low-level Orchestration.


### PR DESCRIPTION
closes: #9239
~~stacked on #9236~~

## Description

 - [x] feat(smart-wallet): tryExitOffer reclaims withdrawn payments
   - [x] logs reclaimed balances
 - [x] upgrade core-eval, app.go
 - [x] feat: tryExitOffer CLI tool
 - [x] a3p-integration test: bad offer in prepare; test exitOffer tool in test phase

### Security / Scaling Considerations

Using `tryExitOffer` to trigger reclaim results in an irrelevant diagnostic that's possibly misleading:

```
2024-04-18T21:32:20.809Z SwingSet: ls: v43: Error#1: key bad-invitation-15 not found in collection live offer seats
```

### Documentation Considerations

the `exitOffer.js` tool is in sort of a strange place

### Testing Considerations

e2e test coverage seems good.

The unit test from #9236 doesn't cover this feature well because it doesn't run in the before-upgrade world

### Upgrade Considerations

needs cherry-picking
