### PR TITLE
ci(restore-node): `corepack enable` to accommodate Endo

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -114,6 +114,8 @@ runs:
           ${{ inputs.path }}/endo-sha.txt
     - uses: kenchan0130/actions-system-info@master
       id: system-info
+    - run: corepack enable
+      shell: bash
     - name: restore built files
       id: built
       uses: actions/cache@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -243,9 +243,7 @@ jobs:
           ignore-endo-branch: 'true'
         id: restore-node
       - name: setup a3p-integration
-        run: |
-          corepack enable
-          yarn install
+        run: yarn install
         working-directory: a3p-integration
       - name: verify SDK image didn't change
         # In the future when we can rebuild the SDK image with resolved endo packages, it would


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Although nightly Endo integration tests have not yet been fully vetted, this PR does at least prevent [the following error](https://github.com/Agoric/agoric-sdk/actions/runs/8874236604/job/24361339426#step:6:27):
```
/home/runner/endo /home/runner/work/agoric-sdk/agoric-sdk
Switched to a new branch 'lerna-publish'
error This project's package.json defines "packageManager": "yarn@4.1.1". However the current global version of Yarn is 1.22.22.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
```

### Security Considerations

CI only.

### Scaling Considerations

No impact.

### Documentation Considerations

n/a, internal CI configuration.

### Testing Considerations

Tested nightly against latest Endo repository.

### Upgrade Considerations

n/a