### PR TITLE
feat(multichain-testing): request body too large

### DIFF
--- a/multichain-testing/README.md
+++ b/multichain-testing/README.md
@@ -46,7 +46,7 @@ make stop
 To setup finish setting up Agoric, also run:
 
 ```bash
-make fund-provision-poool
+make fund-provision-pool
 ```
 
 ## Logs

--- a/multichain-testing/config.yaml
+++ b/multichain-testing/config.yaml
@@ -14,6 +14,9 @@ chains:
         swingset:
           params:
             bootstrap_vat_config: "@agoric/vm-config/decentral-itest-orchestration-config.json"
+    scripts:
+      updateConfig:
+        file: scripts/update-config.sh
     faucet:
       enabled: false
     ports:

--- a/multichain-testing/scripts/update-config.sh
+++ b/multichain-testing/scripts/update-config.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+## see https://github.com/cosmology-tech/starship/blob/1d60f55c631b4d0f92a43ad92e9a935298aa3aa5/starship/charts/devnet/scripts/default/update-config.sh
+
+CHAIN_ID="${CHAIN_ID:=osmosis}"
+CHAIN_DIR="${CHAIN_DIR:=$HOME/.osmosisd}"
+KEYS_CONFIG="${KEYS_CONFIG:=configs/keys.json}"
+
+set -eux
+
+ls $CHAIN_DIR
+
+
+echo "Update config.toml file"
+sed -i -e 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' $CHAIN_DIR/config/config.toml
+sed -i -e 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/config/config.toml
+sed -i -e 's/seeds = ".*"/seeds = ""/g' $CHAIN_DIR/config/config.toml
+sed -i -e 's#cors_allowed_origins = \[\]#cors_allowed_origins = \["*"\]#g' $CHAIN_DIR/config/config.toml
+
+echo "Update client.toml file"
+sed -i -e 's#keyring-backend = "os"#keyring-backend = "test"#g' $CHAIN_DIR/config/client.toml
+sed -i -e 's#output = "text"#output = "json"#g' $CHAIN_DIR/config/client.toml
+sed -i -e "s#chain-id = \"\"#chain-id = \"$CHAIN_ID\"#g" $CHAIN_DIR/config/client.toml
+
+echo "Update app.toml file"
+sed -i -e "s#minimum-gas-prices = \".*\"#minimum-gas-prices = \"0$DENOM\"#g" $CHAIN_DIR/config/app.toml
+sed -i -e "s#pruning = \".*\"#pruning = \"default\"#g" $CHAIN_DIR/config/app.toml
+sed -i -e 's#enabled-unsafe-cors = false#enabled-unsafe-cors = true#g' $CHAIN_DIR/config/app.toml
+sed -i -e 's#swagger = false#swagger = true#g' $CHAIN_DIR/config/app.toml
+sed -i -e 's/enable-unsafe-cors = false/enable-unsafe-cors = true/g' $CHAIN_DIR/config/app.toml
+sed -i -e 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' $CHAIN_DIR/config/app.toml
+
+
+function get_next_line_number() {
+  local txt=$1
+  local file=$2
+  local line_number=$(grep -n "$txt" $file | cut -d: -f1 | head -1)
+  echo $((line_number + 1))
+}
+
+line_number=$(get_next_line_number "Enable defines if the API server should be enabled." $CHAIN_DIR/config/app.toml)
+sed -i -e "${line_number}s/enable = false/enable = true/g" $CHAIN_DIR/config/app.toml
+
+line_number=$(get_next_line_number "Address defines the API server to listen on." $CHAIN_DIR/config/app.toml)
+sed -i -e "${line_number}s#address = \".*\"#address = \"tcp://0.0.0.0:1317\"#g" $CHAIN_DIR/config/app.toml
+
+line_number=$(get_next_line_number "Enable defines if the gRPC server should be enabled." $CHAIN_DIR/config/app.toml)
+sed -i -e "${line_number}s/enable = false/enable = true/g" $CHAIN_DIR/config/app.toml
+
+line_number=$(get_next_line_number "Address defines the gRPC server address to bind to." $CHAIN_DIR/config/app.toml)
+sed -i -e "${line_number}s#address = \".*\"#address = \"0.0.0.0:9090\"#g" $CHAIN_DIR/config/app.toml
+
+if [ "$METRICS" == "true" ]; then
+  line_number=$(get_next_line_number "other sinks such as Prometheus." $CHAIN_DIR/config/app.toml)
+  sed -i -e "${line_number}s/enabled = false/enabled = true/g" $CHAIN_DIR/config/app.toml
+
+  line_number=$(get_next_line_number "PrometheusRetentionTime, when positive, enables a Prometheus metrics sink." $CHAIN_DIR/config/app.toml)
+  sed -i -e "${line_number}s/prometheus-retention-time = 0/prometheus-retention-time = 3600/g" $CHAIN_DIR/config/app.toml
+fi
+
+echo "Update consensus params in config.toml"
+sed -i -e "s#timeout_propose = \".*\"#timeout_propose = \"$TIMEOUT_PROPOSE\"#g" $CHAIN_DIR/config/config.toml
+sed -i -e "s#timeout_propose_delta = \".*\"#timeout_propose_delta = \"$TIMEOUT_PROPOSE_DELTA\"#g" $CHAIN_DIR/config/config.toml
+sed -i -e "s#timeout_prevote = \".*\"#timeout_prevote = \"$TIMEOUT_PREVOTE\"#g" $CHAIN_DIR/config/config.toml
+sed -i -e "s#timeout_prevote_delta = \".*\"#timeout_prevote_delta = \"$TIMEOUT_PREVOTE_DELTA\"#g" $CHAIN_DIR/config/config.toml
+sed -i -e "s#timeout_precommit = \".*\"#timeout_precommit = \"$TIMEOUT_PRECOMMIT\"#g" $CHAIN_DIR/config/config.toml
+sed -i -e "s#timeout_precommit_delta = \".*\"#timeout_precommit_delta = \"$TIMEOUT_PRECOMMIT_DELTA\"#g" $CHAIN_DIR/config/config.toml
+sed -i -e "s#timeout_commit = \".*\"#timeout_commit = \"$TIMEOUT_COMMIT\"#g" $CHAIN_DIR/config/config.toml
+
+if [ "$METRICS" == "true" ]; then
+  sed -i -e "s/prometheus = false/prometheus = true/g" $CHAIN_DIR/config/config.toml
+fi

--- a/multichain-testing/scripts/update-config.sh
+++ b/multichain-testing/scripts/update-config.sh
@@ -17,6 +17,17 @@ sed -i -e 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/config/c
 sed -i -e 's/seeds = ".*"/seeds = ""/g' $CHAIN_DIR/config/config.toml
 sed -i -e 's#cors_allowed_origins = \[\]#cors_allowed_origins = \["*"\]#g' $CHAIN_DIR/config/config.toml
 
+echo "Increase `*_bytes` parameters for MsgInstallBundle"
+# See https://github.com/Agoric/agoric-sdk/blob/7b684a6268c999b082a326fdb22f63e4575bac4f/packages/agoric-cli/src/chain-config.js#L66
+RPC_MAX_BODY_BYTES=15000000
+MAX_HEADER_BYTES=$((RPC_MAX_BODY_BYTES / 10))
+MAX_TXS_BYTES=$((RPC_MAX_BODY_BYTES * 50))
+sed -i -e "s/max_body_bytes = .*/max_body_bytes = $RPC_MAX_BODY_BYTES/g" $CHAIN_DIR/config/config.toml
+sed -i -e "s/max_header_bytes = .*/max_header_bytes = $MAX_HEADER_BYTES/g" $CHAIN_DIR/config/config.toml
+sed -i -e "s/max_txs_bytes = .*/max_txs_bytes = $MAX_TXS_BYTES/g" $CHAIN_DIR/config/config.toml
+sed -i -e "s/max_tx_bytes = .*/max_tx_bytes = $RPC_MAX_BODY_BYTES/g" $CHAIN_DIR/config/config.toml
+sed -i -e "s/^rpc-max-body-bytes =.*/rpc-max-body-bytes = $RPC_MAX_BODY_BYTES/" $CHAIN_DIR/config/app.toml
+
 echo "Update client.toml file"
 sed -i -e 's#keyring-backend = "os"#keyring-backend = "test"#g' $CHAIN_DIR/config/client.toml
 sed -i -e 's#output = "text"#output = "json"#g' $CHAIN_DIR/config/client.toml


### PR DESCRIPTION
refs: #8896 

## Description

The current `stakeIca.contract.js` bundle is ~4.5 MB uncompressed. Any attempted installation resulted in **400 Bad Request: request body too large** .

This change adjusts `app.toml` and `config.toml` params like `max_body_bytes`, `max_header_bytes`, `max_txs_bytes`, `max_tx_bytes`, and `rpc-max-body-bytes`.

### Security Considerations

### Scaling Considerations

The settings may not match other environments, and developers may find their bundles are too large to install if they are only developing against this environment.

### Documentation Considerations

The `update-config.sh` is long and mostly copied from `cosmology-tech/starship`. I've added a note about its source and a separate commit for the adjustments made to it.

### Testing Considerations

Manually tested the parameters in the course of #9042. Expect a test to be checked in with the completion of #9042.

Running the **Multichain E2E Testing** job and ensuring the `Setup Starship Infrastructure` step passes should give us confidence the overrides are also working in CI.

### Upgrade Considerations
