### PR TITLE
test(liveslots): relaxDurability should ignore promises

### DIFF
--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -571,11 +571,15 @@ test('provisionPool publishes metricsOverride promptly', async t => {
     },
   );
 
+  // FIXME: remove the 'await null',
+  // https://github.com/Agoric/agoric-sdk/issues/9598
+  await null;
   const metrics = E(facets.publicFacet).getMetrics();
 
   const {
     head: { value: initialMetrics },
   } = await E(metrics).subscribeAfter();
+  // FIXME fails when fakeVatAdmin.js fixed for non-promise root. Why?
   t.deepEqual(initialMetrics, {
     totalMintedConverted: minted.make(20_000_000n),
     totalMintedProvided: minted.make(750_000n),

--- a/packages/inter-protocol/test/smartWallet/boot-test-utils.js
+++ b/packages/inter-protocol/test/smartWallet/boot-test-utils.js
@@ -5,6 +5,7 @@
  */
 // @ts-check
 import { Fail } from '@endo/errors';
+import { E } from '@endo/eventual-send';
 import {
   makeFakeVatAdmin,
   zcfBundleCap,
@@ -109,7 +110,8 @@ export const makePopulatedFakeVatAdmin = () => {
     const baggage = makeScalarBigMapStore('baggage');
     const adminNode =
       /** @type {import('@agoric/swingset-vat').VatAdminFacet} */ ({});
-    return { root: buildRoot({}, vatParameters, baggage), adminNode };
+    const rootP = buildRoot({}, vatParameters, baggage);
+    return E.when(rootP, root => harden({ root, adminNode }));
   };
   const createVatByName = async name => {
     return createVat(fakeNameToCap.get(name) || Fail`unknown vat ${name}`);

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -111,14 +111,19 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
    */
   const walletBridgeManager = await (bridgeManager &&
     makeScopedBridge(bridgeManager, BridgeId.WALLET));
+
+  const customTerms = await deeplyFulfilledObject(
+    harden({
+      agoricNames, // may be a promise
+      board: consume.board, // may be a promise
+      assetPublisher,
+    }),
+  );
+
   const walletFactory = await E(zoe).startInstance(
     installation,
     {},
-    {
-      agoricNames,
-      board: consume.board,
-      assetPublisher,
-    },
+    customTerms,
     { storageNode, walletBridgeManager },
   );
 

--- a/packages/pegasus/test/fakeVatAdmin.js
+++ b/packages/pegasus/test/fakeVatAdmin.js
@@ -7,15 +7,18 @@ export default harden({
   createMeter: () => {},
   createUnlimitedMeter: () => {},
   createVat: bundle => {
-    return harden({
-      root: E(evalContractBundle(bundle)).buildRootObject(),
-      adminNode: {
-        done: () => {
-          return makePromiseKit().promise;
+    const rootP = E(evalContractBundle(bundle)).buildRootObject();
+    return E.when(rootP, root =>
+      harden({
+        root,
+        adminNode: {
+          done: () => {
+            return makePromiseKit().promise;
+          },
+          terminate: () => {},
         },
-        terminate: () => {},
-      },
-    });
+      }),
+    );
   },
   createVatByName: _name => {
     throw Error(`createVatByName not supported in fake mode`);

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -41,14 +41,19 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
   const bridgeManager = await consume.bridgeManager;
   const walletBridgeManager = await (bridgeManager &&
     makeScopedBridge(bridgeManager, BridgeId.WALLET));
-  const walletFactory = await E(zoe).startInstance(
-    installation,
-    {},
-    {
+
+  const customTerms = await deeplyFulfilledObject(
+    harden({
       agoricNames,
       board: consume.board,
       assetPublisher,
-    },
+    }),
+  );
+
+  const walletFactory = await E(zoe).startInstance(
+    installation,
+    {},
+    customTerms,
     { storageNode, walletBridgeManager },
   );
 

--- a/packages/smart-wallet/test/startWalletFactory.test.js
+++ b/packages/smart-wallet/test/startWalletFactory.test.js
@@ -54,8 +54,11 @@ test.before(async t => {
 
 test('customTermsShape', async t => {
   const { consume, bridgeManager, installation, storageNode } = t.context;
-  const { agoricNames, board, zoe } = consume;
+  const { zoe } = consume;
   const privateArgs = { bridgeManager, storageNode };
+
+  const agoricNames = await consume.agoricNames;
+  const board = await consume.board;
 
   // extra term
   await t.throwsAsync(
@@ -73,7 +76,7 @@ test('customTermsShape', async t => {
     ),
     {
       message:
-        'customTerms: {"agoricNames":"[Promise]","assetPublisher":{},"board":"[Promise]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
+        'customTerms: {"agoricNames":"[Alleged: NameHubKit nameHub]","assetPublisher":{},"board":"[Alleged: Board board]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
     },
   );
 
@@ -90,14 +93,16 @@ test('customTermsShape', async t => {
     ),
     {
       message:
-        'customTerms: {"agoricNames":"[Promise]"} - Must have missing properties ["board","assetPublisher"]',
+        'customTerms: {"agoricNames":"[Alleged: NameHubKit nameHub]"} - Must have missing properties ["board","assetPublisher"]',
     },
   );
 });
 
 test('privateArgsShape', async t => {
   const { consume, bridgeManager, installation } = t.context;
-  const { agoricNames, board, zoe } = consume;
+  const { zoe } = consume;
+  const agoricNames = await consume.agoricNames;
+  const board = await consume.board;
   const terms = {
     agoricNames,
     board,

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -290,7 +290,10 @@ export function makeVirtualReferenceManager(
    */
   function isDurable(vref) {
     const { type, id, virtual, durable, allocatedByVat } = parseVatSlot(vref);
-    if (relaxDurabilityRules) {
+    if (type === 'promise') {
+      // promises are not durable even if `relaxDurabilityRules === true`
+      return false;
+    } else if (relaxDurabilityRules) {
       // we'll pretend an object is durable if running with relaxed rules
       return true;
     } else if (type === 'device') {

--- a/packages/swingset-liveslots/test/durabilityChecks.test.js
+++ b/packages/swingset-liveslots/test/durabilityChecks.test.js
@@ -262,7 +262,7 @@ async function runDurabilityCheckTest(t, relaxDurabilityRules) {
     passVal(() => virtualMap.init('non-scalar key', aNonScalarKey));
     passVal(() => virtualMap.init('non-scalar non-key', aNonScalarNonKey));
 
-    condVal(() => durableMap.init('promise', aPassablePromise));
+    failVal(() => durableMap.init('promise', aPassablePromise));
     passVal(() => durableMap.init('error', aPassableError));
     passVal(() => durableMap.init('non-scalar key', aNonScalarKey));
     passVal(() => durableMap.init('non-scalar non-key', aNonScalarNonKey));

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -1,4 +1,5 @@
 import { Fail } from '@endo/errors';
+import { E } from '@endo/far';
 import { Far } from '@endo/marshal';
 
 import {
@@ -126,7 +127,8 @@ export const makePopulatedFakeVatAdmin = () => {
     const baggage = makeScalarBigMapStore('baggage');
     const adminNode =
       /** @type {import('@agoric/swingset-vat').VatAdminFacet} */ ({});
-    return { root: buildRoot({}, vatParameters, baggage), adminNode };
+    const rootP = buildRoot({}, vatParameters, baggage);
+    return E.when(rootP, root => harden({ root, adminNode }));
   };
   const createVatByName = async name => {
     return createVat(fakeNameToCap.get(name) || Fail`unknown vat ${name}`);

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -103,15 +103,16 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       //     buildRootObject: vp => ns.buildRootObject(vpow, vp, vatBaggage),
       //   }),
       // );
-      return Promise.resolve(
+      const rootP = makeRemote(
+        E(evalContractBundle(zcfBundle)).buildRootObject(
+          vpow,
+          vatParameters,
+          vatBaggage,
+        ),
+      );
+      return E.when(rootP, root =>
         harden({
-          root: makeRemote(
-            E(evalContractBundle(zcfBundle)).buildRootObject(
-              vpow,
-              vatParameters,
-              vatBaggage,
-            ),
-          ),
+          root,
           adminNode: Far('adminNode', {
             done: () => {
               return exitKit.promise;


### PR DESCRIPTION
closes: #9599

## Description

Just an experiment to see what breaks under CI if we make promises non-durable even if `relaxDurabilityRules` is true.


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->

Note that this PR changes liveslots (specifically `src/virtualReferences.js`), which triggers concerns about how pre-existing/deployed vats might (or might not) receive these changes. In this case, the liveslots change does not affect the behavior of real vats: it only behaves differently if `relaxDurabilityRules = true`, and we don't provide any way to enable that in a real kernel.

This will change the contents of the liveslots bundle, which will be used by new vats, or by vats which are upgraded for any reason (once this code is deployed to the chain). But this PR should not cause any concerns about test behavior diverging between trunk and mainnet.
