### PR TITLE
refactor(vats): for state upgrade, use single field

### DIFF
--- a/packages/vats/src/proposals/localchain-proposal.js
+++ b/packages/vats/src/proposals/localchain-proposal.js
@@ -66,7 +66,7 @@ export const setupLocalChainVat = async (
     );
   }
 
-  const { public: newLocalChain } = await E(vats.localchain).makeLocalChain({
+  const newLocalChain = await E(vats.localchain).makeLocalChain({
     system: scopedManager,
     bankManager: await bankManager,
   });

--- a/packages/vats/src/proposals/localchain-proposal.js
+++ b/packages/vats/src/proposals/localchain-proposal.js
@@ -6,13 +6,10 @@ import { BridgeId as BRIDGE_ID } from '@agoric/internal';
  * @param {BootstrapPowers & {
  *   consume: {
  *     loadCriticalVat: VatLoader<any>;
- *     bridgeManager: import('../types').BridgeManager;
  *     localchainBridgeManager: import('../types').ScopedBridgeManager;
- *     bankManager: Promise<import('../vat-bank.js').BankManager>;
  *   };
  *   produce: {
  *     localchain: Producer<any>;
- *     localchainAdmin: Producer<any>;
  *     localchainVat: Producer<any>;
  *     localchainBridgeManager: Producer<any>;
  *   };
@@ -32,12 +29,7 @@ export const setupLocalChainVat = async (
       localchainBridgeManager: localchainBridgeManagerP,
       bankManager,
     },
-    produce: {
-      localchainVat,
-      localchain,
-      localchainAdmin: localchainAdminP,
-      localchainBridgeManager,
-    },
+    produce: { localchainVat, localchain, localchainBridgeManager },
   },
   options,
 ) => {
@@ -74,34 +66,13 @@ export const setupLocalChainVat = async (
     );
   }
 
-  const { admin: localChainAdmin, public: newLocalChain } = await E(
-    vats.localchain,
-  ).makeLocalChain({
+  const { public: newLocalChain } = await E(vats.localchain).makeLocalChain({
     system: scopedManager,
+    bankManager: await bankManager,
   });
 
   localchain.reset();
   localchain.resolve(newLocalChain);
-  localchainAdminP.reset();
-  localchainAdminP.resolve(localChainAdmin);
-
-  /** @type {Record<string, Promise<void>>} */
-  const descToPromise = {
-    'bank manager power': bankManager.then(bm =>
-      E(localChainAdmin).setPower('bankManager', bm),
-    ),
-  };
-  void Promise.all(
-    Object.entries(descToPromise).map(([desc, p]) =>
-      p
-        .then(() =>
-          console.info(`Completed configuration of localchain with ${desc}`),
-        )
-        .catch(e =>
-          console.error(`Failed to configure localchain with ${desc}:`, e),
-        ),
-    ),
-  );
 };
 
 /**
@@ -131,7 +102,6 @@ export const getManifestForLocalChain = (_powers, { localchainRef }) => ({
       },
       produce: {
         localchain: 'localchain',
-        localchainAdmin: 'localchain',
         localchainVat: 'localchain',
         localchainBridgeManager: 'localchain',
       },

--- a/packages/vats/src/vat-localchain.js
+++ b/packages/vats/src/vat-localchain.js
@@ -13,10 +13,10 @@ export const buildRootObject = (_vatPowers, _args, baggage) => {
      * Create a local chain that allows permissionlessly making fresh local
      * chain accounts, then using them to send chain queries and transactions.
      *
-     * @param {Partial<import('./localchain.js').LocalChainPowers>} [initialPowers]
+     * @param {import('./localchain.js').LocalChainPowers} powers
      */
-    makeLocalChain(initialPowers = {}) {
-      return makeLocalChain(initialPowers);
+    makeLocalChain(powers) {
+      return makeLocalChain(powers);
     },
   });
 };


### PR DESCRIPTION
follow-up to: #9086

## Description

In preparation for addressing excess authority (#9354):

 - To allow for state upgrade, rather than introducing the complexity of the power store in this initial version, reserve one property for future use
 - Require all localChain powers at intialization, which eliminates the need for the admin.setPower method.

### Security / Documentation Considerations

n/a

### Scaling Considerations

small constant factor change: removing the indirection thru the power store removes 1 syscall per access

### Testing Considerations

existing tests suffice

### Upgrade Considerations

code is not yet released / deployed
