### PR TITLE
break(agoric-cli)!: Remove support for node -r esm scripts

### DIFF
--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -73,7 +73,6 @@
     "chalk": "^5.2.0",
     "commander": "^11.1.0",
     "deterministic-json": "^1.0.5",
-    "esm": "agoric-labs/esm#Agoric-built",
     "inquirer": "^8.2.2",
     "opener": "^1.5.2",
     "tmp": "^0.2.1",

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -4,7 +4,6 @@
 /* global process */
 
 import '@endo/init/pre.js';
-import 'esm';
 import '@agoric/casting/node-fetch-shim.js';
 import '@endo/init/legacy.js';
 

--- a/packages/agoric-cli/src/scripts.js
+++ b/packages/agoric-cli/src/scripts.js
@@ -2,15 +2,11 @@
 /* global process */
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/captp';
-import { search as readContainingPackageDescriptor } from '@endo/compartment-mapper';
 
-import createEsmRequire from 'esm';
 import { createRequire } from 'module';
 import path from 'path';
-import url from 'url';
 
 const require = createRequire(import.meta.url);
-const esmRequire = createEsmRequire(/** @type {NodeModule} */ ({}));
 
 const PATH_SEP_RE = new RegExp(`${path.sep.replace(/\\/g, '\\\\')}`, 'g');
 
@@ -132,32 +128,8 @@ export { bootPlugin } from ${JSON.stringify(absPath)};
 
       // Use a dynamic import to load the deploy script.
       // It is unconfined.
-
-      // Use Node.js ESM support if package.json of template says "type":
-      // "module".
-      const read = async location => fs.readFile(url.fileURLToPath(location));
-      const { packageDescriptorText } = await readContainingPackageDescriptor(
-        read,
-        url.pathToFileURL(moduleFile).href,
-      ).catch(cause => {
-        throw Error(
-          `Expected a package.json beside deploy script ${moduleFile}, ${cause}`,
-          { cause },
-        );
-      });
-      const packageDescriptor = JSON.parse(packageDescriptorText);
-      const nativeEsm = packageDescriptor.type === 'module';
-      console.log(
-        `Deploy script will run with ${
-          nativeEsm ? 'Node.js ESM' : 'standardthings/esm emulation'
-        }`,
-      );
-
       const modulePath = pathResolve(moduleFile);
-      let mainNS = await (nativeEsm && import(modulePath));
-      if (!mainNS) {
-        mainNS = esmRequire(modulePath);
-      }
+      const mainNS = await import(modulePath);
 
       const allEndowments = harden({
         home: bootP,

--- a/packages/agoric-cli/test/main.test.js
+++ b/packages/agoric-cli/test/main.test.js
@@ -1,7 +1,6 @@
 /* global globalThis */
 import '@agoric/casting/node-fetch-shim.js';
 import '@endo/init/pre.js';
-import 'esm';
 import '@endo/init/debug.js';
 import test from 'ava';
 import fs from 'fs';


### PR DESCRIPTION
*BREAKING CHANGE*: Removes support for scripts in packages that rely on the npm package "esm" to emulate modern JavaScript modules. Any script that breaks due to this change should work by upgrading to modern ESM, probably adding "type": "module" to their package.json and translating idioms like __dirname and __filename to analogues based on import.meta.url.

## Description

This change removes long-deprecated support for `node -r esm` emulation of modern JavaScript modules in favor of actual ESM, which we have supported for a couple years.

### Security Considerations

This removes `esm` from `agoric` CLI supply-chain.

### Scaling Considerations

This may improve the performance of deploy scripts and reduce the weight of node_modules somewhat. This is one less path to entrain a version of Babel.

### Documentation Considerations

I don’t believe this feature is documented and find it unlikely that it will be missed.

### Testing Considerations

This change is proposed to discover any latent dependence on this feature in integration tests.

### Upgrade Considerations

This change impacts scripts used to deploy contracts and is not entrained in any vats.
