### PR TITLE
8273 remove custom Ava glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "ava": {
     "files": [
-      "packages/*/test/**/test-*.*",
       "packages/*/test/**/*.test.*"
     ],
     "timeout": "30m"

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -75,7 +75,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -88,7 +88,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -33,7 +33,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -92,7 +92,6 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "timeout": "2m",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -26,7 +26,6 @@
       "@endo/init/debug.js"
     ],
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   },

--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -51,7 +51,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -47,7 +47,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -50,7 +50,6 @@
       "ts": "module"
     },
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "nodeArguments": [

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -77,7 +77,6 @@
       "ts": "module"
     },
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "nodeArguments": [

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -69,7 +69,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -39,7 +39,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -53,7 +53,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "timeout": "20m",

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -160,7 +160,6 @@
       "compile": false
     },
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -60,7 +60,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/create-dapp/package.json
+++ b/packages/create-dapp/package.json
@@ -39,7 +39,6 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "timeout": "2m",

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -62,7 +62,6 @@
   ],
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -65,7 +65,6 @@
   ],
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -40,7 +40,6 @@
   ],
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   },

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -70,7 +70,6 @@
   ],
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -43,7 +43,6 @@
       "@endo/init/debug.js"
     ],
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   },

--- a/packages/kmarshal/package.json
+++ b/packages/kmarshal/package.json
@@ -33,7 +33,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -56,7 +56,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -68,7 +68,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -61,7 +61,6 @@
       "ts": "module"
     },
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "nodeArguments": [

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -59,7 +59,6 @@
   ],
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -57,7 +57,6 @@
   "homepage": "https://github.com/Agoric/agoric#readme",
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -69,7 +69,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -54,7 +54,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -50,7 +50,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -41,7 +41,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -55,7 +55,6 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -51,7 +51,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -43,7 +43,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -54,7 +54,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -45,7 +45,6 @@
       "@endo/init/debug.js"
     ],
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   },

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -39,7 +39,6 @@
       "@endo/init/debug.js"
     ],
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   },

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -68,7 +68,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/vm-config/package.json
+++ b/packages/vm-config/package.json
@@ -40,7 +40,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -39,7 +39,6 @@
       "@endo/init/debug.js"
     ],
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ]
   },

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -51,7 +51,6 @@
   "homepage": "https://github.com/Agoric/agoric#readme",
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -39,7 +39,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -65,7 +65,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -128,7 +128,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -45,7 +45,6 @@
   },
   "ava": {
     "files": [
-      "test/**/test-*.*",
       "test/**/*.test.*"
     ],
     "require": [


### PR DESCRIPTION
closes: #8273

## Description

https://github.com/Agoric/agoric-sdk/pull/8653 adopted the new glob but left the old one so any in-flight PRs with new tests wouldn't have them ignored.

It's been a month so any should be migrated by now. This removes the old glob.

It doesn't remove the `"files"` option entirely, because the default glob is everything under `test` and we have files there that aren't tests. Ava warns they're not tests and and eslint errors when tests import from them. We could go fully to the default glob by using an underscore prefixes on files in `test` that aren't tests. I don't think we need to do that. This change already meets the goal of matching the DX of Ava in other repos. (Test filenames are indicated by a `.test.js` suffix)

### Security Considerations
n/a


### Scaling Considerations
n/a

### Documentation Considerations

reduces need to document

### Testing Considerations

no older test files in master (`find packages -name 'test-*' |grep 'test/'`)

### Upgrade Considerations

n/a
