### PR TITLE
fix(ci): move untrusted gh context to envvar

### DIFF
--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -57,11 +57,12 @@ jobs:
         with:
           fetch-depth: 0
       - shell: bash
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_LABEL: ${{ github.event.pull_request.base.label }}
         run: |
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          HEAD_LABEL="${{ github.event.pull_request.head.label }}"
-          BASE_SHA=${{ github.event.pull_request.base.sha }}
-          BASE_LABEL="${{ github.event.pull_request.base.label }}"
           merge_commits=$(git rev-list --merges "$BASE_SHA".."$HEAD_SHA")
 
           if [ -n "$merge_commits" ]; then


### PR DESCRIPTION
Mergify workflow directly interpolates elements from GitHub context. While currently there's no significant security implication, we do the [recommended](https://securitylab.github.com/research/github-actions-untrusted-input/) practice of storing them in intermediate environment variables.