### PR TITLE
feat(localchain): add `transfer` method to LocalChainAccountKit holder

### DIFF
--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -64,6 +64,14 @@
       "types": "./dist/codegen/ibc/applications/interchain_accounts/v1/packet.d.ts",
       "default": "./dist/codegen/ibc/applications/interchain_accounts/v1/packet.js"
     },
+    "./ibc/core/channel/v1/channel.js": {
+      "types": "./dist/codegen/ibc/core/channel/v1/channel.d.ts",
+      "default": "./dist/codegen/ibc/core/channel/v1/channel.js"
+    },
+    "./ibc/core/connection/v1/connection.js": {
+      "types": "./dist/codegen/ibc/core/connection/v1/connection.d.ts",
+      "default": "./dist/codegen/ibc/core/connection/v1/connection.js"
+    },
     "./icq/*.js": {
       "types": "./dist/codegen/icq/*.d.ts",
       "default": "./dist/codegen/icq/v1/*.js"

--- a/packages/cosmic-proto/src/helpers.ts
+++ b/packages/cosmic-proto/src/helpers.ts
@@ -12,6 +12,10 @@ import type {
 } from './codegen/cosmos/staking/v1beta1/tx.js';
 import { RequestQuery } from './codegen/tendermint/abci/types.js';
 import type { Any } from './codegen/google/protobuf/any.js';
+import {
+  MsgTransfer,
+  MsgTransferResponse,
+} from './codegen/ibc/applications/transfer/v1/tx.js';
 
 /**
  * The result of Any.toJSON(). The type in cosms-types says it returns
@@ -28,6 +32,8 @@ export type Proto3Shape = {
   '/cosmos.bank.v1beta1.QueryAllBalancesResponse': QueryAllBalancesResponse;
   '/cosmos.staking.v1beta1.MsgDelegate': MsgDelegate;
   '/cosmos.staking.v1beta1.MsgDelegateResponse': MsgDelegateResponse;
+  '/ibc.applications.transfer.v1.MsgTransfer': MsgTransfer;
+  '/ibc.applications.transfer.v1.MsgTransferResponse': MsgTransferResponse;
 };
 
 // Often s/Request$/Response/ but not always
@@ -35,6 +41,7 @@ type ResponseMap = {
   '/cosmos.bank.v1beta1.MsgSend': '/cosmos.bank.v1beta1.MsgSendResponse';
   '/cosmos.bank.v1beta1.QueryAllBalancesRequest': '/cosmos.bank.v1beta1.QueryAllBalancesResponse';
   '/cosmos.staking.v1beta1.MsgDelegate': '/cosmos.staking.v1beta1.MsgDelegateResponse';
+  '/ibc.applications.transfer.v1.MsgTransfer': '/ibc.applications.transfer.v1.MsgTransferResponse';
 };
 
 /**

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -11,6 +11,7 @@ import type {
   LocalIbcAddress,
   RemoteIbcAddress,
 } from '@agoric/vats/tools/ibc-utils.js';
+import { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
 import { IBCChannelID } from '@agoric/vats';
 import { MapStore } from '@agoric/store';
 import type { AmountArg, ChainAddress, DenomAmount } from './types.js';
@@ -207,4 +208,10 @@ export interface IcaAccount {
 
 export type LiquidStakingMethods = {
   liquidStake: (amount: AmountArg) => Promise<void>;
+};
+
+export type IBCMsgTransferOptions = {
+  timeoutHeight?: MsgTransfer['timeoutHeight'];
+  timeoutTimestamp?: MsgTransfer['timeoutTimestamp'];
+  memo?: string;
 };

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -11,6 +11,8 @@ import type {
   LocalIbcAddress,
   RemoteIbcAddress,
 } from '@agoric/vats/tools/ibc-utils.js';
+import { IBCChannelID } from '@agoric/vats';
+import { MapStore } from '@agoric/store';
 import type { AmountArg, ChainAddress, DenomAmount } from './types.js';
 
 /** A helper type for type extensions. */
@@ -29,25 +31,34 @@ export type CosmosValidatorAddress = ChainAddress & {
   addressEncoding: 'bech32';
 };
 
+/** Info for an IBC Connection (Chain:Chain relationship, that can contain multiple Channels) */
+export type IBCConnectionInfo = {
+  id: string; // e.g. connection-0
+  client_id: string; // '07-tendermint-0'
+  state: 'OPEN' | 'TRYOPEN' | 'INIT' | 'CLOSED';
+  counterparty: {
+    client_id: string;
+    connection_id: string;
+    prefix: {
+      key_prefix: string;
+    };
+  };
+  versions: { identifier: string; features: string[] }[];
+  delay_period: bigint;
+  transferChannel: {
+    portId: string;
+    channelId: IBCChannelID;
+    counterPartyPortId: string;
+    counterPartyChannelId: IBCChannelID;
+  };
+};
+
 /**
  * Info for a Cosmos-based chain.
  */
 export type CosmosChainInfo = {
   chainId: string;
-  ibcConnectionInfo: {
-    id: string; // e.g. connection-0
-    client_id: string; // '07-tendermint-0'
-    state: 'OPEN' | 'TRYOPEN' | 'INIT' | 'CLOSED';
-    counterparty: {
-      client_id: string;
-      connection_id: string;
-      prefix: {
-        key_prefix: string;
-      };
-    };
-    versions: { identifier: string; features: string[] }[];
-    delay_period: bigint;
-  };
+  connections: MapStore<string, IBCConnectionInfo>; // chainId or wellKnownName
   icaEnabled: boolean;
   icqEnabled: boolean;
   pfmEnabled: boolean;

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -12,7 +12,12 @@ import type {
   RemoteIbcAddress,
 } from '@agoric/vats/tools/ibc-utils.js';
 import { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
-import { IBCChannelID } from '@agoric/vats';
+import type { State as IBCConnectionState } from '@agoric/cosmic-proto/ibc/core/connection/v1/connection.js';
+import type {
+  Order,
+  State as IBCChannelState,
+} from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
+import { IBCChannelID, IBCConnectionID } from '@agoric/vats';
 import { MapStore } from '@agoric/store';
 import type { AmountArg, ChainAddress, DenomAmount } from './types.js';
 
@@ -32,14 +37,14 @@ export type CosmosValidatorAddress = ChainAddress & {
   addressEncoding: 'bech32';
 };
 
-/** Info for an IBC Connection (Chain:Chain relationship, that can contain multiple Channels) */
+/** Represents an IBC Connection between two chains, which can contain multiple Channels. */
 export type IBCConnectionInfo = {
-  id: string; // e.g. connection-0
+  id: IBCConnectionID; // e.g. connection-0
   client_id: string; // '07-tendermint-0'
-  state: 'OPEN' | 'TRYOPEN' | 'INIT' | 'CLOSED';
+  state: IBCConnectionState;
   counterparty: {
     client_id: string;
-    connection_id: string;
+    connection_id: IBCConnectionID;
     prefix: {
       key_prefix: string;
     };
@@ -51,6 +56,9 @@ export type IBCConnectionInfo = {
     channelId: IBCChannelID;
     counterPartyPortId: string;
     counterPartyChannelId: IBCChannelID;
+    ordering: Order;
+    state: IBCChannelState;
+    version: string; // e.eg. 'ics20-1'
   };
 };
 

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -9,7 +9,7 @@ import { M } from '@endo/patterns';
 import { E } from '@endo/far';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { atomicTransfer } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
-import { prepareLocalchainAccountKit } from '../exos/localchainAccountKit.js';
+import { prepareLocalChainAccountKit } from '../exos/local-chain-account-kit.js';
 
 const trace = makeTracer('StakeBld');
 
@@ -34,7 +34,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     baggage,
     privateArgs.marshaller,
   );
-  const makeLocalchainAccountKit = prepareLocalchainAccountKit(
+  const makeLocalChainAccountKit = prepareLocalChainAccountKit(
     baggage,
     makeRecorderKit,
     zcf,
@@ -55,7 +55,7 @@ export const start = async (zcf, privateArgs, baggage) => {
           await E(lcaSeatKit.userSeat).tryExit();
           trace('awaiting payouts');
           const payouts = await E(lcaSeatKit.userSeat).getPayouts();
-          const { holder, invitationMakers } = makeLocalchainAccountKit(
+          const { holder, invitationMakers } = makeLocalChainAccountKit(
             account,
             privateArgs.storageNode,
           );

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -84,6 +84,7 @@ export const start = async (zcf, privateArgs) => {
       // deposit funds from user seat to LocalChainAccount
       const payments = await withdrawFromSeat(zcf, seat, give);
       await deeplyFulfilled(objectMap(payments, localAccount.deposit));
+      seat.exit();
 
       // build swap instructions with orcUtils library
       const transferMsg = orcUtils.makeOsmosisSwap({

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -1,5 +1,4 @@
 /** @file ChainAccount exo */
-
 import { NonNullish } from '@agoric/assert';
 import { makeTracer } from '@agoric/internal';
 import { V as E } from '@agoric/vow/vat.js';

--- a/packages/orchestration/src/exos/local-chain-account-kit.js
+++ b/packages/orchestration/src/exos/local-chain-account-kit.js
@@ -39,7 +39,7 @@ const PUBLIC_TOPICS = {
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  * @param {ZCF} zcf
  */
-export const prepareLocalchainAccountKit = (baggage, makeRecorderKit, zcf) => {
+export const prepareLocalChainAccountKit = (baggage, makeRecorderKit, zcf) => {
   const makeAccountHolderKit = prepareExoClassKit(
     baggage,
     'Account Holder',
@@ -152,4 +152,4 @@ export const prepareLocalchainAccountKit = (baggage, makeRecorderKit, zcf) => {
   );
   return makeAccountHolderKit;
 };
-/** @typedef {ReturnType<ReturnType<typeof prepareLocalchainAccountKit>>} LocalchainAccountKit */
+/** @typedef {ReturnType<ReturnType<typeof prepareLocalChainAccountKit>>} LocalChainAccountKit */

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -27,7 +27,7 @@ const makeLocalChainFacade = localchain => {
         allowedMessages: [],
         allowedQueries: [],
         chainId: 'agoric-3',
-        ibcConnectionInfo: anyVal,
+        connections: anyVal,
         ibcHooksEnabled: true,
         icaEnabled: true,
         icqEnabled: true,

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -45,7 +45,7 @@ export type DenomAmount = {
   value: bigint; // Nat
 };
 
-/** Amounts can be provided as pure data using denoms or as native Amounts */
+/** Amounts can be provided as pure data using denoms or as ERTP Amounts */
 export type AmountArg = DenomAmount | Amount;
 
 /** An address on some blockchain, e.g., cosmos, eth, etc. */
@@ -145,9 +145,9 @@ export interface OrchestrationAccountI {
   /**
    * Transfer an amount to another account, typically on another chain.
    * The promise settles when the transfer is complete.
-   * @param {AmountArg} amount - the amount to transfer.
-   * @param {ChainAddress} destination - the account to transfer the amount to.
-   * @param {IBCMsgTransferOptions} [opts] - an optional memo to include with the transfer, which could drive custom PFM behavior, and timeout parameters
+   * @param amount - the amount to transfer. Can be provided as pure data using denoms or as ERTP Amounts.
+   * @param destination - the account to transfer the amount to.
+   * @param [opts] - an optional memo to include with the transfer, which could drive custom PFM behavior, and timeout parameters
    * @returns void
    *
    * TODO document the mapping from the address to the destination chain.

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -12,7 +12,7 @@ import type {
 } from '@agoric/ertp/src/types.js';
 import type { LocalChainAccount } from '@agoric/vats/src/localchain.js';
 import type { Timestamp } from '@agoric/time';
-import type { KnownChains } from './types.js';
+import type { IBCMsgTransferOptions, KnownChains } from './types.js';
 
 /**
  * A denom that designates a path to a token type on some blockchain.
@@ -145,9 +145,9 @@ export interface OrchestrationAccountI {
   /**
    * Transfer an amount to another account, typically on another chain.
    * The promise settles when the transfer is complete.
-   * @param amount - the amount to transfer.
-   * @param destination - the account to transfer the amount to.
-   * @param memo - an optional memo to include with the transfer, which could drive custom PFM behavior
+   * @param {AmountArg} amount - the amount to transfer.
+   * @param {ChainAddress} destination - the account to transfer the amount to.
+   * @param {IBCMsgTransferOptions} [opts] - an optional memo to include with the transfer, which could drive custom PFM behavior, and timeout parameters
    * @returns void
    *
    * TODO document the mapping from the address to the destination chain.
@@ -155,7 +155,7 @@ export interface OrchestrationAccountI {
   transfer: (
     amount: AmountArg,
     destination: ChainAddress,
-    memo?: string,
+    opts?: IBCMsgTransferOptions,
   ) => Promise<void>;
 
   /**

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { AmountShape } from '@agoric/ertp';
 import { M } from '@endo/patterns';
 
@@ -26,3 +25,15 @@ export const ChainAmountShape = harden({ denom: M.string(), value: M.nat() });
 export const AmountArgShape = M.or(AmountShape, ChainAmountShape);
 
 export const DelegationShape = M.record(); // TODO: DelegationShape fields
+
+export const IBCTransferOptionsShape = M.splitRecord(
+  {},
+  {
+    timeoutTimestamp: M.bigint(),
+    timeoutHeight: {
+      revisionHeight: M.bigint(),
+      revisionNumber: M.bigint(),
+    },
+    memo: M.string(),
+  },
+);

--- a/packages/orchestration/src/utils/mockChainInfo.js
+++ b/packages/orchestration/src/utils/mockChainInfo.js
@@ -1,0 +1,86 @@
+/**
+ * @file Mocked Chain Info object until #8879
+ */
+import {
+  Order,
+  State as IBCChannelState,
+} from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
+import { State as IBCConnectionState } from '@agoric/cosmic-proto/ibc/core/connection/v1/connection.js';
+
+/**
+ * @import {Zone} from '@agoric/zone';
+ * @import {CosmosChainInfo, IBCConnectionInfo} from '../cosmos-api.js';
+ */
+
+/**
+ * currently keyed by ChainId, as this is what we have
+ * available in ChainAddress to determine the correct IBCChannelID's
+ * for a .transfer() msg.
+ * @type {Record<string, IBCConnectionInfo>}
+ */
+const connectionEntries = harden({
+  cosmoslocal: {
+    id: 'connection-1',
+    client_id: '07-tendermint-3',
+    counterparty: {
+      client_id: '07-tendermint-2',
+      connection_id: 'connection-1',
+      prefix: {
+        key_prefix: '',
+      },
+    },
+    state: IBCConnectionState.STATE_OPEN,
+    transferChannel: {
+      portId: 'transfer',
+      channelId: 'channel-1',
+      counterPartyChannelId: 'channel-1',
+      counterPartyPortId: 'transfer',
+      ordering: Order.ORDER_UNORDERED,
+      state: IBCChannelState.STATE_OPEN,
+      version: 'ics20-1',
+    },
+    versions: [{ identifier: '', features: ['', ''] }],
+    delay_period: 0n,
+  },
+  osmosislocal: {
+    id: 'connection-0',
+    client_id: '07-tendermint-2',
+    counterparty: {
+      client_id: '07-tendermint-2',
+      connection_id: 'connection-1',
+      prefix: {
+        key_prefix: '',
+      },
+    },
+    state: IBCConnectionState.STATE_OPEN,
+    transferChannel: {
+      portId: 'transfer',
+      channelId: 'channel-0',
+      counterPartyChannelId: 'channel-1',
+      counterPartyPortId: 'transfer',
+      ordering: Order.ORDER_UNORDERED,
+      state: IBCChannelState.STATE_OPEN,
+      version: 'ics20-1',
+    },
+    versions: [{ identifier: '', features: ['', ''] }],
+    delay_period: 0n,
+  },
+});
+
+/**
+ * @param {Zone} zone
+ * @returns {Pick<CosmosChainInfo, 'connections' | 'chainId'>}
+ */
+export const prepareMockChainInfo = zone => {
+  const agoricConnections =
+    /** @type {import('@agoric/store').MapStore<string, IBCConnectionInfo>} */ (
+      zone.mapStore('ibcConnections')
+    );
+
+  agoricConnections.addAll(Object.entries(connectionEntries));
+
+  return harden({
+    chainId: 'agoriclocal',
+    connections: agoricConnections,
+  });
+};

--- a/packages/orchestration/src/utils/time.js
+++ b/packages/orchestration/src/utils/time.js
@@ -1,0 +1,38 @@
+import { E } from '@endo/far';
+import { TimeMath } from '@agoric/time';
+
+/**
+ * @import {RelativeTimeRecord, TimerBrand, TimerService} from '@agoric/time';
+ * @import {MsgTransfer} from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
+ */
+
+export const SECONDS_PER_MINUTE = 60n;
+export const NANOSECONDS_PER_SECOND = 1_000_000_000n;
+
+/**
+ * @param {TimerService} timer
+ * @param {TimerBrand} timerBrand
+ */
+export function makeTimestampHelper(timer, timerBrand) {
+  return harden({
+    /**
+     * Takes the current time from ChainTimerService and adds a relative
+     * time to determine a timeout timestamp in nanoseconds.
+     * Useful for {@link MsgTransfer.timeoutTimestamp}.
+     * @param {RelativeTimeRecord} [relativeTime] defaults to 5 minutes
+     * @returns {Promise<bigint>} Timeout timestamp in absolute nanoseconds since unix epoch
+     */
+    async getTimeoutTimestampNS(relativeTime) {
+      const currentTime = await E(timer).getCurrentTimestamp();
+      const timeout =
+        relativeTime ||
+        TimeMath.coerceRelativeTimeRecord(SECONDS_PER_MINUTE * 5n, timerBrand);
+      return (
+        TimeMath.addAbsRel(currentTime, timeout).absValue *
+        NANOSECONDS_PER_SECOND
+      );
+    },
+  });
+}
+
+/** @typedef {Awaited<ReturnType<typeof makeTimestampHelper>>} TimestampHelper */

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -1,0 +1,171 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import { prepareLocalChainTools } from '@agoric/vats/src/localchain.js';
+import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
+import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { makeHeapZone } from '@agoric/zone';
+import { E } from '@endo/far';
+import path from 'path';
+import { makeFakeLocalchainBridge } from '../supports.js';
+
+const { keys } = Object;
+const dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const contractFile = `${dirname}/../../src/examples/stakeBld.contract.js`;
+type StartFn =
+  typeof import('@agoric/orchestration/src/examples/stakeBld.contract.js').start;
+
+const bootstrap = async (t, { issuerKit }) => {
+  t.log('bootstrap vat dependencies');
+  const zone = makeHeapZone();
+  const bankManager = await buildBankVatRoot(
+    undefined,
+    undefined,
+    zone.mapStore('bankManager'),
+  ).makeBankManager();
+  await E(bankManager).addAsset('ubld', 'BLD', 'Staking Token', issuerKit);
+
+  const localchainBridge = makeFakeLocalchainBridge(zone);
+  const localchain = prepareLocalChainTools(
+    zone.subZone('localchain'),
+  ).makeLocalChain({
+    bankManager,
+    system: localchainBridge,
+  });
+  const timer = buildManualTimer(t.log);
+  const marshaller = makeFakeBoard().getReadonlyMarshaller();
+  const storage = makeFakeStorageKit('mockChainStorageRoot', {
+    sequence: false,
+  });
+  return {
+    timer,
+    localchain,
+    marshaller,
+    storage,
+  };
+};
+
+const coreEval = async (
+  t,
+  { timer, localchain, marshaller, storage, stake },
+) => {
+  t.log('install stakeBld contract');
+  const { zoe, bundleAndInstall } = await setUpZoeForTest();
+  const installation: Installation<StartFn> =
+    await bundleAndInstall(contractFile);
+
+  const { publicFacet } = await E(zoe).startInstance(
+    installation,
+    { In: stake.issuer },
+    {},
+    {
+      localchain,
+      marshaller,
+      storageNode: storage.rootNode,
+      timerService: timer,
+      timerBrand: timer.getTimerBrand(),
+    },
+  );
+  return { publicFacet, zoe };
+};
+
+test('stakeBld contract - makeAccount, deposit, withdraw', async t => {
+  const issuerKit = makeIssuerKit('BLD');
+  const stake = withAmountUtils(issuerKit);
+
+  const bootstrapSpace = await bootstrap(t, { issuerKit });
+  const { publicFacet } = await coreEval(t, { ...bootstrapSpace, stake });
+
+  t.log('make a LocalChainAccount');
+  const account = await E(publicFacet).makeAccount();
+  t.truthy(account, 'account is returned');
+  t.regex(await E(account).getAddress(), /agoric1/);
+
+  const oneHundredStakeAmt = stake.make(1_000_000_000n);
+  const oneHundredStakePmt = issuerKit.mint.mintPayment(oneHundredStakeAmt);
+
+  t.log('deposit 100 bld to account');
+  const depositResp = await E(account).deposit(oneHundredStakePmt);
+  t.true(AmountMath.isEqual(depositResp, oneHundredStakeAmt), 'deposit');
+
+  // TODO validate balance, .getBalance()
+
+  t.log('withdraw 1 bld from account');
+  const withdrawResp = await E(account).withdraw(oneHundredStakeAmt);
+  // @ts-expect-error Argument of type 'Payment' is not assignable to parameter of type 'ERef<Payment<"nat", Key>>'.
+  const withdrawAmt = await stake.issuer.getAmountOf(withdrawResp);
+  t.true(AmountMath.isEqual(withdrawAmt, oneHundredStakeAmt), 'withdraw');
+
+  t.log('cannot withdraw more than balance');
+  await t.throwsAsync(
+    () => E(account).withdraw(oneHundredStakeAmt),
+    {
+      message: /Withdrawal of {.*} failed/,
+    },
+    'cannot withdraw more than balance',
+  );
+});
+
+test('stakeBld contract - makeStakeBldInvitation', async t => {
+  const issuerKit = makeIssuerKit('BLD');
+  const stake = withAmountUtils(issuerKit);
+
+  const bootstrapSpace = await bootstrap(t, { issuerKit });
+  const { publicFacet, zoe } = await coreEval(t, { ...bootstrapSpace, stake });
+
+  t.log('call makeStakeBldInvitation');
+  const inv = await E(publicFacet).makeStakeBldInvitation();
+
+  const hundred = stake.make(1_000_000_000n);
+
+  t.log('make an offer for an account');
+  // Want empty until (at least) #9087
+  const userSeat = await E(zoe).offer(
+    inv,
+    { give: { In: hundred } },
+    { In: stake.mint.mintPayment(hundred) },
+  );
+  const { invitationMakers } = await E(userSeat).getOfferResult();
+  t.truthy(invitationMakers, 'received continuing invitation');
+
+  t.log('make Delegate offer using invitationMakers');
+  const delegateInv = await E(invitationMakers).Delegate('agoric1validator1', {
+    brand: stake.brand,
+    value: 1_000_000_000n,
+  });
+  const delegateOffer = await E(zoe).offer(
+    delegateInv,
+    { give: { In: hundred } },
+    { In: stake.mint.mintPayment(hundred) },
+  );
+  const res = await E(delegateOffer).getOfferResult();
+  t.deepEqual(res, {});
+  t.log('Successfully delegated');
+
+  await t.throwsAsync(() => E(invitationMakers).TransferAccount(), {
+    message: 'not yet implemented',
+  });
+  await t.throwsAsync(() => E(invitationMakers).CloseAccount(), {
+    message: 'not yet implemented',
+  });
+});
+
+test('stakeBld contract - makeAccountInvitationMaker', async t => {
+  const issuerKit = makeIssuerKit('BLD');
+  const stake = withAmountUtils(issuerKit);
+
+  const bootstrapSpace = await bootstrap(t, { issuerKit });
+  const { publicFacet, zoe } = await coreEval(t, { ...bootstrapSpace, stake });
+
+  t.log('call makeAcountInvitationMaker');
+  const inv = await E(publicFacet).makeAcountInvitationMaker();
+
+  const userSeat = await E(zoe).offer(inv);
+  const offerResult = await E(userSeat).getOfferResult();
+  t.true('account' in offerResult, 'received account');
+  t.truthy('invitationMakers' in offerResult, 'received continuing invitation');
+});

--- a/packages/orchestration/test/exos/local-chain-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-chain-account-kit.test.ts
@@ -1,0 +1,159 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
+import { M, makeScalarBigMapStore } from '@agoric/vat-data';
+import { prepareLocalChainTools } from '@agoric/vats/src/localchain.js';
+import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
+import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
+import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { makeHeapZone } from '@agoric/zone';
+import { E, Far } from '@endo/far';
+import { makeFakeLocalchainBridge } from '../supports.js';
+import { prepareLocalChainAccountKit } from '../../src/exos/local-chain-account-kit.js';
+import { prepareMockChainInfo } from '../../src/utils/mockChainInfo.js';
+import { ChainAddress } from '../../src/orchestration-api.js';
+import { NANOSECONDS_PER_SECOND } from '../../src/utils/time.js';
+
+test('localChainAccountKit - transfer', async t => {
+  const bootstrap = async () => {
+    const zone = makeHeapZone();
+    const issuerKit = makeIssuerKit('BLD');
+    const stake = withAmountUtils(issuerKit);
+
+    const bankManager = await buildBankVatRoot(
+      undefined,
+      undefined,
+      zone.mapStore('bankManager'),
+    ).makeBankManager();
+
+    await E(bankManager).addAsset('ubld', 'BLD', 'Staking Token', issuerKit);
+    const localchainBridge = makeFakeLocalchainBridge(zone);
+    const localchain = prepareLocalChainTools(
+      zone.subZone('localchain'),
+    ).makeLocalChain({
+      bankManager,
+      system: localchainBridge,
+    });
+    const timer = buildManualTimer(t.log);
+    const marshaller = makeFakeBoard().getReadonlyMarshaller();
+
+    return {
+      timer,
+      localchain,
+      marshaller,
+      stake,
+      issuerKit,
+      rootZone: zone,
+    };
+  };
+
+  const { timer, localchain, stake, marshaller, issuerKit, rootZone } =
+    await bootstrap();
+
+  t.log('chainInfo mocked via `prepareMockChainInfo` until #8879');
+  const agoricChainInfo = prepareMockChainInfo(rootZone.subZone('chainInfo'));
+
+  t.log('exo setup - prepareLocalChainAccountKit');
+  const baggage = makeScalarBigMapStore<string, unknown>('baggage', {
+    durable: true,
+  });
+  const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
+  const makeLocalChainAccountKit = prepareLocalChainAccountKit(
+    baggage,
+    makeRecorderKit,
+    // @ts-expect-error mocked zcf. use `stake-bld.contract.test.ts` to test LCA with offer
+    Far('MockZCF', {}),
+    timer,
+    timer.getTimerBrand(),
+    agoricChainInfo,
+  );
+
+  t.log('request account from vat-localchain');
+  const lca = await E(localchain).makeAccount();
+  const address = await E(lca).getAddress();
+
+  t.log('make a LocalChainAccountKit');
+  const { holder: account } = makeLocalChainAccountKit({
+    account: lca,
+    address,
+    storageNode: makeMockChainStorageRoot().makeChildNode('lcaKit'),
+  });
+
+  t.truthy(account, 'account is returned');
+  t.regex(await E(account).getAddress(), /agoric1/);
+
+  const oneHundredStakeAmt = stake.make(1_000_000_000n);
+  const oneHundredStakePmt = issuerKit.mint.mintPayment(oneHundredStakeAmt);
+  const oneStakeAmt = stake.make(1_000_000n);
+
+  t.log('deposit 100 bld to account');
+  const depositResp = await E(account).deposit(oneHundredStakePmt);
+  t.true(AmountMath.isEqual(depositResp, oneHundredStakeAmt), 'deposit');
+
+  const destination: ChainAddress = {
+    chainId: 'cosmoslocal',
+    address: 'cosmos1pleab',
+    addressEncoding: 'bech32',
+  };
+
+  // TODO #9211, support ERTP amounts
+  t.log('ERTP Amounts not yet supported for AmountArg');
+  await t.throwsAsync(() => E(account).transfer(oneStakeAmt, destination), {
+    message: 'ERTP Amounts not yet supported',
+  });
+
+  t.log('.transfer() 1 bld to cosmos using DenomAmount');
+  const transferResp = await E(account).transfer(
+    { denom: 'ubld', value: 1_000_000n },
+    destination,
+  );
+  t.is(transferResp, undefined, 'Successful transfer returns Promise<void>.');
+
+  await t.throwsAsync(
+    () => E(account).transfer({ denom: 'ubld', value: 504n }, destination),
+    {
+      message: 'simulated unexpected MsgTransfer packet timeout',
+    },
+  );
+
+  const unknownDestination: ChainAddress = {
+    chainId: 'fakenet',
+    address: 'fakenet1pleab',
+    addressEncoding: 'bech32',
+  };
+  await t.throwsAsync(
+    () => E(account).transfer({ denom: 'ubld', value: 1n }, unknownDestination),
+    {
+      message: /not found(.*)fakenet/,
+    },
+    'cannot create transfer msg with unknown chainId',
+  );
+
+  await t.notThrowsAsync(
+    () =>
+      E(account).transfer({ denom: 'ubld', value: 10n }, destination, {
+        memo: 'hello',
+      }),
+    'can create transfer msg with memo',
+  );
+  // TODO, intercept/spy the bridge message to see that it has a memo
+
+  await t.notThrowsAsync(
+    () =>
+      E(account).transfer({ denom: 'ubld', value: 10n }, destination, {
+        // sets to current time, which shouldn't work in a real env
+        timeoutTimestamp: BigInt(new Date().getTime()) * NANOSECONDS_PER_SECOND,
+      }),
+    'accepts custom timeoutTimestamp',
+  );
+
+  await t.notThrowsAsync(
+    () =>
+      E(account).transfer({ denom: 'ubld', value: 10n }, destination, {
+        timeoutHeight: { revisionHeight: 100n, revisionNumber: 1n },
+      }),
+    'accepts custom timeoutHeight',
+  );
+});

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { MsgWithdrawDelegatorRewardResponse } from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/tx.js';

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -7,7 +7,7 @@ import { typedJson } from '@agoric/cosmic-proto';
 import type { MsgDelegateResponse } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import type { QueryAllBalancesResponse } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
 import type { ChainAddress, CosmosValidatorAddress } from '../src/types.js';
-import type { LocalchainAccountKit } from '../src/exos/localchainAccountKit.js';
+import type { LocalChainAccountKit } from '../src/exos/local-chain-account-kit.js';
 
 const validatorAddr = {
   chainId: 'agoric3',
@@ -30,7 +30,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 }
 
 {
-  const lcak: LocalchainAccountKit = null as any;
+  const lcak: LocalChainAccountKit = null as any;
   const lca = lcak.helper.owned();
   const results = await lca.executeTx([
     typedJson('/cosmos.staking.v1beta1.MsgDelegate', {

--- a/packages/orchestration/test/utils/time.test.ts
+++ b/packages/orchestration/test/utils/time.test.ts
@@ -1,0 +1,40 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { TimeMath } from '@agoric/time';
+import {
+  makeTimestampHelper,
+  NANOSECONDS_PER_SECOND,
+  SECONDS_PER_MINUTE,
+} from '../../src/utils/time.js';
+
+test('makeTimestampHelper - getCurrentTimestamp', async t => {
+  const timer = buildManualTimer(t.log);
+  const timerBrand = timer.getTimerBrand();
+  t.is(timer.getCurrentTimestamp().absValue, 0n, 'current time is 0n');
+
+  const { getTimeoutTimestampNS } = makeTimestampHelper(timer, timerBrand);
+  await null;
+  t.is(
+    await getTimeoutTimestampNS(),
+    5n * SECONDS_PER_MINUTE * NANOSECONDS_PER_SECOND,
+    'default timestamp is 5 minutes from current time, in nanoseconds',
+  );
+
+  t.is(
+    await getTimeoutTimestampNS(
+      TimeMath.coerceRelativeTimeRecord(1n, timerBrand),
+    ),
+    1n * NANOSECONDS_PER_SECOND,
+    'timestamp is 1 second since unix epoch, in nanoseconds',
+  );
+
+  // advance timer by 3 seconds
+  await timer.tickN(3);
+  t.is(
+    await getTimeoutTimestampNS(
+      TimeMath.coerceRelativeTimeRecord(1n, timerBrand),
+    ),
+    (1n + 3n) * NANOSECONDS_PER_SECOND,
+    'timestamp is 4 seconds since unix epoch, in nanoseconds',
+  );
+});

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -46,9 +46,7 @@ const makeTestContext = async _t => {
   /** @param {LocalChainPowers} powers */
   const makeLocalChain = async powers => {
     const zone = makeDurableZone(provideBaggage('localchain'));
-    return prepareLocalChainTools(zone.subZone('localchain')).makeLocalChain(
-      powers,
-    );
+    return prepareLocalChainTools(zone).makeLocalChain(powers);
   };
 
   const localchain = await makeLocalChain({
@@ -94,7 +92,7 @@ test('localchain - deposit and withdraw', async t => {
         t.is(getInterfaceOf(lca), 'Alleged: LocalChainAccount');
 
         const address = await E(lca).getAddress();
-        t.is(address, 'agoric1fakeBridgeAddress');
+        t.is(address, 'agoric1fakeLCAAddress');
         contractsLca = lca;
       },
       deposit: async () => {


### PR DESCRIPTION
refs: #9193

## Description

Adds `.transfer()` method to `LocalChainAccountKit`, working towards `OrchestrationAccountI['transfer']` interface.


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
