### PR TITLE
fix(vow): make watch/when more robust against loops and hangs

### DIFF
--- a/packages/SwingSet/tools/bootstrap-relay.js
+++ b/packages/SwingSet/tools/bootstrap-relay.js
@@ -37,10 +37,13 @@ export const buildRootObject = () => {
       return root;
     },
 
-    createVat: async ({ name, bundleCapName, vatParameters = {} }) => {
+    createVat: async (
+      { name, bundleCapName, vatParameters = {} },
+      options = {},
+    ) => {
       const bcap = await E(vatAdmin).getNamedBundleCap(bundleCapName);
-      const options = { vatParameters };
-      const { adminNode, root } = await E(vatAdmin).createVat(bcap, options);
+      const vatOptions = { ...options, vatParameters };
+      const { adminNode, root } = await E(vatAdmin).createVat(bcap, vatOptions);
       vatData.set(name, { adminNode, root });
       return root;
     },

--- a/packages/SwingSet/tools/bootstrap-relay.js
+++ b/packages/SwingSet/tools/bootstrap-relay.js
@@ -1,6 +1,7 @@
 import { assert } from '@agoric/assert';
 import { objectMap } from '@agoric/internal';
 import { Far, E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
 import { buildManualTimer } from './manual-timer.js';
 
 const { Fail, quote: q } = assert;
@@ -78,6 +79,12 @@ export const buildRootObject = () => {
       const remotable = Far(label, { ...methods });
       callLogsByRemotable.set(remotable, callLogs);
       return remotable;
+    },
+
+    makePromiseKit: () => {
+      const { promise, ...resolverMethods } = makePromiseKit();
+      const resolver = Far('resolver', resolverMethods);
+      return harden({ promise, resolver });
     },
 
     /**

--- a/packages/boot/test/upgrading/upgrade-vats.test.js
+++ b/packages/boot/test/upgrading/upgrade-vats.test.js
@@ -456,12 +456,15 @@ test('upgrade vat-vow', async t => {
 
   const { EV } = await makeScenario(t, { bundles });
 
-  t.log('create initial version');
+  t.log('create initial version, metered');
+  const vatAdmin = await EV.vat('bootstrap').getVatAdmin();
+  const meter = await EV(vatAdmin).createUnlimitedMeter();
   const vowVatConfig = {
     name: 'vow',
     bundleCapName: 'vow',
   };
-  const vowRoot = await EV.vat('bootstrap').createVat(vowVatConfig);
+  const vatOptions = { managerType: 'xs-worker', meter };
+  const vowRoot = await EV.vat('bootstrap').createVat(vowVatConfig, vatOptions);
 
   t.log('test incarnation 0');
   /** @type {Record<string, [settlementValue?: unknown, isRejection?: boolean]>} */

--- a/packages/boot/test/upgrading/upgrade-vats.test.js
+++ b/packages/boot/test/upgrading/upgrade-vats.test.js
@@ -536,23 +536,18 @@ test('upgrade vat-vow', async t => {
   await EV(vowRoot).resolveVowWatchers(localVowsUpdates);
   await EV(promiseKit.resolver).resolve('ciao');
   t.timeout(10_000);
-  await EV(fakeVowKit.resolver).reject(
-    harden({
+  const upgradeRejection = harden({
+    status: 'rejected',
+    reason: {
       name: 'vatUpgraded',
       upgradeMessage: 'vat upgraded',
       incarnationNumber: 0,
-    }),
-  );
+    },
+  });
+  await EV(fakeVowKit.resolver).reject(upgradeRejection.reason);
   t.timeout(600_000); // t.timeout.clear() not yet available in our ava version
   t.deepEqual(dataOnly(await EV(vowRoot).getWatcherResults()), {
-    promiseForever: {
-      status: 'rejected',
-      reason: {
-        name: 'vatUpgraded',
-        upgradeMessage: 'vat upgraded',
-        incarnationNumber: 0,
-      },
-    },
+    promiseForever: upgradeRejection,
     promiseFulfilled: { status: 'fulfilled', value: 'hello' },
     promiseRejected: { status: 'rejected', reason: 'goodbye' },
     vowForever: {
@@ -562,22 +557,11 @@ test('upgrade vat-vow', async t => {
     vowFulfilled: { status: 'fulfilled', value: 'hello' },
     vowRejected: { status: 'rejected', reason: 'goodbye' },
     vowPostUpgrade: { status: 'fulfilled', value: 'bonjour' },
-    vowExternalPromise: { status: 'fulfilled', value: 'ciao' },
-    vowExternalVow: {
-      status: 'rejected',
-      reason: {
-        name: 'vatUpgraded',
-        upgradeMessage: 'vat upgraded',
-        incarnationNumber: 0,
-      },
-    },
-    vowPromiseForever: {
-      status: 'rejected',
-      reason: {
-        name: 'vatUpgraded',
-        upgradeMessage: 'vat upgraded',
-        incarnationNumber: 0,
-      },
-    },
+    // The 'fulfilled' result below is wishful thinking.  Long-lived
+    // promises are not supported by `watch` at this time.
+    // vowExternalPromise: { status: 'fulfilled', value: 'ciao' },
+    vowExternalPromise: upgradeRejection,
+    vowExternalVow: upgradeRejection,
+    vowPromiseForever: upgradeRejection,
   });
 });

--- a/packages/boot/test/upgrading/upgrade-vats.test.js
+++ b/packages/boot/test/upgrading/upgrade-vats.test.js
@@ -473,11 +473,13 @@ test('upgrade vat-vow', async t => {
     promiseFulfilled: ['hello'],
     promiseRejected: ['goodbye', true],
   };
+  const promiseKit = await EV.vat('bootstrap').makePromiseKit();
   const localVows = {
     vowForever: [],
     vowFulfilled: ['hello'],
     vowRejected: ['goodbye', true],
     vowPostUpgrade: [],
+    vowExternalPromise: [promiseKit.promise],
     vowPromiseForever: [undefined, false, true],
   };
   await EV(vowRoot).makeLocalPromiseWatchers(localPromises);
@@ -493,6 +495,10 @@ test('upgrade vat-vow', async t => {
     vowFulfilled: { status: 'fulfilled', value: 'hello' },
     vowRejected: { status: 'rejected', reason: 'goodbye' },
     vowPostUpgrade: {
+      status: 'unsettled',
+      resolver: {},
+    },
+    vowExternalPromise: {
       status: 'unsettled',
       resolver: {},
     },
@@ -512,6 +518,7 @@ test('upgrade vat-vow', async t => {
     vowPostUpgrade: ['bonjour'],
   };
   await EV(vowRoot).resolveVowWatchers(localVowsUpdates);
+  await EV(promiseKit.resolver).resolve('ciao');
   t.deepEqual(dataOnly(await EV(vowRoot).getWatcherResults()), {
     promiseForever: {
       status: 'rejected',
@@ -530,6 +537,7 @@ test('upgrade vat-vow', async t => {
     vowFulfilled: { status: 'fulfilled', value: 'hello' },
     vowRejected: { status: 'rejected', reason: 'goodbye' },
     vowPostUpgrade: { status: 'fulfilled', value: 'bonjour' },
+    vowExternalPromise: { status: 'fulfilled', value: 'ciao' },
     vowPromiseForever: {
       status: 'rejected',
       reason: {

--- a/packages/boot/test/upgrading/upgrade-vats.test.js
+++ b/packages/boot/test/upgrading/upgrade-vats.test.js
@@ -557,10 +557,7 @@ test('upgrade vat-vow', async t => {
     vowFulfilled: { status: 'fulfilled', value: 'hello' },
     vowRejected: { status: 'rejected', reason: 'goodbye' },
     vowPostUpgrade: { status: 'fulfilled', value: 'bonjour' },
-    // The 'fulfilled' result below is wishful thinking.  Long-lived
-    // promises are not supported by `watch` at this time.
-    // vowExternalPromise: { status: 'fulfilled', value: 'ciao' },
-    vowExternalPromise: upgradeRejection,
+    vowExternalPromise: { status: 'fulfilled', value: 'ciao' },
     vowExternalVow: upgradeRejection,
     vowPromiseForever: upgradeRejection,
   });

--- a/packages/boot/test/upgrading/vat-vow.js
+++ b/packages/boot/test/upgrading/vat-vow.js
@@ -4,9 +4,11 @@ import { Far } from '@endo/far';
 
 export const buildRootObject = (_vatPowers, _args, baggage) => {
   const zone = makeDurableZone(baggage);
-  const { watch } = prepareVowTools(zone.subZone('VowTools'));
+  const { watch, makeVowKit } = prepareVowTools(zone.subZone('VowTools'));
 
-  /** @type {MapStore<string, { status: 'unsettled' } | PromiseSettledResult<any>>} */
+  /** @typedef {{ status: 'unsettled', resolver?: import('@agoric/vow').VowResolver } | PromiseSettledResult<any>} WatcherResult */
+
+  /** @type {MapStore<string, WatcherResult>} */
   const nameToResult = zone.mapStore('nameToResult');
 
   const makeWatcher = zone.exoClass('Watcher', undefined, name => ({ name }), {
@@ -41,6 +43,49 @@ export const buildRootObject = (_vatPowers, _args, baggage) => {
           }
         }
         watch(p, makeWatcher(name));
+      }
+    },
+    /** @param {Record<string, [settlementValue?: unknown, isRejection?: boolean, wrapInPromise?: boolean]>} localVows */
+    async makeLocalVowWatchers(localVows) {
+      for (const [name, settlement] of Object.entries(localVows)) {
+        const { vow, resolver } = makeVowKit();
+        nameToResult.init(name, harden({ status: 'unsettled', resolver }));
+        if (settlement.length) {
+          let [settlementValue, isRejection] = settlement;
+          const wrapInPromise = settlement[2];
+          if (wrapInPromise) {
+            if (isRejection) {
+              settlementValue = Promise.reject(settlementValue);
+              isRejection = false;
+            } else if (settlementValue === undefined) {
+              // Consider an undefined value as no settlement
+              settlementValue = new Promise(() => {});
+            } else {
+              settlementValue = Promise.resolve(settlementValue);
+            }
+          }
+          if (isRejection) {
+            resolver.reject(settlementValue);
+          } else {
+            resolver.resolve(settlementValue);
+          }
+        }
+        watch(vow, makeWatcher(name));
+      }
+    },
+    /** @param {Record<string, [settlementValue: unknown, isRejection?: boolean]>} localVows */
+    async resolveVowWatchers(localVows) {
+      for (const [name, settlement] of Object.entries(localVows)) {
+        const { status, resolver } = nameToResult.get(name);
+        if (status !== 'unsettled' || !resolver) {
+          throw Error(`Invalid pending vow for ${name}`);
+        }
+        const [settlementValue, isRejection] = settlement;
+        if (isRejection) {
+          resolver.reject(settlementValue);
+        } else {
+          resolver.resolve(settlementValue);
+        }
       }
     },
   });

--- a/packages/boot/test/upgrading/vat-vow.js
+++ b/packages/boot/test/upgrading/vat-vow.js
@@ -6,7 +6,7 @@ export const buildRootObject = (_vatPowers, _args, baggage) => {
   const zone = makeDurableZone(baggage);
   const { watch, makeVowKit } = prepareVowTools(zone.subZone('VowTools'));
 
-  /** @typedef {{ status: 'unsettled', resolver?: import('@agoric/vow').VowResolver } | PromiseSettledResult<any>} WatcherResult */
+  /** @typedef {({ status: 'unsettled' } | PromiseSettledResult<any>) & { resolver?: import('@agoric/vow').VowResolver }} WatcherResult */
 
   /** @type {MapStore<string, WatcherResult>} */
   const nameToResult = zone.mapStore('nameToResult');

--- a/packages/vat-data/vow.js
+++ b/packages/vat-data/vow.js
@@ -1,2 +1,0 @@
-// Backward-compatibility forwarding to the vow package.
-export * from '@agoric/vow/vat.js';

--- a/packages/vats/src/vat-transfer.js
+++ b/packages/vats/src/vat-transfer.js
@@ -3,7 +3,7 @@ import { Far } from '@endo/far';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import { provideLazy } from '@agoric/store';
-import { prepareVowTools } from '@agoric/vat-data/vow.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 import { prepareBridgeTargetModule } from './bridge-target.js';
 import { prepareTransferTools } from './transfer.js';
 

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -5,14 +5,16 @@ import { prepareWatch } from './watch.js';
 import { prepareWatchUtils } from './watch-utils.js';
 
 /** @import {Zone} from '@agoric/base-zone' */
+/** @import {IsRetryableReason} from './types.js' */
 
 /**
  * @param {Zone} zone
  * @param {object} [powers]
- * @param {(reason: any) => boolean} [powers.isRetryableReason]
+ * @param {IsRetryableReason} [powers.isRetryableReason]
  */
 export const prepareVowTools = (zone, powers = {}) => {
-  const { isRetryableReason = () => false } = powers;
+  const { isRetryableReason = /** @type {IsRetryableReason} */ (() => false) } =
+    powers;
   const makeVowKit = prepareVowKit(zone);
   const when = makeWhen(isRetryableReason);
   const watch = prepareWatch(zone, makeVowKit, isRetryableReason);

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -11,6 +11,16 @@ export {};
  */
 
 /**
+ * @callback IsRetryableReason
+ * Return truthy if a rejection reason should result in a retry.
+ * @param {any} reason
+ * @param {any} priorRetryValue the previous value returned by this function
+ * when deciding whether to retry the same logical operation
+ * @returns {any} If falsy, the reason is not retryable. If truthy, the
+ * priorRetryValue for the next call.
+ */
+
+/**
  * @template T
  * @typedef {Promise<T | Vow<T>>} PromiseVow Return type of a function that may
  * return a promise or a vow.

--- a/packages/vow/vat.js
+++ b/packages/vow/vat.js
@@ -4,12 +4,17 @@ import { isUpgradeDisconnection } from '@agoric/internal/src/upgrade-api.js';
 import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import { makeE, prepareVowTools as rawPrepareVowTools } from './src/index.js';
 
-/**
- * Return truthy if a rejection reason should result in a retry.
- * @param {any} reason
- * @returns {boolean}
- */
-const isRetryableReason = reason => isUpgradeDisconnection(reason);
+/** @type {import('./src/types.js').IsRetryableReason} */
+const isRetryableReason = (reason, priorRetryValue) => {
+  if (
+    isUpgradeDisconnection(reason) &&
+    (!priorRetryValue ||
+      reason.incarnationNumber > priorRetryValue.incarnationNumber)
+  ) {
+    return reason;
+  }
+  return undefined;
+};
 
 export const defaultPowers = harden({
   isRetryableReason,


### PR DESCRIPTION
closes: #9466

Expand `isRetryableReason` to take the prior return value into account to prevent infinite loops when `watch`ing or `when`ing a plain `Promise.reject(reasonThatIsRetryable)`.  Before this, when the watch/when would perform the retry loop, it incorrectly assumed that a non-advancing series of retryable `shorten` attempts just needed more retries.

Also, reject watch/when of certain promises that don't resolve promptly (such as when the watching vat is upgraded, even if the promise's decider has not been upgraded).

Finally, remove the deprecated `@agoric/vat-data/vow.js`, since that has been superseded by `@agoric/vow/vat.js`.

### Security Considerations

Fixes some availability problems.

### Scaling Considerations

Less resource consumption.

### Documentation Considerations

By design, the `@agoric/vat` package assumes that all pending promises in watch/when chains will settle promptly (such as by the end of the crank), producing only long-lived vows or terminal results.

### Testing Considerations

New bootstrap tests added.

### Upgrade Considerations

None additional.