### PR TITLE
fix(vlocalchain): sdkerrors.Wrap is deprecated

### DIFF
--- a/golang/cosmos/x/vlocalchain/handler.go
+++ b/golang/cosmos/x/vlocalchain/handler.go
@@ -3,6 +3,7 @@ package vlocalchain
 import (
 	"fmt"
 
+	sdkioerrors "cosmossdk.io/errors"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vlocalchain/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -14,7 +15,7 @@ func NewHandler(keeper keeper.Keeper) sdk.Handler {
 		switch msg := msg.(type) {
 		default:
 			errMsg := fmt.Sprintf("Unrecognized vlocalchain Msg type: %T", msg)
-			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+			return nil, sdkioerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
 		}
 	}
 }


### PR DESCRIPTION
refs: #9445

## Description

Fixes `golangci-lint` _error: SA1019: sdkerrors.Wrap is deprecated: functionality of this package has been moved to it's own module: (staticcheck)_ https://github.com/Agoric/agoric-sdk/actions/runs/9372072920

### Security Considerations

### Scaling Considerations

### Documentation Considerations

### Testing Considerations

Considered adding a small test like this:

<details>
<summary>vlocalchain_test.go</summary>

```go
diff --git a/golang/cosmos/x/vlocalchain/vlocalchain_test.go b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
index 57de979ff..1a5f4c1ab 100644
--- a/golang/cosmos/x/vlocalchain/vlocalchain_test.go
+++ b/golang/cosmos/x/vlocalchain/vlocalchain_test.go
@@ -431,4 +431,16 @@ func TestExecuteTx(t *testing.T) {
                        t.Error("expected 'completionTime' field in response")
                }
        })
+
+       t.Run("Unknown handler", func(t *testing.T) {
+               msg := `{"type":"VLOCALCHAIN_NOT_IMPLEMENTED","value":"test"}`
+               ret, err := handler.Receive(cctx, msg)
+               expectedErr := "unrecognized message type VLOCALCHAIN_NOT_IMPLEMENTED"
+               if err == nil || err.Error() != expectedErr {
+                       t.Fatalf("Expected error: %s, but got: %v", expectedErr, err)
+               }
+               if ret != "" {
+                       t.Fatalf("Expected empty return value, but got: %s", ret)
+               }
+       })
 }
```
</details>

But it doesn't seem like this code block will be reached (vlocalchain's `Receive`'s will handle error on unknown message types in its default block)



### Upgrade Considerations
