### PR TITLE
Upgrade ZCF only

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -899,6 +899,8 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/smart-wallet/build-wallet-factory2-upgrade.js"),
 				// Then, upgrade Zoe and ZCF
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/replace-zoe.js"),
+				// Upgrade ZCF only
+				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/upgrade-zcf.js"),
 				// Then, upgrade the provisioning vat
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/replace-provisioning.js"),
 				// Enable low-level Orchestration.

--- a/packages/builders/scripts/vats/upgrade-zcf.js
+++ b/packages/builders/scripts/vats/upgrade-zcf.js
@@ -1,0 +1,18 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    sourceSpec: '@agoric/vats/src/proposals/zcf-only-proposal.js',
+    getManifestCall: [
+      'getManifestForUpgradingZcf',
+      {
+        zcfRef: publishRef(install('@agoric/zoe/src/contractFacet/vatRoot.js')),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('upgrade-zcf', defaultProposalBuilder);
+};

--- a/packages/vats/src/proposals/zcf-only-proposal.js
+++ b/packages/vats/src/proposals/zcf-only-proposal.js
@@ -1,0 +1,36 @@
+// @ts-check
+import { E } from '@endo/far';
+
+/**
+ * @param {BootstrapPowers} powers
+ * @param {object} options
+ * @param {{ zcfRef: VatSourceRef }} options.options
+ */
+export const upgradeZcfOnly = async ({ consume: { vatStore } }, options) => {
+  const { zcfRef } = options.options;
+
+  const { root: zoeRoot } = await E(vatStore).get('zoe');
+
+  const zoeConfigFacet = await E(zoeRoot).getZoeConfigFacet();
+  await E(zoeConfigFacet).updateZcfBundleId(zcfRef.bundleID);
+  console.log(`ZCF BUNDLE ID: `, zcfRef.bundleID);
+};
+harden(upgradeZcfOnly);
+
+// main and permit are for use with rollup-plugin-core-eval.js
+export const main = upgradeZcfOnly;
+
+export const permit = {
+  consume: {
+    vatStore: true,
+  },
+};
+
+export const manifest = {
+  [upgradeZcfOnly.name]: permit,
+};
+
+export const getManifestForUpgradingZcf = (_powers, options) => ({
+  manifest,
+  options,
+});


### PR DESCRIPTION
refs: #9246

## Description

Add a proposal to upgrade the ZCF bundle only, and run it as a core proposal during chain software upgrade. This is necessary for #9246 but not sufficient as the release also needs to include the fix from #8911.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Will be tested end to end (make sure smart wallet can be upgraded) in #9206 

### Upgrade Considerations

@gibson042 must do a partial cherry-pick of https://github.com/Agoric/agoric-sdk/pull/8911/commits/72c75740aff920ffb53231441d0f00a8747400f1#diff-8dcfebb96abffde204086c5d660142e0c4c74a7bac0800f7c18447e0baad1979 (the `zcfZygote.js` change) in the release-15 branch.

Will be part of that chain software upgrade. 