### PR TITLE
fix(liveslots): cache.delete() does not return a useful value

### DIFF
--- a/packages/swingset-liveslots/src/cache.js
+++ b/packages/swingset-liveslots/src/cache.js
@@ -17,7 +17,7 @@ import { Fail } from '@agoric/assert';
 /**
  * @callback CacheDelete
  * @param {string} key
- * @returns {boolean}
+ * @returns {void}
  *
  * @callback CacheFlush
  * @returns {void}
@@ -83,9 +83,8 @@ export function makeCache(readBacking, writeBacking, deleteBacking) {
     },
     delete: key => {
       assert.typeof(key, 'string');
-      const result = stash.delete(key);
+      stash.delete(key);
       dirtyKeys.add(key);
-      return result;
     },
     flush: () => {
       const keys = [...dirtyKeys.keys()];


### PR DESCRIPTION
Liveslots uses an internal `Cache` utility to hold data about virtual objects, backed by the vatstore. PR #8752 included a change to make its `delete()` method return a "did exist" boolean, just like a JavaScript `Map`. Unfortunately the cache does not know whether a key is present/absent in the backing store, so `delete()` will return an erroneous value. It would cost an extra DB query to make this behave as expected, and liveslots does not have a need for it.

So this commit reverts that change, and makes `delete()` return void as before.
