### PR TITLE
refactor: use `@agoric/vow/vat.js`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,8 @@ compiled
 dist
 lcov-report
 public
+/packages/cosmic-swingset/t[0-9]/
+/packages/cosmic-swingset/t[0-9].*/
 
 # Opt out of these file types for now
 *.html

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -35,6 +35,7 @@
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
     "@agoric/vm-config": "^0.1.0",
+    "@agoric/vow": "^0.1.0",
     "@agoric/zoe": "^0.26.2",
     "@agoric/zone": "^0.2.2",
     "@endo/bundle-source": "^3.2.2",

--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -1,7 +1,7 @@
 /** @file Mock IBC Server */
 // @ts-check
 import { Far } from '@endo/far';
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 
 /**
  * @import {ListenHandler, PortAllocator} from '@agoric/network';

--- a/packages/boot/test/bootstrapTests/ibcServerMock.js
+++ b/packages/boot/test/bootstrapTests/ibcServerMock.js
@@ -2,7 +2,7 @@
 // @ts-check
 import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 
 const { quote: q, Fail } = assert;
 const { log } = console;

--- a/packages/boot/test/bootstrapTests/test-net-ibc-upgrade.ts
+++ b/packages/boot/test/bootstrapTests/test-net-ibc-upgrade.ts
@@ -6,7 +6,7 @@ import type { BridgeHandler } from '@agoric/vats';
 import { BridgeId } from '@agoric/internal';
 import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 // import { E } from '@endo/eventual-send';
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 import { makeBridge } from './ibcBridgeMock.js';
 import { makeSwingsetTestKit } from '../../tools/supports.ts';
 

--- a/packages/boot/test/upgrading/vat-vow.js
+++ b/packages/boot/test/upgrading/vat-vow.js
@@ -1,4 +1,4 @@
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { Far } from '@endo/far';
 

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -25,7 +25,6 @@
     "@agoric/internal": "^0.3.2",
     "@agoric/store": "^0.9.2",
     "@endo/base64": "^1.0.4",
-    "@agoric/vat-data": "^0.5.2",
     "@endo/far": "^1.1.1",
     "@endo/patterns": "^1.3.1",
     "@endo/promise-kit": "^1.1.1"
@@ -33,6 +32,7 @@
   "devDependencies": {
     "@agoric/swingset-liveslots": "^0.10.2",
     "@agoric/swingset-vat": "^0.32.2",
+    "@agoric/vow": "^0.1.0",
     "@agoric/zone": "^0.2.2",
     "@endo/bundle-source": "^3.2.2",
     "ava": "^5.3.0",

--- a/packages/network/test/test-network-misc.js
+++ b/packages/network/test/test-network-misc.js
@@ -4,7 +4,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
 
 import { E } from '@endo/far';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import {

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -39,6 +39,7 @@
     "@agoric/time": "^0.3.2",
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
+    "@agoric/vow": "^0.1.0",
     "@agoric/zoe": "^0.26.2",
     "@agoric/zone": "^0.2.2",
     "@endo/base64": "^1.0.4",

--- a/packages/orchestration/src/examples/stakeAtom.contract.js
+++ b/packages/orchestration/src/examples/stakeAtom.contract.js
@@ -4,7 +4,7 @@
  */
 import { makeTracer } from '@agoric/internal';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 import { M } from '@endo/patterns';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport';
 import { prepareStakingAccountKit } from '../exos/stakingAccountKit.js';

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -6,7 +6,7 @@ import '@agoric/network/exported.js';
 
 import { NonNullish } from '@agoric/assert';
 import { makeTracer } from '@agoric/internal';
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 import { M } from '@endo/patterns';
 import { PaymentShape, PurseShape } from '@agoric/ertp';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';

--- a/packages/orchestration/src/exos/icqConnectionKit.js
+++ b/packages/orchestration/src/exos/icqConnectionKit.js
@@ -2,7 +2,7 @@
 /** @file ICQConnection Exo */
 import { NonNullish } from '@agoric/assert';
 import { makeTracer } from '@agoric/internal';
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 import { M } from '@endo/patterns';
 import { makeQueryPacket, parseQueryPacket } from '../utils/packet.js';
 import { ConnectionHandlerI } from '../typeGuards.js';

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 
 /**
  * @import {PortAllocator} from '@agoric/network';

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -4,7 +4,7 @@
 // XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
 import '@agoric/network/exported.js';
 
-import { V as E } from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
 import { M } from '@endo/patterns';
 import { Shape as NetworkShape } from '@agoric/network';
 import { prepareChainAccountKit } from './exos/chainAccountKit.js';

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -36,7 +36,7 @@
     "@agoric/store": "^0.9.2",
     "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vats": "^0.15.1",
-    "@agoric/vat-data": "^0.5.2",
+    "@agoric/vow": "^0.1.0",
     "@agoric/zoe": "^0.26.2",
     "@endo/bundle-source": "^3.2.2",
     "@agoric/zone": "^0.2.2",
@@ -49,7 +49,8 @@
   "devDependencies": {
     "ava": "^5.3.0",
     "c8": "^9.1.0",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^2.2.1",
+    "@agoric/vat-data": "^0.5.2"
   },
   "files": [
     "scripts/",

--- a/packages/pegasus/src/contract.js
+++ b/packages/pegasus/src/contract.js
@@ -1,4 +1,4 @@
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { makePegasus } from './pegasus.js';
 

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -12,7 +12,7 @@ import bundleSource from '@endo/bundle-source';
 import { AmountMath } from '@agoric/ertp';
 import { makeZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { makeSubscription } from '@agoric/notifier';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 
 import '@agoric/ertp/exported.js';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -33,6 +33,7 @@
     "@agoric/swingset-vat": "^0.32.2",
     "@agoric/time": "^0.3.2",
     "@agoric/vat-data": "^0.5.2",
+    "@agoric/vow": "^0.1.0",
     "@agoric/zoe": "^0.26.2",
     "@agoric/zone": "^0.2.2",
     "@endo/base64": "^1.0.4",

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -9,7 +9,7 @@ import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 // Heap-based vow resolution is used for this module because the
 // bootstrap vat can't yet be upgraded.
-import { when } from '@agoric/vat-data/vow.js';
+import { when } from '@agoric/vow/vat.js';
 
 /**
  * @import {ProtocolHandler} from '@agoric/network';

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -1,7 +1,7 @@
 import { isPromise } from '@endo/promise-kit';
 import { Far } from '@endo/far';
-import { V as E } from '@agoric/vat-data/vow.js';
-import * as vowExports from '@agoric/vat-data/vow.js';
+import { V as E } from '@agoric/vow/vat.js';
+import * as vowExports from '@agoric/vow/vat.js';
 import * as farExports from '@endo/far';
 
 import { Nat } from '@endo/nat';

--- a/packages/vats/src/vat-ibc.js
+++ b/packages/vats/src/vat-ibc.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/far';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { prepareCallbacks, prepareIBCProtocol } from './ibc.js';
 
 export function buildRootObject(_vatPowers, _args, baggage) {

--- a/packages/vats/src/vat-network.js
+++ b/packages/vats/src/vat-network.js
@@ -6,7 +6,7 @@ import {
   preparePortAllocator,
   prepareRouterProtocol,
 } from '@agoric/network';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { Far } from '@endo/far';
 
 export function buildRootObject(_vatPowers, _args, baggage) {

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -8,7 +8,7 @@ import {
   subscribeEach,
 } from '@agoric/notifier';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 
 import { buildRootObject as ibcBuildRootObject } from '../src/vat-ibc.js';
 import { buildRootObject as networkBuildRootObject } from '../src/vat-network.js';

--- a/packages/vow/src/E.js
+++ b/packages/vow/src/E.js
@@ -7,6 +7,10 @@ const { assign, create } = Object;
 
 const onSend = makeMessageBreakpointTester('ENDO_SEND_BREAKPOINTS');
 
+/**
+ * @import { HandledPromiseConstructor, RemotableBrand } from '@endo/eventual-send'
+ * @import { Unwrap, Vow } from './types.js'
+ */
 /** @typedef {(...args: any[]) => any} Callable */
 
 /** @type {ProxyHandler<any>} */
@@ -38,7 +42,7 @@ const baseFreezableProxyHandler = {
  * A Proxy handler for E(x).
  *
  * @param {any} recipient Any value passed to E(x)
- * @param {import('@endo/eventual-send').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @param {(x: any) => Promise<any>} unwrap
  * @returns {ProxyHandler<any>} the Proxy handler
  */
@@ -103,7 +107,7 @@ const makeEProxyHandler = (recipient, HandledPromise, unwrap) =>
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {any} recipient Any value passed to E.sendOnly(x)
- * @param {import('@endo/eventual-send').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @param {(x: any) => Promise<any>} unwrap
  * @returns {ProxyHandler<any>} the Proxy handler
  */
@@ -166,7 +170,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise, unwrap) =>
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {any} x Any value passed to E.get(x)
- * @param {import('@endo/eventual-send').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @param {(x: any) => Promise<any>} unwrap
  * @returns {ProxyHandler<any>} the Proxy handler
  */
@@ -183,7 +187,7 @@ const resolve = x => HandledPromise.resolve(x);
 /**
  * @template [A={}]
  * @template {(x: any) => Promise<any>} [U=(x: any) => Promise<any>]
- * @param {import('@endo/eventual-send').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @param {object} [powers]
  * @param {U} [powers.unwrap]
  * @param {A} [powers.additional]
@@ -263,10 +267,10 @@ const makeE = (
          * unwrapped(x).then(onfulfilled, onrejected)
          *
          * @template T
-         * @template [TResult1=import('./types.js').Unwrap<T>]
+         * @template [TResult1=Unwrap<T>]
          * @template [TResult2=never]
          * @param {ERef<T>} x value to convert to a handled promise
-         * @param {(value: import('./types.js').Unwrap<T>) => ERef<TResult1>} [onfulfilled]
+         * @param {(value: Unwrap<T>) => ERef<TResult1>} [onfulfilled]
          * @param {(reason: any) => ERef<TResult2>} [onrejected]
          * @returns {Promise<TResult1 | TResult2>}
          * @readonly
@@ -307,7 +311,7 @@ export default makeE;
 /**
  * @template {Callable} T
  * @typedef {(
- *   (...args: Parameters<T>) => Promise<import('./types.js').Unwrap<ReturnType<T>>>
+ *   (...args: Parameters<T>) => Promise<Unwrap<ReturnType<T>>>
  * )} ECallable
  */
 
@@ -393,11 +397,11 @@ export default makeE;
  *
  * @template T
  * @typedef {(
- *   T extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>     // if a given T is some remote interface R
+ *   T extends RemotableBrand<infer L, infer R>     // if a given T is some remote interface R
  *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends import('@endo/eventual-send').RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
+ *     : Awaited<T> extends RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
  *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends import('./types.js').Vow<infer U>
+ *     : Awaited<T> extends Vow<infer U>
  *     ? RemoteFunctions<U>                                           // then extract the remotable functions of U
  *     : T extends PromiseLike<infer U>                               // otherwise, if T is a promise
  *     ? Awaited<T>                                                   // then return resolved value T
@@ -408,11 +412,11 @@ export default makeE;
 /**
  * @template T
  * @typedef {(
- *   T extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>
+ *   T extends RemotableBrand<infer L, infer R>
  *     ? L
- *     : Awaited<T> extends import('@endo/eventual-send').RemotableBrand<infer L, infer R>
+ *     : Awaited<T> extends RemotableBrand<infer L, infer R>
  *     ? L
- *     : Awaited<T> extends import('./types.js').Vow<infer U>
+ *     : Awaited<T> extends Vow<infer U>
  *     ? LocalRecord<U>
  *     : T extends PromiseLike<infer U>
  *     ? Awaited<T>

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -4,8 +4,10 @@ import { prepareVowKit } from './vow.js';
 import { prepareWatch } from './watch.js';
 import { prepareWatchUtils } from './watch-utils.js';
 
+/** @import {Zone} from '@agoric/base-zone' */
+
 /**
- * @param {import('@agoric/base-zone').Zone} zone
+ * @param {Zone} zone
  * @param {object} [powers]
  * @param {(reason: any) => boolean} [powers.isRetryableReason]
  */

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -1,6 +1,12 @@
 // @ts-check
 export {};
 
+/**
+ * @import {RemotableBrand} from '@endo/eventual-send'
+ * @import {CopyTagged} from '@endo/pass-style'
+ * @import {prepareVowTools} from './tools.js'
+ */
+
 /** @typedef {(...args: any[]) => any} Callable */
 
 /**
@@ -43,9 +49,9 @@ export {};
  * @template T
  * @typedef {(
  *   T extends PromiseLike<infer U> ? Unwrap<U> :
- *   T extends import('./types').Vow<infer U> ? Unwrap<U> :
+ *   T extends Vow<infer U> ? Unwrap<U> :
  *   IsPrimitive<T> extends true ? T :
- *   T extends import('@endo/eventual-send').RemotableBrand<infer Local, infer Primary> ? Local & T :
+ *   T extends RemotableBrand<infer Local, infer Primary> ? Local & T :
  *   T
  * )} Unwrap
  */
@@ -55,10 +61,9 @@ export {};
  * returned from `Remotable` or `Far`.
  * @template Primary The type of the primary reference.
  * @template [Local=DataOnly<Primary>] The local properties of the object.
- * @typedef {Primary |
- *   import('@endo/eventual-send').RemotableBrand<Local, Primary>
- * } Remote A type that doesn't assume its parameter is local, but is
- * satisfied with both local and remote references.
+ * @typedef {Primary | RemotableBrand<Local, Primary>} Remote A type that
+ * doesn't assume its parameter is local, but is satisfied with both local
+ * and remote references.
  */
 
 /**
@@ -82,9 +87,7 @@ export {};
 
 /**
  * @template [T=any]
- * @typedef {import('@endo/pass-style').CopyTagged<
- *   'Vow', VowPayload<T>
- * >} Vow
+ * @typedef {CopyTagged<'Vow', VowPayload<T>>} Vow
  */
 
 /**
@@ -121,7 +124,7 @@ export {};
 
 /**
  * @template [T=any]
- * @typedef {import('./types.js').ERef<T | import('./types.js').Vow<T>>} Specimen
+ * @typedef {ERef<T | Vow<T>>} Specimen
  */
 
-/** @typedef {ReturnType<import('./tools.js').prepareVowTools>} VowTools */
+/** @typedef {ReturnType<typeof prepareVowTools>} VowTools */

--- a/packages/vow/src/vow-utils.js
+++ b/packages/vow/src/vow-utils.js
@@ -3,6 +3,8 @@ import { E as basicE } from '@endo/eventual-send';
 import { isPassable } from '@endo/pass-style';
 import { M, matches } from '@endo/patterns';
 
+/** @import {VowPayload, Vow} from './types' */
+
 export { basicE };
 
 export const VowShape = M.tagged(
@@ -25,16 +27,14 @@ harden(isVow);
  *
  * @template T
  * @param {any} specimen any value to verify as a vow
- * @returns {import('./types').VowPayload<T> | undefined} undefined if specimen is not a vow, otherwise the vow's payload.
+ * @returns {VowPayload<T> | undefined} undefined if specimen is not a vow, otherwise the vow's payload.
  */
 export const getVowPayload = specimen => {
   if (!isVow(specimen)) {
     return undefined;
   }
 
-  const vow = /** @type {import('./types').Vow<T>} */ (
-    /** @type {unknown} */ (specimen)
-  );
+  const vow = /** @type {Vow<T>} */ (/** @type {unknown} */ (specimen));
   return vow.payload;
 };
 harden(getVowPayload);

--- a/packages/vow/src/vow.js
+++ b/packages/vow/src/vow.js
@@ -4,25 +4,31 @@ import { M } from '@endo/patterns';
 import { makeTagged } from '@endo/pass-style';
 import { PromiseWatcherI } from '@agoric/base-zone';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {VowResolver, VowKit} from './types.js'
+ */
+
 const sink = () => {};
 harden(sink);
 
 /**
- * @typedef {Partial<import('@endo/promise-kit').PromiseKit<any>> &
- *   Pick<import('@endo/promise-kit').PromiseKit<any>, 'promise'>} VowEphemera
+ * @typedef {Partial<PromiseKit<any>> &
+ *   Pick<PromiseKit<any>, 'promise'>} VowEphemera
  */
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
+ * @param {Zone} zone
  */
 export const prepareVowKit = zone => {
-  /** @type {WeakMap<import('./types.js').VowResolver, VowEphemera>} */
+  /** @type {WeakMap<VowResolver, VowEphemera>} */
   const resolverToEphemera = new WeakMap();
 
   /**
    * Get the current incarnation's promise kit associated with a vowV0.
    *
-   * @param {import('./types.js').VowResolver} resolver
+   * @param {VowResolver} resolver
    */
   const provideCurrentKit = resolver => {
     let pk = resolverToEphemera.get(resolver);
@@ -37,7 +43,7 @@ export const prepareVowKit = zone => {
   };
 
   /**
-   * @param {import('./types.js').VowResolver} resolver
+   * @param {VowResolver} resolver
    */
   const getPromiseKitForResolution = resolver => {
     const kit = provideCurrentKit(resolver);
@@ -123,7 +129,7 @@ export const prepareVowKit = zone => {
 
   /**
    * @template T
-   * @returns {import('./types.js').VowKit<T>}
+   * @returns {VowKit<T>}
    */
   const makeVowKit = () => {
     const { resolver, vowV0 } = makeVowInternalsKit();

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -2,7 +2,12 @@
 
 import { M } from '@endo/patterns';
 
-/** @import {MapStore} from '@agoric/store/src/types.js' */
+/**
+ * @import {MapStore} from '@agoric/store/src/types.js'
+ * @import { Zone } from '@agoric/base-zone'
+ * @import { Watch } from './watch.js'
+ * @import {Specimen, VowKit} from './types.js'
+ */
 
 const VowShape = M.tagged(
   'Vow',
@@ -12,9 +17,9 @@ const VowShape = M.tagged(
 );
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
- * @param {import('./watch.js').Watch} watch
- * @param {() => import('./types.js').VowKit<any>} makeVowKit
+ * @param {Zone} zone
+ * @param {Watch} watch
+ * @param {() => VowKit<any>} makeVowKit
  */
 export const prepareWatchUtils = (zone, watch, makeVowKit) => {
   const detached = zone.detached();
@@ -34,7 +39,7 @@ export const prepareWatchUtils = (zone, watch, makeVowKit) => {
        * @typedef {object} VowState
        * @property {number} remaining
        * @property {MapStore<number, any>} resultsMap
-       * @property {import('./types.js').VowKit['resolver']} resolver
+       * @property {VowKit['resolver']} resolver
        */
       /** @type {MapStore<bigint, VowState>} */
       const idToVowState = detached.mapStore('idToVowState');
@@ -48,7 +53,7 @@ export const prepareWatchUtils = (zone, watch, makeVowKit) => {
       utils: {
         /**
          * @template [T=any]
-         * @param {import('./types.js').Specimen<T>[]} vows
+         * @param {Specimen<T>[]} vows
          */
         all(vows) {
           const { nextId: id, idToVowState } = this.state;

--- a/packages/vow/src/watch.js
+++ b/packages/vow/src/watch.js
@@ -5,7 +5,12 @@ import { getVowPayload, basicE } from './vow-utils.js';
 const { apply } = Reflect;
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
+ * @import { PromiseWatcher, Zone } from '@agoric/base-zone';
+ * @import { ERef, Vow, VowKit, VowResolver, Watcher } from './types.js';
+ */
+
+/**
+ * @param {Zone} zone
  */
 const makeWatchNextStep =
   zone =>
@@ -15,7 +20,7 @@ const makeWatchNextStep =
    * (usually durable) watcher object with the promise.
    *
    * @param {any} specimen
-   * @param {import('@agoric/base-zone').PromiseWatcher} promiseWatcher
+   * @param {PromiseWatcher} promiseWatcher
    */
   (specimen, promiseWatcher) => {
     let promise;
@@ -29,9 +34,9 @@ const makeWatchNextStep =
   };
 
 /**
- * @param {import('./types.js').VowResolver | undefined} resolver
- * @param {import('./types.js').Watcher<unknown, unknown, unknown> | undefined} watcher
- * @param {keyof Required<import('./types.js').Watcher>} wcb
+ * @param {VowResolver | undefined} resolver
+ * @param {Watcher<unknown, unknown, unknown> | undefined} watcher
+ * @param {keyof Required<Watcher>} wcb
  * @param {unknown} value
  * @param {unknown} [watcherContext]
  */
@@ -56,7 +61,7 @@ const settle = (resolver, watcher, wcb, value, watcherContext) => {
 };
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
+ * @param {Zone} zone
  * @param {(reason: any) => boolean} isRetryableReason
  * @param {ReturnType<typeof makeWatchNextStep>} watchNextStep
  */
@@ -68,8 +73,8 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
      * @template [T=any]
      * @template [TResult1=T]
      * @template [TResult2=never]
-     * @param {import('./types.js').VowResolver<TResult1 | TResult2>} resolver
-     * @param {import('./types.js').Watcher<T, TResult1, TResult2>} [watcher]
+     * @param {VowResolver<TResult1 | TResult2>} resolver
+     * @param {Watcher<T, TResult1, TResult2>} [watcher]
      * @param {unknown} [watcherContext]
      */
     (resolver, watcher, watcherContext) => {
@@ -82,7 +87,7 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
       return /** @type {Partial<typeof state>} */ (state);
     },
     {
-      /** @type {Required<import('@agoric/base-zone').PromiseWatcher>['onFulfilled']} */
+      /** @type {Required<PromiseWatcher>['onFulfilled']} */
       onFulfilled(value) {
         const { watcher, watcherContext, resolver } = this.state;
         if (getVowPayload(value)) {
@@ -95,7 +100,7 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
         this.state.resolver = undefined;
         settle(resolver, watcher, 'onFulfilled', value, watcherContext);
       },
-      /** @type {Required<import('@agoric/base-zone').PromiseWatcher>['onRejected']} */
+      /** @type {Required<PromiseWatcher>['onRejected']} */
       onRejected(reason) {
         const { vow, watcher, watcherContext, resolver } = this.state;
         if (vow && isRetryableReason(reason)) {
@@ -110,8 +115,8 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
   );
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
- * @param {() => import('./types.js').VowKit<any>} makeVowKit
+ * @param {Zone} zone
+ * @param {() => VowKit<any>} makeVowKit
  * @param {(reason: any) => boolean} [isRetryableReason]
  */
 export const prepareWatch = (
@@ -131,12 +136,12 @@ export const prepareWatch = (
    * @template [TResult1=T]
    * @template [TResult2=T]
    * @template [C=unknown] watcher context
-   * @param {import('./types.js').ERef<T | import('./types.js').Vow<T>>} specimenP
-   * @param {import('./types.js').Watcher<T, TResult1, TResult2>} [watcher]
+   * @param {ERef<T | Vow<T>>} specimenP
+   * @param {Watcher<T, TResult1, TResult2>} [watcher]
    * @param {C} [watcherContext]
    */
   const watch = (specimenP, watcher, watcherContext) => {
-    /** @type {import('./types.js').VowKit<TResult1 | TResult2>} */
+    /** @type {VowKit<TResult1 | TResult2>} */
     const { resolver, vow } = makeVowKit();
 
     // Create a promise watcher to track vows, retrying upon rejection as

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -1,6 +1,8 @@
 // @ts-check
 import { getVowPayload, basicE } from './vow-utils.js';
 
+/** @import { Unwrap } from './types.js' */
+
 /**
  * @param {(reason: any) => boolean} [isRetryableReason]
  */
@@ -9,10 +11,10 @@ export const makeWhen = (isRetryableReason = () => false) => {
    * Shorten `specimenP` until we achieve a final result.
    *
    * @template T
-   * @template [TResult1=import('./types.js').Unwrap<T>]
+   * @template [TResult1=Unwrap<T>]
    * @template [TResult2=never]
    * @param {T} specimenP value to unwrap
-   * @param {(value: import('./types.js').Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
+   * @param {(value: Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
    * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
    * @returns {Promise<TResult1 | TResult2>}
    */
@@ -37,7 +39,7 @@ export const makeWhen = (isRetryableReason = () => false) => {
       payload = getVowPayload(result);
     }
 
-    const unwrapped = /** @type {import('./types.js').Unwrap<T>} */ (result);
+    const unwrapped = /** @type {Unwrap<T>} */ (result);
 
     // We've extracted the final result.
     if (onFulfilled == null && onRejected == null) {

--- a/packages/vow/test/test-disconnect.js
+++ b/packages/vow/test/test-disconnect.js
@@ -5,6 +5,8 @@ import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import { makeTagged } from '@endo/pass-style';
 import { prepareVowTools } from '../src/tools.js';
 
+/** @import {Vow} from '../src/types.js' */
+
 test('retry on disconnection', async t => {
   const zone = makeHeapZone();
   const isRetryableReason = e => e && e.message === 'disconnected';
@@ -57,7 +59,7 @@ test('retry on disconnection', async t => {
     for await (const [final, ...plan] of PLANS) {
       t.log(`testing (plan=${plan}, ${pattern})`);
 
-      /** @type {import('../src/types.js').Vow<string>} */
+      /** @type {Vow<string>} */
       const vow = makeTagged('Vow', {
         vowV0: makeTestVowV0(plan),
       });

--- a/packages/vow/test/test-watch.js
+++ b/packages/vow/test/test-watch.js
@@ -6,8 +6,13 @@ import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import { prepareVowTools } from '../src/tools.js';
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
- * @param {import('ava').ExecutionContext<unknown>} t
+ * @import {ExecutionContext} from 'ava'
+ * @import {Zone} from '@agoric/base-zone'
+ */
+
+/**
+ * @param {Zone} zone
+ * @param {ExecutionContext<unknown>} t
  */
 const prepareAckWatcher = (zone, t) => {
   return zone.exoClass('AckWatcher', undefined, packet => ({ packet }), {
@@ -27,8 +32,8 @@ const prepareAckWatcher = (zone, t) => {
 };
 
 /**
- * @param {import('@agoric/base-zone').Zone} zone
- * @param {import('ava').ExecutionContext<unknown>} t
+ * @param {Zone} zone
+ * @param {ExecutionContext<unknown>} t
  */
 test('ack watcher - shim', async t => {
   const zone = makeHeapZone();


### PR DESCRIPTION
refs: #9321

## Description

Update the preferred way of using SwingSet vat-compatible vows to import `@agoric/vow/vat.js`.

Also, as a drive-by in `@agoric/vow`, avoid `import('./file.js').Type` in favour of the `@import {Type} from './file.js'` Typescript 5.5 syntax.

### Security Considerations

Doesn't change any code semantics.

### Scaling Considerations

n/a

### Documentation Considerations

`@agoric/vat-data/vow.js` is still available, as an alias for `@agoric/vow/vat.js`.

### Testing Considerations

n/a

### Upgrade Considerations

No change in code functionality.