### PR TITLE
feat(vats): support ORACLE_ADDRESSES from environment

### DIFF
--- a/packages/builders/scripts/vats/priceFeedSupport.js
+++ b/packages/builders/scripts/vats/priceFeedSupport.js
@@ -2,10 +2,13 @@
 
 import { DEFAULT_CONTRACT_TERMS } from '../inter-protocol/price-feed-core.js';
 
-const ORACLE_ADDRESSES = [
+const DEFAULT_ORACLE_ADDRESSES = [
   // XXX These are the oracle addresses. They must be provided before the chain
   // is running, which means they must be known ahead of time.
   // see https://github.com/Agoric/agoric-3-proposals/issues/5
+
+  // XXX really? one of the times we seem to be running this code is
+  // well after the chain has started.
   'agoric1lu9hh5vgx05hmlpfu47hukershgdxctk6l5s05',
   'agoric15lpnq2mjsdhtztf6khp7mrsq66hyrssspy92pd',
   'agoric1mwm224epc4l3pjcz7qsxnudcuktpynwkmnfqfp',
@@ -26,12 +29,14 @@ export const priceFeedProposalBuilder = async (
     IN_BRAND_NAME = IN_BRAND_LOOKUP[IN_BRAND_LOOKUP.length - 1],
   } = options;
 
-  const { GOV1ADDR, GOV2ADDR, GOV3ADDR } = process.env;
+  const { GOV1ADDR, GOV2ADDR, GOV3ADDR, ORACLE_ADDRESSES } = process.env;
   const oracleAddresses =
+    // eslint-disable-next-line no-nested-ternary
     GOV1ADDR || GOV2ADDR || GOV3ADDR
       ? [GOV1ADDR, GOV2ADDR, GOV3ADDR].filter(x => x)
-      : ORACLE_ADDRESSES;
-  assert(Array.isArray(oracleAddresses), 'oracleAddresses array is required');
+      : ORACLE_ADDRESSES
+        ? ORACLE_ADDRESSES.split(',')
+        : DEFAULT_ORACLE_ADDRESSES;
 
   assert(AGORIC_INSTANCE_NAME, 'AGORIC_INSTANCE_NAME is required');
 


### PR DESCRIPTION
refs: #9044
refs: https://github.com/Agoric/agoric-sdk/issues/8400
refs: https://github.com/Agoric/agoric-sdk/issues/8740

## Description

#9044 supports getting GOV{1,2,3} addresses from the environment, but not the entire ORACLE_ADDRESSES list.
devnet / emerynet / mainnet usage requires specifying a list of more than 3 oracle operator addresses.

### Security Considerations

The environment in which the proposal builder is run has to be carefully controlled.

### Scaling Considerations

n/a

### Documentation Considerations

A comment in `priceFeedSupport.js` didn't seem right. Rather than delete it, I added another one. This should be cleaned up in due course.

Also, we should

 - [ ] confirm that operational stuff around this code is sufficiently documented

### Testing Considerations

I presume manual integration testing suffices.

### Upgrade Considerations

No _additional_ upgrade considerations.

