### PR TITLE
7747 distinguish Zoe's manual timer

### DIFF
--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -1,5 +1,5 @@
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
@@ -240,7 +240,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
     E(zoe).install(cb.committee),
     E(zoe).install(cb.binaryVoteCounter),
   ]);
-  const timer = buildManualTimer(log);
+  const timer = buildZoeManualTimer(log);
 
   const installations = { committee, binaryVoteCounter };
 

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -1,6 +1,6 @@
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
@@ -280,7 +280,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
     'zcf',
   );
   const installations = await installContracts(zoe, cb);
-  const timer = buildManualTimer(log);
+  const timer = buildZoeManualTimer(log);
   const voterCreator = E(vats.voter).build(zoe);
   const firstElectorateTerms = {
     committeeName: 'TwentyCommittee',

--- a/packages/governance/test/unitTests/ballotBuilder.test.js
+++ b/packages/governance/test/unitTests/ballotBuilder.test.js
@@ -1,6 +1,6 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import {
   coerceQuestionSpec,
   ChoiceMethod,
@@ -10,7 +10,7 @@ import {
 
 const issue = harden({ text: 'will it blend?' });
 const positions = [harden({ text: 'yes' }), harden({ text: 'no' })];
-const timer = buildManualTimer(console.log);
+const timer = buildZoeManualTimer(console.log);
 const closingRule = { timer, deadline: 37n };
 
 test('good QuestionSpec', t => {

--- a/packages/governance/test/unitTests/binaryballotCount.test.js
+++ b/packages/governance/test/unitTests/binaryballotCount.test.js
@@ -1,7 +1,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/eventual-send';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { Far } from '@endo/marshal';
 import { makeStoredPublishKit } from '@agoric/notifier';
@@ -40,7 +40,7 @@ const PARAM_CHANGE_ISSUE = harden({
 });
 
 const FAKE_CLOSING_RULE = {
-  timer: buildManualTimer(console.log),
+  timer: buildZoeManualTimer(console.log),
   deadline: 3n,
 };
 

--- a/packages/governance/test/unitTests/committee.test.js
+++ b/packages/governance/test/unitTests/committee.test.js
@@ -2,7 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { makeZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
@@ -83,7 +83,7 @@ test('committee-open question:one', async t => {
       maxChoices: 1,
       maxWinners: 1,
       closingRule: {
-        timer: buildManualTimer(t.log),
+        timer: buildZoeManualTimer(t.log),
         deadline: 2n,
       },
       quorumRule: QuorumRule.MAJORITY,
@@ -139,7 +139,7 @@ test('committee-open question:mixed, with snapshot', async t => {
     mockChainStorageRoot,
   } = await setupContract();
 
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const positions = [harden({ text: 'because' }), harden({ text: 'why not?' })];
   const questionSpec = coerceQuestionSpec(
     harden({

--- a/packages/governance/test/unitTests/multiCandidateBallotCount.test.js
+++ b/packages/governance/test/unitTests/multiCandidateBallotCount.test.js
@@ -6,7 +6,7 @@ import {
 } from '@agoric/notifier/tools/testSupports.js';
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import {
   ChoiceMethod,
@@ -32,7 +32,7 @@ const MUTTON = harden({ text: 'Mutton' });
 const GOAT = harden({ text: 'Goat' });
 
 const FAKE_CLOSING_RULE = {
-  timer: buildManualTimer(console.log),
+  timer: buildZoeManualTimer(console.log),
   deadline: 3n,
 };
 

--- a/packages/governance/test/unitTests/paramGovernance.test.js
+++ b/packages/governance/test/unitTests/paramGovernance.test.js
@@ -2,7 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { makeZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
@@ -119,7 +119,7 @@ const setUpVoterAndVote = async (committeeCreator, zoe, qHandle, choice) => {
 
 test('governParam no votes', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets, installs, invitationAmount } =
     await setUpGovernedContract(
       zoe,
@@ -173,7 +173,7 @@ test('governParam no votes', async t => {
 
 test('multiple params bad change', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets, installs } = await setUpGovernedContract(
     zoe,
     { committeeName: 'Demos', committeeSize: 1 },
@@ -204,7 +204,7 @@ test('multiple params bad change', async t => {
 
 test('change multiple params', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets, installs, invitationAmount, committeeCreator } =
     await setUpGovernedContract(
       zoe,
@@ -289,7 +289,7 @@ test('change multiple params', async t => {
 
 test('change multiple params used invitation', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets, installs, invitationAmount, committeeCreator } =
     await setUpGovernedContract(
       zoe,
@@ -360,7 +360,7 @@ test('change multiple params used invitation', async t => {
 
 test('change param continuing invitation', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets, installs, committeeCreator } =
     await setUpGovernedContract(
       zoe,

--- a/packages/governance/test/unitTests/puppetContractGovernor.test.js
+++ b/packages/governance/test/unitTests/puppetContractGovernor.test.js
@@ -2,7 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { makeZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
@@ -38,7 +38,7 @@ const governedTerms = {
 
 test('multiple params bad change', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets } = await setUpGovernedContract(
     zoe,
     E(zoe).install(governedBundleP),
@@ -65,7 +65,7 @@ test('multiple params bad change', async t => {
 
 test('change a param', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets, getFakeInvitation } = await setUpGovernedContract(
     zoe,
     E(zoe).install(governedBundleP),
@@ -125,7 +125,7 @@ test('change a param', async t => {
 
 test('set offer Filter directly', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets } = await setUpGovernedContract(
     zoe,
     E(zoe).install(governedBundleP),
@@ -142,7 +142,7 @@ test('set offer Filter directly', async t => {
 
 test('call API directly', async t => {
   const zoe = await makeZoeForTest();
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets } = await setUpGovernedContract(
     zoe,
     E(zoe).install(governedBundleP),
@@ -166,7 +166,7 @@ test('call API directly', async t => {
 test('add issuerKeywordRecord', async t => {
   const zoe = await makeZoeForTest();
   const issuerKit = makeIssuerKit('Food', AssetKind.COPY_BAG);
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { governorFacets } = await setUpGovernedContract(
     zoe,
     E(zoe).install(governedBundleP),

--- a/packages/inter-protocol/test/feeDistributor.test.js
+++ b/packages/inter-protocol/test/feeDistributor.test.js
@@ -1,7 +1,7 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints.js';
 
@@ -73,7 +73,7 @@ const makeScenario = async t => {
     stableMint.mintPayment(AmountMath.makeEmpty(brand));
   const vaultFactory = makeFakeFeeProducer(makeEmptyPayment);
   const amm = makeFakeFeeProducer(makeEmptyPayment);
-  const timerService = buildManualTimer(t.log);
+  const timerService = buildZoeManualTimer(t.log);
   const { publicFacet, creatorFacet } = await makeFeeDistributor(issuer, {
     timerService,
     collectionInterval: 1n,
@@ -196,7 +196,7 @@ test('fee distribution, leftovers', async t => {
     stableMint.mintPayment(AmountMath.makeEmpty(brand));
   const vaultFactory = makeFakeFeeProducer(makeEmptyPayment);
   const amm = makeFakeFeeProducer(makeEmptyPayment);
-  const timerService = buildManualTimer(t.log);
+  const timerService = buildZoeManualTimer(t.log);
   const { creatorFacet } = await makeFeeDistributor(issuer, {
     timerService,
     collectionInterval: 1n,

--- a/packages/inter-protocol/test/price/fluxAggregatorKit.test.js
+++ b/packages/inter-protocol/test/price/fluxAggregatorKit.test.js
@@ -12,7 +12,7 @@ import {
 } from '@agoric/notifier/tools/testSupports.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { TimeMath } from '@agoric/time';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { documentStorageSchema } from '@agoric/governance/tools/storageDoc.js';
@@ -44,7 +44,7 @@ const makeContext = async () => {
     const mockStorageRoot = makeMockChainStorageRoot();
     const storageNode = E(mockStorageRoot).makeChildNode('priceAggregator');
 
-    const manualTimer = buildManualTimer(() => {});
+    const manualTimer = buildZoeManualTimer(() => {});
     const timerBrand = manualTimer.getTimerBrand();
     const toTS = val => TimeMath.coerceTimestampRecord(val, timerBrand);
 

--- a/packages/inter-protocol/test/psm/governedPsm.test.js
+++ b/packages/inter-protocol/test/psm/governedPsm.test.js
@@ -4,7 +4,7 @@ import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeFakeMarshaller } from '@agoric/notifier/tools/testSupports.js';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { setupPsm } from './setupPsm.js';
@@ -16,7 +16,7 @@ test.before(async t => {
 
 test('psm block offers w/Governance', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
+  const timer = buildZoeManualTimer(t.log, 0n, { eventLoopIteration });
 
   const { knut, zoe, psm, committeeCreator, governor, installs } =
     await setupPsm(t, electorateTerms, timer);
@@ -59,7 +59,7 @@ test('psm block offers w/Governance', async t => {
 
 test('psm block offers w/charter', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
+  const timer = buildZoeManualTimer(t.log, 0n, { eventLoopIteration });
 
   const { knut, zoe, psm, committeeCreator, econCharterCreatorFacet } =
     await setupPsm(t, electorateTerms, timer);
@@ -114,7 +114,7 @@ test('psm block offers w/charter', async t => {
 
 test('psm block offers w/charter via invitationMakers', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
+  const timer = buildZoeManualTimer(t.log, 0n, { eventLoopIteration });
 
   const { knut, zoe, psm, committeeCreator, econCharterCreatorFacet } =
     await setupPsm(t, electorateTerms, timer);
@@ -168,7 +168,7 @@ test('psm block offers w/charter via invitationMakers', async t => {
 
 test('replace electorate of Economic Committee', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
+  const timer = buildZoeManualTimer(t.log, 0n, { eventLoopIteration });
 
   const { zoe, governor, installs } = await setupPsm(t, electorateTerms, timer);
 

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -5,7 +5,7 @@ import { makeAgoricNamesAccess, makePromiseSpace } from '@agoric/vats';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { makeScalarMapStore } from '@agoric/vat-data';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { allValues } from '@agoric/internal';
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import { makeIssuerKit } from '@agoric/ertp';
@@ -31,7 +31,7 @@ const charterRoot = './src/econCommitteeCharter.js'; // package relative
  * @param {FarZoeKit} [farZoeKit]
  */
 export const setupPsmBootstrap = async (
-  timer = buildManualTimer(console.log),
+  timer = buildZoeManualTimer(console.log),
   farZoeKit,
 ) => {
   const { zoe: wrappedZoe, feeMintAccessP } = await (farZoeKit ||
@@ -71,7 +71,7 @@ export const setupPsmBootstrap = async (
 export const setupPsm = async (
   t,
   electorateTerms = { committeeName: 'The Cabal', committeeSize: 1 },
-  timer = buildManualTimer(t.log),
+  timer = buildZoeManualTimer(t.log),
   farZoeKit,
 ) => {
   const knut = withAmountUtils(makeIssuerKit('KNUT'));

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -22,7 +22,7 @@ import { startPSM, startEconCharter } from '../../src/proposals/startPSM.js';
 const psmRoot = './src/psm/psm.js'; // package relative
 const charterRoot = './src/econCommitteeCharter.js'; // package relative
 
-/** @import {ManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
+/** @import {ZoeManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
 
 /** @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit */
 
@@ -65,7 +65,7 @@ export const setupPsmBootstrap = async (
 /**
  * @param {any} t
  * @param {{ committeeName: string; committeeSize: number }} electorateTerms
- * @param {ManualTimer} [timer]
+ * @param {ZoeManualTimer} [timer]
  * @param {FarZoeKit} [farZoeKit]
  */
 export const setupPsm = async (

--- a/packages/inter-protocol/test/reserve/reserve.test.js
+++ b/packages/inter-protocol/test/reserve/reserve.test.js
@@ -2,7 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 
 import { documentStorageSchema } from '@agoric/governance/tools/storageDoc.js';
@@ -52,7 +52,7 @@ test('reserve add collateral', async t => {
   const moola = value => AmountMath.make(moolaKit.brand, value);
 
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
 
   const { zoe, reserve } = await setupReserveServices(
     t,
@@ -83,7 +83,7 @@ test('check allocations', async t => {
   const moola = value => AmountMath.make(moolaKit.brand, value);
 
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 1 };
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
 
   const { zoe, reserve, space } = await setupReserveServices(
     t,
@@ -129,7 +129,7 @@ test('check allocations', async t => {
 test('reserve track shortfall', async t => {
   /** @param {NatValue} value */
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
 
   const { reserve, space, zoe } = await setupReserveServices(
     t,
@@ -187,7 +187,7 @@ test('reserve track shortfall', async t => {
 test('reserve burn IST, with snapshot', async t => {
   /** @param {NatValue} value */
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 1 };
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
 
   const {
     zoe,
@@ -270,7 +270,7 @@ test('reserve burn IST, with snapshot', async t => {
 test('storage keys', async t => {
   /** @param {NatValue} value */
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
 
   const { reserve } = await setupReserveServices(t, electorateTerms, timer);
 

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -1,4 +1,4 @@
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { makeAgoricNamesAccess, makePromiseSpace } from '@agoric/vats';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
@@ -72,7 +72,7 @@ const setupReserveBootstrap = async (t, timer, farZoeKit) => {
 export const setupReserveServices = async (
   t,
   electorateTerms,
-  timer = buildManualTimer(t.log),
+  timer = buildZoeManualTimer(t.log),
 ) => {
   const farZoeKit = await setUpZoeForTest({ feeIssuerConfig });
   const { feeMintAccessP, zoe } = farZoeKit;

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -14,7 +14,7 @@ import {
 } from '../supports.js';
 import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.js';
 
-/** @import {ManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
+/** @import {ZoeManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
 
 const reserveRoot = './src/reserve/assetReserve.js'; // package relative
 const faucetRoot = './test/vaultFactory/faucet.js';
@@ -25,7 +25,7 @@ const faucetRoot = './test/vaultFactory/faucet.js';
  * NOTE: called separately by each test so zoe/priceAuthority don't interfere
  *
  * @param {any} t
- * @param {ManualTimer | undefined} timer
+ * @param {ZoeManualTimer | undefined} timer
  * @param {FarZoeKit} farZoeKit
  */
 const setupReserveBootstrap = async (t, timer, farZoeKit) => {
@@ -67,7 +67,7 @@ const setupReserveBootstrap = async (t, timer, farZoeKit) => {
  *
  * @param {import('ava').ExecutionContext<unknown>} t
  * @param {{ committeeName: string; committeeSize: number }} electorateTerms
- * @param {ManualTimer} [timer]
+ * @param {ZoeManualTimer} [timer]
  */
 export const setupReserveServices = async (
   t,

--- a/packages/inter-protocol/test/smartWallet/boot-test-utils.js
+++ b/packages/inter-protocol/test/smartWallet/boot-test-utils.js
@@ -8,7 +8,7 @@ import {
   makeFakeVatAdmin,
   zcfBundleCap,
 } from '@agoric/zoe/tools/fakeVatAdmin.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { Far } from '@endo/marshal';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { vatRoots } from '@agoric/vats/tools/boot-test-utils.js';
@@ -52,7 +52,7 @@ export const makeMock = log =>
         buildSpawner: () => harden({ _: 'spawner' }),
       },
       timer: Far('TimerVat', {
-        createTimerService: async () => buildManualTimer(log),
+        createTimerService: async () => buildZoeManualTimer(log),
       }),
       uploads: { getUploads: () => harden({ _: 'uploads' }) },
 

--- a/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
@@ -20,7 +20,7 @@ import {
   voteForOpenQuestion,
 } from './contexts.js';
 
-/** @import {ManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
+/** @import {ZoeManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
 
 /**
  * @typedef {Awaited<ReturnType<typeof makeDefaultTestContext>> & {
@@ -275,7 +275,7 @@ test.serial('admin price', async t => {
 
   // Verify price result
 
-  const manualTimer = /** @type {Promise<ManualTimer>} */ (
+  const manualTimer = /** @type {Promise<ZoeManualTimer>} */ (
     t.context.consume.chainTimerService
   );
   const timerBrand = await E(manualTimer).getTimerBrand();
@@ -500,7 +500,7 @@ test.serial('govern oracles list', async t => {
   }
 
   const committeePublic = E(zoe).getPublicFacet(economicCommittee);
-  /** @type {ERef<ManualTimer>} */
+  /** @type {ERef<ZoeManualTimer>} */
   // @ts-expect-error cast mock
   const timer = t.context.consume.chainTimerService;
 

--- a/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
@@ -6,7 +6,7 @@ import { zip } from '@agoric/internal';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
 import { TimeMath } from '@agoric/time';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/far';
 import { oracleBrandFeedName } from '../../src/proposals/utils.js';
 import { INVITATION_MAKERS_DESC as EC_INVITATION_MAKERS_DESC } from '../../src/econCommitteeCharter.js';
@@ -64,7 +64,7 @@ const makeTestSpace = async (log, bundleCache) => {
   const space = psmVatRoot.getPromiseSpace();
   await eventLoopIteration();
 
-  const timer = buildManualTimer(log);
+  const timer = buildZoeManualTimer(log);
   space.produce.chainTimerService.resolve(timer);
 
   /** @type {import('@agoric/inter-protocol/src/proposals/price-feed-proposal.js').PriceFeedOptions} */

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -14,7 +14,7 @@ import { makeAgoricNamesAccess, makePromiseSpace } from '@agoric/vats';
 import { produceDiagnostics } from '@agoric/vats/src/core/basic-behaviors.js';
 import * as utils from '@agoric/vats/src/core/utils.js';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { setUpZoeForTest as generalSetUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E } from '@endo/far';
 
@@ -67,7 +67,7 @@ export const setupBootstrap = async (t, optTimer) => {
 
   await produceDiagnostics(space);
 
-  const timer = optTimer || buildManualTimer(t.log);
+  const timer = optTimer || buildZoeManualTimer(t.log);
   produce.chainTimerService.resolve(timer);
   produce.chainStorage.resolve(makeMockChainStorageRoot());
   produce.board.resolve(makeFakeBoard());

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -8,7 +8,7 @@ import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { makeNameHubKit } from '@agoric/vats';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -23,7 +23,7 @@ const outKit = makeIssuerKit('moola');
 export const buildRootObject = async () => {
   const storageKit = makeFakeStorageKit('fluxAggregatorUpgradeTest');
   const { nameAdmin: namesByAddressAdmin } = makeNameHubKit();
-  const timer = buildManualTimer();
+  const timer = buildZoeManualTimer();
   const marshaller = makeFakeBoard().getReadonlyMarshaller();
 
   /** @type {PromiseKit<ZoeService>} */

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -9,7 +9,7 @@ import { mustMatch } from '@agoric/store';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { PaymentPKeywordRecordShape } from '@agoric/zoe/src/typeGuards.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -28,7 +28,7 @@ const secondGive = anchor.units(3);
 
 export const buildRootObject = async () => {
   const storageKit = makeFakeStorageKit('psmUpgradeTest');
-  const timer = buildManualTimer();
+  const timer = buildZoeManualTimer();
   const marshaller = makeFakeBoard().getReadonlyMarshaller();
 
   const { promise: committeeCreator, ...ccPK } = makePromiseKit();

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -7,7 +7,7 @@ import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeNameHubKit } from '@agoric/vats';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -22,7 +22,7 @@ const moola = withAmountUtils(makeIssuerKit('moola'));
 export const buildRootObject = async () => {
   const storageKit = makeFakeStorageKit('assetReserveUpgradeTest');
   const { nameAdmin: namesByAddressAdmin } = makeNameHubKit();
-  const timer = buildManualTimer();
+  const timer = buildZoeManualTimer();
   const marshaller = makeFakeBoard().getReadonlyMarshaller();
 
   const { promise: committeeCreator, ...ccPK } = makePromiseKit();

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -8,7 +8,7 @@ import {
   makeRatioFromAmounts,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { deeplyFulfilled } from '@endo/marshal';
 
@@ -97,7 +97,7 @@ const defaultParamValues = debt =>
  *   rates: any;
  *   run: IssuerKit & AmountUtils;
  *   stableInitialLiquidity: Amount<'nat'>;
- *   timer: ReturnType<typeof buildManualTimer>;
+ *   timer: ReturnType<typeof buildZoeManualTimer>;
  *   zoe: ZoeService;
  * }} DriverContext
  */
@@ -211,7 +211,7 @@ const getRunFromFaucet = async (t, amt) => {
  * @param {Amount} priceBase
  */
 const setupServices = async (t, initialPrice, priceBase) => {
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const { zoe, run, aeth, interestTiming, minInitialDebt, rates } = t.context;
   t.context.timer = timer;
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -580,13 +580,11 @@ export const makeAuctioneerDriver = async t => {
     auctioneerKit,
     advanceTimerByStartFrequency: async () => {
       trace('advanceTimerByStartFrequency');
-      // @ts-expect-error ManualTimer debt https://github.com/Agoric/agoric-sdk/issues/7747
       await t.context.timer.advanceBy(BigInt(startFrequency));
       await eventLoopIteration();
     },
     induceTimequake: async () => {
       trace('induceTimequake');
-      // @ts-expect-error ManualTimer debt https://github.com/Agoric/agoric-sdk/issues/7747
       await t.context.timer.advanceBy(BigInt(startFrequency) * 10n);
       await eventLoopIteration();
     },

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -17,7 +17,7 @@ import {
   multiplyRatios,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
@@ -63,7 +63,7 @@ export async function start(zcf, privateArgs, baggage) {
 
   const { subscriber: assetSubscriber } = makePublishKit();
 
-  const timer = buildManualTimer(console.log, 0n, { timeStep: DAY });
+  const timer = buildZoeManualTimer(console.log, 0n, { timeStep: DAY });
   const options = {
     actualBrandIn: collateralBrand,
     actualBrandOut: stableBrand,

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -23,7 +23,7 @@ import {
 import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
 
 import { documentStorageSchema } from '@agoric/governance/tools/storageDoc.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { calculateCurrentDebt } from '../../src/interest-math.js';
 import { SECONDS_PER_YEAR } from '../../src/interest.js';
@@ -146,7 +146,7 @@ const setupServices = async (
   t,
   priceOrList,
   unitAmountIn,
-  timer = buildManualTimer(t.log, 0n, { eventLoopIteration }),
+  timer = buildZoeManualTimer(t.log, 0n, { eventLoopIteration }),
   quoteInterval = 1n,
   stableInitialLiquidity,
   startFrequency = undefined,
@@ -405,7 +405,7 @@ test('interest on multiple vaults', async t => {
     chargingPeriod: SECONDS_PER_WEEK,
     recordingPeriod: SECONDS_PER_WEEK,
   };
-  const manualTimer = buildManualTimer(t.log, 0n, {
+  const manualTimer = buildZoeManualTimer(t.log, 0n, {
     timeStep: SECONDS_PER_DAY,
     eventLoopIteration,
   });
@@ -604,7 +604,7 @@ test('adjust balances', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log),
+    buildZoeManualTimer(t.log),
     undefined,
     500n,
   );
@@ -848,7 +848,7 @@ test('adjust balances - withdraw RUN', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log),
+    buildZoeManualTimer(t.log),
     undefined,
     500n,
   );
@@ -916,7 +916,7 @@ test('adjust balances after interest charges', async t => {
   const { aeth, run } = t.context;
 
   // charge interest on every tick
-  const manualTimer = buildManualTimer(trace, 0n, {
+  const manualTimer = buildZoeManualTimer(trace, 0n, {
     timeStep: SECONDS_PER_DAY,
   });
   t.context.interestTiming = {
@@ -980,7 +980,7 @@ test('transfer vault', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log),
+    buildZoeManualTimer(t.log),
     undefined,
     500n,
   );
@@ -1113,7 +1113,7 @@ test('overdeposit', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log),
+    buildZoeManualTimer(t.log),
     undefined,
     500n,
   );
@@ -1238,7 +1238,7 @@ test('collect fees from vault', async t => {
   };
 
   // charge interest on every tick
-  const manualTimer = buildManualTimer(t.log, 0n, {
+  const manualTimer = buildZoeManualTimer(t.log, 0n, {
     timeStep: SECONDS_PER_WEEK,
     eventLoopIteration,
   });
@@ -1392,7 +1392,7 @@ test('close vault', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log, 0n, { eventLoopIteration }),
+    buildZoeManualTimer(t.log, 0n, { eventLoopIteration }),
     undefined,
     500n,
   );
@@ -1507,7 +1507,7 @@ test('debt too small - MinInitialDebt', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log),
+    buildZoeManualTimer(t.log),
     undefined,
     500n,
   );
@@ -1548,7 +1548,7 @@ test('excessive debt on collateral type - debtLimit', async t => {
     t,
     [15n],
     aeth.make(1n),
-    buildManualTimer(t.log),
+    buildZoeManualTimer(t.log),
     undefined,
     500n,
   );
@@ -1693,7 +1693,7 @@ test('manager notifiers, with snapshot', async t => {
   const ENOUGH = 10_000n;
 
   const { aeth, run } = t.context;
-  const manualTimer = buildManualTimer(t.log, 0n, {
+  const manualTimer = buildZoeManualTimer(t.log, 0n, {
     timeStep: SECONDS_PER_WEEK,
     eventLoopIteration,
   });

--- a/packages/orchestration/test/exos/local-chain-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-chain-account-kit.test.ts
@@ -7,7 +7,7 @@ import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E, Far } from '@endo/far';
 import { makeFakeLocalchainBridge } from '../supports.js';
@@ -36,7 +36,7 @@ test('localChainAccountKit - transfer', async t => {
       bankManager,
       system: localchainBridge,
     });
-    const timer = buildManualTimer(t.log);
+    const timer = buildZoeManualTimer(t.log);
     const marshaller = makeFakeBoard().getReadonlyMarshaller();
 
     return {

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -10,7 +10,7 @@ import {
 import { makeScalarBigMapStore, type Baggage } from '@agoric/vat-data';
 import { decodeBase64 } from '@endo/base64';
 import { E, Far } from '@endo/far';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import type { TimestampRecord, TimestampValue } from '@agoric/time';
@@ -187,7 +187,7 @@ const makeScenario = () => {
 
   const icqConnection = Far('ICQConnection', {}) as ICQConnection;
 
-  const timer = buildManualTimer(undefined, time.parse(startTime), {
+  const timer = buildZoeManualTimer(undefined, time.parse(startTime), {
     timeStep: TICK,
     eventLoopIteration,
   });

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -5,7 +5,7 @@ import { makeFakeBankManagerKit } from '@agoric/vats/tools/bank-utils.js';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import { makeFakeLocalchainBridge } from '@agoric/vats/tools/fake-bridge.js';
 import type { Installation } from '@agoric/zoe/src/zoeService/utils.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
@@ -38,7 +38,7 @@ export const commonSetup = async t => {
     bankManager,
     system: localchainBridge,
   });
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const marshaller = makeFakeBoard().getReadonlyMarshaller();
   const storage = makeFakeStorageKit('mockChainStorageRoot', {
     sequence: false,

--- a/packages/orchestration/test/utils/time.test.ts
+++ b/packages/orchestration/test/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { TimeMath } from '@agoric/time';
 import {
   makeTimestampHelper,
@@ -8,7 +8,7 @@ import {
 } from '../../src/utils/time.js';
 
 test('makeTimestampHelper - getCurrentTimestamp', async t => {
-  const timer = buildManualTimer(t.log);
+  const timer = buildZoeManualTimer(t.log);
   const timerBrand = timer.getTimerBrand();
   t.is(timer.getCurrentTimestamp().absValue, 0n, 'current time is 0n');
 

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -1,7 +1,7 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 
 import { makePrintLog } from './printLog.js';
 
@@ -33,7 +33,7 @@ const setupBasicMints = () => {
 };
 
 const makeVats = (log, vats, zoe, installations, startingValues) => {
-  const timer = buildManualTimer(log);
+  const timer = buildZoeManualTimer(log);
   const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
     mints.map((mint, i) =>

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -2,7 +2,7 @@ import {
   makeFakeVatAdmin,
   zcfBundleCap,
 } from '@agoric/zoe/tools/fakeVatAdmin.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { Far } from '@endo/marshal';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { bundles, devices } from '../test/devices.js';
@@ -67,7 +67,7 @@ export const makeMock = log =>
         buildSpawner: () => harden({ _: 'spawner' }),
       },
       timer: Far('TimerVat', {
-        createTimerService: async () => buildManualTimer(log),
+        createTimerService: async () => buildZoeManualTimer(log),
       }),
       uploads: { getUploads: () => harden({ _: 'uploads' }) },
 

--- a/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
+++ b/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
@@ -31,7 +31,7 @@ import {
 
 /**
  * @import {PriceAuthority, PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
- * @import {ManualTimer} from '../../../tools/manualTimer.js';
+ * @import {ZoeManualTimer} from '../../../tools/manualTimer.js';
  */
 
 /**
@@ -44,7 +44,7 @@ import {
  * Type to refine the `timer` term used in tests
  *
  * @param {ZCF<{
- * timer: ManualTimer,
+ * timer: ZoeManualTimer,
  * POLL_INTERVAL: bigint,
  * brandIn: Brand<'nat'>,
  * brandOut: Brand<'nat'>,

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -72,7 +72,11 @@ const nolog = (..._args) => {};
  * @returns {ZoeManualTimer}
  */
 
-const buildZoeManualTimer = (log = nolog, startValue = 0n, options = {}) => {
+export const buildZoeManualTimer = (
+  log = nolog,
+  startValue = 0n,
+  options = {},
+) => {
   const { timeStep = 1n, eventLoopIteration, ...buildOptions } = options;
   const optSuffix = msg => (msg ? `: ${msg}` : '');
   const callbacks = {
@@ -127,4 +131,5 @@ const buildZoeManualTimer = (log = nolog, startValue = 0n, options = {}) => {
 };
 harden(buildZoeManualTimer);
 
+// Default export is for backwards compatibility
 export default buildZoeManualTimer;

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/marshal';
 import { bindAllMethods } from '@agoric/internal';
-import { buildManualTimer as build } from '@agoric/swingset-vat/tools/manual-timer.js';
+import { buildManualTimer } from '@agoric/swingset-vat/tools/manual-timer.js';
 import { TimeMath } from '@agoric/time';
 
 /**
@@ -32,7 +32,7 @@ const nolog = (..._args) => {};
  * @property {(nTimes: number, msg?: string) => Promise<void>} tickN
  */
 
-/** @typedef {TimerServiceI & RemotableObject<'TimerService'> & RemotableBrand<ManualTimerAdmin, TimerServiceI & ManualTimerAdmin> & ManualTimerAdmin} ManualTimer */
+/** @typedef {ReturnType<typeof buildManualTimer> & RemotableBrand<ManualTimerAdmin, TimerServiceI & ManualTimerAdmin> & ManualTimerAdmin} ZoeManualTimer */
 
 /**
  * A fake TimerService, for unit tests that do not use a real
@@ -69,10 +69,10 @@ const nolog = (..._args) => {};
  * @param {(...args: any[]) => void} [log]
  * @param {import('@agoric/time').Timestamp | bigint} [startValue=0n]
  * @param {ZoeManualTimerOptions} [options]
- * @returns {ManualTimer}
+ * @returns {ZoeManualTimer}
  */
 
-const buildManualTimer = (log = nolog, startValue = 0n, options = {}) => {
+const buildZoeManualTimer = (log = nolog, startValue = 0n, options = {}) => {
   const { timeStep = 1n, eventLoopIteration, ...buildOptions } = options;
   const optSuffix = msg => (msg ? `: ${msg}` : '');
   const callbacks = {
@@ -90,7 +90,7 @@ const buildManualTimer = (log = nolog, startValue = 0n, options = {}) => {
   assert.typeof(startValue, 'bigint');
   assert.typeof(timeStepValue, 'bigint');
 
-  const timerService = build({
+  const timerService = buildManualTimer({
     startTime: startValue,
     ...buildOptions,
     callbacks,
@@ -125,6 +125,6 @@ const buildManualTimer = (log = nolog, startValue = 0n, options = {}) => {
     setWakeup,
   });
 };
-harden(buildManualTimer);
+harden(buildZoeManualTimer);
 
-export default buildManualTimer;
+export default buildZoeManualTimer;


### PR DESCRIPTION
refs: #7747

## Description

As a stopgap to unifying the manual timer, this
1. fixes the types of ZoeManualTimer
2. gives it a named export that is different from the SwingSet one, so it is more clear in context which is available

### Security Considerations

None, tests
### Scaling Considerations

None, tests

### Documentation Considerations

Not documented

### Testing Considerations

CI
### Upgrade Considerations

None, tests