### PR TITLE
fix: many typing improvements

### DIFF
--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -732,7 +732,7 @@ export {};
  * Akin to StartedInstanceKit but designed for the results of starting governed contracts. Used in bootstrap space.
  * @property {AdminFacet} adminFacet of the governed contract
  * @property {LimitedCF<SF>} creatorFacet creator-like facet within the governed contract (without the powers the governor needs)
- * @property {Guarded<GovernorCreatorFacet<SF>>} governorCreatorFacet of the governing contract
+ * @property {Guarded<GovernorCreatorFacet<SF>> | GovernorCreatorFacet<SF>} governorCreatorFacet of the governing contract
  * @property {AdminFacet} governorAdminFacet of the governing contract
  * @property {Awaited<ReturnType<SF>>['publicFacet']} publicFacet
  * @property {Instance} instance

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -129,7 +129,6 @@ export const addAuction = async ({
   );
 
   newAuctioneerKit.resolve(
-    // @ts-expect-error XXX governance types
     harden({
       label: 'auctioneer',
       creatorFacet: governedCreatorFacet,

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -164,7 +164,6 @@ export const setupReserve = async ({
   ]);
 
   reserveKit.resolve(
-    // @ts-expect-error XXX
     harden({
       label: 'AssetReserve',
       instance,
@@ -349,7 +348,6 @@ export const startVaultFactory = async (
   );
 
   vaultFactoryKit.resolve(
-    // @ts-expect-error XXX
     harden({
       label: 'VaultFactory',
       creatorFacet: vaultFactoryCreator,
@@ -624,7 +622,6 @@ export const startAuctioneer = async (
     ]);
 
   auctioneerKit.resolve(
-    // @ts-expect-error XXX
     harden({
       label: 'auctioneer',
       creatorFacet: governedCreatorFacet,

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -10,6 +10,7 @@ import {
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import path from 'path';
+import { makeScopedBridge } from '@agoric/vats';
 import { oracleBrandFeedName } from '../../src/proposals/utils.js';
 import { createPriceFeed } from '../../src/proposals/price-feed-proposal.js';
 import { withAmountUtils } from '../supports.js';
@@ -108,9 +109,8 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
    * @type {undefined
    *   | import('@agoric/vats').ScopedBridgeManager<'wallet'>}
    */
-  // @ts-expect-error XXX EProxy
   const walletBridgeManager = await (bridgeManager &&
-    E(bridgeManager).register(BridgeId.WALLET));
+    makeScopedBridge(bridgeManager, BridgeId.WALLET));
   const walletFactory = await E(zoe).startInstance(
     installation,
     {},

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -131,7 +131,6 @@ export const buildRootObject = async () => {
      * @param {any} devices
      */
     bootstrap: async (vats, devices) => {
-      // @ts-expect-error XXX adminNode
       vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
       ({ feeMintAccess, zoeService } = await E(vats.zoe).buildZoe(
         vatAdmin,

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -16,7 +16,6 @@ const trace = makeTracer('CoreEvalOrchestration', true);
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     loadCriticalVat: VatLoader<any>;
  *     portAllocator: PortAllocator;
  *   };
  *   produce: {
@@ -26,10 +25,6 @@ const trace = makeTracer('CoreEvalOrchestration', true);
  *   };
  * }} powers
  * @param {{ options: { orchestrationRef: VatSourceRef } }} options
- *
- * @typedef {{
- *   orchestration: ERef<OrchestrationVat>;
- * }} OrchestrationVats
  */
 export const setupOrchestrationVat = async (
   {
@@ -43,7 +38,6 @@ export const setupOrchestrationVat = async (
   options,
 ) => {
   const { orchestrationRef } = options.options;
-  /** @type {OrchestrationVats} */
   const vats = {
     orchestration: E(loadCriticalVat)('orchestration', orchestrationRef),
   };

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -3,6 +3,7 @@ import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js'
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/far';
 import path from 'path';
+import { makeScopedBridge } from '@agoric/vats';
 import { withAmountUtils } from './supports.js';
 
 /**
@@ -38,10 +39,8 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     'anyAddress',
   );
   const bridgeManager = await consume.bridgeManager;
-  /** @type {import('@agoric/vats').ScopedBridgeManager<'wallet'>} */
-  // @ts-expect-error XXX generics through EProxy
   const walletBridgeManager = await (bridgeManager &&
-    E(bridgeManager).register(BridgeId.WALLET));
+    makeScopedBridge(bridgeManager, BridgeId.WALLET));
   const walletFactory = await E(zoe).startInstance(
     installation,
     {},

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -100,12 +100,7 @@ const makeFakeBridgeManager = () =>
 export const makeMockTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
   /**
-   * @type {BootstrapPowers & {
-   *   consume: {
-   *     loadVat: (n: 'mints') => MintsVat;
-   *     loadCriticalVat: (n: 'mints') => MintsVat;
-   *   };
-   * }}
+   * @type {BootstrapPowers}
    */
   const { consume, produce } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -100,7 +100,12 @@ const makeFakeBridgeManager = () =>
 export const makeMockTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
   /**
-   * @type {BootstrapPowers}
+   * @type {BootstrapPowers & {
+   *   produce: {
+   *     loadVat: Producer<VatLoader>;
+   *     loadCriticalVat: Producer<VatLoader>;
+   *   };
+   * }}
    */
   const { consume, produce } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =
@@ -112,13 +117,15 @@ export const makeMockTestSpace = async log => {
   produce.zoe.resolve(zoe);
   produce.feeMintAccess.resolve(feeMintAccessP);
 
-  const vatLoader = name => {
+  /** @type {VatLoader<'mints' | 'board'>} */
+  const vatLoader = async name => {
+    /** @typedef {Awaited<WellKnownVats[typeof name]>} ReturnedVat */
     switch (name) {
       case 'mints':
-        return mintsRoot();
+        return /** @type {ReturnedVat} */ (mintsRoot());
       case 'board': {
         const baggage = makeScalarBigMapStore('baggage');
-        return boardRoot({}, {}, baggage);
+        return /** @type {ReturnedVat} */ (boardRoot({}, {}, baggage));
       }
       default:
         throw Error('unknown loadVat name');

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -14,6 +14,7 @@ import type {
 } from '@agoric/store';
 import type { Amplify, IsInstance, ReceivePower, StateShape } from '@endo/exo';
 import type { RemotableObject } from '@endo/pass-style';
+import type { RemotableBrand } from '@endo/eventual-send';
 import type { InterfaceGuard, Pattern } from '@endo/patterns';
 import type { makeWatchedPromiseManager } from './watchedPromises.js';
 
@@ -38,9 +39,13 @@ type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R
   ? (...args: P) => R
   : never;
 
-export type KindFacet<O> = RemotableObject & {
+// The type of a passable local object with methods.
+// An internal helper to avoid having to repeat `O`.
+type PrimaryRemotable<O> = O & RemotableObject & RemotableBrand<{}, O>;
+
+export type KindFacet<O> = PrimaryRemotable<{
   [K in keyof O]: OmitFirstArg<O[K]>; // omit the 'context' parameter
-};
+}>;
 
 export type KindFacets<B> = {
   [FacetKey in keyof B]: KindFacet<B[FacetKey]>;

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -3,6 +3,27 @@ import { E } from '@endo/far';
 
 const { Fail, details: X } = assert;
 
+/**
+ * Helper to type the registered scoped bridge correctly.
+ *
+ * FIXME: This is needed because `register` is not an async function, so
+ * `E(x).register` needs to reconstruct its return value as a Promise, which
+ * loses the function's genericity. If `register` was async, we could use its
+ * type directly, and it would remain generic.
+ *
+ * @template {import('@agoric/internal').BridgeIdValue} BridgeId
+ * @param {ERef<import('./types.js').BridgeManager>} bridgeManager
+ * @param {BridgeId} bridgeIdValue
+ * @param {import('@agoric/internal').Remote<
+ *   import('./types.js').BridgeHandler
+ * >} [handler]
+ * @returns {Promise<import('./types.js').ScopedBridgeManager<BridgeId>>}
+ */
+export const makeScopedBridge = (bridgeManager, bridgeIdValue, handler) =>
+  /** @type {Promise<import('./types.js').ScopedBridgeManager<BridgeId>>} */ (
+    E(bridgeManager).register(bridgeIdValue, handler)
+  );
+
 export const BridgeHandlerI = M.interface('BridgeHandler', {
   fromBridge: M.call(M.any()).returns(M.promise()),
 });

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -50,7 +50,6 @@ const bootMsgEx = {
  */
 
 /** @typedef {MapStore<string, CreateVatResults>} VatStore */
-/** @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat */
 
 /**
  * @param {BootstrapPowers & {}} powers
@@ -329,9 +328,7 @@ export const produceStartGovernedUpgradable = async ({
 harden(produceStartGovernedUpgradable);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const buildZoe = async ({
   consume: { vatAdminSvc, loadCriticalVat, client },
@@ -360,9 +357,7 @@ export const buildZoe = async ({
 harden(buildZoe);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const startPriceAuthorityRegistry = async ({
   consume: { loadCriticalVat, client },
@@ -418,9 +413,7 @@ harden(produceBoard);
 
 /**
  * @deprecated use produceBoard
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<BoardVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const makeBoard = async ({
   consume: { loadCriticalVat, client },
@@ -607,9 +600,7 @@ harden(mintInitialSupply);
 /**
  * Add IST (with initialSupply payment), BLD (with mint) to BankManager.
  *
- * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<BankVat>> };
- * }} powers
+ * @param {BootstrapSpace} powers
  */
 export const addBankAssets = async ({
   consume: {

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -109,9 +109,7 @@ export const bridgeCoreEval = async allPowers => {
 harden(bridgeCoreEval);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ProvisioningVat>> };
- * }} powers
+ * @param {BootstrapPowers} powers
  */
 export const makeProvisioner = async ({
   consume: { clientCreator, loadCriticalVat },
@@ -303,10 +301,7 @@ export const startTimerService = async ({
 harden(startTimerService);
 
 /**
- * @param {BootDevices<ChainDevices> &
- *   BootstrapSpace & {
- *     consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
- *   }} powers
+ * @param {BootDevices<ChainDevices> & BootstrapSpace} powers
  */
 export const makeBridgeManager = async ({
   consume: { loadCriticalVat },
@@ -345,9 +340,7 @@ export const makeBridgeManager = async ({
 harden(makeBridgeManager);
 
 /**
- * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
- * }} powers
+ * @param {BootstrapSpace} powers
  */
 export const makeChainStorage = async ({
   consume: { loadCriticalVat, bridgeManager: bridgeManagerP },
@@ -380,9 +373,7 @@ export const makeChainStorage = async ({
 };
 
 /**
- * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
- * }} powers
+ * @param {BootstrapSpace} powers
  */
 export const produceHighPrioritySendersManager = async ({
   consume: { loadCriticalVat, storageBridgeManager: storageBridgeManagerP },

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -209,7 +209,7 @@ const mintRunPayment = async (
 
 /**
  * @param {string} name
- * @param {MintsVat} mints
+ * @param {ERef<MintsVat>} mints
  */
 const provideCoin = async (name, mints) => {
   return E(mints).provideIssuerKit(name, AssetKind.NAT, {

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -218,8 +218,7 @@ const provideCoin = async (name, mints) => {
 };
 
 /**
- * @param {BootstrapSpace & { consume: { loadVat: VatLoader<MintsVat> } }} powers
- *   TODO: sync this type with end-user docs?
+ * @param {BootstrapSpace} powers TODO: sync this type with end-user docs?
  *
  * @typedef {{
  *   issuer: ERef<Issuer>;

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -109,7 +109,10 @@ type Producer<T> = {
 };
 
 type VatSourceRef = { bundleName?: string; bundleID?: string };
-type VatLoader<T> = (name: string, sourceRef?: VatSourceRef) => T;
+type VatLoader = <K extends keyof WellKnownVats>(
+  name: K,
+  sourceRef?: VatSourceRef,
+) => WellKnownVats[K];
 
 /** callback to assign a property onto the `home` object of the client */
 type PropertyMaker = (addr: string, flags: string[]) => Record<string, unknown>;
@@ -434,12 +437,12 @@ type BootstrapSpace = WellKnownSpaces &
   PromiseSpaceOf<
     ChainBootstrapSpaceT & {
       vatAdminSvc: VatAdminSvc;
+    } & {
+      loadVat: VatLoader;
+      loadCriticalVat: VatLoader;
     },
     {},
-    {
-      loadVat: VatLoader<unknown>;
-      loadCriticalVat: VatLoader<unknown>;
-    }
+    {}
   >;
 
 type ProvisioningVat = ERef<
@@ -507,3 +510,21 @@ type HttpVat = ERef<
 type UploadsVat = ERef<
   ReturnType<typeof import('@agoric/solo/src/vat-uploads.js').buildRootObject>
 >;
+
+type WellKnownVats = SwingsetVats & {
+  bank: BankVat;
+  board: BoardVat;
+  bridge: ChainStorageVat;
+  localchain: LocalChainVat;
+  ibc: IBCVat;
+  mints: MintsVat;
+  network: NetworkVat;
+  orchestration: ERef<
+    ReturnType<
+      typeof import('@agoric/orchestration/src/vat-orchestration.js').buildRootObject
+    >
+  >;
+  priceAuthority: PriceAuthorityVat;
+  provisioning: ProvisioningVat;
+  zoe: ERef<ReturnType<typeof import('../vat-zoe.js').buildRootObject>>;
+};

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -109,10 +109,10 @@ type Producer<T> = {
 };
 
 type VatSourceRef = { bundleName?: string; bundleID?: string };
-type VatLoader = <K extends keyof WellKnownVats>(
-  name: K,
+type VatLoader<Names extends string = keyof WellKnownVats> = <N extends Names>(
+  name: N,
   sourceRef?: VatSourceRef,
-) => WellKnownVats[K];
+) => Promise<Awaited<WellKnownVats[N]>>;
 
 /** callback to assign a property onto the `home` object of the client */
 type PropertyMaker = (addr: string, flags: string[]) => Record<string, unknown>;
@@ -437,13 +437,21 @@ type BootstrapSpace = WellKnownSpaces &
   PromiseSpaceOf<
     ChainBootstrapSpaceT & {
       vatAdminSvc: VatAdminSvc;
-    } & {
+    },
+    {
       loadVat: VatLoader;
       loadCriticalVat: VatLoader;
     },
-    {},
     {}
   >;
+
+type LocalChainVat = ERef<
+  ReturnType<typeof import('../vat-localchain.js').buildRootObject>
+>;
+
+type TransferVat = ERef<
+  ReturnType<typeof import('../vat-transfer.js').buildRootObject>
+>;
 
 type ProvisioningVat = ERef<
   ReturnType<typeof import('../vat-provisioning.js').buildRootObject>
@@ -467,6 +475,9 @@ type NamedVatPowers = {
     board: Awaited<BoardVat>;
   }>;
 };
+
+type OrchestrationVat = ERef<import('@agoric/orchestration').OrchestrationVat>;
+type ZoeVat = ERef<import('../vat-zoe.js').ZoeVat>;
 
 type RemoteIssuerKit = {
   mint: ERef<Mint>;
@@ -515,16 +526,13 @@ type WellKnownVats = SwingsetVats & {
   bank: BankVat;
   board: BoardVat;
   bridge: ChainStorageVat;
-  localchain: LocalChainVat;
   ibc: IBCVat;
+  localchain: LocalChainVat;
   mints: MintsVat;
   network: NetworkVat;
-  orchestration: ERef<
-    ReturnType<
-      typeof import('@agoric/orchestration/src/vat-orchestration.js').buildRootObject
-    >
-  >;
+  orchestration: OrchestrationVat;
   priceAuthority: PriceAuthorityVat;
   provisioning: ProvisioningVat;
-  zoe: ERef<ReturnType<typeof import('../vat-zoe.js').buildRootObject>>;
+  transfer: TransferVat;
+  zoe: ZoeVat;
 };

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -363,7 +363,6 @@ export const makeVatSpace = (
     {
       get: (_target, name, _rx) => {
         assert.typeof(name, 'string');
-        // @ts-expect-error XXX
         return provideAsync(name, createVatByName).then(vat => {
           if (!durableStore.has(name)) {
             durableStore.init(name, vat);

--- a/packages/vats/src/proposals/localchain-proposal.js
+++ b/packages/vats/src/proposals/localchain-proposal.js
@@ -5,7 +5,6 @@ import { BridgeId as BRIDGE_ID } from '@agoric/internal';
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     loadCriticalVat: VatLoader<any>;
  *     bridgeManager: import('../types').BridgeManager;
  *     localchainBridgeManager: import('../types').ScopedBridgeManager<'vlocalchain'>;
  *     bankManager: Promise<import('../vat-bank.js').BankManager>;

--- a/packages/vats/src/proposals/localchain-proposal.js
+++ b/packages/vats/src/proposals/localchain-proposal.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { E } from '@endo/far';
 import { BridgeId as BRIDGE_ID } from '@agoric/internal';
+import { makeScopedBridge } from '../bridge.js';
 
 /**
  * @param {BootstrapPowers & {
@@ -57,9 +58,10 @@ export const setupLocalChainVat = async (
   /** @type {import('../types').ScopedBridgeManager<'vlocalchain'>} */
   let scopedManager;
   try {
-    /** @type {import('../types.js').ScopedBridgeManager<'vlocalchain'>} */
-    // @ts-expect-error XXX EProxy
-    scopedManager = await E(bridgeManager).register(BRIDGE_ID.VLOCALCHAIN);
+    scopedManager = await makeScopedBridge(
+      bridgeManager,
+      BRIDGE_ID.VLOCALCHAIN,
+    );
     localchainBridgeManager.reset();
     localchainBridgeManager.resolve(scopedManager);
   } catch (e) {

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -79,7 +79,6 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  * - echo port addrees: /ibc-port/custom-echo
  *
  * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: VatLoader<any> };
  *   produce: { portAllocator: Producer<any> };
  * }} powers
  * @param {object} options

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -10,6 +10,7 @@ import { makeScalarBigMapStore } from '@agoric/vat-data';
 // Heap-based vow resolution is used for this module because the
 // bootstrap vat can't yet be upgraded.
 import { heapVowTools } from '@agoric/vow/vat.js';
+import { makeScopedBridge } from '../bridge.js';
 
 const { when } = heapVowTools;
 
@@ -83,10 +84,6 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  * }} powers
  * @param {object} options
  * @param {{ networkRef: VatSourceRef; ibcRef: VatSourceRef }} options.options
- *   // TODO: why doesn't overloading VatLoader work???
- *
- * @typedef {((name: 'network') => NetworkVat) & ((name: 'ibc') => IBCVat)} VatLoader2
- *
  *
  * @typedef {{
  *   network: ERef<NetworkVat>;
@@ -132,10 +129,8 @@ export const setupNetworkProtocols = async (
   const allocator = await portAllocatorP;
 
   const bridgeManager = await bridgeManagerP;
-  /** @type {import('../types.js').ScopedBridgeManager<'dibc'> | undefined} */
-  // @ts-expect-error XXX EProxy
   const dibcBridgeManager =
-    bridgeManager && E(bridgeManager).register(BRIDGE_ID.DIBC);
+    bridgeManager && makeScopedBridge(bridgeManager, BRIDGE_ID.DIBC);
 
   // The Interchain Account (ICA) Controller must be bound to a port that starts
   // with 'icacontroller', so we provide one such port to each client.

--- a/packages/vats/src/proposals/transfer-proposal.js
+++ b/packages/vats/src/proposals/transfer-proposal.js
@@ -1,11 +1,11 @@
 // @ts-check
 import { E } from '@endo/far';
 import { BridgeId as BRIDGE_ID, VTRANSFER_IBC_EVENT } from '@agoric/internal';
+import { makeScopedBridge } from '../bridge.js';
 
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     loadCriticalVat: VatLoader<any>;
  *     bridgeManager: import('../types').BridgeManager;
  *     vtransferBridgeManager: import('../types').ScopedBridgeManager<'vtransfer'>;
  *   };
@@ -17,10 +17,6 @@ import { BridgeId as BRIDGE_ID, VTRANSFER_IBC_EVENT } from '@agoric/internal';
  * }} powers
  * @param {object} options
  * @param {{ transferRef: VatSourceRef }} options.options
- *
- * @typedef {{
- *   transfer: ERef<import('../vat-transfer.js').TransferVat>;
- * }} TransferVats
  */
 export const setupTransferMiddleware = async (
   {
@@ -44,7 +40,6 @@ export const setupTransferMiddleware = async (
   }
 
   const { transferRef } = options.options;
-  /** @type {TransferVats} */
   const vats = {
     transfer: E(loadCriticalVat)('transfer', transferRef),
   };
@@ -73,7 +68,7 @@ export const setupTransferMiddleware = async (
   /** @type {Awaited<ReturnType<typeof provideBridgeTargetKit>>} */
   let bridgeTargetKit;
   try {
-    const vtransferBridge = await E(bridgeManager).register(vtransferID);
+    const vtransferBridge = await makeScopedBridge(bridgeManager, vtransferID);
     produceVtransferBridgeManager.reset();
     produceVtransferBridgeManager.resolve(vtransferBridge);
     bridgeTargetKit = await provideBridgeTargetKit(vtransferBridge);

--- a/packages/vats/src/types.d.ts
+++ b/packages/vats/src/types.d.ts
@@ -114,7 +114,7 @@ export type ScopedBridgeManager<BridgeId extends BridgeIdValue> = Guarded<{
 export type BridgeManager = {
   register: <BridgeId extends BridgeIdValue>(
     bridgeId: BridgeId,
-    handler?: Remote<BridgeHandler | undefined>,
+    handler?: Remote<BridgeHandler>,
   ) => ScopedBridgeManager<BridgeId>;
 };
 

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -52,3 +52,5 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
     getZoeConfigFacet: () => zoeConfigFacet,
   });
 }
+
+/** @typedef {ReturnType<typeof buildRootObject>} ZoeVat */

--- a/packages/vats/test/clientBundle.test.js
+++ b/packages/vats/test/clientBundle.test.js
@@ -34,7 +34,10 @@ test('connectFaucet produces payments', async t => {
   /**
    * @type {BootstrapPowers &
    *   DemoFaucetPowers & {
-   *     consume: { loadVat: LoadVat; loadCriticalVat: LoadVat };
+   *     produce: {
+   *       loadVat: Producer<LoadVat>;
+   *       loadCriticalVat: Producer<LoadVat>;
+   *     };
    *   }}
    */
   const { consume, produce } = space;
@@ -54,13 +57,15 @@ test('connectFaucet produces payments', async t => {
 
   produce.vatAdminSvc.resolve(vatAdminSvc);
 
-  const vatLoader = name => {
+  /** @type {VatLoader<'mints' | 'board'>} */
+  const vatLoader = async (name, _sourceRef) => {
+    /** @typedef {Awaited<WellKnownVats[typeof name]>} ReturnedVat */
     switch (name) {
       case 'mints':
-        return mintsRoot();
+        return /** @type {ReturnedVat} */ (mintsRoot());
       case 'board': {
         const baggage = makeScalarBigMapStore('baggage');
-        return boardRoot({}, {}, baggage);
+        return /** @type {ReturnedVat} */ (boardRoot({}, {}, baggage));
       }
       default:
         throw Error('unknown loadVat name');

--- a/packages/vats/test/vat-bank-integration.test.js
+++ b/packages/vats/test/vat-bank-integration.test.js
@@ -23,9 +23,7 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   // Supply bootstrap prerequisites.
   const space = /** @type {any} */ (makePromiseSpace(t.log));
   /**
-   * @type {BootstrapPowers & {
-   *   consume: { loadCriticalVat: VatLoader<any> };
-   * }}
+   * @type {BootstrapPowers}
    */
   const { produce, consume } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =

--- a/packages/vats/test/vat-bank-integration.test.js
+++ b/packages/vats/test/vat-bank-integration.test.js
@@ -23,7 +23,9 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   // Supply bootstrap prerequisites.
   const space = /** @type {any} */ (makePromiseSpace(t.log));
   /**
-   * @type {BootstrapPowers}
+   * @type {BootstrapPowers & {
+   *   produce: { loadCriticalVat: Producer<VatLoader> };
+   * }}
    */
   const { produce, consume } = space;
   const { agoricNames, agoricNamesAdmin, spaces } =
@@ -85,13 +87,15 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
     'initialSupply of 50 RUN',
   );
 
+  /** @type {VatLoader<'bank'>} */
   const loadCriticalVat = async name => {
     assert.equal(name, 'bank');
-    return E(buildRootObject)(
+    const vatP = E(buildRootObject)(
       null,
       null,
       makeScalarMapStore('addAssets baggage'),
     );
+    return /** @type {Awaited<WellKnownVats[typeof name]>} */ (vatP);
   };
   produce.loadCriticalVat.resolve(loadCriticalVat);
   produce.bridgeManager.resolve(undefined);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #9441

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Finish adopting `WellKnownVats` in `VatLoader` as proposed by @turadg in #9441

Accommodate `Guarded` types in:
- packages/vats: `Producer<T>.resolve`
- packages/governance

packages/swingset-liveslots: `KindFacet` implies `RemotableBrand`

Cast the return type of `BridgeHandler.register` because it wasn't an `async` function, and there's no way I know using TypeScript to be able to transform the return type of a generic function to `Promise<ReturnType<T>>` without losing `T`'s genericity.
