### PR TITLE
9087 defer ownable LCA/ICA accounts

### DIFF
--- a/a3p-integration/proposals/c:stake-bld/package.json
+++ b/a3p-integration/proposals/c:stake-bld/package.json
@@ -13,7 +13,7 @@
     "@agoric/synthetic-chain": "^0.1.0",
     "@cosmjs/stargate": "^0.32.3",
     "@cosmjs/tendermint-rpc": "^0.32.3",
-    "@endo/errors": "^1.1.0",
+    "@endo/errors": "^1.2.2",
     "@endo/far": "^1.0.4",
     "@endo/init": "^1.0.4",
     "agoric": "0.21.2-dev-5676146.0",

--- a/a3p-integration/proposals/c:stake-bld/yarn.lock
+++ b/a3p-integration/proposals/c:stake-bld/yarn.lock
@@ -967,12 +967,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@endo/env-options@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@endo/env-options@npm:1.1.4"
+  checksum: 10c0/8816c8fe1332a6f3366e7e4849b000d757fcd181eac011ed8363ccc4e66dfa2f2d975f8d5cbfb3844f3e327c5391e77ee7e234a59a21744c74c945f683b56df1
+  languageName: node
+  linkType: hard
+
 "@endo/errors@npm:^1.1.0":
   version: 1.1.0
   resolution: "@endo/errors@npm:1.1.0"
   dependencies:
     ses: "npm:^1.3.0"
   checksum: 10c0/3c909f5d76c9d1c0545f72c3e9d5ddb81518f85ea40b3093af01fac828e12fb1f689ba026898f89c5d29e634df7e0e055a1486c47ce939a890c21f2100ecc086
+  languageName: node
+  linkType: hard
+
+"@endo/errors@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@endo/errors@npm:1.2.2"
+  dependencies:
+    ses: "npm:^1.5.0"
+  checksum: 10c0/d90baaf803b17130b83fbc562e253504a6a05e4843d63536e74578503f6bd937fdba3464c4d8eeb9df16b795639cd9c4aad143520525f9e54aa3e91dc5184c17
   languageName: node
   linkType: hard
 
@@ -4570,7 +4586,7 @@ __metadata:
     "@agoric/synthetic-chain": "npm:^0.1.0"
     "@cosmjs/stargate": "npm:^0.32.3"
     "@cosmjs/tendermint-rpc": "npm:^0.32.3"
-    "@endo/errors": "npm:^1.1.0"
+    "@endo/errors": "npm:^1.2.2"
     "@endo/far": "npm:^1.0.4"
     "@endo/init": "npm:^1.0.4"
     agoric: "npm:0.21.2-dev-5676146.0"
@@ -4670,6 +4686,15 @@ __metadata:
   dependencies:
     "@endo/env-options": "npm:^1.1.1"
   checksum: 10c0/a1385c91a23677de3b91ffa93a8f08134b6657f93c3002b2269c961e28c19deeeadce4ae30a7bcc177a312268fa8d21de2aa5acfc4370055c17dd8c53885ffa4
+  languageName: node
+  linkType: hard
+
+"ses@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "ses@npm:1.5.0"
+  dependencies:
+    "@endo/env-options": "npm:^1.1.4"
+  checksum: 10c0/bd5e230ff07abe84632ff212a5dce5163d979ab0ae657c4ac0ee2748aea9f587d83c75639d0058def62eae6dde55c0ae9652f33aecc5e0fe538c89ce54bffcdc
   languageName: node
   linkType: hard
 

--- a/packages/base-zone/src/prepare-revocable.js
+++ b/packages/base-zone/src/prepare-revocable.js
@@ -3,6 +3,8 @@ import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 
 const { Fail, quote: q } = assert;
 
+/** @import {Amplify} from '@endo/exo'; */
+
 /**
  * @template [U=any]
  * @typedef {object} RevocableMakerKit
@@ -94,6 +96,7 @@ export const prepareRevocableMakerKit = (
 
   const revocableKindName = `${uKindName}_caretaker`;
 
+  /** @type {Amplify<any>} */
   let amplifier;
 
   const makeRevocableKit = zone.exoClassKit(

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -155,7 +155,7 @@ test.serial('stakeAtom - smart wallet', async t => {
     invitationSpec: {
       source: 'agoricContract',
       instancePath: ['stakeAtom'],
-      callPipe: [['makeAcountInvitationMaker']],
+      callPipe: [['makeAccountInvitationMaker']],
     },
     proposal: {},
   });

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -204,8 +204,6 @@ export interface IcaAccount {
    * Close the remote account
    */
   close: () => Promise<void>;
-  /* transfer account to new holder */
-  prepareTransfer: () => Promise<Invitation>;
   /** @returns the address of the remote channel */
   getRemoteAddress: () => RemoteIbcAddress;
   /** @returns the address of the local channel */

--- a/packages/orchestration/src/examples/stakeAtom.contract.js
+++ b/packages/orchestration/src/examples/stakeAtom.contract.js
@@ -97,7 +97,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     'StakeAtom',
     M.interface('StakeAtomI', {
       makeAccount: M.callWhen().returns(M.remotable('ChainAccount')),
-      makeAcountInvitationMaker: M.callWhen().returns(InvitationShape),
+      makeAccountInvitationMaker: M.callWhen().returns(InvitationShape),
     }),
     {
       async makeAccount() {
@@ -105,7 +105,7 @@ export const start = async (zcf, privateArgs, baggage) => {
         const { account } = await makeAccountKit();
         return account;
       },
-      makeAcountInvitationMaker() {
+      makeAccountInvitationMaker() {
         trace('makeCreateAccountInvitation');
         return zcf.makeInvitation(
           async seat => {

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -70,7 +70,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     'StakeBld',
     M.interface('StakeBldI', {
       makeAccount: M.callWhen().returns(M.remotable('LocalChainAccountHolder')),
-      makeAcountInvitationMaker: M.callWhen().returns(InvitationShape),
+      makeAccountInvitationMaker: M.callWhen().returns(InvitationShape),
       makeStakeBldInvitation: M.callWhen().returns(InvitationShape),
     }),
     {
@@ -103,7 +103,7 @@ export const start = async (zcf, privateArgs, baggage) => {
         const { holder } = await makeLocalAccountKit();
         return holder;
       },
-      makeAcountInvitationMaker() {
+      makeAccountInvitationMaker() {
         trace('makeCreateAccountInvitation');
         return zcf.makeInvitation(async seat => {
           seat.exit();

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -59,6 +59,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   async function makeLocalAccountKit() {
     const account = await E(privateArgs.localchain).makeAccount();
     const address = await E(account).getAddress();
+    // XXX 'address' is implied by 'account'; use an async maker that get the value itself
     return makeLocalChainAccountKit({
       account,
       address,

--- a/packages/orchestration/src/exos/README.md
+++ b/packages/orchestration/src/exos/README.md
@@ -1,0 +1,56 @@
+# Exo structure
+
+As of 2024-05-29…
+
+```mermaid
+classDiagram
+
+%% Orchestration vat business logic (Zoe)
+    LCAKit --* LocalchainAccount
+    ICQConnectionKit --* Port
+    ICQConnectionKit --* Connection
+    ChainAccountKit --* Port
+    ChainAccountKit --* Connection
+    StakingAccountKit --* IcaAccount
+
+    class ChainAccountKit {
+      port: Port
+      connection: Connection
+      localAddress: LocalIbcAddress
+      requestedRemoteAddress: string
+      remoteAddress: RemoteIbcAddress
+      chainAddress: ChainAddress
+    }
+    class ICQConnectionKit {
+      port: Port
+      connection: Connection
+      localAddress: LocalIbcAddress
+      remoteAddress: RemoteIbcAddress
+    }
+    class StakingAccountKit {
+      chainAddress: ChainAddress 
+      bondDenom: string 
+      account: ICAAccount 
+      timer: Timer
+      topicKit: TopicKit
+      makeTransferInvitation()
+    }
+
+%% In other vats
+    class LCAKit {
+        account: LocalChainAccount
+        address: ChainAddress
+        topicKit: RecorderKit<LocalChainAccountNotification>
+    }
+    class LocalchainAccount {
+        executeTx()
+        deposit()
+        withdraw()
+    }
+    class IcaAccount {
+        executeTx()
+        deposit()
+        getPurse()
+        close()
+    }
+```

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -4,7 +4,6 @@ import { makeTracer } from '@agoric/internal';
 import { V as E } from '@agoric/vow/vat.js';
 import { M } from '@endo/patterns';
 import { PaymentShape, PurseShape } from '@agoric/ertp';
-import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { findAddressField } from '../utils/address.js';
 import {
   ConnectionHandlerI,
@@ -41,7 +40,6 @@ export const ChainAccountI = M.interface('ChainAccount', {
   close: M.callWhen().returns(M.undefined()),
   deposit: M.callWhen(PaymentShape).returns(M.undefined()),
   getPurse: M.callWhen().returns(PurseShape),
-  prepareTransfer: M.callWhen().returns(InvitationShape),
 });
 
 /**
@@ -141,11 +139,6 @@ export const prepareChainAccountKit = zone =>
          */
         async getPurse(brand) {
           console.log('getPurse got', brand);
-          throw new Error('not yet implemented');
-        },
-
-        /* transfer account to new holder */
-        async prepareTransfer() {
           throw new Error('not yet implemented');
         },
       },

--- a/packages/orchestration/src/exos/local-chain-account-kit.js
+++ b/packages/orchestration/src/exos/local-chain-account-kit.js
@@ -53,6 +53,7 @@ const HolderI = M.interface('holder', {
     .optional(IBCTransferOptionsShape)
     .returns(M.promise()),
   getAddress: M.call().returns(M.string()),
+  executeTx: M.callWhen(M.arrayOf(M.record())).returns(M.arrayOf(M.record())),
 });
 
 /** @type {{ [name: string]: [description: string, valueShape: Pattern] }} */
@@ -193,6 +194,11 @@ export const prepareLocalChainAccountKit = (
         /** @type {LocalChainAccount['withdraw']} */
         async withdraw(amount) {
           return E(this.facets.helper.owned()).withdraw(amount);
+        },
+        /** @type {LocalChainAccount['executeTx']} */
+        async executeTx(messages) {
+          // @ts-expect-error subtype
+          return E(this.state.account).executeTx(messages);
         },
         /**
          * @returns {ChainAddress['address']}

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -103,9 +103,6 @@ test('makeStakeBldInvitation', async t => {
   t.deepEqual(res, {});
   t.log('Successfully delegated');
 
-  await t.throwsAsync(() => E(invitationMakers).TransferAccount(), {
-    message: 'not yet implemented',
-  });
   await t.throwsAsync(() => E(invitationMakers).CloseAccount(), {
     message: 'not yet implemented',
   });

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -6,7 +6,6 @@ import { E } from '@endo/far';
 import path from 'path';
 import { commonSetup } from '../supports.js';
 
-const { keys } = Object;
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
 const contractFile = `${dirname}/../../src/examples/stakeBld.contract.js`;
@@ -47,11 +46,10 @@ test('makeAccount, deposit, withdraw', async t => {
   t.truthy(account, 'account is returned');
   t.regex(await E(account).getAddress(), /agoric1/);
 
-  // XXX not observed by vat-bank
-  const oneHundredStakePmt = bld.issuerKit.mint.mintPayment(bld.units(100));
-
   t.log('deposit 100 bld to account');
-  const depositResp = await E(account).deposit(oneHundredStakePmt);
+  const depositResp = await E(account).deposit(
+    await utils.pourPayment(bld.units(100)),
+  );
   t.true(AmountMath.isEqual(depositResp, bld.units(100)), 'deposit');
 
   // TODO validate balance, .getBalance()
@@ -72,6 +70,7 @@ test('makeStakeBldInvitation', async t => {
   const {
     bootstrap,
     brands: { bld },
+    utils,
   } = await commonSetup(t);
   const { publicFacet, zoe } = await coreEval(t, { ...bootstrap, bld });
 
@@ -85,7 +84,7 @@ test('makeStakeBldInvitation', async t => {
   const userSeat = await E(zoe).offer(
     inv,
     { give: { In: hundred } },
-    { In: bld.mint.mintPayment(hundred) },
+    { In: utils.pourPayment(hundred) },
   );
   const { invitationMakers } = await E(userSeat).getOfferResult();
   t.truthy(invitationMakers, 'received continuing invitation');
@@ -98,7 +97,7 @@ test('makeStakeBldInvitation', async t => {
   const delegateOffer = await E(zoe).offer(
     delegateInv,
     { give: { In: hundred } },
-    { In: bld.mint.mintPayment(hundred) },
+    { In: utils.pourPayment(hundred) },
   );
   const res = await E(delegateOffer).getOfferResult();
   t.deepEqual(res, {});

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -34,7 +34,7 @@ const coreEval = async (t, { timer, localchain, marshaller, storage, bld }) => {
   return { publicFacet, zoe };
 };
 
-test('stakeBld contract - makeAccount, deposit, withdraw', async t => {
+test('makeAccount, deposit, withdraw', async t => {
   const {
     bootstrap,
     brands: { bld },
@@ -68,7 +68,7 @@ test('stakeBld contract - makeAccount, deposit, withdraw', async t => {
   );
 });
 
-test('stakeBld contract - makeStakeBldInvitation', async t => {
+test('makeStakeBldInvitation', async t => {
   const {
     bootstrap,
     brands: { bld },
@@ -112,7 +112,7 @@ test('stakeBld contract - makeStakeBldInvitation', async t => {
   });
 });
 
-test('stakeBld contract - makeAccountInvitationMaker', async t => {
+test('makeAccountInvitationMaker', async t => {
   const {
     bootstrap,
     brands: { bld },

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -119,7 +119,7 @@ test('stakeBld contract - makeAccountInvitationMaker', async t => {
   } = await commonSetup(t);
   const { publicFacet, zoe } = await coreEval(t, { ...bootstrap, bld });
 
-  const inv = await E(publicFacet).makeAcountInvitationMaker();
+  const inv = await E(publicFacet).makeAccountInvitationMaker();
 
   const userSeat = await E(zoe).offer(inv);
   const offerResult = await E(userSeat).getOfferResult();

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -30,8 +30,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 
 {
   const lcak: LocalChainAccountKit = null as any;
-  const lca = lcak.helper.owned();
-  const results = await lca.executeTx([
+  const results = await lcak.holder.executeTx([
     typedJson('/cosmos.staking.v1beta1.MsgDelegate', {
       amount: {
         amount: '1',

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -10,6 +10,15 @@ import { provide, VatData as globalVatData } from './vat-data-bindings.js';
  * @import {Baggage, DefineKindOptions, DurableKindHandle, InterfaceGuardKit} from '@agoric/swingset-liveslots';
  */
 
+// Some feedback if the init function is async
+/**
+ * @typedef {(...args: any[]) => any} InitState
+ */
+/**
+ * @template {InitState} I
+ * @typedef {ReturnType<I> extends Promise<any> ? never : ReturnType<I>} StateResult
+ */
+
 /**
  * Make a version of the argument function that takes a kind context but
  * ignores it.
@@ -82,18 +91,18 @@ export const makeExoUtils = VatData => {
   harden(prepareKindMulti);
 
   /**
-   * @template {(...args: any) => any} I init state function
+   * @template {InitState} I init state function
    * @template T behavior
    * @param {string} tag
    * @param {InterfaceGuard | undefined} interfaceGuard
    * @param {I} init
    * @param {T & ThisType<{
    *   self: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} methods
    * @param {DefineKindOptions<{
    *   self: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} [options]
    * @returns {(...args: Parameters<I>) => import('@endo/exo').Guarded<T>}
    */
@@ -107,18 +116,18 @@ export const makeExoUtils = VatData => {
   harden(defineVirtualExoClass);
 
   /**
-   * @template {(...args: any) => any} I init state function
+   * @template {InitState} I init state function
    * @template {Record<string, Record<PropertyKey, CallableFunction>>} T facets
    * @param {string} tag
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
    *   facets: import('@endo/exo').GuardedKit<T>,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} [options]
    * @returns {(...args: Parameters<I>) => import('@endo/exo').GuardedKit<T>}
    */
@@ -138,18 +147,18 @@ export const makeExoUtils = VatData => {
   harden(defineVirtualExoClassKit);
 
   /**
-   * @template {(...args: any) => any} I init state function
+   * @template {InitState} I init state function
    * @template {Record<PropertyKey, CallableFunction>} T methods
    * @param {DurableKindHandle} kindHandle
    * @param {InterfaceGuard | undefined} interfaceGuard
    * @param {I} init
    * @param {T & ThisType<{
    *   self: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} methods
    * @param {DefineKindOptions<{
    *   self: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} [options]
    * @returns {(...args: Parameters<I>) => import('@endo/exo').Guarded<T>}
    */
@@ -169,18 +178,18 @@ export const makeExoUtils = VatData => {
   harden(defineDurableExoClass);
 
   /**
-   * @template {(...args: any) => any} I init state function
+   * @template {InitState} I init state function
    * @template {Record<string, Record<PropertyKey, CallableFunction>>} T facets
    * @param {DurableKindHandle} kindHandle
    * @param {InterfaceGuardKit | undefined} interfaceGuardKit
    * @param {I} init
    * @param {T & ThisType<{
    *   facets: import('@endo/exo').GuardedKit<T>,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} [options]
    * @returns {(...args: Parameters<I>) => import('@endo/exo').GuardedKit<T>}
    */
@@ -200,7 +209,7 @@ export const makeExoUtils = VatData => {
   harden(defineDurableExoClassKit);
 
   /**
-   * @template {(...args: any) => any} I init state function
+   * @template {InitState} I init state function
    * @template {Record<PropertyKey, CallableFunction>} T methods
    * @param {Baggage} baggage
    * @param {string} kindName
@@ -208,11 +217,11 @@ export const makeExoUtils = VatData => {
    * @param {I} init
    * @param {T & ThisType<{
    *   self: RemotableObject & T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} methods
    * @param {DefineKindOptions<{
    *   self: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} [options]
    * @returns {(...args: Parameters<I>) => import('@endo/exo').Guarded<T>}
    */
@@ -234,7 +243,7 @@ export const makeExoUtils = VatData => {
   harden(prepareExoClass);
 
   /**
-   * @template {(...args: any) => any} I init state function
+   * @template {InitState} I init state function
    * @template {Record<string, Record<PropertyKey, CallableFunction>>} T facets
    * @param {Baggage} baggage
    * @param {string} kindName
@@ -242,11 +251,11 @@ export const makeExoUtils = VatData => {
    * @param {I} init
    * @param {T & ThisType<{
    *   facets: import('@endo/exo').GuardedKit<T>,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }> } facets
    * @param {DefineKindOptions<{
    *   facets: T,
-   *   state: ReturnType<I>
+   *   state: StateResult<I>
    * }>} [options]
    * @returns {(...args: Parameters<I>) => import('@endo/exo').GuardedKit<T>}
    */

--- a/packages/zoe/src/contractSupport/prepare-ownable.js
+++ b/packages/zoe/src/contractSupport/prepare-ownable.js
@@ -18,6 +18,10 @@ const TransferProposalShape = M.splitRecord({
  */
 
 /**
+ * Prepare a kind that wraps an 'ownable' object with a `makeTransferInvitation`
+ * ability and delegates to the underlying object methods specified the an
+ * allowlist of method names.
+ *
  * @template {(string | symbol)[]} MN Method names
  * @param {import('@agoric/base-zone').Zone} zone
  * @param {ZCF['makeInvitation']} makeInvitation

--- a/packages/zoe/src/contractSupport/prepare-ownable.js
+++ b/packages/zoe/src/contractSupport/prepare-ownable.js
@@ -19,7 +19,7 @@ const TransferProposalShape = M.splitRecord({
 
 /**
  * Prepare a kind that wraps an 'ownable' object with a `makeTransferInvitation`
- * ability and delegates to the underlying object methods specified the an
+ * ability and delegates to the underlying object methods specified in an
  * allowlist of method names.
  *
  * @template {(string | symbol)[]} MN Method names


### PR DESCRIPTION
refs: #9087 
stacked on: https://github.com/Agoric/agoric-sdk/pull/9415

## Description

Ownabality/tradability of LCA/ICA accounts (#9087) is not a requirement for the next release. When it is needed, we can retrofit with Exo class upgrades.

This PR removes the stubs so they don't appear to be needing implementation.

It also has a bunch of other cleanup done in the course of exploring.

### Security Considerations

Takes away a hypothetical authority.

### Scaling Considerations

none

### Documentation Considerations

Adds some new documentation on the Exo relationship. That could get stale but I think it's worth having.

### Testing Considerations

CI


### Upgrade Considerations

Not yet deployed. 