### PR TITLE
retry flaky agoric-cli integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,7 +90,14 @@ jobs:
           REGISTRY_PUBLISH_WORKSPACES="$HOME/endo" scripts/registry.sh bg-publish ${{ matrix.cli }}
 
       - name: run agoric-cli integration-test
-        run: scripts/registry.sh test ${{ matrix.cli }} ${{steps.get-branch.outputs.result}}
+        # These integration tests can be flaky so retry automatically
+        uses: nick-fields/retry@v3
+        with:
+          # This step usually takes <4 minutes (after 6m setup). The
+          # deployment-test running in parallel takes 35 minutes so 20 minutes
+          # won't increase the time for this workflow to complete.
+          timeout_minutes: 20
+          command: scripts/registry.sh test ${{ matrix.cli }} ${{steps.get-branch.outputs.result}}
 
       - name: notify on failure
         if: >


### PR DESCRIPTION
closes: #9325


## Description

Auto-retry the flaky test.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
The problem it's fixing is intermittent. If it passes CI once, let's let it in and see over the following days whether CI failure is down. (And reopen the issue that landing this closes)

### Upgrade Considerations
none
