### PR TITLE
cosmic-proto export patterns

### DIFF
--- a/packages/boot/test/bootstrapTests/test-vat-orchestration.ts
+++ b/packages/boot/test/bootstrapTests/test-vat-orchestration.ts
@@ -6,7 +6,7 @@ import {
   MsgDelegate,
   MsgDelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
-import { Any } from '@agoric/cosmic-proto/google/protobuf/any';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import type { ChainAccount, OrchestrationService } from '@agoric/orchestration';
 import { decodeBase64 } from '@endo/base64';
 import { M, matches } from '@endo/patterns';

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -32,9 +32,21 @@
       "types": "./dist/codegen/cosmos/*.d.ts",
       "default": "./dist/codegen/cosmos/*.js"
     },
+    "./cosmos/tx/v1beta1/tx.js": {
+      "types": "./dist/codegen/cosmos/tx/v1beta1/tx.d.ts",
+      "default": "./dist/codegen/cosmos/tx/v1beta1/tx.js"
+    },
+    "./cosmos/staking/v1beta1/tx.js": {
+      "types": "./dist/codegen/cosmos/staking/v1beta1/tx.d.ts",
+      "default": "./dist/codegen/cosmos/staking/v1beta1/tx.js"
+    },
     "./google/*.js": {
       "types": "./dist/codegen/google/*.d.ts",
       "default": "./dist/codegen/google/*.js"
+    },
+    "./google/protobuf/any.js": {
+      "types": "./dist/codegen/google/protobuf/any.d.ts",
+      "default": "./dist/codegen/google/protobuf/any.js"
     },
     "./ibc/*.js": {
       "types": "./dist/codegen/ibc/*.d.ts",

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -24,21 +24,21 @@
       "default": "./dist/vatsafe.js"
     },
     "./package.json": "./package.json",
-    "./cosmos": {
-      "types": "./dist/codegen/cosmos/bundle.d.ts",
-      "default": "./dist/codegen/cosmos/bundle.js"
+    "./agoric/*.js": {
+      "types": "./dist/codegen/agoric/*.d.ts",
+      "default": "./dist/codegen/agoric/*.js"
     },
-    "./cosmos/staking/v1beta1/tx": {
-      "types": "./dist/codegen/cosmos/staking/v1beta1/tx.d.ts",
-      "default": "./dist/codegen/cosmos/staking/v1beta1/tx.js"
+    "./cosmos/*.js": {
+      "types": "./dist/codegen/cosmos/*.d.ts",
+      "default": "./dist/codegen/cosmos/*.js"
     },
-    "./ibc/applications/transfer/v1/tx.js": {
-      "types": "./dist/codegen/ibc/applications/transfer/v1/tx.d.ts",
-      "default": "./dist/codegen/ibc/applications/transfer/v1/tx.js"
+    "./google/*.js": {
+      "types": "./dist/codegen/google/*.d.ts",
+      "default": "./dist/codegen/google/*.js"
     },
-    "./google/protobuf/any": {
-      "types": "./dist/codegen/google/protobuf/any.d.ts",
-      "default": "./dist/codegen/google/protobuf/any.js"
+    "./ibc/*.js": {
+      "types": "./dist/codegen/ibc/*.d.ts",
+      "default": "./dist/codegen/ibc/*.js"
     },
     "./swingset/msgs.js": {
       "types": "./dist/codegen/agoric/swingset/msgs.d.ts",
@@ -55,18 +55,6 @@
     "./vstorage/query.js": {
       "types": "./dist/codegen/agoric/vstorage/query.d.ts",
       "default": "./dist/codegen/agoric/vstorage/query.js"
-    },
-    "./cosmos/tx/v1beta1/tx.js": {
-      "types": "./dist/codegen/cosmos/tx/v1beta1/tx.d.ts",
-      "default": "./dist/codegen/cosmos/tx/v1beta1/tx.js"
-    },
-    "./cosmos/staking/v1beta1/staking.js": {
-      "types": "./dist/codegen/cosmos/staking/v1beta1/staking.d.ts",
-      "default": "./dist/codegen/cosmos/staking/v1beta1/staking.js"
-    },
-    "./cosmos/staking/v1beta1/tx.js": {
-      "types": "./dist/codegen/cosmos/staking/v1beta1/tx.d.ts",
-      "default": "./dist/codegen/cosmos/staking/v1beta1/tx.js"
     }
   },
   "main": "dist/index.js",

--- a/packages/cosmic-proto/package.json.md
+++ b/packages/cosmic-proto/package.json.md
@@ -1,0 +1,5 @@
+# Notes about this package.json
+
+The `exports` field uses [subpath patterns](https://nodejs.org/docs/latest-v18.x/api/packages.html#subpath-patterns) but Endo's bundler doesn't yet support those: https://github.com/endojs/endo/issues/2265
+
+Meanwhile, we explicitly export whatever paths are needed by modules that end up in Endo bundles.

--- a/packages/cosmic-proto/test/test-vatsafe.js
+++ b/packages/cosmic-proto/test/test-vatsafe.js
@@ -3,7 +3,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 import { cosmos } from '@agoric/cosmic-proto';
 
-import { MsgDelegate } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx';
+import { MsgDelegate } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 
 // @ts-expect-error
 cosmos.staking.v1beta1.MsgDelegate.missing;

--- a/packages/orchestration/src/exos/stakingAccountKit.js
+++ b/packages/orchestration/src/exos/stakingAccountKit.js
@@ -11,7 +11,7 @@ import { M, prepareExoClassKit } from '@agoric/vat-data';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { decodeBase64 } from '@endo/base64';
 import { E } from '@endo/far';
-import { Any } from '@agoric/cosmic-proto/google/protobuf/any';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 
 /**
  * @import { ChainAccount, ChainAddress } from '../types.js';

--- a/packages/orchestration/src/utils/tx.js
+++ b/packages/orchestration/src/utils/tx.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { TxBody } from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
 import { encodeBase64 } from '@endo/base64';
-import { Any } from '@agoric/cosmic-proto/google/protobuf/any';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 
 /**
  * Makes an IBC packet from an array of messages. Expects the `value` of each message

--- a/packages/orchestration/test/utils/tx.test.js
+++ b/packages/orchestration/test/utils/tx.test.js
@@ -1,5 +1,5 @@
 import test from '@endo/ses-ava/prepare-endo.js';
-import { Any } from '@agoric/cosmic-proto/google/protobuf/any';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { makeTxPacket, parsePacketAck } from '../../src/utils/tx.js';
 
 test('makeTxPacket', t => {


### PR DESCRIPTION
refs: #9307

## Description

Simplify codegen exports using [exports subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns)

Reviewers,
- should the exported path have `.js`?
- should Agoric exports be under `agoric` like the others?

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
