### PR TITLE
chore: Update README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ to use.
 ## Prerequisites
 
 * Git
-* Node.js LTS (version 16.13.0 or higher)
+* Go ^1.20.2
+* Node.js ^18.12 or ^20.9
   * we generally support the latest LTS release: use [nvm](https://github.com/nvm-sh/nvm) to keep your local system up-to-date
 * Yarn (`npm install -g yarn`)
-* gcc-10 or newer, or a compiler with `__has_builtin()`
+* gcc >=10, clang >=10, or another compiler with `__has_builtin()`
 
 Any version of Yarn will do: the `.yarnrc` file should ensure that all
 commands use the specific checked-in version of Yarn (stored in

--- a/docs/node-version.md
+++ b/docs/node-version.md
@@ -14,3 +14,4 @@ When a new version becomes Active LTS:
 - [ ] update the .node-version hint to use it
 - [ ] update Node.js test ranges to remove the EOLed version and add the new LTS
 - [ ] update package.json engines to allow the two LTS versions
+- [ ] update README.md to document the new supported versions

--- a/golang/cosmos/x/vstorage/keeper/keeper.go
+++ b/golang/cosmos/x/vstorage/keeper/keeper.go
@@ -52,14 +52,6 @@ var _ ChangeManager = (*BatchingChangeManager)(nil)
 // 2 ** 256 - 1
 var MaxSDKInt = sdk.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)))
 
-// TODO: Use bytes.CutPrefix once we can rely upon go >= 1.20.
-func cutPrefix(s, prefix []byte) (after []byte, found bool) {
-	if !bytes.HasPrefix(s, prefix) {
-		return s, false
-	}
-	return s[len(prefix):], true
-}
-
 // Keeper maintains the link to data storage and exposes getter/setter methods
 // for the various parts of the state machine
 type Keeper struct {
@@ -164,7 +156,7 @@ func (k Keeper) ExportStorageFromPrefix(ctx sdk.Context, pathPrefix string) []*t
 		if !strings.HasPrefix(path, pathPrefix) {
 			continue
 		}
-		value, hasPrefix := cutPrefix(rawValue, types.EncodedDataPrefix)
+		value, hasPrefix := bytes.CutPrefix(rawValue, types.EncodedDataPrefix)
 		if !hasPrefix {
 			panic(fmt.Errorf("value at path %q starts with unexpected prefix", path))
 		}
@@ -266,7 +258,7 @@ func (k Keeper) GetEntry(ctx sdk.Context, path string) agoric.KVEntry {
 	if bytes.Equal(rawValue, types.EncodedNoDataValue) {
 		return agoric.NewKVEntryWithNoValue(path)
 	}
-	value, hasPrefix := cutPrefix(rawValue, types.EncodedDataPrefix)
+	value, hasPrefix := bytes.CutPrefix(rawValue, types.EncodedDataPrefix)
 	if !hasPrefix {
 		panic(fmt.Errorf("value at path %q starts with unexpected prefix", path))
 	}


### PR DESCRIPTION
Fixes #9294

## Description

Update the master README for Node.js v18/v20 and Go 1.20+.

### Security Considerations

None.

### Scaling Considerations

n/a

### Documentation Considerations

This presumes that README.md is the source of truth as suggested in #9294.

### Testing Considerations

n/a

### Upgrade Considerations

Release commits are expected to have a static snapshot as relevant to them (e.g., release-mainnet1B does not support Node.js v20 AFAIK).