### PR TITLE
Operational swing-store artifact level

### DIFF
--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -64,7 +64,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, swingStoreExportsHandler *SwingStore
 			ReadNextArtifact:    artifactProvider.ReadNextArtifact,
 		},
 		keeper.SwingStoreRestoreOptions{
-			ArtifactMode:   keeper.SwingStoreArtifactModeReplay,
+			ArtifactMode:   keeper.SwingStoreArtifactModeOperational,
 			ExportDataMode: keeper.SwingStoreExportDataModeAll,
 		},
 	)
@@ -98,9 +98,8 @@ func ExportGenesis(ctx sdk.Context, k Keeper, swingStoreExportsHandler *SwingSto
 		// The export will fail if the export of a historical height was requested
 		snapshotHeight,
 		swingStoreGenesisEventHandler{exportDir: swingStoreExportDir, snapshotHeight: snapshotHeight},
-		// The export will fail if the swing-store does not contain all replay artifacts
 		keeper.SwingStoreExportOptions{
-			ArtifactMode:   keeper.SwingStoreArtifactModeReplay,
+			ArtifactMode:   keeper.SwingStoreArtifactModeOperational,
 			ExportDataMode: keeper.SwingStoreExportDataModeSkip,
 		},
 	)

--- a/golang/cosmos/x/swingset/keeper/extension_snapshotter.go
+++ b/golang/cosmos/x/swingset/keeper/extension_snapshotter.go
@@ -125,7 +125,7 @@ func (snapshotter *ExtensionSnapshotter) InitiateSnapshot(height int64) error {
 	blockHeight := uint64(height)
 
 	return snapshotter.swingStoreExportsHandler.InitiateExport(blockHeight, snapshotter, SwingStoreExportOptions{
-		ArtifactMode:   SwingStoreArtifactModeReplay,
+		ArtifactMode:   SwingStoreArtifactModeOperational,
 		ExportDataMode: SwingStoreExportDataModeSkip,
 	})
 }
@@ -304,6 +304,6 @@ func (snapshotter *ExtensionSnapshotter) RestoreExtension(blockHeight uint64, fo
 
 	return snapshotter.swingStoreExportsHandler.RestoreExport(
 		SwingStoreExportProvider{BlockHeight: blockHeight, GetExportDataReader: getExportDataReader, ReadNextArtifact: readNextArtifact},
-		SwingStoreRestoreOptions{ArtifactMode: SwingStoreArtifactModeReplay, ExportDataMode: SwingStoreExportDataModeAll},
+		SwingStoreRestoreOptions{ArtifactMode: SwingStoreArtifactModeOperational, ExportDataMode: SwingStoreExportDataModeAll},
 	)
 }

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -296,11 +296,8 @@ export const main = async (
 
   const stateDir =
     processValue.getFlag('state-dir') ||
-    // We try to find the actual cosmos state directory (default=~/.ag-chain-cosmos)
-    `${processValue.getFlag(
-      'home',
-      `${homedir}/.ag-chain-cosmos`,
-    )}/data/agoric`;
+    // We try to find the actual cosmos state directory (default=~/.agoric)
+    `${processValue.getFlag('home', `${homedir}/.agoric`)}/data/agoric`;
 
   const stateDirStat = await fs.stat(stateDir);
   if (!stateDirStat.isDirectory()) {

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -42,10 +42,10 @@ export const ExportManifestFileName = 'export-manifest.json';
  */
 export const getEffectiveArtifactMode = artifactMode => {
   switch (artifactMode) {
+    case undefined:
     case 'none':
     case 'operational':
       return 'operational';
-    case undefined:
     case 'replay':
       return 'replay';
     case 'archival':

--- a/packages/cosmic-swingset/src/import-kernel-db.js
+++ b/packages/cosmic-swingset/src/import-kernel-db.js
@@ -62,7 +62,7 @@ const checkAndGetImportSwingStoreOptions = (options, manifest) => {
 
   manifest.data || Fail`State-sync manifest missing export data`;
 
-  const { artifactMode = manifest.artifactMode || 'replay' } = options;
+  const { artifactMode = manifest.artifactMode || 'operational' } = options;
 
   if (artifactMode === 'none') {
     throw Fail`Cannot import "export data" without at least "operational" artifacts`;

--- a/packages/cosmic-swingset/src/import-kernel-db.js
+++ b/packages/cosmic-swingset/src/import-kernel-db.js
@@ -247,11 +247,8 @@ export const main = async (
 
   const stateDir =
     processValue.getFlag('state-dir') ||
-    // We try to find the actual cosmos state directory (default=~/.ag-chain-cosmos)
-    `${processValue.getFlag(
-      'home',
-      `${homedir}/.ag-chain-cosmos`,
-    )}/data/agoric`;
+    // We try to find the actual cosmos state directory (default=~/.agoric)
+    `${processValue.getFlag('home', `${homedir}/.agoric`)}/data/agoric`;
 
   const stateDirStat = await fs.stat(stateDir);
   if (!stateDirStat.isDirectory()) {


### PR DESCRIPTION
closes: #9388

## Description

Switch from `replay` to `operational` for state-sync export/restore, genesis export/import, and as the default for cosmic-swingset's export/import of kernel DB command line tool.

Drive by change of the default chain home directory for the import/export tool (this location was effectively changed a couple year ago but not consistently in the rest of the SDK).

### Security Considerations

If all nodes prune historical "replay" artifacts, we lose the ability to perform replay based upgrades in the future. We expect archive nodes to not manually prune their DB in this way.

### Scaling Considerations

This should have no impact on performance right now. In the future, when exporting the IAVL data is not as slow, this would reduce the time it takes for state-sync snapshots to be created.

### Documentation Considerations

Should communicate this change with validators

### Testing Considerations

Covered by existing integration tests.

### Upgrade Considerations

Chain software change