### PR TITLE
fix localchain bridge types and mocks

### DIFF
--- a/a3p-integration/proposals/c:stake-bld/stakeBld.test.js
+++ b/a3p-integration/proposals/c:stake-bld/stakeBld.test.js
@@ -70,6 +70,6 @@ test('basic', async t => {
   t.is(postDelegation.length, 2, 'new delegation now');
   t.like(postDelegation[1], {
     balance: { amount: '10', denom: 'ubld' },
-    // omit 'delegation' because it has 'delgatorAddress' which is different every test run
+    // omit 'delegation' because it has 'delegatorAddress' which is different every test run
   });
 });

--- a/a3p-integration/proposals/c:stake-bld/stakeBld.test.js
+++ b/a3p-integration/proposals/c:stake-bld/stakeBld.test.js
@@ -66,10 +66,31 @@ test('basic', async t => {
     },
   });
 
-  const postDelegation = await currentDelegation();
-  t.is(postDelegation.length, 2, 'new delegation now');
-  t.like(postDelegation[1], {
+  const afterDelegate = await currentDelegation();
+  t.is(afterDelegate.length, 2, 'delegations after delegation');
+  t.like(afterDelegate[1], {
     balance: { amount: '10', denom: 'ubld' },
     // omit 'delegation' because it has 'delegatorAddress' which is different every test run
   });
+
+  await walletUtils.broadcastBridgeAction(GOV1ADDR, {
+    method: 'executeOffer',
+    offer: {
+      id: 'request-undelegate',
+      invitationSpec: {
+        source: 'continuing',
+        previousOffer: 'request-stake',
+        invitationMakerName: 'Undelegate',
+        invitationArgs: [VALIDATOR_ADDRESS, { brand: brand.BLD, value: 5n }],
+      },
+      proposal: {},
+    },
+  });
+
+  // TODO find a way to wait until completionTime, so we can check the count has gone back down
+  // const afterUndelegate = await currentDelegation();
+  // t.is(afterDelegate.length, 1, 'delegations after undelegation');
+  // t.like(afterUndelegate[1], {
+  //   balance: { amount: '5', denom: 'ubld' },
+  // });
 });

--- a/golang/cosmos/x/vlocalchain/vlocalchain.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain.go
@@ -57,7 +57,7 @@ func (h portHandler) Receive(cctx context.Context, str string) (ret string, err 
 		}
 
 		// We need jsonpb for its access to the global registry.
-		marshaller := jsonpb.Marshaler{EmitDefaults: true, OrigName: true}
+		marshaller := jsonpb.Marshaler{EmitDefaults: true, OrigName: false}
 
 		var s string
 		resps := make([]json.RawMessage, len(qms))

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -303,11 +303,11 @@ func TestQuery(t *testing.T) {
 		}
 
 		// Check the field names and values
-		if unbond["delegator_address"] != firstAddr {
-			t.Errorf("expected delegator_address %s, got %v", firstAddr, unbond["delegator_address"])
+		if unbond["delegatorAddress"] != firstAddr {
+			t.Errorf("expected delegatorAddress %s, got %v", firstAddr, unbond["delegator_address"])
 		}
-		if unbond["validator_address"] != "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj" {
-			t.Errorf("expected validator_address cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj, got %v", unbond["validator_address"])
+		if unbond["validatorAddress"] != "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj" {
+			t.Errorf("expected validatorAddress cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj, got %v", unbond["validator_address"])
 		}
 
 		entries, ok := unbond["entries"].([]interface{})
@@ -318,14 +318,14 @@ func TestQuery(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected unbonding delegation entry to be a map, got %v", entries[0])
 		}
-		if entry["creation_height"] != "100" {
-			t.Errorf("expected creation_height \"100\", got %v", entry["creation_height"])
+		if entry["creationHeight"] != "100" {
+			t.Errorf("expected creationHeight \"100\", got %v", entry["creation_height"])
 		}
 		if entry["balance"] != "500" {
 			t.Errorf("expected balance \"500\", got %v", entry["balance"])
 		}
-		if _, ok := entry["completion_time"]; !ok {
-			t.Error("expected completion_time field in the response")
+		if _, ok := entry["completionTime"]; !ok {
+			t.Error("expected completionTime field in the response")
 		}
 	})
 }

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -405,8 +405,8 @@ func TestExecuteTx(t *testing.T) {
 	t.Run("MsgUndelegate", func(t *testing.T) {
 		// create a new message
 		msg := `{"type":"VLOCALCHAIN_EXECUTE_TX","address":"` + addr +
-			`","messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate","delegator_address":"` +
-			addr + `","validator_address":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj","amount":{"denom":"stake","amount":"100"}}]}`
+			`","messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate","delegatorAddress":"` +
+			addr + `","validatorAddress":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj","amount":{"denom":"stake","amount":"100"}}]}`
 
 		ret, err := handler.Receive(cctx, msg)
 		if err != nil {

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/app/params"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
@@ -16,6 +17,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -77,8 +79,36 @@ func (t *mockTransfer) Transfer(cctx context.Context, msg *transfertypes.MsgTran
 	return &transfertypes.MsgTransferResponse{Sequence: 1}, nil
 }
 
+type mockStaking struct {
+	stakingtypes.UnimplementedMsgServer
+	stakingtypes.UnimplementedQueryServer
+}
+
+var _ stakingtypes.MsgServer = (*mockStaking)(nil)
+var _ stakingtypes.QueryServer = (*mockStaking)(nil)
+
+func (s *mockStaking) Undelegate(cctx context.Context, msg *stakingtypes.MsgUndelegate) (*stakingtypes.MsgUndelegateResponse, error) {
+	return &stakingtypes.MsgUndelegateResponse{CompletionTime: time.Now().UTC()}, nil
+}
+
+func (s *mockStaking) UnbondingDelegation(cctx context.Context, req *stakingtypes.QueryUnbondingDelegationRequest) (*stakingtypes.QueryUnbondingDelegationResponse, error) {
+	unbondingDelegation := stakingtypes.UnbondingDelegation{
+		DelegatorAddress: req.DelegatorAddr,
+		ValidatorAddress: "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj",
+		Entries: []stakingtypes.UnbondingDelegationEntry{
+			{
+				CreationHeight: 100,
+				CompletionTime: time.Now().UTC().Add(time.Hour * 24 * 7),
+				InitialBalance: sdk.NewInt(1000),
+				Balance:        sdk.NewInt(500),
+			},
+		},
+	}
+	return &stakingtypes.QueryUnbondingDelegationResponse{Unbond: unbondingDelegation}, nil
+}
+
 // makeTestKit creates a minimal Keeper and Context for use in testing.
-func makeTestKit(bank *mockBank, transfer *mockTransfer) (vm.PortHandler, context.Context) {
+func makeTestKit(bank *mockBank, transfer *mockTransfer, staking *mockStaking) (vm.PortHandler, context.Context) {
 	encodingConfig := params.MakeEncodingConfig()
 	cdc := encodingConfig.Marshaler
 
@@ -93,6 +123,10 @@ func makeTestKit(bank *mockBank, transfer *mockTransfer) (vm.PortHandler, contex
 	transfertypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	transfertypes.RegisterMsgServer(txRouter, transfer)
 	transfertypes.RegisterQueryServer(queryRouter, transfer)
+	stakingtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	stakingtypes.RegisterMsgServer(txRouter, staking)
+	stakingtypes.RegisterQueryServer(queryRouter, staking)
+
 
 	// create a new Keeper
 	keeper := vlocalchain.NewKeeper(cdc, vlocalchainStoreKey, txRouter, queryRouter)
@@ -118,7 +152,8 @@ func makeTestKit(bank *mockBank, transfer *mockTransfer) (vm.PortHandler, contex
 func TestAllocateAddress(t *testing.T) {
 	bank := &mockBank{}
 	transfer := &mockTransfer{}
-	handler, cctx := makeTestKit(bank, transfer)
+	staking := &mockStaking{}
+	handler, cctx := makeTestKit(bank, transfer, staking)
 
 	addrs := map[string]bool{
 		firstAddr: false,
@@ -161,7 +196,8 @@ func TestQuery(t *testing.T) {
 		alreadyAddr: []sdk.Coin{sdk.NewCoin("stale", sdk.NewInt(321))},
 	}}
 	transfer := &mockTransfer{}
-	handler, cctx := makeTestKit(bank, transfer)
+	staking := &mockStaking{}
+	handler, cctx := makeTestKit(bank, transfer, staking)
 
 	// get balances
 	testCases := []struct {
@@ -230,6 +266,68 @@ func TestQuery(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("UnbondingDelegation", func(t *testing.T) {
+		// create a new message
+		msg := `{"type":"VLOCALCHAIN_QUERY_MANY","messages":[{"@type":"/cosmos.staking.v1beta1.QueryUnbondingDelegationRequest","delegator_addr":"` + firstAddr + `","validator_addr":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj"}]}`
+		t.Logf("query request: %v", msg)
+		ret, err := handler.Receive(cctx, msg)
+		t.Logf("query response: %v", ret)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ret == "" {
+			t.Fatalf("expected non-empty json")
+		}
+
+		// Unmarshal the JSON response
+		var respJSON []map[string]interface{}
+		if err := json.Unmarshal([]byte(ret), &respJSON); err != nil {
+			t.Fatalf("unexpected error unmarshalling JSON response: %v", err)
+		}
+
+		// Check the response fields
+		if len(respJSON) != 1 {
+			t.Fatalf("expected 1 response, got %d", len(respJSON))
+		}
+		resp := respJSON[0]
+
+		replyAny, ok := resp["reply"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected reply field to be a map, got %v", resp["reply"])
+		}
+
+		unbond, ok := replyAny["unbond"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected unbond field to be a map, got %v", replyAny["unbond"])
+		}
+
+		// Check the field names and values
+		if unbond["delegator_address"] != firstAddr {
+			t.Errorf("expected delegator_address %s, got %v", firstAddr, unbond["delegator_address"])
+		}
+		if unbond["validator_address"] != "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj" {
+			t.Errorf("expected validator_address cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj, got %v", unbond["validator_address"])
+		}
+
+		entries, ok := unbond["entries"].([]interface{})
+		if !ok || len(entries) != 1 {
+			t.Fatalf("expected 1 unbonding delegation entry, got %v", entries)
+		}
+		entry, ok := entries[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected unbonding delegation entry to be a map, got %v", entries[0])
+		}
+		if entry["creation_height"] != "100" {
+			t.Errorf("expected creation_height \"100\", got %v", entry["creation_height"])
+		}
+		if entry["balance"] != "500" {
+			t.Errorf("expected balance \"500\", got %v", entry["balance"])
+		}
+		if _, ok := entry["completion_time"]; !ok {
+			t.Error("expected completion_time field in the response")
+		}
+	})
 }
 
 func TestExecuteTx(t *testing.T) {
@@ -239,7 +337,8 @@ func TestExecuteTx(t *testing.T) {
 		alreadyAddr: []sdk.Coin{sdk.NewCoin("stale", sdk.NewInt(321))},
 	}}
 	transfer := &mockTransfer{}
-	handler, cctx := makeTestKit(bank, transfer)
+	staking := &mockStaking{}
+	handler, cctx := makeTestKit(bank, transfer, staking)
 
 	// create a new message
 	msg := `{"type":"VLOCALCHAIN_ALLOCATE_ADDRESS"}`
@@ -302,4 +401,34 @@ func TestExecuteTx(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("MsgUndelegate", func(t *testing.T) {
+		// create a new message
+		msg := `{"type":"VLOCALCHAIN_EXECUTE_TX","address":"` + addr +
+			`","messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate","delegator_address":"` +
+			addr + `","validator_address":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj","amount":{"denom":"stake","amount":"100"}}]}`
+
+		ret, err := handler.Receive(cctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if ret == "" {
+			t.Fatalf("expected non-empty json")
+		}
+
+		// Unmarshal the response
+		var resp []map[string]interface{}
+		if err := json.Unmarshal([]byte(ret), &resp); err != nil {
+			t.Fatalf("unexpected error unmarshalling response: %v", err)
+		}
+
+		// Check the response fields
+		if len(resp) != 1 {
+			t.Fatalf("expected 1 response, got %d", len(resp))
+		}
+		
+		if _, ok := resp[0]["completion_time"]; !ok {
+			t.Error("expected 'completion_time' field in response")
+		}
+	})
 }

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -427,8 +427,8 @@ func TestExecuteTx(t *testing.T) {
 			t.Fatalf("expected 1 response, got %d", len(resp))
 		}
 		
-		if _, ok := resp[0]["completion_time"]; !ok {
-			t.Error("expected 'completion_time' field in response")
+		if _, ok := resp[0]["completionTime"]; !ok {
+			t.Error("expected 'completionTime' field in response")
 		}
 	})
 }

--- a/packages/cosmic-proto/src/codegen/json-safe.ts
+++ b/packages/cosmic-proto/src/codegen/json-safe.ts
@@ -6,9 +6,7 @@
  */
 
 export type JsonSafe<T> = {
-  [Prop in keyof T]: T[Prop] extends Uint8Array
+  [Prop in keyof T]: T[Prop] extends Uint8Array | bigint | Date
     ? string
-    : T[Prop] extends bigint
-      ? string
-      : T[Prop];
+    : T[Prop];
 };

--- a/packages/cosmic-proto/test/helpers.test-d.ts
+++ b/packages/cosmic-proto/test/helpers.test-d.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd';
 import { typedJson } from '../src/helpers.js';
-import type { ResponseTo } from '../src/helpers.ts';
+import type { ResponseTo, TypedJson } from '../src/helpers.ts';
+import type { JsonSafe } from '../src/codegen/json-safe.js';
 
 // MsgSend
 {
@@ -29,4 +30,35 @@ import type { ResponseTo } from '../src/helpers.ts';
   // @ts-expect-error invalid value for response
   response['@type'] = '/cosmos.bank.v1beta1.QueryAllBalancesRequest';
   response.balances = [{ denom: 'ucosm', amount: '1' }];
+}
+
+// Delegation
+{
+  const request = typedJson('/cosmos.staking.v1beta1.MsgDelegate', {
+    amount: { denom: 'ucosm', amount: '1' },
+    delegatorAddress: 'agoric1from',
+    validatorAddress: 'agoric1to',
+  });
+  const response: ResponseTo<typeof request> = null as any;
+  expectType<'/cosmos.staking.v1beta1.MsgDelegateResponse'>(response['@type']);
+}
+{
+  const request = typedJson('/cosmos.staking.v1beta1.MsgUndelegate', {
+    amount: { denom: 'ucosm', amount: '1' },
+    delegatorAddress: 'agoric1from',
+    validatorAddress: 'agoric1to',
+  });
+  const response: ResponseTo<typeof request> = null as any;
+  expectType<'/cosmos.staking.v1beta1.MsgUndelegateResponse'>(
+    response['@type'],
+  );
+}
+
+// JsonSafe
+{
+  const response: TypedJson<'/cosmos.staking.v1beta1.MsgUndelegateResponse'> =
+    null as any;
+  expectType<Date>(response.completionTime);
+  const responseJson: JsonSafe<typeof response> = null as any;
+  expectType<string>(responseJson.completionTime);
 }

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -193,7 +193,6 @@ export const makeFakeLocalchainBridge = (zone, onToBridge = () => {}) => {
                 return /** @type {JsonSafe<MsgDelegateResponse>} */ ({});
               }
               case '/cosmos.staking.v1beta1.MsgUndelegate': {
-                // @ts-expect-error XXX JsonSafe doesn't handle Date
                 return /** @type {JsonSafe<MsgUndelegateResponse>} */ ({
                   completionTime: new Date().toJSON(),
                 });

--- a/patches/@cosmology+telescope+1.7.0.patch
+++ b/patches/@cosmology+telescope+1.7.0.patch
@@ -154,6 +154,18 @@ index 07b6e47..87c78db 100644
  
  export interface AminoHeight {
    readonly revision_number?: string;
+diff --git a/node_modules/@cosmology/telescope/main/helpers/json-safe.js b/node_modules/@cosmology/telescope/main/helpers/json-safe.js
+index 3112594..c2cebde 100644
+--- a/node_modules/@cosmology/telescope/main/helpers/json-safe.js
++++ b/node_modules/@cosmology/telescope/main/helpers/json-safe.js
+@@ -3,6 +3,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.jsonSafe = void 0;
+ exports.jsonSafe = `
+ export type JsonSafe<T> = {
+-  [Prop in keyof T]: T[Prop] extends Uint8Array ? string : T[Prop] extends bigint ? string : T[Prop];
++  [Prop in keyof T]: T[Prop] extends Uint8Array | bigint | Date ? string : T[Prop];
+ }
+ `;
 diff --git a/node_modules/@cosmology/telescope/module/helpers/internal-for-bigint.js b/node_modules/@cosmology/telescope/module/helpers/internal-for-bigint.js
 index 1d19b1c..1c182dc 100644
 --- a/node_modules/@cosmology/telescope/module/helpers/internal-for-bigint.js
@@ -307,6 +319,17 @@ index ecb2e3e..4e96aff 100644
  
  export interface AminoHeight {
    readonly revision_number?: string;
+diff --git a/node_modules/@cosmology/telescope/module/helpers/json-safe.js b/node_modules/@cosmology/telescope/module/helpers/json-safe.js
+index 32c77fc..e0f4cbf 100644
+--- a/node_modules/@cosmology/telescope/module/helpers/json-safe.js
++++ b/node_modules/@cosmology/telescope/module/helpers/json-safe.js
+@@ -1,5 +1,5 @@
+ export const jsonSafe = `
+ export type JsonSafe<T> = {
+-  [Prop in keyof T]: T[Prop] extends Uint8Array ? string : T[Prop] extends bigint ? string : T[Prop];
++  [Prop in keyof T]: T[Prop] extends Uint8Array | bigint | Date ? string : T[Prop];
+ }
+ `;
 diff --git a/node_modules/@cosmology/telescope/src/helpers/internal-for-bigint.ts b/node_modules/@cosmology/telescope/src/helpers/internal-for-bigint.ts
 index f7daa3d..1680276 100644
 --- a/node_modules/@cosmology/telescope/src/helpers/internal-for-bigint.ts


### PR DESCRIPTION

## Description

While working on Undelegate, I noticed some inconsistencies in the handling of `completionTime` which is a Date.

This attempts to fix up the type descriptions and mocks for the Cosmos messages going back and forth over the bridge.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

no changes to behavior of deployed code