### PR TITLE
chore: Cherry-pick go.mod changes into dev-upgrade-15

### DIFF
--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -168,9 +168,6 @@ replace (
 
 	github.com/confio/ics23/go => github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1
 
-	// We need a fork of cosmos-sdk until all of the differences are merged.
-	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.1
-
 	// https://pkg.go.dev/vuln/GO-2023-2409
 	github.com/dvsekhvalnov/jose2go => github.com/dvsekhvalnov/jose2go v1.5.1-0.20231206184617-48ba0b76bc88
 
@@ -184,13 +181,19 @@ replace (
 
 	// replace broken goleveldb.
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+)
+
+// Agoric-specific replacements:
+replace (
+	// We need a fork of cosmos-sdk until all of the differences are merged.
+	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.1
 
 	// use cometbft
 	// Use our fork at least until post-v0.34.14 is released with
 	// https://github.com/tendermint/tendermint/issue/6899 resolved.
 	github.com/tendermint/tendermint => github.com/agoric-labs/cometbft v0.34.30-alpha.agoric.1
 
-// For testing against a local cosmos-sdk or tendermint
+// For testing against a local cosmos-sdk or cometbft
 // github.com/cosmos/cosmos-sdk => ../../../forks/cosmos-sdk
-// github.com/tendermint/tendermint => ../../../forks/tendermint
+// github.com/tendermint/tendermint => ../../../forks/cometbft
 )

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -186,7 +186,7 @@ replace (
 // Agoric-specific replacements:
 replace (
 	// We need a fork of cosmos-sdk until all of the differences are merged.
-	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.3
+	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4
 
 	// Pick up an IAVL race fix.
 	github.com/cosmos/iavl => github.com/cosmos/iavl v0.19.7

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -186,7 +186,10 @@ replace (
 // Agoric-specific replacements:
 replace (
 	// We need a fork of cosmos-sdk until all of the differences are merged.
-	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.1
+	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.3
+
+	// Pick up an IAVL race fix.
+	github.com/cosmos/iavl => github.com/cosmos/iavl v0.19.7
 
 	// use cometbft
 	// Use our fork at least until post-v0.34.14 is released with

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -232,8 +232,8 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agoric-labs/cometbft v0.34.30-alpha.agoric.1 h1:tqCNL72pQXdUmBzgv1md5SN2U3K/PaYQ4qZ5pFv8v6w=
 github.com/agoric-labs/cometbft v0.34.30-alpha.agoric.1/go.mod h1:myvkihZD8eg9jKE3WFaugkNoL5nvEqlP7Jbjg98pCek=
-github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.1 h1:VZFX9Mogwt4cVTnkdt9zA6UJue4XYXdBURNhlTWw71Q=
-github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.1/go.mod h1:zUe5lsg/X7SeSO1nGkzOh9EGKO295szfrxIxYmeLYic=
+github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.3 h1:EpuIGO5/l8Hwdo6BhRCvETys6HrFvDBbbtarT9L+gKg=
+github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.3/go.mod h1:d7e4h+w7FNBNmE6ysp6duBVuQg67pqMtvsLwpT9ca3E=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -376,8 +376,8 @@ github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
-github.com/cosmos/iavl v0.19.6 h1:XY78yEeNPrEYyNCKlqr9chrwoeSDJ0bV2VjocTk//OU=
-github.com/cosmos/iavl v0.19.6/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
+github.com/cosmos/iavl v0.19.7 h1:ij32FaEnwxfEurtK0QKDNhTWFnz6NUmrI5gky/WnoY0=
+github.com/cosmos/iavl v0.19.7/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
 github.com/cosmos/ibc-go/v6 v6.2.1 h1:NiaDXTRhKwf3n9kELD4VRIe5zby1yk1jBvaz9tXTQ6k=
 github.com/cosmos/ibc-go/v6 v6.2.1/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -232,8 +232,8 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agoric-labs/cometbft v0.34.30-alpha.agoric.1 h1:tqCNL72pQXdUmBzgv1md5SN2U3K/PaYQ4qZ5pFv8v6w=
 github.com/agoric-labs/cometbft v0.34.30-alpha.agoric.1/go.mod h1:myvkihZD8eg9jKE3WFaugkNoL5nvEqlP7Jbjg98pCek=
-github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.3 h1:EpuIGO5/l8Hwdo6BhRCvETys6HrFvDBbbtarT9L+gKg=
-github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.3/go.mod h1:d7e4h+w7FNBNmE6ysp6duBVuQg67pqMtvsLwpT9ca3E=
+github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4 h1:i5IgChQjTyWulV/y5NpVBB5qBJETQ59hYglod6vhok0=
+github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4/go.mod h1:d7e4h+w7FNBNmE6ysp6duBVuQg67pqMtvsLwpT9ca3E=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=


### PR DESCRIPTION
## Description

Includes commits from the following PRs:
* #9030 (partial cherry-pick; refactors go.mod)
* #9251
* #9263

Constructed using the following `git rebase -i HEAD` todo list:
```
# pull request #9030 branch mfig-ibc-revamp
## Replace this commit with just its refactoring of golang/cosmos/go.mod
## and subsequent `go mod tidy`.
edit fff392b9a30af2d60a6dffe3427eb5bb5ecdde7b build(cosmos): add `ibc-go` fork and `go mod tidy`
exec git commit --amend --reset-author -m 'build(cosmos): Refactor go.mod to match master'

# pull request #9251 branch 9224-u15-changes
label base-9224-u15-changes
## Resolve conflict using `go mod tidy`.
pick 548e758962ad348816d2b3d1618688829cc7c62b fix: various fixes and features for u15
label 9224-u15-changes
reset base-9224-u15-changes
merge -C c1ec5f12460b1936090f7d76941dfedf8521b544 9224-u15-changes # fix: various fixes and features for u15 (#9251)

# pull request #9263 branch 9224-abci-flag-tests
label base-9224-abci-flag-tests
pick 0d9a63d95d25723720686dfebb1283adcf0c9465 test: pick up cosmos-sdk with more abci flag tests
label 9224-abci-flag-tests
reset base-9224-abci-flag-tests
merge -C 947973cdb72b040410cd56de221c2b154582dff8 9224-abci-flag-tests # test: pick up cosmos-sdk with more abci flag tests (#9263)
```

### Security Considerations

None in particular.

### Scaling Considerations

This brings in the ability to switch between "local" and "committing" query client behavior.

### Documentation Considerations

Adopted by reference.

### Testing Considerations

No additions.

### Upgrade Considerations

To be included in agoric-upgrade-15.
