### PR TITLE
explicit heapVowTools

### DIFF
--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -1,7 +1,7 @@
 /** @file Mock IBC Server */
 // @ts-check
 import { Far } from '@endo/far';
-import { V as E } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 
 /**
  * @import {Connection, PortAllocator} from '@agoric/network';

--- a/packages/boot/test/bootstrapTests/ibcServerMock.js
+++ b/packages/boot/test/bootstrapTests/ibcServerMock.js
@@ -2,7 +2,7 @@
 // @ts-check
 import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
-import { V as E } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 
 const { quote: q, Fail } = assert;
 const { log } = console;

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -16,6 +16,7 @@ const { Fail } = assert;
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
  * @import {OrchestrationService} from '../service.js';
  * @import {NameHub} from '@agoric/vats';
+ * @import {VBankAssetDetail} from '@agoric/vats/tools/board-utils.js';
  * @import {Remote} from '@agoric/vow';
  */
 
@@ -56,11 +57,15 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const findBrandInVBank = async brand => {
     const assets = await E(
-      E(privateArgs.agoricNames).lookup('vbankAsset'),
-      // @ts-expect-error XXX heapVowE
+      // XXX heapVowE
+      /** @type {Promise<Promise<NameHub<VBankAssetDetail>>>} */ (
+        E(privateArgs.agoricNames).lookup('vbankAsset')
+      ),
     ).values();
     const it = assets.find(a => a.brand === brand);
-    it || Fail`brand ${brand} not in agoricNames.vbankAsset`;
+    if (!it) {
+      throw Fail`brand ${brand} not in agoricNames.vbankAsset`;
+    }
     return it;
   };
 

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -1,8 +1,7 @@
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
-import { E } from '@endo/far';
 import { M, mustMatch } from '@endo/patterns';
-import { V } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { AmountShape } from '@agoric/ertp';
 import { CosmosChainInfoShape } from '../typeGuards.js';
 import { provideOrchestration } from '../utils/start-helper.js';
@@ -58,6 +57,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const findBrandInVBank = async brand => {
     const assets = await E(
       E(privateArgs.agoricNames).lookup('vbankAsset'),
+      // @ts-expect-error XXX heapVowE
     ).values();
     const it = assets.find(a => a.brand === brand);
     it || Fail`brand ${brand} not in agoricNames.vbankAsset`;
@@ -84,12 +84,12 @@ export const start = async (zcf, privateArgs, baggage) => {
       if (!contractAccount) {
         const agoricChain = await orch.getChain('agoric');
         // XXX when() until membrane
-        contractAccount = await V.when(agoricChain.makeAccount());
+        contractAccount = await E.when(agoricChain.makeAccount());
         console.log('contractAccount', contractAccount);
       }
 
       // XXX when() until membrane
-      const info = await V.when(chain.getChainInfo());
+      const info = await E.when(chain.getChainInfo());
       console.log('info', info);
       const { chainId } = info;
       assert(typeof chainId === 'string', 'bad chainId');
@@ -141,7 +141,7 @@ export const start = async (zcf, privateArgs, baggage) => {
         const chainKey = `${chainInfo.chainId}-${(nonce += 1n)}`;
         // when() because chainHub methods return vows. If this were inside
         // orchestrate() the membrane would wrap/unwrap automatically.
-        const agoricChainInfo = await V.when(chainHub.getChainInfo('agoric'));
+        const agoricChainInfo = await E.when(chainHub.getChainInfo('agoric'));
         chainHub.registerChain(chainKey, chainInfo);
         chainHub.registerConnection(
           agoricChainInfo.chainId,

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -6,8 +6,7 @@ import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/record
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { prepareVowTools, V } from '@agoric/vow/vat.js';
-import { E } from '@endo/far';
+import { prepareVowTools, heapVowE as E } from '@agoric/vow/vat.js';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M } from '@endo/patterns';
 import { prepareLocalOrchestrationAccountKit } from '../exos/local-orchestration-account.js';
@@ -58,8 +57,8 @@ export const start = async (zcf, privateArgs, baggage) => {
   const bldAmountShape = await E(BLD).getAmountShape();
 
   async function makeLocalAccountKit() {
-    const account = await V(privateArgs.localchain).makeAccount();
-    const address = await V(account).getAddress();
+    const account = await E(privateArgs.localchain).makeAccount();
+    const address = await E(account).getAddress();
     // FIXME 'address' is implied by 'account'; use an async maker that get the value itself
     return makeLocalOrchestrationAccountKit({
       account,
@@ -92,7 +91,7 @@ export const start = async (zcf, privateArgs, baggage) => {
             const { In } = await deeplyFulfilled(
               withdrawFromSeat(zcf, seat, give),
             );
-            await V(holder).deposit(In);
+            await E(holder).deposit(In);
             seat.exit();
             return harden({
               publicSubscribers: holder.getPublicTopics(),

--- a/packages/orchestration/src/examples/stakeIca.contract.js
+++ b/packages/orchestration/src/examples/stakeIca.contract.js
@@ -2,7 +2,7 @@
 
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
 import { TimerServiceShape } from '@agoric/time';
-import { V as E, prepareVowTools } from '@agoric/vow/vat.js';
+import { heapVowE as E, prepareVowTools } from '@agoric/vow/vat.js';
 import {
   prepareRecorderKitMakers,
   provideAll,

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -4,7 +4,7 @@ import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js'
 import { Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M, objectMap } from '@endo/patterns';
-import { when } from '@agoric/vow/vat.js';
+import { heapVowTools } from '@agoric/vow/vat.js';
 import { orcUtils } from '../utils/orc.js';
 import { provideOrchestration } from '../utils/start-helper.js';
 
@@ -97,9 +97,9 @@ export const start = async (zcf, privateArgs, baggage) => {
 
       const [omniAccount, localAccount] = await Promise.all([
         // XXX when() until membrane
-        when(omni.makeAccount()),
+        heapVowTools.when(omni.makeAccount()),
         // XXX when() until membrane
-        when(agoric.makeAccount()),
+        heapVowTools.when(agoric.makeAccount()),
       ]);
 
       const omniAddress = omniAccount.getAddress();

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -1,9 +1,12 @@
 import { VowShape } from '@agoric/vow';
-import { allVows, watch } from '@agoric/vow/vat.js';
+import { heapVowTools } from '@agoric/vow/vat.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { CosmosChainInfoShape, IBCConnectionInfoShape } from '../typeGuards.js';
+
+// FIXME test thoroughly whether heap suffices for ChainHub
+const { allVows, watch } = heapVowTools;
 
 const { Fail } = assert;
 

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -1,5 +1,5 @@
 /** @file ChainAccount exo */
-import { V, heapVowTools } from '@agoric/vow/vat.js';
+import { heapVowE as E, heapVowTools } from '@agoric/vow/vat.js';
 
 import { ChainFacadeI } from '../typeGuards.js';
 
@@ -53,7 +53,7 @@ export const prepareLocalChainFacade = (
       /** @returns {Vow<OrchestrationAccount<ChainInfo>>} */
       makeAccount() {
         const { localChainInfo } = this.state;
-        const lcaP = V(localchain).makeAccount();
+        const lcaP = E(localchain).makeAccount();
         // FIXME use watch() from vowTools
         return heapVowTools.watch(allVows([lcaP, E(lcaP).getAddress()]), {
           onFulfilled: ([lca, address]) => {

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -1,5 +1,5 @@
 /** @file ChainAccount exo */
-import { V, watch } from '@agoric/vow/vat.js';
+import { V, heapVowTools } from '@agoric/vow/vat.js';
 
 import { ChainFacadeI } from '../typeGuards.js';
 
@@ -45,7 +45,7 @@ export const prepareLocalChainFacade = (
     },
     {
       getChainInfo() {
-        return watch(this.state.localChainInfo);
+        return heapVowTools.watch(this.state.localChainInfo);
       },
 
       // FIXME parameterize on the remoteChainInfo to make()
@@ -55,7 +55,7 @@ export const prepareLocalChainFacade = (
         const { localChainInfo } = this.state;
         const lcaP = V(localchain).makeAccount();
         // FIXME use watch() from vowTools
-        return watch(allVows([lcaP, V(lcaP).getAddress()]), {
+        return heapVowTools.watch(allVows([lcaP, E(lcaP).getAddress()]), {
           onFulfilled: ([lca, address]) => {
             const { holder: account } = makeLocalOrchestrationAccountKit({
               account: lca,

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -4,10 +4,9 @@ import { AmountShape, PaymentShape } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 import { M } from '@agoric/vat-data';
 import { VowShape } from '@agoric/vow';
-import { V } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
-import { E } from '@endo/far';
 import {
   ChainAddressShape,
   ChainAmountShape,
@@ -285,7 +284,7 @@ export const prepareLocalOrchestrationAccountKit = (
               ? [/** @type {any} */ (null), denomArg]
               : [denomArg, 'FIXME'];
 
-          const natAmount = await V.when(
+          const natAmount = await E.when(
             E(this.state.account).getBalance(brand),
           );
           return harden({ denom, value: natAmount.value });

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -337,6 +337,7 @@ export const prepareLocalOrchestrationAccountKit = (
             denom: 'ubld',
           };
           const { account: lca } = this.state;
+          /** @type {any} XXX heapVowE */
           const results = E(lca).executeTx([
             typedJson('/cosmos.staking.v1beta1.MsgUndelegate', {
               amount,
@@ -344,7 +345,6 @@ export const prepareLocalOrchestrationAccountKit = (
               delegatorAddress: this.state.address.address,
             }),
           ]);
-          // @ts-expect-error  Type 'JsonSafe<MsgUndelegateResponse & { '@type': "/cosmos.staking.v1beta1.MsgUndelegateResponse"; }>' is not assignable to type 'MsgUndelegateResponse'.
           return when(watch(results, this.facets.undelegateWatcher));
         },
         /**

--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -1,6 +1,6 @@
 /** @file ChainAccount exo */
 import { makeTracer } from '@agoric/internal';
-import { V, watch } from '@agoric/vow/vat.js';
+import { V, heapVowTools } from '@agoric/vow/vat.js';
 
 import { ChainFacadeI } from '../typeGuards.js';
 
@@ -55,7 +55,7 @@ export const prepareRemoteChainFacade = (
     },
     {
       getChainInfo() {
-        return watch(this.state.remoteChainInfo);
+        return heapVowTools.watch(this.state.remoteChainInfo);
       },
 
       // FIXME parameterize on the remoteChainInfo to make()
@@ -76,7 +76,7 @@ export const prepareRemoteChainFacade = (
         );
 
         // FIXME use watch() from vowTools
-        return watch(allVows([icaP, V(icaP).getAddress()]), {
+        return heapVowTools.watch(allVows([icaP, V(icaP).getAddress()]), {
           onFulfilled: ([account, address]) => {
             return makeCosmosOrchestrationAccount(address, stakingDenom, {
               account,

--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -1,6 +1,6 @@
 /** @file ChainAccount exo */
 import { makeTracer } from '@agoric/internal';
-import { V, heapVowTools } from '@agoric/vow/vat.js';
+import { heapVowE as E, heapVowTools } from '@agoric/vow/vat.js';
 
 import { ChainFacadeI } from '../typeGuards.js';
 
@@ -69,14 +69,14 @@ export const prepareRemoteChainFacade = (
           throw Fail`chain info lacks staking denom`;
         }
 
-        const icaP = V(orchestration).makeAccount(
+        const icaP = E(orchestration).makeAccount(
           remoteChainInfo.chainId,
           connectionInfo.id,
           connectionInfo.counterparty.connection_id,
         );
 
         // FIXME use watch() from vowTools
-        return heapVowTools.watch(allVows([icaP, V(icaP).getAddress()]), {
+        return heapVowTools.watch(allVows([icaP, E(icaP).getAddress()]), {
           onFulfilled: ([account, address]) => {
             return makeCosmosOrchestrationAccount(address, stakingDenom, {
               account,

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -1,7 +1,6 @@
 import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { E } from '@endo/far';
-import { V } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { makeChainHub } from '../exos/chain-hub.js';
 
 /**
@@ -47,7 +46,7 @@ export const startStakeAtom = async ({
 
   const chainHub = makeChainHub(await agoricNames);
 
-  const [_, cosmoshub, connectionInfo] = await V.when(
+  const [_, cosmoshub, connectionInfo] = await E.when(
     chainHub.getChainsAndConnection('agoric', 'cosmoshub'),
   );
 

--- a/packages/orchestration/src/proposals/start-stakeOsmo.js
+++ b/packages/orchestration/src/proposals/start-stakeOsmo.js
@@ -1,7 +1,6 @@
 import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { V } from '@agoric/vow/vat.js';
-import { E } from '@endo/far';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { makeChainHub } from '../exos/chain-hub.js';
 
 /**
@@ -48,7 +47,7 @@ export const startStakeOsmo = async ({
 
   const chainHub = makeChainHub(await agoricNames);
 
-  const [_, osmosis, connectionInfo] = await V.when(
+  const [_, osmosis, connectionInfo] = await E.when(
     chainHub.getChainsAndConnection('agoric', 'osmosis'),
   );
 

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -2,9 +2,8 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { V } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E } from '@endo/far';
 import path from 'path';
 import { commonSetup } from '../supports.js';
 
@@ -54,7 +53,7 @@ test('makeAccount, deposit, withdraw', async t => {
   t.truthy(account, 'account is returned');
 
   t.log('deposit 100 bld to account');
-  const depositResp = await V(account).deposit(
+  const depositResp = await E(account).deposit(
     await utils.pourPayment(bld.units(100)),
   );
   // FIXME #9211
@@ -63,7 +62,7 @@ test('makeAccount, deposit, withdraw', async t => {
   await eventLoopIteration();
 
   t.log('withdraw bld from account');
-  const withdrawResp = await V(account).withdraw(bld.units(100));
+  const withdrawResp = await E(account).withdraw(bld.units(100));
   const withdrawAmt = await bld.issuer.getAmountOf(withdrawResp);
   t.true(AmountMath.isEqual(withdrawAmt, bld.units(100)), 'withdraw');
 

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -2,7 +2,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { makeNameHubKit } from '@agoric/vats';
-import { V } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { makeChainHub } from '../../src/exos/chain-hub.js';
 
 const connection = {
@@ -38,11 +38,11 @@ test('getConnectionInfo', async t => {
 
   // Look up by string or info object
   t.deepEqual(
-    await V.when(chainHub.getConnectionInfo(aChain.chainId, bChain.chainId)),
+    await E.when(chainHub.getConnectionInfo(aChain.chainId, bChain.chainId)),
     connection,
   );
   t.deepEqual(
-    await V.when(chainHub.getConnectionInfo(aChain, bChain)),
+    await E.when(chainHub.getConnectionInfo(aChain, bChain)),
     connection,
   );
 });

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -2,7 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { V as E } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { Far } from '@endo/far';
 import { prepareLocalOrchestrationAccountKit } from '../../src/exos/local-orchestration-account.js';

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -1,6 +1,6 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { V } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import type { CosmosChainInfo, IBCConnectionInfo } from '../src/cosmos-api.js';
 import type { Chain } from '../src/orchestration-api.js';
@@ -74,7 +74,7 @@ test('chain info', async t => {
   });
 
   const result = (await handle()) as Chain<any>;
-  t.deepEqual(await V.when(result.getChainInfo()), mockChainInfo);
+  t.deepEqual(await E.when(result.getChainInfo()), mockChainInfo);
 });
 
 test.todo('contract upgrade');

--- a/packages/vats/src/proposals/localchain-test.js
+++ b/packages/vats/src/proposals/localchain-test.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { V as E } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import { typedJson } from '@agoric/cosmic-proto/vatsafe';
 
 /**

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -9,7 +9,9 @@ import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 // Heap-based vow resolution is used for this module because the
 // bootstrap vat can't yet be upgraded.
-import { when } from '@agoric/vow/vat.js';
+import { heapVowTools } from '@agoric/vow/vat.js';
+
+const { when } = heapVowTools;
 
 /**
  * @import {ProtocolHandler} from '@agoric/network';

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -2,7 +2,7 @@
 
 import { isPromise } from '@endo/promise-kit';
 import { Far } from '@endo/far';
-import { V as E } from '@agoric/vow/vat.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
 import * as vowExports from '@agoric/vow/vat.js';
 import * as farExports from '@endo/far';
 

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -8,7 +8,7 @@ import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { getInterfaceOf } from '@endo/marshal';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal';
-import { prepareVowTools, V as E } from '@agoric/vow/vat.js';
+import { prepareVowTools, heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareLocalChainTools } from '../src/localchain.js';
 import { prepareBridgeTargetModule } from '../src/bridge-target.js';
 import { prepareTransferTools } from '../src/transfer.js';

--- a/packages/vow/test/vat.test.js
+++ b/packages/vow/test/vat.test.js
@@ -2,7 +2,9 @@
 import test from 'ava';
 import { E, Far } from '@endo/far';
 
-import { V, makeVowKit } from '../vat.js';
+import { V, heapVowTools } from '../vat.js';
+
+const { makeVowKit } = heapVowTools;
 
 test('heap messages', async t => {
   const greeter = Far('Greeter', {

--- a/packages/vow/test/vat.test.js
+++ b/packages/vow/test/vat.test.js
@@ -2,7 +2,7 @@
 import test from 'ava';
 import { E, Far } from '@endo/far';
 
-import { V, heapVowTools } from '../vat.js';
+import { heapVowE, heapVowTools } from '../vat.js';
 
 const { makeVowKit } = heapVowTools;
 
@@ -13,7 +13,7 @@ test('heap messages', async t => {
 
   /** @type {ReturnType<typeof makeVowKit<typeof greeter>>} */
   const { vow, resolver } = makeVowKit();
-  const retP = V(vow).hello('World');
+  const retP = heapVowE(vow).hello('World');
   resolver.resolve(greeter);
 
   // Happy path: WE(vow)[method](...args) calls the method.
@@ -29,10 +29,10 @@ test('heap messages', async t => {
   );
 
   // Happy path: await WE.when unwraps the vow.
-  t.is(await V.when(vow), greeter);
+  t.is(await heapVowE.when(vow), greeter);
 
   t.is(
-    await V.when(vow, res => {
+    await heapVowE.when(vow, res => {
       t.is(res, greeter);
       return 'done';
     }),

--- a/packages/vow/vat.js
+++ b/packages/vow/vat.js
@@ -1,3 +1,8 @@
+/**
+ * @file specialization of the `@agoric/vow` package for the vat disconnection rejections produced by
+ * the SwingSet kernel.
+ */
+
 /* global globalThis */
 // @ts-check
 import { isUpgradeDisconnection } from '@agoric/internal/src/upgrade-api.js';
@@ -21,11 +26,17 @@ export const defaultPowers = harden({
 });
 
 /**
+ * Produce SwingSet-compatible vowTools, with an arbitrary Zone type
+ *
  * @type {typeof rawPrepareVowTools}
  */
 export const prepareVowTools = (zone, powers = {}) =>
   rawPrepareVowTools(zone, { ...defaultPowers, ...powers });
 
+/**
+ * `vowTools` that are not durable, but are useful in non-durable clients that
+ * need to consume vows from other SwingSet vats.
+ */
 export const heapVowTools = prepareVowTools(makeHeapZone());
 
 /**

--- a/packages/vow/vat.js
+++ b/packages/vow/vat.js
@@ -40,12 +40,17 @@ export const prepareVowTools = (zone, powers = {}) =>
 export const heapVowTools = prepareVowTools(makeHeapZone());
 
 /**
- * A vow-shortening E.  CAVEAT: This produces long-lived ephemeral
- * promises that encapsulate the shortening behaviour, and so provides no way
- * for `watch` to durably shorten.  Use the standard `import('@endo/far').E` if
- * you need to `watch` its resulting promises.
+ * A vow-shortening E, for use in vats that are not durable but receive vows.
+ *
+ * When the vows must be watched durably, use vowTools prepared in a durable zone.
+ *
+ * This produces long-lived ephemeral promises that encapsulate the shortening
+ * behaviour, and so provides no way for `watch` to durably shorten. Use the
+ * standard `import('@endo/far').E` if you need to `watch` its resulting
+ * promises.
  */
-export const V = makeE(globalThis.HandledPromise, {
+export const heapVowE = makeE(globalThis.HandledPromise, {
   unwrap: heapVowTools.when,
   additional: { when: heapVowTools.when },
 });
+export const V = heapVowE;

--- a/packages/vow/vat.js
+++ b/packages/vow/vat.js
@@ -53,4 +53,3 @@ export const heapVowE = makeE(globalThis.HandledPromise, {
   unwrap: heapVowTools.when,
   additional: { when: heapVowTools.when },
 });
-export const V = heapVowE;

--- a/packages/vow/vat.js
+++ b/packages/vow/vat.js
@@ -26,8 +26,7 @@ export const defaultPowers = harden({
 export const prepareVowTools = (zone, powers = {}) =>
   rawPrepareVowTools(zone, { ...defaultPowers, ...powers });
 
-export const vowTools = prepareVowTools(makeHeapZone());
-export const { watch, when, makeVowKit, allVows } = vowTools;
+export const heapVowTools = prepareVowTools(makeHeapZone());
 
 /**
  * A vow-shortening E.  CAVEAT: This produces long-lived ephemeral
@@ -36,6 +35,6 @@ export const { watch, when, makeVowKit, allVows } = vowTools;
  * you need to `watch` its resulting promises.
  */
 export const V = makeE(globalThis.HandledPromise, {
-  unwrap: when,
-  additional: { when },
+  unwrap: heapVowTools.when,
+  additional: { when: heapVowTools.when },
 });


### PR DESCRIPTION
refs: #9449

## Description

It was a surprise to me that the `when` from `@agoric/vow/vat.js` was heap-only. It makes sense when thinking about it, but nothing about the import triggered that thinking.

This exports `heapVowTools` to make that explicit. The consumer destructures from it what they need.

### Security Considerations
none
### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
not yet deployed, TMK
