### PR TITLE
fix(bn-patch): fix bad html evasion

### DIFF
--- a/patches/bn.js+5.2.0.patch
+++ b/patches/bn.js+5.2.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/bn.js/lib/bn.js b/node_modules/bn.js/lib/bn.js
-index c9773da..46f3dcd 100644
+index c9773da..0045880 100644
 --- a/node_modules/bn.js/lib/bn.js
 +++ b/node_modules/bn.js/lib/bn.js
 @@ -2632,7 +2632,7 @@
@@ -7,7 +7,7 @@ index c9773da..46f3dcd 100644
        if (i > 0) {
          x.iushrn(i);
 -        while (i-- > 0) {
-+        while (i--, i > 0) {
++        while ([i--][0] > 0) {
            if (A.isOdd() || B.isOdd()) {
              A.iadd(yp);
              B.isub(xp);
@@ -16,7 +16,7 @@ index c9773da..46f3dcd 100644
        if (j > 0) {
          y.iushrn(j);
 -        while (j-- > 0) {
-+        while (j--, j > 0) {
++        while ([j--][0] > 0) {
            if (C.isOdd() || D.isOdd()) {
              C.iadd(yp);
              D.isub(xp);
@@ -25,7 +25,7 @@ index c9773da..46f3dcd 100644
        if (i > 0) {
          a.iushrn(i);
 -        while (i-- > 0) {
-+        while (i--, i > 0) {
++        while ([i--][0] > 0) {
            if (x1.isOdd()) {
              x1.iadd(delta);
            }
@@ -34,7 +34,7 @@ index c9773da..46f3dcd 100644
        if (j > 0) {
          b.iushrn(j);
 -        while (j-- > 0) {
-+        while (j--, j > 0) {
++        while ([j--][0] > 0) {
            if (x2.isOdd()) {
              x2.iadd(delta);
            }


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/endojs/endo/issues/1837 https://github.com/Agoric/agoric-sdk/commit/7accc0286007216d55642056152f3be2a0ba3671 https://github.com/Agoric/agoric-sdk/pull/9112 https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md

## Description

A patch introduced in at https://github.com/Agoric/agoric-sdk/commit/7accc0286007216d55642056152f3be2a0ba3671 in #9112 patched https://www.npmjs.com/package/bn.js/v/5.1.2 to work around the bug explained at https://github.com/endojs/endo/issues/1837 . However, the fix followed the advice at https://github.com/endojs/endo/issues/1837#issuecomment-2136033372 , which is wrong for the reasons explained at https://github.com/endojs/endo/issues/1837#issuecomment-2136252916 .
- wrong: rewrite `x-- > y` as `(x--, x > y)`

This PR fixes that mistake by instead using the technique @gibson042 suggests at https://github.com/endojs/endo/issues/1837#issuecomment-2136074644
- correct: rewrite `x-- > y` as `[x--][0] > y`

### Security Considerations
fixes an integrity bug. I have no idea how significant this bug was.
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
none
### Upgrade Considerations
Well, it is a change. But I have no idea what the patched library was used for, so cannot evaluate.