### PR TITLE
ci(dependency-graph): remove packing artifacts from cache

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -60,13 +60,21 @@ jobs:
       # Due to ambient types, certain build orders (from the dependency graph)
       # may break the type resolution. Run this in the PR to find out before
       # attempting to merge to master. This takes about 1min locally and since
-      # this job is about 30s in CI doing it here doesn't add to wall wait
-      # for CI resolution.
-      # We prepack only because full pack removes the declarations, relying on ambient
-      # resolution in the repo filesystem which will not be available when the packages
-      # are pulled from npm.
-      - name: Pack packages
-        run: yarn lerna run --reject-cycles --concurrency 1 prepack
+      # this job is about 30s in CI doing it here doesn't add to wall wait for
+      # CI resolution.
+      #
+      # We prepack only because full pack removes the declarations, relying on
+      # ambient resolution in the repo filesystem which will not be available
+      # when the packages are pulled from npm.
+      #
+      # After that test, we postpack to avoid putting the prepack artifacts in
+      # the cache maintained by restore-node, since they are not .gitignored and
+      # thus will fail restore-node's check for a clean repo when the cache is
+      # restored.
+      - name: Pack packages without ambient type resolution
+        run: |
+          yarn lerna run --reject-cycles --concurrency 1 prepack
+          yarn lerna run postpack
 
   ##################
   # Lint tests

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -1,20 +1,20 @@
 {
-    "private": true,
-    "agoricSyntheticChain": {
-        "fromTag": "latest"
-    },
-    "scripts": {
-        "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
-        "build:sdk": "make -C ../packages/deployment docker-build-sdk",
-        "build:submissions": "scripts/build-all-submissions.sh",
-        "build:synthetic-chain": "yarn synthetic-chain build",
-        "test": "yarn synthetic-chain test",
-        "doctor": "yarn synthetic-chain doctor"
-    },
-    "dependencies": {
-        "@agoric/synthetic-chain": "^0.1.0",
-        "@types/better-sqlite3": "^7.6.9"
-    },
-    "packageManager": "yarn@4.1.1",
-    "license": "Apache-2.0"
+  "private": true,
+  "agoricSyntheticChain": {
+    "fromTag": "use-upgrade-14"
+  },
+  "scripts": {
+    "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
+    "build:sdk": "make -C ../packages/deployment docker-build-sdk",
+    "build:submissions": "scripts/build-all-submissions.sh",
+    "build:synthetic-chain": "yarn synthetic-chain build",
+    "test": "yarn synthetic-chain test",
+    "doctor": "yarn synthetic-chain doctor"
+  },
+  "dependencies": {
+    "@agoric/synthetic-chain": "^0.1.0",
+    "@types/better-sqlite3": "^7.6.9"
+  },
+  "packageManager": "yarn@4.1.1",
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
closes: #9412

## Description

Take option 1 described in #9412's "Additional Context" and run the `postpack` job to clean up artifacts generated by the explicit `prepack` in the `dependency-graph` job.

### Testing Considerations

Tested on every CI run.