### PR TITLE
test(swingset): fix GC test flake by forcing xsnap worker, not V8

### DIFF
--- a/packages/SwingSet/test/gc/gc-vat.test.js
+++ b/packages/SwingSet/test/gc/gc-vat.test.js
@@ -107,8 +107,8 @@ test('forward to fake zoe', async t => {
       },
       target: {
         sourceSpec: new URL('vat-target.js', import.meta.url).pathname,
-        // creationOptions: { managerType: 'xs-worker' },
-        creationOptions: { managerType: 'local' },
+        // avoid V8's GC nondeterminism, only needed on the target vat
+        creationOptions: { managerType: 'xs-worker' },
       },
       zoe: {
         sourceSpec: new URL('vat-fake-zoe.js', import.meta.url).pathname,


### PR DESCRIPTION
This "forward to fake zoe" in gc-vat.test was added to demonstrate a fix for #3482, in which liveslots was mishandling an intermediate promise by retaining it forever, which made us retain objects that appear in eventual-send results forever.

This problem was discovered while investigating an unrelated XS engine bug (#3406), so "is this specific to a single engine?" was on our mind, and I wasn't sure that we were dealing with two independent bugs until I wrote the test and showed that it failed on both V8 and XS. So the test was originally written with a commented-out `managerType:` option to make it easy to switch back and forth between `local` and `xs-worker`. That switch was left in the `local` state, probably because it's slightly faster.

What we've learned is that V8 sometimes holds on to objects despite a forced GC pass (see #5575 and #3240), and somehow it only seems to fail in CI runs (and only for people other than me). Our usual response is to make the test use XS instead of V8, either by setting `creationOptions.managerType: 'xs-worker'` on the individual vat, or by setting `defaultManagerType: 'xs-worker'` to set it for all vats.

This PR uses the first approach, changing just the one vat being exercised (which should be marginally cheaper than making all vats use XS).

closes #9392
