### PR TITLE
feat(zoe): add type inference for issuerKeywordRecord in ZCF

### DIFF
--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -17,7 +17,7 @@ type ZCFMakeEmptySeatKit = (exit?: ExitRule | undefined) => ZcfSeatKit;
  */
 type ZCF<
   CT extends unknown = Record<string, unknown>,
-  IKR extends Record<Keyword, AssetKind> = Record<Keyword, AssetKind>,
+  IKR extends Record<Keyword, AssetKind> = Record<Keyword, any>,
 > = {
   /**
    * - atomically reallocate amounts among seats.

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -14,6 +14,12 @@ type ZCFMakeEmptySeatKit = (exit?: ExitRule | undefined) => ZcfSeatKit;
  * the Zoe state for that instance. The Zoe Contract Facet is accessed
  * synchronously from within the contract, and usually is referred to
  * in code as zcf.
+ *
+ * @template CT - The Custom Terms of the contract, which extend the
+ * StandardTerms. Defaults to `Record<string, unknown>`.
+ * @template IKR - The Issuer Keyword Record, which specifies the expected
+ * asset kinds for each keyword in the contract terms. Defaults to
+ * `Record<Keyword, any>`, allowing any keyword and asset kind combination.
  */
 type ZCF<
   CT extends unknown = Record<string, unknown>,
@@ -66,6 +72,11 @@ type ZCF<
   shutdownWithFailure: ShutdownWithFailure;
   getZoeService: () => ERef<ZoeService>;
   getInvitationIssuer: () => Issuer<'set'>;
+  /**
+   * Returns the contract terms, including both standard terms and custom terms.
+   * The standard terms include the `issuers` and `brands` properties, which are
+   * typed according to the `IKR` (issuer keyword record) generic parameter.
+   */
   getTerms: () => StandardTerms<IKR> & CT;
   getBrandForIssuer: <K extends AssetKind>(issuer: Issuer<K>) => Brand<K>;
   getIssuerForBrand: <K_1 extends AssetKind>(brand: Brand<K_1>) => Issuer<K_1>;

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -73,9 +73,12 @@ type ZCF<
   getZoeService: () => ERef<ZoeService>;
   getInvitationIssuer: () => Issuer<'set'>;
   /**
-   * Returns the contract terms, including both standard terms and custom terms.
-   * The standard terms include the `issuers` and `brands` properties, which are
-   * typed according to the `IKR` (issuer keyword record) generic parameter.
+   * Returns the contract terms, including both standard terms and custom
+   * terms. The standard terms include the `issuers` and `brands` properties,
+   * which are typed according to the `IKR` (issuer keyword record) generic
+   * parameter. Custom Terms are immutable and can't be updated after
+   * instantiation. Standard Terms (brands and issuers) are append only and can
+   * be updated with `zcf.saveIssuer()` or `saveAllIssuers()`.
    */
   getTerms: () => StandardTerms<IKR> & CT;
   getBrandForIssuer: <K extends AssetKind>(issuer: Issuer<K>) => Brand<K>;

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -15,7 +15,10 @@ type ZCFMakeEmptySeatKit = (exit?: ExitRule | undefined) => ZcfSeatKit;
  * synchronously from within the contract, and usually is referred to
  * in code as zcf.
  */
-type ZCF<CT extends unknown = Record<string, unknown>> = {
+type ZCF<
+  CT extends unknown = Record<string, unknown>,
+  IKR extends Record<Keyword, AssetKind> = Record<Keyword, AssetKind>,
+> = {
   /**
    * - atomically reallocate amounts among seats.
    */
@@ -63,7 +66,7 @@ type ZCF<CT extends unknown = Record<string, unknown>> = {
   shutdownWithFailure: ShutdownWithFailure;
   getZoeService: () => ERef<ZoeService>;
   getInvitationIssuer: () => Issuer<'set'>;
-  getTerms: () => StandardTerms & CT;
+  getTerms: () => StandardTerms<IKR> & CT;
   getBrandForIssuer: <K extends AssetKind>(issuer: Issuer<K>) => Brand<K>;
   getIssuerForBrand: <K_1 extends AssetKind>(brand: Brand<K_1>) => Issuer<K_1>;
   getAssetKind: GetAssetKindByBrand;

--- a/packages/zoe/src/types-ambient.js
+++ b/packages/zoe/src/types-ambient.js
@@ -13,24 +13,40 @@
 /**
  * @typedef {string} Keyword
  * @typedef {Handle<'Invitation'>} InvitationHandle - an opaque handle for an invitation
- * @typedef {Record<Keyword, Issuer<any>>} IssuerKeywordRecord
- * @typedef {Record<Keyword, ERef<Issuer<any>>>} IssuerPKeywordRecord
- * @typedef {Record<Keyword, Brand<any>>} BrandKeywordRecord
  */
 
 /**
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @typedef {{ [K in keyof IKR]: Issuer<IKR[K]> }} IssuerKeywordRecord
+ */
+
+/**
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @typedef {{ [K in keyof IKR]: Brand<IKR[K]> }} BrandKeywordRecord
+ */
+
+/**
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @typedef {{ [K in keyof IKR]: ERef<Issuer<IKR[K]>> }} IssuerPKeywordRecord
+ */
+
+/**
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
  * @typedef {object} StandardTerms
- * @property {IssuerKeywordRecord} issuers - record with
+ * @property {IssuerKeywordRecord<IKR>} issuers - record with
  * keywords keys, issuer values
- * @property {BrandKeywordRecord} brands - record with keywords
+ * @property {BrandKeywordRecord<IKR>} brands - record with keywords
  * keys, brand values
- *
- * @typedef {StandardTerms & Record<string, any>} AnyTerms
  *
  * @typedef {object} InstanceRecord
  * @property {Installation} installation
  * @property {import("./zoeService/utils.js").Instance<any>} instance
  * @property {AnyTerms} terms - contract parameters
+ */
+
+/**
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @typedef {StandardTerms<IKR> & Record<Keyword, any>} AnyTerms
  */
 
 /**

--- a/packages/zoe/src/types-ambient.js
+++ b/packages/zoe/src/types-ambient.js
@@ -16,22 +16,22 @@
  */
 
 /**
- * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, any>]
  * @typedef {{ [K in keyof IKR]: Issuer<IKR[K]> }} IssuerKeywordRecord
  */
 
 /**
- * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, any>]
  * @typedef {{ [K in keyof IKR]: Brand<IKR[K]> }} BrandKeywordRecord
  */
 
 /**
- * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, any>]
  * @typedef {{ [K in keyof IKR]: ERef<Issuer<IKR[K]>> }} IssuerPKeywordRecord
  */
 
 /**
- * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, AssetKind>]
+ * @template {Record<Keyword, AssetKind>} [IKR=Record<Keyword, any>]
  * @typedef {object} StandardTerms
  * @property {IssuerKeywordRecord<IKR>} issuers - record with
  * keywords keys, issuer values

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -79,3 +79,21 @@ import type { prepare as scaledPriceAuthorityStart } from '../src/contracts/scal
   result.notInResult;
   expectType<bigint>(result);
 }
+
+{
+  const zcf = {} as ZCF<{}, { In: 'nat'; Out: 'set' }>;
+  const terms = zcf.getTerms();
+  expectType<Issuer<'nat'>>(terms.issuers.In);
+  expectType<Brand<'set'>>(terms.brands.Out);
+  // @ts-expect-error
+  terms.issuers.NotInIKR;
+  // @ts-expect-error
+  terms.brands.NotInIKR;
+}
+
+{
+  const zcf = {} as ZCF;
+  const terms = zcf.getTerms();
+  expectType<Issuer<AssetKind>>(terms.issuers.AnyStringWorks);
+  expectType<Brand<AssetKind>>(terms.brands.AnyStringWorks);
+}


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

- adds `IKR` (`IssuerKeywordRecord`) generic parameter to `ZCF` to enable type inference for `issuers` and `brands` from contract terms
  - low priority, but seems helpful for contracts that rely on predefined keyword records like `Collateral` or `In`.

### Security Considerations


### Scaling Considerations

### Documentation Considerations


### Testing Considerations


### Upgrade Considerations

