### PR TITLE
fix(orchestration): make the facade more tolerant of vows

### DIFF
--- a/packages/async-flow/src/async-flow.js
+++ b/packages/async-flow/src/async-flow.js
@@ -10,7 +10,14 @@ import { prepareBijection } from './bijection.js';
 import { LogEntryShape, FlowStateShape } from './type-guards.js';
 
 /**
- * @import { WeakMapStore } from '@agoric/store'
+ * @import {WeakMapStore} from '@agoric/store'
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {MapStore} from '@agoric/store';
+ * @import {LogStore} from '../src/log-store.js';
+ * @import {Bijection} from '../src/bijection.js';
+ * @import {FlowState, GuestAsyncFunc, HostAsyncFuncWrapper, PreparationOptions} from '../src/types.js';
+ * @import {ReplayMembrane} from '../src/replay-membrane.js';
  */
 
 const { defineProperties } = Object;

--- a/packages/async-flow/src/bijection.js
+++ b/packages/async-flow/src/bijection.js
@@ -4,6 +4,12 @@ import { Far } from '@endo/pass-style';
 import { toPassableCap } from '@agoric/vow';
 import { makeEphemera } from './ephemera.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {Ephemera} from './types.js';
+ */
+
 const BijectionI = M.interface('Bijection', {
   reset: M.call().returns(),
   init: M.call(M.any(), M.any()).returns(),

--- a/packages/async-flow/src/convert.js
+++ b/packages/async-flow/src/convert.js
@@ -10,6 +10,10 @@ import {
 import { isVow } from '@agoric/vow/src/vow-utils.js';
 import { objectMap } from '@endo/common/object-map.js';
 
+/**
+ * @import {Passable} from '@endo/pass-style'
+ */
+
 const makeConvert = (convertRemotable, convertPromiseOrVow, convertError) => {
   const convertRecur = (specimen, label) => {
     // Open code the synchronous part of applyLabelingError, because

--- a/packages/async-flow/src/ephemera.js
+++ b/packages/async-flow/src/ephemera.js
@@ -1,4 +1,10 @@
 /**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {Ephemera} from './types.js';
+ */
+
+/**
  * Used by a possibly-durable exo to store per-instance ephemeral state.
  * Each ephemera is created at the exo class prepare level, and then
  * used from within the exo class methods to get state `eph.for(self)`.

--- a/packages/async-flow/src/log-store.js
+++ b/packages/async-flow/src/log-store.js
@@ -5,7 +5,10 @@ import { LogEntryShape } from './type-guards.js';
 import { makeEphemera } from './ephemera.js';
 
 /**
- * @import {MapStore} from '@agoric/store'
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {MapStore} from '@agoric/store';
+ * @import {Ephemera, LogEntry} from './types.js';
  */
 
 const LogStoreI = M.interface('LogStore', {

--- a/packages/async-flow/src/replay-membrane.js
+++ b/packages/async-flow/src/replay-membrane.js
@@ -8,6 +8,12 @@ import { makeConvertKit } from './convert.js';
 
 /**
  * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {Vow, VowTools} from '@agoric/vow'
+ * @import {AsyncFlow} from '../src/async-flow.js'
+ * @import {LogStore} from '../src/log-store.js';
+ * @import {Bijection} from '../src/bijection.js';
+ * @import {Host, HostVow, LogEntry, Outcome} from '../src/types.js';
  */
 
 const { fromEntries, defineProperties, assign } = Object;

--- a/packages/async-flow/src/types.js
+++ b/packages/async-flow/src/types.js
@@ -1,5 +1,7 @@
+// Ensure this is a module.
+export {};
+
 /**
- * @import {PromiseKit} from '@endo/promise-kit'
  * @import {Passable} from '@endo/pass-style'
  * @import {Zone} from '@agoric/base-zone'
  * @import {Vow, VowTools} from '@agoric/vow'

--- a/packages/async-flow/test/async-flow-crank.test.js
+++ b/packages/async-flow/test/async-flow-crank.test.js
@@ -16,6 +16,12 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import { prepareAsyncFlowTools } from '../src/async-flow.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {Ephemera} from './types.js';
+ */
+
 const neverSettlesP = new Promise(() => {});
 
 /**

--- a/packages/async-flow/test/async-flow-early-completion.test.js
+++ b/packages/async-flow/test/async-flow-early-completion.test.js
@@ -18,6 +18,8 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareAsyncFlowTools } from '../src/async-flow.js';
 
 /**
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {Vow, VowTools} from '@agoric/vow'
  * @import {AsyncFlow} from '../src/async-flow.js'
  */
 

--- a/packages/async-flow/test/async-flow-no-this.js
+++ b/packages/async-flow/test/async-flow-no-this.js
@@ -9,6 +9,12 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import { prepareAsyncFlowTools } from '../src/async-flow.js';
 
+/**
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {Vow, VowTools} from '@agoric/vow'
+ * @import {AsyncFlow} from '../src/async-flow.js'
+ */
+
 const { apply } = Reflect;
 
 /**

--- a/packages/async-flow/test/async-flow.test.js
+++ b/packages/async-flow/test/async-flow.test.js
@@ -21,6 +21,9 @@ import { prepareAsyncFlowTools } from '../src/async-flow.js';
 
 /**
  * @import {AsyncFlow} from '../src/async-flow.js'
+ * @import {Vow, VowTools} from '@agoric/vow'
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
  */
 
 /**

--- a/packages/async-flow/test/bad-host.test.js
+++ b/packages/async-flow/test/bad-host.test.js
@@ -17,6 +17,11 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import { prepareAsyncFlowTools } from '../src/async-flow.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ */
+
 const nonPassableFunc = () => 'non-passable-function';
 harden(nonPassableFunc);
 const guestCreatedPromise = harden(Promise.resolve('guest-created'));

--- a/packages/async-flow/test/bijection.test.js
+++ b/packages/async-flow/test/bijection.test.js
@@ -16,6 +16,12 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareBijection } from '../src/bijection.js';
 
 /**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {Ephemera} from './types.js';
+ */
+
+/**
  * @param {any} t
  * @param {Zone} zone
  */

--- a/packages/async-flow/test/convert.test.js
+++ b/packages/async-flow/test/convert.test.js
@@ -19,6 +19,11 @@ import { makeConvertKit } from '../src/convert.js';
 import { prepareBijection } from '../src/bijection.js';
 
 /**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ */
+
+/**
  * @param {any} t
  * @param {Zone} zone
  * @param {boolean} [showOnConsole]

--- a/packages/async-flow/test/equate.test.js
+++ b/packages/async-flow/test/equate.test.js
@@ -19,6 +19,10 @@ import { prepareBijection } from '../src/bijection.js';
 import { makeEquate } from '../src/equate.js';
 
 /**
+ * @import {Zone} from '@agoric/base-zone'
+ */
+
+/**
  * @param {any} t
  * @param {Zone} zone
  * @param {boolean} [showOnConsole]

--- a/packages/async-flow/test/log-store.test.js
+++ b/packages/async-flow/test/log-store.test.js
@@ -15,6 +15,14 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareLogStore } from '../src/log-store.js';
 
 /**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {Vow, VowTools} from '@agoric/vow'
+ * @import {LogStore} from '../src/log-store.js';
+ * @import {Bijection} from '../src/bijection.js';
+ */
+
+/**
  * @param {any} t
  * @param {Zone} zone
  */

--- a/packages/async-flow/test/replay-membrane-eventual.test.js
+++ b/packages/async-flow/test/replay-membrane-eventual.test.js
@@ -18,6 +18,13 @@ import { prepareLogStore } from '../src/log-store.js';
 import { prepareBijection } from '../src/bijection.js';
 import { makeReplayMembrane } from '../src/replay-membrane.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {LogStore} from '../src/log-store.js';
+ * @import {Bijection} from '../src/bijection.js';
+ */
+
 const watchWake = _vowish => {};
 const panic = problem => Fail`panic over ${problem}`;
 

--- a/packages/async-flow/test/replay-membrane-settlement.test.js
+++ b/packages/async-flow/test/replay-membrane-settlement.test.js
@@ -17,6 +17,13 @@ import { prepareLogStore } from '../src/log-store.js';
 import { prepareBijection } from '../src/bijection.js';
 import { makeReplayMembrane } from '../src/replay-membrane.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {LogStore} from '../src/log-store.js';
+ * @import {Bijection} from '../src/bijection.js';
+ */
+
 const watchWake = _vowish => {};
 const panic = problem => Fail`panic over ${problem}`;
 

--- a/packages/async-flow/test/replay-membrane-zombie.test.js
+++ b/packages/async-flow/test/replay-membrane-zombie.test.js
@@ -17,6 +17,11 @@ import { prepareLogStore } from '../src/log-store.js';
 import { prepareBijection } from '../src/bijection.js';
 import { makeReplayMembrane } from '../src/replay-membrane.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ */
+
 const watchWake = _vowish => {};
 const panic = problem => Fail`panic over ${problem}`;
 

--- a/packages/async-flow/test/replay-membrane.test.js
+++ b/packages/async-flow/test/replay-membrane.test.js
@@ -18,6 +18,14 @@ import { prepareLogStore } from '../src/log-store.js';
 import { prepareBijection } from '../src/bijection.js';
 import { makeReplayMembrane } from '../src/replay-membrane.js';
 
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {Zone} from '@agoric/base-zone'
+ * @import {MapStore} from '@agoric/store';
+ * @import {LogStore} from '../src/log-store.js';
+ * @import {Bijection} from '../src/bijection.js';
+ */
+
 const watchWake = _vowish => {};
 const panic = problem => Fail`panic over ${problem}`;
 

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
+    "@agoric/async-flow": "^0.1.0",
     "@agoric/assert": "^0.6.0",
     "@agoric/cosmic-proto": "^0.4.0",
     "@agoric/ertp": "^0.16.2",

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -6,6 +6,8 @@ import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js'
 
 import { AmountShape } from '@agoric/ertp';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
+import { prepareAsyncFlowTools } from '@agoric/async-flow';
+import { prepareVowTools } from '@agoric/vow';
 import { CosmosChainInfoShape } from '../typeGuards.js';
 import { makeOrchestrationFacade } from '../facade.js';
 import { prepareLocalChainAccountKit } from '../exos/local-chain-account-kit.js';
@@ -63,11 +65,18 @@ export const start = async (zcf, privateArgs, baggage) => {
     privateArgs.timerService,
     chainHub,
   );
+
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
+    vowTools,
+  });
+
   const { orchestrate } = makeOrchestrationFacade({
     zcf,
     zone,
     chainHub,
     makeLocalChainAccountKit,
+    asyncFlowTools,
     ...orchPowers,
   });
 

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -1,15 +1,17 @@
+import { prepareAsyncFlowTools } from '@agoric/async-flow';
 import { StorageNodeShape } from '@agoric/internal';
 import { TimerServiceShape } from '@agoric/time';
+import { prepareVowTools } from '@agoric/vow';
+import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M, objectMap } from '@endo/patterns';
-import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { makeOrchestrationFacade } from '../facade.js';
-import { orcUtils } from '../utils/orc.js';
-import { makeChainHub } from '../utils/chainHub.js';
 import { prepareLocalChainAccountKit } from '../exos/local-chain-account-kit.js';
+import { makeOrchestrationFacade } from '../facade.js';
+import { makeChainHub } from '../utils/chainHub.js';
+import { orcUtils } from '../utils/orc.js';
 
 /**
  * @import {Orchestrator, IcaAccount, CosmosValidatorAddress} from '../types.js'
@@ -79,6 +81,10 @@ export const start = async (zcf, privateArgs, baggage) => {
     timerService,
     chainHub,
   );
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
+    vowTools,
+  });
 
   const { orchestrate } = makeOrchestrationFacade({
     localchain,
@@ -89,6 +95,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     zone,
     chainHub,
     makeLocalChainAccountKit,
+    asyncFlowTools,
   });
 
   /** deprecated historical example */

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -1,12 +1,6 @@
-import { makeDurableZone } from '@agoric/zone/durable.js';
 import { Far } from '@endo/far';
 import { M } from '@endo/patterns';
-import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { prepareVowTools } from '@agoric/vow';
-import { prepareAsyncFlowTools } from '@agoric/async-flow';
-import { makeOrchestrationFacade } from '../facade.js';
-import { makeChainHub } from '../utils/chainHub.js';
-import { prepareLocalChainAccountKit } from '../exos/local-chain-account-kit.js';
+import { provideOrchestration } from '../utils/start-helper.js';
 
 /**
  * @import {Orchestrator, IcaAccount, CosmosValidatorAddress} from '../types.js'
@@ -39,33 +33,19 @@ export const start = async (zcf, privateArgs, baggage) => {
     marshaller,
     timerService,
   } = privateArgs;
-  const zone = makeDurableZone(baggage);
 
-  const chainHub = makeChainHub(agoricNames);
-  const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
-  const makeLocalChainAccountKit = prepareLocalChainAccountKit(
-    zone,
-    makeRecorderKit,
+  const { orchestrate } = provideOrchestration(
     zcf,
-    privateArgs.timerService,
-    chainHub,
+    baggage,
+    {
+      agoricNames,
+      localchain,
+      orchestrationService,
+      storageNode,
+      timerService,
+    },
+    marshaller,
   );
-  const vowTools = prepareVowTools(zone.subZone('vows'));
-  const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
-    vowTools,
-  });
-
-  const { orchestrate } = makeOrchestrationFacade({
-    localchain,
-    orchestrationService,
-    storageNode,
-    timerService,
-    zcf,
-    zone,
-    chainHub: makeChainHub(agoricNames),
-    makeLocalChainAccountKit,
-    asyncFlowTools,
-  });
 
   /** @type {OfferHandler} */
   const unbondAndLiquidStake = orchestrate(

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -2,6 +2,8 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
 import { Far } from '@endo/far';
 import { M } from '@endo/patterns';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
+import { prepareVowTools } from '@agoric/vow';
+import { prepareAsyncFlowTools } from '@agoric/async-flow';
 import { makeOrchestrationFacade } from '../facade.js';
 import { makeChainHub } from '../utils/chainHub.js';
 import { prepareLocalChainAccountKit } from '../exos/local-chain-account-kit.js';
@@ -48,6 +50,11 @@ export const start = async (zcf, privateArgs, baggage) => {
     privateArgs.timerService,
     chainHub,
   );
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
+    vowTools,
+  });
+
   const { orchestrate } = makeOrchestrationFacade({
     localchain,
     orchestrationService,
@@ -57,6 +64,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     zone,
     chainHub: makeChainHub(agoricNames),
     makeLocalChainAccountKit,
+    asyncFlowTools,
   });
 
   /** @type {OfferHandler} */

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -1,9 +1,11 @@
 /** @file Orchestration service */
 
 import { V as E } from '@agoric/vow/vat.js';
+import { Fail } from '@agoric/assert';
 import { prepareCosmosOrchestrationAccount } from './exos/cosmosOrchestrationAccount.js';
 
 /**
+ * @import {AsyncFlowTools} from '@agoric/async-flow';
  * @import {Zone} from '@agoric/zone';
  * @import {TimerService} from '@agoric/time';
  * @import {IBCConnectionID} from '@agoric/vats';
@@ -153,6 +155,7 @@ const makeRemoteChainFacade = (
  *   makeLocalChainAccountKit: ReturnType<
  *     typeof import('./exos/local-chain-account-kit.js').prepareLocalChainAccountKit
  *   >;
+ *   asyncFlowTools: AsyncFlowTools;
  * }} powers
  */
 export const makeOrchestrationFacade = ({
@@ -164,14 +167,15 @@ export const makeOrchestrationFacade = ({
   localchain,
   chainHub,
   makeLocalChainAccountKit,
+  asyncFlowTools,
 }) => {
-  console.log('makeOrchestrationFacade got', {
-    zone,
-    timerService,
-    zcf,
-    storageNode,
-    orchestrationService,
-  });
+  (zone &&
+    timerService &&
+    zcf &&
+    storageNode &&
+    orchestrationService &&
+    asyncFlowTools) ||
+    Fail`params missing`;
 
   return {
     /**

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -1,5 +1,6 @@
 /** @file Orchestration service */
 
+// import { E } from '@endo/far';
 import { V as E } from '@agoric/vow/vat.js';
 import { Fail } from '@agoric/assert';
 import { prepareCosmosOrchestrationAccount } from './exos/cosmosOrchestrationAccount.js';
@@ -38,7 +39,7 @@ const makeLocalChainFacade = (
     },
 
     async makeAccount() {
-      const lcaP = E(localchain).makeAccount();
+      const lcaP = E.when(E(localchain).makeAccount());
       const [lca, address] = await Promise.all([lcaP, E(lcaP).getAddress()]);
       const { holder: account } = makeLocalChainAccountKit({
         account: lca,
@@ -50,7 +51,7 @@ const makeLocalChainFacade = (
       return {
         async deposit(payment) {
           console.log('deposit got', payment);
-          await E(account).deposit(payment);
+          await E.when(E(account).deposit(payment));
         },
         getAddress() {
           const addressStr = account.getAddress();
@@ -68,7 +69,7 @@ const makeLocalChainFacade = (
               ? [/** @type {any} */ (null), denomArg]
               : [denomArg, 'FIXME'];
 
-          const natAmount = await E(lca).getBalance(brand);
+          const natAmount = await E.when(E(lca).getBalance(brand));
           return harden({ denom, value: natAmount.value });
         },
         getBalances() {
@@ -80,7 +81,7 @@ const makeLocalChainFacade = (
         },
         async transfer(amount, destination, opts) {
           console.log('transfer got', amount, destination, opts);
-          return account.transfer(amount, destination, opts);
+          return E.when(account.transfer(amount, destination, opts));
         },
         transferSteps(amount, msg) {
           console.log('transferSteps got', amount, msg);
@@ -118,13 +119,15 @@ const makeRemoteChainFacade = (
     getChainInfo: async () => chainInfo,
     /** @returns {Promise<OrchestrationAccount<CCI>>} */
     makeAccount: async () => {
-      const icaAccount = await E(orchestration).makeAccount(
-        chainInfo.chainId,
-        connectionInfo.id,
-        connectionInfo.counterparty.connection_id,
+      const icaAccount = await E.when(
+        E(orchestration).makeAccount(
+          chainInfo.chainId,
+          connectionInfo.id,
+          connectionInfo.counterparty.connection_id,
+        ),
       );
 
-      const address = await E(icaAccount).getAddress();
+      const address = await E.when(E(icaAccount).getAddress());
 
       const [{ denom: bondDenom }] = chainInfo.stakingTokens || [
         {
@@ -215,12 +218,12 @@ export const makeOrchestrationFacade = ({
           });
         },
         makeLocalAccount() {
-          return E(localchain).makeAccount();
+          return E.when(E(localchain).makeAccount());
         },
         getBrandInfo: anyVal,
         asAmount: anyVal,
       };
-      return async (...args) => fn(orc, ctx, ...args);
+      return async (...args) => E.when(fn(orc, ctx, ...args));
     },
   };
 };

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -1,0 +1,72 @@
+import { prepareAsyncFlowTools } from '@agoric/async-flow';
+import { prepareVowTools } from '@agoric/vow';
+import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+import { prepareLocalChainAccountKit } from '../exos/local-chain-account-kit.js';
+import { makeOrchestrationFacade } from '../facade.js';
+import { makeChainHub } from './chainHub.js';
+
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {LocalChain} from '@agoric/vats/src/localchain.js';
+ * @import {TimerService, TimerBrand} from '@agoric/time';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {NameHub} from '@agoric/vats';
+ * @import {Remote} from '@agoric/vow';
+ * @import {OrchestrationService} from '../service.js';
+ */
+
+/**
+ * @typedef {{
+ *   localchain: Remote<LocalChain>;
+ *   orchestrationService: Remote<OrchestrationService>;
+ *   storageNode: Remote<StorageNode>;
+ *   timerService: Remote<TimerService>;
+ *   agoricNames: Remote<NameHub>;
+ * }} OrchestrationPowers
+ */
+
+/**
+ * Helper that a contract start function can use to set up the objects needed
+ * for orchestration.
+ *
+ * @param {ZCF} zcf
+ * @param {Baggage} baggage
+ * @param {OrchestrationPowers} remotePowers
+ * @param {Marshaller} marshaller
+ */
+export const provideOrchestration = (
+  zcf,
+  baggage,
+  remotePowers,
+  marshaller,
+) => {
+  const zone = makeDurableZone(baggage);
+
+  const chainHub = makeChainHub(remotePowers.agoricNames);
+
+  const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
+  const makeLocalChainAccountKit = prepareLocalChainAccountKit(
+    zone,
+    makeRecorderKit,
+    zcf,
+    remotePowers.timerService,
+    chainHub,
+  );
+
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
+    vowTools,
+  });
+
+  const facade = makeOrchestrationFacade({
+    zcf,
+    zone,
+    chainHub,
+    makeLocalChainAccountKit,
+    asyncFlowTools,
+    ...remotePowers,
+  });
+  return { ...facade, chainHub, zone };
+};
+harden(provideOrchestration);

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -1,6 +1,8 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
+import { prepareAsyncFlowTools } from '@agoric/async-flow';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
+import { prepareVowTools } from '@agoric/vow';
 import type { CosmosChainInfo, IBCConnectionInfo } from '../src/cosmos-api.js';
 import { makeOrchestrationFacade } from '../src/facade.js';
 import type { Chain } from '../src/orchestration-api.js';
@@ -45,9 +47,12 @@ test('chain info', async t => {
   const { bootstrap, facadeServices } = await commonSetup(t);
 
   const zone = bootstrap.rootZone;
-
   const { zcf } = await setupZCFTest();
   const chainHub = makeChainHub(facadeServices.agoricNames);
+  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const asyncFlowTools = prepareAsyncFlowTools(zone.subZone('asyncFlow'), {
+    vowTools,
+  });
 
   const { orchestrate } = makeOrchestrationFacade({
     ...facadeServices,
@@ -56,6 +61,7 @@ test('chain info', async t => {
     zone,
     chainHub,
     makeLocalChainAccountKit,
+    asyncFlowTools,
   });
 
   chainHub.registerChain('mock', mockChainInfo);

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -122,7 +122,8 @@ export const commonSetup = async t => {
       localchain,
       marshaller,
       orchestration,
-      rootZone,
+      // TODO remove; bootstrap doesn't have a zone
+      rootZone: rootZone.subZone('contract'),
       storage,
     },
     brands: {


### PR DESCRIPTION
- `makeOrchestrationFacade` is already partially tolerant of `Vow`s
- make it more tolerant of invoking libraries that return `Vow`s by adding `E.when` around many return results
- since this is temporary shim only, there may be a few remaining places that require `E.when`
