### PR TITLE
fix(SwingSet): Undo deviceTools behavioral change from #9153

### DIFF
--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -74,11 +74,11 @@ export function buildSerializationTools(syscall, deviceName) {
   }
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
-    marshalName: `deviceTools:${deviceName}`,
+    marshalName: `device:${deviceName}`,
     serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
-    errorIdNum: 40_000,
+    errorIdNum: 60_000,
   });
 
   // for invoke(), these will unserialize the arguments, and serialize the


### PR DESCRIPTION
refs: #9153

## Description

This partially reverts the behavioral change from `deviceTools` from #9153.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

None

### Upgrade Considerations

DeviceTools are bundled into device bundles, so we want to minimize difference between code executing and code on disk.
