### PR TITLE
docs(a3p-integration): Add hyperlinks

### DIFF
--- a/a3p-integration/proposals/a:upgrade-next/README.md
+++ b/a3p-integration/proposals/a:upgrade-next/README.md
@@ -2,10 +2,10 @@
 
 The `UNRELEASED_UPGRADE` software upgrade may include core proposals defined in
 its upgrade handler. See `CoreProposalSteps` in the `unreleasedUpgradeHandler`
-in `agoric-sdk/golang/cosmos/app/app.go`.
+in [golang/cosmos/app/app.go](../../../golang/cosmos/app/app.go).
 
-This test also includes a core proposal in its `upgradeInfo`. This is executed
-after the core proposals defined in the software's upgrade handler. See `agoricProposal`
-in `package.json`.
+This test proposal may also include `coreProposals` in its `upgradeInfo`, which
+are executed after those defined in that upgrade handler. See `agoricProposal`
+in [package.json](./package.json).
 
 The "binaries" property of `upgradeInfo` is now required since Cosmos SDK 0.46, however it cannot be computed for an unreleased upgrade. To disable the check, `releaseNotes` is set to `false`.

--- a/a3p-integration/proposals/b:localchain/README.md
+++ b/a3p-integration/proposals/b:localchain/README.md
@@ -1,5 +1,6 @@
-CoreEvalProposal to install vat-localchain
+# CoreEvalProposal to install vat-localchain
 
-The `submission` for the proposal is automatically generated during `yarn build`
-in `a3p-integration` using the code in agoric-sdk through
-`script/generate-a3p-submissions.sh`. and `script/generate-a3p-submission.sh`
+The `submission` for this proposal is automatically generated during `yarn build`
+in [a3p-integration](../..) using the code in agoric-sdk through
+[build-all-submissions.sh](../../scripts/build-all-submissions.sh) and
+[build-submission.sh](../../scripts/build-submission.sh).

--- a/a3p-integration/proposals/c:stake-bld/README.md
+++ b/a3p-integration/proposals/c:stake-bld/README.md
@@ -1,5 +1,6 @@
-CoreEvalProposal to install stakeBld contract
+# CoreEvalProposal to install stakeBld contract
 
-The `submission` for the proposal is automatically generated during `yarn build`
-in `a3p-integration` using the code in agoric-sdk through
-`script/build-all-submissions.sh`. and `script/build-submission.sh`
+The `submission` for this proposal is automatically generated during `yarn build`
+in [a3p-integration](../..) using the code in agoric-sdk through
+[build-all-submissions.sh](../../scripts/build-all-submissions.sh) and
+[build-submission.sh](../../scripts/build-submission.sh).

--- a/a3p-integration/proposals/z:acceptance/README.md
+++ b/a3p-integration/proposals/z:acceptance/README.md
@@ -1,6 +1,5 @@
 # Inert proposal to test acceptance of the history of upgrades
 
 Its `type` is `/cosmos.params.v1beta1.ParameterChangeProposal` because that is
-the lightest form of actual proposal to execute. It runs the `eval.sh` script,
-which does nothing.
-
+the lightest form of actual proposal to execute. It runs the [eval.sh](./eval.sh)
+script, which does nothing.


### PR DESCRIPTION
## Description

A no-ticket drive-by to improve the usefulness of README files in a3p-integration.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a

### Upgrade Considerations

n/a