### PR TITLE
adopt TypeScript 5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "type-coverage": "^2.27.1",
     "typedoc": "^0.25.13",
     "typedoc-plugin-markdown": "^3.17.1",
-    "typescript": "^5.5.0-beta",
+    "typescript": "^5.5.2",
     "typescript-eslint": "^7.7.1"
   },
   "resolutions": {

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -137,7 +137,7 @@
     "rimraf": "^5.0.0",
     "tsd": "^0.30.7",
     "tsimp": "^2.0.11",
-    "typescript": "^5.5.0-beta"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@cosmjs/amino": "^0.32.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11584,7 +11584,12 @@ typescript-eslint@^7.3.1, typescript-eslint@^7.7.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^5.5.0-beta, typescript@~5.5.0-dev.20240327:
+typescript@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
+  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+
+typescript@~5.5.0-dev.20240327:
   version "5.5.0-dev.20240426"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240426.tgz#e9ba7d0b3cdaa54021faca61d1bc399e4766c93b"
   integrity sha512-96cu+y3DrjSNhNSgB3t3nRiesCwBVjZpbjJ6DcQoCgt0crXXPrOMmJQH/E8TZ41U4JzaULD+cB1Z2owh5HANew==


### PR DESCRIPTION
refs: #9152 

## Description

Typescript 5.5: https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-rc/

(an earlier push also had https://github.com/Agoric/agoric-sdk/pull/9479 but I moved the commits out)

### Security Considerations

n/a, linting

### Scaling Considerations

n/a, linting


### Documentation Considerations

none

### Testing Considerations

none

### Upgrade Considerations

n/a, linting
