### PR TITLE
fix(vow): handle resolution loops in vows

### DIFF
--- a/packages/vow/src/watch.js
+++ b/packages/vow/src/watch.js
@@ -65,8 +65,23 @@ const settle = (resolver, watcher, wcb, value, watcherArgs = []) => {
  * @param {IsRetryableReason} isRetryableReason
  * @param {ReturnType<typeof makeWatchNextStep>} watchNextStep
  */
-const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
-  zone.exoClass(
+const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) => {
+  // We use an ephemeral WeakSet for the previously seen vows in a watch operation
+  // While watch is durable, it suffices to detect the cycle in a single incarnation
+  /** @type {WeakMap<PromiseWatcher, WeakSet<any>>} */
+  const watcherSeenPayloads = new WeakMap();
+
+  /** @param {PromiseWatcher} watcher */
+  const getSeenPayloads = watcher => {
+    let seenPayloads = watcherSeenPayloads.get(watcher);
+    if (!seenPayloads) {
+      seenPayloads = new WeakSet();
+      watcherSeenPayloads.set(watcher, seenPayloads);
+    }
+    return seenPayloads;
+  };
+
+  return zone.exoClass(
     'PromiseWatcher',
     PromiseWatcherI,
     /**
@@ -81,7 +96,6 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
       const state = {
         vow: /** @type {unknown} */ (undefined),
         priorRetryValue: /** @type {any} */ (undefined),
-        seenPayloads: zone.detached().weakSetStore('seenPayloads'),
         resolver,
         watcher,
         watcherArgs: harden(watcherArgs),
@@ -91,19 +105,21 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
     {
       /** @type {Required<PromiseWatcher>['onFulfilled']} */
       onFulfilled(value) {
-        const { watcher, watcherArgs, resolver, seenPayloads } = this.state;
+        const { watcher, watcherArgs, resolver } = this.state;
         const payload = getVowPayload(value);
         if (payload) {
+          const seenPayloads = getSeenPayloads(this.self);
           // TODO: rely on endowed helper to get storable cap from payload
-          if (seenPayloads?.has(payload.vowV0)) {
+          if (seenPayloads.has(payload.vowV0)) {
             return this.self.onRejected(Error('Vow resolution cycle detected'));
           }
-          seenPayloads?.add(payload.vowV0);
+          seenPayloads.add(payload.vowV0);
           // We've been shortened, so reflect our state accordingly, and go again.
           this.state.vow = value;
           watchNextStep(value, this.self);
           return;
         }
+        watcherSeenPayloads.delete(this.self);
         this.state.priorRetryValue = undefined;
         this.state.watcher = undefined;
         this.state.resolver = undefined;
@@ -122,6 +138,7 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
             return;
           }
         }
+        watcherSeenPayloads.delete(this.self);
         this.state.priorRetryValue = undefined;
         this.state.resolver = undefined;
         this.state.watcher = undefined;
@@ -129,6 +146,7 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
       },
     },
   );
+};
 
 /**
  * @param {Zone} zone

--- a/packages/vow/src/watch.js
+++ b/packages/vow/src/watch.js
@@ -94,6 +94,7 @@ const preparePromiseWatcher = (zone, isRetryableReason, watchNextStep) =>
         const { watcher, watcherArgs, resolver, seenPayloads } = this.state;
         const payload = getVowPayload(value);
         if (payload) {
+          // TODO: rely on endowed helper to get storable cap from payload
           if (seenPayloads?.has(payload.vowV0)) {
             return this.self.onRejected(Error('Vow resolution cycle detected'));
           }

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -30,6 +30,8 @@ export const makeWhen = (
     let priorRetryValue;
     const seenPayloads = new WeakSet();
     while (payload) {
+      // TODO: rely on endowed helpers for getting storable cap and performing
+      // shorten "next step"
       const { vowV0 } = payload;
       if (seenPayloads.has(vowV0)) {
         throw Error('Vow resolution cycle detected');

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -28,8 +28,14 @@ export const makeWhen = (
     let result = await specimenP;
     let payload = getVowPayload(result);
     let priorRetryValue;
+    const seenPayloads = new WeakSet();
     while (payload) {
-      result = await basicE(payload.vowV0)
+      const { vowV0 } = payload;
+      if (seenPayloads.has(vowV0)) {
+        throw Error('Vow resolution cycle detected');
+      }
+      seenPayloads.add(vowV0);
+      result = await basicE(vowV0)
         .shorten()
         .then(
           res => {

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -34,11 +34,11 @@ export const makeWhen = (
       if (seenPayloads.has(vowV0)) {
         throw Error('Vow resolution cycle detected');
       }
-      seenPayloads.add(vowV0);
       result = await basicE(vowV0)
         .shorten()
         .then(
           res => {
+            seenPayloads.add(vowV0);
             priorRetryValue = undefined;
             return res;
           },


### PR DESCRIPTION
closes: #9560

## Description
Add a weak set of previously seen vowV0 payloads when shortening during `watch` or `when`

### Security Considerations
None

### Scaling Considerations
Potential churn in storage just for shortening loop detection. Every `watch` will cause a new WeakSetStore to be allocated.

### Documentation Considerations
None

### Testing Considerations
New unit tests

### Upgrade Considerations
To avoid state migration concerns, this needs to be deployed before we start using `watch` more broadly.
