### PR TITLE
lint: warn on non-resumable code

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,25 @@ const deprecatedTerminology = Object.fromEntries(
   ]),
 );
 
+/**
+ * Rules for code that crosses an asyncFlow membrane.
+ */
+const resumable = [
+  {
+    selector: 'FunctionExpression[async=true]',
+    message: 'Non-immediate functions must return vows, not promises',
+  },
+  {
+    selector: 'ArrowFunctionExpression[async=true]',
+    message: 'Non-immediate functions must return vows, not promises',
+  },
+  {
+    selector: "Identifier[name='callWhen']",
+    message:
+      'callWhen wraps the function in a promise; instead immediately return a vow',
+  },
+];
+
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -133,6 +152,14 @@ module.exports = {
           'error',
           { paths: ['@endo/eventual-send', '@endo/far'] },
         ],
+      },
+    },
+    {
+      // Modules with exports that must be resumable
+      files: ['packages/orchestration/src/exos/**'],
+      rules: {
+        // TODO tighten to error
+        'no-restricted-syntax': ['warn', ...resumable],
       },
     },
     {


### PR DESCRIPTION
refs: #9449

## Description
A lint rule to help identify code that doesn't conform to the membrane passing requirements in #9449. 

Once we've brought all the modules into conformance this should be upgraded from a warning to an error.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none
