### PR TITLE
fix!: in SmartWallet, if invitation is invalid, don't process offer

### DIFF
--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.4.0",
     "@agoric/swingset-vat": "^0.32.2",
+    "@agoric/zone": "^0.2.2",
     "@endo/bundle-source": "^3.2.2",
     "@endo/captp": "^4.1.1",
     "@endo/init": "^1.1.1",

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -972,13 +972,14 @@ export const prepareSmartWallet = (baggage, shared) => {
 
             const invitation = invitationFromSpec(offerSpec.invitationSpec);
 
-            const [paymentKeywordRecord, invitationAmount] = await Promise.all([
+            const invitationAmount =
+              await E(invitationIssuer).getAmountOf(invitation);
+
+            const paymentKeywordRecord =
               proposal?.give &&
-                deeplyFulfilledObject(
-                  facets.payments.withdrawGive(proposal.give, offerSpec.id),
-                ),
-              E(invitationIssuer).getAmountOf(invitation),
-            ]);
+              (await deeplyFulfilledObject(
+                facets.payments.withdrawGive(proposal.give, offerSpec.id),
+              ));
 
             // 2. Begin executing offer
             // No explicit signal to user that we reached here but if anything above

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -975,20 +975,20 @@ export const prepareSmartWallet = (baggage, shared) => {
             const invitationAmount =
               await E(invitationIssuer).getAmountOf(invitation);
 
-            const paymentKeywordRecord =
+            // 2. Begin executing offer
+            // No explicit signal to user that we reached here but if anything above
+            // failed they'd get an 'error' status update.
+
+            const withdrawnPayments =
               proposal?.give &&
               (await deeplyFulfilledObject(
                 facets.payments.withdrawGive(proposal.give, offerSpec.id),
               ));
 
-            // 2. Begin executing offer
-            // No explicit signal to user that we reached here but if anything above
-            // failed they'd get an 'error' status update.
-
             seatRef = await E(zoe).offer(
               invitation,
               proposal,
-              paymentKeywordRecord,
+              withdrawnPayments,
               offerSpec.offerArgs,
             );
             facets.helper.logWalletInfo(offerSpec.id, 'seated');

--- a/packages/smart-wallet/test/test-invitation1.js
+++ b/packages/smart-wallet/test/test-invitation1.js
@@ -33,6 +33,7 @@ const mockBootstrapPowers = async (
   log,
   spaceNames = ['installation', 'instance', 'issuer', 'brand'],
 ) => {
+  /** @type {import('@agoric/vat-data').Baggage} */
   const baggage = makeScalarMapStore('bootstrap');
   const zone = makeDurableZone(baggage);
   const { produce, consume } = makePromiseSpace();
@@ -82,7 +83,9 @@ const makeTestContext = async t => {
   const makeSpendableAsset = () => {
     const tok1 = makeIssuerKit('Tok1');
     const { issuer, brand } = bootKit.powers;
+    // @ts-expect-error new symbol
     issuer.produce.Token1.resolve(tok1.issuer);
+    // @ts-expect-error new symbol
     brand.produce.Token1.resolve(tok1.brand);
     return tok1;
   };
@@ -114,6 +117,7 @@ const makeTestContext = async t => {
   /** @type {import('../src/smartWallet.js').BrandDescriptorRegistry} */
   const registry = await makeRegistry();
 
+  /** @type {import('@agoric/vat-data').Baggage} */
   const swBaggage = makeScalarMapStore('smart-wallet');
 
   const secretWalletFactoryKey = Far('Key', {});
@@ -151,6 +155,7 @@ test.serial('handle failure to create invitation', async t => {
   const invitationIssuer = powers.issuer.consume.Invitation;
   const address = 'agoric1234';
 
+  // @ts-expect-error It's a promise.
   const walletsStorage = E(chainStorage).makeChildNode('wallet');
   const walletStorageNode = await E(walletsStorage).makeChildNode(address);
 

--- a/packages/smart-wallet/test/test-invitation1.js
+++ b/packages/smart-wallet/test/test-invitation1.js
@@ -155,7 +155,7 @@ test.serial('handle failure to create invitation', async t => {
   const invitationIssuer = powers.issuer.consume.Invitation;
   const address = 'agoric1234';
 
-  // @ts-expect-error It's a promise.
+  // @ts-expect-error Test setup ensures that chainStorage resolution is not undefined. (see #8247)
   const walletsStorage = E(chainStorage).makeChildNode('wallet');
   const walletStorageNode = await E(walletsStorage).makeChildNode(address);
 


### PR DESCRIPTION
refs: #9239

## Description

When SmartWallet gets a request to exercise an invitation, it shouldn't create an offer if the invitation is broken.

### Security Considerations

Creating an offer requires withdrawing funds, which have to be returned to the user. Better to check the invitation first and skip the rest.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

We added a test and a fix.

### Upgrade Considerations

We'd like to get this into the next available upgrade. There are no complex interactions with other updates.
