### PR TITLE
refactor(internal): deprecate makeAggregateError in favor of Aggregat…

### DIFF
--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -174,9 +174,6 @@ export default async function installMain(progname, rawArgs, powers, opts) {
             ({ status }) => status !== 'fulfilled',
           );
           if (failures.length) {
-            if (typeof AggregateError !== 'function') {
-              throw failures[0].reason;
-            }
             throw AggregateError(
               failures.map(({ reason }) => reason),
               'Failed to prune',

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -239,7 +239,7 @@ export const initiateSwingStoreExport = (
         .catch(err => errors.push(err));
     }
     if (errors.length) {
-      const error = makeAggregateError(errors, 'Errors while cleaning up');
+      const error = AggregateError(errors, 'Errors while cleaning up');
       if (opErr) {
         Object.defineProperty(error, 'cause', { value: opErr });
       }

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -12,7 +12,6 @@ import { fileURLToPath } from 'url';
 
 import { makePromiseKit } from '@endo/promise-kit';
 import { Fail, q } from '@agoric/assert';
-import { makeAggregateError } from '@agoric/internal';
 import { makeShutdown } from '@agoric/internal/src/node/shutdown.js';
 import { makeSwingStoreExporter } from '@agoric/swing-store';
 

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -1,6 +1,5 @@
 import { createWriteStream } from 'node:fs';
 import { open } from 'node:fs/promises';
-import { makeAggregateError } from '../utils.js';
 
 /**
  * @param {import("fs").ReadStream | import("fs").WriteStream} stream

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -78,7 +78,7 @@ export const makeFsStreamWriter = async filePath => {
         Promise.reject(
           written.then(
             () => err,
-            writtenError => makeAggregateError([err, writtenError]),
+            writtenError => AggregateError([err, writtenError]),
           ),
         ),
     );

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -68,13 +68,6 @@ export const makeMeasureSeconds = currentTimeMillisec => {
 };
 
 /**
- * @deprecated Just use `AggregateError`
- * @param {Error[]} errors
- * @param {string} [message]
- */
-export const makeAggregateError = AggregateError;
-
-/**
  * @template T
  * @param {readonly (T | PromiseLike<T>)[]} items
  * @returns {Promise<T[]>}

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -68,21 +68,11 @@ export const makeMeasureSeconds = currentTimeMillisec => {
 };
 
 /**
+ * @deprecated Just use `AggregateError`
  * @param {Error[]} errors
  * @param {string} [message]
  */
-export const makeAggregateError = (errors, message) => {
-  const err = Error(message);
-  Object.defineProperties(err, {
-    name: {
-      value: 'AggregateError',
-    },
-    errors: {
-      value: errors,
-    },
-  });
-  return err;
-};
+export const makeAggregateError = AggregateError;
 
 /**
  * @template T
@@ -101,7 +91,7 @@ export const PromiseAllOrErrors = async items => {
     } else if (errors.length === 1) {
       throw errors[0];
     } else {
-      throw makeAggregateError(errors);
+      throw AggregateError(errors);
     }
   });
 };
@@ -119,7 +109,7 @@ export const aggregateTryFinally = async (trier, finalizer) =>
       finalizer(tryError)
         .then(
           () => tryError,
-          finalizeError => makeAggregateError([tryError, finalizeError]),
+          finalizeError => AggregateError([tryError, finalizeError]),
         )
         .then(error => Promise.reject(error)),
   );

--- a/packages/telemetry/src/slog-sender-pipe-entrypoint.js
+++ b/packages/telemetry/src/slog-sender-pipe-entrypoint.js
@@ -75,7 +75,7 @@ const main = async () => {
       sendErrors.unshift(actualFlushError);
     }
 
-    return makeAggregateError(sendErrors.splice(0));
+    return AggregateError(sendErrors.splice(0));
   };
 
   process.on(

--- a/packages/telemetry/src/slog-sender-pipe-entrypoint.js
+++ b/packages/telemetry/src/slog-sender-pipe-entrypoint.js
@@ -1,7 +1,6 @@
 /* global process */
 import '@endo/init';
 
-import { makeAggregateError } from '@agoric/internal';
 import anylogger from 'anylogger';
 import { makeShutdown } from '@agoric/internal/src/node/shutdown.js';
 


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2042

## Description

Starting at https://github.com/endojs/endo/pull/2042 endo fully supports the real `AggregateError` constructor, so there is no longer any need for the `makeAggregateError` workaround. The @agoric/internal packages *should* not be imported by anything outside the agoric-sdk repo, so technically I could remove it in this same PR. As a conservative don't-break-things, I still export it as deprecated.

Even after upgrading to an endo supporting `AggregateError`, the old `makeAggregateError` was emulating it using a direct instance of `Error`, so this is in theory not a pure refactor. But I would be flabbergasted if any code came to depend on this not being a genuine `AggregateError`, in which case this change is a pure refactor. 

Reviewers, please let me know if you'd prefer that I delete `makeAggregateError`, as I'd be happy to.

### Security Considerations
none

### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

none
### Upgrade Considerations

none