### PR TITLE
feat(types): loadVat WellKnownVats

### DIFF
--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -8,6 +8,7 @@
         'packages/inter-protocol/**/*.js',
         'packages/orchestration/**/*.js',
         'packages/store/**/*.js',
+        'packages/smart-wallet/**/*.js',
         'packages/vats/**/*.js',
       ],
       options: {

--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -6,6 +6,7 @@
       files: [
         'packages/ERTP/**/*.js',
         'packages/inter-protocol/**/*.js',
+        'packages/orchestration/**/*.js',
         'packages/store/**/*.js',
         'packages/vats/**/*.js',
       ],

--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -12,6 +12,7 @@
       options: {
         plugins: ['prettier-plugin-jsdoc'],
         jsdocAddDefaultToDescription: false,
+        jsdocCommentLineStrategy: 'keep',
         jsdocCapitalizeDescription: false,
         tsdoc: true,
       },

--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -6,6 +6,7 @@
       files: [
         'packages/ERTP/**/*.js',
         'packages/inter-protocol/**/*.js',
+        'packages/internal/**/*.js',
         'packages/orchestration/**/*.js',
         'packages/store/**/*.js',
         'packages/smart-wallet/**/*.js',

--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -4,10 +4,10 @@
     {
       // opt into prettier-plugin-jsdoc
       files: [
-        'packages/ERTP/**/*.{js,ts}',
-        'packages/inter-protocol/**/*.{js,ts}',
-        'packages/store/**/*.{js,ts}',
-        'packages/vats/**/*.{js,ts}',
+        'packages/ERTP/**/*.js',
+        'packages/inter-protocol/**/*.js',
+        'packages/store/**/*.js',
+        'packages/vats/**/*.js',
       ],
       options: {
         plugins: ['prettier-plugin-jsdoc'],

--- a/.prettierrc.json5
+++ b/.prettierrc.json5
@@ -12,7 +12,6 @@
       options: {
         plugins: ['prettier-plugin-jsdoc'],
         jsdocAddDefaultToDescription: false,
-        jsdocParser: true,
         jsdocCapitalizeDescription: false,
         tsdoc: true,
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lerna": "^5.6.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
-    "prettier-plugin-jsdoc": "^1.0.0",
+    "prettier-plugin-jsdoc": "^1.3.0",
     "prettier-plugin-sh": "^0.14.0",
     "type-coverage": "^2.27.1",
     "typedoc": "^0.25.13",

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -19,7 +19,7 @@ const scaleDecimals = num => BigInt(num * Number(COSMOS_UNIT));
  *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
  *   'brand'
  * >} agoricNames
- * @param {| { giveMinted?: number; wantMinted?: number }
+ * @param {{ giveMinted?: number; wantMinted?: number }
  *   | {
  *       collateralBrandKey: string;
  *       giveCollateral?: number;
@@ -180,7 +180,7 @@ export const lookupOfferIdForVault = async (vaultId, currentP) => {
  *   string,
  *   import('@agoric/internal/src/marshal.js').BoardRemote
  * >} brands
- * @param {| { wantMinted: number; giveMinted?: undefined }
+ * @param {{ wantMinted: number; giveMinted?: undefined }
  *   | { giveMinted: number; wantMinted?: undefined }} opts
  * @param {number} [fee]
  * @param {string} [anchor]

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -76,6 +76,7 @@ const validRoundId = roundId => {
  *   }
  * >} HeldParams
  *
+ *
  * @typedef {Readonly<
  *   HeldParams & {
  *     details: MapStore<bigint, RoundDetails>;
@@ -83,6 +84,7 @@ const validRoundId = roundId => {
  *     unitIn: bigint;
  *   }
  * >} ImmutableState
+ *
  *
  * @typedef {{
  *   lastValueOutForUnitIn: bigint?;

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -43,6 +43,7 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 /**
  * @typedef {WellKnownSpaces & ChainBootstrapSpace & EconomyBootstrapSpace} EconomyBootstrapPowers
  *
+ *
  * @typedef {PromiseSpaceOf<{
  *   economicCommitteeKit: CommitteeStartResult;
  *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet;

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -49,6 +49,7 @@ const trace = makeTracer('VD', true);
  *   rewardPoolAllocation: AmountKeywordRecord;
  * }} MetricsNotification
  *
+ *
  * @typedef {Readonly<{}>} ImmutableState
  *
  * @typedef {{}} MutableState
@@ -65,6 +66,7 @@ const trace = makeTracer('VD', true);
  *     import('../reserve/assetReserve.js').ShortfallReporter
  *   >;
  * }} FactoryPowersFacet
+ *
  *
  * @typedef {Readonly<{
  *   state: State;

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -147,6 +147,7 @@ export const watchQuoteNotifier = async (notifierP, watcher, ...args) => {
  *   latestInterestUpdate: Timestamp;
  * }} AssetState
  *
+ *
  * @typedef {{
  *   getChargingPeriod: () => RelativeTime;
  *   getRecordingPeriod: () => RelativeTime;

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -15,7 +15,7 @@ const trace = makeTracer('TestMetrics', false);
 
 /**
  * @template {object} N
- * @param {| AsyncIterable<N, N>
+ * @param {AsyncIterable<N, N>
  *   | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} mixed
  */
 const asNotifier = mixed => {
@@ -28,7 +28,7 @@ const asNotifier = mixed => {
 /**
  * @template {object} N
  * @param {import('ava').ExecutionContext} t
- * @param {| AsyncIterable<N, N>
+ * @param {AsyncIterable<N, N>
  *   | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} subscription
  */
 export const subscriptionTracker = async (t, subscription) => {

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -105,7 +105,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
   );
   const bridgeManager = await consume.bridgeManager;
   /**
-   * @type {| undefined
+   * @type {undefined
    *   | import('@agoric/vats').ScopedBridgeManager<'wallet'>}
    */
   // @ts-expect-error XXX EProxy

--- a/packages/internal/src/batched-deliver.js
+++ b/packages/internal/src/batched-deliver.js
@@ -9,7 +9,10 @@ export const DEFAULT_BATCH_TIMEOUT_MS = 1000;
 
 /**
  * @param {DeliverMessages} deliver
- * @param {{ clearTimeout: import('node:timers').clearTimeout, setTimeout: import('node:timers').setTimeout }} io
+ * @param {{
+ *   clearTimeout: import('node:timers').clearTimeout;
+ *   setTimeout: import('node:timers').setTimeout;
+ * }} io
  * @param {number} batchTimeoutMs
  */
 export function makeBatchedDeliver(

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -3,8 +3,8 @@ import { E } from '@endo/far';
 import { isObject, isPassableSymbol } from '@endo/marshal';
 import { getInterfaceMethodKeys } from '@endo/patterns';
 
-/** @import { ERef } from '@endo/far' */
-/** @import { Callback, SyncCallback } from './types.js' */
+/** @import {ERef} from '@endo/far' */
+/** @import {Callback, SyncCallback} from './types.js' */
 
 const { Fail, quote: q } = assert;
 
@@ -12,19 +12,21 @@ const { fromEntries } = Object;
 
 const { ownKeys: rawOwnKeys } = Reflect;
 const ownKeys =
-  /** @type {<T extends PropertyKey>(obj: {[K in T]?: unknown}) => T[]} */ (
+  /** @type {<T extends PropertyKey>(obj: { [K in T]?: unknown }) => T[]} */ (
     rawOwnKeys
   );
 
 /**
  * @template {import('@endo/exo').Methods} T
- * @typedef {(...args: Parameters<ReturnType<prepareAttenuator>>) => import('@endo/exo').Farable<T>} MakeAttenuator
+ * @typedef {(
+ *   ...args: Parameters<ReturnType<prepareAttenuator>>
+ * ) => import('@endo/exo').Farable<T>} MakeAttenuator
  */
 
 /**
  * @param {unknown} key
  * @returns {key is PropertyKey} FIXME: should be just `PropertyKey` but TS
- * complains it can't be used as an index type.
+ *   complains it can't be used as an index type.
  */
 const isPropertyKey = key => {
   switch (typeof key) {
@@ -94,9 +96,7 @@ harden(makeSyncFunctionCallback);
  * Create a callback from a potentially far function.
  *
  * @template {(...args: unknown[]) => any} I
- * @template {ERef<
- *   (...args: [...B, ...Parameters<I>]) => ReturnType<I>
- * >} [T=ERef<I>]
+ * @template {ERef<(...args: [...B, ...Parameters<I>]) => ReturnType<I>>} [T=ERef<I>]
  * @template {unknown[]} [B=[]]
  * @param {T} target
  * @param {B} bound
@@ -117,7 +117,7 @@ harden(makeFunctionCallback);
  * @template {(...args: unknown[]) => any} I
  * @template {PropertyKey} P
  * @template {{
- *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>
+ *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>;
  * }} [T={ [x in P]: I }]
  * @template {unknown[]} [B=[]]
  * @param {T} target
@@ -143,7 +143,7 @@ harden(makeSyncMethodCallback);
  * @template {(...args: unknown[]) => any} I
  * @template {PropertyKey} P
  * @template {ERef<{
- *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>
+ *   [x in P]: (...args: [...B, ...Parameters<I>]) => ReturnType<I>;
  * }>} [T=ERef<{ [x in P]: I }>]
  * @template {unknown[]} [B=[]]
  * @param {T} target
@@ -185,13 +185,14 @@ harden(isCallback);
  * Prepare an attenuator class whose methods can be redirected via callbacks.
  *
  * @template {PropertyKey} M
- * @param {import('@agoric/base-zone').Zone} zone The zone in which to allocate attenuators.
+ * @param {import('@agoric/base-zone').Zone} zone The zone in which to allocate
+ *   attenuators.
  * @param {M[]} methodNames Methods to forward.
  * @param {object} opts
  * @param {import('@endo/patterns').InterfaceGuard<{
- *  [K in M]: import('@endo/patterns').MethodGuard
- * }>} [opts.interfaceGuard] An interface guard for the
- * new attenuator.
+ *   [K in M]: import('@endo/patterns').MethodGuard;
+ * }>} [opts.interfaceGuard]
+ *   An interface guard for the new attenuator.
  * @param {string} [opts.tag] A tag for the new attenuator exoClass.
  */
 export const prepareAttenuator = (
@@ -201,7 +202,9 @@ export const prepareAttenuator = (
 ) => {
   /**
    * @typedef {(this: any, ...args: unknown[]) => any} Method
-   * @typedef {{ [K in M]?: Callback<any> | null}} Overrides
+   *
+   * @typedef {{ [K in M]?: Callback<any> | null }} Overrides
+   *
    * @typedef {{ [K in M]: (this: any, ...args: unknown[]) => any }} Methods
    */
   const methods = /** @type {Methods} */ (
@@ -244,14 +247,13 @@ export const prepareAttenuator = (
    * and/or individual method override callbacks.
    *
    * @param {object} opts
-   * @param {unknown} [opts.target] The target for any methods that
-   * weren't specified in `opts.overrides`.
+   * @param {unknown} [opts.target] The target for any methods that weren't
+   *   specified in `opts.overrides`.
    * @param {boolean} [opts.isSync=false] Whether the target should be treated
-   * as synchronously available.
-   * @param {Overrides} [opts.overrides] Set individual
-   * callbacks for methods (whose names must be defined in the
-   * `prepareAttenuator` or `prepareGuardedAttenuator` call).  Nullish overrides
-   * mean to throw.
+   *   as synchronously available.
+   * @param {Overrides} [opts.overrides] Set individual callbacks for methods
+   *   (whose names must be defined in the `prepareAttenuator` or
+   *   `prepareGuardedAttenuator` call). Nullish overrides mean to throw.
    */
   const makeAttenuator = zone.exoClass(
     tag,

--- a/packages/internal/src/chain-storage-paths.js
+++ b/packages/internal/src/chain-storage-paths.js
@@ -1,9 +1,8 @@
 // @jessie-check
 
 /**
- * These identify top-level paths for SwingSet chain storage
- * (and serve as prefixes).
- * To avoid collisions, they should remain synchronized with
+ * These identify top-level paths for SwingSet chain storage (and serve as
+ * prefixes). To avoid collisions, they should remain synchronized with
  * golang/cosmos/x/swingset/keeper/keeper.go
  */
 export const ACTION_QUEUE = 'actionQueue';

--- a/packages/internal/src/config.js
+++ b/packages/internal/src/config.js
@@ -4,11 +4,13 @@
 /**
  * @file
  *
- * Some of this config info may make more sense in a particular package. However
- * due to https://github.com/Agoric/agoric-sdk/issues/4620 and our lax package
- * dependency graph, sometimes rational placements cause type resolution errors.
+ *   Some of this config info may make more sense in a particular package. However
+ *   due to https://github.com/Agoric/agoric-sdk/issues/4620 and our lax package
+ *   dependency graph, sometimes rational placements cause type resolution
+ *   errors.
  *
- * So as a work-around some constants that need access from more than one package are placed here.
+ *   So as a work-around some constants that need access from more than one
+ *   package are placed here.
  */
 
 /**

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -35,7 +35,8 @@ const { Fail } = assert;
 /**
  * This represents a node in an IAVL tree.
  *
- * The active implementation is x/vstorage, an Agoric extension of the Cosmos SDK.
+ * The active implementation is x/vstorage, an Agoric extension of the Cosmos
+ * SDK.
  *
  * Vstorage is a hierarchical externally-reachable storage structure that
  * identifies children by restricted ASCII name and is associated with arbitrary
@@ -43,9 +44,13 @@ const { Fail } = assert;
  *
  * @typedef {object} StorageNode
  * @property {(data: string) => Promise<void>} setValue publishes some data
- * @property {() => string} getPath the chain storage path at which the node was constructed
+ * @property {() => string} getPath the chain storage path at which the node was
+ *   constructed
  * @property {() => Promise<VStorageKey>} getStoreKey DEPRECATED use getPath
- * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNode} makeChildNode
+ * @property {(
+ *   subPath: string,
+ *   options?: { sequence?: boolean },
+ * ) => StorageNode} makeChildNode
  */
 
 const ChainStorageNodeI = M.interface('StorageNode', {
@@ -59,9 +64,8 @@ const ChainStorageNodeI = M.interface('StorageNode', {
 
 /**
  * This is an imperfect heuristic to navigate the migration from value cells to
- * stream cells.
- * At time of writing, no legacy cells have the same shape as a stream cell,
- * and we do not intend to create any more legacy value cells.
+ * stream cells. At time of writing, no legacy cells have the same shape as a
+ * stream cell, and we do not intend to create any more legacy value cells.
  *
  * @param {any} cell
  * @returns {cell is StreamCell}
@@ -91,9 +95,11 @@ harden(assertCapData);
 
 /**
  * @typedef {object} StoredFacet
- * @property {() => Promise<string>} getPath the chain storage path at which the node was constructed
+ * @property {() => Promise<string>} getPath the chain storage path at which the
+ *   node was constructed
  * @property {StorageNode['getStoreKey']} getStoreKey DEPRECATED use getPath
- * @property {() => Unserializer} getUnserializer get the unserializer for the stored data
+ * @property {() => Unserializer} getUnserializer get the unserializer for the
+ *   stored data
  */
 
 // TODO: Formalize segment constraints.
@@ -113,19 +119,36 @@ harden(assertPathSegment);
 /**
  * Must match the switch in vstorage.go using `vstorageMessage` type
  *
- * @typedef { 'get' | 'getStoreKey' | 'has' | 'children' | 'entries' | 'values' |'size' } StorageGetByPathMessageMethod
- * @typedef { 'set' | 'setWithoutNotify' | 'append' } StorageUpdateEntriesMessageMethod
- * @typedef {StorageGetByPathMessageMethod | StorageUpdateEntriesMessageMethod } StorageMessageMethod
- * @typedef { [path: string] } StorageGetByPathMessageArgs
- * @typedef { [path: string, value?: string | null] } StorageEntry
- * @typedef { StorageEntry[] } StorageUpdateEntriesMessageArgs
+ * @typedef {'get'
+ *   | 'getStoreKey'
+ *   | 'has'
+ *   | 'children'
+ *   | 'entries'
+ *   | 'values'
+ *   | 'size'} StorageGetByPathMessageMethod
+ *
+ *
+ * @typedef {'set' | 'setWithoutNotify' | 'append'} StorageUpdateEntriesMessageMethod
+ *
+ *
+ * @typedef {StorageGetByPathMessageMethod
+ *   | StorageUpdateEntriesMessageMethod} StorageMessageMethod
+ *
+ *
+ * @typedef {[path: string]} StorageGetByPathMessageArgs
+ *
+ * @typedef {[path: string, value?: string | null]} StorageEntry
+ *
+ * @typedef {StorageEntry[]} StorageUpdateEntriesMessageArgs
+ *
  * @typedef {{
- *   method: StorageGetByPathMessageMethod;
- *   args: StorageGetByPathMessageArgs;
- *  } | {
- *   method: StorageUpdateEntriesMessageMethod;
- *   args: StorageUpdateEntriesMessageArgs;
- * }} StorageMessage
+ *       method: StorageGetByPathMessageMethod;
+ *       args: StorageGetByPathMessageArgs;
+ *     }
+ *   | {
+ *       method: StorageUpdateEntriesMessageMethod;
+ *       args: StorageUpdateEntriesMessageArgs;
+ *     }} StorageMessage
  */
 
 /**
@@ -135,22 +158,26 @@ export const prepareChainStorageNode = zone => {
   /**
    * Create a storage node for a given backing storage interface and path.
    *
-   * @param {import('./types.js').Callback<(message: StorageMessage) => any>} messenger a callback
-   * for sending a storageMessage object to the storage implementation
-   * (cf. golang/cosmos/x/vstorage/vstorage.go)
+   * @param {import('./types.js').Callback<
+   *   (message: StorageMessage) => any
+   * >} messenger
+   *   a callback for sending a storageMessage object to the storage
+   *   implementation (cf. golang/cosmos/x/vstorage/vstorage.go)
    * @param {string} path
    * @param {object} [options]
-   * @param {boolean} [options.sequence] set values with `append` messages rather than `set` messages
-   * so the backing implementation employs a wrapping structure that
-   * preserves each value set within a single block.
-   * Child nodes default to inheriting this option from their parent.
+   * @param {boolean} [options.sequence] set values with `append` messages
+   *   rather than `set` messages so the backing implementation employs a
+   *   wrapping structure that preserves each value set within a single block.
+   *   Child nodes default to inheriting this option from their parent.
    * @returns {StorageNode}
    */
   const makeChainStorageNode = zone.exoClass(
     'ChainStorageNode',
     ChainStorageNodeI,
     /**
-     * @param {import('./types.js').Callback<(message: StorageMessage) => any>} messenger
+     * @param {import('./types.js').Callback<
+     *   (message: StorageMessage) => any
+     * >} messenger
      * @param {string} path
      * @param {object} [options]
      * @param {boolean} [options.sequence]
@@ -175,7 +202,12 @@ export const prepareChainStorageNode = zone => {
           args: [path],
         });
       },
-      /** @type {(name: string, childNodeOptions?: {sequence?: boolean}) => StorageNode} */
+      /**
+       * @type {(
+       *   name: string,
+       *   childNodeOptions?: { sequence?: boolean },
+       * ) => StorageNode}
+       */
       makeChildNode(name, childNodeOptions = {}) {
         const { sequence, path, messenger } = this.state;
         assertPathSegment(name);
@@ -217,16 +249,17 @@ export const prepareChainStorageNode = zone => {
 const makeHeapChainStorageNode = prepareChainStorageNode(makeHeapZone());
 
 /**
- * Create a heap-based root storage node for a given backing function and root path.
+ * Create a heap-based root storage node for a given backing function and root
+ * path.
  *
  * @param {(message: StorageMessage) => any} handleStorageMessage a function for
- * sending a storageMessage object to the storage implementation
- * (cf. golang/cosmos/x/vstorage/vstorage.go)
+ *   sending a storageMessage object to the storage implementation (cf.
+ *   golang/cosmos/x/vstorage/vstorage.go)
  * @param {string} rootPath
  * @param {object} [rootOptions]
  * @param {boolean} [rootOptions.sequence] employ a wrapping structure that
- * preserves each value set within a single block, and default child nodes
- * to do the same
+ *   preserves each value set within a single block, and default child nodes to
+ *   do the same
  */
 export function makeChainStorageRoot(
   handleStorageMessage,
@@ -241,7 +274,8 @@ export function makeChainStorageRoot(
 }
 
 /**
- * @returns {StorageNode} an object that confirms to StorageNode API but does not store anywhere.
+ * @returns {StorageNode} an object that confirms to StorageNode API but does
+ *   not store anywhere.
  */
 const makeNullStorageNode = () => {
   // XXX re-use "ChainStorage" methods above which don't actually depend on chains

--- a/packages/internal/src/lib-nodejs/spawnSubprocessWorker.js
+++ b/packages/internal/src/lib-nodejs/spawnSubprocessWorker.js
@@ -18,14 +18,14 @@ function parentLog(first, ...args) {
   // console.error(`--parent: ${first}`, ...args);
 }
 
-/** @typedef { import('child_process').IOType } IOType */
-/** @typedef { import('stream').Writable } Writable */
+/** @typedef {import('child_process').IOType} IOType */
+/** @typedef {import('stream').Writable} Writable */
 
 // we send on fd3, and receive on fd4. We pass fd1/2 (stdout/err) through, so
 // console log/err from the child shows up normally. We don't use Node's
 // built-in serialization feature ('ipc') because the child process won't
 // always be Node.
-/** @type { IOType[] } */
+/** @type {IOType[]} */
 const stdio = harden(['inherit', 'inherit', 'inherit', 'pipe', 'pipe']);
 
 export function startSubprocessWorker(
@@ -68,13 +68,15 @@ export function startSubprocessWorker(
   /* @type {typeof fromChild} */
   const wrappedFromChild = {
     on: (...args) =>
-      fromChild.on(.../** @type {Parameters<typeof fromChild['on']>} */ (args)),
+      fromChild.on(
+        .../** @type {Parameters<(typeof fromChild)['on']>} */ (args),
+      ),
   };
   /* @type {typeof toChild} */
   const wrappedToChild = {
     write: (...args) =>
       toChild.write(
-        .../** @type {Parameters<typeof toChild['write']>} */ (args),
+        .../** @type {Parameters<(typeof toChild)['write']>} */ (args),
       ),
   };
 

--- a/packages/internal/src/lib-nodejs/worker-protocol.js
+++ b/packages/internal/src/lib-nodejs/worker-protocol.js
@@ -6,11 +6,10 @@ import { Transform } from 'stream';
 
 export function arrayEncoderStream() {
   /**
-   *
-   * @this {{ push: (b: Buffer) => void }}
-   * @param {*} object
+   * @param {any} object
    * @param {BufferEncoding} encoding
-   * @param {*} callback
+   * @param {any} callback
+   * @this {{ push: (b: Buffer) => void }}
    */
   function transform(object, encoding, callback) {
     if (!Array.isArray(object)) {
@@ -30,11 +29,10 @@ export function arrayEncoderStream() {
 
 export function arrayDecoderStream() {
   /**
-   *
-   * @this {{ push: (b: Buffer) => void }}
    * @param {Buffer} buf
    * @param {BufferEncoding} encoding
-   * @param {*} callback
+   * @param {any} callback
+   * @this {{ push: (b: Buffer) => void }}
    */
   function transform(buf, encoding, callback) {
     let err;

--- a/packages/internal/src/magic-cookie-test-only.js
+++ b/packages/internal/src/magic-cookie-test-only.js
@@ -3,8 +3,8 @@
 const cookie = harden({});
 
 /**
- * Facilitate static analysis to prevent
- * demo/test facilities from being bundled in production.
+ * Facilitate static analysis to prevent demo/test facilities from being bundled
+ * in production.
  */
 export const notForProductionUse = () => {
   return cookie;

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -6,13 +6,14 @@ import { isStreamCell } from './lib-chainStorage.js';
 const { Fail } = assert;
 
 /**
- * Should be a union with Remotable, but that's `any`, making this type meaningless
+ * Should be a union with Remotable, but that's `any`, making this type
+ * meaningless
  *
  * @typedef {{ getBoardId: () => string | null }} BoardRemote
  */
 
 /**
- * @param {{ boardId: string | null, iface?: string }} slotInfo
+ * @param {{ boardId: string | null; iface?: string }} slotInfo
  * @returns {BoardRemote}
  */
 export const makeBoardRemote = ({ boardId, iface }) => {
@@ -36,13 +37,15 @@ const boardValToSlot = val => {
 };
 
 /**
- * A marshaller which can serialize getBoardId() -bearing
- * Remotables. This allows the caller to pick their slots. The
- * deserializer is configurable: the default cannot handle
- * Remotable-bearing data.
+ * A marshaller which can serialize getBoardId() -bearing Remotables. This
+ * allows the caller to pick their slots. The deserializer is configurable: the
+ * default cannot handle Remotable-bearing data.
  *
  * @param {(slot: string, iface: string) => any} [slotToVal]
- * @returns {Omit<import('@endo/marshal').Marshal<string | null>, 'serialize' | 'unserialize'>}
+ * @returns {Omit<
+ *   import('@endo/marshal').Marshal<string | null>,
+ *   'serialize' | 'unserialize'
+ * >}
  */
 export const boardSlottingMarshaller = (slotToVal = undefined) => {
   return makeMarshal(boardValToSlot, slotToVal, {
@@ -70,9 +73,12 @@ harden(assertCapData);
  *
  * @param {Map<string, string>} data
  * @param {string} key
- * @param {ReturnType<typeof import('@endo/marshal').makeMarshal>['fromCapData']} fromCapData
- * @param {number} index index of the desired value in a deserialized stream cell
- * @return {any}
+ * @param {ReturnType<
+ *   typeof import('@endo/marshal').makeMarshal
+ * >['fromCapData']} fromCapData
+ * @param {number} index index of the desired value in a deserialized stream
+ *   cell
+ * @returns {any}
  */
 export const unmarshalFromVstorage = (data, key, fromCapData, index) => {
   const serialized = data.get(key) || Fail`no data for ${key}`;
@@ -90,7 +96,7 @@ export const unmarshalFromVstorage = (data, key, fromCapData, index) => {
   const marshalled = values.at(index);
   assert.typeof(marshalled, 'string');
 
-  /** @type {import("@endo/marshal").CapData<string>} */
+  /** @type {import('@endo/marshal').CapData<string>} */
   const capData = harden(JSON.parse(marshalled));
   assertCapData(capData);
 
@@ -102,7 +108,7 @@ harden(unmarshalFromVstorage);
 /**
  * Provide access to object graphs serialized in vstorage.
  *
- * @param {Array<[string, string]>} entries
+ * @param {[string, string][]} entries
  * @param {(slot: string, iface?: string) => any} [slotToVal]
  */
 export const makeHistoryReviver = (entries, slotToVal = undefined) => {

--- a/packages/internal/src/method-tools.js
+++ b/packages/internal/src/method-tools.js
@@ -2,7 +2,8 @@
 import { isObject } from '@endo/marshal';
 
 /**
- * @file method-tools use dynamic property lookup, which is not Jessie-compatible
+ * @file method-tools use dynamic property lookup, which is not
+ *   Jessie-compatible
  */
 
 const { getPrototypeOf, create, fromEntries, getOwnPropertyDescriptors } =
@@ -12,8 +13,8 @@ const { ownKeys, apply } = Reflect;
 /**
  * Prioritize symbols as earlier than strings.
  *
- * @param {string|symbol} a
- * @param {string|symbol} b
+ * @param {string | symbol} a
+ * @param {string | symbol} b
  * @returns {-1 | 0 | 1}
  */
 const compareStringified = (a, b) => {
@@ -77,22 +78,22 @@ export const getStringMethodNames = val =>
 /**
  * TODO This function exists only to ease the
  * https://github.com/Agoric/agoric-sdk/pull/5970 transition, from all methods
- * being own properties to methods being inherited from a common prototype.
- * This transition breaks two patterns used in prior code: autobinding,
- * and enumerating methods by enumerating own properties. For both, the
- * preferred repairs are
- *    * autobinding: Replace, for example,
- *      `foo(obj.method)` with `foo(arg => `obj.method(arg))`. IOW, stop relying
- *      on expressions like `obj.method` to extract a method still bound to the
- *      state of `obj` because, for virtual and durable objects,
- *      they no longer will after #5970.
- *    * method enumeration: Replace, for example
- *      `Reflect.ownKeys(obj)` with `getMethodNames(obj)`.
+ * being own properties to methods being inherited from a common prototype. This
+ * transition breaks two patterns used in prior code: autobinding, and
+ * enumerating methods by enumerating own properties. For both, the preferred
+ * repairs are
+ *
+ * - autobinding: Replace, for example, `foo(obj.method)` with `foo(arg =>
+ *   `obj.method(arg))`. IOW, stop relying on expressions like `obj.method`to
+ *   extract a method still bound to the state of`obj` because, for virtual and
+ *   durable objects, they no longer will after #5970.
+ * - method enumeration: Replace, for example `Reflect.ownKeys(obj)` with
+ *   `getMethodNames(obj)`.
  *
  * Once all problematic cases have been converted in this manner, this
  * `bindAllMethods` hack can and TODO should be deleted. However, we currently
- * have no reliable static way to track down and fix all autobinding sites.
- * For those objects that have not yet been fully repaired by the above two
+ * have no reliable static way to track down and fix all autobinding sites. For
+ * those objects that have not yet been fully repaired by the above two
  * techniques, `bindAllMethods` creates an object that acts much like the
  * pre-#5970 objects, with all their methods as instance-bound own properties.
  * It does this by making a new object inheriting from `obj` where the new

--- a/packages/internal/src/netstring.js
+++ b/packages/internal/src/netstring.js
@@ -20,11 +20,10 @@ export function encode(data) {
 // input is a sequence of strings, output is a byte pipe
 export function netstringEncoderStream() {
   /**
-   *
-   * @this {{ push: (b: Buffer) => void }}
    * @param {Buffer} chunk
    * @param {BufferEncoding} encoding
-   * @param {*} callback
+   * @param {any} callback
+   * @this {{ push: (b: Buffer) => void }}
    */
   function transform(chunk, encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {
@@ -44,11 +43,11 @@ export function netstringEncoderStream() {
 }
 
 /**
- *
  * @param {Buffer} data containing zero or more netstrings and maybe some
- * leftover bytes
+ *   leftover bytes
  * @param {number} [optMaxChunkSize]
- * @returns {{ leftover: Buffer, payloads: Buffer[] }} zero or more decoded Buffers, one per netstring,
+ * @returns {{ leftover: Buffer; payloads: Buffer[] }} zero or more decoded
+ *   Buffers, one per netstring,
  */
 export function decode(data, optMaxChunkSize) {
   // TODO: it would be more efficient to accumulate pending data in an array,
@@ -85,19 +84,17 @@ export function decode(data, optMaxChunkSize) {
 }
 
 /**
- *
- * @param {number} [optMaxChunkSize ]
+ * @param {number} [optMaxChunkSize]
  * @returns {Transform}
  */
 // input is a byte pipe, output is a sequence of Buffers
 export function netstringDecoderStream(optMaxChunkSize) {
   let buffered = Buffer.from('');
   /**
-   *
-   * @this {{ push: (b: Buffer) => void }}
    * @param {Buffer} chunk
    * @param {BufferEncoding} encoding
-   * @param {*} callback
+   * @param {any} callback
+   * @this {{ push: (b: Buffer) => void }}
    */
   function transform(chunk, encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {

--- a/packages/internal/src/node/buffer-line-transform.js
+++ b/packages/internal/src/node/buffer-line-transform.js
@@ -5,16 +5,19 @@ import { Transform } from 'node:stream';
 
 /**
  * @typedef {object} BufferLineTransformOptions
- * @property {Buffer | string | number} [break] line break matcher for Buffer.indexOf() (default: 10)
- * @property {BufferEncoding} [breakEncoding] if break is a string, the encoding to use
+ * @property {Buffer | string | number} [break] line break matcher for
+ *   Buffer.indexOf() (default: 10)
+ * @property {BufferEncoding} [breakEncoding] if break is a string, the encoding
+ *   to use
  */
 
 export default class BufferLineTransform extends Transform {
   /**
-   * The BufferLineTransform is reading String or Buffer content from a Readable stream
-   * and writing each line as a Buffer in object mode
+   * The BufferLineTransform is reading String or Buffer content from a Readable
+   * stream and writing each line as a Buffer in object mode
    *
-   * @param {import('node:stream').TransformOptions & BufferLineTransformOptions} [options]
+   * @param {import('node:stream').TransformOptions &
+   *   BufferLineTransformOptions} [options]
    */
   constructor(options) {
     const {
@@ -37,15 +40,15 @@ export default class BufferLineTransform extends Transform {
     }
     this._breakLength = breakLength;
 
-    /** @type {Array<Buffer>} */
+    /** @type {Buffer[]} */
     this._chunks = [];
   }
 
   /**
-   * @override
    * @param {any} chunk
    * @param {BufferEncoding | 'buffer'} encoding
    * @param {import('node:stream').TransformCallback} cb
+   * @override
    */
   _transform(chunk, encoding, cb) {
     try {
@@ -96,8 +99,8 @@ export default class BufferLineTransform extends Transform {
   }
 
   /**
-   * @override
    * @param {import('node:stream').TransformCallback} cb
+   * @override
    */
   _flush(cb) {
     if (this._chunks.length) {

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -2,7 +2,7 @@ import { createWriteStream } from 'node:fs';
 import { open } from 'node:fs/promises';
 
 /**
- * @param {import("fs").ReadStream | import("fs").WriteStream} stream
+ * @param {import('fs').ReadStream | import('fs').WriteStream} stream
  * @returns {Promise<void>}
  */
 export const fsStreamReady = stream =>

--- a/packages/internal/src/priority-senders.js
+++ b/packages/internal/src/priority-senders.js
@@ -20,9 +20,13 @@ harden(normalizeSenderNamespace);
  */
 export const makePrioritySendersManager = sendersNode => {
   /**
-   * address to tuple with storage node and set of namespaces that requested priority
+   * address to tuple with storage node and set of namespaces that requested
+   * priority
    *
-   * @type {Map<string, readonly [node: StorageNode, namespaces: Set<string>]>}
+   * @type {Map<
+   *   string,
+   *   readonly [node: StorageNode, namespaces: Set<string>]
+   * >}
    */
   const addressRecords = new Map();
 
@@ -47,7 +51,7 @@ export const makePrioritySendersManager = sendersNode => {
     const node = await E(sendersNode).makeChildNode(address, {
       sequence: false,
     });
-    /** @type {readonly [ node: StorageNode, namespaces: Set<string> ]} */
+    /** @type {readonly [node: StorageNode, namespaces: Set<string>]} */
     const r = [node, new Set()];
     addressRecords.set(address, r);
     return r;

--- a/packages/internal/src/queue.js
+++ b/packages/internal/src/queue.js
@@ -3,8 +3,8 @@
 import { makePromiseKit } from '@endo/promise-kit';
 
 /**
- * Return a function that can wrap an async or sync method, but
- * ensures only one of them (in order) is running at a time.
+ * Return a function that can wrap an async or sync method, but ensures only one
+ * of them (in order) is running at a time.
  */
 export const makeWithQueue = () => {
   const queue = [];

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -15,11 +15,13 @@ const { Fail } = assert;
 const trace = makeTracer('StorTU', false);
 
 /**
- * A map corresponding with a total function such that `get(key)`
- * is assumed to always succeed.
+ * A map corresponding with a total function such that `get(key)` is assumed to
+ * always succeed.
  *
  * @template K, V
- * @typedef {{[k in Exclude<keyof Map<K, V>, 'get'>]: Map<K, V>[k]} & {get: (key: K) => V}} TotalMap
+ * @typedef {{ [k in Exclude<keyof Map<K, V>, 'get'>]: Map<K, V>[k] } & {
+ *   get: (key: K) => V;
+ * }} TotalMap
  */
 /**
  * @template T
@@ -27,8 +29,8 @@ const trace = makeTracer('StorTU', false);
  */
 
 /**
- * A convertSlotToVal function that produces basic Remotables. Assumes
- * that all slots are Remotables (i.e. none are Promises).
+ * A convertSlotToVal function that produces basic Remotables. Assumes that all
+ * slots are Remotables (i.e. none are Promises).
  *
  * @param {string} _slotId
  * @param {string} iface
@@ -37,34 +39,34 @@ export const slotToRemotable = (_slotId, iface = 'Remotable') =>
   Remotable(iface);
 
 /**
- * A basic marshaller whose unserializer produces Remotables. It can
- * only serialize plain data, not Remotables.
+ * A basic marshaller whose unserializer produces Remotables. It can only
+ * serialize plain data, not Remotables.
  */
 export const defaultMarshaller = makeMarshal(undefined, slotToRemotable, {
   serializeBodyFormat: 'smallcaps',
 });
 
 /**
- * A deserializer which produces slot strings instead of Remotables,
- * so if `a = Far('iface')`, and serializing `{ a }` into `capData`
- * assigned it slot `board123`, then `slotStringUnserialize(capData)`
- * would produce `{ a: 'board123' }`.
+ * A deserializer which produces slot strings instead of Remotables, so if `a =
+ * Far('iface')`, and serializing `{ a }` into `capData` assigned it slot
+ * `board123`, then `slotStringUnserialize(capData)` would produce `{ a:
+ * 'board123' }`.
  *
  * This may be useful for display purposes.
  *
  * Limitations:
- *  * it cannot handle Symbols (registered or well-known)
- *  * it can handle BigInts, but serialized data that contains a
- *     particular unusual string will be unserialized into a BigInt by
- *     mistake
- *  * it cannot handle Promises, NaN, +/- Infinity, undefined, or
- *    other non-JSONable JavaScript values
+ *
+ * - it cannot handle Symbols (registered or well-known)
+ * - it can handle BigInts, but serialized data that contains a particular unusual
+ *   string will be unserialized into a BigInt by mistake
+ * - it cannot handle Promises, NaN, +/- Infinity, undefined, or other
+ *   non-JSONable JavaScript values
  */
 const makeSlotStringUnserialize = () => {
-  /** @type { (slot: string, iface: string) => any } */
+  /** @type {(slot: string, iface: string) => any} */
   const identitySlotToValFn = (slot, _) => Far('unk', { toJSON: () => slot });
   const { fromCapData } = makeMarshal(undefined, identitySlotToValFn);
-  /** @type { (capData: any) => any } */
+  /** @type {(capData: any) => any} */
   const unserialize = capData =>
     JSON.parse(
       JSON.stringify(fromCapData(capData), (_, val) => {
@@ -89,9 +91,9 @@ const makeSlotStringUnserialize = () => {
 export const slotStringUnserialize = makeSlotStringUnserialize();
 
 /**
- * For testing, creates a chainStorage root node over an in-memory map
- * and exposes both the map and the sequence of received messages.
- * The `sequence` option defaults to true.
+ * For testing, creates a chainStorage root node over an in-memory map and
+ * exposes both the map and the sequence of received messages. The `sequence`
+ * option defaults to true.
  *
  * @param {string} rootPath
  * @param {Parameters<typeof makeChainStorageRoot>[2]} [rootOptions]
@@ -205,15 +207,19 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
   };
 };
 harden(makeFakeStorageKit);
-/** @typedef {ReturnType< typeof makeFakeStorageKit>} FakeStorageKit */
+/** @typedef {ReturnType<typeof makeFakeStorageKit>} FakeStorageKit */
 
 /**
  * @typedef MockChainStorageRootMethods
- * @property {(path: string, marshaller?: Marshaller, index?: number) => unknown} getBody
- * Defaults to deserializing slot references into plain Remotable
- * objects having the specified interface name (as from `Far(iface)`),
- * but can accept a different marshaller for producing Remotables
- * that e.g. embed the slot string in their iface name.
+ * @property {(
+ *   path: string,
+ *   marshaller?: Marshaller,
+ *   index?: number,
+ * ) => unknown} getBody
+ *   Defaults to deserializing slot references into plain Remotable objects having
+ *   the specified interface name (as from `Far(iface)`), but can accept a
+ *   different marshaller for producing Remotables that e.g. embed the slot
+ *   string in their iface name.
  * @property {() => string[]} keys
  */
 /** @typedef {StorageNode & MockChainStorageRootMethods} MockChainStorageRoot */
@@ -224,10 +230,10 @@ export const makeMockChainStorageRoot = () => {
   return Far('mockChainStorage', {
     ...bindAllMethods(rootNode),
     /**
-     * Defaults to deserializing slot references into plain Remotable
-     * objects having the specified interface name (as from `Far(iface)`),
-     * but can accept a different marshaller for producing Remotables
-     * that e.g. embed the slot string in their iface name.
+     * Defaults to deserializing slot references into plain Remotable objects
+     * having the specified interface name (as from `Far(iface)`), but can
+     * accept a different marshaller for producing Remotables that e.g. embed
+     * the slot string in their iface name.
      *
      * @param {string} path
      * @param {Marshaller} marshaller
@@ -236,7 +242,11 @@ export const makeMockChainStorageRoot = () => {
      */
     getBody: (path, marshaller = defaultMarshaller, index = -1) => {
       data.size || Fail`no data in storage`;
-      /** @type {ReturnType<typeof import('@endo/marshal').makeMarshal>['fromCapData']} */
+      /**
+       * @type {ReturnType<
+       *   typeof import('@endo/marshal').makeMarshal
+       * >['fromCapData']}
+       */
       const fromCapData = (...args) =>
         Reflect.apply(marshaller.fromCapData, marshaller, args);
       return unmarshalFromVstorage(data, path, fromCapData, index);

--- a/packages/internal/src/testing-utils.js
+++ b/packages/internal/src/testing-utils.js
@@ -1,13 +1,15 @@
-/** @file note this cannot be called test-utils.js due to https://github.com/Agoric/agoric-sdk/issues/7503 */
+/**
+ * @file note this cannot be called test-utils.js due to
+ *   https://github.com/Agoric/agoric-sdk/issues/7503
+ */
 /* global setImmediate */
 
 /**
  * A workaround for some issues with fake time in tests.
  *
- * Lines of test code can depend on async promises outside the test
- * resolving before they run. Awaiting this function result ensures
- * that all promises that can do resolve.
- * Note that this doesn't mean all outstanding promises.
+ * Lines of test code can depend on async promises outside the test resolving
+ * before they run. Awaiting this function result ensures that all promises that
+ * can do resolve. Note that this doesn't mean all outstanding promises.
  */
 export const eventLoopIteration = async () =>
   new Promise(resolve => setImmediate(resolve));

--- a/packages/internal/src/upgrade-api.js
+++ b/packages/internal/src/upgrade-api.js
@@ -6,13 +6,13 @@ import { M, matches } from '@endo/patterns';
 const { isFrozen } = Object;
 
 /**
- * An Error-like object for use as the rejection reason of promises
- * abandoned by upgrade.
+ * An Error-like object for use as the rejection reason of promises abandoned by
+ * upgrade.
  *
  * @typedef {{
- *   name: 'vatUpgraded',
- *   upgradeMessage: string,
- *   incarnationNumber: number
+ *   name: 'vatUpgraded';
+ *   upgradeMessage: string;
+ *   incarnationNumber: number;
  * }} UpgradeDisconnection
  */
 
@@ -39,9 +39,9 @@ export const makeUpgradeDisconnection = (upgradeMessage, toIncarnationNumber) =>
 harden(makeUpgradeDisconnection);
 
 /**
- * @param {any} reason
- *   If `reason` is not frozen, it cannot be an UpgradeDisconnection,
- *   so returns false without even checking against the shape.
+ * @param {any} reason If `reason` is not frozen, it cannot be an
+ *   UpgradeDisconnection, so returns false without even checking against the
+ *   shape.
  * @returns {reason is UpgradeDisconnection}
  */
 export const isUpgradeDisconnection = reason =>

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -12,13 +12,13 @@ const { quote: q, Fail } = assert;
 
 export const BASIS_POINTS = 10_000n;
 
-/** @import { ERef } from '@endo/far' */
+/** @import {ERef} from '@endo/far' */
 
 /**
  * @template T
- * @typedef {{[KeyType in keyof T]: T[KeyType]} & {}} Simplify
- * flatten the type output to improve type hints shown in editors
- * https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ * @typedef {{ [KeyType in keyof T]: T[KeyType] } & {}} Simplify flatten the
+ *   type output to improve type hints shown in editors
+ *   https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
  */
 
 /**
@@ -27,19 +27,24 @@ export const BASIS_POINTS = 10_000n;
 
 /**
  * @template {{}} T
- * @typedef {{ [K in keyof T]: T[K] extends Callable ? T[K] : DeeplyAwaited<T[K]> }} DeeplyAwaitedObject
+ * @typedef {{
+ *   [K in keyof T]: T[K] extends Callable ? T[K] : DeeplyAwaited<T[K]>;
+ * }} DeeplyAwaitedObject
  */
 
 /**
  * @template T
- * @typedef {T extends PromiseLike<any> ? Awaited<T> : T extends {} ? Simplify<DeeplyAwaitedObject<T>> : Awaited<T>} DeeplyAwaited
+ * @typedef {T extends PromiseLike<any>
+ *     ? Awaited<T>
+ *     : T extends {}
+ *       ? Simplify<DeeplyAwaitedObject<T>>
+ *       : Awaited<T>} DeeplyAwaited
  */
 
 /**
  * A more constrained version of {deeplyFulfilled} for type safety until
- * https://github.com/endojs/endo/issues/1257
- * Useful in starting contracts that need all terms to be fulfilled
- * in order to be durable.
+ * https://github.com/endojs/endo/issues/1257 Useful in starting contracts that
+ * need all terms to be fulfilled in order to be durable.
  *
  * @type {<T extends {}>(unfulfilledTerms: T) => Promise<DeeplyAwaited<T>>}
  */
@@ -54,7 +59,9 @@ export const deeplyFulfilledObject = async obj => {
  * and report the result in seconds to match our telemetry standard.
  *
  * @param {typeof import('perf_hooks').performance.now} currentTimeMillisec
- * @returns {<T>(fn: () => Promise<T>) => Promise<{ result: T, duration: number }>}
+ * @returns {<T>(
+ *   fn: () => Promise<T>,
+ * ) => Promise<{ result: T; duration: number }>}
  */
 export const makeMeasureSeconds = currentTimeMillisec => {
   /** @param {() => any} fn */
@@ -92,7 +99,7 @@ export const PromiseAllOrErrors = async items => {
 /**
  * @type {<T>(
  *   trier: () => Promise<T>,
- *  finalizer: (error?: unknown) => Promise<void>,
+ *   finalizer: (error?: unknown) => Promise<void>,
  * ) => Promise<T>}
  */
 export const aggregateTryFinally = async (trier, finalizer) =>
@@ -109,7 +116,7 @@ export const aggregateTryFinally = async (trier, finalizer) =>
 
 /**
  * @template {Record<string, unknown>} T
- * @typedef {{[P in keyof T]: Exclude<T[P], undefined>;}} AllDefined
+ * @typedef {{ [P in keyof T]: Exclude<T[P], undefined> }} AllDefined
  */
 
 /**
@@ -118,8 +125,8 @@ export const aggregateTryFinally = async (trier, finalizer) =>
  *
  * @template {Record<string, unknown>} T
  * @param {T} obj
- * @throws if any value in the object entries is not defined
  * @returns {asserts obj is AllDefined<T>}
+ * @throws if any value in the object entries is not defined
  */
 export const assertAllDefined = obj => {
   const missing = [];
@@ -143,10 +150,9 @@ export const forever = asyncGenerate(() => notDone);
 
 /**
  * @template T
- * @param {() => T} produce
- * The value of `await produce()` is used for its truthiness vs falsiness.
- * IOW, it is coerced to a boolean so the caller need not bother doing this
- * themselves.
+ * @param {() => T} produce The value of `await produce()` is used for its
+ *   truthiness vs falsiness. IOW, it is coerced to a boolean so the caller need
+ *   not bother doing this themselves.
  * @returns {AsyncIterable<Awaited<T>>}
  */
 export const whileTrue = produce =>
@@ -163,10 +169,9 @@ export const whileTrue = produce =>
 
 /**
  * @template T
- * @param {() => T} produce
- * The value of `await produce()` is used for its truthiness vs falsiness.
- * IOW, it is coerced to a boolean so the caller need not bother doing this
- * themselves.
+ * @param {() => T} produce The value of `await produce()` is used for its
+ *   truthiness vs falsiness. IOW, it is coerced to a boolean so the caller need
+ *   not bother doing this themselves.
  * @returns {AsyncIterable<Awaited<T>>}
  */
 export const untilTrue = produce =>
@@ -184,10 +189,14 @@ export const untilTrue = produce =>
     });
   });
 
-/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
+/** @type {<X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
 export const zip = (xs, ys) => harden(xs.map((x, i) => [x, ys[+i]]));
 
-/** @type { <T extends Record<string, ERef<any>>>(obj: T) => Promise<{ [K in keyof T]: Awaited<T[K]>}> } */
+/**
+ * @type {<T extends Record<string, ERef<any>>>(
+ *   obj: T,
+ * ) => Promise<{ [K in keyof T]: Awaited<T[K]> }>}
+ */
 export const allValues = async obj => {
   const resolved = await Promise.all(values(obj));
   // @ts-expect-error cast
@@ -195,9 +204,9 @@ export const allValues = async obj => {
 };
 
 /**
- * A tee implementation where all readers are synchronized with each other.
- * They all consume the source stream in lockstep, and any one returning or
- * throwing early will affect the others.
+ * A tee implementation where all readers are synchronized with each other. They
+ * all consume the source stream in lockstep, and any one returning or throwing
+ * early will affect the others.
  *
  * @template [T=unknown]
  * @param {AsyncIterator<T, void, void>} sourceStream
@@ -207,7 +216,11 @@ export const synchronizedTee = (sourceStream, readerCount) => {
   /** @type {IteratorReturnResult<void> | undefined} */
   let doneResult;
 
-  /** @typedef {IteratorResult<(value: PromiseLike<IteratorResult<T>>) => void>} QueuePayload */
+  /**
+   * @typedef {IteratorResult<
+   *   (value: PromiseLike<IteratorResult<T>>) => void
+   * >} QueuePayload
+   */
   /** @type {import('@endo/stream').AsyncQueue<QueuePayload>[]} */
   const queues = [];
 
@@ -267,13 +280,21 @@ export const synchronizedTee = (sourceStream, readerCount) => {
     /** @type {AsyncGenerator<T, void, void>} */
     const reader = harden({
       async next() {
-        /** @type {import('@endo/promise-kit').PromiseKit<IteratorResult<T>>} */
+        /**
+         * @type {import('@endo/promise-kit').PromiseKit<
+         *   IteratorResult<T>
+         * >}
+         */
         const { promise, resolve } = makePromiseKit();
         queue.put({ value: resolve, done: false });
         return promise;
       },
       async return() {
-        /** @type {import('@endo/promise-kit').PromiseKit<IteratorResult<T>>} */
+        /**
+         * @type {import('@endo/promise-kit').PromiseKit<
+         *   IteratorResult<T>
+         * >}
+         */
         const { promise, resolve } = makePromiseKit();
         queue.put({ value: resolve, done: true });
         return promise;

--- a/packages/internal/test/callback.test.js
+++ b/packages/internal/test/callback.test.js
@@ -5,7 +5,7 @@ import { Far } from '@endo/far';
 import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import * as cb from '../src/callback.js';
 
-/** @import { Callback, SyncCallback } from '../src/types.js' */
+/** @import {Callback, SyncCallback} from '../src/types.js' */
 
 test('near function callbacks', t => {
   /**
@@ -124,7 +124,6 @@ test('far method callbacks', async t => {
   const m2 = Symbol.for('m2');
   const o = Far('MyObject', {
     /**
-     *
      * @param {number} a
      * @param {number} b
      * @param {string} c
@@ -135,7 +134,6 @@ test('far method callbacks', async t => {
     },
 
     /**
-     *
      * @param {number} a
      * @param {number} b
      * @param {string} c

--- a/packages/internal/test/storage-test-utils.test.js
+++ b/packages/internal/test/storage-test-utils.test.js
@@ -264,13 +264,17 @@ test('makeFakeStorageKit sequence data', async t => {
 });
 
 const testUnmarshaller = test.macro((t, format) => {
-  /** @type {(val: import('@endo/marshal').RemotableObject & SlottedRemotable) => string} */
+  /**
+   * @type {(
+   *   val: import('@endo/marshal').RemotableObject & SlottedRemotable,
+   * ) => string}
+   */
   const convertValToSlot = val => val.getBoardId();
   const serializeBodyFormat = /** @type {any} */ (format);
   const m = makeMarshal(convertValToSlot, undefined, { serializeBodyFormat });
 
   // create capdata with specific slots
-  /** @typedef { { getBoardId: () => string } } SlottedRemotable */
+  /** @typedef {{ getBoardId: () => string }} SlottedRemotable */
   const foo = Far('foo');
   const foo1 = Far('foo', { getBoardId: () => 'board1' });
   const foo2 = Far('foo', { getBoardId: () => 'board2' });

--- a/packages/internal/test/utils.test.js
+++ b/packages/internal/test/utils.test.js
@@ -44,7 +44,7 @@ test('makeMeasureSeconds', async t => {
 });
 
 test('assertAllDefined', t => {
-  /** @type {{ s: string, m: string | undefined, u?: string}} */
+  /** @type {{ s: string; m: string | undefined; u?: string }} */
   const obj = { s: 'defined', m: 'maybe' };
   assertAllDefined(obj);
   // typecheck
@@ -118,7 +118,7 @@ test('forever', async t => {
 /**
  * @template T
  * @param {AsyncIterable<T>} stream
- * @param {Array<T>} output
+ * @param {T[]} output
  * @param {number} [maxItems]
  */
 const consumeStreamInto = async (stream, output, maxItems) => {

--- a/packages/orchestration/src/examples/stakeAtom.contract.js
+++ b/packages/orchestration/src/examples/stakeAtom.contract.js
@@ -13,10 +13,10 @@ import { prepareStakingAccountKit } from '../exos/stakingAccountKit.js';
 
 const trace = makeTracer('StakeAtom');
 /**
- * @import { Baggage } from '@agoric/vat-data';
- * @import { IBCConnectionID } from '@agoric/vats';
- * @import { TimerService } from '@agoric/time';
- * @import { ICQConnection, OrchestrationService } from '../types.js';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {IBCConnectionID} from '@agoric/vats';
+ * @import {TimerService} from '@agoric/time';
+ * @import {ICQConnection, OrchestrationService} from '../types.js';
  */
 
 export const meta = harden({
@@ -31,20 +31,19 @@ export const privateArgsShape = meta.privateArgsShape;
 
 /**
  * @typedef {{
- *  hostConnectionId: IBCConnectionID;
- *  controllerConnectionId: IBCConnectionID;
- *  bondDenom: string;
+ *   hostConnectionId: IBCConnectionID;
+ *   controllerConnectionId: IBCConnectionID;
+ *   bondDenom: string;
  * }} StakeAtomTerms
  */
 
 /**
- *
  * @param {ZCF<StakeAtomTerms>} zcf
  * @param {{
- *  orchestration: OrchestrationService;
- *  storageNode: StorageNode;
- *  marshaller: Marshaller;
- *  timer: TimerService;
+ *   orchestration: OrchestrationService;
+ *   storageNode: StorageNode;
+ *   marshaller: Marshaller;
+ *   timer: TimerService;
  * }} privateArgs
  * @param {Baggage} baggage
  */

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -19,7 +19,6 @@ import { prepareMockChainInfo } from '../utils/mockChainInfo.js';
 const trace = makeTracer('StakeBld');
 
 /**
- *
  * @param {ZCF} zcf
  * @param {{
  *   localchain: import('@agoric/vats/src/localchain.js').LocalChain;
@@ -28,7 +27,7 @@ const trace = makeTracer('StakeBld');
  *   timerService: TimerService;
  *   timerBrand: TimerBrand;
  * }} privateArgs
- * @param {import("@agoric/vat-data").Baggage} baggage
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const start = async (zcf, privateArgs, baggage) => {
   const BLD = zcf.getTerms().brands.In;

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -41,11 +41,11 @@ export const makeNatAmountShape = (brand, min) =>
 /**
  * @param {ZCF} zcf
  * @param {{
- * localchain: Remote<LocalChain>;
- * orchestrationService: Remote<OrchestrationService> | null;
- * storageNode: Remote<StorageNode>;
- * timerService: Remote<TimerService> | null;
- * zone: Zone;
+ *   localchain: Remote<LocalChain>;
+ *   orchestrationService: Remote<OrchestrationService> | null;
+ *   storageNode: Remote<StorageNode>;
+ *   timerService: Remote<TimerService> | null;
+ *   zone: Zone;
  * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {
@@ -64,7 +64,12 @@ export const start = async (zcf, privateArgs) => {
   });
 
   /** deprecated historical example */
-  /** @type {OfferHandler<unknown, {staked: Amount<'nat'>, validator: CosmosValidatorAddress}>} */
+  /**
+   * @type {OfferHandler<
+   *   unknown,
+   *   { staked: Amount<'nat'>; validator: CosmosValidatorAddress }
+   * >}
+   */
   const swapAndStakeHandler = orchestrate(
     'LSTTia',
     { zcf },

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -15,10 +15,10 @@ import { makeOrchestrationFacade } from '../facade.js';
 /**
  * @param {ZCF} zcf
  * @param {{
- * localchain: Remote<LocalChain>;
- * orchestrationService: Remote<OrchestrationService>;
- * storageNode: Remote<StorageNode>;
- * timerService: Remote<TimerService>;
+ *   localchain: Remote<LocalChain>;
+ *   orchestrationService: Remote<OrchestrationService>;
+ *   storageNode: Remote<StorageNode>;
+ *   timerService: Remote<TimerService>;
  * }} privateArgs
  * @param {Baggage} baggage
  */

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -13,19 +13,19 @@ import {
 import { makeTxPacket, parseTxPacket } from '../utils/packet.js';
 
 /**
- * @import { Zone } from '@agoric/base-zone';
- * @import { Connection, Port } from '@agoric/network';
- * @import { Remote } from '@agoric/vow';
- * @import { AnyJson } from '@agoric/cosmic-proto';
- * @import { TxBody } from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
- * @import { LocalIbcAddress, RemoteIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
- * @import { ChainAddress } from '../types.js';
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {Connection, Port} from '@agoric/network';
+ * @import {Remote} from '@agoric/vow';
+ * @import {AnyJson} from '@agoric/cosmic-proto';
+ * @import {TxBody} from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
+ * @import {LocalIbcAddress, RemoteIbcAddress} from '@agoric/vats/tools/ibc-utils.js';
+ * @import {ChainAddress} from '../types.js';
  */
 
 const { Fail } = assert;
 const trace = makeTracer('ChainAccountKit');
 
-/** @typedef {'UNPARSABLE_CHAIN_ADDRESS'}  UnparsableChainAddress */
+/** @typedef {'UNPARSABLE_CHAIN_ADDRESS'} UnparsableChainAddress */
 const UNPARSABLE_CHAIN_ADDRESS = 'UNPARSABLE_CHAIN_ADDRESS';
 
 export const ChainAccountI = M.interface('ChainAccount', {
@@ -103,10 +103,13 @@ export const prepareChainAccountKit = zone =>
           throw new Error('not yet implemented');
         },
         /**
-         * Submit a transaction on behalf of the remote account for execution on the remote chain.
+         * Submit a transaction on behalf of the remote account for execution on
+         * the remote chain.
+         *
          * @param {AnyJson[]} msgs
          * @param {Omit<TxBody, 'messages'>} [opts]
-         * @returns {Promise<string>} - base64 encoded bytes string. Can be decoded using the corresponding `Msg*Response` object.
+         * @returns {Promise<string>} - base64 encoded bytes string. Can be
+         *   decoded using the corresponding `Msg*Response` object.
          * @throws {Error} if packet fails to send or an error is returned
          */
         executeEncodedTx(msgs, opts) {
@@ -135,6 +138,7 @@ export const prepareChainAccountKit = zone =>
         },
         /**
          * get Purse for a brand to .withdraw() a Payment from the account
+         *
          * @param {Brand} brand
          */
         async getPurse(brand) {

--- a/packages/orchestration/src/exos/icqConnectionKit.js
+++ b/packages/orchestration/src/exos/icqConnectionKit.js
@@ -39,16 +39,17 @@ export const ICQConnectionI = M.interface('ICQConnection', {
  */
 
 /**
- * Prepares an ICQ Connection Kit based on the {@link https://github.com/cosmos/ibc-apps/blob/e9b46e4bf0ad0a66cf6bc53b5e5496f6e2b4b02b/modules/async-icq/README.md | `icq/v1` IBC application protocol}.
+ * Prepares an ICQ Connection Kit based on the
+ * {@link https://github.com/cosmos/ibc-apps/blob/e9b46e4bf0ad0a66cf6bc53b5e5496f6e2b4b02b/modules/async-icq/README.md | `icq/v1` IBC application protocol}.
  *
- * `icq/v1`, also referred to as `async-icq`, is a protocol for asynchronous queries
- * between IBC-enabled chains. It allows a chain to send queries to another chain
- * and receive responses asynchronously.
+ * `icq/v1`, also referred to as `async-icq`, is a protocol for asynchronous
+ * queries between IBC-enabled chains. It allows a chain to send queries to
+ * another chain and receive responses asynchronously.
  *
- * The ICQ connection kit provides the necessary functionality to establish and manage
- * an ICQ connection between two chains. It includes methods for retrieving the local
- * and remote addresses of the connection, as well as sending queries and handling
- * connection events.
+ * The ICQ connection kit provides the necessary functionality to establish and
+ * manage an ICQ connection between two chains. It includes methods for
+ * retrieving the local and remote addresses of the connection, as well as
+ * sending queries and handling connection events.
  *
  * @param {Zone} zone
  */

--- a/packages/orchestration/src/exos/local-chain-account-kit.js
+++ b/packages/orchestration/src/exos/local-chain-account-kit.js
@@ -110,7 +110,6 @@ export const prepareLocalChainAccountKit = (
     {
       invitationMakers: {
         /**
-         *
          * @param {string} validatorAddress
          * @param {Amount<'nat'>} ertpAmount
          */
@@ -153,7 +152,6 @@ export const prepareLocalChainAccountKit = (
           });
         },
         /**
-         *
          * @param {string} validatorAddress
          * @param {Amount<'nat'>} ertpAmount
          */
@@ -178,7 +176,6 @@ export const prepareLocalChainAccountKit = (
           return result;
         },
         /**
-         *
          * @param {string} validatorAddress
          * @param {Amount<'nat'>} ertpAmount
          * @returns {Promise<void>}
@@ -209,8 +206,9 @@ export const prepareLocalChainAccountKit = (
           );
         },
         /**
-         * Starting a transfer revokes the account holder. The associated updater
-         * will get a special notification that the account is being transferred.
+         * Starting a transfer revokes the account holder. The associated
+         * updater will get a special notification that the account is being
+         * transferred.
          */
         /** @type {LocalChainAccount['deposit']} */
         async deposit(payment, optAmountShape) {
@@ -232,9 +230,12 @@ export const prepareLocalChainAccountKit = (
           return NonNullish(this.state.address, 'Chain address not available.');
         },
         /**
-         * @param {AmountArg} amount an ERTP {@link Amount} or a {@link DenomAmount}
+         * @param {AmountArg} amount an ERTP {@link Amount} or a
+         *   {@link DenomAmount}
          * @param {ChainAddress} destination
-         * @param {IBCMsgTransferOptions} [opts] if either timeoutHeight or timeoutTimestamp are not supplied, a default timeoutTimestamp will be set for 5 minutes in the future
+         * @param {IBCMsgTransferOptions} [opts] if either timeoutHeight or
+         *   timeoutTimestamp are not supplied, a default timeoutTimestamp will
+         *   be set for 5 minutes in the future
          * @returns {Promise<void>}
          */
         async transfer(amount, destination, opts) {

--- a/packages/orchestration/src/exos/stakingAccountKit.js
+++ b/packages/orchestration/src/exos/stakingAccountKit.js
@@ -56,12 +56,12 @@ const { Fail } = assert;
 
 /**
  * @typedef {{
- *  topicKit: RecorderKit<StakingAccountNotification>;
- *  account: IcaAccount;
- *  chainAddress: ChainAddress;
- *  icqConnection: ICQConnection;
- *  bondDenom: string;
- *  timer: TimerService;
+ *   topicKit: RecorderKit<StakingAccountNotification>;
+ *   account: IcaAccount;
+ *   chainAddress: ChainAddress;
+ *   icqConnection: ICQConnection;
+ *   bondDenom: string;
+ *   timer: TimerService;
  * }} State
  */
 
@@ -98,7 +98,7 @@ const expect = (actual, expected, message) => {
   }
 };
 
-/** @type {(c: { denom: string, amount: string }) => DenomAmount} */
+/** @type {(c: { denom: string; amount: string }) => DenomAmount} */
 const toDenomAmount = c => ({ denom: c.denom, value: BigInt(c.amount) });
 
 /**
@@ -184,7 +184,6 @@ export const prepareStakingAccountKit = (zone, makeRecorderKit, zcf) => {
       },
       invitationMakers: {
         /**
-         *
          * @param {CosmosValidatorAddress} validator
          * @param {Amount<'nat'>} amount
          */
@@ -237,8 +236,9 @@ export const prepareStakingAccountKit = (zone, makeRecorderKit, zcf) => {
           throw Error('not yet implemented');
         },
         /**
-         * Starting a transfer revokes the account holder. The associated updater
-         * will get a special notification that the account is being transferred.
+         * Starting a transfer revokes the account holder. The associated
+         * updater will get a special notification that the account is being
+         * transferred.
          */
         TransferAccount() {
           throw Error('not yet implemented');
@@ -264,6 +264,7 @@ export const prepareStakingAccountKit = (zone, makeRecorderKit, zcf) => {
         },
         /**
          * _Assumes users has already sent funds to their ICA, until #9193
+         *
          * @param {CosmosValidatorAddress} validator
          * @param {AmountArg} amount
          */
@@ -286,6 +287,7 @@ export const prepareStakingAccountKit = (zone, makeRecorderKit, zcf) => {
         },
         /**
          * _Assumes users has already sent funds to their ICA, until #9193
+         *
          * @param {CosmosValidatorAddress} srcValidator
          * @param {CosmosValidatorAddress} dstValidator
          * @param {AmountArg} amount
@@ -397,7 +399,7 @@ export const prepareStakingAccountKit = (zone, makeRecorderKit, zcf) => {
   const typeCheck = () => {
     /** @type {any} */
     const arg = null;
-    /** @satisfies { StakingAccountActions } */
+    /** @satisfies {StakingAccountActions} */
     // eslint-disable-next-line no-unused-vars
     const kit = makeStakingAccountKit(arg, arg, arg).holder;
   };

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -131,7 +131,6 @@ const makeRemoteChainFacade = name => {
 };
 
 /**
- *
  * @param {{
  *   zone: Zone;
  *   timerService: Remote<TimerService> | null;

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -18,7 +18,7 @@ import { V as E } from '@agoric/vow/vat.js';
  *     orchestrationVat: Producer<any>;
  *   };
  * }} powers
- * @param {{ options: { orchestrationRef: VatSourceRef }}} options
+ * @param {{ options: { orchestrationRef: VatSourceRef } }} options
  *
  * @typedef {{
  *   orchestration: ERef<OrchestrationVat>;

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -9,7 +9,6 @@ import { V as E } from '@agoric/vow/vat.js';
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     loadCriticalVat: VatLoader<any>;
  *     portAllocator: PortAllocator;
  *   };
  *   produce: {
@@ -19,10 +18,6 @@ import { V as E } from '@agoric/vow/vat.js';
  *   };
  * }} powers
  * @param {{ options: { orchestrationRef: VatSourceRef } }} options
- *
- * @typedef {{
- *   orchestration: ERef<OrchestrationVat>;
- * }} OrchestrationVats
  */
 export const setupOrchestrationVat = async (
   {
@@ -36,7 +31,6 @@ export const setupOrchestrationVat = async (
   options,
 ) => {
   const { orchestrationRef } = options.options;
-  /** @type {OrchestrationVats} */
   const vats = {
     orchestration: E(loadCriticalVat)('orchestration', orchestrationRef),
   };

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -2,13 +2,21 @@ import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/far';
 
-/** @import { StakeAtomSF,  StakeAtomTerms} from '../examples/stakeAtom.contract' */
+/** @import {StakeAtomSF,  StakeAtomTerms} from '../examples/stakeAtom.contract' */
 
 const trace = makeTracer('StartStakeAtom', true);
 
 /**
- * @param {BootstrapPowers & { installation: {consume: {stakeAtom: Installation<import('../examples/stakeAtom.contract.js').start>}}}} powers
- * @param {{options: StakeAtomTerms }} options
+ * @param {BootstrapPowers & {
+ *   installation: {
+ *     consume: {
+ *       stakeAtom: Installation<
+ *         import('../examples/stakeAtom.contract.js').start
+ *       >;
+ *     };
+ *   };
+ * }} powers
+ * @param {{ options: StakeAtomTerms }} options
  */
 export const startStakeAtom = async (
   {

--- a/packages/orchestration/src/proposals/start-stakeBld.js
+++ b/packages/orchestration/src/proposals/start-stakeBld.js
@@ -6,7 +6,15 @@ import { E } from '@endo/far';
 const trace = makeTracer('StartStakeBld', true);
 
 /**
- * @param {BootstrapPowers & {installation: {consume: {stakeBld: Installation<import('../../src/examples/stakeBld.contract.js').start>}}}} powers
+ * @param {BootstrapPowers & {
+ *   installation: {
+ *     consume: {
+ *       stakeBld: Installation<
+ *         import('../../src/examples/stakeBld.contract.js').start
+ *       >;
+ *     };
+ *   };
+ * }} powers
  */
 export const startStakeBld = async ({
   consume: {
@@ -39,7 +47,11 @@ export const startStakeBld = async ({
     chainTimerServiceP.then(ts => E(ts).getTimerBrand()),
   ]);
 
-  /** @type {StartUpgradableOpts<import('../../src/examples/stakeBld.contract.js').start>} */
+  /**
+   * @type {StartUpgradableOpts<
+   *   import('../../src/examples/stakeBld.contract.js').start
+   * >}
+   */
   const startOpts = {
     label: 'stakeBld',
     installation: stakeBld,

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -11,11 +11,11 @@ import {
 } from './utils/address.js';
 
 /**
- * @import { Zone } from '@agoric/base-zone';
+ * @import {Zone} from '@agoric/base-zone';
  * @import {Remote} from '@agoric/internal';
- * @import { Port, PortAllocator } from '@agoric/network';
- * @import { IBCConnectionID } from '@agoric/vats';
- * @import { ICQConnection, IcaAccount, ICQConnectionKit } from './types.js';
+ * @import {Port, PortAllocator} from '@agoric/network';
+ * @import {IBCConnectionID} from '@agoric/vats';
+ * @import {ICQConnection, IcaAccount, ICQConnectionKit} from './types.js';
  */
 
 const { Fail, bare } = assert;
@@ -37,7 +37,7 @@ const { Fail, bare } = assert;
  */
 
 /**
- * @typedef {MapStore<IBCConnectionID,ICQConnectionKit>} ICQConnectionStore
+ * @typedef {MapStore<IBCConnectionID, ICQConnectionKit>} ICQConnectionStore
  */
 
 /**
@@ -59,7 +59,7 @@ export const OrchestrationI = M.interface('Orchestration', {
   ),
 });
 
-/** @typedef {{ powers: PowerStore; icqConnections: ICQConnectionStore } } OrchestrationState */
+/** @typedef {{ powers: PowerStore; icqConnections: ICQConnectionStore }} OrchestrationState */
 
 /**
  * @param {Zone} zone
@@ -109,10 +109,9 @@ const prepareOrchestrationKit = (
       },
       public: {
         /**
-         * @param {IBCConnectionID} hostConnectionId
-         *   the counterparty connection_id
-         * @param {IBCConnectionID} controllerConnectionId
-         *   self connection_id
+         * @param {IBCConnectionID} hostConnectionId the counterparty
+         *   connection_id
+         * @param {IBCConnectionID} controllerConnectionId self connection_id
          * @returns {Promise<IcaAccount>}
          */
         async makeAccount(hostConnectionId, controllerConnectionId) {

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -1,17 +1,19 @@
 import { Fail } from '@agoric/assert';
 
 /**
- * @import { IBCConnectionID } from '@agoric/vats';
- * @import { ChainAddress } from '../types.js';
- * @import { RemoteIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
+ * @import {IBCConnectionID} from '@agoric/vats';
+ * @import {ChainAddress} from '../types.js';
+ * @import {RemoteIbcAddress} from '@agoric/vats/tools/ibc-utils.js';
  */
 
 /**
  * @param {IBCConnectionID} hostConnectionId Counterpart Connection ID
  * @param {IBCConnectionID} controllerConnectionId Self Connection ID
  * @param {object} [opts]
- * @param {string} [opts.encoding] - message encoding format for the channel. default is `proto3`
- * @param {'ordered' | 'unordered'} [opts.ordering] - channel ordering. currently only `ordered` is supported for ics27-1
+ * @param {string} [opts.encoding] - message encoding format for the channel.
+ *   default is `proto3`
+ * @param {'ordered' | 'unordered'} [opts.ordering] - channel ordering.
+ *   currently only `ordered` is supported for ics27-1
  * @param {string} [opts.txType] - default is `sdk_multi_msg`
  * @param {string} [opts.version] - default is `ics27-1`
  * @returns {RemoteIbcAddress}
@@ -41,7 +43,7 @@ export const makeICAChannelAddress = (
 harden(makeICAChannelAddress);
 
 /**
- * @param {IBCConnectionID}  controllerConnectionId
+ * @param {IBCConnectionID} controllerConnectionId
  * @param {{ version?: string }} [opts]
  * @returns {RemoteIbcAddress}
  */
@@ -55,10 +57,13 @@ export const makeICQChannelAddress = (
 harden(makeICQChannelAddress);
 
 /**
- * Parse a chain address from a remote address string.
- * Assumes the address string is in a JSON format and contains an "address" field.
- * This function is designed to be safe against malformed inputs and unexpected data types, and will return `undefined` in those cases.
- * @param {RemoteIbcAddress} remoteAddressString - remote address string, including version
+ * Parse a chain address from a remote address string. Assumes the address
+ * string is in a JSON format and contains an "address" field. This function is
+ * designed to be safe against malformed inputs and unexpected data types, and
+ * will return `undefined` in those cases.
+ *
+ * @param {RemoteIbcAddress} remoteAddressString - remote address string,
+ *   including version
  * @returns {ChainAddress['address'] | undefined} returns undefined on error
  */
 export const findAddressField = remoteAddressString => {

--- a/packages/orchestration/src/utils/cosmos.js
+++ b/packages/orchestration/src/utils/cosmos.js
@@ -6,7 +6,6 @@ import { decodeBase64, encodeBase64 } from '@endo/base64';
 export const maxClockSkew = 10n * 60n;
 
 /**
- *
  * @param {unknown} response
  * @param {(msg: any) => Any} toProtoMsg
  * @returns {string}
@@ -22,7 +21,7 @@ export const encodeTxResponse = (response, toProtoMsg) => {
 /**
  * @template T
  * @param {string} ackStr
- * @param {(p: {typeUrl: string, value: Uint8Array}) => T} fromProtoMsg
+ * @param {(p: { typeUrl: string; value: Uint8Array }) => T} fromProtoMsg
  */
 export const tryDecodeResponse = (ackStr, fromProtoMsg) => {
   try {

--- a/packages/orchestration/src/utils/mockChainInfo.js
+++ b/packages/orchestration/src/utils/mockChainInfo.js
@@ -13,9 +13,9 @@ import { State as IBCConnectionState } from '@agoric/cosmic-proto/ibc/core/conne
  */
 
 /**
- * currently keyed by ChainId, as this is what we have
- * available in ChainAddress to determine the correct IBCChannelID's
- * for a .transfer() msg.
+ * currently keyed by ChainId, as this is what we have available in ChainAddress
+ * to determine the correct IBCChannelID's for a .transfer() msg.
+ *
  * @type {Record<string, IBCConnectionInfo>}
  */
 const connectionEntries = harden({

--- a/packages/orchestration/src/utils/orc.js
+++ b/packages/orchestration/src/utils/orc.js
@@ -19,8 +19,10 @@ export const orcUtils = {
   },
   /**
    * SwapExact or SwapMaxSlippage, with optional AfterAction
-   * @param { (SwapExact | SwapMaxSlippage) &
-  (AfterAction | Record<string, never>)} _args
+   *
+   * @param {(SwapExact | SwapMaxSlippage) &
+   *   (AfterAction | Record<string, never>)} _args
+   *
    * @returns {TransferMsg}
    */
   makeOsmosisSwap(_args) {

--- a/packages/orchestration/src/utils/packet.js
+++ b/packages/orchestration/src/utils/packet.js
@@ -16,9 +16,10 @@ import { Type as PacketType } from '@agoric/cosmic-proto/ibc/applications/interc
  */
 
 /**
- * Makes an IBC transaction packet from an array of messages. Expects the `value` of each message
- * to be base64 encoded bytes.
- * Skips checks for malformed messages in favor of interface guards.
+ * Makes an IBC transaction packet from an array of messages. Expects the
+ * `value` of each message to be base64 encoded bytes. Skips checks for
+ * malformed messages in favor of interface guards.
+ *
  * @param {AnyJson[]} msgs
  * @param {Partial<Omit<TxBody, 'messages'>>} [opts]
  * @returns {string} stringified InterchainAccountPacketData
@@ -44,9 +45,10 @@ export function makeTxPacket(msgs, opts) {
 harden(makeTxPacket);
 
 /**
- * Makes an IBC query packet from an array of query messages. Expects the `data` of each message
- * to be base64 encoded bytes.
- * Skips checks for malformed messages in favor of interface guards.
+ * Makes an IBC query packet from an array of query messages. Expects the `data`
+ * of each message to be base64 encoded bytes. Skips checks for malformed
+ * messages in favor of interface guards.
+ *
  * @param {JsonSafe<RequestQuery>[]} msgs
  * @returns {string} stringified InterchainQueryPacketData
  * @throws {Error} if malformed messages are provided
@@ -68,13 +70,15 @@ export function makeQueryPacket(msgs) {
 harden(makeQueryPacket);
 
 /**
- * Looks for a result or error key in the response string, and returns
- * a Base64Bytes string. This string can be decoded using the corresponding
- * Msg*Response object.
- * Error strings seem to be plain text and do not need decoding.
+ * Looks for a result or error key in the response string, and returns a
+ * Base64Bytes string. This string can be decoded using the corresponding
+ * Msg*Response object. Error strings seem to be plain text and do not need
+ * decoding.
+ *
  * @param {string} response
  * @returns {string} - base64 encoded bytes string
- * @throws {Error} if error key is detected in response string, or result key is not found
+ * @throws {Error} if error key is detected in response string, or result key is
+ *   not found
  */
 export function parseTxPacket(response) {
   const { result, error } = JSON.parse(response);
@@ -86,13 +90,15 @@ harden(parseTxPacket);
 
 /**
  * Looks for a result or error key in the response string. If a result is found,
- * `responses` is decoded via `CosmosResponse`. The `key` and `value` fields on the
- * resulting entries are base64 encoded for inter-vat communication. These can be
- * decoded using the corresponding Query*Response objects.
- * Error strings seem to be plain text and do not need decoding.
+ * `responses` is decoded via `CosmosResponse`. The `key` and `value` fields on
+ * the resulting entries are base64 encoded for inter-vat communication. These
+ * can be decoded using the corresponding Query*Response objects. Error strings
+ * seem to be plain text and do not need decoding.
+ *
  * @param {string} response
  * @returns {JsonSafe<ResponseQuery>[]}
- * @throws {Error} if error key is detected in response string, or result key is not found
+ * @throws {Error} if error key is detected in response string, or result key is
+ *   not found
  */
 export function parseQueryPacket(response) {
   const result = parseTxPacket(response);

--- a/packages/orchestration/src/utils/time.js
+++ b/packages/orchestration/src/utils/time.js
@@ -16,11 +16,13 @@ export const NANOSECONDS_PER_SECOND = 1_000_000_000n;
 export function makeTimestampHelper(timer, timerBrand) {
   return harden({
     /**
-     * Takes the current time from ChainTimerService and adds a relative
-     * time to determine a timeout timestamp in nanoseconds.
-     * Useful for {@link MsgTransfer.timeoutTimestamp}.
+     * Takes the current time from ChainTimerService and adds a relative time to
+     * determine a timeout timestamp in nanoseconds. Useful for
+     * {@link MsgTransfer.timeoutTimestamp}.
+     *
      * @param {RelativeTimeRecord} [relativeTime] defaults to 5 minutes
-     * @returns {Promise<bigint>} Timeout timestamp in absolute nanoseconds since unix epoch
+     * @returns {Promise<bigint>} Timeout timestamp in absolute nanoseconds
+     *   since unix epoch
      */
     async getTimeoutTimestampNS(relativeTime) {
       const currentTime = await E(timer).getCurrentTimestamp();
@@ -38,8 +40,8 @@ export function makeTimestampHelper(timer, timerBrand) {
 /** @typedef {Awaited<ReturnType<typeof makeTimestampHelper>>} TimestampHelper */
 
 /**
- * Convert a Date from a Cosmos message, which has millisecond precision,
- * to a BigInt for number of seconds since epoch, for use in a timer.
+ * Convert a Date from a Cosmos message, which has millisecond precision, to a
+ * BigInt for number of seconds since epoch, for use in a timer.
  *
  * @param {Date} date
  * @returns {bigint}

--- a/packages/orchestration/src/vat-orchestration.js
+++ b/packages/orchestration/src/vat-orchestration.js
@@ -2,7 +2,7 @@ import { Far } from '@endo/far';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareOrchestrationTools } from './service.js';
 
-/** @import { OrchestrationPowers } from './service.js' */
+/** @import {OrchestrationPowers} from './service.js' */
 
 export const buildRootObject = (_vatPowers, _args, baggage) => {
   const zone = makeDurableZone(baggage);

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -10,44 +10,53 @@ const { Fail } = assert;
 const MAX_PIPE_LENGTH = 2;
 
 /**
- * @typedef {AgoricContractInvitationSpec | ContractInvitationSpec | PurseInvitationSpec | ContinuingInvitationSpec} InvitationSpec
- * Specify how to produce an invitation. See each type in the union for details.
+ * @typedef {AgoricContractInvitationSpec
+ *   | ContractInvitationSpec
+ *   | PurseInvitationSpec
+ *   | ContinuingInvitationSpec} InvitationSpec
+ *   Specify how to produce an invitation. See each type in the union for details.
  */
 
 /**
  * @typedef {{
- * source: 'agoricContract',
- * instancePath: string[],
- * callPipe: Array<[methodName: string, methodArgs?: any[]]>,
+ *   source: 'agoricContract';
+ *   instancePath: string[];
+ *   callPipe: [methodName: string, methodArgs?: any[]][];
  * }} AgoricContractInvitationSpec
- * source of invitation is a chain of calls starting with an agoricName
+ *   source of invitation is a chain of calls starting with an agoricName
+ *
  *   - the start of the pipe is a lookup of instancePath within agoricNames
  *   - each entry in the callPipe executes a call on the preceding result
  *   - the end of the pipe is expected to return an Invitation
  *
- * @typedef {{
- * source: 'contract',
- * instance: Instance,
- * publicInvitationMaker: string,
- * invitationArgs?: any[],
- * }} ContractInvitationSpec
- * source is a contract (in which case this takes an Instance to look up in zoe)
  *
  * @typedef {{
- * source: 'purse',
- * instance: Instance,
- * description: string,
+ *   source: 'contract';
+ *   instance: Instance;
+ *   publicInvitationMaker: string;
+ *   invitationArgs?: any[];
+ * }} ContractInvitationSpec
+ *   source is a contract (in which case this takes an Instance to look up in zoe)
+ *
+ * @typedef {{
+ *   source: 'purse';
+ *   instance: Instance;
+ *   description: string;
  * }} PurseInvitationSpec
- * the invitation is already in your Zoe "invitation" purse so we need to query it
+ *   the invitation is already in your Zoe "invitation" purse so we need to query
+ *   it
+ *
  *   - use the find/query invitation by kvs thing
  *
+ *
  * @typedef {{
- * source: 'continuing',
- * previousOffer: import('./offers.js').OfferId,
- * invitationMakerName: string,
- * invitationArgs?: any[],
+ *   source: 'continuing';
+ *   previousOffer: import('./offers.js').OfferId;
+ *   invitationMakerName: string;
+ *   invitationArgs?: any[];
  * }} ContinuingInvitationSpec
- * continuing invitation in which the offer result from a previous invitation had an `invitationMakers` property
+ *   continuing invitation in which the offer result from a previous invitation
+ *   had an `invitationMakers` property
  */
 
 /**

--- a/packages/smart-wallet/src/marshal-contexts.js
+++ b/packages/smart-wallet/src/marshal-contexts.js
@@ -23,10 +23,9 @@ const isDefaultBoardId = specimen => {
 };
 
 /**
- * When marshaling a purse, payment, etc. we partition the slots
- * using prefixes.
+ * When marshaling a purse, payment, etc. we partition the slots using prefixes.
  *
- * @template {Record<string, IdTable<*,*>>} T
+ * @template {Record<string, IdTable<any, any>>} T
  * @typedef {`${string & keyof T}:${Digits}`} WalletSlot
  */
 /**
@@ -35,7 +34,7 @@ const isDefaultBoardId = specimen => {
  */
 
 /**
- * @template {Record<string, IdTable<*,*>>} T
+ * @template {Record<string, IdTable<any, any>>} T
  * @param {T} _tables
  * @param {string & keyof T} kind
  * @param {number} id
@@ -47,10 +46,10 @@ const makeWalletSlot = (_tables, kind, id) => {
 };
 
 /**
- * @template {Record<string, IdTable<*,*>>} T
+ * @template {Record<string, IdTable<any, any>>} T
  * @param {T} record
  * @param {(value: string, index: number, obj: string[]) => boolean} predicate
- * @returns {string & keyof T | undefined}
+ * @returns {(string & keyof T) | undefined}
  */
 const findKey = (record, predicate) => {
   const key = Object.keys(record).find(predicate);
@@ -58,10 +57,10 @@ const findKey = (record, predicate) => {
 };
 
 /**
- * @template {Record<string, IdTable<*,*>>} T
+ * @template {Record<string, IdTable<any, any>>} T
  * @param {T} tables
  * @param {string} slot
- * @returns {{ kind: undefined | string & keyof T, id: number }}
+ * @returns {{ kind: undefined | (string & keyof T); id: number }}
  */
 const parseWalletSlot = (tables, slot) => {
   const kind = findKey(tables, k => slot.startsWith(`${k}:`));
@@ -70,25 +69,23 @@ const parseWalletSlot = (tables, slot) => {
 };
 
 /**
- * Since KindSlots always include a colon and BoardIds never do,
- * we an mix them without confusion.
+ * Since KindSlots always include a colon and BoardIds never do, we an mix them
+ * without confusion.
  *
- * @template {Record<string, IdTable<*,*>>} T
+ * @template {Record<string, IdTable<any, any>>} T
  * @typedef {WalletSlot<T> | BoardId} MixedSlot
  */
 /**
- * @typedef {`1` | `12` | `123`} Digits - 1 or more digits.
- * NOTE: the typescript definition here is more restrictive than
- * actual usage.
+ * @typedef {`1` | `12` | `123`} Digits - 1 or more digits. NOTE: the typescript
+ *   definition here is more restrictive than actual usage.
  */
 
 /**
  * @template {Key} Slot
  * @template {PassableCap} Val
- *
  * @typedef {{
- *   bySlot: MapStore<Slot, Val>,
- *   byVal: MapStore<Val, Slot>,
+ *   bySlot: MapStore<Slot, Val>;
+ *   byVal: MapStore<Val, Slot>;
  * }} IdTable<Value>
  */
 
@@ -105,17 +102,20 @@ const initSlotVal = (table, slot, val) => {
 };
 
 /**
- * Make context for exporting wallet data where brands etc. can be recognized by boardId.
- * Export for use outside the smart wallet.
+ * Make context for exporting wallet data where brands etc. can be recognized by
+ * boardId. Export for use outside the smart wallet.
  *
  * When serializing wallet state for, there's a tension between
  *
- *  - keeping purses etc. closely held
- *  - recognizing identity of brands also referenced in the state of contracts such as the AMM
+ * - keeping purses etc. closely held
+ * - recognizing identity of brands also referenced in the state of contracts such
+ *   as the AMM
  *
- * `makeMarshal()` is parameterized by the type of slots. Here we use a disjoint union of
- *   - board ids for widely shared objects
- *   - kind:seq ids for closely held objects; for example purse:123
+ * `makeMarshal()` is parameterized by the type of slots. Here we use a disjoint
+ * union of
+ *
+ * - board ids for widely shared objects
+ * - kind:seq ids for closely held objects; for example purse:123
  */
 export const makeExportContext = () => {
   const walletObjects = {
@@ -143,14 +143,13 @@ export const makeExportContext = () => {
   };
 
   /**
-   * Look up the slot in mappings from published data
-   * else try walletObjects that we have seen.
-   *
-   * @throws if not found (a slotToVal function typically
-   *         conjures a new identity)
+   * Look up the slot in mappings from published data else try walletObjects
+   * that we have seen.
    *
    * @param {MixedSlot<typeof walletObjects>} slot
    * @param {string} _iface
+   * @throws if not found (a slotToVal function typically conjures a new
+   *   identity)
    */
   const slotToVal = (slot, _iface) => {
     if (isDefaultBoardId(slot) && boardObjects.bySlot.has(slot)) {
@@ -239,8 +238,8 @@ const defaultMakePresence = iface => {
 };
 
 /**
- * Make context for marshalling wallet or board data.
- * To be imported into the client, which never exports objects.
+ * Make context for marshalling wallet or board data. To be imported into the
+ * client, which never exports objects.
  *
  * @param {(iface: string) => PassableCap} [makePresence]
  */
@@ -363,8 +362,12 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
 /**
  * @param {string} iface
  * @param {{
- *   applyMethod: (target: unknown, method: string | symbol, args: unknown[]) => void,
- *   applyFunction: (target: unknown, args: unknown[]) => void,
+ *   applyMethod: (
+ *     target: unknown,
+ *     method: string | symbol,
+ *     args: unknown[],
+ *   ) => void;
+ *   applyFunction: (target: unknown, args: unknown[]) => void;
  * }} handler
  */
 const makePresence = (iface, handler) => {

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -22,9 +22,9 @@ import { UNPUBLISHED_RESULT } from './offers.js';
 
 /**
  * @typedef {{
- * resultWatcher: OfferPromiseWatcher<unknown>,
- * numWantsWatcher: OfferPromiseWatcher<number>,
- * paymentWatcher: OfferPromiseWatcher<PaymentPKeywordRecord>,
+ *   resultWatcher: OfferPromiseWatcher<unknown>;
+ *   numWantsWatcher: OfferPromiseWatcher<number>;
+ *   paymentWatcher: OfferPromiseWatcher<PaymentPKeywordRecord>;
  * }} OutcomeWatchers
  */
 
@@ -108,9 +108,8 @@ export const prepareOfferWatcher = baggage => {
     'OfferWatcher',
     offerWatcherGuard,
     /**
-     *
-     * @param {*} walletHelper
-     * @param {*} deposit
+     * @param {any} walletHelper
+     * @param {any} deposit
      * @param {OfferSpec} offerSpec
      * @param {string} address
      * @param {Amount<'set'>} invitationAmount
@@ -137,9 +136,9 @@ export const prepareOfferWatcher = baggage => {
         },
         /**
          * @param {string} offerId
-         * @param {Amount<"set">} invitationAmount
+         * @param {Amount<'set'>} invitationAmount
          * @param {import('./types.js').InvitationMakers} invitationMakers
-         * @param {import("./types.js").PublicSubscribers} publicSubscribers
+         * @param {import('./types.js').PublicSubscribers} publicSubscribers
          */
         onNewContinuingOffer(
           offerId,
@@ -196,8 +195,9 @@ export const prepareOfferWatcher = baggage => {
         },
         /**
          * Called when the offer result promise rejects. The other two watchers
-         * are waiting for particular values out of Zoe but they settle at the same time
-         * and don't need their own error handling.
+         * are waiting for particular values out of Zoe but they settle at the
+         * same time and don't need their own error handling.
+         *
          * @param {Error} err
          */
         handleError(err) {
@@ -226,9 +226,11 @@ export const prepareOfferWatcher = baggage => {
           facets.helper.updateStatus({ payouts: amounts });
         },
         /**
-         * If promise disconnected, watch again. Or if there's an Error, handle it.
+         * If promise disconnected, watch again. Or if there's an Error, handle
+         * it.
          *
-         * @param {Error | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
+         * @param {Error
+         *   | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
          * @param {UserSeat} seat
          */
         onRejected(reason, seat) {
@@ -248,9 +250,11 @@ export const prepareOfferWatcher = baggage => {
           facets.helper.publishResult(result);
         },
         /**
-         * If promise disconnected, watch again. Or if there's an Error, handle it.
+         * If promise disconnected, watch again. Or if there's an Error, handle
+         * it.
          *
-         * @param {Error | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
+         * @param {Error
+         *   | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
          * @param {UserSeat} seat
          */
         onRejected(reason, seat) {
@@ -277,7 +281,8 @@ export const prepareOfferWatcher = baggage => {
          * and getPayouts() settle the same (they await the same promise and
          * then synchronously return a local value).
          *
-         * @param {Error | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
+         * @param {Error
+         *   | import('@agoric/internal/src/upgrade-api.js').UpgradeDisconnection} reason
          * @param {UserSeat} seat
          */
         onRejected(reason, seat) {

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -4,10 +4,10 @@
 
 /**
  * @typedef {{
- *   id: OfferId,
- *   invitationSpec: import('./invitations.js').InvitationSpec,
- *   proposal: Proposal,
- *   offerArgs?: any
+ *   id: OfferId;
+ *   invitationSpec: import('./invitations.js').InvitationSpec;
+ *   proposal: Proposal;
+ *   offerArgs?: any;
  * }} OfferSpec
  */
 
@@ -16,9 +16,9 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
 
 /**
  * @typedef {OfferSpec & {
- * error?: string,
- * numWantsSatisfied?: number
- * result?: unknown | typeof UNPUBLISHED_RESULT,
- * payouts?: AmountKeywordRecord,
+ *   error?: string;
+ *   numWantsSatisfied?: number;
+ *   result?: unknown | typeof UNPUBLISHED_RESULT;
+ *   payouts?: AmountKeywordRecord;
  * }} OfferStatus
  */

--- a/packages/smart-wallet/src/proposals/upgrade-walletFactory-proposal.js
+++ b/packages/smart-wallet/src/proposals/upgrade-walletFactory-proposal.js
@@ -14,8 +14,7 @@ const BOARD_AUX = 'boardAux';
 const marshalData = makeMarshal(_val => Fail`data only`);
 
 /**
- * @param { BootstrapPowers } powers
- *
+ * @param {BootstrapPowers} powers
  * @param {object} config
  * @param {{ walletFactoryRef: VatSourceRef & { bundleID: string } }} config.options
  */
@@ -71,7 +70,7 @@ export const upgradeWalletFactory = async (
 harden(upgradeWalletFactory);
 
 /**
- * @param { BootstrapPowers } powers
+ * @param {BootstrapPowers} powers
  */
 export const publishAgoricBrandsDisplayInfo = async ({
   consume: { agoricNames, board, chainStorage },
@@ -98,7 +97,7 @@ export const publishAgoricBrandsDisplayInfo = async ({
 };
 harden(publishAgoricBrandsDisplayInfo);
 
-/** @type { import("@agoric/vats/src/core/lib-boot").BootstrapManifest } */
+/** @type {import('@agoric/vats/src/core/lib-boot').BootstrapManifest} */
 const manifest = {
   [upgradeWalletFactory.name]: {
     // include rationale for closely-held, high authority capabilities

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -42,6 +42,8 @@ import { shape } from './typeGuards.js';
 import { objectMapStoragePath } from './utils.js';
 import { prepareOfferWatcher, watchOfferOutcomes } from './offerWatcher.js';
 
+/** @import {OfferId, OfferStatus} from './offers.js'; */
+
 const { Fail, quote: q } = assert;
 
 const trace = makeTracer('SmrtWlt');
@@ -112,12 +114,12 @@ const trace = makeTracer('SmrtWlt');
  *   purses: Array<{brand: Brand, balance: Amount}>,
  *   offerToUsedInvitation: Array<[ offerId: string, usedInvitation: Amount ]>,
  *   offerToPublicSubscriberPaths: Array<[ offerId: string, publicTopics: { [subscriberName: string]: string } ]>,
- *   liveOffers: Array<[OfferId, import('./offers.js').OfferStatus]>,
+ *   liveOffers: Array<[OfferId, OfferStatus]>,
  * }} CurrentWalletRecord
  */
 
 /**
- * @typedef {{ updated: 'offerStatus', status: import('./offers.js').OfferStatus }
+ * @typedef {{ updated: 'offerStatus', status: OfferStatus }
  *   | { updated: 'balance'; currentAmount: Amount }
  *   | { updated: 'walletAction'; status: { error: string } }
  * } UpdateRecord Record of an update to the state of this wallet.
@@ -177,7 +179,7 @@ const trace = makeTracer('SmrtWlt');
  *   purseBalances: MapStore<Purse, Amount>,
  *   updateRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<UpdateRecord>,
  *   currentRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<CurrentWalletRecord>,
- *   liveOffers: MapStore<OfferId, import('./offers.js').OfferStatus>,
+ *   liveOffers: MapStore<OfferId, OfferStatus>,
  *   liveOfferSeats: MapStore<OfferId, UserSeat<unknown>>,
  *   liveOfferPayments: MapStore<OfferId, MapStore<Brand, Payment>>,
  * }>} ImmutableState
@@ -706,7 +708,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           void helper.watchPurse(invitationPurse);
         },
 
-        /** @param {import('./offers.js').OfferStatus} offerStatus */
+        /** @param {OfferStatus} offerStatus */
         updateStatus(offerStatus) {
           const { state, facets } = this;
           facets.helper.logWalletInfo('offerStatus', offerStatus);

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -50,143 +50,168 @@ const trace = makeTracer('SmrtWlt');
 
 /**
  * @file Smart wallet module
- *
- * @see {@link ../README.md}}
+ * @see {@link ../README.md} }
  */
 
 /** @typedef {number | string} OfferId */
 
 /**
  * @typedef {{
- *   id: OfferId,
- *   invitationSpec: import('./invitations').InvitationSpec,
- *   proposal: Proposal,
- *   offerArgs?: any
+ *   id: OfferId;
+ *   invitationSpec: import('./invitations').InvitationSpec;
+ *   proposal: Proposal;
+ *   offerArgs?: any;
  * }} OfferSpec
  */
 
 /**
  * @typedef {{
- *   logger:  {info: (...args: any[]) => void, error: (...args: any[]) => void},
- *   makeOfferWatcher: import('./offerWatcher.js').MakeOfferWatcher,
- *   invitationFromSpec: ERef<Invitation>,
+ *   logger: {
+ *     info: (...args: any[]) => void;
+ *     error: (...args: any[]) => void;
+ *   };
+ *   makeOfferWatcher: import('./offerWatcher.js').MakeOfferWatcher;
+ *   invitationFromSpec: ERef<Invitation>;
  * }} ExecutorPowers
  */
 
 /**
  * @typedef {{
- *   method: 'executeOffer'
- *   offer: OfferSpec,
+ *   method: 'executeOffer';
+ *   offer: OfferSpec;
  * }} ExecuteOfferAction
  */
 
 /**
  * @typedef {{
- *   method: 'tryExitOffer'
- *   offerId: OfferId,
+ *   method: 'tryExitOffer';
+ *   offerId: OfferId;
  * }} TryExitOfferAction
  */
 
 // Discriminated union. Possible future messages types:
 // maybe suggestIssuer for https://github.com/Agoric/agoric-sdk/issues/6132
 // setting petnames and adding brands for https://github.com/Agoric/agoric-sdk/issues/6126
-/**
- * @typedef { ExecuteOfferAction | TryExitOfferAction } BridgeAction
- */
+/** @typedef {ExecuteOfferAction | TryExitOfferAction} BridgeAction */
 
 /**
- * Purses is an array to support a future requirement of multiple purses per brand.
+ * Purses is an array to support a future requirement of multiple purses per
+ * brand.
  *
- * Each map is encoded as an array of entries because a Map doesn't serialize directly.
- * We also considered having a vstorage key for each offer but for now are sticking with this design.
+ * Each map is encoded as an array of entries because a Map doesn't serialize
+ * directly. We also considered having a vstorage key for each offer but for now
+ * are sticking with this design.
  *
  * Cons
- *    - Reserializes previously written results when a new result is added
- *    - Optimizes reads though writes are on-chain (~100 machines) and reads are off-chain (to 1 machine)
+ *
+ * - Reserializes previously written results when a new result is added
+ * - Optimizes reads though writes are on-chain (~100 machines) and reads are
+ *   off-chain (to 1 machine)
  *
  * Pros
- *    - Reading all offer results happens much more (>100) often than storing a new offer result
- *    - Reserialization and writes are paid in execution gas, whereas reads are not
  *
- * This design should be revisited if ever batch querying across vstorage keys become cheaper or reads be paid.
+ * - Reading all offer results happens much more (>100) often than storing a new
+ *   offer result
+ * - Reserialization and writes are paid in execution gas, whereas reads are not
+ *
+ * This design should be revisited if ever batch querying across vstorage keys
+ * become cheaper or reads be paid.
  *
  * @typedef {{
- *   purses: Array<{brand: Brand, balance: Amount}>,
- *   offerToUsedInvitation: Array<[ offerId: string, usedInvitation: Amount ]>,
- *   offerToPublicSubscriberPaths: Array<[ offerId: string, publicTopics: { [subscriberName: string]: string } ]>,
- *   liveOffers: Array<[OfferId, OfferStatus]>,
+ *   purses: { brand: Brand; balance: Amount }[];
+ *   offerToUsedInvitation: [offerId: string, usedInvitation: Amount][];
+ *   offerToPublicSubscriberPaths: [
+ *     offerId: string,
+ *     publicTopics: { [subscriberName: string]: string },
+ *   ][];
+ *   liveOffers: [OfferId, OfferStatus][];
  * }} CurrentWalletRecord
  */
 
 /**
- * @typedef {{ updated: 'offerStatus', status: OfferStatus }
+ * @typedef {{ updated: 'offerStatus'; status: OfferStatus }
  *   | { updated: 'balance'; currentAmount: Amount }
- *   | { updated: 'walletAction'; status: { error: string } }
- * } UpdateRecord Record of an update to the state of this wallet.
+ *   | { updated: 'walletAction'; status: { error: string } }} UpdateRecord
+ *   Record of an update to the state of this wallet.
  *
- * Client is responsible for coalescing updates into a current state. See `coalesceUpdates` utility.
+ *   Client is responsible for coalescing updates into a current state. See
+ *   `coalesceUpdates` utility.
  *
- * The reason for this burden on the client is that publishing
- * the full history of offers with each change is untenable.
+ *   The reason for this burden on the client is that publishing the full history
+ *   of offers with each change is untenable.
  *
- * `balance` update supports forward-compatibility for more than one purse per
- * brand. An additional key will be needed to disambiguate. For now the brand in
- * the amount suffices.
+ *   `balance` update supports forward-compatibility for more than one purse per
+ *   brand. An additional key will be needed to disambiguate. For now the brand
+ *   in the amount suffices.
  */
 
 /**
  * @typedef {{
- *   brand: Brand,
- *   displayInfo: DisplayInfo,
- *   issuer: Issuer,
- *   petname: import('./types.js').Petname
+ *   brand: Brand;
+ *   displayInfo: DisplayInfo;
+ *   issuer: Issuer;
+ *   petname: import('./types.js').Petname;
  * }} BrandDescriptor
- * For use by clients to describe brands to users. Includes `displayInfo` to save a remote call.
+ *   For use by clients to describe brands to users. Includes `displayInfo` to
+ *   save a remote call.
  */
 
 /**
  * @typedef {{
- *   address: string,
- *   bank: ERef<import('@agoric/vats/src/vat-bank.js').Bank>,
- *   currentStorageNode: StorageNode,
- *   invitationPurse: Purse<'set', InvitationDetails>,
- *   walletStorageNode: StorageNode,
+ *   address: string;
+ *   bank: ERef<import('@agoric/vats/src/vat-bank.js').Bank>;
+ *   currentStorageNode: StorageNode;
+ *   invitationPurse: Purse<'set', InvitationDetails>;
+ *   walletStorageNode: StorageNode;
  * }} UniqueParams
  *
+ *
  * @typedef {Pick<MapStore<Brand, BrandDescriptor>, 'has' | 'get' | 'values'>} BrandDescriptorRegistry
+ *
+ *
  * @typedef {{
- *   agoricNames: ERef<import('@agoric/vats').NameHub>,
- *   registry: BrandDescriptorRegistry,
- *   invitationIssuer: Issuer<'set'>,
- *   invitationBrand: Brand<'set'>,
- *   invitationDisplayInfo: DisplayInfo,
- *   publicMarshaller: Marshaller,
- *   zoe: ERef<ZoeService>,
- *   secretWalletFactoryKey: any,
+ *   agoricNames: ERef<import('@agoric/vats').NameHub>;
+ *   registry: BrandDescriptorRegistry;
+ *   invitationIssuer: Issuer<'set'>;
+ *   invitationBrand: Brand<'set'>;
+ *   invitationDisplayInfo: DisplayInfo;
+ *   publicMarshaller: Marshaller;
+ *   zoe: ERef<ZoeService>;
+ *   secretWalletFactoryKey: any;
  * }} SharedParams
  *
- * @typedef {ImmutableState & MutableState} State
- * - `brandPurses` is precious and closely held. defined as late as possible to reduce its scope.
- * - `offerToInvitationMakers` is precious and closely held.
- * - `offerToPublicSubscriberPaths` is precious and closely held.
- * - `purseBalances` is a cache of what we've received from purses. Held so we can publish all balances on change.
  *
- * @typedef {Readonly<UniqueParams & {
- *   paymentQueues: MapStore<Brand, Array<Payment>>,
- *   offerToInvitationMakers: MapStore<string, import('./types.js').InvitationMakers>,
- *   offerToPublicSubscriberPaths: MapStore<string, Record<string, string>>,
- *   offerToUsedInvitation: MapStore<string, Amount<'set'>>,
- *   purseBalances: MapStore<Purse, Amount>,
- *   updateRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<UpdateRecord>,
- *   currentRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<CurrentWalletRecord>,
- *   liveOffers: MapStore<OfferId, OfferStatus>,
- *   liveOfferSeats: MapStore<OfferId, UserSeat<unknown>>,
- *   liveOfferPayments: MapStore<OfferId, MapStore<Brand, Payment>>,
- * }>} ImmutableState
+ * @typedef {ImmutableState & MutableState} State - `brandPurses` is precious
+ *   and closely held. defined as late as possible to reduce its scope.
+ *
+ *   - `offerToInvitationMakers` is precious and closely held.
+ *   - `offerToPublicSubscriberPaths` is precious and closely held.
+ *   - `purseBalances` is a cache of what we've received from purses. Held so we can
+ *       publish all balances on change.
+ *
+ *
+ * @typedef {Readonly<
+ *   UniqueParams & {
+ *     paymentQueues: MapStore<Brand, Payment[]>;
+ *     offerToInvitationMakers: MapStore<
+ *       string,
+ *       import('./types.js').InvitationMakers
+ *     >;
+ *     offerToPublicSubscriberPaths: MapStore<string, Record<string, string>>;
+ *     offerToUsedInvitation: MapStore<string, Amount<'set'>>;
+ *     purseBalances: MapStore<Purse, Amount>;
+ *     updateRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<UpdateRecord>;
+ *     currentRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<CurrentWalletRecord>;
+ *     liveOffers: MapStore<OfferId, OfferStatus>;
+ *     liveOfferSeats: MapStore<OfferId, UserSeat<unknown>>;
+ *     liveOfferPayments: MapStore<OfferId, MapStore<Brand, Payment>>;
+ *   }
+ * >} ImmutableState
+ *
  *
  * @typedef {BrandDescriptor & { purse: Purse }} PurseRecord
- * @typedef {{
- * }} MutableState
+ *
+ * @typedef {{}} MutableState
  */
 
 /**
@@ -298,8 +323,8 @@ export const prepareSmartWallet = (baggage, shared) => {
       (purse, helper) => ({ purse, helper }),
       {
         /**
-         * @param {{ value: Amount, updateCount: bigint | undefined }} updateRecord
-         * @param { Notifier<Amount> } notifier
+         * @param {{ value: Amount; updateCount: bigint | undefined }} updateRecord
+         * @param {Notifier<Amount>} notifier
          * @returns {void}
          */
         onFulfilled(updateRecord, notifier) {
@@ -460,9 +485,10 @@ export const prepareSmartWallet = (baggage, shared) => {
 
   // TODO move to top level so its type can be exported
   /**
-   * Make the durable object to return, but taking some parameters that are awaited by a wrapping function.
-   * This is necessary because the class kit construction helpers, `initState` and `finish` run synchronously
-   * and the child storage node must be awaited until we have durable promises.
+   * Make the durable object to return, but taking some parameters that are
+   * awaited by a wrapping function. This is necessary because the class kit
+   * construction helpers, `initState` and `finish` run synchronously and the
+   * child storage node must be awaited until we have durable promises.
    */
   const makeWalletWithResolvedStorageNodes = prepareExoClassKit(
     baggage,
@@ -559,15 +585,15 @@ export const prepareSmartWallet = (baggage, shared) => {
         },
 
         /**
-         * Provide a purse given a NameHub of issuers and their
-         * brands.
+         * Provide a purse given a NameHub of issuers and their brands.
          *
-         * We currently support only one NameHub, agoricNames, and
-         * hence one purse per brand. But we store an array of them
-         * to facilitate a transition to decentralized introductions.
+         * We currently support only one NameHub, agoricNames, and hence one
+         * purse per brand. But we store an array of them to facilitate a
+         * transition to decentralized introductions.
          *
          * @param {Brand} brand
-         * @param {ERef<import('@agoric/vats').NameHub>} known - namehub with brand, issuer branches
+         * @param {ERef<import('@agoric/vats').NameHub>} known - namehub with
+         *   brand, issuer branches
          * @returns {Promise<Purse | undefined>} undefined if brand is not known
          */
         async getPurseIfKnownBrand(brand, known) {
@@ -738,9 +764,9 @@ export const prepareSmartWallet = (baggage, shared) => {
 
         /**
          * @param {string} offerId
-         * @param {Amount<"set">} invitationAmount
-         * @param {import("./types.js").InvitationMakers} invitationMakers
-         * @param {import("./types.js").PublicSubscribers} publicSubscribers
+         * @param {Amount<'set'>} invitationAmount
+         * @param {import('./types.js').InvitationMakers} invitationMakers
+         * @param {import('./types.js').PublicSubscribers} publicSubscribers
          */
         async addContinuingOffer(
           offerId,
@@ -814,7 +840,8 @@ export const prepareSmartWallet = (baggage, shared) => {
         },
       },
       /**
-       * Similar to {DepositFacet} but async because it has to look up the purse.
+       * Similar to {DepositFacet} but async because it has to look up the
+       * purse.
        */
       deposit: {
         /**
@@ -824,7 +851,8 @@ export const prepareSmartWallet = (baggage, shared) => {
          *
          * @param {Payment} payment
          * @returns {Promise<Amount>}
-         * @throws if there's not yet a purse, though the payment is held to try again when there is
+         * @throws if there's not yet a purse, though the payment is held to try
+         *   again when there is
          */
         async receive(payment) {
           const {
@@ -863,9 +891,11 @@ export const prepareSmartWallet = (baggage, shared) => {
 
       payments: {
         /**
-         * Withdraw the offered amount from the appropriate purse of this wallet.
+         * Withdraw the offered amount from the appropriate purse of this
+         * wallet.
          *
-         * Save its amount in liveOfferPayments in case we need to reclaim the payment.
+         * Save its amount in liveOfferPayments in case we need to reclaim the
+         * payment.
          *
          * @param {AmountKeywordRecord} give
          * @param {OfferId} offerId
@@ -905,7 +935,8 @@ export const prepareSmartWallet = (baggage, shared) => {
         },
 
         /**
-         * Find the live payments for the offer and deposit them back in the appropriate purses.
+         * Find the live payments for the offer and deposit them back in the
+         * appropriate purses.
          *
          * @param {OfferId} offerId
          * @returns {Promise<Amount[]>}
@@ -946,11 +977,14 @@ export const prepareSmartWallet = (baggage, shared) => {
 
       offers: {
         /**
-         * Take an offer description provided in capData, augment it with payments and call zoe.offer()
+         * Take an offer description provided in capData, augment it with
+         * payments and call zoe.offer()
          *
          * @param {OfferSpec} offerSpec
-         * @returns {Promise<void>} after the offer has been both seated and exited by Zoe.
-         * @throws if any parts of the offer can be determined synchronously to be invalid
+         * @returns {Promise<void>} after the offer has been both seated and
+         *   exited by Zoe.
+         * @throws if any parts of the offer can be determined synchronously to
+         *   be invalid
          */
         async executeOffer(offerSpec) {
           const { facets, state } = this;
@@ -1080,9 +1114,11 @@ export const prepareSmartWallet = (baggage, shared) => {
       },
       self: {
         /**
-         * Umarshals the actionCapData and delegates to the appropriate action handler.
+         * Umarshals the actionCapData and delegates to the appropriate action
+         * handler.
          *
-         * @param {import('@endo/marshal').CapData<string | null>} actionCapData of type BridgeAction
+         * @param {import('@endo/marshal').CapData<string | null>} actionCapData
+         *   of type BridgeAction
          * @param {boolean} [canSpend]
          * @returns {Promise<void>}
          */
@@ -1198,7 +1234,12 @@ export const prepareSmartWallet = (baggage, shared) => {
   );
 
   /**
-   * @param {Omit<UniqueParams, 'currentStorageNode' | 'walletStorageNode'> & {walletStorageNode: ERef<StorageNode>}} uniqueWithoutChildNodes
+   * @param {Omit<
+   *   UniqueParams,
+   *   'currentStorageNode' | 'walletStorageNode'
+   * > & {
+   *   walletStorageNode: ERef<StorageNode>;
+   * }} uniqueWithoutChildNodes
    */
   const makeSmartWallet = async uniqueWithoutChildNodes => {
     const [walletStorageNode, currentStorageNode] = await Promise.all([

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -29,7 +29,10 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
    */
   const invitationsReceived = new Map();
 
-  /** @param {import('./smartWallet.js').UpdateRecord | {}} updateRecord newer than previous */
+  /**
+   * @param {import('./smartWallet.js').UpdateRecord | {}} updateRecord newer
+   *   than previous
+   */
   const update = updateRecord => {
     if (!('updated' in updateRecord)) {
       return;
@@ -133,7 +136,8 @@ export const assertHasData = async follower => {
 /**
  * Handles the case of falsy argument so the caller can consistently await.
  *
- * @param {import('./types.js').PublicSubscribers | import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord} [subscribers]
+ * @param {import('./types.js').PublicSubscribers
+ *   | import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord} [subscribers]
  * @returns {ERef<Record<string, string>> | null}
  */
 export const objectMapStoragePath = subscribers => {

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -2,13 +2,15 @@ import { deeplyFulfilledObject, objectMap, makeTracer } from '@agoric/internal';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import { E } from '@endo/far';
 
+/** @import {OfferId, OfferStatus} from './offers.js'; */
+
 export const NO_SMART_WALLET_ERROR = 'no smart wallet';
 
 const trace = makeTracer('WUTIL', false);
 
 /** @param {Brand<'set'>} [invitationBrand] */
 export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
-  /** @type {Map<import('./offers.js').OfferId, import('./offers.js').OfferStatus>} */
+  /** @type {Map<OfferId, OfferStatus>} */
   const offerStatuses = new Map();
   /** @type {Map<Brand, Amount>} */
   const balances = new Map();
@@ -16,7 +18,14 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
   /**
    * keyed by description; xxx assumes unique
    *
-   * @type {Map<import('./offers.js').OfferId, { acceptedIn: import('./offers.js').OfferId, description: string, instance: Instance }>}
+   * @type {Map<
+   *   OfferId,
+   *   {
+   *     acceptedIn: OfferId;
+   *     description: string;
+   *     instance: Instance;
+   *   }
+   * >}
    */
   const invitationsReceived = new Map();
 

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -1,10 +1,10 @@
 /**
  * @file Wallet Factory
  *
- * Contract to make smart wallets.
+ *   Contract to make smart wallets.
  *
- * Note: The upgrade test uses a slightly modified copy of this file. When the
- * interface changes here, that will also need to change.
+ *   Note: The upgrade test uses a slightly modified copy of this file. When the
+ *   interface changes here, that will also need to change.
  */
 
 import { makeTracer, WalletName } from '@agoric/internal';
@@ -16,6 +16,8 @@ import { provideAll } from '@agoric/zoe/src/contractSupport/durability.js';
 import { E } from '@endo/far';
 import { prepareSmartWallet } from './smartWallet.js';
 import { shape } from './typeGuards.js';
+
+/** @import {NameHub} from '@agoric/vats'; */
 
 const trace = makeTracer('WltFct');
 
@@ -62,8 +64,8 @@ export const publishDepositFacet = async (
  * Make a registry for use by the wallet instances.
  *
  * This doesn't need to persist durably because the `assetPublisher` has a
- * "pinned" topic and call to getAssetSubscription gets a fresh stream of all the
- * assets that it knows of.
+ * "pinned" topic and call to getAssetSubscription gets a fresh stream of all
+ * the assets that it knows of.
  *
  * @param {AssetPublisher} assetPublisher
  */
@@ -71,12 +73,13 @@ export const makeAssetRegistry = assetPublisher => {
   trace('makeAssetRegistry', assetPublisher);
   /**
    * @typedef {{
-   *   brand: Brand,
-   *   displayInfo: DisplayInfo,
-   *   issuer: Issuer,
-   *   petname: import('./types.js').Petname
+   *   brand: Brand;
+   *   displayInfo: DisplayInfo;
+   *   issuer: Issuer;
+   *   petname: import('./types.js').Petname;
    * }} BrandDescriptor
-   * For use by clients to describe brands to users. Includes `displayInfo` to save a remote call.
+   *   For use by clients to describe brands to users. Includes `displayInfo` to
+   *   save a remote call.
    */
   /** @type {MapStore<Brand, BrandDescriptor>} */
   const brandDescriptors = makeScalarMapStore();
@@ -116,22 +119,26 @@ export const makeAssetRegistry = assetPublisher => {
 
 /**
  * @typedef {{
- *   agoricNames: ERef<NameHub>,
- *   board: ERef<import('@agoric/vats').Board>,
- *   assetPublisher: AssetPublisher,
+ *   agoricNames: ERef<NameHub>;
+ *   board: ERef<import('@agoric/vats').Board>;
+ *   assetPublisher: AssetPublisher;
  * }} SmartWalletContractTerms
  *
- * @import {NameHub} from '@agoric/vats'
  *
  * @typedef {{
  *   getAssetSubscription: () => ERef<
- *     IterableEachTopic<import('@agoric/vats/src/vat-bank.js').AssetDescriptor>>
+ *     IterableEachTopic<import('@agoric/vats/src/vat-bank.js').AssetDescriptor>
+ *   >;
  * }} AssetPublisher
  *
- * @typedef {boolean} isRevive
+ *
+ * @typedef {boolean} IsRevive
+ *
  * @typedef {{
- *   reviveWallet: (address: string) => Promise<import('./smartWallet.js').SmartWallet>,
- *   ackWallet: (address: string) => isRevive,
+ *   reviveWallet: (
+ *     address: string,
+ *   ) => Promise<import('./smartWallet.js').SmartWallet>;
+ *   ackWallet: (address: string) => IsRevive;
  * }} WalletReviver
  */
 
@@ -141,9 +148,11 @@ export const makeAssetRegistry = assetPublisher => {
 /**
  * @param {ZCF<SmartWalletContractTerms>} zcf
  * @param {{
- *   storageNode: ERef<StorageNode>,
- *   walletBridgeManager?: ERef<import('@agoric/vats').ScopedBridgeManager<'wallet'>>,
- *   walletReviver?: ERef<WalletReviver>,
+ *   storageNode: ERef<StorageNode>;
+ *   walletBridgeManager?: ERef<
+ *     import('@agoric/vats').ScopedBridgeManager<'wallet'>
+ *   >;
+ *   walletReviver?: ERef<WalletReviver>;
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
@@ -167,17 +176,20 @@ export const prepare = async (zcf, privateArgs, baggage) => {
       /**
        * Designed to be called by the bridgeManager vat.
        *
-       * If this errors before calling handleBridgeAction(), the failure will not be observable. The
-       * promise does reject, but as of now bridge manager drops instead of handling it. Eventually
-       * we'll make the bridge able to give feedback about the requesting transaction. Meanwhile we
-       * could write the error to chainStorage but we don't have a guarantee of the wallet owner to
-       * associate it with. (We could have a shared `lastError` node but it would be so noisy as to
-       * not provide much info to the end user.)
+       * If this errors before calling handleBridgeAction(), the failure will
+       * not be observable. The promise does reject, but as of now bridge
+       * manager drops instead of handling it. Eventually we'll make the bridge
+       * able to give feedback about the requesting transaction. Meanwhile we
+       * could write the error to chainStorage but we don't have a guarantee of
+       * the wallet owner to associate it with. (We could have a shared
+       * `lastError` node but it would be so noisy as to not provide much info
+       * to the end user.)
        *
-       * Once the owner is known, this calls handleBridgeAction which ensures that all errors
-       * are published in the owner wallet's vstorage path.
+       * Once the owner is known, this calls handleBridgeAction which ensures
+       * that all errors are published in the owner wallet's vstorage path.
        *
-       * @param {import('./types.js').WalletBridgeMsg} obj validated by shape.WalletBridgeMsg
+       * @param {import('./types.js').WalletBridgeMsg} obj validated by
+       *   shape.WalletBridgeMsg
        * @returns {Promise<void>}
        */
       fromBridge: async obj => {
@@ -248,6 +260,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   /**
    * Holders of this object:
+   *
    * - vat (transitively from holding the wallet factory)
    * - wallet-ui (which has key material; dapps use wallet-ui to propose actions)
    */
@@ -284,14 +297,20 @@ export const prepare = async (zcf, privateArgs, baggage) => {
        * @param {string} address
        * @param {ERef<import('@agoric/vats/src/vat-bank.js').Bank>} bank
        * @param {ERef<import('@agoric/vats/src/types.js').NameAdmin>} namesByAddressAdmin
-       * @returns {Promise<[wallet: import('./smartWallet.js').SmartWallet, isNew: boolean]>} wallet
-       *   along with a flag to distinguish between looking up an existing wallet
-       *   and creating a new one.
+       * @returns {Promise<
+       *   [wallet: import('./smartWallet.js').SmartWallet, isNew: boolean]
+       * >}
+       *   wallet along with a flag to distinguish between looking up an existing
+       *   wallet and creating a new one.
        */
       provideSmartWallet(address, bank, namesByAddressAdmin) {
         let isNew = false;
 
-        /** @type {(address: string) => Promise<import('./smartWallet.js').SmartWallet>} */
+        /**
+         * @type {(
+         *   address: string,
+         * ) => Promise<import('./smartWallet.js').SmartWallet>}
+         */
         const maker = async _address => {
           const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
           const walletStorageNode = E(storageNode).makeChildNode(address);

--- a/packages/smart-wallet/test/addAsset.test.js
+++ b/packages/smart-wallet/test/addAsset.test.js
@@ -18,7 +18,11 @@ const { Fail } = assert;
 const importSpec = spec =>
   importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<makeDefaultTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 test.before(async t => {
@@ -43,8 +47,8 @@ const range = qty => [...Array(qty).keys()];
 // agoricNames and vstorage are shared mutable state.
 
 /**
- * NOTE: this doesn't test all forms of work.
- * A better test would measure inter-vat messages or some such.
+ * NOTE: this doesn't test all forms of work. A better test would measure
+ * inter-vat messages or some such.
  */
 test.serial('avoid O(wallets) storage writes for a new asset', async t => {
   const bankManager = t.context.consume.bankManager;
@@ -125,16 +129,20 @@ const the = async xP => {
 const IST_UNIT = 1_000_000n;
 const CENT = IST_UNIT / 100n;
 
-/** @param {import('ava').ExecutionContext<Awaited<ReturnType<makeDefaultTestContext>>>} t */
+/**
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<makeDefaultTestContext>>
+ * >} t
+ */
 const makeScenario = t => {
   /**
    * A player and their user agent (wallet UI, signer)
    *
    * @param {string} addr
-   * @param {PromiseKit<*>} bridgeKit - to announce UI is ready
+   * @param {PromiseKit<any>} bridgeKit - to announce UI is ready
    * @param {MockVStorageRoot} vsRPC - access to vstorage via RPC
    * @param {typeof t.context.sendToBridge} broadcastMsg
-   * @param {*} walletUpdates - access to wallet updates via RPC
+   * @param {any} walletUpdates - access to wallet updates via RPC
    */
   const aPlayer = async (
     addr,
@@ -314,7 +322,7 @@ test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
 
   /**
    * @param {MockVStorageRoot} rpc - access to vstorage (in prod: via RPC)
-   * @param {*} walletBridge - iframe connection to wallet UI
+   * @param {any} walletBridge - iframe connection to wallet UI
    */
   const dappFrontEnd = async (rpc, walletBridge) => {
     const { fromEntries } = Object;
@@ -458,7 +466,7 @@ test.serial('non-vbank asset: give before deposit', async t => {
    * Goofy client: proposes to give Places before we have any
    *
    * @param {MockVStorageRoot} rpc - access to vstorage (in prod: via RPC)
-   * @param {*} walletBridge - iframe connection to wallet UI
+   * @param {any} walletBridge - iframe connection to wallet UI
    */
   const goofyClient = async (rpc, walletBridge) => {
     const { fromEntries } = Object;
@@ -518,7 +526,11 @@ test.serial('non-vbank asset: give before deposit', async t => {
     vsGet(`agoricNames.brand`);
     vsGet(`agoricNames.instance`);
 
-    /** @type {import('../src/smartWallet.js').UpdateRecord & {updated: 'offerStatus'}} */
+    /**
+     * @type {import('../src/smartWallet.js').UpdateRecord & {
+     *   updated: 'offerStatus';
+     * }}
+     */
     let offerUpdate;
     let ix = -1;
     for (;;) {

--- a/packages/smart-wallet/test/gameAssetContract.js
+++ b/packages/smart-wallet/test/gameAssetContract.js
@@ -20,7 +20,7 @@ const totalPlaces = amt => {
 };
 
 /**
- * @param {ZCF<{joinPrice: Amount}>} zcf
+ * @param {ZCF<{ joinPrice: Amount }>} zcf
  */
 export const start = async zcf => {
   const { joinPrice } = zcf.getTerms();

--- a/packages/smart-wallet/test/invitation1.test.js
+++ b/packages/smart-wallet/test/invitation1.test.js
@@ -74,7 +74,11 @@ const makeTestContext = async t => {
   const { agoricNames, board, zoe } = bootKit.powers.consume;
   const startAnyContract = async () => {
     const bundle = await bundleCache.load(asset.anyContract, 'automaticRefund');
-    /** @type {Promise<Installation<import('../src/walletFactory.js').prepare>>} */
+    /**
+     * @type {Promise<
+     *   Installation<import('../src/walletFactory.js').prepare>
+     * >}
+     */
     const installation = E(zoe).install(bundle);
     return E(zoe).startInstance(installation);
   };
@@ -109,7 +113,12 @@ const makeTestContext = async t => {
         return d;
       }),
     );
-    /** @type {MapStore<Brand, import('../src/smartWallet.js').BrandDescriptor>} */
+    /**
+     * @type {MapStore<
+     *   Brand,
+     *   import('../src/smartWallet.js').BrandDescriptor
+     * >}
+     */
     const store = makeScalarMapStore('registry');
     store.addAll(harden(descriptors.map(d => [d.brand, d])));
     return store;

--- a/packages/smart-wallet/test/start-game1-proposal.js
+++ b/packages/smart-wallet/test/start-game1-proposal.js
@@ -94,7 +94,7 @@ export const startGameContract = async permittedPowers => {
   console.log('game1 (re)installed');
 };
 
-/** @type { import("@agoric/vats/src/core/lib-boot").BootstrapManifest } */
+/** @type {import('@agoric/vats/src/core/lib-boot').BootstrapManifest} */
 const gameManifest = {
   [startGameContract.name]: {
     consume: {

--- a/packages/smart-wallet/test/startWalletFactory.test.js
+++ b/packages/smart-wallet/test/startWalletFactory.test.js
@@ -6,7 +6,11 @@ import { E } from '@endo/far';
 import path from 'path';
 import { makeMockTestSpace } from './supports.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 const makeTestContext = async () => {

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -94,15 +94,19 @@ const makeFakeBridgeManager = () =>
     },
   });
 /**
- * @param {*} log
- * @returns {Promise<ChainBootstrapSpace>}>}
+ * @param {any} log
+ * @returns {Promise<ChainBootstrapSpace>} >}
  */
 export const makeMockTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
-  const { consume, produce } =
-    /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat, loadCriticalVat: (n: 'mints') => MintsVat }} } */ (
-      space
-    );
+  const { consume, produce } = /**
+   * @type {BootstrapPowers & {
+   *   consume: {
+   *     loadVat: (n: 'mints') => MintsVat;
+   *     loadCriticalVat: (n: 'mints') => MintsVat;
+   *   };
+   * }}
+   */ (space);
   const { agoricNames, agoricNamesAdmin, spaces } =
     await makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
@@ -152,7 +156,9 @@ export const makeMockTestSpace = async log => {
 };
 
 /**
- * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord}>} hasTopics
+ * @param {ERef<{
+ *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport/index.js').TopicsRecord;
+ * }>} hasTopics
  * @param {string} subscriberName
  */
 export const topicPath = (hasTopics, subscriberName) => {

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -100,12 +100,7 @@ const makeFakeBridgeManager = () =>
 export const makeMockTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
   /**
-   * @type {BootstrapPowers & {
-   *   consume: {
-   *     loadVat: (n: 'mints') => MintsVat;
-   *     loadCriticalVat: (n: 'mints') => MintsVat;
-   *   };
-   * }}
+   * @type {BootstrapPowers}
    */
   const { consume, produce } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -99,14 +99,15 @@ const makeFakeBridgeManager = () =>
  */
 export const makeMockTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
-  const { consume, produce } = /**
+  /**
    * @type {BootstrapPowers & {
    *   consume: {
    *     loadVat: (n: 'mints') => MintsVat;
    *     loadCriticalVat: (n: 'mints') => MintsVat;
    *   };
    * }}
-   */ (space);
+   */
+  const { consume, produce } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =
     await makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
@@ -1,8 +1,9 @@
 /**
  * @file fixture for an upgrade of the primary walletFactory contract,
- * packages/smart-wallet/src/walletFactory.js
+ *   packages/smart-wallet/src/walletFactory.js
  *
- * This variant adds a sayHelloUpgrade method to check that upgrade has occurred.
+ *   This variant adds a sayHelloUpgrade method to check that upgrade has
+ *   occurred.
  */
 
 import { M, makeExo, mustMatch } from '@agoric/store';
@@ -27,7 +28,12 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   const zoe = zcf.getZoeService();
   const { storageNode, walletBridgeManager } = privateArgs;
 
-  /** @type {MapStore<string, import('../../../src/smartWallet.js').SmartWallet>} */
+  /**
+   * @type {MapStore<
+   *   string,
+   *   import('../../../src/smartWallet.js').SmartWallet
+   * >}
+   */
   const walletsByAddress = provideDurableMapStore(baggage, 'walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
 
@@ -38,8 +44,8 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     }),
     {
       /**
-       *
-       * @param {import('../../../src/types.js').WalletBridgeMsg} obj validated by shape.WalletBridgeMsg
+       * @param {import('../../../src/types.js').WalletBridgeMsg} obj validated
+       *   by shape.WalletBridgeMsg
        */
       fromBridge: async obj => {
         console.log('walletFactory.fromBridge:', obj);
@@ -99,6 +105,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   /**
    * Holders of this object:
+   *
    * - vat (transitively from holding the wallet factory)
    * - wallet-ui (which has key material; dapps use wallet-ui to propose actions)
    */
@@ -121,13 +128,19 @@ export const prepare = async (zcf, privateArgs, baggage) => {
        * @param {string} address
        * @param {ERef<import('@agoric/vats/src/vat-bank.js').Bank>} bank
        * @param {ERef<import('@agoric/vats/src/types.js').NameAdmin>} namesByAddressAdmin
-       * @returns {Promise<[import('../../../src/smartWallet.js').SmartWallet, boolean]>} wallet
-       *   along with a flag to distinguish between looking up an existing wallet
-       *   and creating a new one.
+       * @returns {Promise<
+       *   [import('../../../src/smartWallet.js').SmartWallet, boolean]
+       * >}
+       *   wallet along with a flag to distinguish between looking up an existing
+       *   wallet and creating a new one.
        */
       provideSmartWallet(address, bank, namesByAddressAdmin) {
         let makerCalled = false;
-        /** @type {() => Promise<import('../../../src/smartWallet.js').SmartWallet>} */
+        /**
+         * @type {() => Promise<
+         *   import('../../../src/smartWallet.js').SmartWallet
+         * >}
+         */
         const maker = async () => {
           const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
           const walletStorageNode = E(storageNode).makeChildNode(address);

--- a/packages/smart-wallet/test/walletFactory.test.js
+++ b/packages/smart-wallet/test/walletFactory.test.js
@@ -11,7 +11,11 @@ import {
   topicPath,
 } from './supports.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<makeDefaultTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 const mockAddress1 = 'mockAddress1';

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -50,7 +50,6 @@ const bootMsgEx = {
  */
 
 /** @typedef {MapStore<string, CreateVatResults>} VatStore */
-/** @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat */
 
 /**
  * @param {BootstrapPowers & {}} powers
@@ -329,9 +328,7 @@ export const produceStartGovernedUpgradable = async ({
 harden(produceStartGovernedUpgradable);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const buildZoe = async ({
   consume: { vatAdminSvc, loadCriticalVat, client },
@@ -360,9 +357,7 @@ export const buildZoe = async ({
 harden(buildZoe);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const startPriceAuthorityRegistry = async ({
   consume: { loadCriticalVat, client },
@@ -418,9 +413,7 @@ harden(produceBoard);
 
 /**
  * @deprecated use produceBoard
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<BoardVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const makeBoard = async ({
   consume: { loadCriticalVat, client },
@@ -607,9 +600,7 @@ harden(mintInitialSupply);
 /**
  * Add IST (with initialSupply payment), BLD (with mint) to BankManager.
  *
- * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<BankVat>> };
- * }} powers
+ * @param {BootstrapSpace} powers
  */
 export const addBankAssets = async ({
   consume: {

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -50,6 +50,7 @@ const bootMsgEx = {
  */
 
 /** @typedef {MapStore<string, CreateVatResults>} VatStore */
+/** @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat */
 
 /**
  * @param {BootstrapPowers & {}} powers
@@ -331,8 +332,6 @@ harden(produceStartGovernedUpgradable);
  * @param {BootstrapPowers & {
  *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> };
  * }} powers
- *
- * @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat
  */
 export const buildZoe = async ({
   consume: { vatAdminSvc, loadCriticalVat, client },
@@ -364,10 +363,12 @@ harden(buildZoe);
  * @param {BootstrapPowers & {
  *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
  * }} powers
+ *   <<<<<<< HEAD
  *
  * @typedef {ERef<
  *   ReturnType<import('../vat-priceAuthority.js').buildRootObject>
  * >} PriceAuthorityVat
+ *   ======= > > > > > > > ab5c460791 (fixup separate typedefs)
  */
 export const startPriceAuthorityRegistry = async ({
   consume: { loadCriticalVat, client },

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -363,12 +363,6 @@ harden(buildZoe);
  * @param {BootstrapPowers & {
  *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
  * }} powers
- *   <<<<<<< HEAD
- *
- * @typedef {ERef<
- *   ReturnType<import('../vat-priceAuthority.js').buildRootObject>
- * >} PriceAuthorityVat
- *   ======= > > > > > > > ab5c460791 (fixup separate typedefs)
  */
 export const startPriceAuthorityRegistry = async ({
   consume: { loadCriticalVat, client },

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -49,6 +49,8 @@ const bootMsgEx = {
  * may want/need them later.
  */
 
+/** @typedef {MapStore<string, CreateVatResults>} VatStore */
+
 /**
  * @param {BootstrapPowers & {}} powers
  * @import {CreateVatResults} from '@agoric/swingset-vat'
@@ -330,7 +332,6 @@ harden(produceStartGovernedUpgradable);
  *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> };
  * }} powers
  *
- *
  * @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat
  */
 export const buildZoe = async ({
@@ -363,7 +364,6 @@ harden(buildZoe);
  * @param {BootstrapPowers & {
  *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
  * }} powers
- *
  *
  * @typedef {ERef<
  *   ReturnType<import('../vat-priceAuthority.js').buildRootObject>

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -53,8 +53,6 @@ const bootMsgEx = {
  * @param {BootstrapPowers & {}} powers
  * @import {CreateVatResults} from '@agoric/swingset-vat'
  *   as from createVatByName
- *
- * @typedef {MapStore<string, CreateVatResults>} VatStore
  */
 export const makeVatsFromBundles = async ({
   vats,
@@ -332,6 +330,7 @@ harden(produceStartGovernedUpgradable);
  *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> };
  * }} powers
  *
+ *
  * @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat
  */
 export const buildZoe = async ({
@@ -364,6 +363,7 @@ harden(buildZoe);
  * @param {BootstrapPowers & {
  *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
  * }} powers
+ *
  *
  * @typedef {ERef<
  *   ReturnType<import('../vat-priceAuthority.js').buildRootObject>

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -108,9 +108,7 @@ export const bridgeCoreEval = async allPowers => {
 harden(bridgeCoreEval);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ProvisioningVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const makeProvisioner = async ({
   consume: { clientCreator, loadCriticalVat },
@@ -302,10 +300,7 @@ export const startTimerService = async ({
 harden(startTimerService);
 
 /**
- * @param {BootDevices<ChainDevices> &
- *   BootstrapSpace & {
- *     consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
- *   }} powers
+ * @param {BootDevices<ChainDevices> & BootstrapSpace} powers
  */
 export const makeBridgeManager = async ({
   consume: { loadCriticalVat },
@@ -341,9 +336,7 @@ export const makeBridgeManager = async ({
 harden(makeBridgeManager);
 
 /**
- * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
- * }} powers
+ * @param {BootstrapSpace} powers
  */
 export const makeChainStorage = async ({
   consume: { loadCriticalVat, bridgeManager: bridgeManagerP },
@@ -376,9 +369,7 @@ export const makeChainStorage = async ({
 };
 
 /**
- * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
- * }} powers
+ * @param {BootstrapSpace} powers
  */
 export const produceHighPrioritySendersManager = async ({
   consume: { loadCriticalVat, storageBridgeManager: storageBridgeManagerP },

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -218,8 +218,7 @@ const provideCoin = async (name, mints) => {
 };
 
 /**
- * @param {BootstrapSpace & { consume: { loadVat: VatLoader<MintsVat> } }} powers
- *   TODO: sync this type with end-user docs?
+ * @param {BootstrapSpace} powers TODO: sync this type with end-user docs?
  *
  * @typedef {{
  *   issuer: ERef<Issuer>;

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -10,7 +10,7 @@ import { makePromiseSpace } from './promise-space.js';
 const { Fail, quote: q } = assert;
 
 /**
- * @typedef {| true
+ * @typedef {true
  *   | string
  *   | { [key: string]: BootstrapManifestPermit | undefined }} BootstrapManifestPermit
  */

--- a/packages/vats/src/core/promise-space.js
+++ b/packages/vats/src/core/promise-space.js
@@ -76,7 +76,7 @@ export const makeStoreHooks = (store, log = noop) => {
  * Note: repeated resolve()s without an intervening reset() are noops.
  *
  * @template {Record<string, unknown>} [T=Record<string, unknown>]
- * @param {| ({ log?: typeof console.log } & (
+ * @param {({ log?: typeof console.log } & (
  *       | { hooks?: PromiseSpaceHooks }
  *       | { store: MapStore<string, any> }
  *     ))

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -20,6 +20,7 @@ const trace = makeTracer('StartWF');
  *   import('@agoric/smart-wallet/src/walletFactory.js').start
  * >} inst
  *
+ *
  * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
  */
 // eslint-disable-next-line no-unused-vars

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -109,7 +109,10 @@ type Producer<T> = {
 };
 
 type VatSourceRef = { bundleName?: string; bundleID?: string };
-type VatLoader<T> = (name: string, sourceRef?: VatSourceRef) => T;
+type VatLoader = <K extends keyof WellKnownVats>(
+  name: K,
+  sourceRef?: VatSourceRef,
+) => WellKnownVats[K];
 
 /** callback to assign a property onto the `home` object of the client */
 type PropertyMaker = (addr: string, flags: string[]) => Record<string, unknown>;
@@ -425,12 +428,12 @@ type BootstrapSpace = WellKnownSpaces &
   PromiseSpaceOf<
     ChainBootstrapSpaceT & {
       vatAdminSvc: VatAdminSvc;
+    } & {
+      loadVat: VatLoader;
+      loadCriticalVat: VatLoader;
     },
     {},
-    {
-      loadVat: VatLoader<unknown>;
-      loadCriticalVat: VatLoader<unknown>;
-    }
+    {}
   >;
 
 type ProvisioningVat = ERef<
@@ -498,3 +501,21 @@ type HttpVat = ERef<
 type UploadsVat = ERef<
   ReturnType<typeof import('@agoric/solo/src/vat-uploads.js').buildRootObject>
 >;
+
+type WellKnownVats = SwingsetVats & {
+  bank: BankVat;
+  board: BoardVat;
+  bridge: ChainStorageVat;
+  localchain: LocalChainVat;
+  ibc: IBCVat;
+  mints: MintsVat;
+  network: NetworkVat;
+  orchestration: ERef<
+    ReturnType<
+      typeof import('@agoric/orchestration/src/vat-orchestration.js').buildRootObject
+    >
+  >;
+  priceAuthority: PriceAuthorityVat;
+  provisioning: ProvisioningVat;
+  zoe: ERef<ReturnType<typeof import('../vat-zoe.js').buildRootObject>>;
+};

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -325,6 +325,7 @@ export const makeMyAddressNameAdminKit = address => {
  * @import {CreateVatResults} from '@agoric/swingset-vat'
  *   as from createVatByName
  *
+ *
  * @typedef {MapStore<string, CreateVatResults>} VatStore
  */
 export const makeVatSpace = (

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -317,6 +317,8 @@ export const makeMyAddressNameAdminKit = address => {
   return { nameHub, myAddressNameAdmin };
 };
 
+/** @typedef {MapStore<string, CreateVatResults>} VatStore */
+
 /**
  * @param {ERef<ReturnType<Awaited<VatAdminVat>['createVatAdminService']>>} svc
  * @param {unknown} criticalVatKey
@@ -324,9 +326,6 @@ export const makeMyAddressNameAdminKit = address => {
  * @param {string} [label]
  * @import {CreateVatResults} from '@agoric/swingset-vat'
  *   as from createVatByName
- *
- *
- * @typedef {MapStore<string, CreateVatResults>} VatStore
  */
 export const makeVatSpace = (
   svc,

--- a/packages/vats/src/proposals/localchain-proposal.js
+++ b/packages/vats/src/proposals/localchain-proposal.js
@@ -5,7 +5,6 @@ import { BridgeId as BRIDGE_ID } from '@agoric/internal';
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     loadCriticalVat: VatLoader<any>;
  *     localchainBridgeManager: import('../types').ScopedBridgeManager<'vlocalchain'>;
  *   };
  *   produce: {

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -86,6 +86,7 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  *
  * @typedef {((name: 'network') => NetworkVat) & ((name: 'ibc') => IBCVat)} VatLoader2
  *
+ *
  * @typedef {{
  *   network: ERef<NetworkVat>;
  *   ibc: ERef<IBCVat>;

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -77,7 +77,6 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  * - echo port addrees: /ibc-port/custom-echo
  *
  * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: VatLoader<any> };
  *   produce: { portAllocator: Producer<any> };
  * }} powers
  * @param {object} options

--- a/packages/vats/test/vat-bank-integration.test.js
+++ b/packages/vats/test/vat-bank-integration.test.js
@@ -23,9 +23,7 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   // Supply bootstrap prerequisites.
   const space = /** @type {any} */ (makePromiseSpace(t.log));
   /**
-   * @type {BootstrapPowers & {
-   *   consume: { loadCriticalVat: VatLoader<any> };
-   * }}
+   * @type {BootstrapPowers}
    */
   const { produce, consume } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =

--- a/packages/vats/test/vat-bank.test.js
+++ b/packages/vats/test/vat-bank.test.js
@@ -154,7 +154,7 @@ test('communication', async t => {
   });
 
   /**
-   * @type {| undefined
+   * @type {undefined
    *   | IteratorResult<{
    *       brand: Brand;
    *       issuer: ERef<Issuer>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,10 +3483,10 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
-"@types/mdast@^3.0.0":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
-  integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
   dependencies:
     "@types/unist" "*"
 
@@ -3627,10 +3627,10 @@
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
   integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
 
-"@types/unist@*", "@types/unist@^2.0.0":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
-  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.2.tgz#6dd61e43ef60b34086287f83683a5c1b2dc53d20"
+  integrity sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==
 
 "@types/yargs-parser@*", "@types/yargs-parser@^21.0.0":
   version "21.0.3"
@@ -4881,7 +4881,7 @@ commander@^11.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
-comment-parser@1.4.1, comment-parser@^1.3.1:
+comment-parser@1.4.1, comment-parser@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.1.tgz#bdafead37961ac079be11eb7ec65c4d021eaf9cc"
   integrity sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==
@@ -5381,6 +5381,13 @@ deterministic-json@^1.0.5:
   dependencies:
     json-stable-stringify "^1.0.1"
 
+devlop@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -5398,11 +5405,6 @@ diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
-
-diff@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
-  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -7845,11 +7847,6 @@ klaw-sync@^6.0.0:
   dependencies:
     graceful-fs "^4.1.11"
 
-kleur@^4.0.3:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
-  integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
-
 koalas@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/koalas/-/koalas-1.0.2.tgz#318433f074235db78fae5661a02a8ca53ee295cd"
@@ -8252,30 +8249,30 @@ md5-hex@^3.0.1:
   dependencies:
     blueimp-md5 "^2.10.0"
 
-mdast-util-from-markdown@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz#9421a5a247f10d31d2faed2a30df5ec89ceafcf0"
-  integrity sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==
+mdast-util-from-markdown@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.1.tgz#32a6e8f512b416e1f51eb817fc64bd867ebcd9cc"
+  integrity sha512-aJEUyzZ6TzlsX2s5B4Of7lN7EQtAxvtradMMglCQDyaTFgse6CmtmdJ15ElnVRlCg1vpNyVtbem0PWzlNieZsA==
   dependencies:
-    "@types/mdast" "^3.0.0"
-    "@types/unist" "^2.0.0"
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
     decode-named-character-reference "^1.0.0"
-    mdast-util-to-string "^3.1.0"
-    micromark "^3.0.0"
-    micromark-util-decode-numeric-character-reference "^1.0.0"
-    micromark-util-decode-string "^1.0.0"
-    micromark-util-normalize-identifier "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    unist-util-stringify-position "^3.0.0"
-    uvu "^0.5.0"
+    devlop "^1.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark "^4.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-stringify-position "^4.0.0"
 
-mdast-util-to-string@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
-  integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
+mdast-util-to-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
   dependencies:
-    "@types/mdast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -8369,199 +8366,199 @@ micro-spelling-correcter@^1.1.1:
   resolved "https://registry.yarnpkg.com/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz#805a06a26ccfcad8f3e5c6a1ac5ff29d4530166e"
   integrity sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==
 
-micromark-core-commonmark@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz#1386628df59946b2d39fb2edfd10f3e8e0a75bb8"
-  integrity sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==
+micromark-core-commonmark@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.1.tgz#9a45510557d068605c6e9a80f282b2bb8581e43d"
+  integrity sha512-CUQyKr1e///ZODyD1U3xit6zXwy1a8q2a1S1HKtIlmgvurrEpaw/Y9y6KSIbF8P59cn/NjzHyO+Q2fAyYLQrAA==
   dependencies:
     decode-named-character-reference "^1.0.0"
-    micromark-factory-destination "^1.0.0"
-    micromark-factory-label "^1.0.0"
-    micromark-factory-space "^1.0.0"
-    micromark-factory-title "^1.0.0"
-    micromark-factory-whitespace "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-chunked "^1.0.0"
-    micromark-util-classify-character "^1.0.0"
-    micromark-util-html-tag-name "^1.0.0"
-    micromark-util-normalize-identifier "^1.0.0"
-    micromark-util-resolve-all "^1.0.0"
-    micromark-util-subtokenize "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.1"
-    uvu "^0.5.0"
+    devlop "^1.0.0"
+    micromark-factory-destination "^2.0.0"
+    micromark-factory-label "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-factory-title "^2.0.0"
+    micromark-factory-whitespace "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-html-tag-name "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-factory-destination@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz#eb815957d83e6d44479b3df640f010edad667b9f"
-  integrity sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==
+micromark-factory-destination@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz#857c94debd2c873cba34e0445ab26b74f6a6ec07"
+  integrity sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==
   dependencies:
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-factory-label@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz#cc95d5478269085cfa2a7282b3de26eb2e2dec68"
-  integrity sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==
+micromark-factory-label@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz#17c5c2e66ce39ad6f4fc4cbf40d972f9096f726a"
+  integrity sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==
   dependencies:
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-factory-space@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz#c8f40b0640a0150751d3345ed885a080b0d15faf"
-  integrity sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==
+micromark-factory-space@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz#5e7afd5929c23b96566d0e1ae018ae4fcf81d030"
+  integrity sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==
   dependencies:
-    micromark-util-character "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-factory-title@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz#dd0fe951d7a0ac71bdc5ee13e5d1465ad7f50ea1"
-  integrity sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==
+micromark-factory-title@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz#726140fc77892af524705d689e1cf06c8a83ea95"
+  integrity sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==
   dependencies:
-    micromark-factory-space "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-factory-whitespace@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz#798fb7489f4c8abafa7ca77eed6b5745853c9705"
-  integrity sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==
+micromark-factory-whitespace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz#9e92eb0f5468083381f923d9653632b3cfb5f763"
+  integrity sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==
   dependencies:
-    micromark-factory-space "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-util-character@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.2.0.tgz#4fedaa3646db249bc58caeb000eb3549a8ca5dcc"
-  integrity sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==
+micromark-util-character@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.0.tgz#31320ace16b4644316f6bf057531689c71e2aee1"
+  integrity sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==
   dependencies:
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-util-chunked@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz#37a24d33333c8c69a74ba12a14651fd9ea8a368b"
-  integrity sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==
+micromark-util-chunked@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz#e51f4db85fb203a79dbfef23fd41b2f03dc2ef89"
+  integrity sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==
   dependencies:
-    micromark-util-symbol "^1.0.0"
+    micromark-util-symbol "^2.0.0"
 
-micromark-util-classify-character@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz#6a7f8c8838e8a120c8e3c4f2ae97a2bff9190e9d"
-  integrity sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==
+micromark-util-classify-character@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz#8c7537c20d0750b12df31f86e976d1d951165f34"
+  integrity sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==
   dependencies:
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-util-combine-extensions@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz#192e2b3d6567660a85f735e54d8ea6e3952dbe84"
-  integrity sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==
+micromark-util-combine-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz#75d6ab65c58b7403616db8d6b31315013bfb7ee5"
+  integrity sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==
   dependencies:
-    micromark-util-chunked "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-util-decode-numeric-character-reference@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz#b1e6e17009b1f20bc652a521309c5f22c85eb1c6"
-  integrity sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==
+micromark-util-decode-numeric-character-reference@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz#2698bbb38f2a9ba6310e359f99fcb2b35a0d2bd5"
+  integrity sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==
   dependencies:
-    micromark-util-symbol "^1.0.0"
+    micromark-util-symbol "^2.0.0"
 
-micromark-util-decode-string@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz#dc12b078cba7a3ff690d0203f95b5d5537f2809c"
-  integrity sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==
+micromark-util-decode-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz#7dfa3a63c45aecaa17824e656bcdb01f9737154a"
+  integrity sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==
   dependencies:
     decode-named-character-reference "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-decode-numeric-character-reference "^1.0.0"
-    micromark-util-symbol "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-symbol "^2.0.0"
 
-micromark-util-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz#92e4f565fd4ccb19e0dcae1afab9a173bbeb19a5"
-  integrity sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==
+micromark-util-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz#0921ac7953dc3f1fd281e3d1932decfdb9382ab1"
+  integrity sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==
 
-micromark-util-html-tag-name@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz#48fd7a25826f29d2f71479d3b4e83e94829b3588"
-  integrity sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==
+micromark-util-html-tag-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz#ae34b01cbe063363847670284c6255bb12138ec4"
+  integrity sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==
 
-micromark-util-normalize-identifier@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz#7a73f824eb9f10d442b4d7f120fecb9b38ebf8b7"
-  integrity sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==
+micromark-util-normalize-identifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz#91f9a4e65fe66cc80c53b35b0254ad67aa431d8b"
+  integrity sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==
   dependencies:
-    micromark-util-symbol "^1.0.0"
+    micromark-util-symbol "^2.0.0"
 
-micromark-util-resolve-all@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz#4652a591ee8c8fa06714c9b54cd6c8e693671188"
-  integrity sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==
+micromark-util-resolve-all@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz#189656e7e1a53d0c86a38a652b284a252389f364"
+  integrity sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==
   dependencies:
-    micromark-util-types "^1.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-util-sanitize-uri@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz#613f738e4400c6eedbc53590c67b197e30d7f90d"
-  integrity sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz#ec8fbf0258e9e6d8f13d9e4770f9be64342673de"
+  integrity sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==
   dependencies:
-    micromark-util-character "^1.0.0"
-    micromark-util-encode "^1.0.0"
-    micromark-util-symbol "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
 
-micromark-util-subtokenize@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz#941c74f93a93eaf687b9054aeb94642b0e92edb1"
-  integrity sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==
+micromark-util-subtokenize@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.1.tgz#76129c49ac65da6e479c09d0ec4b5f29ec6eace5"
+  integrity sha512-jZNtiFl/1aY73yS3UGQkutD0UbhTt68qnRpw2Pifmz5wV9h8gOVsN70v+Lq/f1rKaU/W8pxRe8y8Q9FX1AOe1Q==
   dependencies:
-    micromark-util-chunked "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
-micromark-util-symbol@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz#813cd17837bdb912d069a12ebe3a44b6f7063142"
-  integrity sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==
+micromark-util-symbol@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz#12225c8f95edf8b17254e47080ce0862d5db8044"
+  integrity sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==
 
-micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.1.0.tgz#e6676a8cae0bb86a2171c498167971886cb7e283"
-  integrity sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==
+micromark-util-types@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.0.tgz#63b4b7ffeb35d3ecf50d1ca20e68fc7caa36d95e"
+  integrity sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==
 
-micromark@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.2.0.tgz#1af9fef3f995ea1ea4ac9c7e2f19c48fd5c006e9"
-  integrity sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==
+micromark@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-4.0.0.tgz#84746a249ebd904d9658cfabc1e8e5f32cbc6249"
+  integrity sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==
   dependencies:
     "@types/debug" "^4.0.0"
     debug "^4.0.0"
     decode-named-character-reference "^1.0.0"
-    micromark-core-commonmark "^1.0.1"
-    micromark-factory-space "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-chunked "^1.0.0"
-    micromark-util-combine-extensions "^1.0.0"
-    micromark-util-decode-numeric-character-reference "^1.0.0"
-    micromark-util-encode "^1.0.0"
-    micromark-util-normalize-identifier "^1.0.0"
-    micromark-util-resolve-all "^1.0.0"
-    micromark-util-sanitize-uri "^1.0.0"
-    micromark-util-subtokenize "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.1"
-    uvu "^0.5.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.5"
@@ -8824,11 +8821,6 @@ morgan@^1.10.0:
     depd "~2.0.0"
     on-finished "~2.3.0"
     on-headers "~1.0.2"
-
-mri@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
-  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -9840,14 +9832,14 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-jsdoc@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.0.1.tgz#7fb6741969cb503e8f40e96cdc4f5dd9b7ebd2a9"
-  integrity sha512-07q74MfX9m+xHK2+Lr4c+igiEzAKVDWhqkvlm65WoYJUlRiaV6STXcEtcZMhrPPYgNeQRgb9FJmgE/n+OI4MpQ==
+prettier-plugin-jsdoc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.3.0.tgz#98e9cbecc5b8725801cc8a4233a16748500e867b"
+  integrity sha512-cQm8xIa0fN9ieJFMXACQd6JPycl+8ouOijAqUqu44EF/s4fXL3Wi9sKXuEaodsEWgCN42Xby/bNhqgM1iWx4uw==
   dependencies:
     binary-searching "^2.0.5"
-    comment-parser "^1.3.1"
-    mdast-util-from-markdown "^1.2.0"
+    comment-parser "^1.4.0"
+    mdast-util-from-markdown "^2.0.0"
 
 prettier-plugin-sh@^0.14.0:
   version "0.14.0"
@@ -10401,13 +10393,6 @@ rxjs@^7.5.5:
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
-
-sade@^1.7.3:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
-  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
-  dependencies:
-    mri "^1.1.0"
 
 safe-array-concat@^1.1.0:
   version "1.1.0"
@@ -11601,12 +11586,12 @@ unique-slug@^4.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unist-util-stringify-position@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz#03ad3348210c2d930772d64b489580c13a7db39d"
-  integrity sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
   dependencies:
-    "@types/unist" "^2.0.0"
+    "@types/unist" "^3.0.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.1"
@@ -11664,16 +11649,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uvu@^0.5.0:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
-  integrity sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==
-  dependencies:
-    dequal "^2.0.0"
-    diff "^5.0.0"
-    kleur "^4.0.3"
-    sade "^1.7.3"
 
 v8-compile-cache@2.3.0:
   version "2.3.0"
@@ -11981,12 +11956,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.2.2:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.1.tgz#2e57e0b5e995292c25c75d2658f0664765210eed"
-  integrity sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==
-
-yaml@^2.3.4:
+yaml@^2.2.2, yaml@^2.3.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.2.tgz#7a2b30f2243a5fc299e1f14ca58d475ed4bc5362"
   integrity sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==


### PR DESCRIPTION
stacked on https://github.com/Agoric/agoric-sdk/pull/9438

## Description

While working through some bootstrap space types I noticed boilerplate for declaring vat loaders, whereas they could all be from a common lookup.

This makes that change using a `WellKnownVats`, but it's not working due to a bug with EProxy. I ran into that recently somewhere else too. I don't have time rn to dig in further but I'll leave this as a test case to validate a fix. cc @michaelfig 

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
