### PR TITLE
reduce ambient imports and drop maxNodeModuleJsDepth

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -8,12 +8,16 @@ Our use of TypeScript has to accomodate both .js development in agoric-sdk (whic
 - package entrypoint(s) exports explicit types
 - for packages upon which other packages expect ambient types:
   - `exported.js` exports the explicit types and ambient re-exports
+- don't use runtime imports to get types ([issue](https://github.com/Agoric/agoric-sdk/issues/6512))
 
 ## .d.ts modules
 
-We cannot use `.ts` files any modules that are transitively imported into an Endo bundle. The reason is that the Endo bundler doesn't understand `.ts` syntax and we don't want it to until we have sufficient auditability of the transformation. Moreover we've tried to avoid a build step in order to import a module. (The one exception so far is `@agoric/cosmic-proto` because we codegen the types. Those modules are written in `.ts` syntax and build to `.js` by a build step that creates `dist`, which is the package export.)
+We cannot use `.ts` files in any modules that are transitively imported into an Endo bundle. The reason is that the Endo bundler doesn't understand `.ts` syntax and we don't want it to until we have sufficient auditability of the transformation. Moreover we've tried to avoid a build step in order to import a module. (The one exception so far is `@agoric/cosmic-proto` because we codegen the types. Those modules are written in `.ts` syntax and build to `.js` by a build step that creates `dist`, which is the package export.)
 
-A `.d.ts` module allows defining the type in `.ts` syntax, without any risk that it will be included in runtime code. The `.js` is what actually gets imported.
+### Benefits
+
+- A `.d.ts` module allows defining the type in `.ts` syntax, without any risk that it will be included in runtime code. The `.js` is what actually gets imported.
+- Only `.d.ts` files can be used in [triple-slash reference types](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-)
 
 The are some consequences to this approach.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,7 +7,7 @@ Our use of TypeScript has to accomodate both .js development in agoric-sdk (whic
 - `.d.ts` for types modules
 - package entrypoint(s) exports explicit types
 - for packages upon which other packages expect ambient types:
-  - `exported.js` exports the explicit types and ambient re-exports
+  - `exported.js` supplies ambients
 - don't use runtime imports to get types ([issue](https://github.com/Agoric/agoric-sdk/issues/6512))
 
 ## .d.ts modules

--- a/packages/ERTP/exported.d.ts
+++ b/packages/ERTP/exported.d.ts
@@ -5,6 +5,8 @@
 // XXX also explicit exports because `@agoric/ertp` top level confuses the type and value of `AssetKind`
 export * from './src/types.js';
 
+import '@agoric/notifier/exported.js';
+
 import {
   Amount as _Amount,
   Brand as _Brand,

--- a/packages/ERTP/exported.d.ts
+++ b/packages/ERTP/exported.d.ts
@@ -2,9 +2,6 @@
 /** @see {@link /docs/typescript.md} */
 /* eslint-disable -- doesn't understand .d.ts */
 
-// XXX also explicit exports because `@agoric/ertp` top level confuses the type and value of `AssetKind`
-export * from './src/types.js';
-
 import '@agoric/notifier/exported.js';
 
 import {

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -1,14 +1,13 @@
 // @jessie-check
 
+/// <reference types="@agoric/store/exported.js" />
+
 /* eslint-disable no-use-before-define */
 import { isPromise } from '@endo/promise-kit';
 import { mustMatch, M, keyEQ } from '@agoric/store';
 import { AmountMath } from './amountMath.js';
 import { preparePaymentKind } from './payment.js';
 import { preparePurseKind } from './purse.js';
-
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/store/exported.js';
 
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 

--- a/packages/ERTP/tsconfig.json
+++ b/packages/ERTP/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     // omit exported.js because 1) it need not be included in the typecheck of
     // this package because it's only consumed by other packages and 2)

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -5,8 +5,6 @@ import { HandledPromise } from '@endo/eventual-send';
 import { Remotable } from '@endo/marshal';
 import { Far, E } from '@endo/far';
 
-import '@agoric/store/exported.js';
-
 /**
  * @template T
  * @typedef {T | PromiseLike<T>} ERef

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -8,8 +8,6 @@ import '@endo/init/pre-bundle-source.js';
 
 import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
 
-import '@endo/ses-ava/exported.js';
-
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 

--- a/packages/SwingSet/tsconfig.json
+++ b/packages/SwingSet/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "exported.js",

--- a/packages/SwingSet/tsconfig.json
+++ b/packages/SwingSet/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "exported.js",
     "demo/**/*.js",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -99,6 +99,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 76.88
+    "atLeast": 76.99
   }
 }

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import { makePspawn } from './helpers.js';
 
 /// <reference types="@endo/captp/src/types.js" />
-/// <reference types="@agoric/swingset-vat/exported.js" />
 /// <reference types="@agoric/network/exported.js" />
 
 // Use either an absolute template URL, or find it relative to DAPP_URL_BASE.

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import { makePspawn } from './helpers.js';
 
 /// <reference types="@endo/captp/src/types.js" />
-/// <reference types="@agoric/network/exported.js" />
 
 // Use either an absolute template URL, or find it relative to DAPP_URL_BASE.
 const gitURL = (relativeOrAbsoluteURL, base) => {

--- a/packages/agoric-cli/tsconfig.json
+++ b/packages/agoric-cli/tsconfig.json
@@ -3,7 +3,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false,
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/agoric-cli/tsconfig.json
+++ b/packages/agoric-cli/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/assert/exported.js
+++ b/packages/assert/exported.js
@@ -1,1 +1,0 @@
-import './src/types-ambient.js';

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -46,7 +46,6 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "files": [
     "src/",
-    "exported.js",
     "NEWS.md"
   ],
   "publishConfig": {

--- a/packages/assert/tsconfig.json
+++ b/packages/assert/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
   ],

--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -61,6 +61,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 96.68
+    "atLeast": 77.83
   }
 }

--- a/packages/base-zone/src/index.js
+++ b/packages/base-zone/src/index.js
@@ -1,7 +1,6 @@
 // @jessie-check
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/store/exported.js';
+/// <reference types="@agoric/store/exported.js" />
 
 // eslint-disable-next-line import/export
 export * from './exports.js';

--- a/packages/base-zone/tsconfig.json
+++ b/packages/base-zone/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/base-zone/tsconfig.json
+++ b/packages/base-zone/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts",

--- a/packages/benchmark/src/benchmarkerator.js
+++ b/packages/benchmark/src/benchmarkerator.js
@@ -7,7 +7,6 @@ import '@endo/init';
 // XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
 import '@agoric/vats/exported.js';
 import '@agoric/inter-protocol/exported.js';
-import '@agoric/zoe/exported.js';
 import '@agoric/cosmic-swingset/src/launch-chain.js';
 
 import { Fail } from '@agoric/assert';

--- a/packages/benchmark/src/benchmarkerator.js
+++ b/packages/benchmark/src/benchmarkerator.js
@@ -5,7 +5,6 @@ import '@endo/init/pre-bundle-source.js';
 import '@endo/init';
 
 // XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/vats/exported.js';
 import '@agoric/inter-protocol/exported.js';
 import '@agoric/cosmic-swingset/src/launch-chain.js';
 

--- a/packages/benchmark/src/benchmarkerator.js
+++ b/packages/benchmark/src/benchmarkerator.js
@@ -4,8 +4,6 @@ import fs from 'node:fs';
 import '@endo/init/pre-bundle-source.js';
 import '@endo/init';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/inter-protocol/exported.js';
 import '@agoric/cosmic-swingset/src/launch-chain.js';
 
 import { Fail } from '@agoric/assert';

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "checkJs": true,
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "checkJs": true,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/boot/test/bootstrapTests/zcfProbe.js
+++ b/packages/boot/test/bootstrapTests/zcfProbe.js
@@ -1,6 +1,3 @@
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-
 import { makeTracer } from '@agoric/internal';
 import { E } from '@endo/far';
 import {

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -18,9 +18,6 @@ import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
 import { makeSlogSender } from '@agoric/telemetry';
 import { TimeMath, Timestamp } from '@agoric/time';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/vats/exported.js';
-
 import {
   boardSlottingMarshaller,
   slotToBoardRemote,

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "checkJs": true,
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "checkJs": true,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": true,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": true,
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/cache/src/types.js
+++ b/packages/cache/src/types.js
@@ -3,7 +3,6 @@
 /// <reference types="@agoric/store/exported.js" />
 
 // XXX package factoring debt
-import '@agoric/notifier/exported.js';
 
 // Ensure this is a module.
 export {};

--- a/packages/cache/src/types.js
+++ b/packages/cache/src/types.js
@@ -1,8 +1,9 @@
 // @jessie-check
 
+/// <reference types="@agoric/store/exported.js" />
+
 // XXX package factoring debt
 import '@agoric/notifier/exported.js';
-import '@agoric/store/exported.js';
 
 // Ensure this is a module.
 export {};

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "public/**/*.js",

--- a/packages/casting/tsconfig.json
+++ b/packages/casting/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "public/**/*.js",

--- a/packages/casting/tsconfig.json
+++ b/packages/casting/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/cosmic-swingset/tsconfig.json
+++ b/packages/cosmic-swingset/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "calc-*.js",

--- a/packages/deploy-script-support/exported.js
+++ b/packages/deploy-script-support/exported.js
@@ -1,1 +1,0 @@
-import './src/externalTypes.js';

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -58,8 +58,7 @@
   },
   "files": [
     "src",
-    "NEWS.md",
-    "exported.js"
+    "NEWS.md"
   ],
   "ava": {
     "files": [

--- a/packages/deploy-script-support/test/unitTests/depositInvitation.test.js
+++ b/packages/deploy-script-support/test/unitTests/depositInvitation.test.js
@@ -3,8 +3,6 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 
-import '../../exported.js';
-
 import { makeDepositInvitation } from '../../src/depositInvitation.js';
 
 test('depositInvitation', async t => {

--- a/packages/deploy-script-support/test/unitTests/findInvitationAmount.test.js
+++ b/packages/deploy-script-support/test/unitTests/findInvitationAmount.test.js
@@ -3,8 +3,6 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 
-import '../../exported.js';
-
 import { makeOfferAndFindInvitationAmount } from '../../src/offer.js';
 
 test('findInvitationAmount', async t => {

--- a/packages/deploy-script-support/test/unitTests/install.test.js
+++ b/packages/deploy-script-support/test/unitTests/install.test.js
@@ -6,8 +6,6 @@ import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import bundleSource from '@endo/bundle-source';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 
-import '../../exported.js';
-
 import { makeInstall } from '../../src/install.js';
 
 test('install', async t => {

--- a/packages/deploy-script-support/test/unitTests/offer.test.js
+++ b/packages/deploy-script-support/test/unitTests/offer.test.js
@@ -7,8 +7,6 @@ import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { E } from '@endo/far';
 
-import '../../exported.js';
-
 import { makeOfferAndFindInvitationAmount } from '../../src/offer.js';
 
 test('offer', async t => {

--- a/packages/deploy-script-support/tsconfig.json
+++ b/packages/deploy-script-support/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/deploy-script-support/tsconfig.json
+++ b/packages/deploy-script-support/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "src/**/*.js",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -77,6 +77,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 89.32
+    "atLeast": 89.31
   }
 }

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -1,7 +1,6 @@
 /// <reference types="@agoric/internal/exported" />
 /// <reference types="@agoric/ertp/exported" />
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 export {
   ChoiceMethod,

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -699,6 +699,7 @@ export {};
  * @param {ERef<ZoeService>} zoe
  * @param {Instance} allegedGovernor
  * @param {Instance} allegedElectorate
+ * @returns {Promise<true>}
  */
 
 /**

--- a/packages/governance/test/unitTests/binaryballotCount.test.js
+++ b/packages/governance/test/unitTests/binaryballotCount.test.js
@@ -1,8 +1,6 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/eventual-send';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';

--- a/packages/governance/test/unitTests/committee.test.js
+++ b/packages/governance/test/unitTests/committee.test.js
@@ -1,8 +1,5 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';

--- a/packages/governance/test/unitTests/paramChangePositions.test.js
+++ b/packages/governance/test/unitTests/paramChangePositions.test.js
@@ -1,5 +1,5 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import '@agoric/zoe/exported.js';
+
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 

--- a/packages/governance/test/unitTests/paramGovernance.test.js
+++ b/packages/governance/test/unitTests/paramGovernance.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';

--- a/packages/governance/tsconfig.json
+++ b/packages/governance/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     // omit exported.js because 1) it need not be included in the typecheck of
     // this package because it's only consumed by other packages and 2)

--- a/packages/governance/tsconfig.json
+++ b/packages/governance/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     // omit exported.js because 1) it need not be included in the typecheck of

--- a/packages/inter-protocol/exported.js
+++ b/packages/inter-protocol/exported.js
@@ -1,2 +1,0 @@
-import './src/psm/types-ambient.js';
-import './src/vaultFactory/types-ambient.js';

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -66,7 +66,6 @@
   "files": [
     "scripts",
     "src/",
-    "exported.js",
     "NEWS.md"
   ],
   "ava": {

--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -1,9 +1,6 @@
 /// <reference types="@agoric/internal/exported" />
 /// <reference types="@agoric/governance/exported" />
-
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-import '@agoric/zoe/src/contracts/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 import { AmountMath, RatioShape } from '@agoric/ertp';
 import { mustMatch } from '@agoric/store';

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -1,6 +1,5 @@
 /// <reference types="@agoric/governance/exported" />
 /// <reference types="@agoric/zoe/exported" />
-import '@agoric/zoe/src/contracts/exported.js';
 
 import { AmountMath, AmountShape, BrandShape } from '@agoric/ertp';
 import { handleParamGovernance } from '@agoric/governance';

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -1,5 +1,5 @@
 /// <reference types="@agoric/governance/exported" />
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 import '@agoric/zoe/src/contracts/exported.js';
 
 import { AmountMath, AmountShape, BrandShape } from '@agoric/ertp';

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -1,11 +1,10 @@
 // @jessie-check
 /// <reference types="@agoric/governance/exported" />
+/// <reference types="@agoric/zoe/exported" />
 
 import { M, mustMatch } from '@agoric/store';
 import { TimestampShape } from '@agoric/time';
 import { prepareExo, provideDurableMapStore } from '@agoric/vat-data';
-import '@agoric/zoe/exported.js';
-import '@agoric/zoe/src/contracts/exported.js';
 import {
   InstallationShape,
   InstanceHandleShape,

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -269,7 +269,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
 
     /**
      * @param {import('@endo/far').EOnly<
-     *   import('@agoric/ertp/exported.js').DepositFacet
+     *   import('@agoric/ertp/src/types.js').DepositFacet
      * >} depositFacet
      */
     makeDepositFacetDestination: depositFacet => {

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -1,9 +1,6 @@
 // @jessie-check
 /// <reference types="@agoric/governance/exported" />
-
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-import '@agoric/zoe/src/contracts/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 import { AmountMath, AmountShape, BrandShape, RatioShape } from '@agoric/ertp';
 import {

--- a/packages/inter-protocol/src/vaultFactory/burn.js
+++ b/packages/inter-protocol/src/vaultFactory/burn.js
@@ -1,7 +1,6 @@
 // @jessie-check
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 import { E } from '@endo/eventual-send';
 

--- a/packages/inter-protocol/src/vaultFactory/type-imports.js
+++ b/packages/inter-protocol/src/vaultFactory/type-imports.js
@@ -1,4 +1,0 @@
-// @jessie-check
-
-/// <reference types="@agoric/zoe/exported" />
-/// <reference path="./types-ambient.js" />

--- a/packages/inter-protocol/src/vaultFactory/type-imports.js
+++ b/packages/inter-protocol/src/vaultFactory/type-imports.js
@@ -1,4 +1,4 @@
 // @jessie-check
 
-import '@agoric/zoe/exported.js';
-/// <reference path="./types.js" />
+/// <reference types="@agoric/zoe/exported" />
+/// <reference path="./types-ambient.js" />

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -13,9 +13,6 @@ import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
 import { calculateDebtCosts } from './math.js';
 import { prepareVaultKit } from './vaultKit.js';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-
 const { quote: q, Fail } = assert;
 
 const trace = makeTracer('Vault', true);

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -1,6 +1,5 @@
 /// <reference types="@agoric/governance/exported" />
 /// <reference types="@agoric/zoe/exported" />
-import '@agoric/zoe/src/contracts/exported.js';
 
 import { AmountMath, AmountShape, BrandShape, IssuerShape } from '@agoric/ertp';
 import {

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -1,5 +1,5 @@
 /// <reference types="@agoric/governance/exported" />
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 import '@agoric/zoe/src/contracts/exported.js';
 
 import { AmountMath, AmountShape, BrandShape, IssuerShape } from '@agoric/ertp';
@@ -89,6 +89,7 @@ const shortfallInvitationKey = 'shortfallInvitation';
  * @param {ERef<Marshaller>} marshaller
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeERecorderKit} makeERecorderKit
+ * @param managerParams
  */
 const prepareVaultDirector = (
   baggage,

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -1,9 +1,6 @@
 // @jessie-check
 /// <reference types="@agoric/governance/exported" />
-
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-import '@agoric/zoe/src/contracts/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 // The vaultFactory owns a number of VaultManagers and a mint for Minted.
 //

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 import { makeTracer } from '@agoric/internal';
 import { prepareVaultHolder } from './vaultHolder.js';

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -16,7 +16,7 @@
  *   liquidated. If the auction is unsuccessful, the liquidation may be
  *   reverted.
  */
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 import {
   AmountMath,

--- a/packages/inter-protocol/test/auction/auctionContract.test.js
+++ b/packages/inter-protocol/test/auction/auctionContract.test.js
@@ -1,7 +1,5 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import '@agoric/zoe/exported.js';
-
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { documentStorageSchema } from '@agoric/governance/tools/storageDoc.js';
 import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';

--- a/packages/inter-protocol/test/auction/proportionalDist.test.js
+++ b/packages/inter-protocol/test/auction/proportionalDist.test.js
@@ -1,7 +1,5 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import '@agoric/zoe/exported.js';
-
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 

--- a/packages/inter-protocol/test/auction/scheduleMath.test.js
+++ b/packages/inter-protocol/test/auction/scheduleMath.test.js
@@ -2,7 +2,6 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { TimeMath } from '@agoric/time';
 import { Far } from '@endo/marshal';
-import '@agoric/zoe/exported.js';
 
 import { NonNullish } from '@agoric/assert';
 import {

--- a/packages/inter-protocol/test/interest-labeled.test.js
+++ b/packages/inter-protocol/test/interest-labeled.test.js
@@ -1,5 +1,4 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import '@agoric/zoe/exported.js';
 
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';

--- a/packages/inter-protocol/test/interest.test.js
+++ b/packages/inter-protocol/test/interest.test.js
@@ -1,5 +1,4 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import '@agoric/zoe/exported.js';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import {

--- a/packages/inter-protocol/test/psm/psm.test.js
+++ b/packages/inter-protocol/test/psm/psm.test.js
@@ -1,6 +1,5 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import '@agoric/zoe/exported.js';
 import '../../src/vaultFactory/types-ambient.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';

--- a/packages/inter-protocol/test/psm/psm.test.js
+++ b/packages/inter-protocol/test/psm/psm.test.js
@@ -1,7 +1,5 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import '../../src/vaultFactory/types-ambient.js';
-
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { split } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -23,7 +23,6 @@ import {
   startVaultFactory,
 } from '../../src/proposals/econ-behaviors.js';
 import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.js';
-import '../../src/vaultFactory/types-ambient.js';
 import {
   installPuppetGovernance,
   setupBootstrap,

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -1,5 +1,3 @@
-import '@agoric/zoe/exported.js';
-
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { allValues, makeTracer, objectMap } from '@agoric/internal';
 import { makeNotifierFromSubscriber } from '@agoric/notifier';

--- a/packages/inter-protocol/test/vaultFactory/prioritizedVaults.test.js
+++ b/packages/inter-protocol/test/vaultFactory/prioritizedVaults.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';

--- a/packages/inter-protocol/test/vaultFactory/proceeds.test.js
+++ b/packages/inter-protocol/test/vaultFactory/proceeds.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit } from '@agoric/ertp';

--- a/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
+++ b/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';

--- a/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
+++ b/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
@@ -35,7 +35,6 @@ import {
   startVaultFactory,
 } from '../../src/proposals/econ-behaviors.js';
 
-import '../../src/vaultFactory/types-ambient.js';
 import { defaultParamValues } from './vaultFactoryUtils.js';
 
 /**

--- a/packages/inter-protocol/test/vaultFactory/storage.test.js
+++ b/packages/inter-protocol/test/vaultFactory/storage.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeTracer } from '@agoric/internal';

--- a/packages/inter-protocol/test/vaultFactory/storage.test.js
+++ b/packages/inter-protocol/test/vaultFactory/storage.test.js
@@ -6,8 +6,6 @@ import { E } from '@endo/eventual-send';
 import { assertTopicPathData, subscriptionKey } from '../supports.js';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
-import '../../src/vaultFactory/types-ambient.js';
-
 /** @typedef {import('./driver.js').DriverContext & {}} Context */
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;

--- a/packages/inter-protocol/test/vaultFactory/vault-interest.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-interest.test.js
@@ -1,5 +1,4 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import '@agoric/zoe/exported.js';
 
 import { E } from '@endo/eventual-send';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';

--- a/packages/inter-protocol/test/vaultFactory/vault.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vault.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -28,7 +28,6 @@ import { E } from '@endo/eventual-send';
 import { calculateCurrentDebt } from '../../src/interest-math.js';
 import { SECONDS_PER_YEAR } from '../../src/interest.js';
 import { startVaultFactory } from '../../src/proposals/econ-behaviors.js';
-import '../../src/vaultFactory/types-ambient.js';
 import {
   metricsTracker,
   reserveInitialState,

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -1,5 +1,3 @@
-import '@agoric/zoe/exported.js';
-
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -12,7 +12,6 @@ import {
   setupReserve,
   startAuctioneer,
 } from '../../src/proposals/econ-behaviors.js';
-import '../../src/vaultFactory/types-ambient.js';
 import {
   installPuppetGovernance,
   produceInstallations,

--- a/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
@@ -1,4 +1,3 @@
-import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';

--- a/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
@@ -28,7 +28,6 @@ import {
   SECONDS_PER_WEEK as ONE_WEEK,
   startVaultFactory,
 } from '../../src/proposals/econ-behaviors.js';
-import '../../src/vaultFactory/types-ambient.js';
 import {
   reserveInitialState,
   subscriptionTracker,

--- a/packages/inter-protocol/tsconfig.json
+++ b/packages/inter-protocol/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "globals.d.ts",
     "scripts/**/*.js",

--- a/packages/inter-protocol/tsconfig.json
+++ b/packages/inter-protocol/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "globals.d.ts",

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2, // as in jsconfig's default
+    "maxNodeModuleJsDepth": 1, // as in jsconfig's default
     // Disable b/c @endo/init can't pass noImplicitAny
     "checkJs": false,
     "noImplicitAny": true,

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 1, // as in jsconfig's default
     // Disable b/c @endo/init can't pass noImplicitAny
     "checkJs": false,
     "noImplicitAny": true,

--- a/packages/kmarshal/tsconfig.json
+++ b/packages/kmarshal/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/kmarshal/tsconfig.json
+++ b/packages/kmarshal/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "src/**/*.js",

--- a/packages/network/exported.js
+++ b/packages/network/exported.js
@@ -1,1 +1,0 @@
-import './src/types.js';

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -40,17 +40,13 @@
     "c8": "^9.1.0"
   },
   "exports": {
-    ".": "./src/index.js",
-    "./exported.js": "./exported.js"
+    ".": "./src/index.js"
   },
   "files": [
     "CHANGELOG.md",
     "src/",
     "scripts/",
-    "tools/",
-    "*.json",
-    "globals.d.ts",
-    "exported.js"
+    "tools/"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -1,12 +1,13 @@
 // @ts-check
 
+/// <reference types="@agoric/store/exported.js" />
+
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { Fail } from '@agoric/assert';
 import { toBytes } from './bytes.js';
 import { Shape } from './shapes.js';
 
-import '@agoric/store/exported.js';
 /// <reference path="./types.js" />
 /**
  * @import {AttemptDescription, Bytes, Closable, CloseReason, Connection, ConnectionHandler, Endpoint, ListenHandler, Port, Protocol, ProtocolHandler, ProtocolImpl} from './types.js';

--- a/packages/network/src/router.js
+++ b/packages/network/src/router.js
@@ -1,13 +1,14 @@
 // @ts-check
+
+/// <reference types="@agoric/store/exported.js" />
+/// <reference path="./types.js" />
+
 import { E as defaultE } from '@endo/far';
 import { M } from '@endo/patterns';
 import { Fail } from '@agoric/assert';
 import { ENDPOINT_SEPARATOR, prepareNetworkProtocol } from './network.js';
 import { Shape } from './shapes.js';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/store/exported.js';
-/// <reference path="./types.js" />
 /**
  * @import {AttemptDescription, Bytes, Closable, CloseReason, Connection, ConnectionHandler, Endpoint, ListenHandler, Port, Protocol, ProtocolHandler, ProtocolImpl} from './types.js';
  * @import {PromiseVow, Remote, VowKit, VowResolver, VowTools} from '@agoric/vow';

--- a/packages/network/tsconfig.json
+++ b/packages/network/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/notifier/test/notifier-examples.test.js
+++ b/packages/notifier/test/notifier-examples.test.js
@@ -9,8 +9,6 @@ import {
 } from '../src/index.js';
 import { paula, alice, bob } from './iterable-testing-tools.js';
 
-import '../src/types.js';
-
 const last = array => array[array.length - 1];
 
 test('notifier for-await-of success example', async t => {

--- a/packages/notifier/test/publish-kit.test.js
+++ b/packages/notifier/test/publish-kit.test.js
@@ -17,7 +17,6 @@ import {
   subscribeLatest,
   prepareDurablePublishKit,
 } from '../src/index.js';
-import '../src/types.js';
 import { invertPromiseSettlement } from './iterable-testing-tools.js';
 
 /**

--- a/packages/notifier/test/subscriber-examples.test.js
+++ b/packages/notifier/test/subscriber-examples.test.js
@@ -9,8 +9,6 @@ import {
 } from '../src/index.js';
 import { paula, alice, bob, carol } from './iterable-testing-tools.js';
 
-import '../src/types.js';
-
 test('subscription for-await-of success example', async t => {
   const { publication, subscription } = makeSubscriptionKit();
   paula(publication);

--- a/packages/notifier/tsconfig.json
+++ b/packages/notifier/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "src/**/*.js",

--- a/packages/notifier/tsconfig.json
+++ b/packages/notifier/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "src/**/*.js",
     // exclude exported.js so that stub doesn't overwrite exportd.d.ts

--- a/packages/orchestration/index.js
+++ b/packages/orchestration/index.js
@@ -1,8 +1,6 @@
 /// <reference types="@agoric/internal/exported" />
 /// <reference types="@agoric/vats/src/core/types-ambient" />
-
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
+/// <reference types="@agoric/zoe/exported" />
 
 export * from './src/types.js';
 export * from './src/service.js';

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -83,6 +83,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 97.25
+    "atLeast": 97.38
   }
 }

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -5,7 +5,7 @@ import type {
   UnbondingDelegation,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/staking.js';
 import type { TxBody } from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
-import type { Brand, Payment, Purse } from '@agoric/ertp/exported.js';
+import type { Brand, Payment, Purse } from '@agoric/ertp/src/types.js';
 import type { Port } from '@agoric/network';
 import type {
   LocalIbcAddress,

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -1,8 +1,5 @@
 /** @file ChainAccount exo */
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/network/exported.js';
-
 import { NonNullish } from '@agoric/assert';
 import { makeTracer } from '@agoric/internal';
 import { V as E } from '@agoric/vow/vat.js';

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -9,7 +9,7 @@ import type {
   Brand,
   NatAmount,
   Payment,
-} from '@agoric/ertp/exported.js';
+} from '@agoric/ertp/src/types.js';
 import type { LocalChainAccount } from '@agoric/vats/src/localchain.js';
 import type { Timestamp } from '@agoric/time';
 import type { KnownChains } from './types.js';

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -1,8 +1,5 @@
 /** @file Orchestration service */
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/network/exported.js';
-
 import { V as E } from '@agoric/vow/vat.js';
 import { M } from '@endo/patterns';
 import { Shape as NetworkShape } from '@agoric/network';

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -2,4 +2,3 @@ import './src/types.js';
 import '@agoric/notifier/exported.js';
 import '@agoric/ertp/exported.js';
 import '@agoric/store/exported.js';
-import '@agoric/swingset-vat/exported.js';

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -1,2 +1,0 @@
-/// <reference types="@agoric/store/exported.js" />
-import './src/types.js';

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -1,4 +1,4 @@
+/// <reference types="@agoric/store/exported.js" />
 import './src/types.js';
 import '@agoric/notifier/exported.js';
 import '@agoric/ertp/exported.js';
-import '@agoric/store/exported.js';

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -1,3 +1,2 @@
 /// <reference types="@agoric/store/exported.js" />
 import './src/types.js';
-import '@agoric/notifier/exported.js';

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -1,4 +1,3 @@
 /// <reference types="@agoric/store/exported.js" />
 import './src/types.js';
 import '@agoric/notifier/exported.js';
-import '@agoric/ertp/exported.js';

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -72,6 +72,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 90.61
+    "atLeast": 90.6
   }
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -55,7 +55,6 @@
   "files": [
     "scripts/",
     "src/",
-    "exported.js",
     "NEWS.md"
   ],
   "ava": {

--- a/packages/pegasus/src/contract.js
+++ b/packages/pegasus/src/contract.js
@@ -3,8 +3,6 @@ import { prepareVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { makePegasus } from './pegasus.js';
 
-import '@agoric/zoe/exported.js';
-
 import '../exported.js';
 
 /**

--- a/packages/pegasus/src/contract.js
+++ b/packages/pegasus/src/contract.js
@@ -3,8 +3,6 @@ import { prepareVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { makePegasus } from './pegasus.js';
 
-import '../exported.js';
-
 /**
  * @import {Remote} from '@agoric/vow';
  */

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -7,7 +7,7 @@ import { E, Far } from '@endo/far';
 import { makeOncePromiseKit } from './once-promise-kit.js';
 
 /**
- * @import {DepositFacet} from '@agoric/ertp/exported.js'
+ * @import {DepositFacet} from '@agoric/ertp/src/types.js'
  * @import {Connection} from '@agoric/network';
  * @import {Remote} from '@agoric/vow';
  */

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -10,7 +10,6 @@ import {
 import { makeSubscriptionKit } from '@agoric/notifier';
 
 import '@agoric/network/exported.js';
-import '@agoric/zoe/exported.js';
 
 import '../exported.js';
 import { IBCSourceTraceDenomTransformer } from './ibc-trace.js';

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -9,7 +9,6 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeSubscriptionKit } from '@agoric/notifier';
 
-import '../exported.js';
 import { IBCSourceTraceDenomTransformer } from './ibc-trace.js';
 import { ICS20TransferProtocol } from './ics20.js';
 import { makeCourierMaker, getCourierPK } from './courier.js';

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -9,8 +9,6 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeSubscriptionKit } from '@agoric/notifier';
 
-import '@agoric/network/exported.js';
-
 import '../exported.js';
 import { IBCSourceTraceDenomTransformer } from './ibc-trace.js';
 import { ICS20TransferProtocol } from './ics20.js';

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -12,7 +12,7 @@
 
 /**
  * @typedef {object} PacketParts
- * @property {import("@agoric/ertp/exported.js").AmountValue} value
+ * @property {import("@agoric/ertp/src/types.js").AmountValue} value
  * @property {Denom} remoteDenom
  * @property {DepositAddress} depositAddress
  * @property {string} memo

--- a/packages/pegasus/test/peg.test.js
+++ b/packages/pegasus/test/peg.test.js
@@ -14,7 +14,6 @@ import { makeZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { makeSubscription } from '@agoric/notifier';
 import { prepareVowTools } from '@agoric/vow/vat.js';
 
-import '@agoric/ertp/exported.js';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeScalarMapStore } from '@agoric/vat-data';
 import { makeDurableZone } from '@agoric/zone/durable.js';

--- a/packages/pegasus/tsconfig.json
+++ b/packages/pegasus/tsconfig.json
@@ -3,7 +3,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false,
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/pegasus/tsconfig.json
+++ b/packages/pegasus/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -4,9 +4,6 @@ import { InvitationHandleShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/far';
 import { shape } from './typeGuards.js';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-
 const { Fail } = assert;
 
 // A safety limit

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -1,6 +1,3 @@
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/src/zoeService/types-ambient.js';
-
 /**
  * @typedef {number | string} OfferId
  */

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -42,9 +42,6 @@ import { shape } from './typeGuards.js';
 import { objectMapStoragePath } from './utils.js';
 import { prepareOfferWatcher, watchOfferOutcomes } from './offerWatcher.js';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/exported.js';
-
 const { Fail, quote: q } = assert;
 
 const trace = makeTracer('SmrtWlt');

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -2,9 +2,6 @@ import { deeplyFulfilledObject, objectMap, makeTracer } from '@agoric/internal';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import { E } from '@endo/far';
 
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/internal/exported.js';
-
 export const NO_SMART_WALLET_ERROR = 'no smart wallet';
 
 const trace = makeTracer('WUTIL', false);

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -4,7 +4,6 @@ import { E } from '@endo/far';
 
 // XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
 import '@agoric/internal/exported.js';
-import '@agoric/notifier/exported.js';
 
 export const NO_SMART_WALLET_ERROR = 'no smart wallet';
 

--- a/packages/smart-wallet/tsconfig.json
+++ b/packages/smart-wallet/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/smart-wallet/tsconfig.json
+++ b/packages/smart-wallet/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -79,6 +79,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 73.13
+    "atLeast": 73.11
   }
 }

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -63,6 +63,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 55.05
+    "atLeast": 54.79
   }
 }

--- a/packages/store/test/AtomicProvider.test.js
+++ b/packages/store/test/AtomicProvider.test.js
@@ -5,8 +5,6 @@ import { setTimeout } from 'timers';
 import { makeScalarMapStore } from '../src/stores/scalarMapStore.js';
 import { makeAtomicProvider } from '../src/stores/store-utils.js';
 
-import '../src/types.js';
-
 test('race', async t => {
   const store = makeScalarMapStore('foo');
   const provider = makeAtomicProvider(store);

--- a/packages/store/test/store.test.js
+++ b/packages/store/test/store.test.js
@@ -8,8 +8,6 @@ import { makeScalarSetStore } from '../src/stores/scalarSetStore.js';
 import { makeScalarWeakMapStore } from '../src/stores/scalarWeakMapStore.js';
 import { provideLazy } from '../src/stores/store-utils.js';
 
-import '../src/types.js';
-
 function check(t, mode, objMaker) {
   // Check the full API, and make sure object identity isn't a problem by
   // creating two potentially-similar things for use as keys.

--- a/packages/swing-store/tsconfig.json
+++ b/packages/swing-store/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/swingset-liveslots/src/index.js
+++ b/packages/swingset-liveslots/src/index.js
@@ -1,5 +1,4 @@
-// XXX ambient types runtime imports until https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/store/exported.js';
+/// <reference types="@agoric/store/exported.js" />
 
 /* eslint-disable import/export -- types files have no named runtime exports */
 export { makeLiveSlots, makeMarshaller } from './liveslots.js';

--- a/packages/swingset-liveslots/tsconfig.json
+++ b/packages/swingset-liveslots/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -7,8 +7,6 @@ import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { showPurseBalance, setupPurses } from './helpers.js';
 import { makePrintLog } from './printLog.js';
 
-import '@agoric/zoe/exported.js';
-
 const log = makePrintLog();
 
 /**

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -1,8 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
 
-import '@agoric/zoe/exported.js';
-
 export async function showPurseBalance(purseP, name, log) {
   try {
     const amount = await E(purseP).getCurrentAmount();

--- a/packages/swingset-runner/demo/swapBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/swapBenchmark/exchanger.js
@@ -7,8 +7,6 @@ import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { showPurseBalance, setupPurses } from './helpers.js';
 import { makePrintLog } from './printLog.js';
 
-import '@agoric/zoe/exported.js';
-
 const log = makePrintLog();
 
 /**

--- a/packages/swingset-runner/demo/swapBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/swapBenchmark/helpers.js
@@ -1,8 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
 
-import '@agoric/zoe/exported.js';
-
 export async function showPurseBalance(purseP, name, log) {
   try {
     const amount = await E(purseP).getCurrentAmount();

--- a/packages/swingset-xsnap-supervisor/tsconfig.json
+++ b/packages/swingset-xsnap-supervisor/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/swingset-xsnap-supervisor/tsconfig.json
+++ b/packages/swingset-xsnap-supervisor/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "lib/**/*.js",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -64,6 +64,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 87.04
+    "atLeast": 87.03
   }
 }

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts",

--- a/packages/time/tsconfig.json
+++ b/packages/time/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "build",
     "index.js",

--- a/packages/vat-data/tsconfig.json
+++ b/packages/vat-data/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     // XXX to resolve the swingset-liveslots types
-    "maxNodeModuleJsDepth": 1,
     // "strict": true, // disabled for compat with >0 module depth
     // "noImplicitAny": false, // for compat with peer packages using ambient types
   },

--- a/packages/vats/exported.js
+++ b/packages/vats/exported.js
@@ -1,1 +1,0 @@
-import './src/core/types-ambient.js';

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -79,6 +79,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.26
+    "atLeast": 91.27
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -58,8 +58,7 @@
     "src/",
     "scripts/",
     "tools/",
-    "index.*",
-    "exported.*"
+    "index.*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -1,5 +1,4 @@
 import { M } from '@agoric/store';
-import '@agoric/store/exported.js';
 import { E } from '@endo/far';
 
 const { Fail, details: X } = assert;

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -5,7 +5,6 @@ import { E } from '@endo/far';
 
 import { dataToBase64, base64ToBytes } from '@agoric/network';
 
-import '@agoric/store/exported.js';
 import '@agoric/network/exported.js';
 import {
   localAddrToPortID,

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -5,7 +5,6 @@ import { E } from '@endo/far';
 
 import { dataToBase64, base64ToBytes } from '@agoric/network';
 
-import '@agoric/network/exported.js';
 import {
   localAddrToPortID,
   decodeRemoteIbcAddress,

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -19,8 +19,6 @@ import {
   prepareVirtualPurse,
 } from './virtual-purse.js';
 
-import '@agoric/notifier/exported.js';
-
 /**
  * @import {Guarded} from '@endo/exo')
  * @import {Passable, RemotableObject} from '@endo/pass-style')

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -638,7 +638,7 @@ const prepareBankManager = (
        * @param {AssetIssuerKit} feeKit
        * @returns {ERef<
        *   import('@endo/far').EOnly<
-       *     import('@agoric/ertp/exported.js').DepositFacet
+       *     import('@agoric/ertp/src/types.js').DepositFacet
        *   >
        * >}
        */

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -10,7 +10,6 @@ import {
   PaymentShape,
 } from '@agoric/ertp/src/typeGuards.js';
 
-import '@agoric/notifier/exported.js';
 import { getInterfaceGuardPayload } from '@endo/patterns';
 
 const { Fail } = assert;

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -10,7 +10,6 @@ import {
   PaymentShape,
 } from '@agoric/ertp/src/typeGuards.js';
 
-import '@agoric/ertp/exported.js';
 import '@agoric/notifier/exported.js';
 import { getInterfaceGuardPayload } from '@endo/patterns';
 

--- a/packages/vats/test/bootstrapPayment.test.js
+++ b/packages/vats/test/bootstrapPayment.test.js
@@ -1,9 +1,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
 import { E } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
-
-import '@agoric/zoe/exported.js';
-
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { AmountMath } from '@agoric/ertp';
 import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';

--- a/packages/vats/test/network.test.js
+++ b/packages/vats/test/network.test.js
@@ -13,7 +13,6 @@ import { prepareVowTools } from '@agoric/vow/vat.js';
 import { buildRootObject as ibcBuildRootObject } from '../src/vat-ibc.js';
 import { buildRootObject as networkBuildRootObject } from '../src/vat-network.js';
 
-import '../src/types.js';
 import { registerNetworkProtocols } from '../src/proposals/network-proposal.js';
 
 const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });

--- a/packages/vats/tsconfig.json
+++ b/packages/vats/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts",

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -52,6 +52,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 89.34
+    "atLeast": 89.6
   }
 }

--- a/packages/vow/tsconfig.json
+++ b/packages/vow/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
     "checkJs": false
   },
   "include": [

--- a/packages/wallet/api/exported.js
+++ b/packages/wallet/api/exported.js
@@ -1,1 +1,0 @@
-import './src/types-ambient.js';

--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -18,7 +18,7 @@
 
 /**
  * @typedef {object} PurseActions
- * @property {(receiverP: ERef<{ receive: (payment: Payment) => void }>, valueToSend: import('@agoric/ertp/exported.js').AmountValue) => Promise<void>} send
+ * @property {(receiverP: ERef<{ receive: (payment: Payment) => void }>, valueToSend: import('@agoric/ertp/src/types.js').AmountValue) => Promise<void>} send
  * @property {(payment: Payment) => Promise<Amount>} receive
  * @property {(payment: Payment, amount?: Amount) => Promise<Amount>} deposit
  */
@@ -85,7 +85,7 @@
  * @property {string} [issuerBoardId]
  *
  * @typedef {object} PaymentActions
- * @property {(purseOrPetname?: (Purse | Petname)) => Promise<import('@agoric/ertp/exported.js').AmountValue>} deposit
+ * @property {(purseOrPetname?: (Purse | Petname)) => Promise<import('@agoric/ertp/src/types.js').AmountValue>} deposit
  * @property {() => Promise<boolean>} refresh
  * @property {() => Promise<boolean>} getAmountOf
  */

--- a/packages/wallet/api/src/issuerTable.js
+++ b/packages/wallet/api/src/issuerTable.js
@@ -5,7 +5,6 @@ import { E } from '@endo/eventual-send';
 
 import { makeScalarWeakMapStore } from '@agoric/store';
 
-import '../exported.js';
 import './internal-types.js';
 
 /**

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -43,10 +43,7 @@ import { makeId, findOrMakeInvitation } from './findOrMakeInvitation.js';
 import { bigintStringify } from './bigintStringify.js';
 import { makePaymentActions } from './actions.js';
 
-import '@agoric/store/exported.js';
-
 import './internal-types.js';
-/// <reference path="./types.js" />
 
 // does nothing
 const noActionStateChangeHandler = _newState => {};

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -44,7 +44,6 @@ import { bigintStringify } from './bigintStringify.js';
 import { makePaymentActions } from './actions.js';
 
 import '@agoric/store/exported.js';
-import '@agoric/zoe/exported.js';
 
 import './internal-types.js';
 /// <reference path="./types.js" />

--- a/packages/wallet/api/test/continuingInvitationExample.js
+++ b/packages/wallet/api/test/continuingInvitationExample.js
@@ -3,8 +3,6 @@
 import { makeNotifierFromSubscriber, makePublishKit } from '@agoric/notifier';
 import { Far } from '@endo/marshal';
 
-import '@agoric/zoe/exported.js';
-
 export const start = zcf => {
   const { subscriber, publisher } = makePublishKit();
   const notifier = makeNotifierFromSubscriber(subscriber);

--- a/packages/wallet/api/test/getPursesNotifier.test.js
+++ b/packages/wallet/api/test/getPursesNotifier.test.js
@@ -11,8 +11,6 @@ import {
 } from '@agoric/vats/src/nameHub.js';
 import { makeWalletRoot } from '../src/lib-wallet.js';
 
-import '../src/types-ambient.js';
-
 const mixinMyAddress = prepareMixinMyAddress(makeHeapZone());
 
 function makeFakeMyAddressNameAdmin() {

--- a/packages/wallet/api/test/lib-wallet.test.js
+++ b/packages/wallet/api/test/lib-wallet.test.js
@@ -21,8 +21,6 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { makeHeapZone } from '@agoric/zone';
 import { makeWalletRoot } from '../src/lib-wallet.js';
 
-import '../src/types-ambient.js';
-
 const ZOE_INVITE_PURSE_PETNAME = 'Default Zoe invite purse';
 
 const mixinMyAddress = prepareMixinMyAddress(makeHeapZone());

--- a/packages/wallet/api/tsconfig.json
+++ b/packages/wallet/api/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/wallet/api/tsconfig.json
+++ b/packages/wallet/api/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/xsnap-lockdown/tsconfig.json
+++ b/packages/xsnap-lockdown/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/xsnap-lockdown/tsconfig.json
+++ b/packages/xsnap-lockdown/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "lib/**/*.js",

--- a/packages/xsnap/tsconfig.json
+++ b/packages/xsnap/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "lib",

--- a/packages/zoe/exported.d.ts
+++ b/packages/zoe/exported.d.ts
@@ -1,0 +1,8 @@
+import './src/contractFacet/types-ambient.js';
+import './src/zoeService/types-ambient.js';
+import './src/contractSupport/types-ambient.js';
+import './src/contracts/exported.js';
+import './src/types-ambient.js';
+import '@agoric/notifier/exported.js';
+import '@agoric/ertp/exported.js';
+import '@agoric/store/exported.js';

--- a/packages/zoe/exported.d.ts
+++ b/packages/zoe/exported.d.ts
@@ -5,4 +5,3 @@ import './src/contracts/exported.js';
 import './src/types-ambient.js';
 import '@agoric/notifier/exported.js';
 import '@agoric/ertp/exported.js';
-import '@agoric/store/exported.js';

--- a/packages/zoe/exported.d.ts
+++ b/packages/zoe/exported.d.ts
@@ -4,4 +4,3 @@ import './src/contractSupport/types-ambient.js';
 import './src/contracts/exported.js';
 import './src/types-ambient.js';
 import '@agoric/notifier/exported.js';
-import '@agoric/ertp/exported.js';

--- a/packages/zoe/exported.d.ts
+++ b/packages/zoe/exported.d.ts
@@ -3,4 +3,3 @@ import './src/zoeService/types-ambient.js';
 import './src/contractSupport/types-ambient.js';
 import './src/contracts/exported.js';
 import './src/types-ambient.js';
-import '@agoric/notifier/exported.js';

--- a/packages/zoe/exported.js
+++ b/packages/zoe/exported.js
@@ -8,4 +8,3 @@ import './src/types-ambient.js';
 import '@agoric/notifier/exported.js';
 import '@agoric/ertp/exported.js';
 import '@agoric/store/exported.js';
-import '@agoric/swingset-vat/exported.js';

--- a/packages/zoe/exported.js
+++ b/packages/zoe/exported.js
@@ -1,10 +1,1 @@
-// @jessie-check
-
-import './src/contractFacet/types-ambient.js';
-import './src/zoeService/types-ambient.js';
-import './src/contractSupport/types-ambient.js';
-import './src/contracts/exported.js';
-import './src/types-ambient.js';
-import '@agoric/notifier/exported.js';
-import '@agoric/ertp/exported.js';
-import '@agoric/store/exported.js';
+// Dummy file for .d.ts twin to declare ambients

--- a/packages/zoe/src/types-ambient.js
+++ b/packages/zoe/src/types-ambient.js
@@ -39,5 +39,5 @@
  */
 
 /**
- * @typedef {Record<Keyword, import('@agoric/ertp/exported.js').AnyAmount>} Allocation
+ * @typedef {Record<Keyword, import('@agoric/ertp/src/types.js').AnyAmount>} Allocation
  */

--- a/packages/zoe/src/types-ambient.js
+++ b/packages/zoe/src/types-ambient.js
@@ -1,7 +1,5 @@
 // @jessie-check
 
-/// <reference types="ses" />
-
 /**
  * @template {string} H - the name of the handle
  * @typedef {import("@endo/marshal").RemotableObject<H>} Handle Alias for RemotableObject
@@ -11,7 +9,7 @@
  * @typedef {string} Keyword
  * @typedef {Handle<'Invitation'>} InvitationHandle - an opaque handle for an invitation
  * @typedef {Record<Keyword, Issuer<any>>} IssuerKeywordRecord
- * @typedef {Record<Keyword, ERef<Issuer<any>>>} IssuerPKeywordRecord
+ * @typedef {Record<Keyword, import('@endo/far').ERef<Issuer<any>>>} IssuerPKeywordRecord
  * @typedef {Record<Keyword, Brand<any>>} BrandKeywordRecord
  */
 
@@ -25,7 +23,7 @@
  * @typedef {StandardTerms & Record<string, any>} AnyTerms
  *
  * @typedef {object} InstanceRecord
- * @property {Installation} installation
+ * @property {import('./zoeService/utils.js').Installation<any>} installation
  * @property {import("./zoeService/utils.js").Instance<any>} instance
  * @property {AnyTerms} terms - contract parameters
  */
@@ -38,6 +36,8 @@
  * @property {Issuer<K, M>} issuer
  * @property {K} assetKind
  * @property {DisplayInfo<K>} [displayInfo]
- *
- * @typedef {AmountKeywordRecord} Allocation
+ */
+
+/**
+ * @typedef {Record<Keyword, import('@agoric/ertp/exported.js').AnyAmount>} Allocation
  */

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -8,7 +8,6 @@ import { cleanProposal } from '../../cleanProposal.js';
 import { burnInvitation } from './burnInvitation.js';
 import { makeInvitationQueryFns } from '../invitationQueries.js';
 
-import '@agoric/ertp/exported.js';
 import '../internal-types.js';
 
 const { quote: q, Fail } = assert;

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -9,7 +9,6 @@ import { burnInvitation } from './burnInvitation.js';
 import { makeInvitationQueryFns } from '../invitationQueries.js';
 
 import '@agoric/ertp/exported.js';
-import '@agoric/store/exported.js';
 import '../internal-types.js';
 
 const { quote: q, Fail } = assert;

--- a/packages/zoe/src/zoeService/types-ambient.js
+++ b/packages/zoe/src/zoeService/types-ambient.js
@@ -232,7 +232,7 @@
  */
 
 /**
- * @typedef {Record<Keyword, import('@agoric/ertp/exported.js').AnyAmount>} AmountKeywordRecord
+ * @typedef {Record<Keyword, import('@agoric/ertp/src/types.js').AnyAmount>} AmountKeywordRecord
  *
  * The keys are keywords, and the values are amounts. For example:
  * { Asset: AmountMath.make(assetBrand, 5n), Price:

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -2,7 +2,7 @@
 import '../types-ambient.js';
 import '../contractFacet/types-ambient.js';
 
-import type { Issuer } from '@agoric/ertp/exported.js';
+import type { Issuer } from '@agoric/ertp/src/types.js';
 import type { TagContainer } from '@agoric/internal/src/tagged.js';
 import type { Baggage } from '@agoric/swingset-liveslots';
 import type { VatUpgradeResults } from '@agoric/swingset-vat';

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,5 +1,4 @@
 import { M, mustMatch } from '@agoric/store';
-import '../../../exported.js';
 
 import { prepareExoClass, prepareExo } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';

--- a/packages/zoe/test/unitTests/contractSupport/ratio.test.js
+++ b/packages/zoe/test/unitTests/contractSupport/ratio.test.js
@@ -1,7 +1,5 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import '../../../src/contractSupport/types-ambient.js';
-
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import {
   makeRatio,

--- a/packages/zoe/test/unitTests/contracts/loan/addCollateral.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/addCollateral.test.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '../../../../exported.js';
 
 import { AmountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/loan/borrow.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/borrow.test.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '../../../../exported.js';
 
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/close.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/close.test.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '../../../../exported.js';
 
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -4,8 +4,6 @@ import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
 
 import path from 'path';
 
-import '../../../../exported.js';
-
 import { E } from '@endo/eventual-send';
 import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/lend.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/lend.test.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '../../../../exported.js';
 
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/liquidate.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/liquidate.test.js
@@ -1,5 +1,4 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '../../../../exported.js';
 
 import { AmountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/loan/loan-e2e.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/loan-e2e.test.js
@@ -2,8 +2,6 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import path from 'path';
 
-import '../../../../exported.js';
-
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
 import bundleSource from '@endo/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/loan/updateDebt.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/updateDebt.test.js
@@ -1,5 +1,4 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '../../../../exported.js';
 
 import { calculateInterest } from '../../../../src/contracts/loan/updateDebt.js';
 import { makeRatio } from '../../../../src/contractSupport/index.js';

--- a/packages/zoe/test/unitTests/contracts/oracle.test.js
+++ b/packages/zoe/test/unitTests/contracts/oracle.test.js
@@ -12,8 +12,6 @@ import { E } from '@endo/eventual-send';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import { makeZoeForTest } from '../../../tools/setup-zoe.js';
 
-import '../../../src/contracts/exported.js';
-
 /**
  * @typedef {object} TestContext
  * @property {ZoeService} zoe

--- a/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
+++ b/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
@@ -21,7 +21,6 @@ import { makeZoeForTest } from '../../../tools/setup-zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { start } from '../../../src/contracts/priceAggregator.js';
 
-import '../../../src/contracts/exported.js';
 import {
   addRatios,
   makeRatio,

--- a/packages/zoe/test/unitTests/contracts/scaledPriceAuthority.test.js
+++ b/packages/zoe/test/unitTests/contracts/scaledPriceAuthority.test.js
@@ -13,8 +13,6 @@ import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { makeManualPriceAuthority } from '../../../tools/manualPriceAuthority.js';
 
-import '../../../src/contracts/exported.js';
-
 // This contract still uses 'prepare', so this test covers that case.
 /**
  * @typedef {object} TestContext

--- a/packages/zoe/test/unitTests/scriptedOracle.test.js
+++ b/packages/zoe/test/unitTests/scriptedOracle.test.js
@@ -12,7 +12,6 @@ import { assert } from '@agoric/assert';
 import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 import { makeZoeForTest } from '../../tools/setup-zoe.js';
 
-import '../../src/contracts/exported.js';
 import buildManualTimer from '../../tools/manualTimer.js';
 import { setup } from './setupBasicMints.js';
 import { assertPayoutAmount } from '../zoeTestHelpers.js';

--- a/packages/zoe/tsconfig.json
+++ b/packages/zoe/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "contractFacet.js",

--- a/packages/zoe/tsconfig.json
+++ b/packages/zoe/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "contractFacet.js",
     "scripts",

--- a/packages/zone/tsconfig.json
+++ b/packages/zone/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 2,
+    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/zone/tsconfig.json
+++ b/packages/zone/tsconfig.json
@@ -1,9 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
-  },
+  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts",


### PR DESCRIPTION
refs: #6512

## Description

- further improves recent TypeScript best practices doc
- turns the zoe/exported.js into a .d.ts so it can be used in triple-slash references
- adopts that and stops the runtime imports of zoe/exported (progress on #6512)
- remove the `maxNodeModuleJsDepth` now that the types resolve without
- burns down imports so there are no inter-package runtime imports of typedefs. (leaving just a bit for #6512)

I put commit checkpoints of type coverage to guard against any regression, though I took them out again when merging


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
