### PR TITLE
refactor(internal): move async helpers using AggregateError to node

### DIFF
--- a/packages/internal/src/node/utils.js
+++ b/packages/internal/src/node/utils.js
@@ -1,0 +1,46 @@
+// @ts-check
+// @jessie-check
+
+// These tools seem cross platform, but they rely on AggregateError in the error
+// handling path, which is currently not available in xsnap
+import 'node:process';
+
+/**
+ * @template T
+ * @param {readonly (T | PromiseLike<T>)[]} items
+ * @returns {Promise<T[]>}
+ */
+export const PromiseAllOrErrors = async items => {
+  return Promise.allSettled(items).then(results => {
+    const errors = /** @type {PromiseRejectedResult[]} */ (
+      results.filter(({ status }) => status === 'rejected')
+    ).map(result => result.reason);
+    if (!errors.length) {
+      return /** @type {PromiseFulfilledResult<T>[]} */ (results).map(
+        result => result.value,
+      );
+    } else if (errors.length === 1) {
+      throw errors[0];
+    } else {
+      throw AggregateError(errors);
+    }
+  });
+};
+
+/**
+ * @type {<T>(
+ *   trier: () => Promise<T>,
+ *   finalizer: (error?: unknown) => Promise<void>,
+ * ) => Promise<T>}
+ */
+export const aggregateTryFinally = async (trier, finalizer) =>
+  trier().then(
+    async result => finalizer().then(() => result),
+    async tryError =>
+      finalizer(tryError)
+        .then(
+          () => tryError,
+          finalizeError => AggregateError([tryError, finalizeError]),
+        )
+        .then(error => Promise.reject(error)),
+  );

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -75,46 +75,6 @@ export const makeMeasureSeconds = currentTimeMillisec => {
 };
 
 /**
- * @template T
- * @param {readonly (T | PromiseLike<T>)[]} items
- * @returns {Promise<T[]>}
- */
-export const PromiseAllOrErrors = async items => {
-  return Promise.allSettled(items).then(results => {
-    const errors = /** @type {PromiseRejectedResult[]} */ (
-      results.filter(({ status }) => status === 'rejected')
-    ).map(result => result.reason);
-    if (!errors.length) {
-      return /** @type {PromiseFulfilledResult<T>[]} */ (results).map(
-        result => result.value,
-      );
-    } else if (errors.length === 1) {
-      throw errors[0];
-    } else {
-      throw AggregateError(errors);
-    }
-  });
-};
-
-/**
- * @type {<T>(
- *   trier: () => Promise<T>,
- *   finalizer: (error?: unknown) => Promise<void>,
- * ) => Promise<T>}
- */
-export const aggregateTryFinally = async (trier, finalizer) =>
-  trier().then(
-    async result => finalizer().then(() => result),
-    async tryError =>
-      finalizer(tryError)
-        .then(
-          () => tryError,
-          finalizeError => AggregateError([tryError, finalizeError]),
-        )
-        .then(error => Promise.reject(error)),
-  );
-
-/**
  * @template {Record<string, unknown>} T
  * @typedef {{ [P in keyof T]: Exclude<T[P], undefined> }} AllDefined
  */

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -4,7 +4,10 @@ import { finished as finishedCallback, PassThrough, Readable } from 'stream';
 import { promisify } from 'util';
 import { createGzip, createGunzip } from 'zlib';
 import { Fail, q } from '@agoric/assert';
-import { aggregateTryFinally, PromiseAllOrErrors } from '@agoric/internal';
+import {
+  aggregateTryFinally,
+  PromiseAllOrErrors,
+} from '@agoric/internal/src/node/utils.js';
 import { buffer } from './util.js';
 
 /**

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import tmp from 'tmp';
-import { PromiseAllOrErrors } from '@agoric/internal';
+import { PromiseAllOrErrors } from '@agoric/internal/src/node/utils.js';
 import { serializeSlogObj } from './serialize-slog-obj.js';
 
 export const DEFAULT_SLOGSENDER_MODULE =


### PR DESCRIPTION
closes: #9504

## Description

While #9275 switched to a global `AggregrateError` constructor, it was unclear if that was safe because that global is not currently available in xsnap. Instead of reverting, this PR moves the "shared" internal helpers that used an `AggregateError` to the `node` folder, to make it clear they should only be used in that environment. All usages of these helpers were already in Node only.

All other usages of `AggregateError` were audited to confirm they only happened on Node as well.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
We're unfortunately lacking coverage of some code under xsnap, Open to ideas on how to improve testing here

It would also be nice somehow to make sure the `node` folders do no end up imported in bundled code. Maybe having a pseudo `import 'node:process'` could work? @kriskowal 

### Upgrade Considerations
None