### PR TITLE
feat(orchestration): return unwrapped vows

### DIFF
--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -14,6 +14,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*'",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc",
@@ -57,6 +58,7 @@
     "@cosmjs/proto-signing": "^0.32.3",
     "@endo/ses-ava": "^1.2.2",
     "ava": "^5.3.1",
+    "c8": "^9.1.0",
     "prettier": "^3.3.2"
   },
   "ava": {

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -6,7 +6,7 @@ import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/record
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { V } from '@agoric/vow/vat.js';
+import { prepareVowTools, V } from '@agoric/vow/vat.js';
 import { E } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M } from '@endo/patterns';
@@ -40,12 +40,14 @@ export const start = async (zcf, privateArgs, baggage) => {
     baggage,
     privateArgs.marshaller,
   );
+  const vowTools = prepareVowTools(zone.subZone('vows'));
 
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     zone,
     makeRecorderKit,
     zcf,
     privateArgs.timerService,
+    vowTools,
     makeChainHub(privateArgs.agoricNames),
   );
 

--- a/packages/orchestration/src/examples/stakeIca.contract.js
+++ b/packages/orchestration/src/examples/stakeIca.contract.js
@@ -2,7 +2,7 @@
 
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
 import { TimerServiceShape } from '@agoric/time';
-import { V as E } from '@agoric/vow/vat.js';
+import { V as E, prepareVowTools } from '@agoric/vow/vat.js';
 import {
   prepareRecorderKitMakers,
   provideAll,
@@ -76,9 +76,12 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
 
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+
   const makeCosmosOrchestrationAccount = prepareCosmosOrchestrationAccount(
     zone,
     makeRecorderKit,
+    vowTools,
     zcf,
   );
 

--- a/packages/orchestration/src/exos/chain-account-kit.js
+++ b/packages/orchestration/src/exos/chain-account-kit.js
@@ -169,7 +169,7 @@ export const prepareChainAccountKit = zone =>
         },
         async onClose(_connection, reason) {
           trace(`ICA Channel closed. Reason: ${reason}`);
-          // FIXME handle connection closing
+          // FIXME handle connection closing https://github.com/Agoric/agoric-sdk/issues/9192
           // XXX is there a scenario where a connection will unexpectedly close? _I think yes_
         },
         async onReceive(connection, bytes) {

--- a/packages/orchestration/src/exos/chain-account-kit.js
+++ b/packages/orchestration/src/exos/chain-account-kit.js
@@ -65,7 +65,7 @@ export const prepareChainAccountKit = (zone, { watch, when }) =>
     {
       account: ChainAccountI,
       connectionHandler: ConnectionHandlerI,
-      handleExecuteEncodedTxWatcher: M.interface('HandleQueryWatcher', {
+      parseTxPacketWatcher: M.interface('ParseTxPacketWatcher', {
         onFulfilled: M.call(M.string())
           .optional(M.arrayOf(M.undefined())) // does not need watcherContext
           .returns(M.string()),
@@ -87,7 +87,7 @@ export const prepareChainAccountKit = (zone, { watch, when }) =>
         localAddress: undefined,
       }),
     {
-      handleExecuteEncodedTxWatcher: {
+      parseTxPacketWatcher: {
         /** @param {string} ack */
         onFulfilled(ack) {
           return parseTxPacket(ack);
@@ -139,11 +139,13 @@ export const prepareChainAccountKit = (zone, { watch, when }) =>
          */
         executeEncodedTx(msgs, opts) {
           const { connection } = this.state;
+          // TODO #9281 do not throw synchronously when returning a promise; return a rejected Vow
+          /// see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
           if (!connection) throw Fail`connection not available`;
           return when(
             watch(
               E(connection).send(makeTxPacket(msgs, opts)),
-              this.facets.handleExecuteEncodedTxWatcher,
+              this.facets.parseTxPacketWatcher,
             ),
           );
         },
@@ -153,6 +155,8 @@ export const prepareChainAccountKit = (zone, { watch, when }) =>
           // - retrieve assets?
           // - revoke the port?
           const { connection } = this.state;
+          // TODO #9281 do not throw synchronously when returning a promise; return a rejected Vow
+          /// see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
           if (!connection) throw Fail`connection not available`;
           return when(watch(E(connection).close()));
         },

--- a/packages/orchestration/src/exos/chain-account-kit.js
+++ b/packages/orchestration/src/exos/chain-account-kit.js
@@ -137,7 +137,7 @@ export const prepareChainAccountKit = (zone, { watch, when }) =>
          *   decoded using the corresponding `Msg*Response` object.
          * @throws {Error} if packet fails to send or an error is returned
          */
-        executeEncodedTx(msgs, opts) {
+        async executeEncodedTx(msgs, opts) {
           const { connection } = this.state;
           // TODO #9281 do not throw synchronously when returning a promise; return a rejected Vow
           /// see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
@@ -150,7 +150,7 @@ export const prepareChainAccountKit = (zone, { watch, when }) =>
           );
         },
         /** Close the remote account */
-        close() {
+        async close() {
           /// TODO #9192 what should the behavior be here? and `onClose`?
           // - retrieve assets?
           // - revoke the port?

--- a/packages/orchestration/src/exos/icq-connection-kit.js
+++ b/packages/orchestration/src/exos/icq-connection-kit.js
@@ -68,9 +68,7 @@ export const prepareICQConnectionKit = (zone, { watch, when }) =>
       handleQueryWatcher: HandleQueryWatcherI,
       connectionHandler: ConnectionHandlerI,
     },
-    /**
-     * @param {Port} port
-     */
+    /** @param {Port} port */
     port =>
       /** @type {ICQConnectionKitState} */ ({
         port,
@@ -110,7 +108,9 @@ export const prepareICQConnectionKit = (zone, { watch, when }) =>
       },
       handleQueryWatcher: {
         /** @param {string} ack packet acknowledgement string */
-        onFulfilled: ack => parseQueryPacket(ack),
+        onFulfilled(ack) {
+          return parseQueryPacket(ack);
+        },
       },
       connectionHandler: {
         /**

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -55,7 +55,7 @@ export const prepareLocalChainFacade = (
             chainId: localChainInfo.chainId,
             addressEncoding: 'bech32',
           }),
-          // FIXME storage path
+          // FIXME storage path https://github.com/Agoric/agoric-sdk/issues/9066
           storageNode,
         });
 

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -110,7 +110,7 @@ export const prepareLocalOrchestrationAccountKit = (
           .optional(M.arrayOf(M.undefined()))
           .returns(M.record()),
       }),
-      returnVoidWatcher: M.interface('extractFirstResultWatcher', {
+      returnVoidWatcher: M.interface('returnVoidWatcher', {
         onFulfilled: M.call(M.arrayOf(M.record()))
           .optional(M.arrayOf(M.undefined()))
           .returns(M.undefined()),

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -250,6 +250,8 @@ export const prepareLocalOrchestrationAccountKit = (
           // TODO #9211 lookup denom from brand
           if ('brand' in amount) throw Fail`ERTP Amounts not yet supported`;
 
+          // TODO consider using `getChainsAndConnection` but right now it's keyed by chain name
+          // and we only have chainId for destination.
           const agoricChainInfo = await chainHub.getChainInfo('agoric');
           const { transferChannel } = await chainHub.getConnectionInfo(
             agoricChainInfo,

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -252,8 +252,8 @@ export const prepareLocalOrchestrationAccountKit = (
 
           const agoricChainInfo = await chainHub.getChainInfo('agoric');
           const { transferChannel } = await chainHub.getConnectionInfo(
-            agoricChainInfo.chainId,
-            destination.chainId,
+            agoricChainInfo,
+            destination,
           );
 
           await null;

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -7,7 +7,7 @@ import { prepareOrchestrator } from './exos/orchestrator.js';
 /**
  * @import {AsyncFlowTools} from '@agoric/async-flow';
  * @import {Zone} from '@agoric/zone';
- * @import {Vow} from '@agoric/vow';
+ * @import {Vow, VowTools} from '@agoric/vow';
  * @import {TimerService} from '@agoric/time';
  * @import {IBCConnectionID} from '@agoric/vats';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -1,7 +1,7 @@
 import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/far';
-import { makeChainHub } from '../utils/chainHub.js';
+import { getChainsAndConnection, makeChainHub } from '../utils/chainHub.js';
 
 /**
  * @import {IBCConnectionID} from '@agoric/vats';
@@ -46,9 +46,11 @@ export const startStakeAtom = async ({
 
   const chainHub = makeChainHub(await agoricNames);
 
-  const agoric = await chainHub.getChainInfo('agoric');
-  const cosmoshub = await chainHub.getChainInfo('cosmoshub');
-  const connectionInfo = await chainHub.getConnectionInfo(agoric, cosmoshub);
+  const [_, cosmoshub, connectionInfo] = await getChainsAndConnection(
+    chainHub,
+    'agoric',
+    'cosmoshub',
+  );
 
   /** @type {StartUpgradableOpts<StakeIcaSF>} */
   const startOpts = {

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -48,10 +48,7 @@ export const startStakeAtom = async ({
 
   const agoric = await chainHub.getChainInfo('agoric');
   const cosmoshub = await chainHub.getChainInfo('cosmoshub');
-  const connectionInfo = await chainHub.getConnectionInfo(
-    agoric.chainId,
-    cosmoshub.chainId,
-  );
+  const connectionInfo = await chainHub.getConnectionInfo(agoric, cosmoshub);
 
   /** @type {StartUpgradableOpts<StakeIcaSF>} */
   const startOpts = {

--- a/packages/orchestration/src/proposals/start-stakeOsmo.js
+++ b/packages/orchestration/src/proposals/start-stakeOsmo.js
@@ -1,7 +1,7 @@
 import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/far';
-import { makeChainHub } from '../utils/chainHub.js';
+import { getChainsAndConnection, makeChainHub } from '../utils/chainHub.js';
 
 /**
  * @import {IBCConnectionID} from '@agoric/vats';
@@ -47,11 +47,10 @@ export const startStakeOsmo = async ({
 
   const chainHub = makeChainHub(await agoricNames);
 
-  const agoric = await chainHub.getChainInfo('agoric');
-  const osmosis = await chainHub.getChainInfo('osmosis');
-  const connectionInfo = await chainHub.getConnectionInfo(
-    agoric.chainId,
-    osmosis.chainId,
+  const [_, osmosis, connectionInfo] = await getChainsAndConnection(
+    chainHub,
+    'agoric',
+    'osmosis',
   );
 
   /** @type {StartUpgradableOpts<StakeIcaSF>} */

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -213,13 +213,14 @@ const prepareOrchestrationKit = (
         },
         /**
          * @param {IBCConnectionID} controllerConnectionId
-         * @returns {ICQConnection | Promise<ICQConnection>}
+         * @returns {Promise<ICQConnection>}
          */
         provideICQConnection(controllerConnectionId) {
           if (this.state.icqConnections.has(controllerConnectionId)) {
             // TODO #9281 do not return synchronously. see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
-            return this.state.icqConnections.get(controllerConnectionId)
-              .connection;
+            return when(
+              this.state.icqConnections.get(controllerConnectionId).connection,
+            );
           }
           const remoteConnAddr = makeICQChannelAddress(controllerConnectionId);
           const portAllocator = getPower(this.state.powers, 'portAllocator');

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -69,12 +69,12 @@ const prepareOrchestrationKit = (
   zone.exoClassKit(
     'Orchestration',
     {
-      requestICAConnectionWatcher: M.interface('RequestICAConnectionWatcher', {
+      requestICAChannelWatcher: M.interface('RequestICAChannelWatcher', {
         onFulfilled: M.call(M.remotable('Port'))
           .optional({ chainId: M.string(), remoteConnAddr: M.string() })
           .returns(NetworkShape.Vow$(NetworkShape.Connection)),
       }),
-      requestICQConnectionWatcher: M.interface('RequestICQConnectionWatcher', {
+      requestICQChannelWatcher: M.interface('RequestICQChannelWatcher', {
         onFulfilled: M.call(M.remotable('Port'))
           .optional({
             remoteConnAddr: M.string(),
@@ -114,7 +114,7 @@ const prepareOrchestrationKit = (
       return /** @type {OrchestrationState} */ ({ powers, icqConnections });
     },
     {
-      requestICAConnectionWatcher: {
+      requestICAChannelWatcher: {
         /**
          * @param {Port} port
          * @param {{
@@ -135,7 +135,7 @@ const prepareOrchestrationKit = (
           );
         },
       },
-      requestICQConnectionWatcher: {
+      requestICQChannelWatcher: {
         /**
          * @param {Port} port
          * @param {{
@@ -203,7 +203,7 @@ const prepareOrchestrationKit = (
           return when(
             watch(
               E(portAllocator).allocateICAControllerPort(),
-              this.facets.requestICAConnectionWatcher,
+              this.facets.requestICAChannelWatcher,
               {
                 chainId,
                 remoteConnAddr,
@@ -217,6 +217,7 @@ const prepareOrchestrationKit = (
          */
         provideICQConnection(controllerConnectionId) {
           if (this.state.icqConnections.has(controllerConnectionId)) {
+            // TODO #9281 do not return synchronously. see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
             return this.state.icqConnections.get(controllerConnectionId)
               .connection;
           }
@@ -227,7 +228,7 @@ const prepareOrchestrationKit = (
               // allocate a new Port for every Connection
               // TODO #9317 optimize ICQ port allocation
               E(portAllocator).allocateICQControllerPort(),
-              this.facets.requestICQConnectionWatcher,
+              this.facets.requestICQChannelWatcher,
               {
                 remoteConnAddr,
                 controllerConnectionId,

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -15,6 +15,7 @@ import {
  * @import {Remote} from '@agoric/internal';
  * @import {Port, PortAllocator} from '@agoric/network';
  * @import {IBCConnectionID} from '@agoric/vats';
+ * @import {VowTools} from '@agoric/vow';
  * @import {ICQConnection, IcaAccount, ICQConnectionKit} from './types.js';
  */
 
@@ -104,7 +105,7 @@ const prepareOrchestrationKit = (
         },
         async allocateICQControllerPort() {
           const portAllocator = getPower(this.state.powers, 'portAllocator');
-          return E(portAllocator).allocateICAControllerPort();
+          return E(portAllocator).allocateICQControllerPort();
         },
       },
       public: {
@@ -168,10 +169,13 @@ const prepareOrchestrationKit = (
     },
   );
 
-/** @param {Zone} zone */
-export const prepareOrchestrationTools = zone => {
+/**
+ * @param {Zone} zone
+ * @param {VowTools} vowTools
+ */
+export const prepareOrchestrationTools = (zone, vowTools) => {
   const makeChainAccountKit = prepareChainAccountKit(zone);
-  const makeICQConnectionKit = prepareICQConnectionKit(zone);
+  const makeICQConnectionKit = prepareICQConnectionKit(zone, vowTools);
   const makeOrchestrationKit = prepareOrchestrationKit(
     zone,
     makeChainAccountKit,

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -1,6 +1,6 @@
 /** @file Orchestration service */
 
-import { V as E } from '@agoric/vow/vat.js';
+import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { Shape as NetworkShape } from '@agoric/network';
 import { prepareChainAccountKit } from './exos/chain-account-kit.js';
@@ -13,10 +13,11 @@ import {
 /**
  * @import {Zone} from '@agoric/base-zone';
  * @import {Remote} from '@agoric/internal';
- * @import {Port, PortAllocator} from '@agoric/network';
+ * @import {Connection, Port, PortAllocator} from '@agoric/network';
  * @import {IBCConnectionID} from '@agoric/vats';
+ * @import {RemoteIbcAddress} from '@agoric/vats/tools/ibc-utils.js';
  * @import {VowTools} from '@agoric/vow';
- * @import {ICQConnection, IcaAccount, ICQConnectionKit} from './types.js';
+ * @import {ICQConnection, IcaAccount, ICQConnectionKit, ChainAccountKit} from './types.js';
  */
 
 const { Fail, bare } = assert;
@@ -37,9 +38,9 @@ const { Fail, bare } = assert;
  * >} PowerStore
  */
 
-/**
- * @typedef {MapStore<IBCConnectionID, ICQConnectionKit>} ICQConnectionStore
- */
+/** @typedef {MapStore<IBCConnectionID, ICQConnectionKit>} ICQConnectionStore */
+
+/** @typedef {ChainAccountKit | ICQConnectionKit} ConnectionKit */
 
 /**
  * @template {keyof OrchestrationPowers} K
@@ -51,39 +52,54 @@ const getPower = (powers, name) => {
   return /** @type {OrchestrationPowers[K]} */ (powers.get(name));
 };
 
-export const OrchestrationI = M.interface('Orchestration', {
-  makeAccount: M.callWhen(M.string(), M.string(), M.string()).returns(
-    M.remotable('ChainAccount'),
-  ),
-  provideICQConnection: M.callWhen(M.string()).returns(
-    M.remotable('Connection'),
-  ),
-});
-
 /** @typedef {{ powers: PowerStore; icqConnections: ICQConnectionStore }} OrchestrationState */
 
 /**
  * @param {Zone} zone
+ * @param {VowTools} vowTools
  * @param {ReturnType<typeof prepareChainAccountKit>} makeChainAccountKit
  * @param {ReturnType<typeof prepareICQConnectionKit>} makeICQConnectionKit
  */
 const prepareOrchestrationKit = (
   zone,
+  { when, watch },
   makeChainAccountKit,
   makeICQConnectionKit,
 ) =>
   zone.exoClassKit(
     'Orchestration',
     {
-      self: M.interface('OrchestrationSelf', {
-        allocateICAControllerPort: M.callWhen().returns(
-          NetworkShape.Vow$(NetworkShape.Port),
+      requestICAConnectionWatcher: M.interface('RequestICAConnectionWatcher', {
+        onFulfilled: M.call(M.remotable('Port'))
+          .optional({ chainId: M.string(), remoteConnAddr: M.string() })
+          .returns(NetworkShape.Vow$(NetworkShape.Connection)),
+      }),
+      requestICQConnectionWatcher: M.interface('RequestICQConnectionWatcher', {
+        onFulfilled: M.call(M.remotable('Port'))
+          .optional({
+            remoteConnAddr: M.string(),
+            controllerConnectionId: M.string(),
+          })
+          .returns(NetworkShape.Vow$(NetworkShape.Connection)),
+      }),
+      channelOpenWatcher: M.interface('ChannelOpenWatcher', {
+        onFulfilled: M.call(M.remotable('Connection'))
+          .optional(
+            M.splitRecord(
+              { connectionKit: M.record(), returnFacet: M.string() },
+              { saveICQConnection: M.string() },
+            ),
+          )
+          .returns(M.remotable('ConnectionKit Holder facet')),
+      }),
+      public: M.interface('OrchestrationService', {
+        makeAccount: M.callWhen(M.string(), M.string(), M.string()).returns(
+          M.remotable('ChainAccountKit'),
         ),
-        allocateICQControllerPort: M.callWhen().returns(
-          NetworkShape.Vow$(NetworkShape.Port),
+        provideICQConnection: M.callWhen(M.string()).returns(
+          M.remotable('ICQConnection'),
         ),
       }),
-      public: OrchestrationI,
     },
     /** @param {Partial<OrchestrationPowers>} [initialPowers] */
     initialPowers => {
@@ -98,15 +114,77 @@ const prepareOrchestrationKit = (
       return /** @type {OrchestrationState} */ ({ powers, icqConnections });
     },
     {
-      self: {
-        async allocateICAControllerPort() {
-          const portAllocator = getPower(this.state.powers, 'portAllocator');
-          return E(portAllocator).allocateICAControllerPort();
+      requestICAConnectionWatcher: {
+        /**
+         * @param {Port} port
+         * @param {{
+         *   chainId: string;
+         *   remoteConnAddr: RemoteIbcAddress;
+         * }} watchContext
+         */
+        onFulfilled(port, { chainId, remoteConnAddr }) {
+          const chainAccountKit = makeChainAccountKit(
+            chainId,
+            port,
+            remoteConnAddr,
+          );
+          return watch(
+            E(port).connect(remoteConnAddr, chainAccountKit.connectionHandler),
+            this.facets.channelOpenWatcher,
+            { returnFacet: 'account', connectionKit: chainAccountKit },
+          );
         },
-        async allocateICQControllerPort() {
-          const portAllocator = getPower(this.state.powers, 'portAllocator');
-          return E(portAllocator).allocateICQControllerPort();
+      },
+      requestICQConnectionWatcher: {
+        /**
+         * @param {Port} port
+         * @param {{
+         *   remoteConnAddr: RemoteIbcAddress;
+         *   controllerConnectionId: IBCConnectionID;
+         * }} watchContext
+         */
+        onFulfilled(port, { remoteConnAddr, controllerConnectionId }) {
+          const connectionKit = makeICQConnectionKit(port);
+          /** @param {ICQConnectionKit} kit */
+          return watch(
+            E(port).connect(remoteConnAddr, connectionKit.connectionHandler),
+            this.facets.channelOpenWatcher,
+            {
+              connectionKit,
+              returnFacet: 'connection',
+              saveICQConnection: controllerConnectionId,
+            },
+          );
         },
+      },
+      /**
+       * Waits for a channel (ICA, ICQ) to open and returns the consumer-facing
+       * facet of the ConnectionKit, specified by `returnFacet`. Saves the
+       * ConnectionKit if `saveICQConnection` is provided.
+       */
+      channelOpenWatcher: {
+        /**
+         * @param {Connection} _connection
+         * @param {{
+         *   connectionKit: ConnectionKit;
+         *   returnFacet: string;
+         *   saveICQConnection?: IBCConnectionID;
+         * }} watchContext
+         */
+        onFulfilled(
+          _connection,
+          { connectionKit, returnFacet, saveICQConnection },
+        ) {
+          if (saveICQConnection) {
+            this.state.icqConnections.init(
+              saveICQConnection,
+              /** @type {ICQConnectionKit} */ (connectionKit),
+            );
+          }
+          return connectionKit[returnFacet];
+        },
+        // TODO #9317 if we fail, should we revoke the port (if it was created in this flow)?
+        // onRejected() {}
       },
       public: {
         /**
@@ -116,54 +194,46 @@ const prepareOrchestrationKit = (
          * @param {IBCConnectionID} controllerConnectionId self connection_id
          * @returns {Promise<IcaAccount>}
          */
-        async makeAccount(chainId, hostConnectionId, controllerConnectionId) {
-          const port = await this.facets.self.allocateICAControllerPort();
-
+        makeAccount(chainId, hostConnectionId, controllerConnectionId) {
           const remoteConnAddr = makeICAChannelAddress(
             hostConnectionId,
             controllerConnectionId,
           );
-          const chainAccountKit = makeChainAccountKit(
-            chainId,
-            port,
-            remoteConnAddr,
+          const portAllocator = getPower(this.state.powers, 'portAllocator');
+          return when(
+            watch(
+              E(portAllocator).allocateICAControllerPort(),
+              this.facets.requestICAConnectionWatcher,
+              {
+                chainId,
+                remoteConnAddr,
+              },
+            ),
           );
-
-          // await so we do not return a ChainAccount before it successfully instantiates
-          await E(port).connect(
-            remoteConnAddr,
-            chainAccountKit.connectionHandler,
-          );
-          // FIXME if we fail, should we close the port (if it was created in this flow)?
-          return chainAccountKit.account;
         },
         /**
          * @param {IBCConnectionID} controllerConnectionId
-         * @returns {Promise<ICQConnection>}
+         * @returns {ICQConnection | Promise<ICQConnection>}
          */
-        async provideICQConnection(controllerConnectionId) {
+        provideICQConnection(controllerConnectionId) {
           if (this.state.icqConnections.has(controllerConnectionId)) {
             return this.state.icqConnections.get(controllerConnectionId)
               .connection;
           }
-          // allocate a new Port for every Connection
-          // TODO #9317 optimize ICQ port allocation
-          const port = await this.facets.self.allocateICQControllerPort();
           const remoteConnAddr = makeICQChannelAddress(controllerConnectionId);
-          const icqConnectionKit = makeICQConnectionKit(port);
-
-          // await so we do not return/save a ICQConnection before it successfully instantiates
-          await E(port).connect(
-            remoteConnAddr,
-            icqConnectionKit.connectionHandler,
+          const portAllocator = getPower(this.state.powers, 'portAllocator');
+          return when(
+            watch(
+              // allocate a new Port for every Connection
+              // TODO #9317 optimize ICQ port allocation
+              E(portAllocator).allocateICQControllerPort(),
+              this.facets.requestICQConnectionWatcher,
+              {
+                remoteConnAddr,
+                controllerConnectionId,
+              },
+            ),
           );
-
-          this.state.icqConnections.init(
-            controllerConnectionId,
-            icqConnectionKit,
-          );
-
-          return icqConnectionKit.connection;
         },
       },
     },
@@ -178,6 +248,7 @@ export const prepareOrchestrationTools = (zone, vowTools) => {
   const makeICQConnectionKit = prepareICQConnectionKit(zone, vowTools);
   const makeOrchestrationKit = prepareOrchestrationKit(
     zone,
+    vowTools,
     makeChainAccountKit,
     makeICQConnectionKit,
   );

--- a/packages/orchestration/src/service.js
+++ b/packages/orchestration/src/service.js
@@ -244,7 +244,7 @@ const prepareOrchestrationKit = (
  * @param {VowTools} vowTools
  */
 export const prepareOrchestrationTools = (zone, vowTools) => {
-  const makeChainAccountKit = prepareChainAccountKit(zone);
+  const makeChainAccountKit = prepareChainAccountKit(zone, vowTools);
   const makeICQConnectionKit = prepareICQConnectionKit(zone, vowTools);
   const makeOrchestrationKit = prepareOrchestrationKit(
     zone,

--- a/packages/orchestration/src/utils/chainHub.js
+++ b/packages/orchestration/src/utils/chainHub.js
@@ -114,11 +114,13 @@ export const makeChainHub = (agoricNames, zone = makeHeapZone()) => {
     },
 
     /**
-     * @param {string} chainId1
-     * @param {string} chainId2
+     * @param {string | { chainId: string }} chain1
+     * @param {string | { chainId: string }} chain2
      * @returns {Promise<IBCConnectionInfo>}
      */
-    async getConnectionInfo(chainId1, chainId2) {
+    async getConnectionInfo(chain1, chain2) {
+      const chainId1 = typeof chain1 === 'string' ? chain1 : chain1.chainId;
+      const chainId2 = typeof chain2 === 'string' ? chain2 : chain2.chainId;
       const key = connectionKey(chainId1, chainId2);
       if (connectionInfos.has(key)) {
         return connectionInfos.get(key);

--- a/packages/orchestration/src/utils/chainHub.js
+++ b/packages/orchestration/src/utils/chainHub.js
@@ -13,6 +13,13 @@ const { Fail } = assert;
  * @import {Zone} from '@agoric/zone';
  */
 
+/**
+ * @template {string} K
+ * @typedef {K extends keyof KnownChains
+ *   ? Omit<KnownChains[K], 'connections'>
+ *   : ChainInfo} ActualChainInfo
+ */
+
 /** agoricNames key for ChainInfo hub */
 export const CHAIN_KEY = 'chain';
 /** namehub for connection info */
@@ -82,11 +89,7 @@ export const makeChainHub = (agoricNames, zone = makeHeapZone()) => {
     /**
      * @template {string} K
      * @param {K} chainName
-     * @returns {Promise<
-     *   K extends keyof KnownChains
-     *     ? Omit<KnownChains[K], 'connections'>
-     *     : ChainInfo
-     * >}
+     * @returns {Promise<ActualChainInfo<K>>}
      */
     async getChainInfo(chainName) {
       // Either from registerChain or memoized remote lookup()
@@ -176,4 +179,28 @@ export const registerChain = async (
   }
   // Bundle to pipeline IO
   await Promise.all(promises);
+};
+
+/**
+ * @template {string} C1
+ * @template {string} C2
+ * @param {ChainHub} chainHub
+ * @param {C1} chainName1
+ * @param {C2} chainName2
+ * @returns {Promise<
+ *   [ActualChainInfo<C1>, ActualChainInfo<C2>, IBCConnectionInfo]
+ * >}
+ */
+export const getChainsAndConnection = async (
+  chainHub,
+  chainName1,
+  chainName2,
+) => {
+  const [chain1, chain2] = await Promise.all([
+    chainHub.getChainInfo(chainName1),
+    chainHub.getChainInfo(chainName2),
+  ]);
+  const connectionInfo = await chainHub.getConnectionInfo(chain2, chain1);
+
+  return [chain1, chain2, connectionInfo];
 };

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -48,16 +48,18 @@ export const provideOrchestration = (
 
   const chainHub = makeChainHub(remotePowers.agoricNames);
 
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     zone,
     makeRecorderKit,
     zcf,
     remotePowers.timerService,
+    vowTools,
     chainHub,
   );
 
-  const vowTools = prepareVowTools(zone.subZone('vows'));
   const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
     vowTools,
   });

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -68,6 +68,7 @@ export const provideOrchestration = (
     // FIXME what zone?
     zone,
     makeRecorderKit,
+    vowTools,
     zcf,
   );
 

--- a/packages/orchestration/src/utils/time.js
+++ b/packages/orchestration/src/utils/time.js
@@ -21,6 +21,8 @@ export function makeTimestampHelper(timer) {
 
   return harden({
     /**
+     * XXX do this need to be resumable / use Vows?
+     *
      * Takes the current time from ChainTimerService and adds a relative time to
      * determine a timeout timestamp in nanoseconds. Useful for
      * {@link MsgTransfer.timeoutTimestamp}.

--- a/packages/orchestration/src/vat-orchestration.js
+++ b/packages/orchestration/src/vat-orchestration.js
@@ -1,4 +1,5 @@
 import { Far } from '@endo/far';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareOrchestrationTools } from './service.js';
 
@@ -6,8 +7,10 @@ import { prepareOrchestrationTools } from './service.js';
 
 export const buildRootObject = (_vatPowers, _args, baggage) => {
   const zone = makeDurableZone(baggage);
+  const vowTools = prepareVowTools(zone.subZone('VowTools'));
   const { makeOrchestrationKit } = prepareOrchestrationTools(
     zone.subZone('orchestration'),
+    vowTools,
   );
 
   return Far('OrchestrationVat', {

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -1,8 +1,9 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { V } from '@agoric/vow/vat.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E } from '@endo/far';
 import path from 'path';
 import { commonSetup } from '../supports.js';
@@ -58,6 +59,8 @@ test('makeAccount, deposit, withdraw', async t => {
   );
   // FIXME #9211
   // t.deepEqual(await E(account).getBalance('ubld'), bld.units(100));
+  // XXX races in the bridge
+  await eventLoopIteration();
 
   t.log('withdraw bld from account');
   const withdrawResp = await V(account).withdraw(bld.units(100));

--- a/packages/orchestration/test/network-fakes.ts
+++ b/packages/orchestration/test/network-fakes.ts
@@ -92,26 +92,25 @@ export const prepareProtocolHandler = (
 };
 
 export const fakeNetworkEchoStuff = (zone: Zone) => {
-  const powers = prepareVowTools(zone);
-  const { makeVowKit, when } = powers;
+  const vowTools = prepareVowTools(zone);
+  const { makeVowKit, when } = vowTools;
 
-  const makeNetworkProtocol = prepareNetworkProtocol(zone, powers);
+  const makeNetworkProtocol = prepareNetworkProtocol(zone, vowTools);
   const makeEchoConnectionHandler = prepareEchoConnectionKit(zone);
   const makeProtocolHandler = prepareProtocolHandler(
     zone,
     makeEchoConnectionHandler,
-    powers,
+    vowTools,
   );
   const protocol = makeNetworkProtocol(makeProtocolHandler());
 
-  const makePortAllocator = preparePortAllocator(zone, powers);
+  const makePortAllocator = preparePortAllocator(zone, vowTools);
   const portAllocator = makePortAllocator({ protocol });
 
   return {
     makeEchoConnectionHandler,
-    makeVowKit,
     portAllocator,
     protocol,
-    when,
+    vowTools,
   };
 };

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -1,0 +1,50 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { toRequestQueryJson } from '@agoric/cosmic-proto';
+import { QueryBalanceRequest } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
+import { E } from '@endo/far';
+import { commonSetup } from './supports.js';
+
+test('makeICQConnection returns an ICQConnection', async t => {
+  const {
+    bootstrap: { orchestration },
+  } = await commonSetup(t);
+
+  const CONNECTION_ID = 'connection-0';
+
+  const icqConnection =
+    await E(orchestration).provideICQConnection(CONNECTION_ID);
+  const [localAddr, remoteAddr] = await Promise.all([
+    E(icqConnection).getLocalAddress(),
+    E(icqConnection).getRemoteAddress(),
+  ]);
+  t.log(icqConnection, {
+    localAddr,
+    remoteAddr,
+  });
+  t.regex(localAddr, /ibc-port\/icqcontroller-\d+/);
+  t.regex(
+    remoteAddr,
+    new RegExp(`/ibc-hop/${CONNECTION_ID}`),
+    'remote address contains provided connectionId',
+  );
+  t.regex(
+    remoteAddr,
+    /icqhost\/unordered\/icq-1/,
+    'remote address contains icqhost port, unordered ordering, and icq-1 version string',
+  );
+
+  await t.throwsAsync(
+    E(icqConnection).query([
+      toRequestQueryJson(
+        QueryBalanceRequest.toProtoMsg({
+          address: 'cosmos1test',
+          denom: 'uatom',
+        }),
+      ),
+    ]),
+    { message: /"data":"(.*)"memo":""/ },
+    'TODO do not use echo connection',
+  );
+});
+
+test.todo('makeAccount');

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -38,6 +38,12 @@ test('makeICQConnection returns an ICQConnection', async t => {
     'remote address contains icqhost port, unordered ordering, and icq-1 version string',
   );
 
+  const icqConnection2 = await E(orchestration).provideICQConnection(
+    CONTROLLER_CONNECTION_ID,
+  );
+  const localAddr2 = await E(icqConnection2).getLocalAddress();
+  t.is(localAddr, localAddr2, 'provideICQConnection is idempotent');
+
   await t.throwsAsync(
     E(icqConnection).query([
       toRequestQueryJson(

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -1,7 +1,9 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { E } from '@endo/far';
 import { toRequestQueryJson } from '@agoric/cosmic-proto';
 import { QueryBalanceRequest } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
-import { E } from '@endo/far';
+import { MsgDelegate } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { commonSetup } from './supports.js';
 
 test('makeICQConnection returns an ICQConnection', async t => {
@@ -9,10 +11,11 @@ test('makeICQConnection returns an ICQConnection', async t => {
     bootstrap: { orchestration },
   } = await commonSetup(t);
 
-  const CONNECTION_ID = 'connection-0';
+  const CONTROLLER_CONNECTION_ID = 'connection-0';
 
-  const icqConnection =
-    await E(orchestration).provideICQConnection(CONNECTION_ID);
+  const icqConnection = await E(orchestration).provideICQConnection(
+    CONTROLLER_CONNECTION_ID,
+  );
   const [localAddr, remoteAddr] = await Promise.all([
     E(icqConnection).getLocalAddress(),
     E(icqConnection).getRemoteAddress(),
@@ -24,7 +27,7 @@ test('makeICQConnection returns an ICQConnection', async t => {
   t.regex(localAddr, /ibc-port\/icqcontroller-\d+/);
   t.regex(
     remoteAddr,
-    new RegExp(`/ibc-hop/${CONNECTION_ID}`),
+    new RegExp(`/ibc-hop/${CONTROLLER_CONNECTION_ID}`),
     'remote address contains provided connectionId',
   );
   t.regex(
@@ -47,4 +50,58 @@ test('makeICQConnection returns an ICQConnection', async t => {
   );
 });
 
-test.todo('makeAccount');
+test('makeAccount returns a ChainAccount', async t => {
+  const {
+    bootstrap: { orchestration },
+  } = await commonSetup(t);
+
+  const CHAIN_ID = 'cosmoshub-99';
+  const HOST_CONNECTION_ID = 'connection-0';
+  const CONTROLLER_CONNECTION_ID = 'connection-1';
+
+  const account = await E(orchestration).makeAccount(
+    CHAIN_ID,
+    HOST_CONNECTION_ID,
+    CONTROLLER_CONNECTION_ID,
+  );
+  const [localAddr, remoteAddr, chainAddr] = await Promise.all([
+    E(account).getLocalAddress(),
+    E(account).getRemoteAddress(),
+    E(account).getAddress(),
+  ]);
+  t.log(account, {
+    localAddr,
+    remoteAddr,
+    chainAddr,
+  });
+  t.regex(localAddr, /ibc-port\/icacontroller-\d+/);
+  t.regex(
+    remoteAddr,
+    new RegExp(`/ibc-hop/${CONTROLLER_CONNECTION_ID}`),
+    'remote address contains provided connectionId',
+  );
+  t.regex(
+    remoteAddr,
+    /icahost\/ordered/,
+    'remote address contains icahost port, ordered ordering',
+  );
+  t.regex(
+    remoteAddr,
+    /"version":"ics27-1"(.*)"encoding":"proto3"/,
+    'remote address contains version and encoding in version string',
+  );
+
+  await t.throwsAsync(
+    E(account).executeEncodedTx([
+      Any.toJSON(
+        MsgDelegate.toProtoMsg({
+          delegatorAddress: 'cosmos1test',
+          validatorAddress: 'cosmosvaloper1test',
+          amount: { denom: 'uatom', amount: '10' },
+        }),
+      ),
+    ]),
+    { message: /"type":1(.*)"data":"(.*)"memo":""/ },
+    'TODO do not use echo connection',
+  );
+});

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -4,7 +4,9 @@ import { toRequestQueryJson } from '@agoric/cosmic-proto';
 import { QueryBalanceRequest } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
 import { MsgDelegate } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
+import { matches } from '@endo/patterns';
 import { commonSetup } from './supports.js';
+import { ChainAddressShape } from '../src/typeGuards.js';
 
 test('makeICQConnection returns an ICQConnection', async t => {
   const {
@@ -91,17 +93,32 @@ test('makeAccount returns a ChainAccount', async t => {
     'remote address contains version and encoding in version string',
   );
 
+  t.true(matches(chainAddr, ChainAddressShape));
+  t.regex(
+    chainAddr.address,
+    /UNPARSABLE_CHAIN_ADDRESS/,
+    'TODO use mocked ibc connection instead of echo connection',
+  );
+
+  const delegateMsg = Any.toJSON(
+    MsgDelegate.toProtoMsg({
+      delegatorAddress: 'cosmos1test',
+      validatorAddress: 'cosmosvaloper1test',
+      amount: { denom: 'uatom', amount: '10' },
+    }),
+  );
   await t.throwsAsync(
-    E(account).executeEncodedTx([
-      Any.toJSON(
-        MsgDelegate.toProtoMsg({
-          delegatorAddress: 'cosmos1test',
-          validatorAddress: 'cosmosvaloper1test',
-          amount: { denom: 'uatom', amount: '10' },
-        }),
-      ),
-    ]),
+    E(account).executeEncodedTx([delegateMsg]),
     { message: /"type":1(.*)"data":"(.*)"memo":""/ },
     'TODO do not use echo connection',
+  );
+
+  await E(account).close();
+  await t.throwsAsync(
+    E(account).executeEncodedTx([delegateMsg]),
+    {
+      message: 'Connection closed',
+    },
+    'cannot execute transaction if connection is closed',
   );
 });

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -1,5 +1,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
+import type { AnyJson } from '@agoric/cosmic-proto';
+import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import { MsgWithdrawDelegatorRewardResponse } from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/tx.js';
 import {
   MsgBeginRedelegateResponse,
@@ -7,27 +9,28 @@ import {
   MsgDelegateResponse,
   MsgUndelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
+import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { makeNotifierFromSubscriber } from '@agoric/notifier';
+import type { TimestampRecord, TimestampValue } from '@agoric/time';
 import { makeScalarBigMapStore, type Baggage } from '@agoric/vat-data';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
+import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
+import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
+import { makeDurableZone } from '@agoric/zone/durable.js';
 import { decodeBase64 } from '@endo/base64';
 import { E, Far } from '@endo/far';
-import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
-import type { TimestampRecord, TimestampValue } from '@agoric/time';
-import type { AnyJson } from '@agoric/cosmic-proto';
-import { makeDurableZone } from '@agoric/zone/durable.js';
-import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { makeNotifierFromSubscriber } from '@agoric/notifier';
-import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import {
-  prepareCosmosOrchestrationAccountKit,
-  trivialDelegateResponse,
-} from '../src/exos/cosmos-orchestration-account.js';
+import { prepareCosmosOrchestrationAccountKit } from '../src/exos/cosmos-orchestration-account.js';
+import type { ChainAddress, IcaAccount, ICQConnection } from '../src/types.js';
 import { encodeTxResponse } from '../src/utils/cosmos.js';
-import type { IcaAccount, ChainAddress, ICQConnection } from '../src/types.js';
 
 const { Fail } = assert;
+
+const trivialDelegateResponse = encodeTxResponse(
+  {},
+  MsgDelegateResponse.toProtoMsg,
+);
 
 test('MsgDelegateResponse trivial response', t => {
   t.is(
@@ -189,6 +192,8 @@ const makeScenario = () => {
     sequence: false,
   });
 
+  const vowTools = prepareVowTools(zone.subZone('VowTools'));
+
   const icqConnection = Far('ICQConnection', {}) as ICQConnection;
 
   const timer = buildZoeManualTimer(undefined, time.parse(startTime), {
@@ -203,6 +208,7 @@ const makeScenario = () => {
     storageNode: rootNode,
     timer,
     icqConnection,
+    vowTools,
     ...mockZCF(),
   };
 };
@@ -210,8 +216,14 @@ const makeScenario = () => {
 test('makeAccount() writes to storage', async t => {
   const s = makeScenario();
   const { account, timer } = s;
-  const { makeRecorderKit, storageNode, zcf, icqConnection, zone } = s;
-  const make = prepareCosmosOrchestrationAccountKit(zone, makeRecorderKit, zcf);
+  const { makeRecorderKit, storageNode, zcf, icqConnection, vowTools, zone } =
+    s;
+  const make = prepareCosmosOrchestrationAccountKit(
+    zone,
+    makeRecorderKit,
+    vowTools,
+    zcf,
+  );
 
   const { holder } = make(account.getAddress(), 'uatom', {
     account,
@@ -233,8 +245,14 @@ test('makeAccount() writes to storage', async t => {
 test('withdrawRewards() on StakingAccountHolder formats message correctly', async t => {
   const s = makeScenario();
   const { account, calls, timer } = s;
-  const { makeRecorderKit, storageNode, zcf, icqConnection, zone } = s;
-  const make = prepareCosmosOrchestrationAccountKit(zone, makeRecorderKit, zcf);
+  const { makeRecorderKit, storageNode, zcf, icqConnection, vowTools, zone } =
+    s;
+  const make = prepareCosmosOrchestrationAccountKit(
+    zone,
+    makeRecorderKit,
+    vowTools,
+    zcf,
+  );
 
   // Higher fidelity tests below use invitationMakers.
   const { holder } = make(account.getAddress(), 'uatom', {
@@ -256,11 +274,20 @@ test('withdrawRewards() on StakingAccountHolder formats message correctly', asyn
 test(`delegate; redelegate using invitationMakers`, async t => {
   const s = makeScenario();
   const { account, calls, timer } = s;
-  const { makeRecorderKit, storageNode, zcf, zoe, icqConnection, zone } = s;
+  const {
+    makeRecorderKit,
+    storageNode,
+    zcf,
+    zoe,
+    icqConnection,
+    vowTools,
+    zone,
+  } = s;
   const aBrand = Far('Token') as Brand<'nat'>;
   const makeAccountKit = prepareCosmosOrchestrationAccountKit(
     zone,
     makeRecorderKit,
+    vowTools,
     zcf,
   );
 
@@ -329,10 +356,19 @@ test(`delegate; redelegate using invitationMakers`, async t => {
 test(`withdraw rewards using invitationMakers`, async t => {
   const s = makeScenario();
   const { account, calls, timer } = s;
-  const { makeRecorderKit, storageNode, zcf, zoe, icqConnection, zone } = s;
+  const {
+    makeRecorderKit,
+    storageNode,
+    zcf,
+    zoe,
+    icqConnection,
+    vowTools,
+    zone,
+  } = s;
   const makeAccountKit = prepareCosmosOrchestrationAccountKit(
     zone,
     makeRecorderKit,
+    vowTools,
     zcf,
   );
 
@@ -359,10 +395,19 @@ test(`withdraw rewards using invitationMakers`, async t => {
 test(`undelegate waits for unbonding period`, async t => {
   const s = makeScenario();
   const { account, calls, timer } = s;
-  const { makeRecorderKit, storageNode, zcf, zoe, icqConnection, zone } = s;
+  const {
+    makeRecorderKit,
+    storageNode,
+    zcf,
+    zoe,
+    icqConnection,
+    vowTools,
+    zone,
+  } = s;
   const makeAccountKit = prepareCosmosOrchestrationAccountKit(
     zone,
     makeRecorderKit,
+    vowTools,
     zcf,
   );
 

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -104,11 +104,12 @@ export const commonSetup = async t => {
     sequence: false,
   });
 
+  const { portAllocator } = fakeNetworkEchoStuff(rootZone.subZone('network'));
+
   const { makeOrchestrationKit } = prepareOrchestrationTools(
     rootZone.subZone('orchestration'),
+    vowTools,
   );
-
-  const { portAllocator } = fakeNetworkEchoStuff(rootZone.subZone('network'));
   const { public: orchestration } = makeOrchestrationKit({ portAllocator });
 
   await registerChainNamespace(agoricNamesAdmin, () => {});
@@ -125,6 +126,7 @@ export const commonSetup = async t => {
       // TODO remove; bootstrap doesn't have a zone
       rootZone: rootZone.subZone('contract'),
       storage,
+      vowTools,
     },
     brands: {
       bld: bldSansMint,

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -60,6 +60,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
     anyVal,
     anyVal,
     anyVal,
+    anyVal,
   );
   makeCosmosOrchestrationAccount(
     anyVal,

--- a/packages/orchestration/test/utils/chainHub.test.ts
+++ b/packages/orchestration/test/utils/chainHub.test.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @jessie.js/safe-await-separator -- XXX irrelevant for tests */
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { makeNameHubKit } from '@agoric/vats';
+import { makeChainHub } from '../../src/utils/chainHub.js';
+
+const connection = {
+  id: 'connection-1',
+  client_id: '07-tendermint-3',
+  counterparty: {
+    client_id: '07-tendermint-2',
+    connection_id: 'connection-1',
+    prefix: {
+      key_prefix: '',
+    },
+  },
+  state: 3 /* IBCConnectionState.STATE_OPEN */,
+  transferChannel: {
+    portId: 'transfer',
+    channelId: 'channel-1',
+    counterPartyChannelId: 'channel-1',
+    counterPartyPortId: 'transfer',
+    ordering: 1 /* Order.ORDER_UNORDERED */,
+    state: 3 /* IBCConnectionState.STATE_OPEN */,
+    version: 'ics20-1',
+  },
+} as const;
+
+test('getConnectionInfo', async t => {
+  const { nameHub } = makeNameHubKit();
+  const chainHub = makeChainHub(nameHub);
+
+  const aChain = { chainId: 'a-1' };
+  const bChain = { chainId: 'b-2' };
+
+  chainHub.registerConnection(aChain.chainId, bChain.chainId, connection);
+
+  // Look up by string or info object
+  t.deepEqual(
+    await chainHub.getConnectionInfo(aChain.chainId, bChain.chainId),
+    connection,
+  );
+  t.deepEqual(await chainHub.getConnectionInfo(aChain, bChain), connection);
+});

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -71,6 +71,8 @@ export const makeFakeBankBridge = (zone, opts = { balances: {} }) => {
         case 'VBANK_GIVE': {
           const { amount, denom } = obj;
           const address = type === 'VBANK_GRAB' ? obj.sender : obj.recipient;
+          (address && typeof address === 'string') ||
+            Fail`invalid address ${address}`;
           balances[address] ||= {};
           balances[address][denom] ||= 0n;
 

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -31,3 +31,5 @@ export const prepareVowTools = (zone, powers = {}) => {
   return harden({ when, watch, makeVowKit, allVows });
 };
 harden(prepareVowTools);
+
+/** @typedef {ReturnType<typeof prepareVowTools>} VowTools */

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -86,5 +86,3 @@ export {};
  * @property {(value: T, context?: C) => Vow<TResult1> | PromiseVow<TResult1> | TResult1} [onFulfilled]
  * @property {(reason: any) => Vow<TResult2> | PromiseVow<TResult2> | TResult2} [onRejected]
  */
-
-/** @typedef {ReturnType<typeof prepareVowTools>} VowTools */


### PR DESCRIPTION
refs: #9449 

## Description

- [x] convert icqConnectionKit to return vows
- [x] convert Orchestration service (`service.js`) to return vows 
- [x] convert chainAccountKit to return vows

### Security Considerations


### Scaling Considerations

These changes are necessary towards supporting using `orchestration` in `asyncFlow`. 


### Documentation Considerations


### Testing Considerations


### Upgrade Considerations
