### PR TITLE
test: Add Node.js 22.x to CI

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x', '20.x']
+        node-version: ['18.x', '20.x', '22.x']
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
refs: https://github.com/endojs/endo/issues/2230