### PR TITLE
fix(scripts): Update gen-upgrade-proposal.sh to take a target tag argument

### DIFF
--- a/scripts/gen-upgrade-proposal.sh
+++ b/scripts/gen-upgrade-proposal.sh
@@ -9,7 +9,8 @@ https://github.com/agoric-labs/cosmos-sdk/tree/Agoric/cosmovisor#readme
 ------------------------------------------------------------------------
 EOF
 
-COMMIT_ID=$(git rev-parse HEAD)
+UPGRADE_TO="${1:-HEAD}"
+COMMIT_ID=$(git rev-parse "$UPGRADE_TO")
 ZIP_URL="https://github.com/Agoric/agoric-sdk/archive/${COMMIT_ID}.zip"
 
 echo "Verifying archive is at $ZIP_URL..." 1>&2


### PR DESCRIPTION
Fixes #9335

## Description

If a non-empty argument is present, it is used as the git ref defining the upgrade target. Otherwise, we fall back on HEAD.

### Security Considerations

None known.

### Scaling Considerations

n/a

### Documentation Considerations

The new pattern should be used in future community.agoric.com posts.

### Testing Considerations

None, but the desired approach has already been used to craft the mainnet proposal for agoric-upgrade-15.

### Upgrade Considerations

This will allow starting from a checkout of the previous tag, which in general is correct for crafting proposals to be understood by the corresponding software.