### PR TITLE
fix tsc errors detected by skipLibCheck: false

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "resolutions": {
     "**/protobufjs": "^7.2.6",
+    "**/@types/estree": "^1.0.0",
     "**/@typescript-eslint/typescript-estree": "^7.7.1"
   },
   "engines": {

--- a/packages/ERTP/exported.d.ts
+++ b/packages/ERTP/exported.d.ts
@@ -19,6 +19,7 @@ import {
   Purse as _Purse,
 } from './src/types.js';
 declare global {
+  // @ts-ignore TS2666: Exports and export assignments are not permitted in module augmentations.
   export {
     _Amount as Amount,
     _Brand as Brand,

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -86,6 +86,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 91.21
+    "atLeast": 91.22
   }
 }

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -56,6 +56,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 90.77
+    "atLeast": 91.11
   }
 }

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -90,6 +90,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 86.74
+    "atLeast": 87.28
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -78,6 +78,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 74.23
+    "atLeast": 74.36
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -68,6 +68,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 80.48
+    "atLeast": 80.49
   }
 }

--- a/packages/governance/exported.d.ts
+++ b/packages/governance/exported.d.ts
@@ -16,6 +16,7 @@ import {
   GovernableStartFn as _GovernableStartFn,
 } from './src/types.js';
 declare global {
+  // @ts-ignore TS2666: Exports and export assignments are not permitted in module augmentations.
   export {
     _CommitteeElectoratePublic as CommitteeElectoratePublic,
     _GovernableStartFn as GovernableStartFn,

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 95.87
+    "atLeast": 95.85
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 95.85
+    "atLeast": 95.81
   }
 }

--- a/packages/internal/exported.d.ts
+++ b/packages/internal/exported.d.ts
@@ -15,6 +15,7 @@ import {
 } from './src/lib-chainStorage.js';
 
 declare global {
+  // @ts-ignore TS2666: Exports and export assignments are not permitted in module augmentations.
   export {
     _ERef as ERef,
     _Marshaller as Marshaller,

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -56,6 +56,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.81
+    "atLeast": 93.89
   }
 }

--- a/packages/internal/src/types.d.ts
+++ b/packages/internal/src/types.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
-import type { Callable, RemotableBrand } from '@endo/eventual-send';
+import type { RemotableBrand } from '@endo/eventual-send';
 import type { Primitive } from '@endo/pass-style';
+import type { Callable } from './utils.js';
 
 export declare class Callback<I extends (...args: unknown[]) => any> {
   private iface: I;

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -65,6 +65,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 89.39
+    "atLeast": 89.7
   }
 }

--- a/packages/notifier/exported.d.ts
+++ b/packages/notifier/exported.d.ts
@@ -21,6 +21,7 @@ import {
 } from './src/types.js';
 
 declare global {
+  // @ts-ignore TS2666: Exports and export assignments are not permitted in module augmentations.
   export {
     _EachTopic as EachTopic,
     _IterableEachTopic as IterableEachTopic,

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 97.17
+    "atLeast": 97.1
   }
 }

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 97.38
+    "atLeast": 97.17
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -68,6 +68,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 94.35
+    "atLeast": 94.3
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -68,6 +68,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 94.3
+    "atLeast": 94.36
   }
 }

--- a/packages/store/exported.d.ts
+++ b/packages/store/exported.d.ts
@@ -12,6 +12,7 @@ import {
 } from './src/types.js';
 import { Pattern as _Pattern } from '@endo/patterns';
 declare global {
+  // @ts-ignore TS2666: Exports and export assignments are not permitted in module augmentations.
   export {
     _LegacyMap as LegacyMap,
     _LegacyWeakMap as LegacyWeakMap,

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -49,6 +49,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 76.3
+    "atLeast": 76.31
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -77,6 +77,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.11
+    "atLeast": 91.21
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -77,6 +77,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.27
+    "atLeast": 91.11
   }
 }

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -331,11 +331,14 @@ export const makeBridgeManager = async ({
   const bridgeManager = E(vat).provideManagerForBridge(bridge);
   bridgeManagerP.resolve(bridgeManager);
   provisionBridgeManager.resolve(
+    // @ts-expect-error XXX EProxy
     E(bridgeManager).register(BRIDGE_ID.PROVISION),
   );
   provisionWalletBridgeManager.resolve(
+    // @ts-expect-error XXX EProxy
     E(bridgeManager).register(BRIDGE_ID.PROVISION_SMART_WALLET),
   );
+  // @ts-expect-error XXX EProxy
   walletBridgeManager.resolve(E(bridgeManager).register(BRIDGE_ID.WALLET));
 };
 harden(makeBridgeManager);

--- a/packages/vats/src/core/core-eval-env.d.ts
+++ b/packages/vats/src/core/core-eval-env.d.ts
@@ -11,8 +11,8 @@
  */
 
 import type { VatData } from '@agoric/swingset-liveslots/src/vatDataTypes.js';
-import type { E, Far, getInterfaceOf, passStyleOf } from '@endo/far';
-import type { Assert, VirtualConsole } from 'ses';
+import type * as far from '@endo/far';
+import type { Assert } from 'ses';
 import type { BootstrapModules } from './boot-chain.js';
 
 // Provided by 'CORE_EVAL' handler in chain-behaviors.js
@@ -22,10 +22,10 @@ declare global {
   var utils: BootstrapModules['utils'];
 
   // @endo/far exports
-  var E: E;
-  var Far: Far;
-  var getInterfaceOfFar: getInterfaceOfFar;
-  var passStyleOfFar: passStyleOfFar;
+  var E: typeof far.E;
+  var Far: typeof far.Far;
+  var getInterfaceOfFar: typeof far.getInterfaceOf;
+  var passStyleOfFar: typeof far.passStyleOf;
 
   // endowments
   var VatData: VatData;

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -202,13 +202,13 @@ type WellKnownName = {
 };
 
 type ContractInstallationPromises<
-  StartFns extends Record<WellKnownNames['installation'], ContractStartFn>,
+  StartFns extends Record<WellKnownName['installation'], ContractStartFn>,
 > = {
   [Property in keyof StartFns]: Promise<Installation<StartFns[Property]>>;
 };
 
 type ContractInstancePromises<
-  StartFns extends Record<WellKnownNames['instance'], ContractStartFn>,
+  StartFns extends Record<WellKnownName['instance'], ContractStartFn>,
 > = {
   [Property in keyof StartFns]: Promise<
     import('@agoric/zoe/src/zoeService/utils.js').Instance<StartFns[Property]>
@@ -259,11 +259,13 @@ type WellKnownSpaces = {
       WellKnownName['installation'],
       Promise<Installation<unknown>>
     > &
+      // @ts-expect-error XXX
       ContractInstallationPromises<WellKnownContracts>;
   };
   instance: {
     produce: Record<WellKnownName['instance'], Producer<Instance>>;
     consume: Record<WellKnownName['instance'], Promise<Instance>> &
+      // @ts-expect-error XXX
       ContractInstancePromises<WellKnownContracts>;
   };
   uiConfig: {
@@ -281,6 +283,7 @@ type StartGovernedUpgradableOpts<SF extends GovernableStartFn> = {
     'brands' | 'issuers' | 'governedParams' | 'electionManager'
   >;
   privateArgs: Omit<
+    // @ts-expect-error XXX
     import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['privateArgs'],
     'initialPoserInvitation'
   >;
@@ -314,8 +317,9 @@ type StartUpgradable = <
   }
 >;
 
-type StartedInstanceKit<T> =
-  import('@agoric/zoe/src/zoeService/utils').StartedInstanceKit<T>;
+type StartedInstanceKit<
+  T extends import('@agoric/zoe/src/zoeService/utils').ContractStartFunction,
+> = import('@agoric/zoe/src/zoeService/utils').StartedInstanceKit<T>;
 
 type StartedInstanceKitWithLabel = {
   label: string;
@@ -365,12 +369,14 @@ type ChainBootstrapSpaceT = {
   pegasusConnections: import('@agoric/vats').NameHubKit;
   pegasusConnectionsAdmin: import('@agoric/vats').NameAdmin;
   priceAuthorityVat: Awaited<PriceAuthorityVat>;
-  priceAuthority: PriceAuthority;
+  priceAuthority: import('@agoric/zoe/tools/types.js').PriceAuthority;
   priceAuthorityAdmin: import('@agoric/vats/src/priceAuthorityRegistry').PriceAuthorityRegistryAdmin;
   provisioning: Awaited<ProvisioningVat> | undefined;
-  provisionBridgeManager: import('../types.js').ScopedBridgeManager | undefined;
+  provisionBridgeManager:
+    | import('../types.js').ScopedBridgeManager<'provision'>
+    | undefined;
   provisionWalletBridgeManager:
-    | import('../types.js').ScopedBridgeManager
+    | import('../types.js').ScopedBridgeManager<'provisionWallet'>
     | undefined;
   storageBridgeManager:
     | import('../types.js').ScopedBridgeManager<'storage'>
@@ -391,7 +397,9 @@ type ChainBootstrapSpaceT = {
   >;
   /** Used only for testing. Should not appear in any production proposals. */
   testFirstAnchorKit: import('../vat-bank.js').AssetIssuerKit;
-  walletBridgeManager: import('../types.js').ScopedBridgeManager | undefined;
+  walletBridgeManager:
+    | import('../types.js').ScopedBridgeManager<'wallet'>
+    | undefined;
   walletFactoryStartResult: import('./startWalletFactory.js').WalletFactoryStartResult;
   provisionPoolStartResult: GovernanceFacetKit<
     typeof import('@agoric/inter-protocol/src/provisionPool.js').start

--- a/packages/vats/src/types.d.ts
+++ b/packages/vats/src/types.d.ts
@@ -1,6 +1,6 @@
 import type { BridgeIdValue, Remote } from '@agoric/internal';
 import type { Bytes } from '@agoric/network';
-import type { PromiseVow, Remote } from '@agoric/vow';
+import type { PromiseVow } from '@agoric/vow';
 import type { Guarded } from '@endo/exo';
 
 export type Board = ReturnType<

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -74,6 +74,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 94.04
+    "atLeast": 93.95
   }
 }

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -244,7 +244,8 @@ type ContractStartFnResult<PF, CF> = {
 };
 
 // XXX redef, losing documentation
-type ContractOf<S> = import('../zoeService/utils').ContractOf<S>;
+type ContractOf<S extends (...args: any) => any> =
+  import('../zoeService/utils').ContractOf<S>;
 type AdminFacet = import('../zoeService/utils').AdminFacet<any>;
 
 declare const OfferReturn: unique symbol;

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -104,13 +104,16 @@ export type StartInstance = <SF>(
   issuerKeywordRecord?: Record<Keyword, Issuer<any>>,
   // 'brands' and 'issuers' need not be passed in; Zoe provides them as StandardTerms
   terms?: Omit<StartParams<SF>['terms'], 'brands' | 'issuers'>,
+  // @ts-expect-error XXX
   privateArgs?: Parameters<SF>[1],
   label?: string,
+  // @ts-expect-error XXX
 ) => Promise<StartedInstanceKit<SF>>;
 
 // XXX SF should extend ContractStartFunction but doing that triggers a bunch of tech debt type errors
 export type GetPublicFacet = <SF>(
   instance: Instance<SF> | PromiseLike<Instance<SF>>,
+  // @ts-expect-error XXX
 ) => Promise<StartResult<SF>['publicFacet']>;
 
 export type GetTerms = <SF>(instance: Instance<SF>) => Promise<

--- a/yarn.lock
+++ b/yarn.lock
@@ -3389,10 +3389,10 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+"@types/estree@*", "@types/estree@0.0.39", "@types/estree@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.35"


### PR DESCRIPTION
## Description

In a recent discussion we noticed that the test wasn't showing a type error where it should have: https://github.com/Agoric/agoric-sdk/pull/9452#discussion_r1628077332

It would have with `noImplicitAny: false` but that pulls in way too many other errors. While investigating I noticed some other things that could be cleaned up and tackled those here.

The remaining blocker for `skipLibCheck: false` is the Telescope output in `dist`. The .js files have `@ts-nocheck` but the .d.ts don't. Surprising but not worth more effort.

### Security Considerations

n/a, types
### Scaling Considerations
n/a, types

### Documentation Considerations
none


### Testing Considerations

CI

### Upgrade Considerations

Potential cherry-pick complexities but we're moving to release based on master
