### PR TITLE
feat(vlocalchain): use `jsonp.Marshaller` with `OrigName: false` for response marshalling

### DIFF
--- a/golang/cosmos/vm/proto_json.go
+++ b/golang/cosmos/vm/proto_json.go
@@ -1,0 +1,38 @@
+package vm
+
+import (
+	"encoding/json"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+// We need jsonpb for its access to the global registry.
+var marshaller = jsonpb.Marshaler{EmitDefaults: true}
+
+func ProtoJSONMarshal(val interface{}) ([]byte, error) {
+	if pm, ok := val.(proto.Message); ok {
+		var s string
+		s, err := marshaller.MarshalToString(pm)
+		return []byte(s), err
+	}
+
+	// Marshal a non-proto value to JSON.
+	return json.Marshal(val)
+}
+
+// ProtoJSONMarshalSlice marshals a slice of proto messages and non-proto values to
+// a single JSON byte slice.
+func ProtoJSONMarshalSlice(vals []interface{}) ([]byte, error) {
+	var err error
+	jsonSlice := make([]json.RawMessage, len(vals))
+	for i, val := range vals {
+		jsonSlice[i], err = ProtoJSONMarshal(val)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Marshal the JSON array to a single JSON byte slice.
+	return json.Marshal(jsonSlice)
+}

--- a/golang/cosmos/vm/proto_json_test.go
+++ b/golang/cosmos/vm/proto_json_test.go
@@ -1,0 +1,103 @@
+package vm_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+func TestProtoJSONMarshal(t *testing.T) {
+	accAddr, err := sdk.AccAddressFromHexUnsafe("0123456789")
+	if err != nil {
+		panic(err)
+	}
+	valAddr, err := sdk.ValAddressFromHex("9876543210")
+	if err != nil {
+		panic(err)
+	}
+	coin := sdk.NewInt64Coin("uatom", 1234567)
+
+	testCases := []struct {
+		name     string
+		create   func() interface{}
+		expected string
+	}{
+		{
+			"nil",
+			func() interface{} {
+				return nil
+			},
+			`null`,
+		},
+		{
+			"primitive number",
+			func() interface{} {
+				return 12345
+			},
+			`12345`,
+		},
+		{
+			"MsgDelegate",
+			func() interface{} {
+				return stakingtypes.NewMsgDelegate(accAddr, valAddr, coin)
+			},
+			`{"delegatorAddress":"cosmos1qy352eufjjmc9c","validatorAddress":"cosmosvaloper1npm9gvss52mlmk","amount":{"denom":"uatom","amount":"1234567"}}`,
+		},
+		{
+			"QueryDenomOwnersResponse",
+			func() interface{} {
+				return &banktypes.QueryDenomOwnersResponse{
+					DenomOwners: []*banktypes.DenomOwner{
+						{
+							Address: accAddr.String(),
+							Balance: coin,
+						},
+						{
+							Address: valAddr.String(),
+							Balance: coin.Add(coin),
+						},
+					},
+				}
+			},
+			`{"denomOwners":[{"address":"cosmos1qy352eufjjmc9c","balance":{"denom":"uatom","amount":"1234567"}},{"address":"cosmosvaloper1npm9gvss52mlmk","balance":{"denom":"uatom","amount":"2469134"}}],"pagination":null}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val := tc.create()
+			bz, err := vm.ProtoJSONMarshal(val)
+			if err != nil {
+				t.Errorf("ProtoJSONMarshal of %q failed %v", val, err)
+			}
+			if !bytes.Equal(bz, []byte(tc.expected)) {
+				t.Errorf("ProtoJSONMarshal of %q returned %q, expected %q", val, string(bz), tc.expected)
+			}
+		})
+	}
+
+	t.Run("all in a slice", func(t *testing.T) {
+		vals := make([]interface{}, len(testCases))
+		expectedJson := make([]string, len(testCases))
+		for i, tc := range testCases {
+			vals[i] = tc.create()
+			expectedJson[i] = tc.expected
+		}
+		bz, err := vm.ProtoJSONMarshalSlice(vals)
+		if err != nil {
+			t.Errorf("ProtoJSONMarshalSlice of %q failed %v", vals, err)
+		}
+
+		expected := "[" + strings.Join(expectedJson, ",") + "]"
+		if !bytes.Equal(bz, []byte(expected)) {
+			t.Errorf("ProtoJSONMarshalSlice of %q returned %q, expected %q", vals, string(bz), expected)
+		}
+	})
+}

--- a/golang/cosmos/x/vlocalchain/keeper/keeper_test.go
+++ b/golang/cosmos/x/vlocalchain/keeper/keeper_test.go
@@ -1,6 +1,15 @@
 package keeper
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/app/params"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
 
 func TestKeeper_ParseRequestTypeURL(t *testing.T) {
 	testCases := []struct {
@@ -26,6 +35,62 @@ func TestKeeper_ParseRequestTypeURL(t *testing.T) {
 			}
 			if responseURL != tc.responseURL {
 				t.Errorf("%v response expected %v, got %v", tc.typeUrl, tc.responseURL, responseURL)
+			}
+		})
+	}
+}
+
+func TestKeeper_DeserializeTxMessages(t *testing.T) {
+	encodingConfig := params.MakeEncodingConfig()
+	cdc := encodingConfig.Marshaler
+
+	banktypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	keeper := NewKeeper(cdc, nil, nil, nil)
+
+	expectedMsgSend := []sdk.Msg{
+		&banktypes.MsgSend{
+			FromAddress: "cosmos1abc",
+			ToAddress:   "cosmos1xyz",
+			Amount:      sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100))),
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		json     string
+		expected []sdk.Msg
+		wantErr  bool
+	}{
+		{
+			name: "camelCase keys",
+			json: `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","fromAddress":"cosmos1abc","toAddress":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
+			expected: expectedMsgSend,
+			wantErr: false,
+		},
+		{
+			name: "snake_case keys",
+			json: `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_address":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
+			expected: expectedMsgSend,
+			wantErr: false,
+		},
+		{
+			name: "misspelled key",
+			json: `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_addresss":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
+			expected: expectedMsgSend,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs, err := keeper.DeserializeTxMessages([]byte(tc.json))
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, msgs)
 			}
 		})
 	}

--- a/golang/cosmos/x/vlocalchain/vlocalchain.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain.go
@@ -57,7 +57,7 @@ func (h portHandler) Receive(cctx context.Context, str string) (ret string, err 
 		}
 
 		// We need jsonpb for its access to the global registry.
-		marshaller := jsonpb.Marshaler{EmitDefaults: true, OrigName: true}
+		marshaller := jsonpb.Marshaler{EmitDefaults: true, OrigName: false}
 
 		var s string
 		resps := make([]json.RawMessage, len(qms))

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -405,8 +405,8 @@ func TestExecuteTx(t *testing.T) {
 	t.Run("MsgUndelegate", func(t *testing.T) {
 		// create a new message
 		msg := `{"type":"VLOCALCHAIN_EXECUTE_TX","address":"` + addr +
-			`","messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate","delegator_address":"` +
-			addr + `","validator_address":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj","amount":{"denom":"stake","amount":"100"}}]}`
+			`","messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate","delegatorAddress":"` +
+			addr + `","validatorAddress":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj","amount":{"denom":"stake","amount":"100"}}]}`
 
 		ret, err := handler.Receive(cctx, msg)
 		if err != nil {
@@ -427,8 +427,8 @@ func TestExecuteTx(t *testing.T) {
 			t.Fatalf("expected 1 response, got %d", len(resp))
 		}
 		
-		if _, ok := resp[0]["completion_time"]; !ok {
-			t.Error("expected 'completion_time' field in response")
+		if _, ok := resp[0]["completionTime"]; !ok {
+			t.Error("expected 'completionTime' field in response")
 		}
 	})
 }

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -303,11 +303,11 @@ func TestQuery(t *testing.T) {
 		}
 
 		// Check the field names and values
-		if unbond["delegator_address"] != firstAddr {
-			t.Errorf("expected delegator_address %s, got %v", firstAddr, unbond["delegator_address"])
+		if unbond["delegatorAddress"] != firstAddr {
+			t.Errorf("expected delegatorAddress %s, got %v", firstAddr, unbond["delegator_address"])
 		}
-		if unbond["validator_address"] != "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj" {
-			t.Errorf("expected validator_address cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj, got %v", unbond["validator_address"])
+		if unbond["validatorAddress"] != "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj" {
+			t.Errorf("expected validatorAddress cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj, got %v", unbond["validator_address"])
 		}
 
 		entries, ok := unbond["entries"].([]interface{})
@@ -318,14 +318,14 @@ func TestQuery(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected unbonding delegation entry to be a map, got %v", entries[0])
 		}
-		if entry["creation_height"] != "100" {
-			t.Errorf("expected creation_height \"100\", got %v", entry["creation_height"])
+		if entry["creationHeight"] != "100" {
+			t.Errorf("expected creationHeight \"100\", got %v", entry["creation_height"])
 		}
 		if entry["balance"] != "500" {
 			t.Errorf("expected balance \"500\", got %v", entry["balance"])
 		}
-		if _, ok := entry["completion_time"]; !ok {
-			t.Error("expected completion_time field in the response")
+		if _, ok := entry["completionTime"]; !ok {
+			t.Error("expected completionTime field in the response")
 		}
 	})
 }

--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/app/params"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
@@ -16,6 +17,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -77,8 +79,36 @@ func (t *mockTransfer) Transfer(cctx context.Context, msg *transfertypes.MsgTran
 	return &transfertypes.MsgTransferResponse{Sequence: 1}, nil
 }
 
+type mockStaking struct {
+	stakingtypes.UnimplementedMsgServer
+	stakingtypes.UnimplementedQueryServer
+}
+
+var _ stakingtypes.MsgServer = (*mockStaking)(nil)
+var _ stakingtypes.QueryServer = (*mockStaking)(nil)
+
+func (s *mockStaking) Undelegate(cctx context.Context, msg *stakingtypes.MsgUndelegate) (*stakingtypes.MsgUndelegateResponse, error) {
+	return &stakingtypes.MsgUndelegateResponse{CompletionTime: time.Now().UTC()}, nil
+}
+
+func (s *mockStaking) UnbondingDelegation(cctx context.Context, req *stakingtypes.QueryUnbondingDelegationRequest) (*stakingtypes.QueryUnbondingDelegationResponse, error) {
+	unbondingDelegation := stakingtypes.UnbondingDelegation{
+		DelegatorAddress: req.DelegatorAddr,
+		ValidatorAddress: "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj",
+		Entries: []stakingtypes.UnbondingDelegationEntry{
+			{
+				CreationHeight: 100,
+				CompletionTime: time.Now().UTC().Add(time.Hour * 24 * 7),
+				InitialBalance: sdk.NewInt(1000),
+				Balance:        sdk.NewInt(500),
+			},
+		},
+	}
+	return &stakingtypes.QueryUnbondingDelegationResponse{Unbond: unbondingDelegation}, nil
+}
+
 // makeTestKit creates a minimal Keeper and Context for use in testing.
-func makeTestKit(bank *mockBank, transfer *mockTransfer) (vm.PortHandler, context.Context) {
+func makeTestKit(bank *mockBank, transfer *mockTransfer, staking *mockStaking) (vm.PortHandler, context.Context) {
 	encodingConfig := params.MakeEncodingConfig()
 	cdc := encodingConfig.Marshaler
 
@@ -93,6 +123,10 @@ func makeTestKit(bank *mockBank, transfer *mockTransfer) (vm.PortHandler, contex
 	transfertypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	transfertypes.RegisterMsgServer(txRouter, transfer)
 	transfertypes.RegisterQueryServer(queryRouter, transfer)
+	stakingtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	stakingtypes.RegisterMsgServer(txRouter, staking)
+	stakingtypes.RegisterQueryServer(queryRouter, staking)
+
 
 	// create a new Keeper
 	keeper := vlocalchain.NewKeeper(cdc, vlocalchainStoreKey, txRouter, queryRouter)
@@ -118,7 +152,8 @@ func makeTestKit(bank *mockBank, transfer *mockTransfer) (vm.PortHandler, contex
 func TestAllocateAddress(t *testing.T) {
 	bank := &mockBank{}
 	transfer := &mockTransfer{}
-	handler, cctx := makeTestKit(bank, transfer)
+	staking := &mockStaking{}
+	handler, cctx := makeTestKit(bank, transfer, staking)
 
 	addrs := map[string]bool{
 		firstAddr: false,
@@ -161,7 +196,8 @@ func TestQuery(t *testing.T) {
 		alreadyAddr: []sdk.Coin{sdk.NewCoin("stale", sdk.NewInt(321))},
 	}}
 	transfer := &mockTransfer{}
-	handler, cctx := makeTestKit(bank, transfer)
+	staking := &mockStaking{}
+	handler, cctx := makeTestKit(bank, transfer, staking)
 
 	// get balances
 	testCases := []struct {
@@ -230,6 +266,68 @@ func TestQuery(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("UnbondingDelegation", func(t *testing.T) {
+		// create a new message
+		msg := `{"type":"VLOCALCHAIN_QUERY_MANY","messages":[{"@type":"/cosmos.staking.v1beta1.QueryUnbondingDelegationRequest","delegator_addr":"` + firstAddr + `","validator_addr":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj"}]}`
+		t.Logf("query request: %v", msg)
+		ret, err := handler.Receive(cctx, msg)
+		t.Logf("query response: %v", ret)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ret == "" {
+			t.Fatalf("expected non-empty json")
+		}
+
+		// Unmarshal the JSON response
+		var respJSON []map[string]interface{}
+		if err := json.Unmarshal([]byte(ret), &respJSON); err != nil {
+			t.Fatalf("unexpected error unmarshalling JSON response: %v", err)
+		}
+
+		// Check the response fields
+		if len(respJSON) != 1 {
+			t.Fatalf("expected 1 response, got %d", len(respJSON))
+		}
+		resp := respJSON[0]
+
+		replyAny, ok := resp["reply"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected reply field to be a map, got %v", resp["reply"])
+		}
+
+		unbond, ok := replyAny["unbond"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected unbond field to be a map, got %v", replyAny["unbond"])
+		}
+
+		// Check the field names and values
+		if unbond["delegator_address"] != firstAddr {
+			t.Errorf("expected delegator_address %s, got %v", firstAddr, unbond["delegator_address"])
+		}
+		if unbond["validator_address"] != "cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj" {
+			t.Errorf("expected validator_address cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj, got %v", unbond["validator_address"])
+		}
+
+		entries, ok := unbond["entries"].([]interface{})
+		if !ok || len(entries) != 1 {
+			t.Fatalf("expected 1 unbonding delegation entry, got %v", entries)
+		}
+		entry, ok := entries[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected unbonding delegation entry to be a map, got %v", entries[0])
+		}
+		if entry["creation_height"] != "100" {
+			t.Errorf("expected creation_height \"100\", got %v", entry["creation_height"])
+		}
+		if entry["balance"] != "500" {
+			t.Errorf("expected balance \"500\", got %v", entry["balance"])
+		}
+		if _, ok := entry["completion_time"]; !ok {
+			t.Error("expected completion_time field in the response")
+		}
+	})
 }
 
 func TestExecuteTx(t *testing.T) {
@@ -239,7 +337,8 @@ func TestExecuteTx(t *testing.T) {
 		alreadyAddr: []sdk.Coin{sdk.NewCoin("stale", sdk.NewInt(321))},
 	}}
 	transfer := &mockTransfer{}
-	handler, cctx := makeTestKit(bank, transfer)
+	staking := &mockStaking{}
+	handler, cctx := makeTestKit(bank, transfer, staking)
 
 	// create a new message
 	msg := `{"type":"VLOCALCHAIN_ALLOCATE_ADDRESS"}`
@@ -302,4 +401,34 @@ func TestExecuteTx(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("MsgUndelegate", func(t *testing.T) {
+		// create a new message
+		msg := `{"type":"VLOCALCHAIN_EXECUTE_TX","address":"` + addr +
+			`","messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate","delegator_address":"` +
+			addr + `","validator_address":"cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj","amount":{"denom":"stake","amount":"100"}}]}`
+
+		ret, err := handler.Receive(cctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if ret == "" {
+			t.Fatalf("expected non-empty json")
+		}
+
+		// Unmarshal the response
+		var resp []map[string]interface{}
+		if err := json.Unmarshal([]byte(ret), &resp); err != nil {
+			t.Fatalf("unexpected error unmarshalling response: %v", err)
+		}
+
+		// Check the response fields
+		if len(resp) != 1 {
+			t.Fatalf("expected 1 response, got %d", len(resp))
+		}
+		
+		if _, ok := resp[0]["completion_time"]; !ok {
+			t.Error("expected 'completion_time' field in response")
+		}
+	})
 }


### PR DESCRIPTION
closes: #9445 

## Description

Uses `jsonp.Marshaller` with `OrigName: false` for response marshalling for `vlocalchain` queries and transactions to ensure responses sent to the JS side of the bridge are camelCase instead of snake_case.

### Security Considerations


### Scaling Considerations


### Documentation Considerations


### Testing Considerations

Starts with new tests that have multiword response keys (e.g. `completion_time`/`completionTime`, `validator_address`/`validatorAddress`) to demonstrate current behavior.

### Upgrade Considerations

`vlocalchain` has yet to be released, but this is important to land in the initial iteration to avoid future breaking changes.
