### PR TITLE
compat for NPM lifecycle scripts

### DIFF
--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -72,7 +72,7 @@
     "!CHANGELOG.md"
   ],
   "scripts": {
-    "build": "yarn tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "clean": "rimraf dist",
     "codegen": "yarn protos-update && node scripts/codegen.cjs",
     "prepare": "npm run build",

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -16,7 +16,7 @@
     "build:env": "node src/build.js --show-env > build.env",
     "build:from-env": "{ cat build.env; echo node src/build.js; } | xargs env",
     "build": "yarn build:bin && yarn build:env",
-    "postinstall": "yarn build:from-env",
+    "postinstall": "npm run build:from-env",
     "clean": "rm -rf xsnap-native/xsnap/build",
     "lint": "run-s --continue-on-error lint:*",
     "lint:js": "eslint 'src/**/*.js' 'test/**/*.js' api.js",


### PR DESCRIPTION
closes: #8288

## Description

ui-kit was recently bumped to Yarn 4 and @samsiegart hit a snag that required patching : https://github.com/Agoric/ui-kit/pull/98/commits/464f61db578212b2baf4f1d2bf633a7845c95abe

This removes `yarn` dependence in [NPM lifecycle scripts](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-operation-order).  It does so by using `npm run`, which should be available everywhere. In Node 22 we'll [have `node --run`](https://github.com/nodejs/corepack/issues/57#issuecomment-2037834669) available.

### Security Considerations

none
### Scaling Considerations

none

### Documentation Considerations

none
### Testing Considerations

working in https://github.com/Agoric/ui-kit/pull/98/commits/464f61db578212b2baf4f1d2bf633a7845c95abe

### Upgrade Considerations

none