### PR TITLE
refactor(vats): Remove makeBridgeTargetKit from prepareTransferTools

### DIFF
--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -2,6 +2,7 @@ import { makeIssuerKit } from '@agoric/ertp';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { prepareLocalChainTools } from '@agoric/vats/src/localchain.js';
+import { prepareBridgeTargetModule } from '@agoric/vats/src/bridge-target.js';
 import { prepareTransferTools } from '@agoric/vats/src/transfer.js';
 import { makeFakeBankManagerKit } from '@agoric/vats/tools/bank-utils.js';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
@@ -66,11 +67,14 @@ export const commonSetup = async t => {
   );
 
   const transferBridge = makeFakeTransferBridge(rootZone);
-  const { makeTransferMiddlewareKit, makeBridgeTargetKit } =
-    prepareTransferTools(
-      rootZone.subZone('transfer'),
-      prepareVowTools(rootZone.subZone('vows')),
-    );
+  const { makeBridgeTargetKit } = prepareBridgeTargetModule(
+    rootZone.subZone('bridge'),
+  );
+  const { makeTransferMiddlewareKit } = prepareTransferTools(
+    rootZone.subZone('transfer'),
+    prepareVowTools(rootZone.subZone('vows')),
+  );
+
   const { finisher, interceptorFactory, transferMiddleware } =
     makeTransferMiddlewareKit();
   const bridgeTargetKit = makeBridgeTargetKit(

--- a/packages/vats/src/transfer.js
+++ b/packages/vats/src/transfer.js
@@ -3,11 +3,7 @@ import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal';
 import { coerceToByteSource, byteSourceToBase64 } from '@agoric/network';
-import {
-  prepareBridgeTargetModule,
-  TargetAppI,
-  AppTransformerI,
-} from './bridge-target.js';
+import { TargetAppI, AppTransformerI } from './bridge-target.js';
 
 /**
  * @import {TargetApp, TargetHost} from './bridge-target.js'
@@ -260,15 +256,10 @@ const prepareTransferMiddlewareKit = (zone, makeTransferInterceptor) =>
  */
 export const prepareTransferTools = (zone, vowTools) => {
   const makeTransferInterceptor = prepareTransferInterceptor(zone, vowTools);
-  const { makeBridgeTargetKit } = prepareBridgeTargetModule(
-    zone.subZone('bridge-target'),
-  );
-
   const makeTransferMiddlewareKit = prepareTransferMiddlewareKit(
     zone,
     makeTransferInterceptor,
   );
-
-  return harden({ makeTransferMiddlewareKit, makeBridgeTargetKit });
+  return harden({ makeTransferMiddlewareKit });
 };
 harden(prepareTransferTools);

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -11,6 +11,7 @@ import { getInterfaceOf } from '@endo/marshal';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal';
 import { prepareVowTools } from '@agoric/vow/vat.js';
 import { prepareLocalChainTools } from '../src/localchain.js';
+import { prepareBridgeTargetModule } from '../src/bridge-target.js';
 import { prepareTransferTools } from '../src/transfer.js';
 import { makeFakeBankManagerKit } from '../tools/bank-utils.js';
 import {
@@ -45,14 +46,16 @@ const makeTestContext = async _t => {
   );
 
   const transferZone = makeDurableZone(provideBaggage('transfer'));
-  const transferBridge = makeFakeTransferBridge(transferZone.subZone('bridge'));
-  const transferTools = prepareTransferTools(
+  const bridgeZone = transferZone.subZone('bridge');
+  const transferBridge = makeFakeTransferBridge(bridgeZone);
+  const { makeBridgeTargetKit } = prepareBridgeTargetModule(bridgeZone);
+  const { makeTransferMiddlewareKit } = prepareTransferTools(
     transferZone,
     prepareVowTools(transferZone.subZone('vows')),
   );
   const { finisher, interceptorFactory, transferMiddleware } =
-    transferTools.makeTransferMiddlewareKit();
-  const bridgeTargetKit = transferTools.makeBridgeTargetKit(
+    makeTransferMiddlewareKit();
+  const bridgeTargetKit = makeBridgeTargetKit(
     transferBridge,
     VTRANSFER_IBC_EVENT,
     interceptorFactory,


### PR DESCRIPTION
https://github.com/Agoric/agoric-sdk/pull/8624#discussion_r1628506033

makeBridgeTargetKit can be more general than "IBC transfer", and is already pulled in separately by vat-transfer.js
