### PR TITLE
feat(cosmosStakingAccount): publish chain address to vstorage

### DIFF
--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -123,7 +123,7 @@ test.serial('stakeAtom - repl-style', async t => {
 });
 
 test.serial('stakeAtom - smart wallet', async t => {
-  const { agoricNamesRemotes } = t.context;
+  const { agoricNamesRemotes, readLatest } = t.context;
 
   const wd = await t.context.walletFactoryDriver.provideSmartWallet(
     'agoric1testStakAtom',
@@ -140,11 +140,19 @@ test.serial('stakeAtom - smart wallet', async t => {
   });
   t.like(wd.getCurrentWalletRecord(), {
     offerToPublicSubscriberPaths: [
-      ['request-account', { account: 'published.stakeAtom' }],
+      [
+        'request-account',
+        {
+          account: 'published.stakeAtom.accounts.cosmos1test',
+        },
+      ],
     ],
   });
   t.like(wd.getLatestUpdateRecord(), {
     status: { id: 'request-account', numWantsSatisfied: 1 },
+  });
+  t.like(readLatest('published.stakeAtom.accounts.cosmos1test'), {
+    sequence: 0n,
   });
 
   const { ATOM } = agoricNamesRemotes.brand;

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -72,6 +72,42 @@ test.serial('config', async t => {
   }
 });
 
+test.serial('stakeOsmo - queries', async t => {
+  const {
+    buildProposal,
+    evalProposal,
+    runUtils: { EV },
+  } = t.context;
+  await evalProposal(
+    buildProposal('@agoric/builders/scripts/orchestration/init-stakeOsmo.js'),
+  );
+
+  const agoricNames = await EV.vat('bootstrap').consumeItem('agoricNames');
+  const instance: Instance<typeof startStakeIca> = await EV(agoricNames).lookup(
+    'instance',
+    'stakeOsmo',
+  );
+  t.truthy(instance, 'stakeOsmo instance is available');
+
+  const zoe: ZoeService = await EV.vat('bootstrap').consumeItem('zoe');
+  const publicFacet = await EV(zoe).getPublicFacet(instance);
+  t.truthy(publicFacet, 'stakeOsmo publicFacet is available');
+
+  const account = await EV(publicFacet).makeAccount();
+  t.log('account', account);
+  t.truthy(account, 'makeAccount returns an account on OSMO connection');
+
+  const queryRes = await EV(account).getBalance('uatom');
+  t.deepEqual(queryRes, { value: 0n, denom: 'uatom' });
+
+  const queryUnknownDenom = await EV(account).getBalance('some-invalid-denom');
+  t.deepEqual(
+    queryUnknownDenom,
+    { value: 0n, denom: 'some-invalid-denom' },
+    'getBalance for unknown denom returns value: 0n',
+  );
+});
+
 test.serial('stakeAtom - repl-style', async t => {
   const {
     buildProposal,
@@ -111,15 +147,9 @@ test.serial('stakeAtom - repl-style', async t => {
   };
   await t.notThrowsAsync(EV(account).delegate(validatorAddress, atomAmount));
 
-  const queryRes = await EV(account).getBalance('uatom');
-  t.deepEqual(queryRes, { value: 0n, denom: 'uatom' });
-
-  const queryUnknownDenom = await EV(account).getBalance('some-invalid-denom');
-  t.deepEqual(
-    queryUnknownDenom,
-    { value: 0n, denom: 'some-invalid-denom' },
-    'getBalance for unknown denom returns value: 0n',
-  );
+  await t.throwsAsync(EV(account).getBalance('uatom'), {
+    message: 'Queries not available for chain "cosmoshub-4"',
+  });
 });
 
 test.serial('stakeAtom - smart wallet', async t => {
@@ -151,9 +181,7 @@ test.serial('stakeAtom - smart wallet', async t => {
   t.like(wd.getLatestUpdateRecord(), {
     status: { id: 'request-account', numWantsSatisfied: 1 },
   });
-  t.like(readLatest('published.stakeAtom.accounts.cosmos1test'), {
-    sequence: 0n,
-  });
+  t.is(readLatest('published.stakeAtom.accounts.cosmos1test'), '');
 
   const { ATOM } = agoricNamesRemotes.brand;
   ATOM || Fail`ATOM missing from agoricNames`;

--- a/packages/builders/scripts/orchestration/init-stakeAtom.js
+++ b/packages/builders/scripts/orchestration/init-stakeAtom.js
@@ -9,6 +9,7 @@ export const defaultProposalBuilder = async (
     hostConnectionId = 'connection-1',
     controllerConnectionId = 'connection-0',
     bondDenom = 'uatom',
+    icqEnabled = true,
   } = options;
   return harden({
     sourceSpec: '@agoric/orchestration/src/proposals/start-stakeAtom.js',
@@ -23,6 +24,7 @@ export const defaultProposalBuilder = async (
         hostConnectionId,
         controllerConnectionId,
         bondDenom,
+        icqEnabled,
       },
     ],
   });

--- a/packages/builders/scripts/orchestration/init-stakeOsmo.js
+++ b/packages/builders/scripts/orchestration/init-stakeOsmo.js
@@ -3,9 +3,9 @@ import { makeHelpers } from '@agoric/deploy-script-support';
 /** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
 export const defaultProposalBuilder = async ({ publishRef, install }) => {
   return harden({
-    sourceSpec: '@agoric/orchestration/src/proposals/start-stakeAtom.js',
+    sourceSpec: '@agoric/orchestration/src/proposals/start-stakeOsmo.js',
     getManifestCall: [
-      'getManifestForStakeAtom',
+      'getManifestForStakeOsmo',
       {
         installKeys: {
           stakeIca: publishRef(
@@ -19,5 +19,5 @@ export const defaultProposalBuilder = async ({ publishRef, install }) => {
 
 export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
-  await writeCoreEval('start-stakeAtom', defaultProposalBuilder);
+  await writeCoreEval('start-stakeOsmo', defaultProposalBuilder);
 };

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -151,7 +151,9 @@ export interface StakingAccountActions {
    * The unbonding time is padded by 10 minutes to account for clock skew.
    * @param delegations - the delegation to undelegate
    */
-  undelegate: (delegations: Delegation[]) => Promise<void>;
+  undelegate: (
+    delegations: Omit<Delegation, 'delegatorAddress'>[],
+  ) => Promise<void>;
 
   /**
    * Withdraw rewards from all validators. The promise settles when the rewards are withdrawn.

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -68,6 +68,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     zone,
     chainHub,
     makeLocalChainAccountKit,
+    makeRecorderKit,
     ...orchPowers,
   });
 

--- a/packages/orchestration/src/examples/stakeIca.contract.js
+++ b/packages/orchestration/src/examples/stakeIca.contract.js
@@ -137,4 +137,4 @@ export const start = async (zcf, privateArgs, baggage) => {
   return { publicFacet };
 };
 
-/** @typedef {typeof start} StakeAtomSF */
+/** @typedef {typeof start} StakeIcaSF */

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -2,9 +2,10 @@ import { StorageNodeShape } from '@agoric/internal';
 import { TimerServiceShape } from '@agoric/time';
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { Far } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M, objectMap } from '@endo/patterns';
+import { provideAll } from '@agoric/zoe/src/contractSupport';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { makeOrchestrationFacade } from '../facade.js';
 import { orcUtils } from '../utils/orc.js';
@@ -79,16 +80,20 @@ export const start = async (zcf, privateArgs, baggage) => {
     timerService,
     chainHub,
   );
+  const { accountsStorageNode } = await provideAll(baggage, {
+    accountsStorageNode: () => E(storageNode).makeChildNode('accounts'),
+  });
 
   const { orchestrate } = makeOrchestrationFacade({
     localchain,
     orchestrationService,
-    storageNode,
+    storageNode: accountsStorageNode,
     timerService,
     zcf,
     zone,
     chainHub,
     makeLocalChainAccountKit,
+    makeRecorderKit,
   });
 
   /** deprecated historical example */

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -57,6 +57,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     zone,
     chainHub: makeChainHub(agoricNames),
     makeLocalChainAccountKit,
+    makeRecorderKit,
   });
 
   /** @type {OfferHandler} */

--- a/packages/orchestration/src/exos/chainAccountKit.js
+++ b/packages/orchestration/src/exos/chainAccountKit.js
@@ -160,6 +160,8 @@ export const prepareChainAccountKit = zone =>
           this.state.remoteAddress = remoteAddr;
           this.state.localAddress = localAddr;
           this.state.chainAddress = harden({
+            // FIXME need a fallback value like icacontroller-1-connection-1 if this fails
+            // https://github.com/Agoric/agoric-sdk/issues/9066
             address: findAddressField(remoteAddr) || UNPARSABLE_CHAIN_ADDRESS,
             chainId: this.state.chainId,
             addressEncoding: 'bech32',

--- a/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
+++ b/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
@@ -158,6 +158,9 @@ export const prepareCosmosOrchestrationAccountKit = (
       // must be the fully synchronous maker because the kit is held in durable state
       // @ts-expect-error XXX Patterns
       const topicKit = makeRecorderKit(storageNode, PUBLIC_TOPICS.account[1]);
+      // TODO https://github.com/Agoric/agoric-sdk/issues/9066
+      // update sequence after successful executeEncodedTx, _if we want sequence in `vstorage`_
+      void E(topicKit.recorder).write(harden({ sequence: 0n }));
 
       return { chainAddress, bondDenom, topicKit, ...rest };
     },

--- a/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
+++ b/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
@@ -60,7 +60,7 @@ const { Fail } = assert;
  *   topicKit: RecorderKit<ComosOrchestrationAccountNotification>;
  *   account: IcaAccount;
  *   chainAddress: ChainAddress;
- *   icqConnection: ICQConnection;
+ *   icqConnection: ICQConnection | undefined;
  *   bondDenom: string;
  *   timer: Remote<TimerService>;
  * }} State
@@ -149,7 +149,7 @@ export const prepareCosmosOrchestrationAccountKit = (
      * @param {object} io
      * @param {IcaAccount} io.account
      * @param {Remote<StorageNode>} io.storageNode
-     * @param {ICQConnection} io.icqConnection
+     * @param {ICQConnection | undefined} io.icqConnection
      * @param {Remote<TimerService>} io.timer
      * @returns {State}
      */
@@ -363,6 +363,7 @@ export const prepareCosmosOrchestrationAccountKit = (
          */
         async getBalance(denom) {
           const { chainAddress, icqConnection } = this.state;
+          if (!icqConnection) throw Error('Queries not enabled.');
           // TODO #9211 lookup denom from brand
           assert.typeof(denom, 'string');
 

--- a/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
+++ b/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
@@ -234,7 +234,7 @@ export const prepareCosmosOrchestrationAccountKit = (
             return this.facets.holder.withdrawReward(validator);
           }, 'WithdrawReward');
         },
-        /** @param {Delegation[]} delegations */
+        /** @param {Omit<Delegation, 'delegatorAddress'>[]} delegations */
         Undelegate(delegations) {
           trace('Undelegate', delegations);
 
@@ -407,7 +407,7 @@ export const prepareCosmosOrchestrationAccountKit = (
           throw assert.error('Not implemented');
         },
 
-        /** @param {Delegation[]} delegations */
+        /** @param {Omit<Delegation, 'delegatorAddress'>[]} delegations */
         async undelegate(delegations) {
           trace('undelegate', delegations);
           const { helper } = this.facets;

--- a/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
+++ b/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
@@ -158,9 +158,8 @@ export const prepareCosmosOrchestrationAccountKit = (
       // must be the fully synchronous maker because the kit is held in durable state
       // @ts-expect-error XXX Patterns
       const topicKit = makeRecorderKit(storageNode, PUBLIC_TOPICS.account[1]);
-      // TODO https://github.com/Agoric/agoric-sdk/issues/9066
-      // update sequence after successful executeEncodedTx, _if we want sequence in `vstorage`_
-      void E(topicKit.recorder).write(harden({ sequence: 0n }));
+      // TODO determine what goes in vstorage https://github.com/Agoric/agoric-sdk/issues/9066
+      void E(topicKit.recorder).write('');
 
       return { chainAddress, bondDenom, topicKit, ...rest };
     },
@@ -366,7 +365,9 @@ export const prepareCosmosOrchestrationAccountKit = (
          */
         async getBalance(denom) {
           const { chainAddress, icqConnection } = this.state;
-          if (!icqConnection) throw Error('Queries not enabled.');
+          if (!icqConnection) {
+            throw Fail`Queries not available for chain ${chainAddress.chainId}`;
+          }
           // TODO #9211 lookup denom from brand
           assert.typeof(denom, 'string');
 

--- a/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
+++ b/packages/orchestration/src/exos/cosmosOrchestrationAccount.js
@@ -16,7 +16,6 @@ import {
   MsgUndelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
-import { AmountShape } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 import { M } from '@agoric/vat-data';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
@@ -75,11 +74,13 @@ export const IcaAccountHolderI = M.interface('IcaAccountHolder', {
     holder: M.any(),
   }),
   getPublicTopics: M.call().returns(TopicsRecordShape),
-  delegate: M.callWhen(ChainAddressShape, AmountShape).returns(M.undefined()),
+  delegate: M.callWhen(ChainAddressShape, AmountArgShape).returns(
+    M.undefined(),
+  ),
   redelegate: M.callWhen(
     ChainAddressShape,
     ChainAddressShape,
-    AmountShape,
+    AmountArgShape,
   ).returns(M.undefined()),
   withdrawReward: M.callWhen(ChainAddressShape).returns(
     M.arrayOf(ChainAmountShape),
@@ -123,11 +124,11 @@ export const prepareCosmosOrchestrationAccountKit = (
       helper: M.interface('helper', {
         owned: M.call().returns(M.remotable()),
         getUpdater: M.call().returns(M.remotable()),
-        amountToCoin: M.call(AmountShape).returns(M.record()),
+        amountToCoin: M.call(AmountArgShape).returns(M.record()),
       }),
       holder: IcaAccountHolderI,
       invitationMakers: M.interface('invitationMakers', {
-        Delegate: M.callWhen(ChainAddressShape, AmountShape).returns(
+        Delegate: M.callWhen(ChainAddressShape, AmountArgShape).returns(
           InvitationShape,
         ),
         Redelegate: M.callWhen(
@@ -197,7 +198,7 @@ export const prepareCosmosOrchestrationAccountKit = (
       invitationMakers: {
         /**
          * @param {CosmosValidatorAddress} validator
-         * @param {Amount<'nat'>} amount
+         * @param {AmountArg} amount
          */
         Delegate(validator, amount) {
           trace('Delegate', validator, amount);

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -8,6 +8,7 @@ import { prepareCosmosOrchestrationAccount } from './exos/cosmosOrchestrationAcc
  * @import {TimerService} from '@agoric/time';
  * @import {IBCConnectionID} from '@agoric/vats';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
+ * @import {RecorderKit, MakeRecorderKit} from '@agoric/zoe/src/contractSupport/recorder.js'.
  * @import {Remote} from '@agoric/internal';
  * @import {OrchestrationService} from './service.js';
  * @import {Chain, ChainInfo, CosmosChainInfo, IBCConnectionInfo, OrchestrationAccount, Orchestrator} from './types.js';
@@ -95,6 +96,8 @@ const makeLocalChainFacade = (
  * @param {IBCConnectionInfo} connectionInfo
  * @param {object} io
  * @param {Remote<OrchestrationService>} io.orchestration
+ * @param {MakeRecorderKit} io.makeRecorderKit
+ * @param {Remote<StorageNode>} io.storageNode
  * @param {Remote<TimerService>} io.timer
  * @param {ZCF} io.zcf
  * @param {Zone} io.zone
@@ -103,9 +106,8 @@ const makeLocalChainFacade = (
 const makeRemoteChainFacade = (
   chainInfo,
   connectionInfo,
-  { orchestration, timer, zcf, zone },
+  { orchestration, makeRecorderKit, storageNode, timer, zcf, zone },
 ) => {
-  const makeRecorderKit = () => anyVal;
   const makeCosmosOrchestrationAccount = prepareCosmosOrchestrationAccount(
     zone.subZone(chainInfo.chainId),
     makeRecorderKit,
@@ -133,7 +135,7 @@ const makeRemoteChainFacade = (
       // @ts-expect-error XXX dynamic method availability
       return makeCosmosOrchestrationAccount(address, bondDenom, {
         account: icaAccount,
-        storageNode: anyVal,
+        storageNode,
         icqConnection: anyVal,
         timer,
       });
@@ -153,6 +155,7 @@ const makeRemoteChainFacade = (
  *   makeLocalChainAccountKit: ReturnType<
  *     typeof import('./exos/local-chain-account-kit.js').prepareLocalChainAccountKit
  *   >;
+ *   makeRecorderKit: MakeRecorderKit;
  * }} powers
  */
 export const makeOrchestrationFacade = ({
@@ -164,6 +167,7 @@ export const makeOrchestrationFacade = ({
   localchain,
   chainHub,
   makeLocalChainAccountKit,
+  makeRecorderKit,
 }) => {
   console.log('makeOrchestrationFacade got', {
     zone,
@@ -205,6 +209,8 @@ export const makeOrchestrationFacade = ({
 
           return makeRemoteChainFacade(remoteChainInfo, connectionInfo, {
             orchestration: orchestrationService,
+            makeRecorderKit,
+            storageNode,
             timer: timerService,
             zcf,
             zone,

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -65,6 +65,8 @@ export const startStakeAtom = async ({
       hostConnectionId: connectionInfo.id,
       controllerConnectionId: connectionInfo.counterparty.connection_id,
       bondDenom: cosmoshub.stakingTokens[0].denom,
+      // @ts-expect-error icqEnabled exists on CosmosChainInfo type
+      icqEnabled: !!cosmoshub.icqEnabled,
     },
     privateArgs: {
       orchestration: await orchestration,

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -65,8 +65,7 @@ export const startStakeAtom = async ({
       hostConnectionId: connectionInfo.id,
       controllerConnectionId: connectionInfo.counterparty.connection_id,
       bondDenom: cosmoshub.stakingTokens[0].denom,
-      // @ts-expect-error icqEnabled exists on CosmosChainInfo type
-      icqEnabled: !!cosmoshub.icqEnabled,
+      icqEnabled: cosmoshub.icqEnabled,
     },
     privateArgs: {
       orchestration: await orchestration,

--- a/packages/orchestration/src/proposals/start-stakeOsmo.js
+++ b/packages/orchestration/src/proposals/start-stakeOsmo.js
@@ -5,10 +5,10 @@ import { makeChainHub } from '../utils/chainHub.js';
 
 /**
  * @import {IBCConnectionID} from '@agoric/vats';
- * @import {StakeIcaSF,  StakeIcaTerms} from '../examples/stakeIca.contract';
+ * @import {StakeIcaSF} from '../examples/stakeIca.contract';
  */
 
-const trace = makeTracer('StartStakeAtom', true);
+const trace = makeTracer('StartStakeOsmo', true);
 
 /**
  * @param {BootstrapPowers & {
@@ -21,7 +21,7 @@ const trace = makeTracer('StartStakeAtom', true);
  *   };
  * }} powers
  */
-export const startStakeAtom = async ({
+export const startStakeOsmo = async ({
   consume: {
     agoricNames,
     board,
@@ -34,11 +34,12 @@ export const startStakeAtom = async ({
     consume: { stakeIca },
   },
   instance: {
-    produce: { stakeAtom: produceInstance },
+    // @ts-expect-error stakeOsmo not typed
+    produce: { stakeOsmo: produceInstance },
   },
 }) => {
-  const VSTORAGE_PATH = 'stakeAtom';
-  trace('startStakeAtom');
+  const VSTORAGE_PATH = 'stakeOsmo';
+  trace('startStakeOsmo');
   await null;
 
   const storageNode = await makeStorageNodeChild(chainStorage, VSTORAGE_PATH);
@@ -47,22 +48,22 @@ export const startStakeAtom = async ({
   const chainHub = makeChainHub(await agoricNames);
 
   const agoric = await chainHub.getChainInfo('agoric');
-  const cosmoshub = await chainHub.getChainInfo('cosmoshub');
+  const osmosis = await chainHub.getChainInfo('osmosis');
   const connectionInfo = await chainHub.getConnectionInfo(
     agoric.chainId,
-    cosmoshub.chainId,
+    osmosis.chainId,
   );
 
   /** @type {StartUpgradableOpts<StakeIcaSF>} */
   const startOpts = {
-    label: 'stakeAtom',
+    label: 'stakeOsmo',
     installation: stakeIca,
     terms: {
-      chainId: cosmoshub.chainId,
+      chainId: osmosis.chainId,
       hostConnectionId: connectionInfo.id,
       controllerConnectionId: connectionInfo.counterparty.connection_id,
-      bondDenom: cosmoshub.stakingTokens[0].denom,
-      icqEnabled: cosmoshub.icqEnabled,
+      bondDenom: osmosis.stakingTokens[0].denom,
+      icqEnabled: osmosis.icqEnabled,
     },
     privateArgs: {
       orchestration: await orchestration,
@@ -75,15 +76,15 @@ export const startStakeAtom = async ({
   const { instance } = await E(startUpgradable)(startOpts);
   produceInstance.resolve(instance);
 };
-harden(startStakeAtom);
+harden(startStakeOsmo);
 
-export const getManifestForStakeAtom = (
+export const getManifestForStakeOsmo = (
   { restoreRef },
   { installKeys, ...options },
 ) => {
   return {
     manifest: {
-      [startStakeAtom.name]: {
+      [startStakeOsmo.name]: {
         consume: {
           agoricNames: true,
           board: true,
@@ -96,7 +97,7 @@ export const getManifestForStakeAtom = (
           consume: { stakeIca: true },
         },
         instance: {
-          produce: { stakeAtom: true },
+          produce: { stakeOsmo: true },
         },
       },
     },

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -25,7 +25,6 @@ export const ChainAmountShape = harden({ denom: M.string(), value: M.nat() });
 export const AmountArgShape = M.or(AmountShape, ChainAmountShape);
 
 export const DelegationShape = harden({
-  delegatorAddress: M.string(),
   validatorAddress: M.string(),
   shares: M.string(), // TODO: bigint?
 });

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -1,6 +1,7 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
+import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import type { CosmosChainInfo, IBCConnectionInfo } from '../src/cosmos-api.js';
 import { makeOrchestrationFacade } from '../src/facade.js';
 import type { Chain } from '../src/orchestration-api.js';
@@ -48,6 +49,10 @@ test('chain info', async t => {
 
   const { zcf } = await setupZCFTest();
   const chainHub = makeChainHub(facadeServices.agoricNames);
+  const { makeRecorderKit } = prepareRecorderKitMakers(
+    zone.mapStore('recorder'),
+    bootstrap.marshaller,
+  );
 
   const { orchestrate } = makeOrchestrationFacade({
     ...facadeServices,
@@ -56,6 +61,7 @@ test('chain info', async t => {
     zone,
     chainHub,
     makeLocalChainAccountKit,
+    makeRecorderKit,
   });
 
   chainHub.registerChain('mock', mockChainInfo);

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -185,7 +185,7 @@ const makeScenario = () => {
 
   const { delegations, startTime } = configStaking;
 
-  const { rootNode } = makeFakeStorageKit('mockChainStorageRoot', {
+  const { rootNode } = makeFakeStorageKit('stakingOpsTest', {
     sequence: false,
   });
 
@@ -209,11 +209,10 @@ const makeScenario = () => {
 
 test('makeAccount() writes to storage', async t => {
   const s = makeScenario();
-  const { account, calls, timer } = s;
+  const { account, timer } = s;
   const { makeRecorderKit, storageNode, zcf, icqConnection, zone } = s;
   const make = prepareCosmosOrchestrationAccountKit(zone, makeRecorderKit, zcf);
 
-  // Higher fidelity tests below use invitationMakers.
   const { holder } = make(account.getAddress(), 'uatom', {
     account,
     storageNode,
@@ -227,9 +226,7 @@ test('makeAccount() writes to storage', async t => {
   const storageUpdate = await E(accountNotifier).getUpdateSince();
   t.deepEqual(storageUpdate, {
     updateCount: 1n,
-    value: {
-      sequence: 0n,
-    },
+    value: '',
   });
 });
 

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -378,7 +378,6 @@ test(`undelegate waits for unbonding period`, async t => {
   const value = BigInt(Object.values(delegations)[0].amount);
   const anAmount = { brand: Far('Token'), value } as Amount<'nat'>;
   const delegation = {
-    delegatorAddress: account.getAddress().address,
     shares: `${anAmount.value}`,
     validatorAddress: validator.address,
   };

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -274,8 +274,11 @@ test(`delegate; redelegate using invitationMakers`, async t => {
   const { validator, delegations } = configStaking;
   {
     const value = BigInt(Object.values(delegations)[0].amount);
-    const anAmount = { brand: aBrand, value };
-    const toDelegate = await E(invitationMakers).Delegate(validator, anAmount);
+    const anAmountArg = { denom: 'uatom', value };
+    const toDelegate = await E(invitationMakers).Delegate(
+      validator,
+      anAmountArg,
+    );
     const seat = E(zoe).offer(toDelegate);
     const result = await E(seat).getOfferResult();
 

--- a/packages/vm-config/decentral-devnet-config.json
+++ b/packages/vm-config/decentral-devnet-config.json
@@ -165,19 +165,6 @@
             }
           ]
         }
-      ],
-      [
-        {
-          "module": "@agoric/builders/scripts/orchestration/init-stakeAtom.js",
-          "entrypoint": "defaultProposalBuilder",
-          "args": [
-            {
-              "hostConnectionId": "connection-1",
-              "controllerConnectionId": "connection-0",
-              "bondDenom": "uatom"
-            }
-          ]
-        }
       ]
     ]
   },


### PR DESCRIPTION
refs: #9042 
refs: #9193
refs: #9066

## Description

- **Motivation:** wallet clients need a way to view their address so they can send funds to it
- Updates `stakeAtom.contract.js` to create a vstorage entry for newly created accounts, keyed by `ChainAccount['address']` (e.g. `cosmos1testing1234`)
   - TODO: if we hit `UNPARSABLE_ADDRESS` in parseAddress we should throw, or use a fallback value
- Writes an empty string  to provided storageNode in `exos/cosmosOrchestrationAccount.js`
   - adds TODO for fleshing out vstorage requirements via #9066
  
 - Drive-by fixes:
    - use `AmountArg` consistently in `/exos/cosmosOrchestrationAccount.js`
    - remove `delegatorAddress` from `undelegate(Delegations[])` interface and implementation

### Security Considerations


### Scaling Considerations

This is some experimentation within a contract in order to get experience with what should be pushed down into the platform.

The approach delegates vstorage publishing responsibilities to guest contracts. We might consider posting information for all accounts to a shared global namespace.

### Documentation Considerations


### Testing Considerations

Tests, including ones for `swapExample.contract.js` and `facade.js`, were updated to accommodate these changes. Mocking facilities for `.getAddress()` are light - including in boostrap tests - so using `ChainAddress['address']` might lead to unexpected behavior (accounts overwriting each other in storage) in a testing environment.

### Upgrade Considerations


