### PR TITLE
compat with Endo on Yarn 4

### DIFF
--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -187,7 +187,7 @@ $do_not_build || (
     files=(package.json)
     while IFS= read -r line; do
       files+=("$line")
-    done < <(lazy_yarn -s workspaces info \
+    done < <(npm query .workspace \
       | sed -ne '/"location":/{ s/.*": "//; s!",.*!/package.json!; p; }')
 
     src=$(find "${files[@]}" "${print[@]}" | head -1 || true)

--- a/scripts/get-packed-versions.sh
+++ b/scripts/get-packed-versions.sh
@@ -19,12 +19,13 @@ WORKDIR=${1:-.}
 cd -- "$WORKDIR" 1>&2
 
 # Install and build the source directory.
+corepack enable
 yarn install 1>&2
 yarn build 1>&2
 
 yarn lerna run build:types 1>&2
 
-yarn --silent workspaces info | jq -r '.[].location' | while read -r dir; do
+npm query .workspace | jq -r '.[].location' | while read -r dir; do
   # Skip private packages.
   echo "dir=$dir" 1>&2
   test "$(jq .private < "$dir/package.json")" != true || continue
@@ -36,7 +37,7 @@ yarn --silent workspaces info | jq -r '.[].location' | while read -r dir; do
   name=$(jq -r .name < package.json)
   version=$(jq -r .version < package.json)
   stem=$(echo "$name" | sed -e 's!^@!!; s!/!-!g;')
-  file="$(pwd)/${stem}-v${version}.tgz"
+  file="$(pwd)/package.tgz"
 
   # Clean up.
   rm -f "${stem}"-v*.tgz

--- a/scripts/get-versions.sh
+++ b/scripts/get-versions.sh
@@ -5,7 +5,7 @@ set -ueo pipefail
 WORKDIR=${1:-.}
 
 cd -- "$WORKDIR"
-yarn workspaces --json info \
-  | jq -r '.data | fromjson | .[].location | "\(.)/package.json"' \
+npm query .workspace \
+  | jq -r '.[].location | "\(.)/package.json"' \
   | xargs jq '{key: .name, value: "^\(.version)"}' \
   | jq --slurp from_entries

--- a/scripts/replace-packages.sh
+++ b/scripts/replace-packages.sh
@@ -14,7 +14,7 @@ DSTDIR=${2-$PWD/node_modules}
 pushd "$SRCDIR"
 yarn install
 yarn build
-yarn --silent workspaces info | jq -r '.[].location' | while read -r dir; do
+npm query .workspace | jq -r '.[].location' | while read -r dir; do
   # Skip private packages.
   test "$(jq .private < "$dir/package.json")" != true || continue
 

--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -11,8 +11,8 @@ cd -- "${1-"$DIR/.."}"
 
 VERSIONSHASH=$(git hash-object -w --stdin)
 
-yarn workspaces --json info \
-  | jq -r '.data | fromjson | .[].location | "\(.)/package.json"' \
+npm query .workspace \
+  | jq -r '.[].location | "\(.)/package.json"' \
   | while read PACKAGEJSON; do
     PACKAGEJSONHASH=$(
       jq --slurpfile versions <(git cat-file blob "$VERSIONSHASH") '


### PR DESCRIPTION
refs: #451
refs: #9209 

## Description

We need agoric-sdk's integration tests to work with Endo running Yarn 4. https://github.com/Agoric/agoric-sdk/pull/9285 tested against https://github.com/endojs/endo/pull/2222. This PR is to land the necessary changes in master so the Endo PR can land without breaking SDK CI.

This helps with #9209 and is a subset of https://github.com/Agoric/agoric-sdk/pull/9286 , all that we need for Endo right now.

### Security Considerations

none

### Scaling Considerations

none, build time

### Documentation Considerations

Nothing for SDK

### Testing Considerations

CI

### Upgrade Considerations

n/a