### PR TITLE
feat(graph): also generate the transitive reduction

### DIFF
--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -2,7 +2,7 @@
 # Generates visualizations of the internal package dependency graph.
 # Also generates visualizations of the transitive reduction (tred) of
 # that graph, which is the minimal graph with the same *transitive*
-# dependcies. Much more legible by itelf. Seeing the two side by side
+# dependencies. Much more legible by itelf. Seeing the two side by side
 # often helps to understand the full picture.
 set -ueo pipefail
 DIR=$(dirname -- "${BASH_SOURCE[0]}")

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -24,7 +24,7 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
     '
   echo '}'
   # normalize
-} | dot -Tcanon | tred > packages-graph.dot
+} | dot -Tcanon >packages-graph.dot
 dot -Tpng < packages-graph.dot > "$DIR"/../packages-graph.png
 
 dot -Tsvg < packages-graph.dot > "$DIR"/../packages-graph.svg

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -24,14 +24,14 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
     '
   echo '}'
   # normalize
-} | dot -Tcanon >packages-graph.dot
+} | dot -Tcanon > packages-graph.dot
 dot -Tpng < packages-graph.dot > "$DIR"/../packages-graph.png
 
 dot -Tsvg < packages-graph.dot > "$DIR"/../packages-graph.svg
 
-tred <packages-graph.dot >packages-graph-tred.dot
-dot -Tpng <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.png
-dot -Tsvg <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.svg
+tred < packages-graph.dot > packages-graph-tred.dot
+dot -Tpng < packages-graph-tred.dot > "$DIR"/../packages-graph-tred.png
+dot -Tsvg < packages-graph-tred.dot > "$DIR"/../packages-graph-tred.svg
 
 if acyclic packages-graph.dot | dot -Tcanon > packages-graph-sans-cycles.dot; then
   echo 1>&2 "No cycles in 'dependencies' of packages."

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Generates visualizations of the internal package dependency graph.
+# Also generates visualizations of the transitive reduction (tred) of
+# that graph, which is the minimal graph with the same *transitive*
+# dependcies. Much more legible by itelf. Seeing the two side by side
+# often helps to understand the full picture.
 set -ueo pipefail
 DIR=$(dirname -- "${BASH_SOURCE[0]}")
 {
@@ -20,10 +24,14 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
     '
   echo '}'
   # normalize
-} | dot -Tcanon > packages-graph.dot
+} | dot -Tcanon | tred > packages-graph.dot
 dot -Tpng < packages-graph.dot > "$DIR"/../packages-graph.png
 
 dot -Tsvg < packages-graph.dot > "$DIR"/../packages-graph.svg
+
+tred <packages-graph.dot >packages-graph-tred.dot
+dot -Tpng <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.png
+dot -Tsvg <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.svg
 
 if acyclic packages-graph.dot | dot -Tcanon > packages-graph-sans-cycles.dot; then
   echo 1>&2 "No cycles in 'dependencies' of packages."


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/endojs/endo/pull/2282

## Description

Use the "tred" executable that seems to already be bundled with graphviz to

```
# Also generates visualizations of the transitive reduction (tred) of
# that graph, which is the minimal graph with the same *transitive*
# dependencies. Much more legible by itelf. Seeing the two side by side
# often helps to understand the full picture.
```

At the time of writing, the current graph of agoric-sdk dependencies is

![packages-graph](https://github.com/Agoric/agoric-sdk/assets/273868/4fbcba59-6081-41fd-8866-7372b14a7696)

and the transitive reduction of those is

![packages-graph-tred](https://github.com/Agoric/agoric-sdk/assets/273868/ef7e4b4e-986c-4bc6-96cc-df8587272fd5)

Notice how the columns *mostly* align. Unfortunately, the columns don't fully align, and the vertical order of elements within each column is not the same. For viewing them side by side for better understanding, it would be better if both of these annoyances were fixed. But I have no idea how to do that, so this PR does not try.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

potentially helps someone who wants to understand how our system is internally layered, which is the point. Otherwise, none
### Testing Considerations

none
### Compatibility Considerations

none
### Upgrade Considerations

none