### PR TITLE
reduce Endo build coupling

### DIFF
--- a/packages/base-zone/src/make-once.js
+++ b/packages/base-zone/src/make-once.js
@@ -35,7 +35,7 @@ export const makeOnceKit = (debugName, stores, backingStore = undefined) => {
    * Ensure the wrapped function is only called once per incarnation.  It is
    * expected to update the backing store directly.
    *
-   * @template {(key: string, ...rest: unknown[]) => any} T
+   * @template {(key: string, ...rest: any[]) => any} T
    * @param {T} provider
    * @param {(label: string) => string[]} [labelToKeys]
    * @returns {T}

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -41,7 +41,7 @@ const isPropertyKey = key => {
 /**
  * Synchronously call a callback.
  *
- * @template {(...args: unknown[]) => any} I
+ * @template {(...args: any[]) => any} I
  * @param {SyncCallback<I>} callback
  * @param {Parameters<I>} args
  * @returns {ReturnType<I>}
@@ -58,7 +58,7 @@ harden(callSync);
 /**
  * Eventual send to a callback.
  *
- * @template {(...args: unknown[]) => any} I
+ * @template {(...args: any[]) => any} I
  * @param {Callback<I>} callback
  * @param {Parameters<I>} args
  * @returns {Promise<Awaited<ReturnType<I>>>}
@@ -75,9 +75,9 @@ harden(callE);
 /**
  * Create a callback from a near function.
  *
- * @template {(...args: unknown[]) => any} I
+ * @template {(...args: any[]) => any} I
  * @template {(...args: [...B, ...Parameters<I>]) => ReturnType<I>} [T=I]
- * @template {unknown[]} [B=[]]
+ * @template {any[]} [B=[]]
  * @param {T} target
  * @param {B} bound
  * @returns {SyncCallback<I>}
@@ -94,9 +94,9 @@ harden(makeSyncFunctionCallback);
 /**
  * Create a callback from a potentially far function.
  *
- * @template {(...args: unknown[]) => any} I
+ * @template {(...args: any[]) => any} I
  * @template {ERef<(...args: [...B, ...Parameters<I>]) => ReturnType<I>>} [T=ERef<I>]
- * @template {unknown[]} [B=[]]
+ * @template {any[]} [B=[]]
  * @param {T} target
  * @param {B} bound
  * @returns {Callback<I>}
@@ -113,12 +113,12 @@ harden(makeFunctionCallback);
 /**
  * Create a callback from a near method.
  *
- * @template {(...args: unknown[]) => any} I
+ * @template {(...args: any[]) => any} I
  * @template {PropertyKey} P
  * @template {{
  *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>;
  * }} [T={ [x in P]: I }]
- * @template {unknown[]} [B=[]]
+ * @template {any[]} [B=[]]
  * @param {T} target
  * @param {P} methodName
  * @param {B} bound
@@ -139,12 +139,12 @@ harden(makeSyncMethodCallback);
 /**
  * Create a callback from a potentially far method.
  *
- * @template {(...args: unknown[]) => any} I
+ * @template {(...args: any[]) => any} I
  * @template {PropertyKey} P
  * @template {ERef<{
  *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>;
  * }>} [T=ERef<{ [x in P]: I }>]
- * @template {unknown[]} [B=[]]
+ * @template {any[]} [B=[]]
  * @param {T} target
  * @param {P} methodName
  * @param {B} bound
@@ -200,11 +200,11 @@ export const prepareAttenuator = (
   { interfaceGuard, tag = 'Attenuator' } = {},
 ) => {
   /**
-   * @typedef {(this: any, ...args: unknown[]) => any} Method
+   * @typedef {(this: any, ...args: any[]) => any} Method
    *
    * @typedef {{ [K in M]?: Callback<any> | null }} Overrides
    *
-   * @typedef {{ [K in M]: (this: any, ...args: unknown[]) => any }} Methods
+   * @typedef {{ [K in M]: (this: any, ...args: any[]) => any }} Methods
    */
   const methods = /** @type {Methods} */ (
     fromEntries(

--- a/packages/internal/src/types.d.ts
+++ b/packages/internal/src/types.d.ts
@@ -14,7 +14,7 @@ export type TotalMap<K, V> = Omit<Map<K, V>, 'get'> & {
 export type TotalMapFrom<M extends Map> =
   M extends Map<infer K, infer V> ? TotalMap<K, V> : never;
 
-export declare class Callback<I extends (...args: unknown[]) => any> {
+export declare class Callback<I extends (...args: any[]) => any> {
   private iface: I;
 
   public target: any;

--- a/patches/@endo+eventual-send+1.2.4.patch
+++ b/patches/@endo+eventual-send+1.2.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@endo/eventual-send/src/types.d.ts b/node_modules/@endo/eventual-send/src/types.d.ts
+index d847557..64bb686 100644
+--- a/node_modules/@endo/eventual-send/src/types.d.ts
++++ b/node_modules/@endo/eventual-send/src/types.d.ts
+@@ -17,7 +17,7 @@ export type * from './track-turns.js';
+ //   Types exposed to modules.
+ //
+ 
+-export type Callable = (...args: unknown[]) => any;
++export type Callable = (...args: any[]) => any;
+ 
+ /**
+  * Nominal type to carry the local and remote interfaces of a Remotable.

--- a/scripts/get-packed-versions.sh
+++ b/scripts/get-packed-versions.sh
@@ -23,8 +23,6 @@ corepack enable
 yarn install 1>&2
 yarn build 1>&2
 
-yarn lerna run build:types 1>&2
-
 npm query .workspace | jq -r '.[].location' | while read -r dir; do
   # Skip private packages.
   echo "dir=$dir" 1>&2

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -70,16 +70,10 @@ publish() {
     yarn build
     git commit --allow-empty -am "chore: prepare for publishing"
 
-    # Convention used in Endo
-    yarn lerna run build:types
-
     # Publish the packages to our local service.
     # without concurrency until https://github.com/Agoric/agoric-sdk/issues/8091
     yarn lerna version --concurrency 1 prerelease --exact \
       --preid=dev --no-push --no-git-tag-version --yes
-
-    # Convention used in Endo
-    yarn lerna run clean:types
 
     # Change any version prefices to an exact match, and merge our versions.
     VERSIONSHASH=$(jq --slurpfile versions <(popd > /dev/null && git cat-file blob "$VERSIONSHASH") \

--- a/scripts/replace-packages.sh
+++ b/scripts/replace-packages.sh
@@ -14,8 +14,7 @@ DSTDIR=${2-$PWD/node_modules}
 pushd "$SRCDIR"
 yarn install
 npm run build
-# Endo requires this
-npx lerna run build:types || true
+
 npm query .workspace | jq -r '.[].location' | while read -r dir; do
   # Skip private packages.
   test "$(jq .private < "$dir/package.json")" != true || continue


### PR DESCRIPTION
#endo-branch: master

## Description

Removes some build code that references Endo code that's no longer there.

Also slips in a typedefs fix to re-spin CI after I changed the endo-branch target. These fixes are good to get in ASAP and didn't seem worth a whole other PR.

After this merges I think https://github.com/Agoric/agoric-sdk/pull/9385 can be reset to master

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

CI suffices

### Upgrade Considerations

none