### PR TITLE
Support for `snapshots export` command

### DIFF
--- a/a3p-integration/.yarn/patches/@agoric-synthetic-chain-npm-0.1.0-148de716a6.patch
+++ b/a3p-integration/.yarn/patches/@agoric-synthetic-chain-npm-0.1.0-148de716a6.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/upgrade-test-scripts/env_setup.sh b/dist/upgrade-test-scripts/env_setup.sh
+index 617a0fbe7efdfa457e28fc52806dba1b323930d8..25f52a6cf133dca830bd0dcd47c91700e6a8effe 100755
+--- a/dist/upgrade-test-scripts/env_setup.sh
++++ b/dist/upgrade-test-scripts/env_setup.sh
+@@ -100,7 +100,7 @@ killAgd() {
+   AGD_PID=$(cat $HOME/.agoric/agd.pid)
+   kill $AGD_PID
+   rm $HOME/.agoric/agd.pid
+-  wait $AGD_PID || true
++  tail --pid=$AGD_PID -f /dev/null || true
+ }
+ 
+ provisionSmartWallet() {

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -12,7 +12,7 @@
     "doctor": "yarn synthetic-chain doctor"
   },
   "dependencies": {
-    "@agoric/synthetic-chain": "^0.1.0",
+    "@agoric/synthetic-chain": "patch:@agoric/synthetic-chain@npm%3A0.1.0#~/.yarn/patches/@agoric-synthetic-chain-npm-0.1.0-148de716a6.patch",
     "@types/better-sqlite3": "^7.6.9"
   },
   "packageManager": "yarn@4.2.2",

--- a/a3p-integration/proposals/z:acceptance/state-sync-snapshots-test.sh
+++ b/a3p-integration/proposals/z:acceptance/state-sync-snapshots-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source /usr/src/upgrade-test-scripts/env_setup.sh
+
+set -e
+
+killAgd
+agd snapshots export
+SNAPSHOT_DETAILS=$(agd snapshots list | head -n1 | sed -E 's/height: ([0-9]+) format: ([0-9]+) chunks: [0-9]+/\1 \2/')
+echo found snapshot $SNAPSHOT_DETAILS
+rm -rf /root/.agoric/data/application.db /root/.agoric/data/agoric
+agd snapshots restore $SNAPSHOT_DETAILS
+
+startAgd

--- a/a3p-integration/proposals/z:acceptance/test.sh
+++ b/a3p-integration/proposals/z:acceptance/test.sh
@@ -11,3 +11,5 @@ GLOBIGNORE=initial.test.js
 yarn ava ./*.test.js
 
 ./create-kread-item-test.sh
+
+./state-sync-snapshots-test.sh

--- a/a3p-integration/yarn.lock
+++ b/a3p-integration/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@agoric/synthetic-chain@npm:^0.1.0":
+"@agoric/synthetic-chain@npm:0.1.0":
   version: 0.1.0
   resolution: "@agoric/synthetic-chain@npm:0.1.0"
   dependencies:
@@ -16,6 +16,20 @@ __metadata:
   bin:
     synthetic-chain: dist/cli/cli.js
   checksum: 10c0/8305293d085cde9cbf94670134216e06337c5624c45faf5dfebb86762042abe7b4340cf3205e671dfce54e888bd4e9b3428400756833fa06f2bbb21b44668c44
+  languageName: node
+  linkType: hard
+
+"@agoric/synthetic-chain@patch:@agoric/synthetic-chain@npm%3A0.1.0#~/.yarn/patches/@agoric-synthetic-chain-npm-0.1.0-148de716a6.patch":
+  version: 0.1.0
+  resolution: "@agoric/synthetic-chain@patch:@agoric/synthetic-chain@npm%3A0.1.0#~/.yarn/patches/@agoric-synthetic-chain-npm-0.1.0-148de716a6.patch::version=0.1.0&hash=4a65eb"
+  dependencies:
+    "@endo/zip": "npm:^1.0.1"
+    better-sqlite3: "npm:^9.4.0"
+    chalk: "npm:^5.3.0"
+    execa: "npm:^8.0.1"
+  bin:
+    synthetic-chain: dist/cli/cli.js
+  checksum: 10c0/e974038161b1a9570912a02d9366c6680bc13ee3dfd0e49d06e5ce5e93dbcddf04d1d4cd453af0969bf29ccfe96ce3e141a214539722449add90b13f0785f1f7
   languageName: node
   linkType: hard
 
@@ -990,7 +1004,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@agoric/synthetic-chain": "npm:^0.1.0"
+    "@agoric/synthetic-chain": "patch:@agoric/synthetic-chain@npm%3A0.1.0#~/.yarn/patches/@agoric-synthetic-chain-npm-0.1.0-148de716a6.patch"
     "@types/better-sqlite3": "npm:^7.6.9"
   languageName: unknown
   linkType: soft

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -8,7 +8,6 @@ import (
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/debug"
@@ -19,9 +18,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	"github.com/cosmos/cosmos-sdk/snapshots"
-	snapshottypes "github.com/cosmos/cosmos-sdk/snapshots/types"
-	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -264,20 +260,11 @@ func (ac appCreator) newApp(
 		}
 	}
 
-	var cache sdk.MultiStorePersistentCache
-
-	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
-		cache = store.NewCommitKVStoreCacheManager()
-	}
+	baseappOptions := server.DefaultBaseappOptions(appOpts)
 
 	skipUpgradeHeights := make(map[int64]bool)
 	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {
 		skipUpgradeHeights[int64(h)] = true
-	}
-
-	pruningOpts, err := server.GetPruningOptionsFromFlags(appOpts)
-	if err != nil {
-		panic(err)
 	}
 
 	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
@@ -289,20 +276,6 @@ func (ac appCreator) newApp(
 		viper.Set(gaia.FlagSwingStoreExportDir, filepath.Join(homePath, "config", ExportedSwingStoreDirectoryName))
 	}
 
-	snapshotDir := filepath.Join(homePath, "data", "snapshots")
-	snapshotDB, err := dbm.NewDB("metadata", dbm.GoLevelDBBackend, snapshotDir)
-	if err != nil {
-		panic(err)
-	}
-	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
-	if err != nil {
-		panic(err)
-	}
-	snapshotOptions := snapshottypes.NewSnapshotOptions(
-		cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval)),
-		cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent)),
-	)
-
 	return gaia.NewAgoricApp(
 		ac.sender, ac.agdServer,
 		logger, db, traceStore, true, skipUpgradeHeights,
@@ -310,18 +283,7 @@ func (ac appCreator) newApp(
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
 		ac.encCfg,
 		appOpts,
-		baseapp.SetPruning(pruningOpts),
-		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(server.FlagMinGasPrices))),
-		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),
-		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(server.FlagHaltTime))),
-		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
-		baseapp.SetInterBlockCache(cache),
-		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
-		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
-		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
-		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
-		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagDisableIAVLFastNode))),
-		baseapp.SetIAVLLazyLoading(cast.ToBool(appOpts.Get(server.FlagIAVLLazyLoading))),
+		baseappOptions...,
 	)
 }
 

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -145,9 +145,19 @@ func initRootCmd(sender vm.Sender, rootCmd *cobra.Command, encodingConfig params
 	server.AddCommands(rootCmd, gaia.DefaultNodeHome, ac.newApp, ac.appExport, addModuleInitFlags)
 
 	for _, command := range rootCmd.Commands() {
-		if command.Name() == "export" {
+		switch command.Name() {
+		case "export":
+			addAgoricVMFlags(command)
 			extendCosmosExportCommand(command)
-			break
+		case "snapshots":
+			for _, subCommand := range command.Commands() {
+				switch subCommand.Name() {
+				case "restore":
+					addAgoricVMFlags(subCommand)
+				case "export":
+					addAgoricVMFlags(subCommand)
+				}
+			}
 		}
 	}
 
@@ -331,7 +341,6 @@ const (
 // cosmos-sdk to add a required "export-dir" command-line flag, and create the
 // genesis export in the specified directory if the VM is running.
 func extendCosmosExportCommand(cmd *cobra.Command) {
-	addAgoricVMFlags(cmd)
 	cmd.Flags().String(FlagExportDir, "", "The directory where to create the genesis export")
 	err := cmd.MarkFlagRequired(FlagExportDir)
 	if err != nil {


### PR DESCRIPTION
closes: #9100 
closes: #9425

## Description
Until we have better layering of the snapshots extensions in cosmos-sdk, this replaces the implementation of the `snapshots export` command to initiate the snapshot creation through our front-running mechanism used for state-sync.

Drive-by cleanup of the root command as well to address #9425

### Security Considerations
None,

### Scaling Considerations
None

### Documentation Considerations
Communicate to validators that we fixed the command and that it's usable as expected with any cosmos chain.

### Testing Considerations
Added an integration test since this only modifies the command line handling

Manually tested with the following
```
cd packages/cosmic-swingset
make scenario2-setup
make scenario2-run-chain
# wait until there are blocks, then kill
agd --home t1/n0 snapshots export
rm -rf t1/n0/data/application.db t1/n0/data/agoric
# the above removes app state without removing cometbft state as that cannot
# be restored easily in a single node chain
agd --home t1/n0 snapshot restore $snapshot_height 2
make scenario2-run-chain
# verify blocks are being produced
```

### Upgrade Considerations
Since we replace the upstream sdk command handling, any future changes upstream would have to be reflected in the override.
