### PR TITLE
chore: Cherry-pick smart-wallet changes into dev-upgrade-15

### DIFF
--- a/a3p-integration/proposals/a:upgrade-15/exit-reclaim.test.js
+++ b/a3p-integration/proposals/a:upgrade-15/exit-reclaim.test.js
@@ -1,0 +1,36 @@
+import test from 'ava';
+import { $ } from 'execa';
+import { execFileSync } from 'node:child_process';
+import { makeAgd, waitForBlock } from './synthetic-chain-excerpt.js';
+
+const offerId = 'bad-invitation-15'; // cf. prepare.sh
+const from = 'gov1';
+
+test('exitOffer tool reclaims stuck payment', async t => {
+  const showAndExec = (file, args, opts) => {
+    console.log('$', file, ...args);
+    return execFileSync(file, args, opts);
+  };
+  const agd = makeAgd({ execFileSync: showAndExec }).withOpts({
+    keyringBackend: 'test',
+  });
+
+  const addr = await agd.lookup(from);
+  t.log(from, 'addr', addr);
+
+  const getBalance = async target => {
+    const { balances } = await agd.query(['bank', 'balances', addr]);
+    const { amount } = balances.find(({ denom }) => denom === target);
+    return Number(amount);
+  };
+
+  const before = await getBalance('uist');
+  t.log('uist balance before:', before);
+
+  await $`node ./exitOffer.js --id ${offerId} --from ${from}`;
+
+  await waitForBlock(2);
+  const after = await getBalance('uist');
+  t.log('uist balance after:', after);
+  t.true(after > before);
+});

--- a/a3p-integration/proposals/a:upgrade-15/exitOffer.js
+++ b/a3p-integration/proposals/a:upgrade-15/exitOffer.js
@@ -1,0 +1,97 @@
+// Note: limit imports to node modules for portability
+import { parseArgs, promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const options = /** @type {const} */ ({
+  id: { type: 'string' },
+  from: { type: 'string' },
+  bin: { type: 'string', default: '/usr/src/agoric-sdk/node_modules/.bin' },
+});
+
+const Usage = `
+Try to exit an offer, reclaiming any associated payments.
+
+  node exitOffer.js --id ID --from FROM [--bin PATH]
+
+Options:
+  --id <offer id>
+  --from <address or key name>
+
+  --bin <path to agoric and agd> default: ${options.bin.default}
+`;
+
+const badUsage = () => {
+  const reason = new Error(Usage);
+  reason.name = 'USAGE';
+  throw reason;
+};
+
+const { stringify: q } = JSON;
+// limited to JSON data: no remotables/promises; no undefined.
+const toCapData = data => ({ body: `#${q(data)}`, slots: [] });
+
+const { entries } = Object;
+/**
+ * @param {Record<string, string>} obj - e.g. { color: 'blue' }
+ * @returns {string[]} - e.g. ['--color', 'blue']
+ */
+const flags = obj =>
+  entries(obj)
+    .map(([k, v]) => [`--${k}`, v])
+    .flat();
+
+const execP = promisify(execFile);
+
+const showAndRun = (file, args) => {
+  console.log('$', file, ...args);
+  return execP(file, args);
+};
+
+const withTempFile = async (tail, fn) => {
+  const tmpDir = await mkdtemp('offers-');
+  const tmpFile = join(tmpDir, tail);
+  try {
+    const result = await fn(tmpFile);
+    return result;
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(err =>
+      console.error(err),
+    );
+  }
+};
+
+const doAction = async (action, from) => {
+  await withTempFile('offer.json', async tmpOffer => {
+    await writeFile(tmpOffer, q(toCapData(action)));
+
+    const out = await showAndRun('agoric', [
+      'wallet',
+      ...flags({ 'keyring-backend': 'test' }),
+      'send',
+      ...flags({ offer: tmpOffer, from }),
+    ]);
+    return out.stdout;
+  });
+};
+
+const main = async (argv, env) => {
+  const { values } = parseArgs({ args: argv.slice(2), options });
+  const { id: offerId, from, bin } = values;
+  (offerId && from) || badUsage();
+
+  env.PATH = `${bin}:${env.PATH}`;
+  const action = { method: 'tryExitOffer', offerId };
+  const out = await doAction(action, from);
+  console.log(out);
+};
+
+main(process.argv, process.env).catch(e => {
+  if (e.name === 'USAGE' || e.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION') {
+    console.error(e.message);
+  } else {
+    console.error(e);
+  }
+  process.exit(1);
+});

--- a/a3p-integration/proposals/a:upgrade-15/initial.test.js
+++ b/a3p-integration/proposals/a:upgrade-15/initial.test.js
@@ -3,7 +3,7 @@ import test from 'ava';
 import { getVatDetails } from '@agoric/synthetic-chain';
 
 const vats = {
-  walletFactory: { incarnation: 2 },
+  walletFactory: { incarnation: 3 },
   zoe: { incarnation: 1 },
 };
 

--- a/a3p-integration/proposals/a:upgrade-15/prepare.sh
+++ b/a3p-integration/proposals/a:upgrade-15/prepare.sh
@@ -1,9 +1,29 @@
 #!/bin/bash
 
 # Exit when any command fails
-set -e
+set -uxeo pipefail
 
 # Place here any actions that should happen before the upgrade is proposed. The
 # actions are executed in the previous chain software, and the effects are
 # persisted so they can be used in the steps after the upgrade is complete,
 # such as in the "use" or "test" steps, or further proposal layers.
+
+printISTBalance() {
+  addr=$(agd keys show -a "$1" --keyring-backend=test)
+  agd query bank balances "$addr" -o json \
+    | jq -c '.balances[] | select(.denom=="uist")'
+
+}
+
+echo TEST: Offer with bad invitation
+printISTBalance gov1
+
+badInvitationOffer=$(mktemp)
+cat > "$badInvitationOffer" << 'EOF'
+{"body":"#{\"method\":\"executeOffer\",\"offer\":{\"id\":\"bad-invitation-15\",\"invitationSpec\":{\"callPipe\":[[\"badMethodName\"]],\"instancePath\":[\"reserve\"],\"source\":\"agoricContract\"},\"proposal\":{\"give\":{\"Collateral\":{\"brand\":\"$0.Alleged: IST brand\",\"value\":\"+15000\"}}}}}","slots":["board0257"]}
+EOF
+
+PATH=/usr/src/agoric-sdk/node_modules/.bin:$PATH
+agops perf satisfaction --keyring-backend=test send --executeOffer "$badInvitationOffer" --from gov1 || true
+
+printISTBalance gov1

--- a/a3p-integration/proposals/a:upgrade-15/synthetic-chain-excerpt.js
+++ b/a3p-integration/proposals/a:upgrade-15/synthetic-chain-excerpt.js
@@ -1,0 +1,166 @@
+/**
+ * @file work-around: importing @agoric/synthetic-chain hangs XXX
+ */
+// @ts-check
+import { $ } from 'execa';
+
+const waitForBootstrap = async () => {
+  const endpoint = 'localhost';
+  while (true) {
+    const { stdout: json } = await $({
+      reject: false,
+    })`curl -s --fail -m 15 ${`${endpoint}:26657/status`}`;
+
+    if (json.length === 0) {
+      continue;
+    }
+
+    const data = JSON.parse(json);
+
+    if (data.jsonrpc !== '2.0') {
+      continue;
+    }
+
+    const lastHeight = data.result.sync_info.latest_block_height;
+
+    if (lastHeight !== '1') {
+      return lastHeight;
+    }
+
+    await new Promise(r => setTimeout(r, 2000));
+  }
+};
+
+export const waitForBlock = async (times = 1) => {
+  console.log(times);
+  let time = 0;
+  while (time < times) {
+    const block1 = await waitForBootstrap();
+    while (true) {
+      const block2 = await waitForBootstrap();
+
+      if (block1 !== block2) {
+        console.log('block produced');
+        break;
+      }
+
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    time += 1;
+  }
+};
+
+const { freeze } = Object;
+
+const agdBinary = 'agd';
+
+/**
+ * @param {{execFileSync: typeof import('child_process').execFileSync }} io
+ * @returns
+ */
+export const makeAgd = ({ execFileSync }) => {
+  /**
+   * @param {{
+   *   home?: string;
+   *   keyringBackend?: string;
+   *   rpcAddrs?: string[];
+   * }} opts
+   */
+  const make = ({ home, keyringBackend, rpcAddrs } = {}) => {
+    const keyringArgs = [
+      ...(home ? ['--home', home] : []),
+      ...(keyringBackend ? [`--keyring-backend`, keyringBackend] : []),
+    ];
+    if (rpcAddrs) {
+      assert.equal(
+        rpcAddrs.length,
+        1,
+        'XXX rpcAddrs must contain only one entry',
+      );
+    }
+    const nodeArgs = [...(rpcAddrs ? [`--node`, rpcAddrs[0]] : [])];
+
+    const exec = (args, opts) => execFileSync(agdBinary, args, opts).toString();
+
+    const outJson = ['--output', 'json'];
+
+    const ro = freeze({
+      status: async () => JSON.parse(exec([...nodeArgs, 'status'])),
+      query: async qArgs => {
+        const out = exec(['query', ...qArgs, ...nodeArgs, ...outJson], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+
+        try {
+          return JSON.parse(out);
+        } catch (e) {
+          console.error(e);
+          console.info('output:', out);
+        }
+      },
+    });
+    const nameHub = freeze({
+      /**
+       * NOTE: synchronous I/O
+       */
+      lookup: (...path) => {
+        if (!Array.isArray(path)) {
+          // TODO: use COND || Fail``
+          throw TypeError();
+        }
+        if (path.length !== 1) {
+          throw Error(`path length limited to 1: ${path.length}`);
+        }
+        const [name] = path;
+        const txt = exec(['keys', 'show', `--address`, name, ...keyringArgs]);
+        return txt.trim();
+      },
+    });
+    const rw = freeze({
+      /**
+       * @param {string[]} txArgs
+       * @param {{ chainId: string, from: string, yes?: boolean }} opts
+       */
+      tx: async (txArgs, { chainId, from, yes }) => {
+        const yesArg = yes ? ['--yes'] : [];
+        const args = [
+          ...nodeArgs,
+          ...[`--chain-id`, chainId],
+          ...keyringArgs,
+          ...[`--from`, from],
+          'tx',
+          ...['--broadcast-mode', 'block'],
+          ...['--gas', 'auto'],
+          ...['--gas-adjustment', '1.3'],
+          ...txArgs,
+          ...yesArg,
+          ...outJson,
+        ];
+        const out = exec(args);
+        try {
+          return JSON.parse(out);
+        } catch (e) {
+          console.error(e);
+          console.info('output:', out);
+        }
+      },
+      ...ro,
+      ...nameHub,
+      readOnly: () => ro,
+      nameHub: () => nameHub,
+      keys: {
+        add: (name, mnemonic) => {
+          return execFileSync(
+            agdBinary,
+            [...keyringArgs, 'keys', 'add', name, '--recover'],
+            { input: mnemonic },
+          ).toString();
+        },
+      },
+      withOpts: opts => make({ home, keyringBackend, rpcAddrs, ...opts }),
+    });
+    return rw;
+  };
+  return make();
+};

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -859,6 +859,8 @@ func upgrade15Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgr
 			CoreProposalSteps = []vm.CoreProposalStep{
 				// Upgrade ZCF only
 				vm.CoreProposalStepForModules("@agoric/vats/scripts/upgrade-zcf.js"),
+				// Upgrade walletFactory
+				vm.CoreProposalStepForModules("@agoric/vats/scripts/build-wallet-factory2-upgrade.js"),
 			}
 		}
 

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.3.1-u14.0",
     "@agoric/vats": "^0.15.2-u13.0",
+    "@agoric/zone": "^0.2.3-u14.0",
     "@endo/bundle-source": "2.5.2-upstream-rollup",
     "@endo/captp": "3.1.1",
     "@endo/init": "0.5.56",

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -967,13 +967,14 @@ export const prepareSmartWallet = (baggage, shared) => {
 
             const invitation = invitationFromSpec(offerSpec.invitationSpec);
 
-            const [paymentKeywordRecord, invitationAmount] = await Promise.all([
+            const invitationAmount =
+              await E(invitationIssuer).getAmountOf(invitation);
+
+            const paymentKeywordRecord =
               proposal?.give &&
-                deeplyFulfilledObject(
-                  facets.payments.withdrawGive(proposal.give, offerSpec.id),
-                ),
-              E(invitationIssuer).getAmountOf(invitation),
-            ]);
+              (await deeplyFulfilledObject(
+                facets.payments.withdrawGive(proposal.give, offerSpec.id),
+              ));
 
             // 2. Begin executing offer
             // No explicit signal to user that we reached here but if anything above

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -970,21 +970,20 @@ export const prepareSmartWallet = (baggage, shared) => {
             const invitationAmount =
               await E(invitationIssuer).getAmountOf(invitation);
 
-            const paymentKeywordRecord =
+            // 2. Begin executing offer
+            // No explicit signal to user that we reached here but if anything above
+            // failed they'd get an 'error' status update.
+
+            const withdrawnPayments =
               proposal?.give &&
               (await deeplyFulfilledObject(
                 facets.payments.withdrawGive(proposal.give, offerSpec.id),
               ));
 
-            // 2. Begin executing offer
-            // No explicit signal to user that we reached here but if anything above
-            // failed they'd get an 'error' status update.
-
-            /** @type {UserSeat} */
             seatRef = await E(zoe).offer(
               invitation,
               proposal,
-              paymentKeywordRecord,
+              withdrawnPayments,
               offerSpec.offerArgs,
             );
             facets.helper.logWalletInfo(offerSpec.id, 'seated');

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -902,7 +902,7 @@ export const prepareSmartWallet = (baggage, shared) => {
          * Find the live payments for the offer and deposit them back in the appropriate purses.
          *
          * @param {OfferId} offerId
-         * @returns {Promise<void>}
+         * @returns {Promise<Amount[]>}
          */
         async tryReclaimingWithdrawnPayments(offerId) {
           const { facets } = this;
@@ -913,8 +913,9 @@ export const prepareSmartWallet = (baggage, shared) => {
           if (liveOfferPayments.has(offerId)) {
             const brandPaymentRecord = liveOfferPayments.get(offerId);
             if (!brandPaymentRecord) {
-              return;
+              return [];
             }
+            const out = [];
             // Use allSettled to ensure we attempt all the deposits, regardless of
             // individual rejections.
             await Promise.allSettled(
@@ -924,10 +925,16 @@ export const prepareSmartWallet = (baggage, shared) => {
                 const purseP = facets.helper.purseForBrand(b);
 
                 // Now send it back to the purse.
-                return E(purseP).deposit(p);
+                return E(purseP)
+                  .deposit(p)
+                  .then(amt => {
+                    out.push(amt);
+                  });
               }),
             );
+            return harden(out);
           }
+          return [];
         },
       },
 
@@ -1048,6 +1055,19 @@ export const prepareSmartWallet = (baggage, shared) => {
          * @throws if the seat can't be found or E(seatRef).tryExit() fails.
          */
         async tryExitOffer(offerId) {
+          const { facets } = this;
+          const amts = await facets.payments
+            .tryReclaimingWithdrawnPayments(offerId)
+            .catch(e => {
+              facets.helper.logWalletError(
+                'recovery failed reclaiming payments',
+                e,
+              );
+              return [];
+            });
+          if (amts.length > 0) {
+            facets.helper.logWalletInfo('reclaimed', amts, 'from', offerId);
+          }
           const seatRef = this.state.liveOfferSeats.get(offerId);
           await E(seatRef).tryExit();
         },

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -967,6 +967,7 @@ export const prepareSmartWallet = (baggage, shared) => {
 
             const invitation = invitationFromSpec(offerSpec.invitationSpec);
 
+            // prettier-ignore
             const invitationAmount =
               await E(invitationIssuer).getAmountOf(invitation);
 

--- a/packages/smart-wallet/test/test-invitation1.js
+++ b/packages/smart-wallet/test/test-invitation1.js
@@ -1,0 +1,243 @@
+// @ts-check
+/* global setTimeout */
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { createRequire } from 'module';
+import { E, Far } from '@endo/far';
+import { makeScalarMapStore } from '@agoric/store';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+import { makeNameHubKit, makePromiseSpace } from '@agoric/vats';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
+import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
+import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
+import { allValues } from '@agoric/internal';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { prepareSmartWallet } from '../src/smartWallet.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
+const test = anyTest;
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const nodeRequire = createRequire(import.meta.url);
+const asset = {
+  anyContract: nodeRequire.resolve(
+    '@agoric/zoe/src/contracts/automaticRefund.js',
+  ),
+};
+
+const mockBootstrapPowers = async (
+  log,
+  spaceNames = ['installation', 'instance', 'issuer', 'brand'],
+) => {
+  const baggage = makeScalarMapStore('bootstrap');
+  const zone = makeDurableZone(baggage);
+  const { produce, consume } = makePromiseSpace();
+
+  const { admin, vatAdminState } = makeFakeVatAdmin();
+  const { zoeService: zoe } = makeZoeKitForTest(admin);
+  produce.zoe.resolve(zoe);
+
+  const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
+    makeNameHubKit();
+  produce.agoricNames.resolve(agoricNames);
+
+  const spaces = await makeWellKnownSpaces(agoricNamesAdmin, log, spaceNames);
+
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationBrand = await E(invitationIssuer).getBrand();
+  spaces.brand.produce.Invitation.resolve(invitationBrand);
+  spaces.issuer.produce.Invitation.resolve(invitationIssuer);
+
+  const chainStorage = makeMockChainStorageRoot();
+  produce.chainStorage.resolve(chainStorage);
+
+  const board = makeFakeBoard();
+  produce.board.resolve(board);
+
+  /** @type {BootstrapPowers} */
+  // @ts-expect-error mock
+  const powers = { produce, consume, ...spaces, zone };
+  const shared = {};
+
+  return { powers, vatAdminState, chainStorage, shared };
+};
+
+const makeTestContext = async t => {
+  const bootKit = await mockBootstrapPowers(t.log);
+  const bundleCache = await makeNodeBundleCache('bundles/', {}, s => import(s));
+
+  const { agoricNames, board, zoe } = bootKit.powers.consume;
+  const startAnyContract = async () => {
+    const bundle = await bundleCache.load(asset.anyContract, 'automaticRefund');
+    /** @type {Promise<Installation<import('../src/walletFactory.js').prepare>>} */
+    const installation = E(zoe).install(bundle);
+    return E(zoe).startInstance(installation);
+  };
+  const { instance: anyInstance } = await startAnyContract();
+
+  const makeSpendableAsset = () => {
+    const tok1 = makeIssuerKit('Tok1');
+    const { issuer, brand } = bootKit.powers;
+    issuer.produce.Token1.resolve(tok1.issuer);
+    brand.produce.Token1.resolve(tok1.brand);
+    return tok1;
+  };
+  const spendable = makeSpendableAsset();
+
+  const makeRegistry = async () => {
+    /** @type {[string, Brand][]} */
+    const be = await E(E(agoricNames).lookup('brand')).entries();
+    /** @type {[string, Issuer][]} */
+    const ie = await E(E(agoricNames).lookup('issuer')).entries();
+    const byName = Object.fromEntries(ie);
+    const descriptors = await Promise.all(
+      be.map(([name, b]) => {
+        /** @type {Promise<import('../src/smartWallet.js').BrandDescriptor>} */
+        const d = allValues({
+          brand: b,
+          displayInfo: E(b).getDisplayInfo(),
+          issuer: byName[name],
+          petname: name,
+        });
+        return d;
+      }),
+    );
+    /** @type {MapStore<Brand, import('../src/smartWallet.js').BrandDescriptor>} */
+    const store = makeScalarMapStore('registry');
+    store.addAll(harden(descriptors.map(d => [d.brand, d])));
+    return store;
+  };
+  /** @type {import('../src/smartWallet.js').BrandDescriptorRegistry} */
+  const registry = await makeRegistry();
+
+  const swBaggage = makeScalarMapStore('smart-wallet');
+
+  const secretWalletFactoryKey = Far('Key', {});
+
+  const { brand: brandSpace, issuer: issuerSpace } = bootKit.powers;
+  /** @type {Issuer<'set'>} */
+  // @ts-expect-error cast
+  const invitationIssuer = await issuerSpace.consume.Invitation;
+  /** @type {Brand<'set'>} */
+  // @ts-expect-error cast
+  const invitationBrand = await brandSpace.consume.Invitation;
+  const invitationDisplayInfo = await E(invitationBrand).getDisplayInfo();
+  const publicMarshaller = await E(board).getPublishingMarshaller();
+  const makeSmartWallet = prepareSmartWallet(swBaggage, {
+    agoricNames,
+    invitationBrand,
+    invitationDisplayInfo,
+    invitationIssuer,
+    publicMarshaller,
+    zoe,
+    secretWalletFactoryKey,
+    registry,
+  });
+
+  return { ...bootKit, makeSmartWallet, anyInstance, spendable };
+};
+
+test.before(async t => (t.context = await makeTestContext(t)));
+
+test.serial('handle failure to create invitation', async t => {
+  const { powers, makeSmartWallet, spendable, shared } = t.context;
+  const { chainStorage, board } = powers.consume;
+  /** @type {Issuer<'set'>} */
+  // @ts-expect-error cast
+  const invitationIssuer = powers.issuer.consume.Invitation;
+  const address = 'agoric1234';
+
+  const walletsStorage = E(chainStorage).makeChildNode('wallet');
+  const walletStorageNode = await E(walletsStorage).makeChildNode(address);
+
+  const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
+
+  /** @type {() => import('@agoric/vats/src/vat-bank.js').Bank} */
+  const makeBank = () =>
+    Far('Bank', {
+      getPurse: async brand => {
+        assert(brand === spendable.brand);
+        if (shared.thePurse) return shared.thePurse;
+
+        const purse = await E(spendable.issuer).makeEmptyPurse();
+        const amt = AmountMath.make(spendable.brand, 100n);
+        const pmt = await E(spendable.mint).mintPayment(amt);
+        await E(purse).deposit(pmt);
+        shared.thePurse = purse;
+        const slowWithdrawPurse = {
+          ...purse,
+          withdraw: async a => {
+            await delay(100);
+            console.log('@@slow withdraw', a);
+            return E(purse).withdraw(a);
+          },
+        };
+        return slowWithdrawPurse;
+      },
+      getAssetSubscription: () => {
+        throw new Error('TODO');
+      },
+    });
+
+  const smartWallet = await makeSmartWallet({
+    address,
+    walletStorageNode,
+    bank: makeBank(),
+    invitationPurse,
+  });
+  shared.theWallet = smartWallet;
+
+  const { anyInstance } = t.context;
+  const In = AmountMath.make(spendable.brand, 5n);
+
+  /** @type {import('../src/smartWallet.js').BridgeAction} */
+  const spec1 = {
+    method: 'executeOffer',
+    offer: {
+      id: 1,
+      invitationSpec: {
+        source: 'contract',
+        instance: anyInstance,
+        publicInvitationMaker: 'noSuchMethod',
+      },
+      proposal: {
+        give: { In },
+      },
+    },
+  };
+
+  const publicMarshaller = await E(board).getPublishingMarshaller();
+  const actionCapData = await E(publicMarshaller).toCapData(spec1);
+  await t.throwsAsync(E(smartWallet).handleBridgeAction(actionCapData, true));
+  await delay(200);
+});
+
+test.serial.failing('funds should be back in the purse', async t => {
+  t.like(t.context.shared.thePurse.getCurrentAmount(), { value: 100n });
+});
+
+test.serial('recover withdrawn payments', async t => {
+  const { powers, shared } = t.context;
+  const { thePurse, theWallet } = shared;
+
+  /** @type {import('../src/smartWallet.js').BridgeAction} */
+  const spec1 = {
+    method: 'tryExitOffer',
+    offerId: 1,
+  };
+
+  const { board } = powers.consume;
+  const publicMarshaller = await E(board).getPublishingMarshaller();
+
+  const actionCapData = await E(publicMarshaller).toCapData(spec1);
+  await t.throwsAsync(E(theWallet).handleBridgeAction(actionCapData, true), {
+    message: /key 1 not found in collection "live offer seats"/,
+  });
+  await eventLoopIteration();
+  await delay(10);
+  t.like(thePurse.getCurrentAmount(), { value: 100n });
+});

--- a/packages/smart-wallet/test/test-invitation1.js
+++ b/packages/smart-wallet/test/test-invitation1.js
@@ -33,6 +33,7 @@ const mockBootstrapPowers = async (
   log,
   spaceNames = ['installation', 'instance', 'issuer', 'brand'],
 ) => {
+  /** @type {import('@agoric/vat-data').Baggage} */
   const baggage = makeScalarMapStore('bootstrap');
   const zone = makeDurableZone(baggage);
   const { produce, consume } = makePromiseSpace();
@@ -82,7 +83,9 @@ const makeTestContext = async t => {
   const makeSpendableAsset = () => {
     const tok1 = makeIssuerKit('Tok1');
     const { issuer, brand } = bootKit.powers;
+    // @ts-expect-error new symbol
     issuer.produce.Token1.resolve(tok1.issuer);
+    // @ts-expect-error new symbol
     brand.produce.Token1.resolve(tok1.brand);
     return tok1;
   };
@@ -114,6 +117,7 @@ const makeTestContext = async t => {
   /** @type {import('../src/smartWallet.js').BrandDescriptorRegistry} */
   const registry = await makeRegistry();
 
+  /** @type {import('@agoric/vat-data').Baggage} */
   const swBaggage = makeScalarMapStore('smart-wallet');
 
   const secretWalletFactoryKey = Far('Key', {});
@@ -151,6 +155,7 @@ test.serial('handle failure to create invitation', async t => {
   const invitationIssuer = powers.issuer.consume.Invitation;
   const address = 'agoric1234';
 
+  // @ts-expect-error It's a promise.
   const walletsStorage = E(chainStorage).makeChildNode('wallet');
   const walletStorageNode = await E(walletsStorage).makeChildNode(address);
 

--- a/packages/smart-wallet/test/test-invitation1.js
+++ b/packages/smart-wallet/test/test-invitation1.js
@@ -155,7 +155,7 @@ test.serial('handle failure to create invitation', async t => {
   const invitationIssuer = powers.issuer.consume.Invitation;
   const address = 'agoric1234';
 
-  // @ts-expect-error It's a promise.
+  // @ts-expect-error Test setup ensures that chainStorage resolution is not undefined. (see #8247)
   const walletsStorage = E(chainStorage).makeChildNode('wallet');
   const walletStorageNode = await E(walletsStorage).makeChildNode(address);
 


### PR DESCRIPTION
## Description

Includes commits from the following PRs:
* #9236
* #9238

Constructed using the following `git rebase -i HEAD` todo list:
```
# pull request #9236 branch dc-invitation-testing
label base-dc-invitation-testing
pick 11a91835ef0678d352d84bccb4fcbbc2e809e500 test: unit test for failure in invitation creation
## Resolve conflict by making a branch-appropriate dependency: `"@agoric/zone": "^0.2.3-u14.0"`.
pick 6328b12554a2d08c71e5690e4cdad99815330bc0 chore: lint happiness
pick 559db01f90b7729598f8b94859322da7850bd076 fix: in SmartWallet, if invitation is invalid, don't process offer
## Resolve conflict by removing the `/** @type {UserSeat} */` hint.
pick 93170ad6522ec52a61382d6803f82d148f8df4df chore: comment improvements from review
## Fix CI lint issue
exec sedi () { if sed --help 2>&1 | sed 2q | grep -qe '-i '; then sed -i '' "$@"; else sed -i "$@"; fi; }; sedi -E 's#^( *)const invitationAmount =#\1// prettier-ignore\n&#' packages/smart-wallet/src/smartWallet.js && git add packages/smart-wallet/src/smartWallet.js && git commit -m 'chore(smart-wallet): Lint'
label dc-invitation-testing
reset base-dc-invitation-testing
merge -C 5d76a839a600191aa8969ae192fc30a56c70ae23 dc-invitation-testing # fix(smart-wallet): handling payments in case of failure to create invitation (#9236)

# pull request #9238 branch dc-tryReclaim
label base-dc-tryReclaim
pick f7bc1ead33cea3cd16bc1ccc70951d1d46678932 feat(smart-wallet): tryExitOffer reclaims withdrawn payments
## Resolve conflict by taking the single golang/cosmos/app/app.go `CoreProposalSteps` addition
## (replacing `@agoric/builders/scripts/smart-wallet` with `@agoric/vats/scripts`)
## and only the incarnation number bump in a3p-integration/proposals/*/initial.test.js.
pick 114ed86e83e2095aa0373a05b281b104da82e4f3 chore(smart-wallet): upgrade
pick 1057520a447f4058e3aa6aa5160a0fd9fc3a1c03 test: make an offer with a bad invitation before upgrade
## Resolve conflict by accepting the new file as a3p-integration/proposals/a:upgrade-15/exitOffer.js.
pick c26e40f1f8b3b18219b5d83cce4924667730b753 feat: tryExitOffer CLI tool
## Resolve conflict by accepting the new files in a3p-integration/proposals/a:upgrade-15/.
pick 8860d970972d210304bdc212dacd643181b72b6c test: exitOffer tool reclaims stuck payment
label dc-tryReclaim
reset base-dc-tryReclaim
merge -C da4e17183306815220996aeaa531ea5293c25382 dc-tryReclaim # feat(smart-wallet): tryExitOffer also tries to reclaim (#9238)
```

### Security Considerations

None in particular.

### Scaling Considerations

None.

### Documentation Considerations

Should we mention exitOffer.js in the release notes?

### Testing Considerations

Includes a3p-integration.

### Upgrade Considerations

To be included in agoric-upgrade-15.
