### PR TITLE
feat: make vat-localchain resumable

### DIFF
--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -4,13 +4,14 @@ import { Far } from '@endo/far';
 import { V as E } from '@agoric/vow/vat.js';
 
 /**
- * @import {ListenHandler, PortAllocator} from '@agoric/network';
+ * @import {Connection, PortAllocator} from '@agoric/network';
+ * @import {FarRef, ERef} from '@agoric/vow';
  */
 
 /**
  * @param {ZCF} zcf
  * @param {{
- *   portAllocator: ERef<PortAllocator>;
+ *   portAllocator: FarRef<PortAllocator>;
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} _baggage
  */
@@ -20,7 +21,13 @@ export const start = async (zcf, privateArgs, _baggage) => {
   const myPort = await E(portAllocator).allocateCustomIBCPort();
 
   const { log } = console;
+  /**
+   * @type {FarRef<Connection>}
+   */
   let connP;
+  /**
+   * @type {ERef<string>}
+   */
   let ackP;
 
   const creatorFacet = Far('CF', {

--- a/packages/internal/src/types.d.ts
+++ b/packages/internal/src/types.d.ts
@@ -57,6 +57,7 @@ export type Remote<Primary, Local = DataOnly<Primary>> =
   | Primary
   | RemotableBrand<Local, Primary>;
 
+// TODO: Add type tests for FarRef and Remote.
 /**
  * Potentially remote promises or settled references.
  */

--- a/packages/internal/src/types.d.ts
+++ b/packages/internal/src/types.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import type { RemotableBrand } from '@endo/eventual-send';
+import type { ERef, RemotableBrand } from '@endo/eventual-send';
 import type { Primitive } from '@endo/pass-style';
 import type { Callable } from './utils.js';
 
@@ -56,3 +56,10 @@ export type DataOnly<T> =
 export type Remote<Primary, Local = DataOnly<Primary>> =
   | Primary
   | RemotableBrand<Local, Primary>;
+
+/**
+ * Potentially remote promises or settled references.
+ */
+export type FarRef<Primary, Local = DataOnly<Primary>> = ERef<
+  Remote<Primary, Local>
+>;

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -1475,7 +1475,7 @@ export const preparePortAllocator = (zone, { watch }) =>
      */
     ({ protocol }) => ({ protocol, lastICAPortNum: 0n, lastICQPortNum: 0n }),
     {
-      allocateCustomIBCPort(specifiedName = '') {
+      async allocateCustomIBCPort(specifiedName = '') {
         const { state } = this;
         let localAddr = `/ibc-port/`;
 
@@ -1488,7 +1488,7 @@ export const preparePortAllocator = (zone, { watch }) =>
         // Allocate an IBC port with a unique generated name.
         return watch(E(state.protocol).bindPort(localAddr));
       },
-      allocateICAControllerPort() {
+      async allocateICAControllerPort() {
         const { state } = this;
         state.lastICAPortNum += 1n;
         return watch(
@@ -1497,7 +1497,7 @@ export const preparePortAllocator = (zone, { watch }) =>
           ),
         );
       },
-      allocateICQControllerPort() {
+      async allocateICQControllerPort() {
         const { state } = this;
         state.lastICQPortNum += 1n;
         return watch(
@@ -1506,7 +1506,7 @@ export const preparePortAllocator = (zone, { watch }) =>
           ),
         );
       },
-      allocateCustomLocalPort(specifiedName = '') {
+      async allocateCustomLocalPort(specifiedName = '') {
         const { state } = this;
 
         let localAddr = `/local/`;

--- a/packages/orchestration/src/exos/local-chain-account-kit.js
+++ b/packages/orchestration/src/exos/local-chain-account-kit.js
@@ -6,6 +6,7 @@ import { makeTracer } from '@agoric/internal';
 import { M } from '@agoric/vat-data';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
+import { V } from '@agoric/vow/vat.js';
 import { E } from '@endo/far';
 import {
   AmountArgShape,
@@ -159,9 +160,9 @@ export const prepareLocalChainAccountKit = (
           };
           const { account: lca } = this.state;
           trace('lca', lca);
-          const delegatorAddress = await E(lca).getAddress();
+          const delegatorAddress = await V(lca).getAddress();
           trace('delegatorAddress', delegatorAddress);
-          const [result] = await E(lca).executeTx([
+          const [result] = await V(lca).executeTx([
             typedJson('/cosmos.staking.v1beta1.MsgDelegate', {
               amount,
               validatorAddress,
@@ -184,9 +185,9 @@ export const prepareLocalChainAccountKit = (
           };
           const { account: lca } = this.state;
           trace('lca', lca);
-          const delegatorAddress = await E(lca).getAddress();
+          const delegatorAddress = await V(lca).getAddress();
           trace('delegatorAddress', delegatorAddress);
-          const [response] = await E(lca).executeTx([
+          const [response] = await V(lca).executeTx([
             typedJson('/cosmos.staking.v1beta1.MsgUndelegate', {
               amount,
               validatorAddress,
@@ -208,16 +209,16 @@ export const prepareLocalChainAccountKit = (
          */
         /** @type {LocalChainAccount['deposit']} */
         async deposit(payment, optAmountShape) {
-          return E(this.state.account).deposit(payment, optAmountShape);
+          return V(this.state.account).deposit(payment, optAmountShape);
         },
         /** @type {LocalChainAccount['withdraw']} */
         async withdraw(amount) {
-          return E(this.state.account).withdraw(amount);
+          return V(this.state.account).withdraw(amount);
         },
         /** @type {LocalChainAccount['executeTx']} */
         async executeTx(messages) {
           // @ts-expect-error subtype
-          return E(this.state.account).executeTx(messages);
+          return V(this.state.account).executeTx(messages);
         },
         /** @returns {ChainAddress['address']} */
         getAddress() {
@@ -252,7 +253,7 @@ export const prepareLocalChainAccountKit = (
               ? 0n
               : await timestampHelper.getTimeoutTimestampNS());
 
-          const [result] = await E(this.state.account).executeTx([
+          const [result] = await V(this.state.account).executeTx([
             typedJson('/ibc.applications.transfer.v1.MsgTransfer', {
               sourcePort: transferChannel.portId,
               sourceChannel: transferChannel.channelId,

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -1,6 +1,6 @@
 /** @file Orchestration service */
 
-import { E } from '@endo/far';
+import { V as E } from '@agoric/vow/vat.js';
 import { prepareCosmosOrchestrationAccount } from './exos/cosmosOrchestrationAccount.js';
 
 /**

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -2,6 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { V } from '@agoric/vow/vat.js';
 import { E } from '@endo/far';
 import path from 'path';
 import { commonSetup } from '../supports.js';
@@ -53,7 +54,7 @@ test('makeAccount, deposit, withdraw', async t => {
   t.regex(await E(account).getAddress(), /agoric1/);
 
   t.log('deposit 100 bld to account');
-  const depositResp = await E(account).deposit(
+  const depositResp = await V(account).deposit(
     await utils.pourPayment(bld.units(100)),
   );
   t.true(AmountMath.isEqual(depositResp, bld.units(100)), 'deposit');
@@ -61,7 +62,7 @@ test('makeAccount, deposit, withdraw', async t => {
   // TODO validate balance, .getBalance()
 
   t.log('withdraw bld from account');
-  const withdrawResp = await E(account).withdraw(bld.units(100));
+  const withdrawResp = await V(account).withdraw(bld.units(100));
   const withdrawAmt = await bld.issuer.getAmountOf(withdrawResp);
   t.true(AmountMath.isEqual(withdrawAmt, bld.units(100)), 'withdraw');
 

--- a/packages/orchestration/test/exos/local-chain-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-chain-account-kit.test.ts
@@ -2,7 +2,8 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { E, Far } from '@endo/far';
+import { V as E } from '@agoric/vow/vat.js';
+import { Far } from '@endo/far';
 import { commonSetup } from '../supports.js';
 import { prepareLocalChainAccountKit } from '../../src/exos/local-chain-account-kit.js';
 import { ChainAddress } from '../../src/orchestration-api.js';

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -66,13 +66,15 @@ export const commonSetup = async t => {
     }),
   );
 
+  const vowTools = prepareVowTools(rootZone.subZone('vows'));
+
   const transferBridge = makeFakeTransferBridge(rootZone);
   const { makeBridgeTargetKit } = prepareBridgeTargetModule(
     rootZone.subZone('bridge'),
   );
   const { makeTransferMiddlewareKit } = prepareTransferTools(
     rootZone.subZone('transfer'),
-    prepareVowTools(rootZone.subZone('vows')),
+    vowTools,
   );
 
   const { finisher, interceptorFactory, transferMiddleware } =
@@ -90,6 +92,7 @@ export const commonSetup = async t => {
   );
   const localchain = prepareLocalChainTools(
     rootZone.subZone('localchain'),
+    vowTools,
   ).makeLocalChain({
     bankManager,
     system: localchainBridge,

--- a/packages/vats/src/localchain.js
+++ b/packages/vats/src/localchain.js
@@ -2,11 +2,14 @@
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { AmountShape, BrandShape, PaymentShape } from '@agoric/ertp';
+import { Shape as NetworkShape } from '@agoric/network';
 
 const { Fail } = assert;
 
 /**
  * @import {TypedJson, ResponseTo, JsonSafe} from '@agoric/cosmic-proto';
+ * @import {PromiseVow, VowTools} from '@agoric/vow';
+ * @import {TargetApp, TargetRegistration} from './bridge-target.js';
  * @import {BankManager, Bank} from './vat-bank.js';
  * @import {ScopedBridgeManager} from './types.js';
  */
@@ -30,7 +33,9 @@ const { Fail } = assert;
 export const LocalChainAccountI = M.interface('LocalChainAccount', {
   getAddress: M.callWhen().returns(M.string()),
   getBalance: M.callWhen(BrandShape).returns(AmountShape),
-  deposit: M.callWhen(PaymentShape).optional(M.pattern()).returns(AmountShape),
+  deposit: M.callWhen(PaymentShape)
+    .optional(M.pattern())
+    .returns(NetworkShape.Vow$(AmountShape)),
   withdraw: M.callWhen(AmountShape).returns(PaymentShape),
   executeTx: M.callWhen(M.arrayOf(M.record())).returns(M.arrayOf(M.record())),
   monitorTransfers: M.callWhen(M.remotable('TransferTap')).returns(
@@ -38,89 +43,137 @@ export const LocalChainAccountI = M.interface('LocalChainAccount', {
   ),
 });
 
-/** @param {import('@agoric/base-zone').Zone} zone */
-const prepareLocalChainAccount = zone =>
-  zone.exoClass(
-    'LocalChainAccount',
-    LocalChainAccountI,
+/**
+ * @param {import('@agoric/base-zone').Zone} zone
+ * @param {VowTools} vowTools
+ */
+export const prepareLocalChainAccountKit = (zone, { watch }) =>
+  zone.exoClassKit(
+    'LocalChainAccountKit',
+    {
+      account: LocalChainAccountI,
+      depositPaymentWatcher: M.interface('DepositPaymentWatcher', {
+        onFulfilled: M.call(BrandShape)
+          .optional({
+            payment: PaymentShape,
+            optAmountShape: M.or(M.undefined(), AmountShape),
+          })
+          .returns(M.promise()),
+      }),
+    },
     /**
      * @param {string} address
      * @param {AccountPowers} powers
      */
-    (address, powers) => ({ address, ...powers, reserved: undefined }),
+    (address, powers) => ({
+      address,
+      ...powers,
+      reserved: undefined,
+    }),
     {
-      // Information that the account creator needs.
-      getAddress() {
-        return this.state.address;
+      depositPaymentWatcher: {
+        /**
+         * @param {Brand<'nat'>} brand
+         * @param {{
+         *   payment: Payment<'nat'>;
+         *   optAmountShape: Amount<'nat'>;
+         * }} ctx
+         */
+        onFulfilled(brand, { payment, optAmountShape }) {
+          const purse = E(this.state.bank).getPurse(brand);
+          return E(purse).deposit(payment, optAmountShape);
+        },
       },
-      /** @param {Brand<'nat'>} brand */
-      async getBalance(brand) {
-        const { bank } = this.state;
-        const purse = E(bank).getPurse(brand);
-        return E(purse).getCurrentAmount();
-      },
-      /**
-       * Deposit a payment into the bank purse that matches the alleged brand.
-       * This is safe, since even if the payment lies about its brand, ERTP will
-       * reject spoofed payment objects when depositing into a purse.
-       *
-       * @param {Payment<'nat'>} payment
-       * @param {Pattern} [optAmountShape] throws if the Amount of the Payment
-       *   does not match the provided Pattern
-       * @returns {Promise<Amount>}
-       */
-      async deposit(payment, optAmountShape) {
-        const { bank } = this.state;
+      account: {
+        // Information that the account creator needs.
+        getAddress() {
+          return this.state.address;
+        },
+        /**
+         * @param {Brand<'nat'>} brand
+         * @returns {PromiseVow<Amount<'nat'>>}
+         */
+        async getBalance(brand) {
+          const { bank } = this.state;
+          const purse = E(bank).getPurse(brand);
+          return E(purse).getCurrentAmount();
+        },
+        /**
+         * Deposit a payment into the bank purse that matches the alleged brand.
+         * This is safe, since even if the payment lies about its brand, ERTP
+         * will reject spoofed payment objects when depositing into a purse.
+         *
+         * @param {Payment<'nat'>} payment
+         * @param {Pattern} [optAmountShape] throws if the Amount of the Payment
+         *   does not match the provided Pattern
+         * @returns {PromiseVow<Amount<'nat'>>}
+         */
+        async deposit(payment, optAmountShape) {
+          return watch(
+            E(payment).getAllegedBrand(),
+            this.facets.depositPaymentWatcher,
+            {
+              payment,
+              optAmountShape,
+            },
+          );
+        },
+        /**
+         * Withdraw a payment from the account's bank purse of the amount's
+         * brand.
+         *
+         * @param {Amount<'nat'>} amount
+         * @returns {PromiseVow<Payment<'nat'>>} payment
+         */
+        async withdraw(amount) {
+          const { bank } = this.state;
+          const purse = E(bank).getPurse(amount.brand);
+          return E(purse).withdraw(amount);
+        },
+        /**
+         * Execute a batch of transactions and return the responses. Use
+         * `typedJson()` on the arguments to get typed return values.
+         *
+         * @template {TypedJson[]} MT messages tuple (use const with multiple
+         *   elements or it will be a mixed array)
+         * @param {MT} messages
+         * @returns {PromiseVow<{
+         *   [K in keyof MT]: JsonSafe<ResponseTo<MT[K]>>;
+         * }>}
+         */
+        async executeTx(messages) {
+          const { address, system } = this.state;
+          messages.length > 0 || Fail`need at least one message to execute`;
 
-        const allegedBrand = await E(payment).getAllegedBrand();
-        const purse = E(bank).getPurse(allegedBrand);
-        return E(purse).deposit(payment, optAmountShape);
-      },
-      /**
-       * Withdraw a payment from the account's bank purse of the amount's brand.
-       *
-       * @param {Amount<'nat'>} amount
-       * @returns {Promise<Payment<'nat'>>} payment
-       */
-      async withdraw(amount) {
-        const { bank } = this.state;
-        const purse = E(bank).getPurse(amount.brand);
-        return E(purse).withdraw(amount);
-      },
-      /**
-       * Execute a batch of transactions and return the responses. Use
-       * `typedJson()` on the arguments to get typed return values.
-       *
-       * @template {TypedJson[]} MT messages tuple (use const with multiple
-       *   elements or it will be a mixed array)
-       * @param {MT} messages
-       * @returns {Promise<{ [K in keyof MT]: JsonSafe<ResponseTo<MT[K]>> }>}
-       */
-      async executeTx(messages) {
-        const { address, system } = this.state;
-        messages.length > 0 || Fail`need at least one message to execute`;
-
-        const obj = {
-          type: 'VLOCALCHAIN_EXECUTE_TX',
-          // This address is the only one that `VLOCALCHAIN_EXECUTE_TX` will
-          // accept as a signer for the transaction.  If the messages have other
-          // addresses in signer positions, the transaction will be aborted.
-          address,
-          messages,
-        };
-        return E(system).toBridge(obj);
-      },
-      async monitorTransfers(tap) {
-        const { address, transfer } = this.state;
-        return E(transfer).registerTap(address, tap);
+          const obj = {
+            type: 'VLOCALCHAIN_EXECUTE_TX',
+            // This address is the only one that `VLOCALCHAIN_EXECUTE_TX` will
+            // accept as a signer for the transaction.  If the messages have other
+            // addresses in signer positions, the transaction will be aborted.
+            address,
+            messages,
+          };
+          return E(system).toBridge(obj);
+        },
+        /**
+         * @param {TargetApp} tap
+         * @returns {PromiseVow<TargetRegistration>}
+         */
+        async monitorTransfers(tap) {
+          const { address, transfer } = this.state;
+          return E(transfer).registerTap(address, tap);
+        },
       },
     },
   );
+
 /**
  * @typedef {Awaited<
- *   ReturnType<Awaited<ReturnType<typeof prepareLocalChainAccount>>>
- * >} LocalChainAccount
+ *   ReturnType<ReturnType<typeof prepareLocalChainAccountKit>>
+ * >} LocalChainAccountKit
  */
+
+/** @typedef {LocalChainAccountKit['account']} LocalChainAccount */
 
 export const LocalChainI = M.interface('LocalChain', {
   makeAccount: M.callWhen().returns(M.remotable('LocalChainAccount')),
@@ -130,77 +183,118 @@ export const LocalChainI = M.interface('LocalChain', {
 
 /**
  * @param {import('@agoric/base-zone').Zone} zone
- * @param {ReturnType<typeof prepareLocalChainAccount>} makeAccount
+ * @param {ReturnType<typeof prepareLocalChainAccountKit>} makeAccountKit
+ * @param {VowTools} vowTools
  */
-const prepareLocalChain = (zone, makeAccount) =>
-  zone.exoClass(
-    'LocalChain',
-    LocalChainI,
+const prepareLocalChain = (zone, makeAccountKit, { watch }) => {
+  const makeLocalChainKit = zone.exoClassKit(
+    'LocalChainKit',
+    {
+      public: LocalChainI,
+      extractFirstQueryResultWatcher: M.interface(
+        'ExtractFirstQueryResultWatcher',
+        {
+          onFulfilled: M.call(M.arrayOf(M.record())).returns(M.record()),
+        },
+      ),
+    },
     /** @param {LocalChainPowers} powers */
     powers => {
       return { ...powers };
     },
     {
-      /**
-       * Allocate a fresh address that doesn't correspond with a public key, and
-       * follows the ICA guidelines to help reduce collisions. See
-       * x/vlocalchain/keeper/keeper.go AllocateAddress for the use of the app
-       * hash and block data hash.
-       */
-      async makeAccount() {
-        const { system, bankManager, transfer } = this.state;
-        const address = await E(system).toBridge({
-          type: 'VLOCALCHAIN_ALLOCATE_ADDRESS',
-        });
-        const bank = await E(bankManager).getBankForAddress(address);
-        return makeAccount(address, { system, bank, transfer });
+      public: {
+        /**
+         * Allocate a fresh address that doesn't correspond with a public key,
+         * and follows the ICA guidelines to help reduce collisions. See
+         * x/vlocalchain/keeper/keeper.go AllocateAddress for the use of the app
+         * hash and block data hash.
+         *
+         * @returns {PromiseVow<LocalChainAccount>}
+         */
+        async makeAccount() {
+          const { system, bankManager, transfer } = this.state;
+          const address = await E(system).toBridge({
+            type: 'VLOCALCHAIN_ALLOCATE_ADDRESS',
+          });
+          const bank = await E(bankManager).getBankForAddress(address);
+          return makeAccountKit(address, { system, bank, transfer }).account;
+        },
+        /**
+         * Make a single query to the local chain. Will reject with an error if
+         * the query fails. Otherwise, return the response as a JSON-compatible
+         * object.
+         *
+         * @template {TypedJson} [T=TypedJson]
+         * @param {T} request
+         * @returns {PromiseVow<JsonSafe<ResponseTo<T>>>}
+         */
+        async query(request) {
+          const requests = harden([request]);
+          return watch(
+            E(this.facets.public).queryMany(requests),
+            this.facets.extractFirstQueryResultWatcher,
+          );
+        },
+        /**
+         * Send a batch of query requests to the local chain. Unless there is a
+         * system error, will return all results to indicate their success or
+         * failure.
+         *
+         * @template {import('@agoric/cosmic-proto').TypedJson[]} RT
+         * @param {RT} requests
+         * @returns {PromiseVowOfTupleMappedToGenerics<{
+         *   [K in keyof RT]: JsonSafe<{
+         *     error?: string;
+         *     reply: ResponseTo<RT[K]>;
+         *   }>;
+         * }>}
+         */
+        async queryMany(requests) {
+          const { system } = this.state;
+          return E(system).toBridge({
+            type: 'VLOCALCHAIN_QUERY_MANY',
+            messages: requests,
+          });
+        },
       },
-      /**
-       * Make a single query to the local chain. Will reject with an error if
-       * the query fails. Otherwise, return the response as a JSON-compatible
-       * object.
-       *
-       * @param {import('@agoric/cosmic-proto').TypedJson} request
-       * @returns {Promise<import('@agoric/cosmic-proto').TypedJson>}
-       */
-      async query(request) {
-        const requests = harden([request]);
-        const results = await E(this.self).queryMany(requests);
-        results.length === 1 ||
-          Fail`expected exactly one result; got ${results}`;
-        const { error, reply } = results[0];
-        if (error) {
-          throw Fail`query failed: ${error}`;
-        }
-        return reply;
-      },
-      /**
-       * Send a batch of query requests to the local chain. Unless there is a
-       * system error, will return all results to indicate their success or
-       * failure.
-       *
-       * @param {import('@agoric/cosmic-proto').TypedJson[]} requests
-       * @returns {Promise<
-       *   {
-       *     error?: string;
-       *     reply: import('@agoric/cosmic-proto').TypedJson;
-       *   }[]
-       * >}
-       */
-      async queryMany(requests) {
-        const { system } = this.state;
-        return E(system).toBridge({
-          type: 'VLOCALCHAIN_QUERY_MANY',
-          messages: requests,
-        });
+      extractFirstQueryResultWatcher: {
+        /**
+         * Extract the first result from the array of results or throw an error
+         * if that result failed.
+         *
+         * @param {JsonSafe<{
+         *   error?: string;
+         *   reply: TypedJson<any>;
+         * }>[]} results
+         */
+        onFulfilled(results) {
+          results.length === 1 ||
+            Fail`expected exactly one result; got ${results}`;
+          const { error, reply } = results[0];
+          if (error) {
+            throw Fail`query failed: ${error}`;
+          }
+          return reply;
+        },
       },
     },
   );
 
-/** @param {import('@agoric/base-zone').Zone} zone */
-export const prepareLocalChainTools = zone => {
-  const makeAccount = prepareLocalChainAccount(zone);
-  const makeLocalChain = prepareLocalChain(zone, makeAccount);
+  /**
+   * @param {LocalChainPowers} powers
+   */
+  const makeLocalChain = powers => makeLocalChainKit(powers).public;
+  return makeLocalChain;
+};
+
+/**
+ * @param {import('@agoric/base-zone').Zone} zone
+ * @param {VowTools} vowTools
+ */
+export const prepareLocalChainTools = (zone, vowTools) => {
+  const makeAccountKit = prepareLocalChainAccountKit(zone, vowTools);
+  const makeLocalChain = prepareLocalChain(zone, makeAccountKit, vowTools);
 
   return harden({ makeLocalChain });
 };

--- a/packages/vats/src/localchain.js
+++ b/packages/vats/src/localchain.js
@@ -15,6 +15,20 @@ const { Fail } = assert;
  */
 
 /**
+ * @template {unknown[]} T
+ * @typedef {Promise<T>} PromiseVowOfTupleMappedToGenerics Temporary hack
+ *
+ *   UNTIL(microsoft/TypeScript#57122): This type should be replaced with just
+ *   PromiseVow<T>, but TypeScript doesn't understand that the result of a
+ *   mapping a tuple type using generics is iterable:
+ *
+ *   'JsonSafe<MsgTransferResponse & { '@type':
+ *   "/ibc.applications.transfer.v1.MsgTransferResponse"; }>[] |
+ *   Vow<JsonSafe<MsgTransferResponse & { ...; }>[]>' must have a
+ *   '[Symbol.iterator]()' method that returns an iterator.
+ */
+
+/**
  * @typedef {{
  *   system: ScopedBridgeManager<'vlocalchain'>;
  *   bank: Bank;
@@ -131,13 +145,15 @@ export const prepareLocalChainAccountKit = (zone, { watch }) =>
           return E(purse).withdraw(amount);
         },
         /**
-         * Execute a batch of transactions and return the responses. Use
-         * `typedJson()` on the arguments to get typed return values.
+         * Execute a batch of messages in order as a single atomic transaction
+         * and return the responses. If any of the messages fails, the entire
+         * batch will be rolled back. Use `typedJson()` on the arguments to get
+         * typed return values.
          *
          * @template {TypedJson[]} MT messages tuple (use const with multiple
          *   elements or it will be a mixed array)
          * @param {MT} messages
-         * @returns {PromiseVow<{
+         * @returns {PromiseVowOfTupleMappedToGenerics<{
          *   [K in keyof MT]: JsonSafe<ResponseTo<MT[K]>>;
          * }>}
          */

--- a/packages/vats/src/proposals/localchain-test.js
+++ b/packages/vats/src/proposals/localchain-test.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { E } from '@endo/far';
+import { V as E } from '@agoric/vow/vat.js';
 import { typedJson } from '@agoric/cosmic-proto/vatsafe';
 
 /**

--- a/packages/vats/src/vat-localchain.js
+++ b/packages/vats/src/vat-localchain.js
@@ -1,12 +1,17 @@
 // @ts-check
 import { Far } from '@endo/far';
 import { makeDurableZone } from '@agoric/zone/durable.js';
+import { prepareVowTools } from '@agoric/vow/vat.js';
 
 import { prepareLocalChainTools } from './localchain.js';
 
 export const buildRootObject = (_vatPowers, _args, baggage) => {
   const zone = makeDurableZone(baggage);
-  const { makeLocalChain } = prepareLocalChainTools(zone.subZone('localchain'));
+  const vowTools = prepareVowTools(zone.subZone('VowTools'));
+  const { makeLocalChain } = prepareLocalChainTools(
+    zone.subZone('localchain'),
+    vowTools,
+  );
 
   return Far('LocalChainVat', {
     /**

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -6,10 +6,9 @@ import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { E } from '@endo/far';
 import { getInterfaceOf } from '@endo/marshal';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal';
-import { prepareVowTools } from '@agoric/vow/vat.js';
+import { prepareVowTools, V as E } from '@agoric/vow/vat.js';
 import { prepareLocalChainTools } from '../src/localchain.js';
 import { prepareBridgeTargetModule } from '../src/bridge-target.js';
 import { prepareTransferTools } from '../src/transfer.js';
@@ -71,7 +70,8 @@ const makeTestContext = async _t => {
   /** @param {LocalChainPowers} powers */
   const makeLocalChain = async powers => {
     const zone = makeDurableZone(provideBaggage('localchain'));
-    return prepareLocalChainTools(zone).makeLocalChain(powers);
+    const vowTools = prepareVowTools(zone.subZone('vows'));
+    return prepareLocalChainTools(zone, vowTools).makeLocalChain(powers);
   };
 
   const localchain = await makeLocalChain({
@@ -113,7 +113,7 @@ test('localchain - deposit and withdraw', async t => {
     return {
       makeAccount: async () => {
         const lca = await E(localchain).makeAccount();
-        t.is(getInterfaceOf(lca), 'Alleged: LocalChainAccount');
+        t.is(getInterfaceOf(lca), 'Alleged: LocalChainAccountKit account');
 
         const address = await E(lca).getAddress();
         t.is(address, LOCALCHAIN_DEFAULT_ADDRESS);

--- a/packages/vow/src/E.js
+++ b/packages/vow/src/E.js
@@ -1,4 +1,20 @@
 // @ts-check
+/**
+ * @file provides a `makeE` that can be parameterized with an `unwrap` function
+ * and corresponding `import('./types').EUnwrap<T>`.  These will be used to
+ * extract the final settlement from a chain of PromiseLikes and PromiseSteps or
+ * similar non-thenable pseudo-promises.
+ *
+ * `@agoric/vow/vat.js` uses this mechanism to export a `V` function with
+ * similar behaviour as the default `E`, augmented with automatic unwrapping of
+ * recipient Vows as if they were PromiseLikes.
+ */
+
+/*
+ * TODO: Once this implementation has been polished and well-tested, it is
+ * designed to be a drop-in replacement for the version in
+ * `@endo/eventual-send/src/E.js` which contained no concept of "unwrap",
+ */
 import { trackTurns } from './track-turns.js';
 import { makeMessageBreakpointTester } from './message-breakpoints.js';
 
@@ -9,9 +25,9 @@ const onSend = makeMessageBreakpointTester('ENDO_SEND_BREAKPOINTS');
 
 /**
  * @import { HandledPromiseConstructor, RemotableBrand } from '@endo/eventual-send'
- * @import { Unwrap, Vow } from './types.js'
+ * @import { EUnwrap } from './types.js'
  */
-/** @typedef {(...args: any[]) => any} Callable */
+/** @typedef {(...args: unknown[]) => any} Callable */
 
 /** @type {ProxyHandler<any>} */
 const baseFreezableProxyHandler = {
@@ -43,7 +59,7 @@ const baseFreezableProxyHandler = {
  *
  * @param {any} recipient Any value passed to E(x)
  * @param {HandledPromiseConstructor} HandledPromise
- * @param {(x: any) => Promise<any>} unwrap
+ * @param {<T>(x: T) => Promise<EUnwrap<T>>} unwrap
  * @returns {ProxyHandler<any>} the Proxy handler
  */
 const makeEProxyHandler = (recipient, HandledPromise, unwrap) =>
@@ -108,7 +124,7 @@ const makeEProxyHandler = (recipient, HandledPromise, unwrap) =>
  *
  * @param {any} recipient Any value passed to E.sendOnly(x)
  * @param {HandledPromiseConstructor} HandledPromise
- * @param {(x: any) => Promise<any>} unwrap
+ * @param {<T>(x: T) => Promise<EUnwrap<T>>} unwrap
  * @returns {ProxyHandler<any>} the Proxy handler
  */
 const makeESendOnlyProxyHandler = (recipient, HandledPromise, unwrap) =>
@@ -171,7 +187,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise, unwrap) =>
  *
  * @param {any} x Any value passed to E.get(x)
  * @param {HandledPromiseConstructor} HandledPromise
- * @param {(x: any) => Promise<any>} unwrap
+ * @param {<T>(x: T) => Promise<EUnwrap<T>>} unwrap
  * @returns {ProxyHandler<any>} the Proxy handler
  */
 const makeEGetProxyHandler = (x, HandledPromise, unwrap) =>
@@ -186,19 +202,17 @@ const resolve = x => HandledPromise.resolve(x);
 
 /**
  * @template [A={}]
- * @template {(x: any) => Promise<any>} [U=(x: any) => Promise<any>]
  * @param {HandledPromiseConstructor} HandledPromise
  * @param {object} [powers]
- * @param {U} [powers.unwrap]
+ * @param {<T>(x: T) => Promise<EUnwrap<T>>} [powers.unwrap]
  * @param {A} [powers.additional]
  */
-const makeE = (
-  HandledPromise,
-  {
+const makeE = (HandledPromise, powers = {}) => {
+  const {
     additional = /** @type {A} */ ({}),
-    unwrap = /** @type {U} */ (resolve),
-  } = {},
-) => {
+    unwrap = /** @type {NonNullable<typeof powers.unwrap>} */ (resolve),
+  } = powers;
+
   return harden(
     assign(
       /**
@@ -264,13 +278,13 @@ const makeE = (
 
         /**
          * E.when(x, res, rej) is equivalent to
-         * unwrapped(x).then(onfulfilled, onrejected)
+         * unwrap(x).then(onfulfilled, onrejected)
          *
          * @template T
-         * @template [TResult1=Unwrap<T>]
+         * @template [TResult1=EUnwrap<T>]
          * @template [TResult2=never]
          * @param {ERef<T>} x value to convert to a handled promise
-         * @param {(value: Unwrap<T>) => ERef<TResult1>} [onfulfilled]
+         * @param {(value: EUnwrap<T>) => ERef<TResult1>} [onfulfilled]
          * @param {(reason: any) => ERef<TResult2>} [onrejected]
          * @returns {Promise<TResult1 | TResult2>}
          * @readonly
@@ -310,9 +324,11 @@ export default makeE;
 
 /**
  * @template {Callable} T
- * @typedef {(
- *   (...args: Parameters<T>) => Promise<Unwrap<ReturnType<T>>>
- * )} ECallable
+ * @typedef {ReturnType<T> extends EUnwrap<ReturnType<T>>
+ *     ? (...args: Parameters<T>) => Promise<ReturnType<T>>
+ *     : ReturnType<T> extends Promise<EUnwrap<ReturnType<T>>>
+ *       ? T
+ *       : (...args: Parameters<T>) => Promise<EUnwrap<ReturnType<T>>>} ECallable
  */
 
 /**
@@ -327,7 +343,7 @@ export default makeE;
 /**
  * @template T
  * @typedef {{
- *   readonly [P in keyof T]: T[P] extends PromiseLike<infer U>
+ *   readonly [P in keyof T]: T[P] extends PromiseLike<any>
  *     ? T[P]
  *     : Promise<Awaited<T[P]>>;
  * }} EGetters
@@ -387,7 +403,9 @@ export default makeE;
  * @template T
  * @typedef {(
  *   T extends Callable
- *     ? (...args: Parameters<T>) => ReturnType<T>                     // a root callable, no methods
+ *     ? (...args: Parameters<T>) => ReturnType<T>   // a root callable, no methods
+ *     : FilteredKeys<T, Callable> extends never
+ *     ? never
  *     : Pick<T, FilteredKeys<T, Callable>>          // any callable methods
  * )} PickCallable
  */
@@ -397,30 +415,18 @@ export default makeE;
  *
  * @template T
  * @typedef {(
- *   T extends RemotableBrand<infer L, infer R>     // if a given T is some remote interface R
- *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
- *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends Vow<infer U>
- *     ? RemoteFunctions<U>                                           // then extract the remotable functions of U
- *     : T extends PromiseLike<infer U>                               // otherwise, if T is a promise
- *     ? Awaited<T>                                                   // then return resolved value T
- *     : T                                                            // otherwise, return T
+ *   EUnwrap<T> extends RemotableBrand<any, infer R>  // if a given T will settle to some remote interface R
+ *     ? PickCallable<R>                         // then return the callable properties of R
+ *     : PickCallable<EUnwrap<T>>                 // otherwise return the callable properties of the settled T
  * )} RemoteFunctions
  */
 
 /**
  * @template T
  * @typedef {(
- *   T extends RemotableBrand<infer L, infer R>
+ *   T extends RemotableBrand<infer L, any>
  *     ? L
- *     : Awaited<T> extends RemotableBrand<infer L, infer R>
- *     ? L
- *     : Awaited<T> extends Vow<infer U>
- *     ? LocalRecord<U>
- *     : T extends PromiseLike<infer U>
- *     ? Awaited<T>
- *     : T
+ *     : EUnwrap<T>
  * )} LocalRecord
  */
 

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -2,11 +2,9 @@
 export {};
 
 /**
- * @import {RemotableBrand} from '@endo/eventual-send'
  * @import {CopyTagged} from '@endo/pass-style'
  * @import {RemotableObject} from '@endo/pass-style';
- * @import {IsPrimitive, Remote} from '@agoric/internal';
- * @import {PromiseVow} from '@agoric/vow';
+ * @import {Remote} from '@agoric/internal';
  * @import {prepareVowTools} from './tools.js'
  */
 
@@ -36,12 +34,10 @@ export {};
  * This is used within E, so we must narrow the type to its remote form.
  * @template T
  * @typedef {(
- *   T extends PromiseLike<infer U> ? Unwrap<U> :
- *   T extends Vow<infer U> ? Unwrap<U> :
- *   IsPrimitive<T> extends true ? T :
- *   T extends RemotableBrand<infer Local, infer Primary> ? Local & T :
+ *   T extends Vow<infer U> ? EUnwrap<U> :
+ *   T extends PromiseLike<infer U> ? EUnwrap<U> :
  *   T
- * )} Unwrap
+ * )} EUnwrap
  */
 
 /**

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getVowPayload, basicE } from './vow-utils.js';
 
-/** @import { IsRetryableReason, Unwrap } from './types.js' */
+/** @import { IsRetryableReason, EUnwrap } from './types.js' */
 
 /**
  * @param {IsRetryableReason} [isRetryableReason]
@@ -13,10 +13,10 @@ export const makeWhen = (
    * Shorten `specimenP` until we achieve a final result.
    *
    * @template T
-   * @template [TResult1=Unwrap<T>]
+   * @template [TResult1=EUnwrap<T>]
    * @template [TResult2=never]
    * @param {T} specimenP value to unwrap
-   * @param {(value: Unwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
+   * @param {(value: EUnwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
    * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
    * @returns {Promise<TResult1 | TResult2>}
    */
@@ -50,7 +50,7 @@ export const makeWhen = (
       payload = getVowPayload(result);
     }
 
-    const unwrapped = /** @type {Unwrap<T>} */ (result);
+    const unwrapped = /** @type {EUnwrap<T>} */ (result);
 
     // We've extracted the final result.
     if (onFulfilled == null && onRejected == null) {


### PR DESCRIPTION
closes: #9484 closes: #9497

## Description

 - Changes the type of every return in `localchain.js` to `PromiseVow`
 - Uses `watch` for `.query()` and `.deposit()` methods and returns a `Vow`
 - Updates call sites outside `vat-localchain` to expect and unwrap PromiseVows (using `V`) 

### Upgrade Considerations

These changes better prepare us for upgrades - consumers will know to expect a `PromiseVow`.