### PR TITLE
fix(liveslots): promise watcher to cause unhandled rejection if no handler

### DIFF
--- a/packages/swingset-liveslots/src/watchedPromises.js
+++ b/packages/swingset-liveslots/src/watchedPromises.js
@@ -157,9 +157,15 @@ export function makeWatchedPromiseManager({
   function providePromiseWatcher(
     kindHandle,
     // @ts-expect-error xxx rest params in typedef
-    fulfillHandler = _value => {},
+    fulfillHandler = _value => {
+      // It's fine to not pass the value through since promise watchers are not chainable
+    },
     // @ts-expect-error xxx rest params in typedef
-    rejectHandler = _reason => {},
+    rejectHandler = reason => {
+      // Replicate the unhandled rejection that would have happened if the
+      // watcher had not implemented an `onRejected` method. See `settle` above
+      throw reason;
+    },
   ) {
     assert.typeof(fulfillHandler, 'function');
     assert.typeof(rejectHandler, 'function');


### PR DESCRIPTION
refs: #8596

## Description

Reverts a behavioral change questioned in https://github.com/Agoric/agoric-sdk/pull/8596#discussion_r1414436455, which was indeed not appropriate.

If the reject handler is missing, it should result in an unhandled rejection.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
No coverage

### Upgrade Considerations
Maintains currently deployed behavior on mainnet
