### PR TITLE
feat(orchestration): deposit ERTP payment to ICA

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -77,6 +77,11 @@ export const AmountShape = harden({
   value: AmountValueShape,
 });
 
+export const NatAmountShape = harden({
+  brand: BrandShape,
+  value: NatValueShape,
+});
+
 export const RatioShape = harden({
   numerator: AmountShape,
   denominator: AmountShape,

--- a/packages/builders/scripts/orchestration/init-stakeAtom.js
+++ b/packages/builders/scripts/orchestration/init-stakeAtom.js
@@ -7,8 +7,16 @@ export const defaultProposalBuilder = async (
 ) => {
   const {
     hostConnectionId = 'connection-1',
-    controllerConnectionId = 'connection-0',
+    controllerConnectionId = 'connection-1',
     bondDenom = 'uatom',
+    bondDenomLocal = 'ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9',
+    transferChannel = {
+      counterpartyChannelId: 'channel-1',
+      counterpartyPortId: 'transfer',
+      sourceChannelId: 'channel-1',
+      sourcePortId: 'transfer',
+    },
+    icqEnabled = true,
   } = options;
   return harden({
     sourceSpec: '@agoric/orchestration/src/proposals/start-stakeAtom.js',
@@ -23,6 +31,9 @@ export const defaultProposalBuilder = async (
         hostConnectionId,
         controllerConnectionId,
         bondDenom,
+        bondDenomLocal,
+        transferChannel,
+        icqEnabled,
       },
     ],
   });

--- a/packages/cosmic-proto/src/helpers.ts
+++ b/packages/cosmic-proto/src/helpers.ts
@@ -3,6 +3,7 @@ import type { MsgSend } from './codegen/cosmos/bank/v1beta1/tx.js';
 import type { MsgDelegate } from './codegen/cosmos/staking/v1beta1/tx.js';
 import { RequestQuery } from './codegen/tendermint/abci/types.js';
 import type { Any } from './codegen/google/protobuf/any.js';
+import { MsgTransfer } from './codegen/ibc/applications/transfer/v1/tx.js';
 
 /**
  * The result of Any.toJSON(). The type in cosms-types says it returns
@@ -16,6 +17,7 @@ export type Proto3Shape = {
   '/cosmos.bank.v1beta1.MsgSend': MsgSend;
   '/cosmos.bank.v1beta1.QueryAllBalancesRequest': QueryAllBalancesRequest;
   '/cosmos.staking.v1beta1.MsgDelegate': MsgDelegate;
+  '/ibc.applications.transfer.v1.MsgTransfer': MsgTransfer;
 };
 
 /**

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -48,6 +48,7 @@
     "@endo/patterns": "^1.3.1"
   },
   "devDependencies": {
+    "@agoric/swingset-vat": "^0.32.2",
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
     "@endo/ses-ava": "^1.2.1",

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -60,7 +60,8 @@
     },
     "files": [
       "test/**/*.test.js",
-      "test/**/*.test.ts"
+      "test/**/*.test.ts",
+      "test/**/test-*.js"
     ],
     "nodeArguments": [
       "--loader=tsx",

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -136,6 +136,10 @@ export const prepareChainAccountKit = zone =>
           if (!connection) throw Fail`connection not available`;
           await E(connection).close();
         },
+        /**
+         * see stakingAccountKit.js for an example until #9212
+         * @param {Payment} payment
+         */
         async deposit(payment) {
           console.log('deposit got', payment);
           throw new Error('not yet implemented');

--- a/packages/orchestration/src/exos/stakingAccountKit.js
+++ b/packages/orchestration/src/exos/stakingAccountKit.js
@@ -367,6 +367,8 @@ export const prepareStakingAccountKit = (baggage, makeRecorderKit, zcf) => {
 
           const { localAccount } = this.state;
           trace('Depositing funds to LCA');
+          // XXX consider adding exposing an interface to withdraw / send
+          // messages from the LCA (e.g., withdraw funds)
           await E(localAccount).deposit(payment);
 
           const timeoutTimestamp =

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -3,7 +3,10 @@ import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/far';
 
-/** @import { StakeAtomSF,  StakeAtomTerms} from '../examples/stakeAtom.contract' */
+/**
+ * @import {Issuer} from '@agoric/ertp/exported.js';
+ * @import {StakeAtomSF,  StakeAtomTerms} from '../examples/stakeAtom.contract.js';
+ */
 
 const trace = makeTracer('StartStakeAtom', true);
 
@@ -17,6 +20,8 @@ export const startStakeAtom = async (
       agoricNames,
       board,
       chainStorage,
+      chainTimerService: chainTimerServiceP,
+      localchain,
       orchestration,
       startUpgradable,
     },
@@ -27,32 +32,62 @@ export const startStakeAtom = async (
       produce: { stakeAtom: produceInstance },
     },
   },
-  { options: { hostConnectionId, controllerConnectionId, bondDenom } },
+  {
+    options: {
+      hostConnectionId,
+      controllerConnectionId,
+      bondDenom,
+      bondDenomLocal,
+      transferChannel,
+      icqEnabled,
+    },
+  },
 ) => {
   const VSTORAGE_PATH = 'stakeAtom';
   trace('startStakeAtom', {
     hostConnectionId,
     controllerConnectionId,
     bondDenom,
+    bondDenomLocal,
+    transferChannel,
+    icqEnabled,
   });
   await null;
 
   const storageNode = await makeStorageNodeChild(chainStorage, VSTORAGE_PATH);
   const marshaller = await E(board).getPublishingMarshaller();
-  const atomIssuer = await E(agoricNames).lookup('issuer', 'ATOM');
-  trace('ATOM Issuer', atomIssuer);
+
+  /** @type {Issuer[]} */
+  const [ATOM, BLD, IST] = await Promise.all([
+    E(agoricNames).lookup('issuer', 'ATOM'),
+    E(agoricNames).lookup('issuer', 'BLD'),
+    E(agoricNames).lookup('issuer', 'IST'),
+  ]);
+
+  const chainTimerService = await chainTimerServiceP;
+  const chainTimerBrand = await E(chainTimerService).getTimerBrand();
 
   /** @type {StartUpgradableOpts<StakeAtomSF>} */
   const startOpts = {
     label: 'stakeAtom',
     installation: stakeAtom,
-    issuerKeywordRecord: harden({ ATOM: atomIssuer }),
+    issuerKeywordRecord: harden({
+      ATOM,
+      BLD,
+      IST,
+    }),
     terms: {
       hostConnectionId,
       controllerConnectionId,
       bondDenom,
+      bondDenomLocal,
+      transferChannel,
+      icqEnabled,
+      chainTimerBrand,
     },
     privateArgs: {
+      chainTimerService,
+      localchain: await localchain,
       orchestration: await orchestration,
       storageNode,
       marshaller,
@@ -75,6 +110,8 @@ export const getManifestForStakeAtom = (
           agoricNames: true,
           board: true,
           chainStorage: true,
+          chainTimerService: true,
+          localchain: true,
           orchestration: true,
           startUpgradable: true,
         },

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -1,3 +1,4 @@
+import { NatAmountShape } from '@agoric/ertp';
 import { M } from '@endo/patterns';
 
 export const ConnectionHandlerI = M.interface('ConnectionHandler', {
@@ -18,3 +19,19 @@ export const Proto3Shape = {
 };
 
 export const CoinShape = { value: M.bigint(), denom: M.string() };
+
+/**
+ * - `give` allows any `Nat` `issuerKeyword` record. Must be exactly one entry.
+ * - `exit` must be `{ waived: null }`
+ * - `want` must be empty
+ */
+export const DepositProposalShape = M.splitRecord(
+  {
+    give: M.recordOf(M.string(), NatAmountShape, {
+      numPropertiesLimit: 1,
+    }),
+
+    exit: { waived: M.null() },
+  },
+  { want: {} },
+);

--- a/packages/orchestration/src/types.d.ts
+++ b/packages/orchestration/src/types.d.ts
@@ -26,6 +26,7 @@ export type * from './service.js';
 export type * from './vat-orchestration.js';
 export type * from './exos/chainAccountKit.js';
 export type * from './exos/icqConnectionKit.js';
+export type * from './exos/stakingAccountKit.js';
 
 /**
  * static declaration of known chain types will allow type support for
@@ -266,7 +267,7 @@ export interface ChainAccount {
     opts?: Partial<Omit<TxBody, 'messages'>>,
   ) => Promise<string>;
   /** deposit payment from zoe to the account*/
-  deposit: (payment: Payment) => Promise<void>;
+  deposit: (payment: Payment) => Promise<{ sequence: number }>;
   /** get Purse for a brand to .withdraw() a Payment from the account */
   getPurse: (brand: Brand) => Promise<Purse>;
   /**
@@ -432,7 +433,7 @@ export interface BaseOrchestrationAccount {
    * deposit payment from zoe to the account. For remote accounts,
    * an IBC Transfer will be executed to transfer funds there.
    */
-  deposit: (payment: Payment) => Promise<void>;
+  deposit: (payment: Payment) => Promise<{ sequence: number }>;
 }
 
 export type OrchestrationAccount<C extends keyof KnownChains> =
@@ -479,4 +480,12 @@ export type SwapMaxSlippage = {
   amountIn: Amount;
   brandOut: Brand;
   slippage: number;
+};
+
+export type IBCChannelInfo = {
+  counterpartyChannelId: IBCChannelID;
+  counterpartyPortId: string;
+  sourceChannelId: IBCChannelID;
+  sourcePortId: string;
+  // consider including `order`, `version`, `state`
 };

--- a/packages/orchestration/test/typeGuards.test.js
+++ b/packages/orchestration/test/typeGuards.test.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { makeCopyBagFromElements, matches } from '@endo/patterns';
+import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { DepositProposalShape } from '../src/typeGuards.js';
+
+test('DepositProposalShape', t => {
+  const { brand: natBrand } = makeIssuerKit('myToken', AssetKind.NAT);
+  const anyNatAmount = AmountMath.make(natBrand, 1n);
+  const { brand: copyBagBrand } = makeIssuerKit('myNft', AssetKind.COPY_BAG);
+  const anyCopyBagAmount = AmountMath.make(
+    copyBagBrand,
+    makeCopyBagFromElements([1]),
+  );
+
+  t.true(
+    matches(
+      harden({ give: { ANY_KEYWORD: anyNatAmount }, exit: { waived: null } }),
+      DepositProposalShape,
+    ),
+  );
+  t.false(
+    matches(
+      harden({
+        give: { ANY_KEYWORD: anyCopyBagAmount },
+        exit: { waived: null },
+      }),
+      DepositProposalShape,
+    ),
+    'give entry value must be a Nat amount',
+  );
+  t.false(
+    matches(
+      harden({
+        give: { ONE: anyNatAmount, TWO: anyNatAmount },
+        exit: { waived: null },
+      }),
+      DepositProposalShape,
+    ),
+    'only one entry allowed for give',
+  );
+  t.false(
+    matches(
+      harden({
+        give: { ANY_KEYWORD: anyNatAmount },
+        want: { ANY_KEYWORD: anyNatAmount },
+        exit: { waived: null },
+      }),
+      DepositProposalShape,
+    ),
+    'want must be empty',
+  );
+  t.false(
+    matches(
+      harden({ give: { ANY_KEYWORD: anyNatAmount } }),
+      DepositProposalShape,
+    ),
+    'exit waived: null required',
+  );
+});

--- a/packages/vm-config/decentral-devnet-config.json
+++ b/packages/vm-config/decentral-devnet-config.json
@@ -172,8 +172,16 @@
           "args": [
             {
               "hostConnectionId": "connection-1",
-              "controllerConnectionId": "connection-0",
-              "bondDenom": "uatom"
+              "controllerConnectionId": "connection-1",
+              "bondDenom": "uatom",
+              "bondDenomLocal": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+              "transferChannel": {
+                "counterpartyChannelId": "channel-1",
+                "counterpartyPortId": "transfer",
+                "sourceChannelId": "channel-1",
+                "sourcePortId": "transfer"
+              },
+              "icqEnabled": false
             }
           ]
         }


### PR DESCRIPTION
closes: #9193
closes: #9042

## Description

- Adds `.deposit()` method to `stakingAccountHolder` to enable ERTP payment deposits to an Interchain Account. Flow:
   1. `LocalChainAccount` is created and `Payment` is deposited there
   2. `LocalChainAccount` sends ibc/`MsgTransfer` to `ChainAccount` 
        - `ChainTimerService` is used to create a timeout timestamp. We take the current time and add five minutes to it
   3. If anything fails in the wallet offer flow:
       - Attempt is made to deposit live payment back to the user's seat
       - If payment is already in LCA, but failed to make it to the ICA, it is withdrawn back to the user's seat
- Adds `.withdraw()` method to `LocalChainAccount`
- Only accepts deposits of `bondDenom` until #9211, #9063 (need to determine `denom` from `Amount`/`Brand`
- Hardcodes chain parameters in terms until #9063, #8879

### Security Considerations

- Offer Safety: `withdrawFromSeat` is needed to retrieve a live payment from a seat. Offer safety is upheld because the user is not allowed to request a Want, but we need to proceed carefully. There is a chance the deposit fails along the way, and we need to ensure the payment can be recovered and deposited back to a users seat. 

- `chainTimerService` is needed to create a timeout parameter for `MsgTransfer`

### Scaling Considerations

- In order for a `ChainAccount` to have a `deposit()` functionality, a `LocalChainAccount` needs to be created. This could lead to a lot of LCA's

   - given the LCA is currently closed over in state, and might wind up with funds the holder needs to access, we might want to consider exposing interfaces for the LCA's (`.withdraw`, `.executeTx`, `.query`)

- TimerService is needed to create a `MsgTransfer` timeout parameter. See #9324 for more details

### Documentation Considerations


### Testing Considerations

- I wanted to add more explicit tests for the functionality added to `LocalChainAccount`, but struggled to find a place to add them (and get access to a mint in bootstrap tests). Both `deposit()` and `withdraw()` are tested indirectly by tests in `boot/../test-orchestration.ts`

- I would like feedback on the imperative `.deposit()` flow - what happens if this throws? Can we assume the callers supplied payment is still live if it wasn't deposited to the LCA? 


### Upgrade Considerations

