### PR TITLE
repair ZCF to unblock contract upgrade 

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -857,7 +857,8 @@ func upgrade15Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgr
 			// Each CoreProposalStep runs sequentially, and can be constructed from
 			// one or more modules executing in parallel within the step.
 			CoreProposalSteps = []vm.CoreProposalStep{
-				// empty for now
+				// Upgrade ZCF only
+				vm.CoreProposalStepForModules("@agoric/vats/scripts/upgrade-zcf.js"),
 			}
 		}
 

--- a/packages/vats/scripts/upgrade-zcf.js
+++ b/packages/vats/scripts/upgrade-zcf.js
@@ -1,0 +1,18 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('packages/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    sourceSpec: '@agoric/vats/src/proposals/zcf-only-proposal.js',
+    getManifestCall: [
+      'getManifestForUpgradingZcf',
+      {
+        zcfRef: publishRef(install('@agoric/zoe/src/contractFacet/vatRoot.js')),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('upgrade-zcf', defaultProposalBuilder);
+};

--- a/packages/vats/src/proposals/zcf-only-proposal.js
+++ b/packages/vats/src/proposals/zcf-only-proposal.js
@@ -1,0 +1,36 @@
+// @ts-check
+import { E } from '@endo/far';
+
+/**
+ * @param {BootstrapPowers} powers
+ * @param {object} options
+ * @param {{ zcfRef: VatSourceRef }} options.options
+ */
+export const upgradeZcfOnly = async ({ consume: { vatStore } }, options) => {
+  const { zcfRef } = options.options;
+
+  const { root: zoeRoot } = await E(vatStore).get('zoe');
+
+  const zoeConfigFacet = await E(zoeRoot).getZoeConfigFacet();
+  await E(zoeConfigFacet).updateZcfBundleId(zcfRef.bundleID);
+  console.log(`ZCF BUNDLE ID: `, zcfRef.bundleID);
+};
+harden(upgradeZcfOnly);
+
+// main and permit are for use with rollup-plugin-core-eval.js
+export const main = upgradeZcfOnly;
+
+export const permit = {
+  consume: {
+    vatStore: true,
+  },
+};
+
+export const manifest = {
+  [upgradeZcfOnly.name]: permit,
+};
+
+export const getManifestForUpgradingZcf = (_powers, options) => ({
+  manifest,
+  options,
+});

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -426,8 +426,12 @@ export const makeZCFZygote = async (
 
       await null;
       if (!zcfBaggage.has('repairedContractCompletionWatcher')) {
-        await E(zoeInstanceAdmin).repairContractCompletionWatcher();
-        console.log(`Repaired contract completion watcher`);
+        // We don't wait because it's a cross-vat call (to Zoe) that can't be
+        // completed during this vat's start-up
+        E(zoeInstanceAdmin)
+          .repairContractCompletionWatcher()
+          .catch(() => {});
+
         zcfBaggage.init('repairedContractCompletionWatcher', true);
       }
 


### PR DESCRIPTION
closes: #9246

## Description

#8911 fixes an issue with ZCF on the master branch. That issue effectively blocks contract upgrade. This ports that fix to the release branch, and adds a proposal that tells Zoe to use the new ZCF.

### Security Considerations

Zoe and ZCF and the ability to upgrade contracts are crucial.

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

After installing the fix, we will test contract upgrades in a3p and the dev chains. The fix itself is tested in #8911.

### Upgrade Considerations

It's all about upgrade.