### PR TITLE
fix(xsnap): Avoid snapshot data memory leak

### DIFF
--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@endo/base64": "^1.0.5",
+    "@endo/nat": "^5.0.7",
     "@types/glob": "^8.1.0",
     "ava": "^5.3.0",
     "c8": "^9.1.0"

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -109,7 +109,6 @@ export async function xsnap(options) {
   const ptmpName = fs.tmpName && promisify(fs.tmpName);
 
   const makeLoadSnapshotHandlerWithFS = async sourceBytes => {
-    assert(sourceBytes);
     const snapPath = await ptmpName({
       template: `load-snapshot-${safeHintFromDescription(
         snapshotDescription,
@@ -140,11 +139,8 @@ export async function xsnap(options) {
 
     const cleanup = async () => done;
 
-    /** @param {Writable} loadSnapshotsStream */
-    const afterSpawn = async loadSnapshotsStream => {
-      assert(sourceBytes);
-      const destStream = loadSnapshotsStream;
-
+    /** @param {Writable} destStream */
+    const afterSpawn = async destStream => {
       const sourceStream = Readable.from(sourceBytes);
       sourceStream.pipe(destStream, { end: false });
 

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -57,6 +57,81 @@ const safeHintFromDescription = description =>
   description.replaceAll(/[^a-zA-Z0-9_.-]/g, '-');
 
 /**
+ * @typedef {object} SnapshotLoader
+ * @property {string} snapPath
+ *   where XS can load the snapshot from, either a filesystem path or a string
+ *   like `@${fileDescriptorNumber}:${readableDescription}`
+ * @property {(destStream?: Writable) => Promise<void>} afterSpawn
+ *   callback for providing a destination stream to which the data should be
+ *   piped (only relevant for a stream-based loader)
+ * @property {() => Promise<void>} cleanup
+ *   callback to free resources when the loader is no longer needed
+ */
+
+/**
+ * @callback MakeSnapshotLoader
+ * @param {AsyncIterable<Uint8Array>} sourceBytes
+ * @param {string} description
+ * @param {{fs: Pick<typeof import('fs/promises'), 'open' | 'unlink'>, ptmpName: (opts: import('tmp').TmpNameOptions) => Promise<string>}} ioPowers
+ * @returns {Promise<SnapshotLoader>}
+ */
+
+/** @type {MakeSnapshotLoader} */
+const makeSnapshotLoaderWithFS = async (
+  sourceBytes,
+  description,
+  { fs, ptmpName },
+) => {
+  const snapPath = await ptmpName({
+    template: `load-snapshot-${safeHintFromDescription(description)}-XXXXXX.xss`,
+  });
+
+  const afterSpawn = async () => {};
+  const cleanup = async () => fs.unlink(snapPath);
+
+  try {
+    const tmpSnap = await fs.open(snapPath, 'w');
+    // @ts-expect-error incorrect typings; writeFile does support AsyncIterable
+    await tmpSnap.writeFile(sourceBytes);
+    await tmpSnap.close();
+  } catch (e) {
+    await cleanup();
+    throw e;
+  }
+
+  return harden({
+    snapPath,
+    afterSpawn,
+    cleanup,
+  });
+};
+
+/** @type {MakeSnapshotLoader} */
+const makeSnapshotLoaderWithPipe = async (
+  sourceBytes,
+  description,
+  _ioPowers,
+) => {
+  let done = Promise.resolve();
+
+  const cleanup = async () => done;
+
+  const afterSpawn = async destStream => {
+    const sourceStream = Readable.from(sourceBytes);
+    sourceStream.pipe(destStream, { end: false });
+
+    done = finished(sourceStream);
+    void done.catch(noop).then(() => sourceStream.unpipe(destStream));
+  };
+
+  return harden({
+    snapPath: `@${SNAPSHOT_LOAD_FD}:${safeHintFromDescription(description)}`,
+    afterSpawn,
+    cleanup,
+  });
+};
+
+/**
  * @param {XSnapOptions} options
  *
  * @typedef {object} XSnapOptions
@@ -87,7 +162,7 @@ export async function xsnap(options) {
     netstringMaxChunkSize = undefined,
     parserBufferSize = undefined,
     snapshotStream,
-    snapshotDescription = snapshotStream && 'unknown',
+    snapshotDescription = 'unknown',
     snapshotUseFs = false,
     stdout = 'ignore',
     stderr = 'ignore',
@@ -105,58 +180,6 @@ export async function xsnap(options) {
     throw Error(`xsnap does not support platform ${os}`);
   }
 
-  /** @type {(opts: import('tmp').TmpNameOptions) => Promise<string>} */
-  const ptmpName = fs.tmpName && promisify(fs.tmpName);
-
-  const makeLoadSnapshotHandlerWithFS = async sourceBytes => {
-    const snapPath = await ptmpName({
-      template: `load-snapshot-${safeHintFromDescription(
-        snapshotDescription,
-      )}-XXXXXX.xss`,
-    });
-
-    const afterSpawn = async () => {};
-    const cleanup = async () => fs.unlink(snapPath);
-
-    try {
-      const tmpSnap = await fs.open(snapPath, 'w');
-      await tmpSnap.writeFile(sourceBytes);
-      await tmpSnap.close();
-    } catch (e) {
-      await cleanup();
-      throw e;
-    }
-
-    return harden({
-      snapPath,
-      afterSpawn,
-      cleanup,
-    });
-  };
-
-  const makeLoadSnapshotHandlerWithPipe = async sourceBytes => {
-    let done = Promise.resolve();
-
-    const cleanup = async () => done;
-
-    /** @param {Writable} destStream */
-    const afterSpawn = async destStream => {
-      const sourceStream = Readable.from(sourceBytes);
-      sourceStream.pipe(destStream, { end: false });
-
-      done = finished(sourceStream);
-      void done.catch(noop).then(() => sourceStream.unpipe(destStream));
-    };
-
-    return harden({
-      snapPath: `@${SNAPSHOT_LOAD_FD}:${safeHintFromDescription(
-        snapshotDescription,
-      )}`,
-      afterSpawn,
-      cleanup,
-    });
-  };
-
   let bin = new URL(
     `../xsnap-native/xsnap/build/bin/${platform}/${
       debug ? 'debug' : 'release'
@@ -169,15 +192,18 @@ export async function xsnap(options) {
 
   assert(!/^-/.test(name), `name '${name}' cannot start with hyphen`);
 
-  let loadSnapshotHandler = await (snapshotStream &&
-    (snapshotUseFs
-      ? makeLoadSnapshotHandlerWithFS
-      : makeLoadSnapshotHandlerWithPipe)(snapshotStream));
+  /** @type {(opts: import('tmp').TmpNameOptions) => Promise<string>} */
+  const ptmpName = fs.tmpName && promisify(fs.tmpName);
+  const makeSnapshotLoader = snapshotUseFs
+    ? makeSnapshotLoaderWithFS
+    : makeSnapshotLoaderWithPipe;
+  let snapshotLoader = await (snapshotStream &&
+    makeSnapshotLoader(snapshotStream, snapshotDescription, { fs, ptmpName }));
 
   let args = [name];
 
-  if (loadSnapshotHandler) {
-    args.push('-r', loadSnapshotHandler.snapPath);
+  if (snapshotLoader) {
+    args.push('-r', snapshotLoader.snapPath);
   }
 
   if (meteringLimit) {
@@ -248,13 +274,13 @@ export async function xsnap(options) {
   const snapshotSaveStream = xsnapProcessStdio[SNAPSHOT_SAVE_FD];
   const snapshotLoadStream = xsnapProcessStdio[SNAPSHOT_LOAD_FD];
 
-  await loadSnapshotHandler?.afterSpawn(snapshotLoadStream);
+  await snapshotLoader?.afterSpawn(snapshotLoadStream);
 
-  if (loadSnapshotHandler) {
+  if (snapshotLoader) {
     void vatExit.promise.catch(noop).then(() => {
-      if (loadSnapshotHandler) {
-        const { cleanup } = loadSnapshotHandler;
-        loadSnapshotHandler = undefined;
+      if (snapshotLoader) {
+        const { cleanup } = snapshotLoader;
+        snapshotLoader = undefined;
         return cleanup();
       }
     });
@@ -276,9 +302,9 @@ export async function xsnap(options) {
   async function runToIdle() {
     for await (const _ of forever) {
       const iteration = await messagesFromXsnap.next(undefined);
-      if (loadSnapshotHandler) {
-        const { cleanup } = loadSnapshotHandler;
-        loadSnapshotHandler = undefined;
+      if (snapshotLoader) {
+        const { cleanup } = snapshotLoader;
+        snapshotLoader = undefined;
         await cleanup();
       }
       if (iteration.done) {

--- a/packages/xsnap/test/leakiness.mjs
+++ b/packages/xsnap/test/leakiness.mjs
@@ -1,0 +1,182 @@
+/* global setTimeout, process */
+
+// This file functions as both an ava-importable module and a standalone script.
+// See below for usage detail about the latter.
+import 'ses';
+import '@endo/eventual-send/shim.js';
+import 'data:text/javascript,try { lockdown(); } catch (_err) {}';
+
+import * as proc from 'child_process';
+import * as os from 'os';
+import fs from 'fs';
+import { tmpName } from 'tmp';
+import { parseArgs } from 'util';
+import { isMainThread } from 'worker_threads';
+
+import { Nat } from '@endo/nat';
+import { makePromiseKit } from '@endo/promise-kit';
+
+import { xsnap } from '../src/xsnap.js';
+
+import { options as makeXSnapOptions } from './message-tools.js';
+
+const io = { spawn: proc.spawn, os: os.type(), fs, tmpName }; // WARNING: ambient
+
+/** @import {XSnapOptions} from '@agoric/xsnap/src/xsnap.js' */
+
+/**
+ * Creates an Xsnap instance that responds to each inbound command by
+ * interpreting it as a decimal count of bytes to retain.
+ *
+ * @param {Partial<XSnapOptions>} [xsnapOptions]
+ * @returns {Promise<Awaited<ReturnType<xsnap>>>}
+ */
+export const makeRetentiveVat = async xsnapOptions => {
+  const vat = await xsnap({ ...makeXSnapOptions(io), ...xsnapOptions });
+  // Retain data for each message in a new ArrayBuffer, populating each such
+  // buffer with globally descending binary64 values (as buffer space permits)
+  // to limit compressibility.
+  await vat.evaluate(`
+    const decoder = new TextDecoder();
+    const buffers = [];
+    let x = Number.MAX_SAFE_INTEGER;
+    function handleCommand(message) {
+      const n = +decoder.decode(message);
+      const view = new DataView(new ArrayBuffer(n));
+      for (let offset = 0; offset + 8 <= n; offset += 8) {
+        view.setFloat64(offset, x);
+        x -= 1;
+      }
+      buffers.push(view.buffer);
+    }
+  `);
+  return vat;
+};
+harden(makeRetentiveVat);
+
+/**
+ * Spawns a heap-preserving sequence of Xsnap instances, each retaining
+ * approximately the same amount of additional data.
+ *
+ * @param {object} options
+ * @param {(newVat: Awaited<ReturnType<xsnap>>, loadedSnapshotStream: AsyncIterable<Uint8Array> | undefined) => Promise<void>} [options.afterCommand]
+ *   a callback to run after a vat handles its command, for e.g. interrogation and/or
+ *   inserting delays between instances
+ * @param {number} options.chunkCount the number of instances to spawn
+ * @param {number} options.chunkSize the count of bytes to retain per instance
+ * @param {Partial<XSnapOptions>} [options.xsnapOptions]
+ * @returns {Promise<void>}
+ */
+export const spawnRetentiveVatSequence = async ({
+  afterCommand,
+  chunkCount,
+  chunkSize,
+  xsnapOptions,
+}) => {
+  await null;
+  /** @type {Awaited<ReturnType<xsnap>> | undefined} */
+  let vat = undefined;
+  try {
+    for (let i = 0; i < chunkCount; i += 1) {
+      // Make a new vat, replacing a previous vat if present.
+      const oldVat = vat;
+      vat = await makeRetentiveVat({
+        ...xsnapOptions,
+        snapshotStream: oldVat?.makeSnapshotStream(),
+      });
+      await oldVat?.close();
+
+      // Issue the command.
+      const label = `command number ${i}`;
+      try {
+        await vat.issueStringCommand(`${chunkSize}`);
+      } catch (err) {
+        throw Error(`Error with ${label}`, { cause: err });
+      }
+      await afterCommand?.(vat);
+    }
+  } finally {
+    await vat?.close();
+  }
+};
+harden(spawnRetentiveVatSequence);
+
+/**
+ * Spawns a heap-preserving sequence of Xsnap instances with intervening delays.
+ *
+ * @param {object} options
+ * @param {number} options.chunkCount
+ * @param {number} options.chunkSize
+ * @param {number} options.idleDuration
+ * @param {Partial<XSnapOptions>} [options.xsnapOptions]
+ * @returns {Promise<void>}
+ */
+const main = async ({ chunkCount, chunkSize, idleDuration, xsnapOptions }) => {
+  const afterCommand = async _vat => {
+    const { promise, resolve } = makePromiseKit();
+    setTimeout(resolve, idleDuration);
+    return promise;
+  };
+  return spawnRetentiveVatSequence({
+    afterCommand,
+    chunkCount,
+    chunkSize,
+    xsnapOptions,
+  });
+};
+
+const isEntryPoint =
+  !/[/]node_modules[/]/.test(process.argv[1]) &&
+  // cf. https://github.com/avajs/ava/blob/f8bf00cd988b5e981b6c7d87523a1e0c5dc947c0/lib/worker/guard-environment.cjs
+  typeof process.send !== 'function' &&
+  isMainThread !== false;
+if (isEntryPoint) {
+  /** @typedef {{type: 'string' | 'boolean', short?: string, multiple?: boolean, default?: string | boolean | string[] | boolean[]}} ParseArgsOptionConfig */
+  /** @type {Record<string, ParseArgsOptionConfig>} */
+  const cliOptions = {
+    help: { type: 'boolean' },
+    chunkCount: {
+      type: 'string',
+      default: '10',
+    },
+    chunkSize: {
+      type: 'string',
+      default: '10000',
+    },
+    idleDuration: {
+      type: 'string',
+      default: '10000',
+    },
+    xsnapOptions: {
+      type: 'string',
+      default: '{ "snapshotUseFs": false }',
+    },
+  };
+  const { values: config } = parseArgs({ options: cliOptions });
+  let chunkCount, chunkSize, idleDuration, xsnapOptions;
+  try {
+    if (config.help) throw Error();
+    const parseNat = str => Nat(/[0-9]/.test(str || '') ? Number(str) : NaN);
+    chunkCount = Number(parseNat(config.chunkCount));
+    chunkSize = Number(parseNat(config.chunkSize));
+    idleDuration = Number(parseNat(config.idleDuration));
+    xsnapOptions = JSON.parse(/** @type {string} */ (config.xsnapOptions));
+  } catch (err) {
+    const log = config.help ? console.log : console.error;
+    if (!config.help) log(err.message);
+    log(`Usage: node [--inspect-brk] $script \\
+  [--chunkCount N (default ${cliOptions.chunkCount.default})] \\
+  [--chunkSize BYTE_COUNT (default ${cliOptions.chunkSize.default})] \\
+  [--idleDuration MILLISECONDS (default ${cliOptions.idleDuration.default})] \\
+  [--xsnapOptions JSON (default ${cliOptions.xsnapOptions.default})]
+
+Spawns a heap-preserving sequence of $chunkCount xsnap instances, each retaining
+approximately $chunkSize additional bytes, waiting $idleDuration milliseconds
+before spawning each instance's successor.`);
+    process.exit(64);
+  }
+  main({ chunkCount, chunkSize, idleDuration, xsnapOptions }).catch(err => {
+    console.error(err);
+    process.exitCode ||= 1;
+  });
+}

--- a/packages/xsnap/test/leakiness.mjs
+++ b/packages/xsnap/test/leakiness.mjs
@@ -80,9 +80,10 @@ export const spawnRetentiveVatSequence = async ({
     for (let i = 0; i < chunkCount; i += 1) {
       // Make a new vat, replacing a previous vat if present.
       const oldVat = vat;
+      const snapshotStream = oldVat?.makeSnapshotStream();
       vat = await makeRetentiveVat({
         ...xsnapOptions,
-        snapshotStream: oldVat?.makeSnapshotStream(),
+        snapshotStream,
       });
       await oldVat?.close();
 
@@ -93,7 +94,7 @@ export const spawnRetentiveVatSequence = async ({
       } catch (err) {
         throw Error(`Error with ${label}`, { cause: err });
       }
-      await afterCommand?.(vat);
+      await afterCommand?.(vat, snapshotStream);
     }
   } finally {
     await vat?.close();
@@ -112,7 +113,7 @@ harden(spawnRetentiveVatSequence);
  * @returns {Promise<void>}
  */
 const main = async ({ chunkCount, chunkSize, idleDuration, xsnapOptions }) => {
-  const afterCommand = async _vat => {
+  const afterCommand = async (_vat, _snapshotStream) => {
     const { promise, resolve } = makePromiseKit();
     setTimeout(resolve, idleDuration);
     return promise;

--- a/packages/xsnap/test/leakiness.test.js
+++ b/packages/xsnap/test/leakiness.test.js
@@ -81,10 +81,10 @@ const testRetention = async (t, xsnapOptions) => {
   );
 };
 
-test.serial.failing('snapshot GC with pipes', testRetention, {
+test.serial('snapshot GC with pipes', testRetention, {
   snapshotUseFs: false,
 });
 
-test.serial.failing('snapshot GC with temp files', testRetention, {
+test.serial('snapshot GC with temp files', testRetention, {
   snapshotUseFs: true,
 });

--- a/packages/xsnap/test/leakiness.test.js
+++ b/packages/xsnap/test/leakiness.test.js
@@ -1,20 +1,90 @@
+/** global FinalizationRegistry */
+
 import test from 'ava';
+
+import process from 'node:process';
+import v8 from 'node:v8';
+
+import engineGC from '@agoric/internal/src/lib-nodejs/engine-gc.js';
+import { waitUntilQuiescent } from '@agoric/internal/src/lib-nodejs/waitUntilQuiescent.js';
+
 import { spawnRetentiveVatSequence } from './leakiness.mjs';
 
-test('use pipes', async t => {
+/** @import {XSnapOptions} from '@agoric/xsnap/src/xsnap.js' */
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {Partial<XSnapOptions>} xsnapOptions
+ */
+const testRetention = async (t, xsnapOptions) => {
+  let snapshotsCreated = 0;
+  let snapshotsFreed = 0;
+  let lastVat = null;
+  /** @type {FinalizationRegistry<void>} */
+  const fr = new FinalizationRegistry(() => {
+    snapshotsFreed += 1;
+  });
+
+  t.plan(4);
+
+  await waitUntilQuiescent();
+  engineGC();
+  if (process.env.TAKE_HEAP_SNAPSHOT) {
+    v8.writeHeapSnapshot(
+      `Heap-${process.pid}-${t.title}-${Date.now()}-before.heapsnapshot`,
+    );
+  }
+
   await spawnRetentiveVatSequence({
+    afterCommand: async (vat, snapshotStream) => {
+      lastVat = vat;
+      if (snapshotStream) {
+        snapshotsCreated += 1;
+        fr.register(snapshotStream);
+      }
+    },
     chunkCount: 10,
     chunkSize: 1000,
-    xsnapOptions: { snapshotUseFs: false },
+    xsnapOptions,
   });
-  t.pass();
+
+  t.truthy(lastVat);
+  t.true(snapshotsCreated >= 1);
+
+  await waitUntilQuiescent();
+  engineGC();
+  await waitUntilQuiescent();
+  if (process.env.TAKE_HEAP_SNAPSHOT) {
+    v8.writeHeapSnapshot(
+      `Heap-${process.pid}-${t.title}-${Date.now()}-after-tail.heapsnapshot`,
+    );
+  }
+
+  const snapshotsFreedWithLastVatAlive = snapshotsFreed;
+
+  lastVat = null;
+
+  await waitUntilQuiescent();
+  engineGC();
+  await waitUntilQuiescent();
+  if (process.env.TAKE_HEAP_SNAPSHOT) {
+    v8.writeHeapSnapshot(
+      `Heap-${process.pid}-${t.title}-${Date.now()}-after-all.heapsnapshot`,
+    );
+  }
+
+  t.is(snapshotsFreed, snapshotsCreated, 'all snapshots freed');
+  t.is(
+    snapshotsFreedWithLastVatAlive,
+    snapshotsFreed,
+    'snapshots not tail retained',
+  );
+};
+
+test.serial.failing('snapshot GC with pipes', testRetention, {
+  snapshotUseFs: false,
 });
 
-test('use temp files', async t => {
-  await spawnRetentiveVatSequence({
-    chunkCount: 10,
-    chunkSize: 1000,
-    xsnapOptions: { snapshotUseFs: true },
-  });
-  t.pass();
+test.serial.failing('snapshot GC with temp files', testRetention, {
+  snapshotUseFs: true,
 });

--- a/packages/xsnap/test/leakiness.test.js
+++ b/packages/xsnap/test/leakiness.test.js
@@ -1,0 +1,20 @@
+import test from 'ava';
+import { spawnRetentiveVatSequence } from './leakiness.mjs';
+
+test('use pipes', async t => {
+  await spawnRetentiveVatSequence({
+    chunkCount: 10,
+    chunkSize: 1000,
+    xsnapOptions: { snapshotUseFs: false },
+  });
+  t.pass();
+});
+
+test('use temp files', async t => {
+  await spawnRetentiveVatSequence({
+    chunkCount: 10,
+    chunkSize: 1000,
+    xsnapOptions: { snapshotUseFs: true },
+  });
+  t.pass();
+});


### PR DESCRIPTION
Fixes #9316

## Description

Add testing code to observe memory leaks related to xsnap snapshots, and fix the leak that retains them.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

Covered!

### Upgrade Considerations

None (this is kernel code).