### PR TITLE
feat: vat-safe denomHash using noble sha256

### DIFF
--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -50,13 +50,16 @@
     "@endo/errors": "^1.2.2",
     "@endo/far": "^1.1.2",
     "@endo/marshal": "^1.5.0",
-    "@endo/patterns": "^1.4.0"
+    "@endo/patterns": "^1.4.0",
+    "@noble/hashes": "^1.4.0"
   },
   "devDependencies": {
     "@agoric/swingset-liveslots": "^0.10.2",
     "@chain-registry/client": "^1.47.4",
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
+    "@endo/bundle-source": "^3.2.3",
+    "@endo/import-bundle": "^1.1.2",
     "@endo/ses-ava": "^1.2.2",
     "ava": "^5.3.1",
     "c8": "^9.1.0",

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -51,7 +51,7 @@
     "@endo/far": "^1.1.2",
     "@endo/marshal": "^1.5.0",
     "@endo/patterns": "^1.4.0",
-    "@noble/hashes": "^1.4.0"
+    "@noble/hashes": "github:paulmillr/noble-hashes#ae060da"
   },
   "devDependencies": {
     "@agoric/swingset-liveslots": "^0.10.2",

--- a/packages/orchestration/src/utils/denomHash.js
+++ b/packages/orchestration/src/utils/denomHash.js
@@ -1,0 +1,22 @@
+// @ts-check
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+
+/**
+ * cf. https://tutorials.cosmos.network/tutorials/6-ibc-dev/
+ *
+ * @param {object} opts
+ * @param {string} [opts.portId]
+ * @param {string} [opts.channelId] required unless `path` is supplied
+ * @param {string} [opts.path] alternative to portId, channelId
+ * @param {string} opts.denom base denom
+ */
+export const denomHash = ({
+  portId = 'transfer',
+  channelId = /** @type {string | undefined} */ (undefined),
+  path = `${portId}/${channelId}`,
+  denom,
+}) => {
+  const h = sha256.create().update(`${path}/${denom}`).digest();
+  return bytesToHex(h).toUpperCase();
+};

--- a/packages/orchestration/test/utils/denomHash.test.ts
+++ b/packages/orchestration/test/utils/denomHash.test.ts
@@ -1,0 +1,18 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import bundleSource from '@endo/bundle-source';
+import { importBundle } from '@endo/import-bundle';
+import { createRequire } from 'node:module';
+import { denomHash } from '../../src/utils/denomHash.js';
+
+const nodeRequire = createRequire(import.meta.url);
+
+test('compartment use of denomHash', async t => {
+  const bundle = await bundleSource(nodeRequire.resolve('./denomHashEx.js'));
+  const { length } = JSON.stringify(bundle);
+  t.log('bundle length', length);
+  const expected = denomHash({ channelId: 'channel-0', denom: 'uatom' });
+
+  const { denomHashExample } = await importBundle(bundle);
+  t.deepEqual(denomHashExample(), expected);
+});

--- a/packages/orchestration/test/utils/denomHashEx.js
+++ b/packages/orchestration/test/utils/denomHashEx.js
@@ -1,0 +1,6 @@
+import { denomHash } from '../../src/utils/denomHash.js';
+
+export const denomHashExample = () => {
+  const h = denomHash({ channelId: 'channel-0', denom: 'uatom' });
+  return h;
+};

--- a/patches/@agoric+orchestration++@noble+hashes+1.4.0.patch
+++ b/patches/@agoric+orchestration++@noble+hashes+1.4.0.patch
@@ -1,0 +1,9910 @@
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.d.ts
+new file mode 100644
+index 0000000..f66656f
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.d.ts
+@@ -0,0 +1,24 @@
++declare function number(n: number): void;
++declare function bool(b: boolean): void;
++export declare function isBytes(a: unknown): a is Uint8Array;
++declare function bytes(b: Uint8Array | undefined, ...lengths: number[]): void;
++type Hash = {
++    (data: Uint8Array): Uint8Array;
++    blockLen: number;
++    outputLen: number;
++    create: any;
++};
++declare function hash(h: Hash): void;
++declare function exists(instance: any, checkFinished?: boolean): void;
++declare function output(out: any, instance: any): void;
++export { number, bool, bytes, hash, exists, output };
++declare const assert: {
++    number: typeof number;
++    bool: typeof bool;
++    bytes: typeof bytes;
++    hash: typeof hash;
++    exists: typeof exists;
++    output: typeof output;
++};
++export default assert;
++//# sourceMappingURL=_assert.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.d.ts.map
+new file mode 100644
+index 0000000..f3420f1
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_assert.d.ts","sourceRoot":"","sources":["src/_assert.ts"],"names":[],"mappings":"AAAA,iBAAS,MAAM,CAAC,CAAC,EAAE,MAAM,QAExB;AAED,iBAAS,IAAI,CAAC,CAAC,EAAE,OAAO,QAEvB;AAGD,wBAAgB,OAAO,CAAC,CAAC,EAAE,OAAO,GAAG,CAAC,IAAI,UAAU,CAKnD;AAED,iBAAS,KAAK,CAAC,CAAC,EAAE,UAAU,GAAG,SAAS,EAAE,GAAG,OAAO,EAAE,MAAM,EAAE,QAI7D;AAED,KAAK,IAAI,GAAG;IACV,CAAC,IAAI,EAAE,UAAU,GAAG,UAAU,CAAC;IAC/B,QAAQ,EAAE,MAAM,CAAC;IACjB,SAAS,EAAE,MAAM,CAAC;IAClB,MAAM,EAAE,GAAG,CAAC;CACb,CAAC;AACF,iBAAS,IAAI,CAAC,CAAC,EAAE,IAAI,QAKpB;AAED,iBAAS,MAAM,CAAC,QAAQ,EAAE,GAAG,EAAE,aAAa,UAAO,QAGlD;AACD,iBAAS,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,QAAQ,EAAE,GAAG,QAMtC;AAED,OAAO,EAAE,MAAM,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,MAAM,EAAE,MAAM,EAAE,CAAC;AAErD,QAAA,MAAM,MAAM;;;;;;;CAAgD,CAAC;AAC7D,eAAe,MAAM,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.js
+new file mode 100644
+index 0000000..8740278
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.js
+@@ -0,0 +1,50 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.isBytes = isBytes;
++exports.number = number;
++exports.bool = bool;
++exports.bytes = bytes;
++exports.hash = hash;
++exports.exists = exists;
++exports.output = output;
++function number(n) {
++    if (!Number.isSafeInteger(n) || n < 0)
++        throw new Error(`positive integer expected, not ${n}`);
++}
++function bool(b) {
++    if (typeof b !== 'boolean')
++        throw new Error(`boolean expected, not ${b}`);
++}
++// copied from utils
++function isBytes(a) {
++    return (a instanceof Uint8Array ||
++        (a != null && typeof a === 'object' && a.constructor.name === 'Uint8Array'));
++}
++function bytes(b, ...lengths) {
++    if (!isBytes(b))
++        throw new Error('Uint8Array expected');
++    if (lengths.length > 0 && !lengths.includes(b.length))
++        throw new Error(`Uint8Array expected of length ${lengths}, not of length=${b.length}`);
++}
++function hash(h) {
++    if (typeof h !== 'function' || typeof h.create !== 'function')
++        throw new Error('Hash should be wrapped by utils.wrapConstructor');
++    number(h.outputLen);
++    number(h.blockLen);
++}
++function exists(instance, checkFinished = true) {
++    if (instance.destroyed)
++        throw new Error('Hash instance has been destroyed');
++    if (checkFinished && instance.finished)
++        throw new Error('Hash#digest() has already been called');
++}
++function output(out, instance) {
++    bytes(out);
++    const min = instance.outputLen;
++    if (out.length < min) {
++        throw new Error(`digestInto() expects output buffer of length at least ${min}`);
++    }
++}
++const assert = { number, bool, bytes, hash, exists, output };
++exports.default = assert;
++//# sourceMappingURL=_assert.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.js.map
+new file mode 100644
+index 0000000..ac2d77a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_assert.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_assert.js","sourceRoot":"","sources":["src/_assert.ts"],"names":[],"mappings":";;AASA,0BAKC;AAiCQ,wBAAM;AAAE,oBAAI;AAAE,sBAAK;AAAE,oBAAI;AAAE,wBAAM;AAAE,wBAAM;AA/ClD,SAAS,MAAM,CAAC,CAAS;IACvB,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,kCAAkC,CAAC,EAAE,CAAC,CAAC;AAChG,CAAC;AAED,SAAS,IAAI,CAAC,CAAU;IACtB,IAAI,OAAO,CAAC,KAAK,SAAS;QAAE,MAAM,IAAI,KAAK,CAAC,yBAAyB,CAAC,EAAE,CAAC,CAAC;AAC5E,CAAC;AAED,oBAAoB;AACpB,SAAgB,OAAO,CAAC,CAAU;IAChC,OAAO,CACL,CAAC,YAAY,UAAU;QACvB,CAAC,CAAC,IAAI,IAAI,IAAI,OAAO,CAAC,KAAK,QAAQ,IAAI,CAAC,CAAC,WAAW,CAAC,IAAI,KAAK,YAAY,CAAC,CAC5E,CAAC;AACJ,CAAC;AAED,SAAS,KAAK,CAAC,CAAyB,EAAE,GAAG,OAAiB;IAC5D,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,qBAAqB,CAAC,CAAC;IACxD,IAAI,OAAO,CAAC,MAAM,GAAG,CAAC,IAAI,CAAC,OAAO,CAAC,QAAQ,CAAC,CAAC,CAAC,MAAM,CAAC;QACnD,MAAM,IAAI,KAAK,CAAC,iCAAiC,OAAO,mBAAmB,CAAC,CAAC,MAAM,EAAE,CAAC,CAAC;AAC3F,CAAC;AAQD,SAAS,IAAI,CAAC,CAAO;IACnB,IAAI,OAAO,CAAC,KAAK,UAAU,IAAI,OAAO,CAAC,CAAC,MAAM,KAAK,UAAU;QAC3D,MAAM,IAAI,KAAK,CAAC,iDAAiD,CAAC,CAAC;IACrE,MAAM,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC;IACpB,MAAM,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC;AACrB,CAAC;AAED,SAAS,MAAM,CAAC,QAAa,EAAE,aAAa,GAAG,IAAI;IACjD,IAAI,QAAQ,CAAC,SAAS;QAAE,MAAM,IAAI,KAAK,CAAC,kCAAkC,CAAC,CAAC;IAC5E,IAAI,aAAa,IAAI,QAAQ,CAAC,QAAQ;QAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;AACnG,CAAC;AACD,SAAS,MAAM,CAAC,GAAQ,EAAE,QAAa;IACrC,KAAK,CAAC,GAAG,CAAC,CAAC;IACX,MAAM,GAAG,GAAG,QAAQ,CAAC,SAAS,CAAC;IAC/B,IAAI,GAAG,CAAC,MAAM,GAAG,GAAG,EAAE,CAAC;QACrB,MAAM,IAAI,KAAK,CAAC,yDAAyD,GAAG,EAAE,CAAC,CAAC;IAClF,CAAC;AACH,CAAC;AAID,MAAM,MAAM,GAAG,EAAE,MAAM,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,MAAM,EAAE,MAAM,EAAE,CAAC;AAC7D,kBAAe,MAAM,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.d.ts
+new file mode 100644
+index 0000000..ddb3f3a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.d.ts
+@@ -0,0 +1,28 @@
++import { Hash, Input } from './utils.js';
++export declare const SIGMA: Uint8Array;
++export type BlakeOpts = {
++    dkLen?: number;
++    key?: Input;
++    salt?: Input;
++    personalization?: Input;
++};
++export declare abstract class BLAKE<T extends BLAKE<T>> extends Hash<T> {
++    readonly blockLen: number;
++    outputLen: number;
++    protected abstract compress(msg: Uint32Array, offset: number, isLast: boolean): void;
++    protected abstract get(): number[];
++    protected abstract set(...args: number[]): void;
++    abstract destroy(): void;
++    protected buffer: Uint8Array;
++    protected buffer32: Uint32Array;
++    protected length: number;
++    protected pos: number;
++    protected finished: boolean;
++    protected destroyed: boolean;
++    constructor(blockLen: number, outputLen: number, opts: BlakeOpts | undefined, keyLen: number, saltLen: number, persLen: number);
++    update(data: Input): this;
++    digestInto(out: Uint8Array): void;
++    digest(): Uint8Array;
++    _cloneInto(to?: T): T;
++}
++//# sourceMappingURL=_blake.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.d.ts.map
+new file mode 100644
+index 0000000..5227d84
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_blake.d.ts","sourceRoot":"","sources":["src/_blake.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAE,KAAK,EAAgD,MAAM,YAAY,CAAC;AAMvF,eAAO,MAAM,KAAK,YAahB,CAAC;AAEH,MAAM,MAAM,SAAS,GAAG;IACtB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,GAAG,CAAC,EAAE,KAAK,CAAC;IACZ,IAAI,CAAC,EAAE,KAAK,CAAC;IACb,eAAe,CAAC,EAAE,KAAK,CAAC;CACzB,CAAC;AAEF,8BAAsB,KAAK,CAAC,CAAC,SAAS,KAAK,CAAC,CAAC,CAAC,CAAE,SAAQ,IAAI,CAAC,CAAC,CAAC;IAa3D,QAAQ,CAAC,QAAQ,EAAE,MAAM;IAClB,SAAS,EAAE,MAAM;IAb1B,SAAS,CAAC,QAAQ,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,OAAO,GAAG,IAAI;IACpF,SAAS,CAAC,QAAQ,CAAC,GAAG,IAAI,MAAM,EAAE;IAClC,SAAS,CAAC,QAAQ,CAAC,GAAG,CAAC,GAAG,IAAI,EAAE,MAAM,EAAE,GAAG,IAAI;IAC/C,QAAQ,CAAC,OAAO,IAAI,IAAI;IACxB,SAAS,CAAC,MAAM,EAAE,UAAU,CAAC;IAC7B,SAAS,CAAC,QAAQ,EAAE,WAAW,CAAC;IAChC,SAAS,CAAC,MAAM,EAAE,MAAM,CAAK;IAC7B,SAAS,CAAC,GAAG,EAAE,MAAM,CAAK;IAC1B,SAAS,CAAC,QAAQ,UAAS;IAC3B,SAAS,CAAC,SAAS,UAAS;gBAGjB,QAAQ,EAAE,MAAM,EAClB,SAAS,EAAE,MAAM,EACxB,IAAI,EAAE,SAAS,YAAK,EACpB,MAAM,EAAE,MAAM,EACd,OAAO,EAAE,MAAM,EACf,OAAO,EAAE,MAAM;IAejB,MAAM,CAAC,IAAI,EAAE,KAAK;IAuClB,UAAU,CAAC,GAAG,EAAE,UAAU;IAa1B,MAAM;IAON,UAAU,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC;CAYtB"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.js
+new file mode 100644
+index 0000000..1ecb94c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.js
+@@ -0,0 +1,124 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.BLAKE = exports.SIGMA = void 0;
++const _assert_js_1 = require("./_assert.js");
++const utils_js_1 = require("./utils.js");
++// Blake is based on ChaCha permutation.
++// For BLAKE2b, the two extra permutations for rounds 10 and 11 are SIGMA[10..11] = SIGMA[0..1].
++// prettier-ignore
++exports.SIGMA = new Uint8Array([
++    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
++    14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
++    11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4,
++    7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8,
++    9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13,
++    2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9,
++    12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11,
++    13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10,
++    6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5,
++    10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0,
++    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
++    14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
++]);
++class BLAKE extends utils_js_1.Hash {
++    constructor(blockLen, outputLen, opts = {}, keyLen, saltLen, persLen) {
++        super();
++        this.blockLen = blockLen;
++        this.outputLen = outputLen;
++        this.length = 0;
++        this.pos = 0;
++        this.finished = false;
++        this.destroyed = false;
++        (0, _assert_js_1.number)(blockLen);
++        (0, _assert_js_1.number)(outputLen);
++        (0, _assert_js_1.number)(keyLen);
++        if (outputLen < 0 || outputLen > keyLen)
++            throw new Error('outputLen bigger than keyLen');
++        if (opts.key !== undefined && (opts.key.length < 1 || opts.key.length > keyLen))
++            throw new Error(`key must be up 1..${keyLen} byte long or undefined`);
++        if (opts.salt !== undefined && opts.salt.length !== saltLen)
++            throw new Error(`salt must be ${saltLen} byte long or undefined`);
++        if (opts.personalization !== undefined && opts.personalization.length !== persLen)
++            throw new Error(`personalization must be ${persLen} byte long or undefined`);
++        this.buffer32 = (0, utils_js_1.u32)((this.buffer = new Uint8Array(blockLen)));
++    }
++    update(data) {
++        (0, _assert_js_1.exists)(this);
++        // Main difference with other hashes: there is flag for last block,
++        // so we cannot process current block before we know that there
++        // is the next one. This significantly complicates logic and reduces ability
++        // to do zero-copy processing
++        const { blockLen, buffer, buffer32 } = this;
++        data = (0, utils_js_1.toBytes)(data);
++        const len = data.length;
++        const offset = data.byteOffset;
++        const buf = data.buffer;
++        for (let pos = 0; pos < len;) {
++            // If buffer is full and we still have input (don't process last block, same as blake2s)
++            if (this.pos === blockLen) {
++                if (!utils_js_1.isLE)
++                    (0, utils_js_1.byteSwap32)(buffer32);
++                this.compress(buffer32, 0, false);
++                if (!utils_js_1.isLE)
++                    (0, utils_js_1.byteSwap32)(buffer32);
++                this.pos = 0;
++            }
++            const take = Math.min(blockLen - this.pos, len - pos);
++            const dataOffset = offset + pos;
++            // full block && aligned to 4 bytes && not last in input
++            if (take === blockLen && !(dataOffset % 4) && pos + take < len) {
++                const data32 = new Uint32Array(buf, dataOffset, Math.floor((len - pos) / 4));
++                if (!utils_js_1.isLE)
++                    (0, utils_js_1.byteSwap32)(data32);
++                for (let pos32 = 0; pos + blockLen < len; pos32 += buffer32.length, pos += blockLen) {
++                    this.length += blockLen;
++                    this.compress(data32, pos32, false);
++                }
++                if (!utils_js_1.isLE)
++                    (0, utils_js_1.byteSwap32)(data32);
++                continue;
++            }
++            buffer.set(data.subarray(pos, pos + take), this.pos);
++            this.pos += take;
++            this.length += take;
++            pos += take;
++        }
++        return this;
++    }
++    digestInto(out) {
++        (0, _assert_js_1.exists)(this);
++        (0, _assert_js_1.output)(out, this);
++        const { pos, buffer32 } = this;
++        this.finished = true;
++        // Padding
++        this.buffer.subarray(pos).fill(0);
++        if (!utils_js_1.isLE)
++            (0, utils_js_1.byteSwap32)(buffer32);
++        this.compress(buffer32, 0, true);
++        if (!utils_js_1.isLE)
++            (0, utils_js_1.byteSwap32)(buffer32);
++        const out32 = (0, utils_js_1.u32)(out);
++        this.get().forEach((v, i) => (out32[i] = (0, utils_js_1.byteSwapIfBE)(v)));
++    }
++    digest() {
++        const { buffer, outputLen } = this;
++        this.digestInto(buffer);
++        const res = buffer.slice(0, outputLen);
++        this.destroy();
++        return res;
++    }
++    _cloneInto(to) {
++        const { buffer, length, finished, destroyed, outputLen, pos } = this;
++        to || (to = new this.constructor({ dkLen: outputLen }));
++        to.set(...this.get());
++        to.length = length;
++        to.finished = finished;
++        to.destroyed = destroyed;
++        to.outputLen = outputLen;
++        to.buffer.set(buffer);
++        to.pos = pos;
++        return to;
++    }
++}
++exports.BLAKE = BLAKE;
++//# sourceMappingURL=_blake.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.js.map
+new file mode 100644
+index 0000000..38b815b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_blake.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_blake.js","sourceRoot":"","sources":["src/_blake.ts"],"names":[],"mappings":";;;AAAA,6CAAsD;AACtD,yCAAuF;AAEvF,wCAAwC;AAExC,gGAAgG;AAChG,kBAAkB;AACL,QAAA,KAAK,GAAmB,IAAI,UAAU,CAAC;IAClD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE;IACpD,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;IACpD,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;IACpD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC;IACpD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE;IACpD,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC;IACpD,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE;IACpD,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE;IACpD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC;IACpD,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC;IACpD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE;IACpD,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;CACrD,CAAC,CAAC;AASH,MAAsB,KAA0B,SAAQ,eAAO;IAY7D,YACW,QAAgB,EAClB,SAAiB,EACxB,OAAkB,EAAE,EACpB,MAAc,EACd,OAAe,EACf,OAAe;QAEf,KAAK,EAAE,CAAC;QAPC,aAAQ,GAAR,QAAQ,CAAQ;QAClB,cAAS,GAAT,SAAS,CAAQ;QAPhB,WAAM,GAAW,CAAC,CAAC;QACnB,QAAG,GAAW,CAAC,CAAC;QAChB,aAAQ,GAAG,KAAK,CAAC;QACjB,cAAS,GAAG,KAAK,CAAC;QAW1B,IAAA,mBAAM,EAAC,QAAQ,CAAC,CAAC;QACjB,IAAA,mBAAM,EAAC,SAAS,CAAC,CAAC;QAClB,IAAA,mBAAM,EAAC,MAAM,CAAC,CAAC;QACf,IAAI,SAAS,GAAG,CAAC,IAAI,SAAS,GAAG,MAAM;YAAE,MAAM,IAAI,KAAK,CAAC,8BAA8B,CAAC,CAAC;QACzF,IAAI,IAAI,CAAC,GAAG,KAAK,SAAS,IAAI,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,GAAG,CAAC,IAAI,IAAI,CAAC,GAAG,CAAC,MAAM,GAAG,MAAM,CAAC;YAC7E,MAAM,IAAI,KAAK,CAAC,qBAAqB,MAAM,yBAAyB,CAAC,CAAC;QACxE,IAAI,IAAI,CAAC,IAAI,KAAK,SAAS,IAAI,IAAI,CAAC,IAAI,CAAC,MAAM,KAAK,OAAO;YACzD,MAAM,IAAI,KAAK,CAAC,gBAAgB,OAAO,yBAAyB,CAAC,CAAC;QACpE,IAAI,IAAI,CAAC,eAAe,KAAK,SAAS,IAAI,IAAI,CAAC,eAAe,CAAC,MAAM,KAAK,OAAO;YAC/E,MAAM,IAAI,KAAK,CAAC,2BAA2B,OAAO,yBAAyB,CAAC,CAAC;QAC/E,IAAI,CAAC,QAAQ,GAAG,IAAA,cAAG,EAAC,CAAC,IAAI,CAAC,MAAM,GAAG,IAAI,UAAU,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;IAChE,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,IAAA,mBAAM,EAAC,IAAI,CAAC,CAAC;QACb,mEAAmE;QACnE,+DAA+D;QAC/D,4EAA4E;QAC5E,6BAA6B;QAC7B,MAAM,EAAE,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC5C,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;QACrB,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,MAAM,MAAM,GAAG,IAAI,CAAC,UAAU,CAAC;QAC/B,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAC9B,wFAAwF;YACxF,IAAI,IAAI,CAAC,GAAG,KAAK,QAAQ,EAAE,CAAC;gBAC1B,IAAI,CAAC,eAAI;oBAAE,IAAA,qBAAU,EAAC,QAAQ,CAAC,CAAC;gBAChC,IAAI,CAAC,QAAQ,CAAC,QAAQ,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;gBAClC,IAAI,CAAC,eAAI;oBAAE,IAAA,qBAAU,EAAC,QAAQ,CAAC,CAAC;gBAChC,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;YACf,CAAC;YACD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACtD,MAAM,UAAU,GAAG,MAAM,GAAG,GAAG,CAAC;YAChC,wDAAwD;YACxD,IAAI,IAAI,KAAK,QAAQ,IAAI,CAAC,CAAC,UAAU,GAAG,CAAC,CAAC,IAAI,GAAG,GAAG,IAAI,GAAG,GAAG,EAAE,CAAC;gBAC/D,MAAM,MAAM,GAAG,IAAI,WAAW,CAAC,GAAG,EAAE,UAAU,EAAE,IAAI,CAAC,KAAK,CAAC,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;gBAC7E,IAAI,CAAC,eAAI;oBAAE,IAAA,qBAAU,EAAC,MAAM,CAAC,CAAC;gBAC9B,KAAK,IAAI,KAAK,GAAG,CAAC,EAAE,GAAG,GAAG,QAAQ,GAAG,GAAG,EAAE,KAAK,IAAI,QAAQ,CAAC,MAAM,EAAE,GAAG,IAAI,QAAQ,EAAE,CAAC;oBACpF,IAAI,CAAC,MAAM,IAAI,QAAQ,CAAC;oBACxB,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,KAAK,EAAE,KAAK,CAAC,CAAC;gBACtC,CAAC;gBACD,IAAI,CAAC,eAAI;oBAAE,IAAA,qBAAU,EAAC,MAAM,CAAC,CAAC;gBAC9B,SAAS;YACX,CAAC;YACD,MAAM,CAAC,GAAG,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,IAAI,CAAC,GAAG,CAAC,CAAC;YACrD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC;YACjB,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC;YACpB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,IAAI,CAAC;IACd,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,IAAA,mBAAM,EAAC,IAAI,CAAC,CAAC;QACb,IAAA,mBAAM,EAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,MAAM,EAAE,GAAG,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC/B,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,UAAU;QACV,IAAI,CAAC,MAAM,CAAC,QAAQ,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QAClC,IAAI,CAAC,eAAI;YAAE,IAAA,qBAAU,EAAC,QAAQ,CAAC,CAAC;QAChC,IAAI,CAAC,QAAQ,CAAC,QAAQ,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;QACjC,IAAI,CAAC,eAAI;YAAE,IAAA,qBAAU,EAAC,QAAQ,CAAC,CAAC;QAChC,MAAM,KAAK,GAAG,IAAA,cAAG,EAAC,GAAG,CAAC,CAAC;QACvB,IAAI,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC,GAAG,IAAA,uBAAY,EAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IAC7D,CAAC;IACD,MAAM;QACJ,MAAM,EAAE,MAAM,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACnC,IAAI,CAAC,UAAU,CAAC,MAAM,CAAC,CAAC;QACxB,MAAM,GAAG,GAAG,MAAM,CAAC,KAAK,CAAC,CAAC,EAAE,SAAS,CAAC,CAAC;QACvC,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,UAAU,CAAC,EAAM;QACf,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,QAAQ,EAAE,SAAS,EAAE,SAAS,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QACrE,EAAE,KAAF,EAAE,GAAK,IAAK,IAAI,CAAC,WAAmB,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,CAAM,EAAC;QAChE,EAAE,CAAC,GAAG,CAAC,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC;QACtB,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;QACtB,EAAE,CAAC,GAAG,GAAG,GAAG,CAAC;QACb,OAAO,EAAE,CAAC;IACZ,CAAC;CACF;AAxGD,sBAwGC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.d.ts
+new file mode 100644
+index 0000000..1c34636
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.d.ts
+@@ -0,0 +1,36 @@
++import { Hash, Input } from './utils.js';
++/**
++ * Choice: a ? b : c
++ */
++export declare const Chi: (a: number, b: number, c: number) => number;
++/**
++ * Majority function, true if any two inputs is true
++ */
++export declare const Maj: (a: number, b: number, c: number) => number;
++/**
++ * Merkle-Damgard hash construction base class.
++ * Could be used to create MD5, RIPEMD, SHA1, SHA2.
++ */
++export declare abstract class HashMD<T extends HashMD<T>> extends Hash<T> {
++    readonly blockLen: number;
++    outputLen: number;
++    readonly padOffset: number;
++    readonly isLE: boolean;
++    protected abstract process(buf: DataView, offset: number): void;
++    protected abstract get(): number[];
++    protected abstract set(...args: number[]): void;
++    abstract destroy(): void;
++    protected abstract roundClean(): void;
++    protected buffer: Uint8Array;
++    protected view: DataView;
++    protected finished: boolean;
++    protected length: number;
++    protected pos: number;
++    protected destroyed: boolean;
++    constructor(blockLen: number, outputLen: number, padOffset: number, isLE: boolean);
++    update(data: Input): this;
++    digestInto(out: Uint8Array): void;
++    digest(): Uint8Array;
++    _cloneInto(to?: T): T;
++}
++//# sourceMappingURL=_md.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.d.ts.map
+new file mode 100644
+index 0000000..de94f66
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_md.d.ts","sourceRoot":"","sources":["src/_md.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAc,KAAK,EAAW,MAAM,YAAY,CAAC;AAiB9D;;GAEG;AACH,eAAO,MAAM,GAAG,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuB,CAAC;AAE3E;;GAEG;AACH,eAAO,MAAM,GAAG,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAEpF;;;GAGG;AACH,8BAAsB,MAAM,CAAC,CAAC,SAAS,MAAM,CAAC,CAAC,CAAC,CAAE,SAAQ,IAAI,CAAC,CAAC,CAAC;IAe7D,QAAQ,CAAC,QAAQ,EAAE,MAAM;IAClB,SAAS,EAAE,MAAM;IACxB,QAAQ,CAAC,SAAS,EAAE,MAAM;IAC1B,QAAQ,CAAC,IAAI,EAAE,OAAO;IAjBxB,SAAS,CAAC,QAAQ,CAAC,OAAO,CAAC,GAAG,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAC/D,SAAS,CAAC,QAAQ,CAAC,GAAG,IAAI,MAAM,EAAE;IAClC,SAAS,CAAC,QAAQ,CAAC,GAAG,CAAC,GAAG,IAAI,EAAE,MAAM,EAAE,GAAG,IAAI;IAC/C,QAAQ,CAAC,OAAO,IAAI,IAAI;IACxB,SAAS,CAAC,QAAQ,CAAC,UAAU,IAAI,IAAI;IAErC,SAAS,CAAC,MAAM,EAAE,UAAU,CAAC;IAC7B,SAAS,CAAC,IAAI,EAAE,QAAQ,CAAC;IACzB,SAAS,CAAC,QAAQ,UAAS;IAC3B,SAAS,CAAC,MAAM,SAAK;IACrB,SAAS,CAAC,GAAG,SAAK;IAClB,SAAS,CAAC,SAAS,UAAS;gBAGjB,QAAQ,EAAE,MAAM,EAClB,SAAS,EAAE,MAAM,EACf,SAAS,EAAE,MAAM,EACjB,IAAI,EAAE,OAAO;IAMxB,MAAM,CAAC,IAAI,EAAE,KAAK,GAAG,IAAI;IAyBzB,UAAU,CAAC,GAAG,EAAE,UAAU;IAkC1B,MAAM;IAON,UAAU,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC;CAWtB"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.js
+new file mode 100644
+index 0000000..6ef2bc7
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.js
+@@ -0,0 +1,134 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.HashMD = exports.Maj = exports.Chi = void 0;
++const _assert_js_1 = require("./_assert.js");
++const utils_js_1 = require("./utils.js");
++/**
++ * Polyfill for Safari 14
++ */
++function setBigUint64(view, byteOffset, value, isLE) {
++    if (typeof view.setBigUint64 === 'function')
++        return view.setBigUint64(byteOffset, value, isLE);
++    const _32n = BigInt(32);
++    const _u32_max = BigInt(0xffffffff);
++    const wh = Number((value >> _32n) & _u32_max);
++    const wl = Number(value & _u32_max);
++    const h = isLE ? 4 : 0;
++    const l = isLE ? 0 : 4;
++    view.setUint32(byteOffset + h, wh, isLE);
++    view.setUint32(byteOffset + l, wl, isLE);
++}
++/**
++ * Choice: a ? b : c
++ */
++const Chi = (a, b, c) => (a & b) ^ (~a & c);
++exports.Chi = Chi;
++/**
++ * Majority function, true if any two inputs is true
++ */
++const Maj = (a, b, c) => (a & b) ^ (a & c) ^ (b & c);
++exports.Maj = Maj;
++/**
++ * Merkle-Damgard hash construction base class.
++ * Could be used to create MD5, RIPEMD, SHA1, SHA2.
++ */
++class HashMD extends utils_js_1.Hash {
++    constructor(blockLen, outputLen, padOffset, isLE) {
++        super();
++        this.blockLen = blockLen;
++        this.outputLen = outputLen;
++        this.padOffset = padOffset;
++        this.isLE = isLE;
++        this.finished = false;
++        this.length = 0;
++        this.pos = 0;
++        this.destroyed = false;
++        this.buffer = new Uint8Array(blockLen);
++        this.view = (0, utils_js_1.createView)(this.buffer);
++    }
++    update(data) {
++        (0, _assert_js_1.exists)(this);
++        const { view, buffer, blockLen } = this;
++        data = (0, utils_js_1.toBytes)(data);
++        const len = data.length;
++        for (let pos = 0; pos < len;) {
++            const take = Math.min(blockLen - this.pos, len - pos);
++            // Fast path: we have at least one block in input, cast it to view and process
++            if (take === blockLen) {
++                const dataView = (0, utils_js_1.createView)(data);
++                for (; blockLen <= len - pos; pos += blockLen)
++                    this.process(dataView, pos);
++                continue;
++            }
++            buffer.set(data.subarray(pos, pos + take), this.pos);
++            this.pos += take;
++            pos += take;
++            if (this.pos === blockLen) {
++                this.process(view, 0);
++                this.pos = 0;
++            }
++        }
++        this.length += data.length;
++        this.roundClean();
++        return this;
++    }
++    digestInto(out) {
++        (0, _assert_js_1.exists)(this);
++        (0, _assert_js_1.output)(out, this);
++        this.finished = true;
++        // Padding
++        // We can avoid allocation of buffer for padding completely if it
++        // was previously not allocated here. But it won't change performance.
++        const { buffer, view, blockLen, isLE } = this;
++        let { pos } = this;
++        // append the bit '1' to the message
++        buffer[pos++] = 0b10000000;
++        this.buffer.subarray(pos).fill(0);
++        // we have less than padOffset left in buffer, so we cannot put length in
++        // current block, need process it and pad again
++        if (this.padOffset > blockLen - pos) {
++            this.process(view, 0);
++            pos = 0;
++        }
++        // Pad until full block byte with zeros
++        for (let i = pos; i < blockLen; i++)
++            buffer[i] = 0;
++        // Note: sha512 requires length to be 128bit integer, but length in JS will overflow before that
++        // You need to write around 2 exabytes (u64_max / 8 / (1024**6)) for this to happen.
++        // So we just write lowest 64 bits of that value.
++        setBigUint64(view, blockLen - 8, BigInt(this.length * 8), isLE);
++        this.process(view, 0);
++        const oview = (0, utils_js_1.createView)(out);
++        const len = this.outputLen;
++        // NOTE: we do division by 4 later, which should be fused in single op with modulo by JIT
++        if (len % 4)
++            throw new Error('_sha2: outputLen should be aligned to 32bit');
++        const outLen = len / 4;
++        const state = this.get();
++        if (outLen > state.length)
++            throw new Error('_sha2: outputLen bigger than state');
++        for (let i = 0; i < outLen; i++)
++            oview.setUint32(4 * i, state[i], isLE);
++    }
++    digest() {
++        const { buffer, outputLen } = this;
++        this.digestInto(buffer);
++        const res = buffer.slice(0, outputLen);
++        this.destroy();
++        return res;
++    }
++    _cloneInto(to) {
++        to || (to = new this.constructor());
++        to.set(...this.get());
++        const { blockLen, buffer, length, finished, destroyed, pos } = this;
++        to.length = length;
++        to.pos = pos;
++        to.finished = finished;
++        to.destroyed = destroyed;
++        if (length % blockLen)
++            to.buffer.set(buffer);
++        return to;
++    }
++}
++exports.HashMD = HashMD;
++//# sourceMappingURL=_md.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.js.map
+new file mode 100644
+index 0000000..95bf1ec
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_md.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_md.js","sourceRoot":"","sources":["src/_md.ts"],"names":[],"mappings":";;;AAAA,6CAA8C;AAC9C,yCAA8D;AAE9D;;GAEG;AACH,SAAS,YAAY,CAAC,IAAc,EAAE,UAAkB,EAAE,KAAa,EAAE,IAAa;IACpF,IAAI,OAAO,IAAI,CAAC,YAAY,KAAK,UAAU;QAAE,OAAO,IAAI,CAAC,YAAY,CAAC,UAAU,EAAE,KAAK,EAAE,IAAI,CAAC,CAAC;IAC/F,MAAM,IAAI,GAAG,MAAM,CAAC,EAAE,CAAC,CAAC;IACxB,MAAM,QAAQ,GAAG,MAAM,CAAC,UAAU,CAAC,CAAC;IACpC,MAAM,EAAE,GAAG,MAAM,CAAC,CAAC,KAAK,IAAI,IAAI,CAAC,GAAG,QAAQ,CAAC,CAAC;IAC9C,MAAM,EAAE,GAAG,MAAM,CAAC,KAAK,GAAG,QAAQ,CAAC,CAAC;IACpC,MAAM,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACvB,MAAM,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACvB,IAAI,CAAC,SAAS,CAAC,UAAU,GAAG,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CAAC;IACzC,IAAI,CAAC,SAAS,CAAC,UAAU,GAAG,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CAAC;AAC3C,CAAC;AAED;;GAEG;AACI,MAAM,GAAG,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;AAA9D,QAAA,GAAG,OAA2D;AAE3E;;GAEG;AACI,MAAM,GAAG,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;AAAvE,QAAA,GAAG,OAAoE;AAEpF;;;GAGG;AACH,MAAsB,MAA4B,SAAQ,eAAO;IAc/D,YACW,QAAgB,EAClB,SAAiB,EACf,SAAiB,EACjB,IAAa;QAEtB,KAAK,EAAE,CAAC;QALC,aAAQ,GAAR,QAAQ,CAAQ;QAClB,cAAS,GAAT,SAAS,CAAQ;QACf,cAAS,GAAT,SAAS,CAAQ;QACjB,SAAI,GAAJ,IAAI,CAAS;QATd,aAAQ,GAAG,KAAK,CAAC;QACjB,WAAM,GAAG,CAAC,CAAC;QACX,QAAG,GAAG,CAAC,CAAC;QACR,cAAS,GAAG,KAAK,CAAC;QAS1B,IAAI,CAAC,MAAM,GAAG,IAAI,UAAU,CAAC,QAAQ,CAAC,CAAC;QACvC,IAAI,CAAC,IAAI,GAAG,IAAA,qBAAU,EAAC,IAAI,CAAC,MAAM,CAAC,CAAC;IACtC,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,IAAA,mBAAM,EAAC,IAAI,CAAC,CAAC;QACb,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QACxC,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;QACrB,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAC9B,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACtD,8EAA8E;YAC9E,IAAI,IAAI,KAAK,QAAQ,EAAE,CAAC;gBACtB,MAAM,QAAQ,GAAG,IAAA,qBAAU,EAAC,IAAI,CAAC,CAAC;gBAClC,OAAO,QAAQ,IAAI,GAAG,GAAG,GAAG,EAAE,GAAG,IAAI,QAAQ;oBAAE,IAAI,CAAC,OAAO,CAAC,QAAQ,EAAE,GAAG,CAAC,CAAC;gBAC3E,SAAS;YACX,CAAC;YACD,MAAM,CAAC,GAAG,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,IAAI,CAAC,GAAG,CAAC,CAAC;YACrD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC;YACjB,GAAG,IAAI,IAAI,CAAC;YACZ,IAAI,IAAI,CAAC,GAAG,KAAK,QAAQ,EAAE,CAAC;gBAC1B,IAAI,CAAC,OAAO,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;gBACtB,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;YACf,CAAC;QACH,CAAC;QACD,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC,MAAM,CAAC;QAC3B,IAAI,CAAC,UAAU,EAAE,CAAC;QAClB,OAAO,IAAI,CAAC;IACd,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,IAAA,mBAAM,EAAC,IAAI,CAAC,CAAC;QACb,IAAA,mBAAM,EAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,UAAU;QACV,iEAAiE;QACjE,sEAAsE;QACtE,MAAM,EAAE,MAAM,EAAE,IAAI,EAAE,QAAQ,EAAE,IAAI,EAAE,GAAG,IAAI,CAAC;QAC9C,IAAI,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QACnB,oCAAoC;QACpC,MAAM,CAAC,GAAG,EAAE,CAAC,GAAG,UAAU,CAAC;QAC3B,IAAI,CAAC,MAAM,CAAC,QAAQ,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QAClC,yEAAyE;QACzE,+CAA+C;QAC/C,IAAI,IAAI,CAAC,SAAS,GAAG,QAAQ,GAAG,GAAG,EAAE,CAAC;YACpC,IAAI,CAAC,OAAO,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;YACtB,GAAG,GAAG,CAAC,CAAC;QACV,CAAC;QACD,uCAAuC;QACvC,KAAK,IAAI,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,QAAQ,EAAE,CAAC,EAAE;YAAE,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnD,gGAAgG;QAChG,oFAAoF;QACpF,iDAAiD;QACjD,YAAY,CAAC,IAAI,EAAE,QAAQ,GAAG,CAAC,EAAE,MAAM,CAAC,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC,EAAE,IAAI,CAAC,CAAC;QAChE,IAAI,CAAC,OAAO,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;QACtB,MAAM,KAAK,GAAG,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;QAC9B,MAAM,GAAG,GAAG,IAAI,CAAC,SAAS,CAAC;QAC3B,yFAAyF;QACzF,IAAI,GAAG,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,CAAC;QAC5E,MAAM,MAAM,GAAG,GAAG,GAAG,CAAC,CAAC;QACvB,MAAM,KAAK,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC;QACzB,IAAI,MAAM,GAAG,KAAK,CAAC,MAAM;YAAE,MAAM,IAAI,KAAK,CAAC,oCAAoC,CAAC,CAAC;QACjF,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,EAAE,CAAC,EAAE;YAAE,KAAK,CAAC,SAAS,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC,EAAE,IAAI,CAAC,CAAC;IAC1E,CAAC;IACD,MAAM;QACJ,MAAM,EAAE,MAAM,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACnC,IAAI,CAAC,UAAU,CAAC,MAAM,CAAC,CAAC;QACxB,MAAM,GAAG,GAAG,MAAM,CAAC,KAAK,CAAC,CAAC,EAAE,SAAS,CAAC,CAAC;QACvC,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,UAAU,CAAC,EAAM;QACf,EAAE,KAAF,EAAE,GAAK,IAAK,IAAI,CAAC,WAAmB,EAAO,EAAC;QAC5C,EAAE,CAAC,GAAG,CAAC,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC;QACtB,MAAM,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,EAAE,QAAQ,EAAE,SAAS,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QACpE,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,GAAG,GAAG,GAAG,CAAC;QACb,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,IAAI,MAAM,GAAG,QAAQ;YAAE,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;QAC7C,OAAO,EAAE,CAAC;IACZ,CAAC;CACF;AArGD,wBAqGC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.d.ts
+new file mode 100644
+index 0000000..6b8c273
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.d.ts
+@@ -0,0 +1,55 @@
++declare function fromBig(n: bigint, le?: boolean): {
++    h: number;
++    l: number;
++};
++declare function split(lst: bigint[], le?: boolean): Uint32Array[];
++declare const toBig: (h: number, l: number) => bigint;
++declare const shrSH: (h: number, _l: number, s: number) => number;
++declare const shrSL: (h: number, l: number, s: number) => number;
++declare const rotrSH: (h: number, l: number, s: number) => number;
++declare const rotrSL: (h: number, l: number, s: number) => number;
++declare const rotrBH: (h: number, l: number, s: number) => number;
++declare const rotrBL: (h: number, l: number, s: number) => number;
++declare const rotr32H: (_h: number, l: number) => number;
++declare const rotr32L: (h: number, _l: number) => number;
++declare const rotlSH: (h: number, l: number, s: number) => number;
++declare const rotlSL: (h: number, l: number, s: number) => number;
++declare const rotlBH: (h: number, l: number, s: number) => number;
++declare const rotlBL: (h: number, l: number, s: number) => number;
++declare function add(Ah: number, Al: number, Bh: number, Bl: number): {
++    h: number;
++    l: number;
++};
++declare const add3L: (Al: number, Bl: number, Cl: number) => number;
++declare const add3H: (low: number, Ah: number, Bh: number, Ch: number) => number;
++declare const add4L: (Al: number, Bl: number, Cl: number, Dl: number) => number;
++declare const add4H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number) => number;
++declare const add5L: (Al: number, Bl: number, Cl: number, Dl: number, El: number) => number;
++declare const add5H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: number) => number;
++export { fromBig, split, toBig, shrSH, shrSL, rotrSH, rotrSL, rotrBH, rotrBL, rotr32H, rotr32L, rotlSH, rotlSL, rotlBH, rotlBL, add, add3L, add3H, add4L, add4H, add5H, add5L, };
++declare const u64: {
++    fromBig: typeof fromBig;
++    split: typeof split;
++    toBig: (h: number, l: number) => bigint;
++    shrSH: (h: number, _l: number, s: number) => number;
++    shrSL: (h: number, l: number, s: number) => number;
++    rotrSH: (h: number, l: number, s: number) => number;
++    rotrSL: (h: number, l: number, s: number) => number;
++    rotrBH: (h: number, l: number, s: number) => number;
++    rotrBL: (h: number, l: number, s: number) => number;
++    rotr32H: (_h: number, l: number) => number;
++    rotr32L: (h: number, _l: number) => number;
++    rotlSH: (h: number, l: number, s: number) => number;
++    rotlSL: (h: number, l: number, s: number) => number;
++    rotlBH: (h: number, l: number, s: number) => number;
++    rotlBL: (h: number, l: number, s: number) => number;
++    add: typeof add;
++    add3L: (Al: number, Bl: number, Cl: number) => number;
++    add3H: (low: number, Ah: number, Bh: number, Ch: number) => number;
++    add4L: (Al: number, Bl: number, Cl: number, Dl: number) => number;
++    add4H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number) => number;
++    add5H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: number) => number;
++    add5L: (Al: number, Bl: number, Cl: number, Dl: number, El: number) => number;
++};
++export default u64;
++//# sourceMappingURL=_u64.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.d.ts.map
+new file mode 100644
+index 0000000..63a4e15
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_u64.d.ts","sourceRoot":"","sources":["src/_u64.ts"],"names":[],"mappings":"AAIA,iBAAS,OAAO,CAAC,CAAC,EAAE,MAAM,EAAE,EAAE,UAAQ;;;EAGrC;AAED,iBAAS,KAAK,CAAC,GAAG,EAAE,MAAM,EAAE,EAAE,EAAE,UAAQ,iBAQvC;AAED,QAAA,MAAM,KAAK,MAAO,MAAM,KAAK,MAAM,WAAgD,CAAC;AAEpF,QAAA,MAAM,KAAK,MAAO,MAAM,MAAM,MAAM,KAAK,MAAM,WAAY,CAAC;AAC5D,QAAA,MAAM,KAAK,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAE/E,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAChF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAEhF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AACvF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AAEvF,QAAA,MAAM,OAAO,OAAQ,MAAM,KAAK,MAAM,WAAM,CAAC;AAC7C,QAAA,MAAM,OAAO,MAAO,MAAM,MAAM,MAAM,WAAM,CAAC;AAE7C,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAChF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAEhF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AACvF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AAIvF,iBAAS,GAAG,CAAC,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;;;EAG1D;AAED,QAAA,MAAM,KAAK,OAAQ,MAAM,MAAM,MAAM,MAAM,MAAM,WAAyC,CAAC;AAC3F,QAAA,MAAM,KAAK,QAAS,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WAClB,CAAC;AAC7C,QAAA,MAAM,KAAK,OAAQ,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WACV,CAAC;AACpD,QAAA,MAAM,KAAK,QAAS,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WACzB,CAAC;AAClD,QAAA,MAAM,KAAK,OAAQ,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WACT,CAAC;AACjE,QAAA,MAAM,KAAK,QAAS,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WAChC,CAAC;AAGvD,OAAO,EACL,OAAO,EAAE,KAAK,EAAE,KAAK,EACrB,KAAK,EAAE,KAAK,EACZ,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAC9B,OAAO,EAAE,OAAO,EAChB,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAC9B,GAAG,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,GAC9C,CAAC;AAEF,QAAA,MAAM,GAAG;;;eAjDS,MAAM,KAAK,MAAM;eAEjB,MAAM,MAAM,MAAM,KAAK,MAAM;eAC7B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAE3B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAE5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;kBAE1B,MAAM,KAAK,MAAM;iBAClB,MAAM,MAAM,MAAM;gBAEnB,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAE5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;;gBAS5B,MAAM,MAAM,MAAM,MAAM,MAAM;iBAC7B,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;gBAE3C,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;iBAEzC,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;iBAItD,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;gBAFnE,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;CAsBxE,CAAC;AACF,eAAe,GAAG,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.js
+new file mode 100644
+index 0000000..ae296cc
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.js
+@@ -0,0 +1,85 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.add5L = exports.add5H = exports.add4H = exports.add4L = exports.add3H = exports.add3L = exports.rotlBL = exports.rotlBH = exports.rotlSL = exports.rotlSH = exports.rotr32L = exports.rotr32H = exports.rotrBL = exports.rotrBH = exports.rotrSL = exports.rotrSH = exports.shrSL = exports.shrSH = exports.toBig = void 0;
++exports.fromBig = fromBig;
++exports.split = split;
++exports.add = add;
++const U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
++const _32n = /* @__PURE__ */ BigInt(32);
++// We are not using BigUint64Array, because they are extremely slow as per 2022
++function fromBig(n, le = false) {
++    if (le)
++        return { h: Number(n & U32_MASK64), l: Number((n >> _32n) & U32_MASK64) };
++    return { h: Number((n >> _32n) & U32_MASK64) | 0, l: Number(n & U32_MASK64) | 0 };
++}
++function split(lst, le = false) {
++    let Ah = new Uint32Array(lst.length);
++    let Al = new Uint32Array(lst.length);
++    for (let i = 0; i < lst.length; i++) {
++        const { h, l } = fromBig(lst[i], le);
++        [Ah[i], Al[i]] = [h, l];
++    }
++    return [Ah, Al];
++}
++const toBig = (h, l) => (BigInt(h >>> 0) << _32n) | BigInt(l >>> 0);
++exports.toBig = toBig;
++// for Shift in [0, 32)
++const shrSH = (h, _l, s) => h >>> s;
++exports.shrSH = shrSH;
++const shrSL = (h, l, s) => (h << (32 - s)) | (l >>> s);
++exports.shrSL = shrSL;
++// Right rotate for Shift in [1, 32)
++const rotrSH = (h, l, s) => (h >>> s) | (l << (32 - s));
++exports.rotrSH = rotrSH;
++const rotrSL = (h, l, s) => (h << (32 - s)) | (l >>> s);
++exports.rotrSL = rotrSL;
++// Right rotate for Shift in (32, 64), NOTE: 32 is special case.
++const rotrBH = (h, l, s) => (h << (64 - s)) | (l >>> (s - 32));
++exports.rotrBH = rotrBH;
++const rotrBL = (h, l, s) => (h >>> (s - 32)) | (l << (64 - s));
++exports.rotrBL = rotrBL;
++// Right rotate for shift===32 (just swaps l&h)
++const rotr32H = (_h, l) => l;
++exports.rotr32H = rotr32H;
++const rotr32L = (h, _l) => h;
++exports.rotr32L = rotr32L;
++// Left rotate for Shift in [1, 32)
++const rotlSH = (h, l, s) => (h << s) | (l >>> (32 - s));
++exports.rotlSH = rotlSH;
++const rotlSL = (h, l, s) => (l << s) | (h >>> (32 - s));
++exports.rotlSL = rotlSL;
++// Left rotate for Shift in (32, 64), NOTE: 32 is special case.
++const rotlBH = (h, l, s) => (l << (s - 32)) | (h >>> (64 - s));
++exports.rotlBH = rotlBH;
++const rotlBL = (h, l, s) => (h << (s - 32)) | (l >>> (64 - s));
++exports.rotlBL = rotlBL;
++// JS uses 32-bit signed integers for bitwise operations which means we cannot
++// simple take carry out of low bit sum by shift, we need to use division.
++function add(Ah, Al, Bh, Bl) {
++    const l = (Al >>> 0) + (Bl >>> 0);
++    return { h: (Ah + Bh + ((l / 2 ** 32) | 0)) | 0, l: l | 0 };
++}
++// Addition with more than 2 elements
++const add3L = (Al, Bl, Cl) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0);
++exports.add3L = add3L;
++const add3H = (low, Ah, Bh, Ch) => (Ah + Bh + Ch + ((low / 2 ** 32) | 0)) | 0;
++exports.add3H = add3H;
++const add4L = (Al, Bl, Cl, Dl) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0);
++exports.add4L = add4L;
++const add4H = (low, Ah, Bh, Ch, Dh) => (Ah + Bh + Ch + Dh + ((low / 2 ** 32) | 0)) | 0;
++exports.add4H = add4H;
++const add5L = (Al, Bl, Cl, Dl, El) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0) + (El >>> 0);
++exports.add5L = add5L;
++const add5H = (low, Ah, Bh, Ch, Dh, Eh) => (Ah + Bh + Ch + Dh + Eh + ((low / 2 ** 32) | 0)) | 0;
++exports.add5H = add5H;
++// prettier-ignore
++const u64 = {
++    fromBig, split, toBig,
++    shrSH, shrSL,
++    rotrSH, rotrSL, rotrBH, rotrBL,
++    rotr32H, rotr32L,
++    rotlSH, rotlSL, rotlBH, rotlBL,
++    add, add3L, add3H, add4L, add4H, add5H, add5L,
++};
++exports.default = u64;
++//# sourceMappingURL=_u64.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.js.map
+new file mode 100644
+index 0000000..3543a9c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/_u64.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_u64.js","sourceRoot":"","sources":["src/_u64.ts"],"names":[],"mappings":";;;AA4DE,0BAAO;AAAE,sBAAK;AAKd,kBAAG;AAjEL,MAAM,UAAU,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC,CAAC;AACvD,MAAM,IAAI,GAAG,eAAe,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC;AAExC,+EAA+E;AAC/E,SAAS,OAAO,CAAC,CAAS,EAAE,EAAE,GAAG,KAAK;IACpC,IAAI,EAAE;QAAE,OAAO,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,GAAG,UAAU,CAAC,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC,GAAG,UAAU,CAAC,EAAE,CAAC;IAClF,OAAO,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC,GAAG,UAAU,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,GAAG,UAAU,CAAC,GAAG,CAAC,EAAE,CAAC;AACpF,CAAC;AAED,SAAS,KAAK,CAAC,GAAa,EAAE,EAAE,GAAG,KAAK;IACtC,IAAI,EAAE,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrC,IAAI,EAAE,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACpC,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;QACrC,CAAC,EAAE,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;IAC1B,CAAC;IACD,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAClB,CAAC;AAED,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,MAAM,CAAC,CAAC,KAAK,CAAC,CAAC,IAAI,IAAI,CAAC,GAAG,MAAM,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AAyClE,sBAAK;AAxCvB,uBAAuB;AACvB,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,EAAU,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,KAAK,CAAC,CAAC;AAwC1D,sBAAK;AAvCP,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AAuCtE,sBAAK;AAtCd,oCAAoC;AACpC,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AAsC9E,wBAAM;AArCR,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AAqCtE,wBAAM;AApChB,gEAAgE;AAChE,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC;AAmCrE,wBAAM;AAlCxB,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AAkC7D,wBAAM;AAjChC,+CAA+C;AAC/C,MAAM,OAAO,GAAG,CAAC,EAAU,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC;AAiC3C,0BAAO;AAhCT,MAAM,OAAO,GAAG,CAAC,CAAS,EAAE,EAAU,EAAE,EAAE,CAAC,CAAC,CAAC;AAgClC,0BAAO;AA/BlB,mCAAmC;AACnC,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AA+B9E,wBAAM;AA9BR,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AA8BtE,wBAAM;AA7BhB,+DAA+D;AAC/D,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AA4BrE,wBAAM;AA3BxB,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AA2B7D,wBAAM;AAzBhC,8EAA8E;AAC9E,0EAA0E;AAC1E,SAAS,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;IACzD,MAAM,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;IAClC,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC;AAC9D,CAAC;AACD,qCAAqC;AACrC,MAAM,KAAK,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAAC,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;AAmBpF,sBAAK;AAlBZ,MAAM,KAAK,GAAG,CAAC,GAAW,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAChE,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,GAAG,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;AAiB/B,sBAAK;AAhBnB,MAAM,KAAK,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAC/D,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;AAe/B,sBAAK;AAd1B,MAAM,KAAK,GAAG,CAAC,GAAW,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAC5E,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,GAAG,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;AAatB,sBAAK;AAZjC,MAAM,KAAK,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAC3E,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;AAWvB,sBAAK;AAV/C,MAAM,KAAK,GAAG,CAAC,GAAW,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CACxF,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,GAAG,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;AASpB,sBAAK;AAExC,kBAAkB;AAClB,MAAM,GAAG,GAAG;IACV,OAAO,EAAE,KAAK,EAAE,KAAK;IACrB,KAAK,EAAE,KAAK;IACZ,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM;IAC9B,OAAO,EAAE,OAAO;IAChB,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM;IAC9B,GAAG,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK;CAC9C,CAAC;AACF,kBAAe,GAAG,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.d.ts
+new file mode 100644
+index 0000000..9d4139c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.d.ts
+@@ -0,0 +1,17 @@
++import { Input } from './utils.js';
++export type ArgonOpts = {
++    t: number;
++    m: number;
++    p: number;
++    version?: number;
++    key?: Input;
++    personalization?: Input;
++    dkLen?: number;
++    asyncTick?: number;
++    maxmem?: number;
++    onProgress?: (progress: number) => void;
++};
++export declare const argon2d: (password: Input, salt: Input, opts: ArgonOpts) => Uint8Array;
++export declare const argon2i: (password: Input, salt: Input, opts: ArgonOpts) => Uint8Array;
++export declare const argon2id: (password: Input, salt: Input, opts: ArgonOpts) => Uint8Array;
++//# sourceMappingURL=argon2.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.d.ts.map
+new file mode 100644
+index 0000000..001375d
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"argon2.d.ts","sourceRoot":"","sources":["src/argon2.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,KAAK,EAAoB,MAAM,YAAY,CAAC;AAkKrD,MAAM,MAAM,SAAS,GAAG;IACtB,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,OAAO,CAAC,EAAE,MAAM,CAAC;IACjB,GAAG,CAAC,EAAE,KAAK,CAAC;IACZ,eAAe,CAAC,EAAE,KAAK,CAAC;IACxB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,SAAS,CAAC,EAAE,MAAM,CAAC;IACnB,MAAM,CAAC,EAAE,MAAM,CAAC;IAChB,UAAU,CAAC,EAAE,CAAC,QAAQ,EAAE,MAAM,KAAK,IAAI,CAAC;CACzC,CAAC;AAkMF,eAAO,MAAM,OAAO,aAAc,KAAK,QAAQ,KAAK,QAAQ,SAAS,eACvB,CAAC;AAC/C,eAAO,MAAM,OAAO,aAAc,KAAK,QAAQ,KAAK,QAAQ,SAAS,eACxB,CAAC;AAC9C,eAAO,MAAM,QAAQ,aAAc,KAAK,QAAQ,KAAK,QAAQ,SAAS,eACxB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.js
+new file mode 100644
+index 0000000..945f4b8
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.js
+@@ -0,0 +1,303 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.argon2id = exports.argon2i = exports.argon2d = void 0;
++const _assert_js_1 = require("./_assert.js");
++const utils_js_1 = require("./utils.js");
++const blake2b_js_1 = require("./blake2b.js");
++const _u64_js_1 = require("./_u64.js");
++const ARGON2_SYNC_POINTS = 4;
++const toBytesOptional = (buf) => (buf !== undefined ? (0, utils_js_1.toBytes)(buf) : new Uint8Array([]));
++function mul(a, b) {
++    const aL = a & 0xffff;
++    const aH = a >>> 16;
++    const bL = b & 0xffff;
++    const bH = b >>> 16;
++    const ll = Math.imul(aL, bL);
++    const hl = Math.imul(aH, bL);
++    const lh = Math.imul(aL, bH);
++    const hh = Math.imul(aH, bH);
++    const BUF = ((ll >>> 16) + (hl & 0xffff) + lh) | 0;
++    const h = ((hl >>> 16) + (BUF >>> 16) + hh) | 0;
++    return { h, l: (BUF << 16) | (ll & 0xffff) };
++}
++function relPos(areaSize, relativePos) {
++    // areaSize - 1 - ((areaSize * ((relativePos ** 2) >>> 32)) >>> 32)
++    return areaSize - 1 - mul(areaSize, mul(relativePos, relativePos).h).h;
++}
++function mul2(a, b) {
++    // 2 * a * b (via shifts)
++    const { h, l } = mul(a, b);
++    return { h: ((h << 1) | (l >>> 31)) & 4294967295, l: (l << 1) & 4294967295 };
++}
++function blamka(Ah, Al, Bh, Bl) {
++    const { h: Ch, l: Cl } = mul2(Al, Bl);
++    // A + B + (2 * A * B)
++    const Rll = (0, _u64_js_1.add3L)(Al, Bl, Cl);
++    return { h: (0, _u64_js_1.add3H)(Rll, Ah, Bh, Ch), l: Rll | 0 };
++}
++// Temporary block buffer
++const A2_BUF = new Uint32Array(256);
++function G(a, b, c, d) {
++    let Al = A2_BUF[2 * a], Ah = A2_BUF[2 * a + 1]; // prettier-ignore
++    let Bl = A2_BUF[2 * b], Bh = A2_BUF[2 * b + 1]; // prettier-ignore
++    let Cl = A2_BUF[2 * c], Ch = A2_BUF[2 * c + 1]; // prettier-ignore
++    let Dl = A2_BUF[2 * d], Dh = A2_BUF[2 * d + 1]; // prettier-ignore
++    ({ h: Ah, l: Al } = blamka(Ah, Al, Bh, Bl));
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: (0, _u64_js_1.rotr32H)(Dh, Dl), Dl: (0, _u64_js_1.rotr32L)(Dh, Dl) });
++    ({ h: Ch, l: Cl } = blamka(Ch, Cl, Dh, Dl));
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: (0, _u64_js_1.rotrSH)(Bh, Bl, 24), Bl: (0, _u64_js_1.rotrSL)(Bh, Bl, 24) });
++    ({ h: Ah, l: Al } = blamka(Ah, Al, Bh, Bl));
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: (0, _u64_js_1.rotrSH)(Dh, Dl, 16), Dl: (0, _u64_js_1.rotrSL)(Dh, Dl, 16) });
++    ({ h: Ch, l: Cl } = blamka(Ch, Cl, Dh, Dl));
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: (0, _u64_js_1.rotrBH)(Bh, Bl, 63), Bl: (0, _u64_js_1.rotrBL)(Bh, Bl, 63) });
++    (A2_BUF[2 * a] = Al), (A2_BUF[2 * a + 1] = Ah);
++    (A2_BUF[2 * b] = Bl), (A2_BUF[2 * b + 1] = Bh);
++    (A2_BUF[2 * c] = Cl), (A2_BUF[2 * c + 1] = Ch);
++    (A2_BUF[2 * d] = Dl), (A2_BUF[2 * d + 1] = Dh);
++}
++// prettier-ignore
++function P(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15) {
++    G(v00, v04, v08, v12);
++    G(v01, v05, v09, v13);
++    G(v02, v06, v10, v14);
++    G(v03, v07, v11, v15);
++    G(v00, v05, v10, v15);
++    G(v01, v06, v11, v12);
++    G(v02, v07, v08, v13);
++    G(v03, v04, v09, v14);
++}
++function block(x, xPos, yPos, outPos, needXor) {
++    for (let i = 0; i < 256; i++)
++        A2_BUF[i] = x[xPos + i] ^ x[yPos + i];
++    // columns
++    for (let i = 0; i < 128; i += 16) {
++        // prettier-ignore
++        P(i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7, i + 8, i + 9, i + 10, i + 11, i + 12, i + 13, i + 14, i + 15);
++    }
++    // rows
++    for (let i = 0; i < 16; i += 2) {
++        // prettier-ignore
++        P(i, i + 1, i + 16, i + 17, i + 32, i + 33, i + 48, i + 49, i + 64, i + 65, i + 80, i + 81, i + 96, i + 97, i + 112, i + 113);
++    }
++    if (needXor)
++        for (let i = 0; i < 256; i++)
++            x[outPos + i] ^= A2_BUF[i] ^ x[xPos + i] ^ x[yPos + i];
++    else
++        for (let i = 0; i < 256; i++)
++            x[outPos + i] = A2_BUF[i] ^ x[xPos + i] ^ x[yPos + i];
++}
++// Variable-Length Hash Function H'
++function Hp(A, dkLen) {
++    const A8 = (0, utils_js_1.u8)(A);
++    const T = new Uint32Array(1);
++    const T8 = (0, utils_js_1.u8)(T);
++    T[0] = dkLen;
++    // Fast path
++    if (dkLen <= 64)
++        return blake2b_js_1.blake2b.create({ dkLen }).update(T8).update(A8).digest();
++    const out = new Uint8Array(dkLen);
++    let V = blake2b_js_1.blake2b.create({}).update(T8).update(A8).digest();
++    let pos = 0;
++    // First block
++    out.set(V.subarray(0, 32));
++    pos += 32;
++    // Rest blocks
++    for (; dkLen - pos > 64; pos += 32)
++        out.set((V = (0, blake2b_js_1.blake2b)(V)).subarray(0, 32), pos);
++    // Last block
++    out.set((0, blake2b_js_1.blake2b)(V, { dkLen: dkLen - pos }), pos);
++    return (0, utils_js_1.u32)(out);
++}
++function indexAlpha(r, s, laneLen, segmentLen, index, randL, sameLane = false) {
++    let area;
++    if (0 == r) {
++        if (0 == s)
++            area = index - 1;
++        else if (sameLane)
++            area = s * segmentLen + index - 1;
++        else
++            area = s * segmentLen + (index == 0 ? -1 : 0);
++    }
++    else if (sameLane)
++        area = laneLen - segmentLen + index - 1;
++    else
++        area = laneLen - segmentLen + (index == 0 ? -1 : 0);
++    const startPos = r !== 0 && s !== ARGON2_SYNC_POINTS - 1 ? (s + 1) * segmentLen : 0;
++    const rel = relPos(area, randL);
++    // NOTE: check about overflows here
++    //     absPos = (startPos + relPos) % laneLength;
++    return (startPos + rel) % laneLen;
++}
++function argon2Init(type, password, salt, opts) {
++    password = (0, utils_js_1.toBytes)(password);
++    salt = (0, utils_js_1.toBytes)(salt);
++    let { p, dkLen, m, t, version, key, personalization, maxmem, onProgress } = {
++        ...opts,
++        version: opts.version || 0x13,
++        dkLen: opts.dkLen || 32,
++        maxmem: 2 ** 32,
++    };
++    // Validation
++    (0, _assert_js_1.number)(p);
++    (0, _assert_js_1.number)(dkLen);
++    (0, _assert_js_1.number)(m);
++    (0, _assert_js_1.number)(t);
++    (0, _assert_js_1.number)(version);
++    if (dkLen < 4 || dkLen >= 2 ** 32)
++        throw new Error('Argon2: dkLen should be at least 4 bytes');
++    if (p < 1 || p >= 2 ** 32)
++        throw new Error('Argon2: p (parallelism) should be at least 1');
++    if (t < 1 || t >= 2 ** 32)
++        throw new Error('Argon2: t (iterations) should be at least 1');
++    if (m < 8 * p)
++        throw new Error(`Argon2: memory should be at least 8*p bytes`);
++    if (version !== 16 && version !== 19)
++        throw new Error(`Argon2: unknown version=${version}`);
++    password = (0, utils_js_1.toBytes)(password);
++    if (password.length < 0 || password.length >= 2 ** 32)
++        throw new Error('Argon2: password should be less than 4 GB');
++    salt = (0, utils_js_1.toBytes)(salt);
++    if (salt.length < 8)
++        throw new Error('Argon2: salt should be at least 8 bytes');
++    key = toBytesOptional(key);
++    personalization = toBytesOptional(personalization);
++    if (onProgress !== undefined && typeof onProgress !== 'function')
++        throw new Error('progressCb should be function');
++    // Params
++    const lanes = p;
++    // m' = 4 * p * floor (m / 4p)
++    const mP = 4 * p * Math.floor(m / (ARGON2_SYNC_POINTS * p));
++    //q = m' / p columns
++    const laneLen = Math.floor(mP / p);
++    const segmentLen = Math.floor(laneLen / ARGON2_SYNC_POINTS);
++    // H0
++    const h = blake2b_js_1.blake2b.create({});
++    const BUF = new Uint32Array(1);
++    const BUF8 = (0, utils_js_1.u8)(BUF);
++    for (const i of [p, dkLen, m, t, version, type]) {
++        if (i < 0 || i >= 2 ** 32)
++            throw new Error(`Argon2: wrong parameter=${i}, expected uint32`);
++        BUF[0] = i;
++        h.update(BUF8);
++    }
++    for (let i of [password, salt, key, personalization]) {
++        BUF[0] = i.length;
++        h.update(BUF8).update(i);
++    }
++    const H0 = new Uint32Array(18);
++    const H0_8 = (0, utils_js_1.u8)(H0);
++    h.digestInto(H0_8);
++    // 256 u32 = 1024 (BLOCK_SIZE)
++    const memUsed = mP * 256;
++    if (memUsed < 0 || memUsed >= 2 ** 32 || memUsed > maxmem) {
++        throw new Error(`Argon2: wrong params (memUsed=${memUsed} maxmem=${maxmem}), should be less than 2**32`);
++    }
++    const B = new Uint32Array(memUsed);
++    // Fill first blocks
++    for (let l = 0; l < p; l++) {
++        const i = 256 * laneLen * l;
++        // B[i][0] = H'^(1024)(H_0 || LE32(0) || LE32(i))
++        H0[17] = l;
++        H0[16] = 0;
++        B.set(Hp(H0, 1024), i);
++        // B[i][1] = H'^(1024)(H_0 || LE32(1) || LE32(i))
++        H0[16] = 1;
++        B.set(Hp(H0, 1024), i + 256);
++    }
++    let perBlock = () => { };
++    if (onProgress) {
++        const totalBlock = t * ARGON2_SYNC_POINTS * p * segmentLen;
++        // Invoke callback if progress changes from 10.01 to 10.02
++        // Allows to draw smooth progress bar on up to 8K screen
++        const callbackPer = Math.max(Math.floor(totalBlock / 10000), 1);
++        let blockCnt = 0;
++        perBlock = () => {
++            blockCnt++;
++            if (onProgress && (!(blockCnt % callbackPer) || blockCnt === totalBlock))
++                onProgress(blockCnt / totalBlock);
++        };
++    }
++    return { type, mP, p, t, version, B, laneLen, lanes, segmentLen, dkLen, perBlock };
++}
++function argon2Output(B, p, laneLen, dkLen) {
++    const B_final = new Uint32Array(256);
++    for (let l = 0; l < p; l++)
++        for (let j = 0; j < 256; j++)
++            B_final[j] ^= B[256 * (laneLen * l + laneLen - 1) + j];
++    return (0, utils_js_1.u8)(Hp(B_final, dkLen));
++}
++function processBlock(B, address, l, r, s, index, laneLen, segmentLen, lanes, offset, prev, dataIndependent, needXor) {
++    if (offset % laneLen)
++        prev = offset - 1;
++    let randL, randH;
++    if (dataIndependent) {
++        if (index % 128 === 0) {
++            address[256 + 12]++;
++            block(address, 256, 2 * 256, 0, false);
++            block(address, 0, 2 * 256, 0, false);
++        }
++        randL = address[2 * (index % 128)];
++        randH = address[2 * (index % 128) + 1];
++    }
++    else {
++        const T = 256 * prev;
++        randL = B[T];
++        randH = B[T + 1];
++    }
++    // address block
++    const refLane = r === 0 && s === 0 ? l : randH % lanes;
++    const refPos = indexAlpha(r, s, laneLen, segmentLen, index, randL, refLane == l);
++    const refBlock = laneLen * refLane + refPos;
++    // B[i][j] = G(B[i][j-1], B[l][z])
++    block(B, 256 * prev, 256 * refBlock, offset * 256, needXor);
++}
++function argon2(type, password, salt, opts) {
++    const { mP, p, t, version, B, laneLen, lanes, segmentLen, dkLen, perBlock } = argon2Init(type, password, salt, opts);
++    // Pre-loop setup
++    // [address, input, zero_block] format so we can pass single U32 to block function
++    const address = new Uint32Array(3 * 256);
++    address[256 + 6] = mP;
++    address[256 + 8] = t;
++    address[256 + 10] = type;
++    for (let r = 0; r < t; r++) {
++        const needXor = r !== 0 && version === 0x13;
++        address[256 + 0] = r;
++        for (let s = 0; s < ARGON2_SYNC_POINTS; s++) {
++            address[256 + 4] = s;
++            const dataIndependent = type == 1 /* Types.Argon2i */ || (type == 2 /* Types.Argon2id */ && r === 0 && s < 2);
++            for (let l = 0; l < p; l++) {
++                address[256 + 2] = l;
++                address[256 + 12] = 0;
++                let startPos = 0;
++                if (r === 0 && s === 0) {
++                    startPos = 2;
++                    if (dataIndependent) {
++                        address[256 + 12]++;
++                        block(address, 256, 2 * 256, 0, false);
++                        block(address, 0, 2 * 256, 0, false);
++                    }
++                }
++                // current block postion
++                let offset = l * laneLen + s * segmentLen + startPos;
++                // previous block position
++                let prev = offset % laneLen ? offset - 1 : offset + laneLen - 1;
++                for (let index = startPos; index < segmentLen; index++, offset++, prev++) {
++                    perBlock();
++                    processBlock(B, address, l, r, s, index, laneLen, segmentLen, lanes, offset, prev, dataIndependent, needXor);
++                }
++            }
++        }
++    }
++    return argon2Output(B, p, laneLen, dkLen);
++}
++const argon2d = (password, salt, opts) => argon2(0 /* Types.Argond2d */, password, salt, opts);
++exports.argon2d = argon2d;
++const argon2i = (password, salt, opts) => argon2(1 /* Types.Argon2i */, password, salt, opts);
++exports.argon2i = argon2i;
++const argon2id = (password, salt, opts) => argon2(2 /* Types.Argon2id */, password, salt, opts);
++exports.argon2id = argon2id;
++//# sourceMappingURL=argon2.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.js.map
+new file mode 100644
+index 0000000..4991e74
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/argon2.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"argon2.js","sourceRoot":"","sources":["src/argon2.ts"],"names":[],"mappings":";;;AAAA,6CAAsD;AACtD,yCAAqD;AACrD,6CAAuC;AACvC,uCAA2F;AAS3F,MAAM,kBAAkB,GAAG,CAAC,CAAC;AAE7B,MAAM,eAAe,GAAG,CAAC,GAAW,EAAE,EAAE,CAAC,CAAC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,IAAA,kBAAO,EAAC,GAAG,CAAC,CAAC,CAAC,CAAC,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC,CAAC;AAEjG,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS;IAC/B,MAAM,EAAE,GAAG,CAAC,GAAG,MAAM,CAAC;IACtB,MAAM,EAAE,GAAG,CAAC,KAAK,EAAE,CAAC;IACpB,MAAM,EAAE,GAAG,CAAC,GAAG,MAAM,CAAC;IACtB,MAAM,EAAE,GAAG,CAAC,KAAK,EAAE,CAAC;IACpB,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,GAAG,GAAG,CAAC,CAAC,EAAE,KAAK,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,MAAM,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;IACnD,MAAM,CAAC,GAAG,CAAC,CAAC,EAAE,KAAK,EAAE,CAAC,GAAG,CAAC,GAAG,KAAK,EAAE,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;IAChD,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,IAAI,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,MAAM,CAAC,EAAE,CAAC;AAC/C,CAAC;AAED,SAAS,MAAM,CAAC,QAAgB,EAAE,WAAmB;IACnD,mEAAmE;IACnE,OAAO,QAAQ,GAAG,CAAC,GAAG,GAAG,CAAC,QAAQ,EAAE,GAAG,CAAC,WAAW,EAAE,WAAW,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACzE,CAAC;AAED,SAAS,IAAI,CAAC,CAAS,EAAE,CAAS;IAChC,yBAAyB;IACzB,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;IAC3B,OAAO,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,CAAC,CAAC,GAAG,UAAW,EAAE,CAAC,EAAE,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,UAAW,EAAE,CAAC;AACjF,CAAC;AAED,SAAS,MAAM,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;IAC5D,MAAM,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IACtC,sBAAsB;IACtB,MAAM,GAAG,GAAG,IAAA,eAAK,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC9B,OAAO,EAAE,CAAC,EAAE,IAAA,eAAK,EAAC,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,CAAC;AACnD,CAAC;AAED,yBAAyB;AACzB,MAAM,MAAM,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,CAAC;AAEpC,SAAS,CAAC,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IACnD,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAE9D,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,IAAA,iBAAO,EAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAA,iBAAO,EAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,IAAA,gBAAM,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAA,gBAAM,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAElE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,IAAA,gBAAM,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAA,gBAAM,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAElE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,IAAA,gBAAM,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAA,gBAAM,EAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAElE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC/C,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC/C,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC/C,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AACjD,CAAC;AAED,kBAAkB;AAClB,SAAS,CAAC,CACR,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EACtG,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW;IAEtG,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;AACxB,CAAC;AAED,SAAS,KAAK,CAAC,CAAc,EAAE,IAAY,EAAE,IAAY,EAAE,MAAc,EAAE,OAAgB;IACzF,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;QAAE,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;IAEpE,UAAU;IACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,IAAI,EAAE,EAAE,CAAC;QACjC,kBAAkB;QAClB,CAAC,CACC,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAClD,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,CAC7D,CAAC;IACJ,CAAC;IACD,OAAO;IACP,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC;QAC/B,kBAAkB;QAClB,CAAC,CACC,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EACxD,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,GAAG,CACjE,CAAC;IACJ,CAAC;IAED,IAAI,OAAO;QAAE,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,IAAI,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;;QAC7F,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;AAC3F,CAAC;AAED,mCAAmC;AACnC,SAAS,EAAE,CAAC,CAAc,EAAE,KAAa;IACvC,MAAM,EAAE,GAAG,IAAA,aAAE,EAAC,CAAC,CAAC,CAAC;IACjB,MAAM,CAAC,GAAG,IAAI,WAAW,CAAC,CAAC,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAA,aAAE,EAAC,CAAC,CAAC,CAAC;IACjB,CAAC,CAAC,CAAC,CAAC,GAAG,KAAK,CAAC;IACb,YAAY;IACZ,IAAI,KAAK,IAAI,EAAE;QAAE,OAAO,oBAAO,CAAC,MAAM,CAAC,EAAE,KAAK,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,EAAE,CAAC;IACjF,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC;IAClC,IAAI,CAAC,GAAG,oBAAO,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,EAAE,CAAC;IAC1D,IAAI,GAAG,GAAG,CAAC,CAAC;IACZ,cAAc;IACd,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC;IAC3B,GAAG,IAAI,EAAE,CAAC;IACV,cAAc;IACd,OAAO,KAAK,GAAG,GAAG,GAAG,EAAE,EAAE,GAAG,IAAI,EAAE;QAAE,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,IAAA,oBAAO,EAAC,CAAC,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;IACnF,aAAa;IACb,GAAG,CAAC,GAAG,CAAC,IAAA,oBAAO,EAAC,CAAC,EAAE,EAAE,KAAK,EAAE,KAAK,GAAG,GAAG,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;IACjD,OAAO,IAAA,cAAG,EAAC,GAAG,CAAC,CAAC;AAClB,CAAC;AAED,SAAS,UAAU,CACjB,CAAS,EACT,CAAS,EACT,OAAe,EACf,UAAkB,EAClB,KAAa,EACb,KAAa,EACb,WAAoB,KAAK;IAEzB,IAAI,IAAI,CAAC;IACT,IAAI,CAAC,IAAI,CAAC,EAAE,CAAC;QACX,IAAI,CAAC,IAAI,CAAC;YAAE,IAAI,GAAG,KAAK,GAAG,CAAC,CAAC;aACxB,IAAI,QAAQ;YAAE,IAAI,GAAG,CAAC,GAAG,UAAU,GAAG,KAAK,GAAG,CAAC,CAAC;;YAChD,IAAI,GAAG,CAAC,GAAG,UAAU,GAAG,CAAC,KAAK,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACrD,CAAC;SAAM,IAAI,QAAQ;QAAE,IAAI,GAAG,OAAO,GAAG,UAAU,GAAG,KAAK,GAAG,CAAC,CAAC;;QACxD,IAAI,GAAG,OAAO,GAAG,UAAU,GAAG,CAAC,KAAK,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACzD,MAAM,QAAQ,GAAG,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,kBAAkB,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;IACpF,MAAM,GAAG,GAAG,MAAM,CAAC,IAAI,EAAE,KAAK,CAAC,CAAC;IAChC,mCAAmC;IACnC,iDAAiD;IACjD,OAAO,CAAC,QAAQ,GAAG,GAAG,CAAC,GAAG,OAAO,CAAC;AACpC,CAAC;AAgBD,SAAS,UAAU,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IAC5E,QAAQ,GAAG,IAAA,kBAAO,EAAC,QAAQ,CAAC,CAAC;IAC7B,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;IACrB,IAAI,EAAE,CAAC,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,GAAG,EAAE,eAAe,EAAE,MAAM,EAAE,UAAU,EAAE,GAAG;QAC1E,GAAG,IAAI;QACP,OAAO,EAAE,IAAI,CAAC,OAAO,IAAI,IAAI;QAC7B,KAAK,EAAE,IAAI,CAAC,KAAK,IAAI,EAAE;QACvB,MAAM,EAAE,CAAC,IAAI,EAAE;KAChB,CAAC;IACF,aAAa;IACb,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,KAAK,CAAC,CAAC;IACpB,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,OAAO,CAAC,CAAC;IACtB,IAAI,KAAK,GAAG,CAAC,IAAI,KAAK,IAAI,CAAC,IAAI,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,0CAA0C,CAAC,CAAC;IAC/F,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,8CAA8C,CAAC,CAAC;IAC3F,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,CAAC;IAC1F,IAAI,CAAC,GAAG,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,CAAC;IAC9E,IAAI,OAAO,KAAK,EAAE,IAAI,OAAO,KAAK,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,2BAA2B,OAAO,EAAE,CAAC,CAAC;IAC5F,QAAQ,GAAG,IAAA,kBAAO,EAAC,QAAQ,CAAC,CAAC;IAC7B,IAAI,QAAQ,CAAC,MAAM,GAAG,CAAC,IAAI,QAAQ,CAAC,MAAM,IAAI,CAAC,IAAI,EAAE;QACnD,MAAM,IAAI,KAAK,CAAC,2CAA2C,CAAC,CAAC;IAC/D,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;IACrB,IAAI,IAAI,CAAC,MAAM,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,yCAAyC,CAAC,CAAC;IAChF,GAAG,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC;IAC3B,eAAe,GAAG,eAAe,CAAC,eAAe,CAAC,CAAC;IACnD,IAAI,UAAU,KAAK,SAAS,IAAI,OAAO,UAAU,KAAK,UAAU;QAC9D,MAAM,IAAI,KAAK,CAAC,+BAA+B,CAAC,CAAC;IACnD,SAAS;IACT,MAAM,KAAK,GAAG,CAAC,CAAC;IAChB,8BAA8B;IAC9B,MAAM,EAAE,GAAG,CAAC,GAAG,CAAC,GAAG,IAAI,CAAC,KAAK,CAAC,CAAC,GAAG,CAAC,kBAAkB,GAAG,CAAC,CAAC,CAAC,CAAC;IAC5D,oBAAoB;IACpB,MAAM,OAAO,GAAG,IAAI,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC;IACnC,MAAM,UAAU,GAAG,IAAI,CAAC,KAAK,CAAC,OAAO,GAAG,kBAAkB,CAAC,CAAC;IAC5D,KAAK;IACL,MAAM,CAAC,GAAG,oBAAO,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC;IAC7B,MAAM,GAAG,GAAG,IAAI,WAAW,CAAC,CAAC,CAAC,CAAC;IAC/B,MAAM,IAAI,GAAG,IAAA,aAAE,EAAC,GAAG,CAAC,CAAC;IACrB,KAAK,MAAM,CAAC,IAAI,CAAC,CAAC,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,IAAI,CAAC,EAAE,CAAC;QAChD,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE;YAAE,MAAM,IAAI,KAAK,CAAC,2BAA2B,CAAC,mBAAmB,CAAC,CAAC;QAC5F,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACX,CAAC,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IACjB,CAAC;IACD,KAAK,IAAI,CAAC,IAAI,CAAC,QAAQ,EAAE,IAAI,EAAE,GAAG,EAAE,eAAe,CAAC,EAAE,CAAC;QACrD,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,MAAM,CAAC;QAClB,CAAC,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;IAC3B,CAAC;IACD,MAAM,EAAE,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;IAC/B,MAAM,IAAI,GAAG,IAAA,aAAE,EAAC,EAAE,CAAC,CAAC;IACpB,CAAC,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC;IAEnB,8BAA8B;IAC9B,MAAM,OAAO,GAAG,EAAE,GAAG,GAAG,CAAC;IACzB,IAAI,OAAO,GAAG,CAAC,IAAI,OAAO,IAAI,CAAC,IAAI,EAAE,IAAI,OAAO,GAAG,MAAM,EAAE,CAAC;QAC1D,MAAM,IAAI,KAAK,CACb,iCAAiC,OAAO,WAAW,MAAM,8BAA8B,CACxF,CAAC;IACJ,CAAC;IACD,MAAM,CAAC,GAAG,IAAI,WAAW,CAAC,OAAO,CAAC,CAAC;IACnC,oBAAoB;IACpB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;QAC3B,MAAM,CAAC,GAAG,GAAG,GAAG,OAAO,GAAG,CAAC,CAAC;QAC5B,iDAAiD;QACjD,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACX,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACX,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,CAAC,CAAC,CAAC;QACvB,iDAAiD;QACjD,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACX,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,CAAC;IAC/B,CAAC;IACD,IAAI,QAAQ,GAAG,GAAG,EAAE,GAAE,CAAC,CAAC;IACxB,IAAI,UAAU,EAAE,CAAC;QACf,MAAM,UAAU,GAAG,CAAC,GAAG,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC;QAC3D,0DAA0D;QAC1D,wDAAwD;QACxD,MAAM,WAAW,GAAG,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,KAAK,CAAC,UAAU,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC;QAChE,IAAI,QAAQ,GAAG,CAAC,CAAC;QACjB,QAAQ,GAAG,GAAG,EAAE;YACd,QAAQ,EAAE,CAAC;YACX,IAAI,UAAU,IAAI,CAAC,CAAC,CAAC,QAAQ,GAAG,WAAW,CAAC,IAAI,QAAQ,KAAK,UAAU,CAAC;gBACtE,UAAU,CAAC,QAAQ,GAAG,UAAU,CAAC,CAAC;QACtC,CAAC,CAAC;IACJ,CAAC;IACD,OAAO,EAAE,IAAI,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,CAAC,EAAE,OAAO,EAAE,KAAK,EAAE,UAAU,EAAE,KAAK,EAAE,QAAQ,EAAE,CAAC;AACrF,CAAC;AAED,SAAS,YAAY,CAAC,CAAc,EAAE,CAAS,EAAE,OAAe,EAAE,KAAa;IAC7E,MAAM,OAAO,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,CAAC;IACrC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE;QACxB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;YAAE,OAAO,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,GAAG,CAAC,OAAO,GAAG,CAAC,GAAG,OAAO,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACvF,OAAO,IAAA,aAAE,EAAC,EAAE,CAAC,OAAO,EAAE,KAAK,CAAC,CAAC,CAAC;AAChC,CAAC;AAED,SAAS,YAAY,CACnB,CAAc,EACd,OAAoB,EACpB,CAAS,EACT,CAAS,EACT,CAAS,EACT,KAAa,EACb,OAAe,EACf,UAAkB,EAClB,KAAa,EACb,MAAc,EACd,IAAY,EACZ,eAAwB,EACxB,OAAgB;IAEhB,IAAI,MAAM,GAAG,OAAO;QAAE,IAAI,GAAG,MAAM,GAAG,CAAC,CAAC;IACxC,IAAI,KAAK,EAAE,KAAK,CAAC;IACjB,IAAI,eAAe,EAAE,CAAC;QACpB,IAAI,KAAK,GAAG,GAAG,KAAK,CAAC,EAAE,CAAC;YACtB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,CAAC;YACpB,KAAK,CAAC,OAAO,EAAE,GAAG,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;YACvC,KAAK,CAAC,OAAO,EAAE,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;QACvC,CAAC;QACD,KAAK,GAAG,OAAO,CAAC,CAAC,GAAG,CAAC,KAAK,GAAG,GAAG,CAAC,CAAC,CAAC;QACnC,KAAK,GAAG,OAAO,CAAC,CAAC,GAAG,CAAC,KAAK,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC;IACzC,CAAC;SAAM,CAAC;QACN,MAAM,CAAC,GAAG,GAAG,GAAG,IAAI,CAAC;QACrB,KAAK,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;QACb,KAAK,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACnB,CAAC;IACD,gBAAgB;IAChB,MAAM,OAAO,GAAG,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,KAAK,GAAG,KAAK,CAAC;IACvD,MAAM,MAAM,GAAG,UAAU,CAAC,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,UAAU,EAAE,KAAK,EAAE,KAAK,EAAE,OAAO,IAAI,CAAC,CAAC,CAAC;IACjF,MAAM,QAAQ,GAAG,OAAO,GAAG,OAAO,GAAG,MAAM,CAAC;IAC5C,kCAAkC;IAClC,KAAK,CAAC,CAAC,EAAE,GAAG,GAAG,IAAI,EAAE,GAAG,GAAG,QAAQ,EAAE,MAAM,GAAG,GAAG,EAAE,OAAO,CAAC,CAAC;AAC9D,CAAC;AAED,SAAS,MAAM,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IACxE,MAAM,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,CAAC,EAAE,OAAO,EAAE,KAAK,EAAE,UAAU,EAAE,KAAK,EAAE,QAAQ,EAAE,GAAG,UAAU,CACtF,IAAI,EACJ,QAAQ,EACR,IAAI,EACJ,IAAI,CACL,CAAC;IACF,iBAAiB;IACjB,kFAAkF;IAClF,MAAM,OAAO,GAAG,IAAI,WAAW,CAAC,CAAC,GAAG,GAAG,CAAC,CAAC;IACzC,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;IACtB,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IACrB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,IAAI,CAAC;IACzB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;QAC3B,MAAM,OAAO,GAAG,CAAC,KAAK,CAAC,IAAI,OAAO,KAAK,IAAI,CAAC;QAC5C,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,kBAAkB,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5C,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;YACrB,MAAM,eAAe,GAAG,IAAI,yBAAiB,IAAI,CAAC,IAAI,0BAAkB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;YAC9F,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;gBAC3B,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;gBACrB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;gBACtB,IAAI,QAAQ,GAAG,CAAC,CAAC;gBACjB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,CAAC,EAAE,CAAC;oBACvB,QAAQ,GAAG,CAAC,CAAC;oBACb,IAAI,eAAe,EAAE,CAAC;wBACpB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,CAAC;wBACpB,KAAK,CAAC,OAAO,EAAE,GAAG,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;wBACvC,KAAK,CAAC,OAAO,EAAE,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;oBACvC,CAAC;gBACH,CAAC;gBACD,wBAAwB;gBACxB,IAAI,MAAM,GAAG,CAAC,GAAG,OAAO,GAAG,CAAC,GAAG,UAAU,GAAG,QAAQ,CAAC;gBACrD,0BAA0B;gBAC1B,IAAI,IAAI,GAAG,MAAM,GAAG,OAAO,CAAC,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,CAAC,MAAM,GAAG,OAAO,GAAG,CAAC,CAAC;gBAChE,KAAK,IAAI,KAAK,GAAG,QAAQ,EAAE,KAAK,GAAG,UAAU,EAAE,KAAK,EAAE,EAAE,MAAM,EAAE,EAAE,IAAI,EAAE,EAAE,CAAC;oBACzE,QAAQ,EAAE,CAAC;oBACX,YAAY,CACV,CAAC,EACD,OAAO,EACP,CAAC,EACD,CAAC,EACD,CAAC,EACD,KAAK,EACL,OAAO,EACP,UAAU,EACV,KAAK,EACL,MAAM,EACN,IAAI,EACJ,eAAe,EACf,OAAO,CACR,CAAC;gBACJ,CAAC;YACH,CAAC;QACH,CAAC;IACH,CAAC;IACD,OAAO,YAAY,CAAC,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,KAAK,CAAC,CAAC;AAC5C,CAAC;AAEM,MAAM,OAAO,GAAG,CAAC,QAAe,EAAE,IAAW,EAAE,IAAe,EAAE,EAAE,CACvE,MAAM,yBAAiB,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;AADlC,QAAA,OAAO,WAC2B;AACxC,MAAM,OAAO,GAAG,CAAC,QAAe,EAAE,IAAW,EAAE,IAAe,EAAE,EAAE,CACvE,MAAM,wBAAgB,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;AADjC,QAAA,OAAO,WAC0B;AACvC,MAAM,QAAQ,GAAG,CAAC,QAAe,EAAE,IAAW,EAAE,IAAe,EAAE,EAAE,CACxE,MAAM,yBAAiB,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;AADlC,QAAA,QAAQ,YAC0B"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.d.ts
+new file mode 100644
+index 0000000..fa5b7f9
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.d.ts
+@@ -0,0 +1,53 @@
++import { BLAKE, BlakeOpts } from './_blake.js';
++export declare class BLAKE2b extends BLAKE<BLAKE2b> {
++    private v0l;
++    private v0h;
++    private v1l;
++    private v1h;
++    private v2l;
++    private v2h;
++    private v3l;
++    private v3h;
++    private v4l;
++    private v4h;
++    private v5l;
++    private v5h;
++    private v6l;
++    private v6h;
++    private v7l;
++    private v7h;
++    constructor(opts?: BlakeOpts);
++    protected get(): [
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number
++    ];
++    protected set(v0l: number, v0h: number, v1l: number, v1h: number, v2l: number, v2h: number, v3l: number, v3h: number, v4l: number, v4h: number, v5l: number, v5h: number, v6l: number, v6h: number, v7l: number, v7h: number): void;
++    protected compress(msg: Uint32Array, offset: number, isLast: boolean): void;
++    destroy(): void;
++}
++/**
++ * BLAKE2b - optimized for 64-bit platforms. JS doesn't have uint64, so it's slower than BLAKE2s.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++export declare const blake2b: {
++    (msg: import("./utils.js").Input, opts?: BlakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: BlakeOpts): import("./utils.js").Hash<BLAKE2b>;
++};
++//# sourceMappingURL=blake2b.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.d.ts.map
+new file mode 100644
+index 0000000..fa909ed
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2b.d.ts","sourceRoot":"","sources":["src/blake2b.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,SAAS,EAAS,MAAM,aAAa,CAAC;AAgEtD,qBAAa,OAAQ,SAAQ,KAAK,CAAC,OAAO,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;gBAEjB,IAAI,GAAE,SAAc;IA0BhC,SAAS,CAAC,GAAG,IAAI;QACf,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAC9D,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;KAC/D;IAKD,SAAS,CAAC,GAAG,CACX,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAClD,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAClD,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAClD,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM;IAmBpD,SAAS,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,OAAO;IAkDpE,OAAO;CAKR;AAED;;;;GAIG;AACH,eAAO,MAAM,OAAO;;;;;CAEnB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.js
+new file mode 100644
+index 0000000..269e97c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.js
+@@ -0,0 +1,193 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.blake2b = exports.BLAKE2b = void 0;
++const _blake_js_1 = require("./_blake.js");
++const _u64_js_1 = require("./_u64.js");
++const utils_js_1 = require("./utils.js");
++// Same as SHA-512 but LE
++// prettier-ignore
++const B2B_IV = /* @__PURE__ */ new Uint32Array([
++    0xf3bcc908, 0x6a09e667, 0x84caa73b, 0xbb67ae85, 0xfe94f82b, 0x3c6ef372, 0x5f1d36f1, 0xa54ff53a,
++    0xade682d1, 0x510e527f, 0x2b3e6c1f, 0x9b05688c, 0xfb41bd6b, 0x1f83d9ab, 0x137e2179, 0x5be0cd19
++]);
++// Temporary buffer
++const BBUF = /* @__PURE__ */ new Uint32Array(32);
++// Mixing function G splitted in two halfs
++function G1b(a, b, c, d, msg, x) {
++    // NOTE: V is LE here
++    const Xl = msg[x], Xh = msg[x + 1]; // prettier-ignore
++    let Al = BBUF[2 * a], Ah = BBUF[2 * a + 1]; // prettier-ignore
++    let Bl = BBUF[2 * b], Bh = BBUF[2 * b + 1]; // prettier-ignore
++    let Cl = BBUF[2 * c], Ch = BBUF[2 * c + 1]; // prettier-ignore
++    let Dl = BBUF[2 * d], Dh = BBUF[2 * d + 1]; // prettier-ignore
++    // v[a] = (v[a] + v[b] + x) | 0;
++    let ll = _u64_js_1.default.add3L(Al, Bl, Xl);
++    Ah = _u64_js_1.default.add3H(ll, Ah, Bh, Xh);
++    Al = ll | 0;
++    // v[d] = rotr(v[d] ^ v[a], 32)
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: _u64_js_1.default.rotr32H(Dh, Dl), Dl: _u64_js_1.default.rotr32L(Dh, Dl) });
++    // v[c] = (v[c] + v[d]) | 0;
++    ({ h: Ch, l: Cl } = _u64_js_1.default.add(Ch, Cl, Dh, Dl));
++    // v[b] = rotr(v[b] ^ v[c], 24)
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: _u64_js_1.default.rotrSH(Bh, Bl, 24), Bl: _u64_js_1.default.rotrSL(Bh, Bl, 24) });
++    (BBUF[2 * a] = Al), (BBUF[2 * a + 1] = Ah);
++    (BBUF[2 * b] = Bl), (BBUF[2 * b + 1] = Bh);
++    (BBUF[2 * c] = Cl), (BBUF[2 * c + 1] = Ch);
++    (BBUF[2 * d] = Dl), (BBUF[2 * d + 1] = Dh);
++}
++function G2b(a, b, c, d, msg, x) {
++    // NOTE: V is LE here
++    const Xl = msg[x], Xh = msg[x + 1]; // prettier-ignore
++    let Al = BBUF[2 * a], Ah = BBUF[2 * a + 1]; // prettier-ignore
++    let Bl = BBUF[2 * b], Bh = BBUF[2 * b + 1]; // prettier-ignore
++    let Cl = BBUF[2 * c], Ch = BBUF[2 * c + 1]; // prettier-ignore
++    let Dl = BBUF[2 * d], Dh = BBUF[2 * d + 1]; // prettier-ignore
++    // v[a] = (v[a] + v[b] + x) | 0;
++    let ll = _u64_js_1.default.add3L(Al, Bl, Xl);
++    Ah = _u64_js_1.default.add3H(ll, Ah, Bh, Xh);
++    Al = ll | 0;
++    // v[d] = rotr(v[d] ^ v[a], 16)
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: _u64_js_1.default.rotrSH(Dh, Dl, 16), Dl: _u64_js_1.default.rotrSL(Dh, Dl, 16) });
++    // v[c] = (v[c] + v[d]) | 0;
++    ({ h: Ch, l: Cl } = _u64_js_1.default.add(Ch, Cl, Dh, Dl));
++    // v[b] = rotr(v[b] ^ v[c], 63)
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: _u64_js_1.default.rotrBH(Bh, Bl, 63), Bl: _u64_js_1.default.rotrBL(Bh, Bl, 63) });
++    (BBUF[2 * a] = Al), (BBUF[2 * a + 1] = Ah);
++    (BBUF[2 * b] = Bl), (BBUF[2 * b + 1] = Bh);
++    (BBUF[2 * c] = Cl), (BBUF[2 * c + 1] = Ch);
++    (BBUF[2 * d] = Dl), (BBUF[2 * d + 1] = Dh);
++}
++class BLAKE2b extends _blake_js_1.BLAKE {
++    constructor(opts = {}) {
++        super(128, opts.dkLen === undefined ? 64 : opts.dkLen, opts, 64, 16, 16);
++        // Same as SHA-512, but LE
++        this.v0l = B2B_IV[0] | 0;
++        this.v0h = B2B_IV[1] | 0;
++        this.v1l = B2B_IV[2] | 0;
++        this.v1h = B2B_IV[3] | 0;
++        this.v2l = B2B_IV[4] | 0;
++        this.v2h = B2B_IV[5] | 0;
++        this.v3l = B2B_IV[6] | 0;
++        this.v3h = B2B_IV[7] | 0;
++        this.v4l = B2B_IV[8] | 0;
++        this.v4h = B2B_IV[9] | 0;
++        this.v5l = B2B_IV[10] | 0;
++        this.v5h = B2B_IV[11] | 0;
++        this.v6l = B2B_IV[12] | 0;
++        this.v6h = B2B_IV[13] | 0;
++        this.v7l = B2B_IV[14] | 0;
++        this.v7h = B2B_IV[15] | 0;
++        const keyLength = opts.key ? opts.key.length : 0;
++        this.v0l ^= this.outputLen | (keyLength << 8) | (0x01 << 16) | (0x01 << 24);
++        if (opts.salt) {
++            const salt = (0, utils_js_1.u32)((0, utils_js_1.toBytes)(opts.salt));
++            this.v4l ^= (0, utils_js_1.byteSwapIfBE)(salt[0]);
++            this.v4h ^= (0, utils_js_1.byteSwapIfBE)(salt[1]);
++            this.v5l ^= (0, utils_js_1.byteSwapIfBE)(salt[2]);
++            this.v5h ^= (0, utils_js_1.byteSwapIfBE)(salt[3]);
++        }
++        if (opts.personalization) {
++            const pers = (0, utils_js_1.u32)((0, utils_js_1.toBytes)(opts.personalization));
++            this.v6l ^= (0, utils_js_1.byteSwapIfBE)(pers[0]);
++            this.v6h ^= (0, utils_js_1.byteSwapIfBE)(pers[1]);
++            this.v7l ^= (0, utils_js_1.byteSwapIfBE)(pers[2]);
++            this.v7h ^= (0, utils_js_1.byteSwapIfBE)(pers[3]);
++        }
++        if (opts.key) {
++            // Pad to blockLen and update
++            const tmp = new Uint8Array(this.blockLen);
++            tmp.set((0, utils_js_1.toBytes)(opts.key));
++            this.update(tmp);
++        }
++    }
++    // prettier-ignore
++    get() {
++        let { v0l, v0h, v1l, v1h, v2l, v2h, v3l, v3h, v4l, v4h, v5l, v5h, v6l, v6h, v7l, v7h } = this;
++        return [v0l, v0h, v1l, v1h, v2l, v2h, v3l, v3h, v4l, v4h, v5l, v5h, v6l, v6h, v7l, v7h];
++    }
++    // prettier-ignore
++    set(v0l, v0h, v1l, v1h, v2l, v2h, v3l, v3h, v4l, v4h, v5l, v5h, v6l, v6h, v7l, v7h) {
++        this.v0l = v0l | 0;
++        this.v0h = v0h | 0;
++        this.v1l = v1l | 0;
++        this.v1h = v1h | 0;
++        this.v2l = v2l | 0;
++        this.v2h = v2h | 0;
++        this.v3l = v3l | 0;
++        this.v3h = v3h | 0;
++        this.v4l = v4l | 0;
++        this.v4h = v4h | 0;
++        this.v5l = v5l | 0;
++        this.v5h = v5h | 0;
++        this.v6l = v6l | 0;
++        this.v6h = v6h | 0;
++        this.v7l = v7l | 0;
++        this.v7h = v7h | 0;
++    }
++    compress(msg, offset, isLast) {
++        this.get().forEach((v, i) => (BBUF[i] = v)); // First half from state.
++        BBUF.set(B2B_IV, 16); // Second half from IV.
++        let { h, l } = _u64_js_1.default.fromBig(BigInt(this.length));
++        BBUF[24] = B2B_IV[8] ^ l; // Low word of the offset.
++        BBUF[25] = B2B_IV[9] ^ h; // High word.
++        // Invert all bits for last block
++        if (isLast) {
++            BBUF[28] = ~BBUF[28];
++            BBUF[29] = ~BBUF[29];
++        }
++        let j = 0;
++        const s = _blake_js_1.SIGMA;
++        for (let i = 0; i < 12; i++) {
++            G1b(0, 4, 8, 12, msg, offset + 2 * s[j++]);
++            G2b(0, 4, 8, 12, msg, offset + 2 * s[j++]);
++            G1b(1, 5, 9, 13, msg, offset + 2 * s[j++]);
++            G2b(1, 5, 9, 13, msg, offset + 2 * s[j++]);
++            G1b(2, 6, 10, 14, msg, offset + 2 * s[j++]);
++            G2b(2, 6, 10, 14, msg, offset + 2 * s[j++]);
++            G1b(3, 7, 11, 15, msg, offset + 2 * s[j++]);
++            G2b(3, 7, 11, 15, msg, offset + 2 * s[j++]);
++            G1b(0, 5, 10, 15, msg, offset + 2 * s[j++]);
++            G2b(0, 5, 10, 15, msg, offset + 2 * s[j++]);
++            G1b(1, 6, 11, 12, msg, offset + 2 * s[j++]);
++            G2b(1, 6, 11, 12, msg, offset + 2 * s[j++]);
++            G1b(2, 7, 8, 13, msg, offset + 2 * s[j++]);
++            G2b(2, 7, 8, 13, msg, offset + 2 * s[j++]);
++            G1b(3, 4, 9, 14, msg, offset + 2 * s[j++]);
++            G2b(3, 4, 9, 14, msg, offset + 2 * s[j++]);
++        }
++        this.v0l ^= BBUF[0] ^ BBUF[16];
++        this.v0h ^= BBUF[1] ^ BBUF[17];
++        this.v1l ^= BBUF[2] ^ BBUF[18];
++        this.v1h ^= BBUF[3] ^ BBUF[19];
++        this.v2l ^= BBUF[4] ^ BBUF[20];
++        this.v2h ^= BBUF[5] ^ BBUF[21];
++        this.v3l ^= BBUF[6] ^ BBUF[22];
++        this.v3h ^= BBUF[7] ^ BBUF[23];
++        this.v4l ^= BBUF[8] ^ BBUF[24];
++        this.v4h ^= BBUF[9] ^ BBUF[25];
++        this.v5l ^= BBUF[10] ^ BBUF[26];
++        this.v5h ^= BBUF[11] ^ BBUF[27];
++        this.v6l ^= BBUF[12] ^ BBUF[28];
++        this.v6h ^= BBUF[13] ^ BBUF[29];
++        this.v7l ^= BBUF[14] ^ BBUF[30];
++        this.v7h ^= BBUF[15] ^ BBUF[31];
++        BBUF.fill(0);
++    }
++    destroy() {
++        this.destroyed = true;
++        this.buffer32.fill(0);
++        this.set(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
++    }
++}
++exports.BLAKE2b = BLAKE2b;
++/**
++ * BLAKE2b - optimized for 64-bit platforms. JS doesn't have uint64, so it's slower than BLAKE2s.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++exports.blake2b = (0, utils_js_1.wrapConstructorWithOpts)((opts) => new BLAKE2b(opts));
++//# sourceMappingURL=blake2b.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.js.map
+new file mode 100644
+index 0000000..9b618d9
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2b.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2b.js","sourceRoot":"","sources":["src/blake2b.ts"],"names":[],"mappings":";;;AAAA,2CAAsD;AACtD,uCAA4B;AAC5B,yCAAiF;AAEjF,yBAAyB;AACzB,kBAAkB;AAClB,MAAM,MAAM,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAC7C,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AACH,mBAAmB;AACnB,MAAM,IAAI,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AAEjD,0CAA0C;AAC1C,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,GAAgB,EAAE,CAAS;IAClF,qBAAqB;IACrB,MAAM,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IACtD,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,gCAAgC;IAChC,IAAI,EAAE,GAAG,iBAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,iBAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACZ,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,iBAAG,CAAC,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,iBAAG,CAAC,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IACpE,4BAA4B;IAC5B,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC7C,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAC1E,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AAC7C,CAAC;AAED,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,GAAgB,EAAE,CAAS;IAClF,qBAAqB;IACrB,MAAM,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IACtD,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,gCAAgC;IAChC,IAAI,EAAE,GAAG,iBAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,iBAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACZ,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAC1E,4BAA4B;IAC5B,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC7C,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAC1E,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AAC7C,CAAC;AAED,MAAa,OAAQ,SAAQ,iBAAc;IAmBzC,YAAY,OAAkB,EAAE;QAC9B,KAAK,CAAC,GAAG,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;QAnB3E,0BAA0B;QAClB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QAI3B,MAAM,SAAS,GAAG,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;QACjD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,SAAS,GAAG,CAAC,SAAS,IAAI,CAAC,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,CAAC;QAC5E,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;YACd,MAAM,IAAI,GAAG,IAAA,cAAG,EAAC,IAAA,kBAAO,EAAC,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC;YACrC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpC,CAAC;QACD,IAAI,IAAI,CAAC,eAAe,EAAE,CAAC;YACzB,MAAM,IAAI,GAAG,IAAA,cAAG,EAAC,IAAA,kBAAO,EAAC,IAAI,CAAC,eAAe,CAAC,CAAC,CAAC;YAChD,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpC,CAAC;QACD,IAAI,IAAI,CAAC,GAAG,EAAE,CAAC;YACb,6BAA6B;YAC7B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YAC1C,GAAG,CAAC,GAAG,CAAC,IAAA,kBAAO,EAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;YAC3B,IAAI,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACnB,CAAC;IACH,CAAC;IACD,kBAAkB;IACR,GAAG;QAIX,IAAI,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QAC9F,OAAO,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IAC1F,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAClD,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAClD,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAClD,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW;QAElD,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;IACrB,CAAC;IACS,QAAQ,CAAC,GAAgB,EAAE,MAAc,EAAE,MAAe;QAClE,IAAI,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,yBAAyB;QACtE,IAAI,CAAC,GAAG,CAAC,MAAM,EAAE,EAAE,CAAC,CAAC,CAAC,uBAAuB;QAC7C,IAAI,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,iBAAG,CAAC,OAAO,CAAC,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC,CAAC;QAChD,IAAI,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,0BAA0B;QACpD,IAAI,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,aAAa;QACvC,iCAAiC;QACjC,IAAI,MAAM,EAAE,CAAC;YACX,IAAI,CAAC,EAAE,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YACrB,IAAI,CAAC,EAAE,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;QACvB,CAAC;QACD,IAAI,CAAC,GAAG,CAAC,CAAC;QACV,MAAM,CAAC,GAAG,iBAAK,CAAC;QAChB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAE5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;QAC7C,CAAC;QACD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACf,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACtB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC3D,CAAC;CACF;AAnID,0BAmIC;AAED;;;;GAIG;AACU,QAAA,OAAO,GAAmB,IAAA,kCAAuB,EAC5D,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,OAAO,CAAC,IAAI,CAAC,CAC5B,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.d.ts
+new file mode 100644
+index 0000000..29d4b2f
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.d.ts
+@@ -0,0 +1,47 @@
++import { BLAKE, BlakeOpts } from './_blake.js';
++export declare const B2S_IV: Uint32Array;
++export declare function compress(s: Uint8Array, offset: number, msg: Uint32Array, rounds: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number): {
++    v0: number;
++    v1: number;
++    v2: number;
++    v3: number;
++    v4: number;
++    v5: number;
++    v6: number;
++    v7: number;
++    v8: number;
++    v9: number;
++    v10: number;
++    v11: number;
++    v12: number;
++    v13: number;
++    v14: number;
++    v15: number;
++};
++export declare class BLAKE2s extends BLAKE<BLAKE2s> {
++    private v0;
++    private v1;
++    private v2;
++    private v3;
++    private v4;
++    private v5;
++    private v6;
++    private v7;
++    constructor(opts?: BlakeOpts);
++    protected get(): [number, number, number, number, number, number, number, number];
++    protected set(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number): void;
++    protected compress(msg: Uint32Array, offset: number, isLast: boolean): void;
++    destroy(): void;
++}
++/**
++ * BLAKE2s - optimized for 32-bit platforms. JS doesn't have uint64, so it's faster than BLAKE2b.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++export declare const blake2s: {
++    (msg: import("./utils.js").Input, opts?: BlakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: BlakeOpts): import("./utils.js").Hash<BLAKE2s>;
++};
++//# sourceMappingURL=blake2s.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.d.ts.map
+new file mode 100644
+index 0000000..01296a1
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2s.d.ts","sourceRoot":"","sources":["src/blake2s.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,SAAS,EAAS,MAAM,aAAa,CAAC;AAOtD,eAAO,MAAM,MAAM,aAEjB,CAAC;AAoBH,wBAAgB,QAAQ,CAAC,CAAC,EAAE,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EACtF,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAC9F,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM;;;;;;;;;;;;;;;;;EAuBrG;AAED,qBAAa,OAAQ,SAAQ,KAAK,CAAC,OAAO,CAAC;IAEzC,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;gBAEf,IAAI,GAAE,SAAc;IAqBhC,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAKjF,SAAS,CAAC,GAAG,CACX,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;IAWhG,SAAS,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,OAAO;IAkBpE,OAAO;CAKR;AAED;;;;GAIG;AACH,eAAO,MAAM,OAAO;;;;;CAEnB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.js
+new file mode 100644
+index 0000000..789b070
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.js
+@@ -0,0 +1,124 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.blake2s = exports.BLAKE2s = exports.B2S_IV = void 0;
++exports.compress = compress;
++const _blake_js_1 = require("./_blake.js");
++const _u64_js_1 = require("./_u64.js");
++const utils_js_1 = require("./utils.js");
++// Initial state: same as SHA256
++// first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19
++// prettier-ignore
++exports.B2S_IV = new Uint32Array([
++    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
++]);
++// Mixing function G splitted in two halfs
++function G1s(a, b, c, d, x) {
++    a = (a + b + x) | 0;
++    d = (0, utils_js_1.rotr)(d ^ a, 16);
++    c = (c + d) | 0;
++    b = (0, utils_js_1.rotr)(b ^ c, 12);
++    return { a, b, c, d };
++}
++function G2s(a, b, c, d, x) {
++    a = (a + b + x) | 0;
++    d = (0, utils_js_1.rotr)(d ^ a, 8);
++    c = (c + d) | 0;
++    b = (0, utils_js_1.rotr)(b ^ c, 7);
++    return { a, b, c, d };
++}
++// prettier-ignore
++function compress(s, offset, msg, rounds, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) {
++    let j = 0;
++    for (let i = 0; i < rounds; i++) {
++        ({ a: v0, b: v4, c: v8, d: v12 } = G1s(v0, v4, v8, v12, msg[offset + s[j++]]));
++        ({ a: v0, b: v4, c: v8, d: v12 } = G2s(v0, v4, v8, v12, msg[offset + s[j++]]));
++        ({ a: v1, b: v5, c: v9, d: v13 } = G1s(v1, v5, v9, v13, msg[offset + s[j++]]));
++        ({ a: v1, b: v5, c: v9, d: v13 } = G2s(v1, v5, v9, v13, msg[offset + s[j++]]));
++        ({ a: v2, b: v6, c: v10, d: v14 } = G1s(v2, v6, v10, v14, msg[offset + s[j++]]));
++        ({ a: v2, b: v6, c: v10, d: v14 } = G2s(v2, v6, v10, v14, msg[offset + s[j++]]));
++        ({ a: v3, b: v7, c: v11, d: v15 } = G1s(v3, v7, v11, v15, msg[offset + s[j++]]));
++        ({ a: v3, b: v7, c: v11, d: v15 } = G2s(v3, v7, v11, v15, msg[offset + s[j++]]));
++        ({ a: v0, b: v5, c: v10, d: v15 } = G1s(v0, v5, v10, v15, msg[offset + s[j++]]));
++        ({ a: v0, b: v5, c: v10, d: v15 } = G2s(v0, v5, v10, v15, msg[offset + s[j++]]));
++        ({ a: v1, b: v6, c: v11, d: v12 } = G1s(v1, v6, v11, v12, msg[offset + s[j++]]));
++        ({ a: v1, b: v6, c: v11, d: v12 } = G2s(v1, v6, v11, v12, msg[offset + s[j++]]));
++        ({ a: v2, b: v7, c: v8, d: v13 } = G1s(v2, v7, v8, v13, msg[offset + s[j++]]));
++        ({ a: v2, b: v7, c: v8, d: v13 } = G2s(v2, v7, v8, v13, msg[offset + s[j++]]));
++        ({ a: v3, b: v4, c: v9, d: v14 } = G1s(v3, v4, v9, v14, msg[offset + s[j++]]));
++        ({ a: v3, b: v4, c: v9, d: v14 } = G2s(v3, v4, v9, v14, msg[offset + s[j++]]));
++    }
++    return { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
++}
++class BLAKE2s extends _blake_js_1.BLAKE {
++    constructor(opts = {}) {
++        super(64, opts.dkLen === undefined ? 32 : opts.dkLen, opts, 32, 8, 8);
++        // Internal state, same as SHA-256
++        this.v0 = exports.B2S_IV[0] | 0;
++        this.v1 = exports.B2S_IV[1] | 0;
++        this.v2 = exports.B2S_IV[2] | 0;
++        this.v3 = exports.B2S_IV[3] | 0;
++        this.v4 = exports.B2S_IV[4] | 0;
++        this.v5 = exports.B2S_IV[5] | 0;
++        this.v6 = exports.B2S_IV[6] | 0;
++        this.v7 = exports.B2S_IV[7] | 0;
++        const keyLength = opts.key ? opts.key.length : 0;
++        this.v0 ^= this.outputLen | (keyLength << 8) | (0x01 << 16) | (0x01 << 24);
++        if (opts.salt) {
++            const salt = (0, utils_js_1.u32)((0, utils_js_1.toBytes)(opts.salt));
++            this.v4 ^= (0, utils_js_1.byteSwapIfBE)(salt[0]);
++            this.v5 ^= (0, utils_js_1.byteSwapIfBE)(salt[1]);
++        }
++        if (opts.personalization) {
++            const pers = (0, utils_js_1.u32)((0, utils_js_1.toBytes)(opts.personalization));
++            this.v6 ^= (0, utils_js_1.byteSwapIfBE)(pers[0]);
++            this.v7 ^= (0, utils_js_1.byteSwapIfBE)(pers[1]);
++        }
++        if (opts.key) {
++            // Pad to blockLen and update
++            const tmp = new Uint8Array(this.blockLen);
++            tmp.set((0, utils_js_1.toBytes)(opts.key));
++            this.update(tmp);
++        }
++    }
++    get() {
++        const { v0, v1, v2, v3, v4, v5, v6, v7 } = this;
++        return [v0, v1, v2, v3, v4, v5, v6, v7];
++    }
++    // prettier-ignore
++    set(v0, v1, v2, v3, v4, v5, v6, v7) {
++        this.v0 = v0 | 0;
++        this.v1 = v1 | 0;
++        this.v2 = v2 | 0;
++        this.v3 = v3 | 0;
++        this.v4 = v4 | 0;
++        this.v5 = v5 | 0;
++        this.v6 = v6 | 0;
++        this.v7 = v7 | 0;
++    }
++    compress(msg, offset, isLast) {
++        const { h, l } = (0, _u64_js_1.fromBig)(BigInt(this.length));
++        // prettier-ignore
++        const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = compress(_blake_js_1.SIGMA, offset, msg, 10, this.v0, this.v1, this.v2, this.v3, this.v4, this.v5, this.v6, this.v7, exports.B2S_IV[0], exports.B2S_IV[1], exports.B2S_IV[2], exports.B2S_IV[3], l ^ exports.B2S_IV[4], h ^ exports.B2S_IV[5], isLast ? ~exports.B2S_IV[6] : exports.B2S_IV[6], exports.B2S_IV[7]);
++        this.v0 ^= v0 ^ v8;
++        this.v1 ^= v1 ^ v9;
++        this.v2 ^= v2 ^ v10;
++        this.v3 ^= v3 ^ v11;
++        this.v4 ^= v4 ^ v12;
++        this.v5 ^= v5 ^ v13;
++        this.v6 ^= v6 ^ v14;
++        this.v7 ^= v7 ^ v15;
++    }
++    destroy() {
++        this.destroyed = true;
++        this.buffer32.fill(0);
++        this.set(0, 0, 0, 0, 0, 0, 0, 0);
++    }
++}
++exports.BLAKE2s = BLAKE2s;
++/**
++ * BLAKE2s - optimized for 32-bit platforms. JS doesn't have uint64, so it's faster than BLAKE2b.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++exports.blake2s = (0, utils_js_1.wrapConstructorWithOpts)((opts) => new BLAKE2s(opts));
++//# sourceMappingURL=blake2s.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.js.map
+new file mode 100644
+index 0000000..9d81df0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake2s.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2s.js","sourceRoot":"","sources":["src/blake2s.ts"],"names":[],"mappings":";;;AA6BA,4BAyBC;AAtDD,2CAAsD;AACtD,uCAAoC;AACpC,yCAAuF;AAEvF,gCAAgC;AAChC,wFAAwF;AACxF,kBAAkB;AACL,QAAA,MAAM,GAAmB,IAAI,WAAW,CAAC;IACpD,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AAEH,0CAA0C;AAC1C,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IAChE,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IACpB,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;IACpB,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IAChB,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;IACpB,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;AACxB,CAAC;AAED,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IAChE,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IACpB,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC,CAAC;IACnB,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IAChB,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC,CAAC;IACnB,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;AACxB,CAAC;AAED,kBAAkB;AAClB,SAAgB,QAAQ,CAAC,CAAa,EAAE,MAAc,EAAE,GAAgB,EAAE,MAAc,EACtF,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAC9F,EAAU,EAAE,EAAU,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW;IAEpG,IAAI,CAAC,GAAG,CAAC,CAAC;IACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QAChC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAEjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;IACjF,CAAC;IACD,OAAO,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC;AAClF,CAAC;AAED,MAAa,OAAQ,SAAQ,iBAAc;IAWzC,YAAY,OAAkB,EAAE;QAC9B,KAAK,CAAC,EAAE,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QAXxE,kCAAkC;QAC1B,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,cAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QAIzB,MAAM,SAAS,GAAG,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;QACjD,IAAI,CAAC,EAAE,IAAI,IAAI,CAAC,SAAS,GAAG,CAAC,SAAS,IAAI,CAAC,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,CAAC;QAC3E,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;YACd,MAAM,IAAI,GAAG,IAAA,cAAG,EAAC,IAAA,kBAAO,EAAC,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC;YACrC,IAAI,CAAC,EAAE,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YACjC,IAAI,CAAC,EAAE,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACnC,CAAC;QACD,IAAI,IAAI,CAAC,eAAe,EAAE,CAAC;YACzB,MAAM,IAAI,GAAG,IAAA,cAAG,EAAC,IAAA,kBAAO,EAAC,IAAI,CAAC,eAAe,CAAC,CAAC,CAAC;YAChD,IAAI,CAAC,EAAE,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YACjC,IAAI,CAAC,EAAE,IAAI,IAAA,uBAAY,EAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACnC,CAAC;QACD,IAAI,IAAI,CAAC,GAAG,EAAE,CAAC;YACb,6BAA6B;YAC7B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YAC1C,GAAG,CAAC,GAAG,CAAC,IAAA,kBAAO,EAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;YAC3B,IAAI,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACnB,CAAC;IACH,CAAC;IACS,GAAG;QACX,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QAChD,OAAO,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC1C,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;QAE9F,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACnB,CAAC;IACS,QAAQ,CAAC,GAAgB,EAAE,MAAc,EAAE,MAAe;QAClE,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAA,iBAAO,EAAC,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC,CAAC;QAC9C,kBAAkB;QAClB,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAC5E,QAAQ,CACN,iBAAK,EAAE,MAAM,EAAE,GAAG,EAAE,EAAE,EACtB,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EACtE,cAAM,CAAC,CAAC,CAAC,EAAE,cAAM,CAAC,CAAC,CAAC,EAAE,cAAM,CAAC,CAAC,CAAC,EAAE,cAAM,CAAC,CAAC,CAAC,EAAE,CAAC,GAAG,cAAM,CAAC,CAAC,CAAC,EAAE,CAAC,GAAG,cAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,CAAC,cAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,cAAM,CAAC,CAAC,CAAC,EAAE,cAAM,CAAC,CAAC,CAAC,CACrH,CAAC;QACJ,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,EAAE,CAAC;QACnB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,EAAE,CAAC;QACnB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;IACtB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACtB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IACnC,CAAC;CACF;AAxED,0BAwEC;AAED;;;;GAIG;AACU,QAAA,OAAO,GAAmB,IAAA,kCAAuB,EAC5D,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,OAAO,CAAC,IAAI,CAAC,CAC5B,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.d.ts
+new file mode 100644
+index 0000000..701b389
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.d.ts
+@@ -0,0 +1,46 @@
++import { BLAKE } from './_blake.js';
++import { Input, HashXOF } from './utils.js';
++export type Blake3Opts = {
++    dkLen?: number;
++    key?: Input;
++    context?: Input;
++};
++export declare class BLAKE3 extends BLAKE<BLAKE3> implements HashXOF<BLAKE3> {
++    private IV;
++    private flags;
++    private state;
++    private chunkPos;
++    private chunksDone;
++    private stack;
++    private posOut;
++    private bufferOut32;
++    private bufferOut;
++    private chunkOut;
++    private enableXOF;
++    constructor(opts?: Blake3Opts, flags?: number);
++    protected get(): never[];
++    protected set(): void;
++    private b2Compress;
++    protected compress(buf: Uint32Array, bufPos?: number, isLast?: boolean): void;
++    _cloneInto(to?: BLAKE3): BLAKE3;
++    destroy(): void;
++    private b2CompressOut;
++    protected finish(): void;
++    private writeInto;
++    xofInto(out: Uint8Array): Uint8Array;
++    xof(bytes: number): Uint8Array;
++    digestInto(out: Uint8Array): Uint8Array;
++    digest(): Uint8Array;
++}
++/**
++ * BLAKE3 hash function.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, context
++ */
++export declare const blake3: {
++    (msg: Input, opts?: Blake3Opts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: Blake3Opts): HashXOF<BLAKE3>;
++};
++//# sourceMappingURL=blake3.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.d.ts.map
+new file mode 100644
+index 0000000..e6ff86a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake3.d.ts","sourceRoot":"","sources":["src/blake3.ts"],"names":[],"mappings":"AAEA,OAAO,EAAE,KAAK,EAAE,MAAM,aAAa,CAAC;AAEpC,OAAO,EACL,KAAK,EAIL,OAAO,EAIR,MAAM,YAAY,CAAC;AA4BpB,MAAM,MAAM,UAAU,GAAG;IAAE,KAAK,CAAC,EAAE,MAAM,CAAC;IAAC,GAAG,CAAC,EAAE,KAAK,CAAC;IAAC,OAAO,CAAC,EAAE,KAAK,CAAA;CAAE,CAAC;AAU1E,qBAAa,MAAO,SAAQ,KAAK,CAAC,MAAM,CAAE,YAAW,OAAO,CAAC,MAAM,CAAC;IAClE,OAAO,CAAC,EAAE,CAAc;IACxB,OAAO,CAAC,KAAK,CAAS;IACtB,OAAO,CAAC,KAAK,CAAc;IAC3B,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,UAAU,CAAK;IACvB,OAAO,CAAC,KAAK,CAAqB;IAElC,OAAO,CAAC,MAAM,CAAK;IACnB,OAAO,CAAC,WAAW,CAAuB;IAC1C,OAAO,CAAC,SAAS,CAAa;IAC9B,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,SAAS,CAAQ;gBAEb,IAAI,GAAE,UAAe,EAAE,KAAK,SAAI;IA2B5C,SAAS,CAAC,GAAG;IAGb,SAAS,CAAC,GAAG;IACb,OAAO,CAAC,UAAU;IAmBlB,SAAS,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,GAAE,MAAU,EAAE,MAAM,GAAE,OAAe;IAiChF,UAAU,CAAC,EAAE,CAAC,EAAE,MAAM,GAAG,MAAM;IAe/B,OAAO;IASP,OAAO,CAAC,aAAa;IAiCrB,SAAS,CAAC,MAAM;IAoBhB,OAAO,CAAC,SAAS;IAcjB,OAAO,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU;IAIpC,GAAG,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU;IAI9B,UAAU,CAAC,GAAG,EAAE,UAAU;IAQ1B,MAAM;CAGP;AAED;;;;GAIG;AACH,eAAO,MAAM,MAAM;;;;;CAElB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.js
+new file mode 100644
+index 0000000..607d7f0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.js
+@@ -0,0 +1,244 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.blake3 = exports.BLAKE3 = void 0;
++const _assert_js_1 = require("./_assert.js");
++const _u64_js_1 = require("./_u64.js");
++const _blake_js_1 = require("./_blake.js");
++const blake2s_js_1 = require("./blake2s.js");
++const utils_js_1 = require("./utils.js");
++const SIGMA = /* @__PURE__ */ (() => {
++    const Id = Array.from({ length: 16 }, (_, i) => i);
++    const permute = (arr) => [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8].map((i) => arr[i]);
++    const res = [];
++    for (let i = 0, v = Id; i < 7; i++, v = permute(v))
++        res.push(...v);
++    return Uint8Array.from(res);
++})();
++// Why is this so slow? It should be 6x faster than blake2b.
++// - There is only 30% reduction in number of rounds from blake2s
++// - This function uses tree mode to achive parallelisation via SIMD and threading,
++//   however in JS we don't have threads and SIMD, so we get only overhead from tree structure
++// - It is possible to speed it up via Web Workers, hovewer it will make code singnificantly more
++//   complicated, which we are trying to avoid, since this library is intended to be used
++//   for cryptographic purposes. Also, parallelization happens only on chunk level (1024 bytes),
++//   which won't really benefit small inputs.
++class BLAKE3 extends _blake_js_1.BLAKE {
++    constructor(opts = {}, flags = 0) {
++        super(64, opts.dkLen === undefined ? 32 : opts.dkLen, {}, Number.MAX_SAFE_INTEGER, 0, 0);
++        this.flags = 0 | 0;
++        this.chunkPos = 0; // Position of current block in chunk
++        this.chunksDone = 0; // How many chunks we already have
++        this.stack = [];
++        // Output
++        this.posOut = 0;
++        this.bufferOut32 = new Uint32Array(16);
++        this.chunkOut = 0; // index of output chunk
++        this.enableXOF = true;
++        this.outputLen = opts.dkLen === undefined ? 32 : opts.dkLen;
++        (0, _assert_js_1.number)(this.outputLen);
++        if (opts.key !== undefined && opts.context !== undefined)
++            throw new Error('Blake3: only key or context can be specified at same time');
++        else if (opts.key !== undefined) {
++            const key = (0, utils_js_1.toBytes)(opts.key).slice();
++            if (key.length !== 32)
++                throw new Error('Blake3: key should be 32 byte');
++            this.IV = (0, utils_js_1.u32)(key);
++            if (!utils_js_1.isLE)
++                (0, utils_js_1.byteSwap32)(this.IV);
++            this.flags = flags | 16 /* B3_Flags.KEYED_HASH */;
++        }
++        else if (opts.context !== undefined) {
++            const context_key = new BLAKE3({ dkLen: 32 }, 32 /* B3_Flags.DERIVE_KEY_CONTEXT */)
++                .update(opts.context)
++                .digest();
++            this.IV = (0, utils_js_1.u32)(context_key);
++            if (!utils_js_1.isLE)
++                (0, utils_js_1.byteSwap32)(this.IV);
++            this.flags = flags | 64 /* B3_Flags.DERIVE_KEY_MATERIAL */;
++        }
++        else {
++            this.IV = blake2s_js_1.B2S_IV.slice();
++            this.flags = flags;
++        }
++        this.state = this.IV.slice();
++        this.bufferOut = (0, utils_js_1.u8)(this.bufferOut32);
++    }
++    // Unused
++    get() {
++        return [];
++    }
++    set() { }
++    b2Compress(counter, flags, buf, bufPos = 0) {
++        const { state: s, pos } = this;
++        const { h, l } = (0, _u64_js_1.fromBig)(BigInt(counter), true);
++        // prettier-ignore
++        const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = (0, blake2s_js_1.compress)(SIGMA, bufPos, buf, 7, s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], blake2s_js_1.B2S_IV[0], blake2s_js_1.B2S_IV[1], blake2s_js_1.B2S_IV[2], blake2s_js_1.B2S_IV[3], h, l, pos, flags);
++        s[0] = v0 ^ v8;
++        s[1] = v1 ^ v9;
++        s[2] = v2 ^ v10;
++        s[3] = v3 ^ v11;
++        s[4] = v4 ^ v12;
++        s[5] = v5 ^ v13;
++        s[6] = v6 ^ v14;
++        s[7] = v7 ^ v15;
++    }
++    compress(buf, bufPos = 0, isLast = false) {
++        // Compress last block
++        let flags = this.flags;
++        if (!this.chunkPos)
++            flags |= 1 /* B3_Flags.CHUNK_START */;
++        if (this.chunkPos === 15 || isLast)
++            flags |= 2 /* B3_Flags.CHUNK_END */;
++        if (!isLast)
++            this.pos = this.blockLen;
++        this.b2Compress(this.chunksDone, flags, buf, bufPos);
++        this.chunkPos += 1;
++        // If current block is last in chunk (16 blocks), then compress chunks
++        if (this.chunkPos === 16 || isLast) {
++            let chunk = this.state;
++            this.state = this.IV.slice();
++            // If not the last one, compress only when there are trailing zeros in chunk counter
++            // chunks used as binary tree where current stack is path. Zero means current leaf is finished and can be compressed.
++            // 1 (001) - leaf not finished (just push current chunk to stack)
++            // 2 (010) - leaf finished at depth=1 (merge with last elm on stack and push back)
++            // 3 (011) - last leaf not finished
++            // 4 (100) - leafs finished at depth=1 and depth=2
++            for (let last, chunks = this.chunksDone + 1; isLast || !(chunks & 1); chunks >>= 1) {
++                if (!(last = this.stack.pop()))
++                    break;
++                this.buffer32.set(last, 0);
++                this.buffer32.set(chunk, 8);
++                this.pos = this.blockLen;
++                this.b2Compress(0, this.flags | 4 /* B3_Flags.PARENT */, this.buffer32, 0);
++                chunk = this.state;
++                this.state = this.IV.slice();
++            }
++            this.chunksDone++;
++            this.chunkPos = 0;
++            this.stack.push(chunk);
++        }
++        this.pos = 0;
++    }
++    _cloneInto(to) {
++        to = super._cloneInto(to);
++        const { IV, flags, state, chunkPos, posOut, chunkOut, stack, chunksDone } = this;
++        to.state.set(state.slice());
++        to.stack = stack.map((i) => Uint32Array.from(i));
++        to.IV.set(IV);
++        to.flags = flags;
++        to.chunkPos = chunkPos;
++        to.chunksDone = chunksDone;
++        to.posOut = posOut;
++        to.chunkOut = chunkOut;
++        to.enableXOF = this.enableXOF;
++        to.bufferOut32.set(this.bufferOut32);
++        return to;
++    }
++    destroy() {
++        this.destroyed = true;
++        this.state.fill(0);
++        this.buffer32.fill(0);
++        this.IV.fill(0);
++        this.bufferOut32.fill(0);
++        for (let i of this.stack)
++            i.fill(0);
++    }
++    // Same as b2Compress, but doesn't modify state and returns 16 u32 array (instead of 8)
++    b2CompressOut() {
++        const { state: s, pos, flags, buffer32, bufferOut32: out32 } = this;
++        const { h, l } = (0, _u64_js_1.fromBig)(BigInt(this.chunkOut++));
++        if (!utils_js_1.isLE)
++            (0, utils_js_1.byteSwap32)(buffer32);
++        // prettier-ignore
++        const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = (0, blake2s_js_1.compress)(SIGMA, 0, buffer32, 7, s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], blake2s_js_1.B2S_IV[0], blake2s_js_1.B2S_IV[1], blake2s_js_1.B2S_IV[2], blake2s_js_1.B2S_IV[3], l, h, pos, flags);
++        out32[0] = v0 ^ v8;
++        out32[1] = v1 ^ v9;
++        out32[2] = v2 ^ v10;
++        out32[3] = v3 ^ v11;
++        out32[4] = v4 ^ v12;
++        out32[5] = v5 ^ v13;
++        out32[6] = v6 ^ v14;
++        out32[7] = v7 ^ v15;
++        out32[8] = s[0] ^ v8;
++        out32[9] = s[1] ^ v9;
++        out32[10] = s[2] ^ v10;
++        out32[11] = s[3] ^ v11;
++        out32[12] = s[4] ^ v12;
++        out32[13] = s[5] ^ v13;
++        out32[14] = s[6] ^ v14;
++        out32[15] = s[7] ^ v15;
++        if (!utils_js_1.isLE) {
++            (0, utils_js_1.byteSwap32)(buffer32);
++            (0, utils_js_1.byteSwap32)(out32);
++        }
++        this.posOut = 0;
++    }
++    finish() {
++        if (this.finished)
++            return;
++        this.finished = true;
++        // Padding
++        this.buffer.fill(0, this.pos);
++        // Process last chunk
++        let flags = this.flags | 8 /* B3_Flags.ROOT */;
++        if (this.stack.length) {
++            flags |= 4 /* B3_Flags.PARENT */;
++            if (!utils_js_1.isLE)
++                (0, utils_js_1.byteSwap32)(this.buffer32);
++            this.compress(this.buffer32, 0, true);
++            if (!utils_js_1.isLE)
++                (0, utils_js_1.byteSwap32)(this.buffer32);
++            this.chunksDone = 0;
++            this.pos = this.blockLen;
++        }
++        else {
++            flags |= (!this.chunkPos ? 1 /* B3_Flags.CHUNK_START */ : 0) | 2 /* B3_Flags.CHUNK_END */;
++        }
++        this.flags = flags;
++        this.b2CompressOut();
++    }
++    writeInto(out) {
++        (0, _assert_js_1.exists)(this, false);
++        (0, _assert_js_1.bytes)(out);
++        this.finish();
++        const { blockLen, bufferOut } = this;
++        for (let pos = 0, len = out.length; pos < len;) {
++            if (this.posOut >= blockLen)
++                this.b2CompressOut();
++            const take = Math.min(blockLen - this.posOut, len - pos);
++            out.set(bufferOut.subarray(this.posOut, this.posOut + take), pos);
++            this.posOut += take;
++            pos += take;
++        }
++        return out;
++    }
++    xofInto(out) {
++        if (!this.enableXOF)
++            throw new Error('XOF is not possible after digest call');
++        return this.writeInto(out);
++    }
++    xof(bytes) {
++        (0, _assert_js_1.number)(bytes);
++        return this.xofInto(new Uint8Array(bytes));
++    }
++    digestInto(out) {
++        (0, _assert_js_1.output)(out, this);
++        if (this.finished)
++            throw new Error('digest() was already called');
++        this.enableXOF = false;
++        this.writeInto(out);
++        this.destroy();
++        return out;
++    }
++    digest() {
++        return this.digestInto(new Uint8Array(this.outputLen));
++    }
++}
++exports.BLAKE3 = BLAKE3;
++/**
++ * BLAKE3 hash function.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, context
++ */
++exports.blake3 = (0, utils_js_1.wrapXOFConstructorWithOpts)((opts) => new BLAKE3(opts));
++//# sourceMappingURL=blake3.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.js.map
+new file mode 100644
+index 0000000..abe1edb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/blake3.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake3.js","sourceRoot":"","sources":["src/blake3.ts"],"names":[],"mappings":";;;AAAA,6CAA6D;AAC7D,uCAAoC;AACpC,2CAAoC;AACpC,6CAAgD;AAChD,yCASoB;AAepB,MAAM,KAAK,GAAe,eAAe,CAAC,CAAC,GAAG,EAAE;IAC9C,MAAM,EAAE,GAAG,KAAK,CAAC,IAAI,CAAC,EAAE,MAAM,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC;IACnD,MAAM,OAAO,GAAG,CAAC,GAAa,EAAE,EAAE,CAChC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;IAC5E,MAAM,GAAG,GAAa,EAAE,CAAC;IACzB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,GAAG,OAAO,CAAC,CAAC,CAAC;QAAE,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;IACnE,OAAO,UAAU,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC;AAC9B,CAAC,CAAC,EAAE,CAAC;AAQL,4DAA4D;AAC5D,iEAAiE;AACjE,mFAAmF;AACnF,8FAA8F;AAC9F,iGAAiG;AACjG,yFAAyF;AACzF,gGAAgG;AAChG,6CAA6C;AAC7C,MAAa,MAAO,SAAQ,iBAAa;IAcvC,YAAY,OAAmB,EAAE,EAAE,KAAK,GAAG,CAAC;QAC1C,KAAK,CAAC,EAAE,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,EAAE,EAAE,MAAM,CAAC,gBAAgB,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QAbnF,UAAK,GAAG,CAAC,GAAG,CAAC,CAAC;QAEd,aAAQ,GAAG,CAAC,CAAC,CAAC,qCAAqC;QACnD,eAAU,GAAG,CAAC,CAAC,CAAC,kCAAkC;QAClD,UAAK,GAAkB,EAAE,CAAC;QAClC,SAAS;QACD,WAAM,GAAG,CAAC,CAAC;QACX,gBAAW,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;QAElC,aAAQ,GAAG,CAAC,CAAC,CAAC,wBAAwB;QACtC,cAAS,GAAG,IAAI,CAAC;QAIvB,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC;QAC5D,IAAA,mBAAM,EAAC,IAAI,CAAC,SAAS,CAAC,CAAC;QACvB,IAAI,IAAI,CAAC,GAAG,KAAK,SAAS,IAAI,IAAI,CAAC,OAAO,KAAK,SAAS;YACtD,MAAM,IAAI,KAAK,CAAC,2DAA2D,CAAC,CAAC;aAC1E,IAAI,IAAI,CAAC,GAAG,KAAK,SAAS,EAAE,CAAC;YAChC,MAAM,GAAG,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,CAAC;YACtC,IAAI,GAAG,CAAC,MAAM,KAAK,EAAE;gBAAE,MAAM,IAAI,KAAK,CAAC,+BAA+B,CAAC,CAAC;YACxE,IAAI,CAAC,EAAE,GAAG,IAAA,cAAG,EAAC,GAAG,CAAC,CAAC;YACnB,IAAI,CAAC,eAAI;gBAAE,IAAA,qBAAU,EAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAC/B,IAAI,CAAC,KAAK,GAAG,KAAK,+BAAsB,CAAC;QAC3C,CAAC;aAAM,IAAI,IAAI,CAAC,OAAO,KAAK,SAAS,EAAE,CAAC;YACtC,MAAM,WAAW,GAAG,IAAI,MAAM,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,uCAA8B;iBACvE,MAAM,CAAC,IAAI,CAAC,OAAO,CAAC;iBACpB,MAAM,EAAE,CAAC;YACZ,IAAI,CAAC,EAAE,GAAG,IAAA,cAAG,EAAC,WAAW,CAAC,CAAC;YAC3B,IAAI,CAAC,eAAI;gBAAE,IAAA,qBAAU,EAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAC/B,IAAI,CAAC,KAAK,GAAG,KAAK,wCAA+B,CAAC;QACpD,CAAC;aAAM,CAAC;YACN,IAAI,CAAC,EAAE,GAAG,mBAAM,CAAC,KAAK,EAAE,CAAC;YACzB,IAAI,CAAC,KAAK,GAAG,KAAK,CAAC;QACrB,CAAC;QACD,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,EAAE,CAAC,KAAK,EAAE,CAAC;QAC7B,IAAI,CAAC,SAAS,GAAG,IAAA,aAAE,EAAC,IAAI,CAAC,WAAW,CAAC,CAAC;IACxC,CAAC;IACD,SAAS;IACC,GAAG;QACX,OAAO,EAAE,CAAC;IACZ,CAAC;IACS,GAAG,KAAI,CAAC;IACV,UAAU,CAAC,OAAe,EAAE,KAAa,EAAE,GAAgB,EAAE,SAAiB,CAAC;QACrF,MAAM,EAAE,KAAK,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QAC/B,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAA,iBAAO,EAAC,MAAM,CAAC,OAAO,CAAC,EAAE,IAAI,CAAC,CAAC;QAChD,kBAAkB;QAClB,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAC5E,IAAA,qBAAQ,EACN,KAAK,EAAE,MAAM,EAAE,GAAG,EAAE,CAAC,EACrB,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAC9C,mBAAM,CAAC,CAAC,CAAC,EAAE,mBAAM,CAAC,CAAC,CAAC,EAAE,mBAAM,CAAC,CAAC,CAAC,EAAE,mBAAM,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,EAAE,KAAK,CAC7D,CAAC;QACJ,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACf,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACf,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;IAClB,CAAC;IACS,QAAQ,CAAC,GAAgB,EAAE,SAAiB,CAAC,EAAE,SAAkB,KAAK;QAC9E,sBAAsB;QACtB,IAAI,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC;QACvB,IAAI,CAAC,IAAI,CAAC,QAAQ;YAAE,KAAK,gCAAwB,CAAC;QAClD,IAAI,IAAI,CAAC,QAAQ,KAAK,EAAE,IAAI,MAAM;YAAE,KAAK,8BAAsB,CAAC;QAChE,IAAI,CAAC,MAAM;YAAE,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;QACtC,IAAI,CAAC,UAAU,CAAC,IAAI,CAAC,UAAU,EAAE,KAAK,EAAE,GAAG,EAAE,MAAM,CAAC,CAAC;QACrD,IAAI,CAAC,QAAQ,IAAI,CAAC,CAAC;QACnB,sEAAsE;QACtE,IAAI,IAAI,CAAC,QAAQ,KAAK,EAAE,IAAI,MAAM,EAAE,CAAC;YACnC,IAAI,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC;YACvB,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,EAAE,CAAC,KAAK,EAAE,CAAC;YAC7B,oFAAoF;YACpF,qHAAqH;YACrH,iEAAiE;YACjE,kFAAkF;YAClF,mCAAmC;YACnC,kDAAkD;YAClD,KAAK,IAAI,IAAI,EAAE,MAAM,GAAG,IAAI,CAAC,UAAU,GAAG,CAAC,EAAE,MAAM,IAAI,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,EAAE,MAAM,KAAK,CAAC,EAAE,CAAC;gBACnF,IAAI,CAAC,CAAC,IAAI,GAAG,IAAI,CAAC,KAAK,CAAC,GAAG,EAAE,CAAC;oBAAE,MAAM;gBACtC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;gBAC3B,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC,KAAK,EAAE,CAAC,CAAC,CAAC;gBAC5B,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;gBACzB,IAAI,CAAC,UAAU,CAAC,CAAC,EAAE,IAAI,CAAC,KAAK,0BAAkB,EAAE,IAAI,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC;gBACnE,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC;gBACnB,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,EAAE,CAAC,KAAK,EAAE,CAAC;YAC/B,CAAC;YACD,IAAI,CAAC,UAAU,EAAE,CAAC;YAClB,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;YAClB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC;QACzB,CAAC;QACD,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;IACf,CAAC;IACD,UAAU,CAAC,EAAW;QACpB,EAAE,GAAG,KAAK,CAAC,UAAU,CAAC,EAAE,CAAW,CAAC;QACpC,MAAM,EAAE,EAAE,EAAE,KAAK,EAAE,KAAK,EAAE,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,KAAK,EAAE,UAAU,EAAE,GAAG,IAAI,CAAC;QACjF,EAAE,CAAC,KAAK,CAAC,GAAG,CAAC,KAAK,CAAC,KAAK,EAAE,CAAC,CAAC;QAC5B,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,WAAW,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACjD,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;QACd,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC;QACjB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,UAAU,GAAG,UAAU,CAAC;QAC3B,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,IAAI,CAAC,SAAS,CAAC;QAC9B,EAAE,CAAC,WAAW,CAAC,GAAG,CAAC,IAAI,CAAC,WAAW,CAAC,CAAC;QACrC,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACnB,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACtB,IAAI,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QAChB,IAAI,CAAC,WAAW,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACzB,KAAK,IAAI,CAAC,IAAI,IAAI,CAAC,KAAK;YAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACtC,CAAC;IACD,uFAAuF;IAC/E,aAAa;QACnB,MAAM,EAAE,KAAK,EAAE,CAAC,EAAE,GAAG,EAAE,KAAK,EAAE,QAAQ,EAAE,WAAW,EAAE,KAAK,EAAE,GAAG,IAAI,CAAC;QACpE,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAA,iBAAO,EAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC;QAClD,IAAI,CAAC,eAAI;YAAE,IAAA,qBAAU,EAAC,QAAQ,CAAC,CAAC;QAChC,kBAAkB;QAClB,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAC5E,IAAA,qBAAQ,EACN,KAAK,EAAE,CAAC,EAAE,QAAQ,EAAE,CAAC,EACrB,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAC9C,mBAAM,CAAC,CAAC,CAAC,EAAE,mBAAM,CAAC,CAAC,CAAC,EAAE,mBAAM,CAAC,CAAC,CAAC,EAAE,mBAAM,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,EAAE,KAAK,CAC7D,CAAC;QACJ,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACnB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACnB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC;QACrB,KAAK,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC;QACrB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,IAAI,CAAC,eAAI,EAAE,CAAC;YACV,IAAA,qBAAU,EAAC,QAAQ,CAAC,CAAC;YACrB,IAAA,qBAAU,EAAC,KAAK,CAAC,CAAC;QACpB,CAAC;QACD,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC;IAClB,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,UAAU;QACV,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,EAAE,IAAI,CAAC,GAAG,CAAC,CAAC;QAC9B,qBAAqB;QACrB,IAAI,KAAK,GAAG,IAAI,CAAC,KAAK,wBAAgB,CAAC;QACvC,IAAI,IAAI,CAAC,KAAK,CAAC,MAAM,EAAE,CAAC;YACtB,KAAK,2BAAmB,CAAC;YACzB,IAAI,CAAC,eAAI;gBAAE,IAAA,qBAAU,EAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YACrC,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,QAAQ,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;YACtC,IAAI,CAAC,eAAI;gBAAE,IAAA,qBAAU,EAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YACrC,IAAI,CAAC,UAAU,GAAG,CAAC,CAAC;YACpB,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC3B,CAAC;aAAM,CAAC;YACN,KAAK,IAAI,CAAC,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC,8BAAsB,CAAC,CAAC,CAAC,CAAC,6BAAqB,CAAC;QAC5E,CAAC;QACD,IAAI,CAAC,KAAK,GAAG,KAAK,CAAC;QACnB,IAAI,CAAC,aAAa,EAAE,CAAC;IACvB,CAAC;IACO,SAAS,CAAC,GAAe;QAC/B,IAAA,mBAAM,EAAC,IAAI,EAAE,KAAK,CAAC,CAAC;QACpB,IAAA,kBAAK,EAAC,GAAG,CAAC,CAAC;QACX,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,MAAM,EAAE,QAAQ,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACrC,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAChD,IAAI,IAAI,CAAC,MAAM,IAAI,QAAQ;gBAAE,IAAI,CAAC,aAAa,EAAE,CAAC;YAClD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACzD,GAAG,CAAC,GAAG,CAAC,SAAS,CAAC,QAAQ,CAAC,IAAI,CAAC,MAAM,EAAE,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC;YAClE,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC;YACpB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,GAAG,CAAC;IACb,CAAC;IACD,OAAO,CAAC,GAAe;QACrB,IAAI,CAAC,IAAI,CAAC,SAAS;YAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;QAC9E,OAAO,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;IAC7B,CAAC;IACD,GAAG,CAAC,KAAa;QACf,IAAA,mBAAM,EAAC,KAAK,CAAC,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,CAAC,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;IAC7C,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,IAAA,mBAAM,EAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,IAAI,IAAI,CAAC,QAAQ;YAAE,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;QAClE,IAAI,CAAC,SAAS,GAAG,KAAK,CAAC;QACvB,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;QACpB,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,MAAM;QACJ,OAAO,IAAI,CAAC,UAAU,CAAC,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC;IACzD,CAAC;CACF;AA/MD,wBA+MC;AAED;;;;GAIG;AACU,QAAA,MAAM,GAAmB,IAAA,qCAA0B,EAC9D,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,MAAM,CAAC,IAAI,CAAC,CAC3B,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.d.ts
+new file mode 100644
+index 0000000..ac181a0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.d.ts
+@@ -0,0 +1,2 @@
++export declare const crypto: any;
++//# sourceMappingURL=crypto.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.d.ts.map
+new file mode 100644
+index 0000000..a9ad2b4
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"crypto.d.ts","sourceRoot":"","sources":["src/crypto.ts"],"names":[],"mappings":"AAGA,eAAO,MAAM,MAAM,KACuE,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.js
+new file mode 100644
+index 0000000..8226391
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.js
+@@ -0,0 +1,5 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.crypto = void 0;
++exports.crypto = typeof globalThis === 'object' && 'crypto' in globalThis ? globalThis.crypto : undefined;
++//# sourceMappingURL=crypto.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.js.map
+new file mode 100644
+index 0000000..9f794e2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/crypto.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"crypto.js","sourceRoot":"","sources":["src/crypto.ts"],"names":[],"mappings":";;;AAGa,QAAA,MAAM,GACjB,OAAO,UAAU,KAAK,QAAQ,IAAI,QAAQ,IAAI,UAAU,CAAC,CAAC,CAAC,UAAU,CAAC,MAAM,CAAC,CAAC,CAAC,SAAS,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.d.ts
+new file mode 100644
+index 0000000..98bda7b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.d.ts
+@@ -0,0 +1,2 @@
++export declare const crypto: any;
++//# sourceMappingURL=cryptoNode.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.d.ts.map
+new file mode 100644
+index 0000000..5f3c48d
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"cryptoNode.d.ts","sourceRoot":"","sources":["src/cryptoNode.ts"],"names":[],"mappings":"AAKA,eAAO,MAAM,MAAM,KACoE,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.js
+new file mode 100644
+index 0000000..a88676d
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.js
+@@ -0,0 +1,10 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.crypto = void 0;
++// We use WebCrypto aka globalThis.crypto, which exists in browsers and node.js 16+.
++// See utils.ts for details.
++// The file will throw on node.js 14 and earlier.
++// @ts-ignore
++const nc = require("node:crypto");
++exports.crypto = nc && typeof nc === 'object' && 'webcrypto' in nc ? nc.webcrypto : undefined;
++//# sourceMappingURL=cryptoNode.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.js.map
+new file mode 100644
+index 0000000..9287d27
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/cryptoNode.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"cryptoNode.js","sourceRoot":"","sources":["src/cryptoNode.ts"],"names":[],"mappings":";;;AAAA,oFAAoF;AACpF,4BAA4B;AAC5B,iDAAiD;AACjD,aAAa;AACb,kCAAkC;AACrB,QAAA,MAAM,GACjB,EAAE,IAAI,OAAO,EAAE,KAAK,QAAQ,IAAI,WAAW,IAAI,EAAE,CAAC,CAAC,CAAE,EAAE,CAAC,SAAiB,CAAC,CAAC,CAAC,SAAS,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.d.ts
+new file mode 100644
+index 0000000..66721eb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.d.ts
+@@ -0,0 +1,47 @@
++export declare function scrypt(password: string, salt: string): Uint8Array;
++export declare function pbkdf2(password: string, salt: string): Uint8Array;
++/**
++ * Derives main seed. Takes a lot of time. Prefer `eskdf` method instead.
++ */
++export declare function deriveMainSeed(username: string, password: string): Uint8Array;
++type AccountID = number | string;
++type OptsLength = {
++    keyLength: number;
++};
++type OptsMod = {
++    modulus: bigint;
++};
++type KeyOpts = undefined | OptsLength | OptsMod;
++export interface ESKDF {
++    /**
++     * Derives a child key. Child key will not be associated with any
++     * other child key because of properties of underlying KDF.
++     *
++     * @param protocol - 3-15 character protocol name
++     * @param accountId - numeric identifier of account
++     * @param options - `keyLength: 64` or `modulus: 41920438n`
++     * @example deriveChildKey('aes', 0)
++     */
++    deriveChildKey: (protocol: string, accountId: AccountID, options?: KeyOpts) => Uint8Array;
++    /**
++     * Deletes the main seed from eskdf instance
++     */
++    expire: () => void;
++    /**
++     * Account fingerprint
++     */
++    fingerprint: string;
++}
++/**
++ * ESKDF
++ * @param username - username, email, or identifier, min: 8 characters, should have enough entropy
++ * @param password - password, min: 8 characters, should have enough entropy
++ * @example
++ * const kdf = await eskdf('example-university', 'beginning-new-example');
++ * const key = kdf.deriveChildKey('aes', 0);
++ * console.log(kdf.fingerprint);
++ * kdf.expire();
++ */
++export declare function eskdf(username: string, password: string): Promise<ESKDF>;
++export {};
++//# sourceMappingURL=eskdf.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.d.ts.map
+new file mode 100644
+index 0000000..a10e762
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"eskdf.d.ts","sourceRoot":"","sources":["src/eskdf.ts"],"names":[],"mappings":"AAeA,wBAAgB,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,IAAI,EAAE,MAAM,GAAG,UAAU,CAEjE;AAGD,wBAAgB,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,IAAI,EAAE,MAAM,GAAG,UAAU,CAEjE;AAiBD;;GAEG;AACH,wBAAgB,cAAc,CAAC,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,GAAG,UAAU,CAS7E;AAED,KAAK,SAAS,GAAG,MAAM,GAAG,MAAM,CAAC;AA+BjC,KAAK,UAAU,GAAG;IAAE,SAAS,EAAE,MAAM,CAAA;CAAE,CAAC;AACxC,KAAK,OAAO,GAAG;IAAE,OAAO,EAAE,MAAM,CAAA;CAAE,CAAC;AACnC,KAAK,OAAO,GAAG,SAAS,GAAG,UAAU,GAAG,OAAO,CAAC;AAwChD,MAAM,WAAW,KAAK;IACpB;;;;;;;;OAQG;IACH,cAAc,EAAE,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,SAAS,EAAE,OAAO,CAAC,EAAE,OAAO,KAAK,UAAU,CAAC;IAC1F;;OAEG;IACH,MAAM,EAAE,MAAM,IAAI,CAAC;IACnB;;OAEG;IACH,WAAW,EAAE,MAAM,CAAC;CACrB;AAED;;;;;;;;;GASG;AACH,wBAAsB,KAAK,CAAC,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,GAAG,OAAO,CAAC,KAAK,CAAC,CAuB9E"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.js
+new file mode 100644
+index 0000000..6a7671a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.js
+@@ -0,0 +1,161 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.scrypt = scrypt;
++exports.pbkdf2 = pbkdf2;
++exports.deriveMainSeed = deriveMainSeed;
++exports.eskdf = eskdf;
++const _assert_js_1 = require("./_assert.js");
++const hkdf_js_1 = require("./hkdf.js");
++const sha256_js_1 = require("./sha256.js");
++const pbkdf2_js_1 = require("./pbkdf2.js");
++const scrypt_js_1 = require("./scrypt.js");
++const utils_js_1 = require("./utils.js");
++// A tiny KDF for various applications like AES key-gen.
++// Uses HKDF in a non-standard way, so it's not "KDF-secure", only "PRF-secure".
++// Which is good enough: assume sha2-256 retained preimage resistance.
++const SCRYPT_FACTOR = 2 ** 19;
++const PBKDF2_FACTOR = 2 ** 17;
++// Scrypt KDF
++function scrypt(password, salt) {
++    return (0, scrypt_js_1.scrypt)(password, salt, { N: SCRYPT_FACTOR, r: 8, p: 1, dkLen: 32 });
++}
++// PBKDF2-HMAC-SHA256
++function pbkdf2(password, salt) {
++    return (0, pbkdf2_js_1.pbkdf2)(sha256_js_1.sha256, password, salt, { c: PBKDF2_FACTOR, dkLen: 32 });
++}
++// Combines two 32-byte byte arrays
++function xor32(a, b) {
++    (0, _assert_js_1.bytes)(a, 32);
++    (0, _assert_js_1.bytes)(b, 32);
++    const arr = new Uint8Array(32);
++    for (let i = 0; i < 32; i++) {
++        arr[i] = a[i] ^ b[i];
++    }
++    return arr;
++}
++function strHasLength(str, min, max) {
++    return typeof str === 'string' && str.length >= min && str.length <= max;
++}
++/**
++ * Derives main seed. Takes a lot of time. Prefer `eskdf` method instead.
++ */
++function deriveMainSeed(username, password) {
++    if (!strHasLength(username, 8, 255))
++        throw new Error('invalid username');
++    if (!strHasLength(password, 8, 255))
++        throw new Error('invalid password');
++    const scr = scrypt(password + '\u{1}', username + '\u{1}');
++    const pbk = pbkdf2(password + '\u{2}', username + '\u{2}');
++    const res = xor32(scr, pbk);
++    scr.fill(0);
++    pbk.fill(0);
++    return res;
++}
++/**
++ * Converts protocol & accountId pair to HKDF salt & info params.
++ */
++function getSaltInfo(protocol, accountId = 0) {
++    // Note that length here also repeats two lines below
++    // We do an additional length check here to reduce the scope of DoS attacks
++    if (!(strHasLength(protocol, 3, 15) && /^[a-z0-9]{3,15}$/.test(protocol))) {
++        throw new Error('invalid protocol');
++    }
++    // Allow string account ids for some protocols
++    const allowsStr = /^password\d{0,3}|ssh|tor|file$/.test(protocol);
++    let salt; // Extract salt. Default is undefined.
++    if (typeof accountId === 'string') {
++        if (!allowsStr)
++            throw new Error('accountId must be a number');
++        if (!strHasLength(accountId, 1, 255))
++            throw new Error('accountId must be valid string');
++        salt = (0, utils_js_1.toBytes)(accountId);
++    }
++    else if (Number.isSafeInteger(accountId)) {
++        if (accountId < 0 || accountId > 2 ** 32 - 1)
++            throw new Error('invalid accountId');
++        // Convert to Big Endian Uint32
++        salt = new Uint8Array(4);
++        (0, utils_js_1.createView)(salt).setUint32(0, accountId, false);
++    }
++    else {
++        throw new Error(`accountId must be a number${allowsStr ? ' or string' : ''}`);
++    }
++    const info = (0, utils_js_1.toBytes)(protocol);
++    return { salt, info };
++}
++function countBytes(num) {
++    if (typeof num !== 'bigint' || num <= BigInt(128))
++        throw new Error('invalid number');
++    return Math.ceil(num.toString(2).length / 8);
++}
++/**
++ * Parses keyLength and modulus options to extract length of result key.
++ * If modulus is used, adds 64 bits to it as per FIPS 186 B.4.1 to combat modulo bias.
++ */
++function getKeyLength(options) {
++    if (!options || typeof options !== 'object')
++        return 32;
++    const hasLen = 'keyLength' in options;
++    const hasMod = 'modulus' in options;
++    if (hasLen && hasMod)
++        throw new Error('cannot combine keyLength and modulus options');
++    if (!hasLen && !hasMod)
++        throw new Error('must have either keyLength or modulus option');
++    // FIPS 186 B.4.1 requires at least 64 more bits
++    const l = hasMod ? countBytes(options.modulus) + 8 : options.keyLength;
++    if (!(typeof l === 'number' && l >= 16 && l <= 8192))
++        throw new Error('invalid keyLength');
++    return l;
++}
++/**
++ * Converts key to bigint and divides it by modulus. Big Endian.
++ * Implements FIPS 186 B.4.1, which removes 0 and modulo bias from output.
++ */
++function modReduceKey(key, modulus) {
++    const _1 = BigInt(1);
++    const num = BigInt('0x' + (0, utils_js_1.bytesToHex)(key)); // check for ui8a, then bytesToNumber()
++    const res = (num % (modulus - _1)) + _1; // Remove 0 from output
++    if (res < _1)
++        throw new Error('expected positive number'); // Guard against bad values
++    const len = key.length - 8; // FIPS requires 64 more bits = 8 bytes
++    const hex = res.toString(16).padStart(len * 2, '0'); // numberToHex()
++    const bytes = (0, utils_js_1.hexToBytes)(hex);
++    if (bytes.length !== len)
++        throw new Error('invalid length of result key');
++    return bytes;
++}
++/**
++ * ESKDF
++ * @param username - username, email, or identifier, min: 8 characters, should have enough entropy
++ * @param password - password, min: 8 characters, should have enough entropy
++ * @example
++ * const kdf = await eskdf('example-university', 'beginning-new-example');
++ * const key = kdf.deriveChildKey('aes', 0);
++ * console.log(kdf.fingerprint);
++ * kdf.expire();
++ */
++async function eskdf(username, password) {
++    // We are using closure + object instead of class because
++    // we want to make `seed` non-accessible for any external function.
++    let seed = deriveMainSeed(username, password);
++    function deriveCK(protocol, accountId = 0, options) {
++        (0, _assert_js_1.bytes)(seed, 32);
++        const { salt, info } = getSaltInfo(protocol, accountId); // validate protocol & accountId
++        const keyLength = getKeyLength(options); // validate options
++        const key = (0, hkdf_js_1.hkdf)(sha256_js_1.sha256, seed, salt, info, keyLength);
++        // Modulus has already been validated
++        return options && 'modulus' in options ? modReduceKey(key, options.modulus) : key;
++    }
++    function expire() {
++        if (seed)
++            seed.fill(1);
++        seed = undefined;
++    }
++    // prettier-ignore
++    const fingerprint = Array.from(deriveCK('fingerprint', 0))
++        .slice(0, 6)
++        .map((char) => char.toString(16).padStart(2, '0').toUpperCase())
++        .join(':');
++    return Object.freeze({ deriveChildKey: deriveCK, expire, fingerprint });
++}
++//# sourceMappingURL=eskdf.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.js.map
+new file mode 100644
+index 0000000..43a4ede
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/eskdf.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"eskdf.js","sourceRoot":"","sources":["src/eskdf.ts"],"names":[],"mappings":";;AAeA,wBAEC;AAGD,wBAEC;AAoBD,wCASC;AA0GD,sBAuBC;AApLD,6CAAoD;AACpD,uCAAiC;AACjC,2CAAqC;AACrC,2CAAgD;AAChD,2CAAgD;AAChD,yCAAyE;AAEzE,wDAAwD;AACxD,gFAAgF;AAChF,sEAAsE;AAEtE,MAAM,aAAa,GAAG,CAAC,IAAI,EAAE,CAAC;AAC9B,MAAM,aAAa,GAAG,CAAC,IAAI,EAAE,CAAC;AAE9B,aAAa;AACb,SAAgB,MAAM,CAAC,QAAgB,EAAE,IAAY;IACnD,OAAO,IAAA,kBAAO,EAAC,QAAQ,EAAE,IAAI,EAAE,EAAE,CAAC,EAAE,aAAa,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,CAAC,CAAC;AAC9E,CAAC;AAED,qBAAqB;AACrB,SAAgB,MAAM,CAAC,QAAgB,EAAE,IAAY;IACnD,OAAO,IAAA,kBAAO,EAAC,kBAAM,EAAE,QAAQ,EAAE,IAAI,EAAE,EAAE,CAAC,EAAE,aAAa,EAAE,KAAK,EAAE,EAAE,EAAE,CAAC,CAAC;AAC1E,CAAC;AAED,mCAAmC;AACnC,SAAS,KAAK,CAAC,CAAa,EAAE,CAAa;IACzC,IAAA,kBAAW,EAAC,CAAC,EAAE,EAAE,CAAC,CAAC;IACnB,IAAA,kBAAW,EAAC,CAAC,EAAE,EAAE,CAAC,CAAC;IACnB,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC;IAC/B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;QAC5B,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;IACvB,CAAC;IACD,OAAO,GAAG,CAAC;AACb,CAAC;AAED,SAAS,YAAY,CAAC,GAAW,EAAE,GAAW,EAAE,GAAW;IACzD,OAAO,OAAO,GAAG,KAAK,QAAQ,IAAI,GAAG,CAAC,MAAM,IAAI,GAAG,IAAI,GAAG,CAAC,MAAM,IAAI,GAAG,CAAC;AAC3E,CAAC;AAED;;GAEG;AACH,SAAgB,cAAc,CAAC,QAAgB,EAAE,QAAgB;IAC/D,IAAI,CAAC,YAAY,CAAC,QAAQ,EAAE,CAAC,EAAE,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,kBAAkB,CAAC,CAAC;IACzE,IAAI,CAAC,YAAY,CAAC,QAAQ,EAAE,CAAC,EAAE,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,kBAAkB,CAAC,CAAC;IACzE,MAAM,GAAG,GAAG,MAAM,CAAC,QAAQ,GAAG,OAAO,EAAE,QAAQ,GAAG,OAAO,CAAC,CAAC;IAC3D,MAAM,GAAG,GAAG,MAAM,CAAC,QAAQ,GAAG,OAAO,EAAE,QAAQ,GAAG,OAAO,CAAC,CAAC;IAC3D,MAAM,GAAG,GAAG,KAAK,CAAC,GAAG,EAAE,GAAG,CAAC,CAAC;IAC5B,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACZ,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACZ,OAAO,GAAG,CAAC;AACb,CAAC;AAID;;GAEG;AACH,SAAS,WAAW,CAAC,QAAgB,EAAE,YAAuB,CAAC;IAC7D,qDAAqD;IACrD,2EAA2E;IAC3E,IAAI,CAAC,CAAC,YAAY,CAAC,QAAQ,EAAE,CAAC,EAAE,EAAE,CAAC,IAAI,kBAAkB,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC,EAAE,CAAC;QAC1E,MAAM,IAAI,KAAK,CAAC,kBAAkB,CAAC,CAAC;IACtC,CAAC;IAED,8CAA8C;IAC9C,MAAM,SAAS,GAAG,gCAAgC,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;IAClE,IAAI,IAAgB,CAAC,CAAC,sCAAsC;IAC5D,IAAI,OAAO,SAAS,KAAK,QAAQ,EAAE,CAAC;QAClC,IAAI,CAAC,SAAS;YAAE,MAAM,IAAI,KAAK,CAAC,4BAA4B,CAAC,CAAC;QAC9D,IAAI,CAAC,YAAY,CAAC,SAAS,EAAE,CAAC,EAAE,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,gCAAgC,CAAC,CAAC;QACxF,IAAI,GAAG,IAAA,kBAAO,EAAC,SAAS,CAAC,CAAC;IAC5B,CAAC;SAAM,IAAI,MAAM,CAAC,aAAa,CAAC,SAAS,CAAC,EAAE,CAAC;QAC3C,IAAI,SAAS,GAAG,CAAC,IAAI,SAAS,GAAG,CAAC,IAAI,EAAE,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,mBAAmB,CAAC,CAAC;QACnF,+BAA+B;QAC/B,IAAI,GAAG,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC;QACzB,IAAA,qBAAU,EAAC,IAAI,CAAC,CAAC,SAAS,CAAC,CAAC,EAAE,SAAS,EAAE,KAAK,CAAC,CAAC;IAClD,CAAC;SAAM,CAAC;QACN,MAAM,IAAI,KAAK,CAAC,6BAA6B,SAAS,CAAC,CAAC,CAAC,YAAY,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;IAChF,CAAC;IACD,MAAM,IAAI,GAAG,IAAA,kBAAO,EAAC,QAAQ,CAAC,CAAC;IAC/B,OAAO,EAAE,IAAI,EAAE,IAAI,EAAE,CAAC;AACxB,CAAC;AAMD,SAAS,UAAU,CAAC,GAAW;IAC7B,IAAI,OAAO,GAAG,KAAK,QAAQ,IAAI,GAAG,IAAI,MAAM,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,gBAAgB,CAAC,CAAC;IACrF,OAAO,IAAI,CAAC,IAAI,CAAC,GAAG,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;AAC/C,CAAC;AAED;;;GAGG;AACH,SAAS,YAAY,CAAC,OAAgB;IACpC,IAAI,CAAC,OAAO,IAAI,OAAO,OAAO,KAAK,QAAQ;QAAE,OAAO,EAAE,CAAC;IACvD,MAAM,MAAM,GAAG,WAAW,IAAI,OAAO,CAAC;IACtC,MAAM,MAAM,GAAG,SAAS,IAAI,OAAO,CAAC;IACpC,IAAI,MAAM,IAAI,MAAM;QAAE,MAAM,IAAI,KAAK,CAAC,8CAA8C,CAAC,CAAC;IACtF,IAAI,CAAC,MAAM,IAAI,CAAC,MAAM;QAAE,MAAM,IAAI,KAAK,CAAC,8CAA8C,CAAC,CAAC;IACxF,gDAAgD;IAChD,MAAM,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,UAAU,CAAC,OAAO,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,OAAO,CAAC,SAAS,CAAC;IACvE,IAAI,CAAC,CAAC,OAAO,CAAC,KAAK,QAAQ,IAAI,CAAC,IAAI,EAAE,IAAI,CAAC,IAAI,IAAI,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,mBAAmB,CAAC,CAAC;IAC3F,OAAO,CAAC,CAAC;AACX,CAAC;AAED;;;GAGG;AACH,SAAS,YAAY,CAAC,GAAe,EAAE,OAAe;IACpD,MAAM,EAAE,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC;IACrB,MAAM,GAAG,GAAG,MAAM,CAAC,IAAI,GAAG,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC,CAAC,CAAC,uCAAuC;IACnF,MAAM,GAAG,GAAG,CAAC,GAAG,GAAG,CAAC,OAAO,GAAG,EAAE,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,uBAAuB;IAChE,IAAI,GAAG,GAAG,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,0BAA0B,CAAC,CAAC,CAAC,2BAA2B;IACtF,MAAM,GAAG,GAAG,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,uCAAuC;IACnE,MAAM,GAAG,GAAG,GAAG,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,gBAAgB;IACrE,MAAM,KAAK,GAAG,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC9B,IAAI,KAAK,CAAC,MAAM,KAAK,GAAG;QAAE,MAAM,IAAI,KAAK,CAAC,8BAA8B,CAAC,CAAC;IAC1E,OAAO,KAAK,CAAC;AACf,CAAC;AAwBD;;;;;;;;;GASG;AACI,KAAK,UAAU,KAAK,CAAC,QAAgB,EAAE,QAAgB;IAC5D,yDAAyD;IACzD,mEAAmE;IACnE,IAAI,IAAI,GAA2B,cAAc,CAAC,QAAQ,EAAE,QAAQ,CAAC,CAAC;IAEtE,SAAS,QAAQ,CAAC,QAAgB,EAAE,YAAuB,CAAC,EAAE,OAAiB;QAC7E,IAAA,kBAAW,EAAC,IAAI,EAAE,EAAE,CAAC,CAAC;QACtB,MAAM,EAAE,IAAI,EAAE,IAAI,EAAE,GAAG,WAAW,CAAC,QAAQ,EAAE,SAAS,CAAC,CAAC,CAAC,gCAAgC;QACzF,MAAM,SAAS,GAAG,YAAY,CAAC,OAAO,CAAC,CAAC,CAAC,mBAAmB;QAC5D,MAAM,GAAG,GAAG,IAAA,cAAI,EAAC,kBAAM,EAAE,IAAK,EAAE,IAAI,EAAE,IAAI,EAAE,SAAS,CAAC,CAAC;QACvD,qCAAqC;QACrC,OAAO,OAAO,IAAI,SAAS,IAAI,OAAO,CAAC,CAAC,CAAC,YAAY,CAAC,GAAG,EAAE,OAAO,CAAC,OAAO,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC;IACpF,CAAC;IACD,SAAS,MAAM;QACb,IAAI,IAAI;YAAE,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACvB,IAAI,GAAG,SAAS,CAAC;IACnB,CAAC;IACD,kBAAkB;IAClB,MAAM,WAAW,GAAG,KAAK,CAAC,IAAI,CAAC,QAAQ,CAAC,aAAa,EAAE,CAAC,CAAC,CAAC;SACvD,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC;SACX,GAAG,CAAC,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,WAAW,EAAE,CAAC;SAC/D,IAAI,CAAC,GAAG,CAAC,CAAC;IACb,OAAO,MAAM,CAAC,MAAM,CAAC,EAAE,cAAc,EAAE,QAAQ,EAAE,MAAM,EAAE,WAAW,EAAE,CAAC,CAAC;AAC1E,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.d.ts
+new file mode 100644
+index 0000000..f66656f
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.d.ts
+@@ -0,0 +1,24 @@
++declare function number(n: number): void;
++declare function bool(b: boolean): void;
++export declare function isBytes(a: unknown): a is Uint8Array;
++declare function bytes(b: Uint8Array | undefined, ...lengths: number[]): void;
++type Hash = {
++    (data: Uint8Array): Uint8Array;
++    blockLen: number;
++    outputLen: number;
++    create: any;
++};
++declare function hash(h: Hash): void;
++declare function exists(instance: any, checkFinished?: boolean): void;
++declare function output(out: any, instance: any): void;
++export { number, bool, bytes, hash, exists, output };
++declare const assert: {
++    number: typeof number;
++    bool: typeof bool;
++    bytes: typeof bytes;
++    hash: typeof hash;
++    exists: typeof exists;
++    output: typeof output;
++};
++export default assert;
++//# sourceMappingURL=_assert.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.d.ts.map
+new file mode 100644
+index 0000000..19f6194
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_assert.d.ts","sourceRoot":"","sources":["../src/_assert.ts"],"names":[],"mappings":"AAAA,iBAAS,MAAM,CAAC,CAAC,EAAE,MAAM,QAExB;AAED,iBAAS,IAAI,CAAC,CAAC,EAAE,OAAO,QAEvB;AAGD,wBAAgB,OAAO,CAAC,CAAC,EAAE,OAAO,GAAG,CAAC,IAAI,UAAU,CAKnD;AAED,iBAAS,KAAK,CAAC,CAAC,EAAE,UAAU,GAAG,SAAS,EAAE,GAAG,OAAO,EAAE,MAAM,EAAE,QAI7D;AAED,KAAK,IAAI,GAAG;IACV,CAAC,IAAI,EAAE,UAAU,GAAG,UAAU,CAAC;IAC/B,QAAQ,EAAE,MAAM,CAAC;IACjB,SAAS,EAAE,MAAM,CAAC;IAClB,MAAM,EAAE,GAAG,CAAC;CACb,CAAC;AACF,iBAAS,IAAI,CAAC,CAAC,EAAE,IAAI,QAKpB;AAED,iBAAS,MAAM,CAAC,QAAQ,EAAE,GAAG,EAAE,aAAa,UAAO,QAGlD;AACD,iBAAS,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,QAAQ,EAAE,GAAG,QAMtC;AAED,OAAO,EAAE,MAAM,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,MAAM,EAAE,MAAM,EAAE,CAAC;AAErD,QAAA,MAAM,MAAM;;;;;;;CAAgD,CAAC;AAC7D,eAAe,MAAM,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.js
+new file mode 100644
+index 0000000..b6006b2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.js
+@@ -0,0 +1,42 @@
++function number(n) {
++    if (!Number.isSafeInteger(n) || n < 0)
++        throw new Error(`positive integer expected, not ${n}`);
++}
++function bool(b) {
++    if (typeof b !== 'boolean')
++        throw new Error(`boolean expected, not ${b}`);
++}
++// copied from utils
++export function isBytes(a) {
++    return (a instanceof Uint8Array ||
++        (a != null && typeof a === 'object' && a.constructor.name === 'Uint8Array'));
++}
++function bytes(b, ...lengths) {
++    if (!isBytes(b))
++        throw new Error('Uint8Array expected');
++    if (lengths.length > 0 && !lengths.includes(b.length))
++        throw new Error(`Uint8Array expected of length ${lengths}, not of length=${b.length}`);
++}
++function hash(h) {
++    if (typeof h !== 'function' || typeof h.create !== 'function')
++        throw new Error('Hash should be wrapped by utils.wrapConstructor');
++    number(h.outputLen);
++    number(h.blockLen);
++}
++function exists(instance, checkFinished = true) {
++    if (instance.destroyed)
++        throw new Error('Hash instance has been destroyed');
++    if (checkFinished && instance.finished)
++        throw new Error('Hash#digest() has already been called');
++}
++function output(out, instance) {
++    bytes(out);
++    const min = instance.outputLen;
++    if (out.length < min) {
++        throw new Error(`digestInto() expects output buffer of length at least ${min}`);
++    }
++}
++export { number, bool, bytes, hash, exists, output };
++const assert = { number, bool, bytes, hash, exists, output };
++export default assert;
++//# sourceMappingURL=_assert.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.js.map
+new file mode 100644
+index 0000000..3596c9e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_assert.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_assert.js","sourceRoot":"","sources":["../src/_assert.ts"],"names":[],"mappings":"AAAA,SAAS,MAAM,CAAC,CAAS;IACvB,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,kCAAkC,CAAC,EAAE,CAAC,CAAC;AAChG,CAAC;AAED,SAAS,IAAI,CAAC,CAAU;IACtB,IAAI,OAAO,CAAC,KAAK,SAAS;QAAE,MAAM,IAAI,KAAK,CAAC,yBAAyB,CAAC,EAAE,CAAC,CAAC;AAC5E,CAAC;AAED,oBAAoB;AACpB,MAAM,UAAU,OAAO,CAAC,CAAU;IAChC,OAAO,CACL,CAAC,YAAY,UAAU;QACvB,CAAC,CAAC,IAAI,IAAI,IAAI,OAAO,CAAC,KAAK,QAAQ,IAAI,CAAC,CAAC,WAAW,CAAC,IAAI,KAAK,YAAY,CAAC,CAC5E,CAAC;AACJ,CAAC;AAED,SAAS,KAAK,CAAC,CAAyB,EAAE,GAAG,OAAiB;IAC5D,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,qBAAqB,CAAC,CAAC;IACxD,IAAI,OAAO,CAAC,MAAM,GAAG,CAAC,IAAI,CAAC,OAAO,CAAC,QAAQ,CAAC,CAAC,CAAC,MAAM,CAAC;QACnD,MAAM,IAAI,KAAK,CAAC,iCAAiC,OAAO,mBAAmB,CAAC,CAAC,MAAM,EAAE,CAAC,CAAC;AAC3F,CAAC;AAQD,SAAS,IAAI,CAAC,CAAO;IACnB,IAAI,OAAO,CAAC,KAAK,UAAU,IAAI,OAAO,CAAC,CAAC,MAAM,KAAK,UAAU;QAC3D,MAAM,IAAI,KAAK,CAAC,iDAAiD,CAAC,CAAC;IACrE,MAAM,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC;IACpB,MAAM,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC;AACrB,CAAC;AAED,SAAS,MAAM,CAAC,QAAa,EAAE,aAAa,GAAG,IAAI;IACjD,IAAI,QAAQ,CAAC,SAAS;QAAE,MAAM,IAAI,KAAK,CAAC,kCAAkC,CAAC,CAAC;IAC5E,IAAI,aAAa,IAAI,QAAQ,CAAC,QAAQ;QAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;AACnG,CAAC;AACD,SAAS,MAAM,CAAC,GAAQ,EAAE,QAAa;IACrC,KAAK,CAAC,GAAG,CAAC,CAAC;IACX,MAAM,GAAG,GAAG,QAAQ,CAAC,SAAS,CAAC;IAC/B,IAAI,GAAG,CAAC,MAAM,GAAG,GAAG,EAAE,CAAC;QACrB,MAAM,IAAI,KAAK,CAAC,yDAAyD,GAAG,EAAE,CAAC,CAAC;IAClF,CAAC;AACH,CAAC;AAED,OAAO,EAAE,MAAM,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,MAAM,EAAE,MAAM,EAAE,CAAC;AAErD,MAAM,MAAM,GAAG,EAAE,MAAM,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,MAAM,EAAE,MAAM,EAAE,CAAC;AAC7D,eAAe,MAAM,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.d.ts
+new file mode 100644
+index 0000000..ddb3f3a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.d.ts
+@@ -0,0 +1,28 @@
++import { Hash, Input } from './utils.js';
++export declare const SIGMA: Uint8Array;
++export type BlakeOpts = {
++    dkLen?: number;
++    key?: Input;
++    salt?: Input;
++    personalization?: Input;
++};
++export declare abstract class BLAKE<T extends BLAKE<T>> extends Hash<T> {
++    readonly blockLen: number;
++    outputLen: number;
++    protected abstract compress(msg: Uint32Array, offset: number, isLast: boolean): void;
++    protected abstract get(): number[];
++    protected abstract set(...args: number[]): void;
++    abstract destroy(): void;
++    protected buffer: Uint8Array;
++    protected buffer32: Uint32Array;
++    protected length: number;
++    protected pos: number;
++    protected finished: boolean;
++    protected destroyed: boolean;
++    constructor(blockLen: number, outputLen: number, opts: BlakeOpts | undefined, keyLen: number, saltLen: number, persLen: number);
++    update(data: Input): this;
++    digestInto(out: Uint8Array): void;
++    digest(): Uint8Array;
++    _cloneInto(to?: T): T;
++}
++//# sourceMappingURL=_blake.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.d.ts.map
+new file mode 100644
+index 0000000..ef482c7
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_blake.d.ts","sourceRoot":"","sources":["../src/_blake.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAE,KAAK,EAAgD,MAAM,YAAY,CAAC;AAMvF,eAAO,MAAM,KAAK,YAahB,CAAC;AAEH,MAAM,MAAM,SAAS,GAAG;IACtB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,GAAG,CAAC,EAAE,KAAK,CAAC;IACZ,IAAI,CAAC,EAAE,KAAK,CAAC;IACb,eAAe,CAAC,EAAE,KAAK,CAAC;CACzB,CAAC;AAEF,8BAAsB,KAAK,CAAC,CAAC,SAAS,KAAK,CAAC,CAAC,CAAC,CAAE,SAAQ,IAAI,CAAC,CAAC,CAAC;IAa3D,QAAQ,CAAC,QAAQ,EAAE,MAAM;IAClB,SAAS,EAAE,MAAM;IAb1B,SAAS,CAAC,QAAQ,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,OAAO,GAAG,IAAI;IACpF,SAAS,CAAC,QAAQ,CAAC,GAAG,IAAI,MAAM,EAAE;IAClC,SAAS,CAAC,QAAQ,CAAC,GAAG,CAAC,GAAG,IAAI,EAAE,MAAM,EAAE,GAAG,IAAI;IAC/C,QAAQ,CAAC,OAAO,IAAI,IAAI;IACxB,SAAS,CAAC,MAAM,EAAE,UAAU,CAAC;IAC7B,SAAS,CAAC,QAAQ,EAAE,WAAW,CAAC;IAChC,SAAS,CAAC,MAAM,EAAE,MAAM,CAAK;IAC7B,SAAS,CAAC,GAAG,EAAE,MAAM,CAAK;IAC1B,SAAS,CAAC,QAAQ,UAAS;IAC3B,SAAS,CAAC,SAAS,UAAS;gBAGjB,QAAQ,EAAE,MAAM,EAClB,SAAS,EAAE,MAAM,EACxB,IAAI,EAAE,SAAS,YAAK,EACpB,MAAM,EAAE,MAAM,EACd,OAAO,EAAE,MAAM,EACf,OAAO,EAAE,MAAM;IAejB,MAAM,CAAC,IAAI,EAAE,KAAK;IAuClB,UAAU,CAAC,GAAG,EAAE,UAAU;IAa1B,MAAM;IAON,UAAU,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC;CAYtB"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.js
+new file mode 100644
+index 0000000..e3da803
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.js
+@@ -0,0 +1,120 @@
++import { number, exists, output } from './_assert.js';
++import { Hash, toBytes, u32, isLE, byteSwap32, byteSwapIfBE } from './utils.js';
++// Blake is based on ChaCha permutation.
++// For BLAKE2b, the two extra permutations for rounds 10 and 11 are SIGMA[10..11] = SIGMA[0..1].
++// prettier-ignore
++export const SIGMA = /* @__PURE__ */ new Uint8Array([
++    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
++    14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
++    11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4,
++    7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8,
++    9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13,
++    2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9,
++    12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11,
++    13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10,
++    6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5,
++    10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0,
++    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
++    14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
++]);
++export class BLAKE extends Hash {
++    constructor(blockLen, outputLen, opts = {}, keyLen, saltLen, persLen) {
++        super();
++        this.blockLen = blockLen;
++        this.outputLen = outputLen;
++        this.length = 0;
++        this.pos = 0;
++        this.finished = false;
++        this.destroyed = false;
++        number(blockLen);
++        number(outputLen);
++        number(keyLen);
++        if (outputLen < 0 || outputLen > keyLen)
++            throw new Error('outputLen bigger than keyLen');
++        if (opts.key !== undefined && (opts.key.length < 1 || opts.key.length > keyLen))
++            throw new Error(`key must be up 1..${keyLen} byte long or undefined`);
++        if (opts.salt !== undefined && opts.salt.length !== saltLen)
++            throw new Error(`salt must be ${saltLen} byte long or undefined`);
++        if (opts.personalization !== undefined && opts.personalization.length !== persLen)
++            throw new Error(`personalization must be ${persLen} byte long or undefined`);
++        this.buffer32 = u32((this.buffer = new Uint8Array(blockLen)));
++    }
++    update(data) {
++        exists(this);
++        // Main difference with other hashes: there is flag for last block,
++        // so we cannot process current block before we know that there
++        // is the next one. This significantly complicates logic and reduces ability
++        // to do zero-copy processing
++        const { blockLen, buffer, buffer32 } = this;
++        data = toBytes(data);
++        const len = data.length;
++        const offset = data.byteOffset;
++        const buf = data.buffer;
++        for (let pos = 0; pos < len;) {
++            // If buffer is full and we still have input (don't process last block, same as blake2s)
++            if (this.pos === blockLen) {
++                if (!isLE)
++                    byteSwap32(buffer32);
++                this.compress(buffer32, 0, false);
++                if (!isLE)
++                    byteSwap32(buffer32);
++                this.pos = 0;
++            }
++            const take = Math.min(blockLen - this.pos, len - pos);
++            const dataOffset = offset + pos;
++            // full block && aligned to 4 bytes && not last in input
++            if (take === blockLen && !(dataOffset % 4) && pos + take < len) {
++                const data32 = new Uint32Array(buf, dataOffset, Math.floor((len - pos) / 4));
++                if (!isLE)
++                    byteSwap32(data32);
++                for (let pos32 = 0; pos + blockLen < len; pos32 += buffer32.length, pos += blockLen) {
++                    this.length += blockLen;
++                    this.compress(data32, pos32, false);
++                }
++                if (!isLE)
++                    byteSwap32(data32);
++                continue;
++            }
++            buffer.set(data.subarray(pos, pos + take), this.pos);
++            this.pos += take;
++            this.length += take;
++            pos += take;
++        }
++        return this;
++    }
++    digestInto(out) {
++        exists(this);
++        output(out, this);
++        const { pos, buffer32 } = this;
++        this.finished = true;
++        // Padding
++        this.buffer.subarray(pos).fill(0);
++        if (!isLE)
++            byteSwap32(buffer32);
++        this.compress(buffer32, 0, true);
++        if (!isLE)
++            byteSwap32(buffer32);
++        const out32 = u32(out);
++        this.get().forEach((v, i) => (out32[i] = byteSwapIfBE(v)));
++    }
++    digest() {
++        const { buffer, outputLen } = this;
++        this.digestInto(buffer);
++        const res = buffer.slice(0, outputLen);
++        this.destroy();
++        return res;
++    }
++    _cloneInto(to) {
++        const { buffer, length, finished, destroyed, outputLen, pos } = this;
++        to || (to = new this.constructor({ dkLen: outputLen }));
++        to.set(...this.get());
++        to.length = length;
++        to.finished = finished;
++        to.destroyed = destroyed;
++        to.outputLen = outputLen;
++        to.buffer.set(buffer);
++        to.pos = pos;
++        return to;
++    }
++}
++//# sourceMappingURL=_blake.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.js.map
+new file mode 100644
+index 0000000..73c73dc
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_blake.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_blake.js","sourceRoot":"","sources":["../src/_blake.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,cAAc,CAAC;AACtD,OAAO,EAAE,IAAI,EAAS,OAAO,EAAE,GAAG,EAAE,IAAI,EAAE,UAAU,EAAE,YAAY,EAAE,MAAM,YAAY,CAAC;AAEvF,wCAAwC;AAExC,gGAAgG;AAChG,kBAAkB;AAClB,MAAM,CAAC,MAAM,KAAK,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC;IAClD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE;IACpD,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;IACpD,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;IACpD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC;IACpD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE;IACpD,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC;IACpD,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE;IACpD,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE;IACpD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC;IACpD,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC;IACpD,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE;IACpD,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;CACrD,CAAC,CAAC;AASH,MAAM,OAAgB,KAA0B,SAAQ,IAAO;IAY7D,YACW,QAAgB,EAClB,SAAiB,EACxB,OAAkB,EAAE,EACpB,MAAc,EACd,OAAe,EACf,OAAe;QAEf,KAAK,EAAE,CAAC;QAPC,aAAQ,GAAR,QAAQ,CAAQ;QAClB,cAAS,GAAT,SAAS,CAAQ;QAPhB,WAAM,GAAW,CAAC,CAAC;QACnB,QAAG,GAAW,CAAC,CAAC;QAChB,aAAQ,GAAG,KAAK,CAAC;QACjB,cAAS,GAAG,KAAK,CAAC;QAW1B,MAAM,CAAC,QAAQ,CAAC,CAAC;QACjB,MAAM,CAAC,SAAS,CAAC,CAAC;QAClB,MAAM,CAAC,MAAM,CAAC,CAAC;QACf,IAAI,SAAS,GAAG,CAAC,IAAI,SAAS,GAAG,MAAM;YAAE,MAAM,IAAI,KAAK,CAAC,8BAA8B,CAAC,CAAC;QACzF,IAAI,IAAI,CAAC,GAAG,KAAK,SAAS,IAAI,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,GAAG,CAAC,IAAI,IAAI,CAAC,GAAG,CAAC,MAAM,GAAG,MAAM,CAAC;YAC7E,MAAM,IAAI,KAAK,CAAC,qBAAqB,MAAM,yBAAyB,CAAC,CAAC;QACxE,IAAI,IAAI,CAAC,IAAI,KAAK,SAAS,IAAI,IAAI,CAAC,IAAI,CAAC,MAAM,KAAK,OAAO;YACzD,MAAM,IAAI,KAAK,CAAC,gBAAgB,OAAO,yBAAyB,CAAC,CAAC;QACpE,IAAI,IAAI,CAAC,eAAe,KAAK,SAAS,IAAI,IAAI,CAAC,eAAe,CAAC,MAAM,KAAK,OAAO;YAC/E,MAAM,IAAI,KAAK,CAAC,2BAA2B,OAAO,yBAAyB,CAAC,CAAC;QAC/E,IAAI,CAAC,QAAQ,GAAG,GAAG,CAAC,CAAC,IAAI,CAAC,MAAM,GAAG,IAAI,UAAU,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;IAChE,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,MAAM,CAAC,IAAI,CAAC,CAAC;QACb,mEAAmE;QACnE,+DAA+D;QAC/D,4EAA4E;QAC5E,6BAA6B;QAC7B,MAAM,EAAE,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC5C,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;QACrB,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,MAAM,MAAM,GAAG,IAAI,CAAC,UAAU,CAAC;QAC/B,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAC9B,wFAAwF;YACxF,IAAI,IAAI,CAAC,GAAG,KAAK,QAAQ,EAAE,CAAC;gBAC1B,IAAI,CAAC,IAAI;oBAAE,UAAU,CAAC,QAAQ,CAAC,CAAC;gBAChC,IAAI,CAAC,QAAQ,CAAC,QAAQ,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;gBAClC,IAAI,CAAC,IAAI;oBAAE,UAAU,CAAC,QAAQ,CAAC,CAAC;gBAChC,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;YACf,CAAC;YACD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACtD,MAAM,UAAU,GAAG,MAAM,GAAG,GAAG,CAAC;YAChC,wDAAwD;YACxD,IAAI,IAAI,KAAK,QAAQ,IAAI,CAAC,CAAC,UAAU,GAAG,CAAC,CAAC,IAAI,GAAG,GAAG,IAAI,GAAG,GAAG,EAAE,CAAC;gBAC/D,MAAM,MAAM,GAAG,IAAI,WAAW,CAAC,GAAG,EAAE,UAAU,EAAE,IAAI,CAAC,KAAK,CAAC,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;gBAC7E,IAAI,CAAC,IAAI;oBAAE,UAAU,CAAC,MAAM,CAAC,CAAC;gBAC9B,KAAK,IAAI,KAAK,GAAG,CAAC,EAAE,GAAG,GAAG,QAAQ,GAAG,GAAG,EAAE,KAAK,IAAI,QAAQ,CAAC,MAAM,EAAE,GAAG,IAAI,QAAQ,EAAE,CAAC;oBACpF,IAAI,CAAC,MAAM,IAAI,QAAQ,CAAC;oBACxB,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,KAAK,EAAE,KAAK,CAAC,CAAC;gBACtC,CAAC;gBACD,IAAI,CAAC,IAAI;oBAAE,UAAU,CAAC,MAAM,CAAC,CAAC;gBAC9B,SAAS;YACX,CAAC;YACD,MAAM,CAAC,GAAG,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,IAAI,CAAC,GAAG,CAAC,CAAC;YACrD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC;YACjB,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC;YACpB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,IAAI,CAAC;IACd,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,MAAM,CAAC,IAAI,CAAC,CAAC;QACb,MAAM,CAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,MAAM,EAAE,GAAG,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC/B,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,UAAU;QACV,IAAI,CAAC,MAAM,CAAC,QAAQ,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QAClC,IAAI,CAAC,IAAI;YAAE,UAAU,CAAC,QAAQ,CAAC,CAAC;QAChC,IAAI,CAAC,QAAQ,CAAC,QAAQ,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;QACjC,IAAI,CAAC,IAAI;YAAE,UAAU,CAAC,QAAQ,CAAC,CAAC;QAChC,MAAM,KAAK,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;QACvB,IAAI,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC,GAAG,YAAY,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IAC7D,CAAC;IACD,MAAM;QACJ,MAAM,EAAE,MAAM,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACnC,IAAI,CAAC,UAAU,CAAC,MAAM,CAAC,CAAC;QACxB,MAAM,GAAG,GAAG,MAAM,CAAC,KAAK,CAAC,CAAC,EAAE,SAAS,CAAC,CAAC;QACvC,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,UAAU,CAAC,EAAM;QACf,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,QAAQ,EAAE,SAAS,EAAE,SAAS,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QACrE,EAAE,KAAF,EAAE,GAAK,IAAK,IAAI,CAAC,WAAmB,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,CAAM,EAAC;QAChE,EAAE,CAAC,GAAG,CAAC,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC;QACtB,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;QACtB,EAAE,CAAC,GAAG,GAAG,GAAG,CAAC;QACb,OAAO,EAAE,CAAC;IACZ,CAAC;CACF"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.d.ts
+new file mode 100644
+index 0000000..1c34636
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.d.ts
+@@ -0,0 +1,36 @@
++import { Hash, Input } from './utils.js';
++/**
++ * Choice: a ? b : c
++ */
++export declare const Chi: (a: number, b: number, c: number) => number;
++/**
++ * Majority function, true if any two inputs is true
++ */
++export declare const Maj: (a: number, b: number, c: number) => number;
++/**
++ * Merkle-Damgard hash construction base class.
++ * Could be used to create MD5, RIPEMD, SHA1, SHA2.
++ */
++export declare abstract class HashMD<T extends HashMD<T>> extends Hash<T> {
++    readonly blockLen: number;
++    outputLen: number;
++    readonly padOffset: number;
++    readonly isLE: boolean;
++    protected abstract process(buf: DataView, offset: number): void;
++    protected abstract get(): number[];
++    protected abstract set(...args: number[]): void;
++    abstract destroy(): void;
++    protected abstract roundClean(): void;
++    protected buffer: Uint8Array;
++    protected view: DataView;
++    protected finished: boolean;
++    protected length: number;
++    protected pos: number;
++    protected destroyed: boolean;
++    constructor(blockLen: number, outputLen: number, padOffset: number, isLE: boolean);
++    update(data: Input): this;
++    digestInto(out: Uint8Array): void;
++    digest(): Uint8Array;
++    _cloneInto(to?: T): T;
++}
++//# sourceMappingURL=_md.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.d.ts.map
+new file mode 100644
+index 0000000..2422450
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_md.d.ts","sourceRoot":"","sources":["../src/_md.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAc,KAAK,EAAW,MAAM,YAAY,CAAC;AAiB9D;;GAEG;AACH,eAAO,MAAM,GAAG,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuB,CAAC;AAE3E;;GAEG;AACH,eAAO,MAAM,GAAG,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAEpF;;;GAGG;AACH,8BAAsB,MAAM,CAAC,CAAC,SAAS,MAAM,CAAC,CAAC,CAAC,CAAE,SAAQ,IAAI,CAAC,CAAC,CAAC;IAe7D,QAAQ,CAAC,QAAQ,EAAE,MAAM;IAClB,SAAS,EAAE,MAAM;IACxB,QAAQ,CAAC,SAAS,EAAE,MAAM;IAC1B,QAAQ,CAAC,IAAI,EAAE,OAAO;IAjBxB,SAAS,CAAC,QAAQ,CAAC,OAAO,CAAC,GAAG,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAC/D,SAAS,CAAC,QAAQ,CAAC,GAAG,IAAI,MAAM,EAAE;IAClC,SAAS,CAAC,QAAQ,CAAC,GAAG,CAAC,GAAG,IAAI,EAAE,MAAM,EAAE,GAAG,IAAI;IAC/C,QAAQ,CAAC,OAAO,IAAI,IAAI;IACxB,SAAS,CAAC,QAAQ,CAAC,UAAU,IAAI,IAAI;IAErC,SAAS,CAAC,MAAM,EAAE,UAAU,CAAC;IAC7B,SAAS,CAAC,IAAI,EAAE,QAAQ,CAAC;IACzB,SAAS,CAAC,QAAQ,UAAS;IAC3B,SAAS,CAAC,MAAM,SAAK;IACrB,SAAS,CAAC,GAAG,SAAK;IAClB,SAAS,CAAC,SAAS,UAAS;gBAGjB,QAAQ,EAAE,MAAM,EAClB,SAAS,EAAE,MAAM,EACf,SAAS,EAAE,MAAM,EACjB,IAAI,EAAE,OAAO;IAMxB,MAAM,CAAC,IAAI,EAAE,KAAK,GAAG,IAAI;IAyBzB,UAAU,CAAC,GAAG,EAAE,UAAU;IAkC1B,MAAM;IAON,UAAU,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC;CAWtB"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.js
+new file mode 100644
+index 0000000..691d84b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.js
+@@ -0,0 +1,128 @@
++import { exists, output } from './_assert.js';
++import { Hash, createView, toBytes } from './utils.js';
++/**
++ * Polyfill for Safari 14
++ */
++function setBigUint64(view, byteOffset, value, isLE) {
++    if (typeof view.setBigUint64 === 'function')
++        return view.setBigUint64(byteOffset, value, isLE);
++    const _32n = BigInt(32);
++    const _u32_max = BigInt(0xffffffff);
++    const wh = Number((value >> _32n) & _u32_max);
++    const wl = Number(value & _u32_max);
++    const h = isLE ? 4 : 0;
++    const l = isLE ? 0 : 4;
++    view.setUint32(byteOffset + h, wh, isLE);
++    view.setUint32(byteOffset + l, wl, isLE);
++}
++/**
++ * Choice: a ? b : c
++ */
++export const Chi = (a, b, c) => (a & b) ^ (~a & c);
++/**
++ * Majority function, true if any two inputs is true
++ */
++export const Maj = (a, b, c) => (a & b) ^ (a & c) ^ (b & c);
++/**
++ * Merkle-Damgard hash construction base class.
++ * Could be used to create MD5, RIPEMD, SHA1, SHA2.
++ */
++export class HashMD extends Hash {
++    constructor(blockLen, outputLen, padOffset, isLE) {
++        super();
++        this.blockLen = blockLen;
++        this.outputLen = outputLen;
++        this.padOffset = padOffset;
++        this.isLE = isLE;
++        this.finished = false;
++        this.length = 0;
++        this.pos = 0;
++        this.destroyed = false;
++        this.buffer = new Uint8Array(blockLen);
++        this.view = createView(this.buffer);
++    }
++    update(data) {
++        exists(this);
++        const { view, buffer, blockLen } = this;
++        data = toBytes(data);
++        const len = data.length;
++        for (let pos = 0; pos < len;) {
++            const take = Math.min(blockLen - this.pos, len - pos);
++            // Fast path: we have at least one block in input, cast it to view and process
++            if (take === blockLen) {
++                const dataView = createView(data);
++                for (; blockLen <= len - pos; pos += blockLen)
++                    this.process(dataView, pos);
++                continue;
++            }
++            buffer.set(data.subarray(pos, pos + take), this.pos);
++            this.pos += take;
++            pos += take;
++            if (this.pos === blockLen) {
++                this.process(view, 0);
++                this.pos = 0;
++            }
++        }
++        this.length += data.length;
++        this.roundClean();
++        return this;
++    }
++    digestInto(out) {
++        exists(this);
++        output(out, this);
++        this.finished = true;
++        // Padding
++        // We can avoid allocation of buffer for padding completely if it
++        // was previously not allocated here. But it won't change performance.
++        const { buffer, view, blockLen, isLE } = this;
++        let { pos } = this;
++        // append the bit '1' to the message
++        buffer[pos++] = 0b10000000;
++        this.buffer.subarray(pos).fill(0);
++        // we have less than padOffset left in buffer, so we cannot put length in
++        // current block, need process it and pad again
++        if (this.padOffset > blockLen - pos) {
++            this.process(view, 0);
++            pos = 0;
++        }
++        // Pad until full block byte with zeros
++        for (let i = pos; i < blockLen; i++)
++            buffer[i] = 0;
++        // Note: sha512 requires length to be 128bit integer, but length in JS will overflow before that
++        // You need to write around 2 exabytes (u64_max / 8 / (1024**6)) for this to happen.
++        // So we just write lowest 64 bits of that value.
++        setBigUint64(view, blockLen - 8, BigInt(this.length * 8), isLE);
++        this.process(view, 0);
++        const oview = createView(out);
++        const len = this.outputLen;
++        // NOTE: we do division by 4 later, which should be fused in single op with modulo by JIT
++        if (len % 4)
++            throw new Error('_sha2: outputLen should be aligned to 32bit');
++        const outLen = len / 4;
++        const state = this.get();
++        if (outLen > state.length)
++            throw new Error('_sha2: outputLen bigger than state');
++        for (let i = 0; i < outLen; i++)
++            oview.setUint32(4 * i, state[i], isLE);
++    }
++    digest() {
++        const { buffer, outputLen } = this;
++        this.digestInto(buffer);
++        const res = buffer.slice(0, outputLen);
++        this.destroy();
++        return res;
++    }
++    _cloneInto(to) {
++        to || (to = new this.constructor());
++        to.set(...this.get());
++        const { blockLen, buffer, length, finished, destroyed, pos } = this;
++        to.length = length;
++        to.pos = pos;
++        to.finished = finished;
++        to.destroyed = destroyed;
++        if (length % blockLen)
++            to.buffer.set(buffer);
++        return to;
++    }
++}
++//# sourceMappingURL=_md.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.js.map
+new file mode 100644
+index 0000000..912b473
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_md.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_md.js","sourceRoot":"","sources":["../src/_md.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,cAAc,CAAC;AAC9C,OAAO,EAAE,IAAI,EAAE,UAAU,EAAS,OAAO,EAAE,MAAM,YAAY,CAAC;AAE9D;;GAEG;AACH,SAAS,YAAY,CAAC,IAAc,EAAE,UAAkB,EAAE,KAAa,EAAE,IAAa;IACpF,IAAI,OAAO,IAAI,CAAC,YAAY,KAAK,UAAU;QAAE,OAAO,IAAI,CAAC,YAAY,CAAC,UAAU,EAAE,KAAK,EAAE,IAAI,CAAC,CAAC;IAC/F,MAAM,IAAI,GAAG,MAAM,CAAC,EAAE,CAAC,CAAC;IACxB,MAAM,QAAQ,GAAG,MAAM,CAAC,UAAU,CAAC,CAAC;IACpC,MAAM,EAAE,GAAG,MAAM,CAAC,CAAC,KAAK,IAAI,IAAI,CAAC,GAAG,QAAQ,CAAC,CAAC;IAC9C,MAAM,EAAE,GAAG,MAAM,CAAC,KAAK,GAAG,QAAQ,CAAC,CAAC;IACpC,MAAM,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACvB,MAAM,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACvB,IAAI,CAAC,SAAS,CAAC,UAAU,GAAG,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CAAC;IACzC,IAAI,CAAC,SAAS,CAAC,UAAU,GAAG,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CAAC;AAC3C,CAAC;AAED;;GAEG;AACH,MAAM,CAAC,MAAM,GAAG,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;AAE3E;;GAEG;AACH,MAAM,CAAC,MAAM,GAAG,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;AAEpF;;;GAGG;AACH,MAAM,OAAgB,MAA4B,SAAQ,IAAO;IAc/D,YACW,QAAgB,EAClB,SAAiB,EACf,SAAiB,EACjB,IAAa;QAEtB,KAAK,EAAE,CAAC;QALC,aAAQ,GAAR,QAAQ,CAAQ;QAClB,cAAS,GAAT,SAAS,CAAQ;QACf,cAAS,GAAT,SAAS,CAAQ;QACjB,SAAI,GAAJ,IAAI,CAAS;QATd,aAAQ,GAAG,KAAK,CAAC;QACjB,WAAM,GAAG,CAAC,CAAC;QACX,QAAG,GAAG,CAAC,CAAC;QACR,cAAS,GAAG,KAAK,CAAC;QAS1B,IAAI,CAAC,MAAM,GAAG,IAAI,UAAU,CAAC,QAAQ,CAAC,CAAC;QACvC,IAAI,CAAC,IAAI,GAAG,UAAU,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC;IACtC,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,MAAM,CAAC,IAAI,CAAC,CAAC;QACb,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QACxC,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;QACrB,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAC9B,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACtD,8EAA8E;YAC9E,IAAI,IAAI,KAAK,QAAQ,EAAE,CAAC;gBACtB,MAAM,QAAQ,GAAG,UAAU,CAAC,IAAI,CAAC,CAAC;gBAClC,OAAO,QAAQ,IAAI,GAAG,GAAG,GAAG,EAAE,GAAG,IAAI,QAAQ;oBAAE,IAAI,CAAC,OAAO,CAAC,QAAQ,EAAE,GAAG,CAAC,CAAC;gBAC3E,SAAS;YACX,CAAC;YACD,MAAM,CAAC,GAAG,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,IAAI,CAAC,GAAG,CAAC,CAAC;YACrD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC;YACjB,GAAG,IAAI,IAAI,CAAC;YACZ,IAAI,IAAI,CAAC,GAAG,KAAK,QAAQ,EAAE,CAAC;gBAC1B,IAAI,CAAC,OAAO,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;gBACtB,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;YACf,CAAC;QACH,CAAC;QACD,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC,MAAM,CAAC;QAC3B,IAAI,CAAC,UAAU,EAAE,CAAC;QAClB,OAAO,IAAI,CAAC;IACd,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,MAAM,CAAC,IAAI,CAAC,CAAC;QACb,MAAM,CAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,UAAU;QACV,iEAAiE;QACjE,sEAAsE;QACtE,MAAM,EAAE,MAAM,EAAE,IAAI,EAAE,QAAQ,EAAE,IAAI,EAAE,GAAG,IAAI,CAAC;QAC9C,IAAI,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QACnB,oCAAoC;QACpC,MAAM,CAAC,GAAG,EAAE,CAAC,GAAG,UAAU,CAAC;QAC3B,IAAI,CAAC,MAAM,CAAC,QAAQ,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QAClC,yEAAyE;QACzE,+CAA+C;QAC/C,IAAI,IAAI,CAAC,SAAS,GAAG,QAAQ,GAAG,GAAG,EAAE,CAAC;YACpC,IAAI,CAAC,OAAO,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;YACtB,GAAG,GAAG,CAAC,CAAC;QACV,CAAC;QACD,uCAAuC;QACvC,KAAK,IAAI,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,QAAQ,EAAE,CAAC,EAAE;YAAE,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnD,gGAAgG;QAChG,oFAAoF;QACpF,iDAAiD;QACjD,YAAY,CAAC,IAAI,EAAE,QAAQ,GAAG,CAAC,EAAE,MAAM,CAAC,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC,EAAE,IAAI,CAAC,CAAC;QAChE,IAAI,CAAC,OAAO,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;QACtB,MAAM,KAAK,GAAG,UAAU,CAAC,GAAG,CAAC,CAAC;QAC9B,MAAM,GAAG,GAAG,IAAI,CAAC,SAAS,CAAC;QAC3B,yFAAyF;QACzF,IAAI,GAAG,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,CAAC;QAC5E,MAAM,MAAM,GAAG,GAAG,GAAG,CAAC,CAAC;QACvB,MAAM,KAAK,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC;QACzB,IAAI,MAAM,GAAG,KAAK,CAAC,MAAM;YAAE,MAAM,IAAI,KAAK,CAAC,oCAAoC,CAAC,CAAC;QACjF,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,EAAE,CAAC,EAAE;YAAE,KAAK,CAAC,SAAS,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC,EAAE,IAAI,CAAC,CAAC;IAC1E,CAAC;IACD,MAAM;QACJ,MAAM,EAAE,MAAM,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACnC,IAAI,CAAC,UAAU,CAAC,MAAM,CAAC,CAAC;QACxB,MAAM,GAAG,GAAG,MAAM,CAAC,KAAK,CAAC,CAAC,EAAE,SAAS,CAAC,CAAC;QACvC,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,UAAU,CAAC,EAAM;QACf,EAAE,KAAF,EAAE,GAAK,IAAK,IAAI,CAAC,WAAmB,EAAO,EAAC;QAC5C,EAAE,CAAC,GAAG,CAAC,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC;QACtB,MAAM,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,EAAE,QAAQ,EAAE,SAAS,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QACpE,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,GAAG,GAAG,GAAG,CAAC;QACb,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,IAAI,MAAM,GAAG,QAAQ;YAAE,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;QAC7C,OAAO,EAAE,CAAC;IACZ,CAAC;CACF"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.d.ts
+new file mode 100644
+index 0000000..6b8c273
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.d.ts
+@@ -0,0 +1,55 @@
++declare function fromBig(n: bigint, le?: boolean): {
++    h: number;
++    l: number;
++};
++declare function split(lst: bigint[], le?: boolean): Uint32Array[];
++declare const toBig: (h: number, l: number) => bigint;
++declare const shrSH: (h: number, _l: number, s: number) => number;
++declare const shrSL: (h: number, l: number, s: number) => number;
++declare const rotrSH: (h: number, l: number, s: number) => number;
++declare const rotrSL: (h: number, l: number, s: number) => number;
++declare const rotrBH: (h: number, l: number, s: number) => number;
++declare const rotrBL: (h: number, l: number, s: number) => number;
++declare const rotr32H: (_h: number, l: number) => number;
++declare const rotr32L: (h: number, _l: number) => number;
++declare const rotlSH: (h: number, l: number, s: number) => number;
++declare const rotlSL: (h: number, l: number, s: number) => number;
++declare const rotlBH: (h: number, l: number, s: number) => number;
++declare const rotlBL: (h: number, l: number, s: number) => number;
++declare function add(Ah: number, Al: number, Bh: number, Bl: number): {
++    h: number;
++    l: number;
++};
++declare const add3L: (Al: number, Bl: number, Cl: number) => number;
++declare const add3H: (low: number, Ah: number, Bh: number, Ch: number) => number;
++declare const add4L: (Al: number, Bl: number, Cl: number, Dl: number) => number;
++declare const add4H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number) => number;
++declare const add5L: (Al: number, Bl: number, Cl: number, Dl: number, El: number) => number;
++declare const add5H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: number) => number;
++export { fromBig, split, toBig, shrSH, shrSL, rotrSH, rotrSL, rotrBH, rotrBL, rotr32H, rotr32L, rotlSH, rotlSL, rotlBH, rotlBL, add, add3L, add3H, add4L, add4H, add5H, add5L, };
++declare const u64: {
++    fromBig: typeof fromBig;
++    split: typeof split;
++    toBig: (h: number, l: number) => bigint;
++    shrSH: (h: number, _l: number, s: number) => number;
++    shrSL: (h: number, l: number, s: number) => number;
++    rotrSH: (h: number, l: number, s: number) => number;
++    rotrSL: (h: number, l: number, s: number) => number;
++    rotrBH: (h: number, l: number, s: number) => number;
++    rotrBL: (h: number, l: number, s: number) => number;
++    rotr32H: (_h: number, l: number) => number;
++    rotr32L: (h: number, _l: number) => number;
++    rotlSH: (h: number, l: number, s: number) => number;
++    rotlSL: (h: number, l: number, s: number) => number;
++    rotlBH: (h: number, l: number, s: number) => number;
++    rotlBL: (h: number, l: number, s: number) => number;
++    add: typeof add;
++    add3L: (Al: number, Bl: number, Cl: number) => number;
++    add3H: (low: number, Ah: number, Bh: number, Ch: number) => number;
++    add4L: (Al: number, Bl: number, Cl: number, Dl: number) => number;
++    add4H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number) => number;
++    add5H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: number) => number;
++    add5L: (Al: number, Bl: number, Cl: number, Dl: number, El: number) => number;
++};
++export default u64;
++//# sourceMappingURL=_u64.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.d.ts.map
+new file mode 100644
+index 0000000..7580fea
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_u64.d.ts","sourceRoot":"","sources":["../src/_u64.ts"],"names":[],"mappings":"AAIA,iBAAS,OAAO,CAAC,CAAC,EAAE,MAAM,EAAE,EAAE,UAAQ;;;EAGrC;AAED,iBAAS,KAAK,CAAC,GAAG,EAAE,MAAM,EAAE,EAAE,EAAE,UAAQ,iBAQvC;AAED,QAAA,MAAM,KAAK,MAAO,MAAM,KAAK,MAAM,WAAgD,CAAC;AAEpF,QAAA,MAAM,KAAK,MAAO,MAAM,MAAM,MAAM,KAAK,MAAM,WAAY,CAAC;AAC5D,QAAA,MAAM,KAAK,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAE/E,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAChF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAEhF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AACvF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AAEvF,QAAA,MAAM,OAAO,OAAQ,MAAM,KAAK,MAAM,WAAM,CAAC;AAC7C,QAAA,MAAM,OAAO,MAAO,MAAM,MAAM,MAAM,WAAM,CAAC;AAE7C,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAChF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAgC,CAAC;AAEhF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AACvF,QAAA,MAAM,MAAM,MAAO,MAAM,KAAK,MAAM,KAAK,MAAM,WAAuC,CAAC;AAIvF,iBAAS,GAAG,CAAC,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;;;EAG1D;AAED,QAAA,MAAM,KAAK,OAAQ,MAAM,MAAM,MAAM,MAAM,MAAM,WAAyC,CAAC;AAC3F,QAAA,MAAM,KAAK,QAAS,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WAClB,CAAC;AAC7C,QAAA,MAAM,KAAK,OAAQ,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WACV,CAAC;AACpD,QAAA,MAAM,KAAK,QAAS,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WACzB,CAAC;AAClD,QAAA,MAAM,KAAK,OAAQ,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WACT,CAAC;AACjE,QAAA,MAAM,KAAK,QAAS,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,WAChC,CAAC;AAGvD,OAAO,EACL,OAAO,EAAE,KAAK,EAAE,KAAK,EACrB,KAAK,EAAE,KAAK,EACZ,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAC9B,OAAO,EAAE,OAAO,EAChB,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAC9B,GAAG,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,GAC9C,CAAC;AAEF,QAAA,MAAM,GAAG;;;eAjDS,MAAM,KAAK,MAAM;eAEjB,MAAM,MAAM,MAAM,KAAK,MAAM;eAC7B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAE3B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAE5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;kBAE1B,MAAM,KAAK,MAAM;iBAClB,MAAM,MAAM,MAAM;gBAEnB,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAE5B,MAAM,KAAK,MAAM,KAAK,MAAM;gBAC5B,MAAM,KAAK,MAAM,KAAK,MAAM;;gBAS5B,MAAM,MAAM,MAAM,MAAM,MAAM;iBAC7B,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;gBAE3C,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;iBAEzC,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;iBAItD,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;gBAFnE,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM,MAAM;CAsBxE,CAAC;AACF,eAAe,GAAG,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.js
+new file mode 100644
+index 0000000..66cce47
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.js
+@@ -0,0 +1,62 @@
++const U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
++const _32n = /* @__PURE__ */ BigInt(32);
++// We are not using BigUint64Array, because they are extremely slow as per 2022
++function fromBig(n, le = false) {
++    if (le)
++        return { h: Number(n & U32_MASK64), l: Number((n >> _32n) & U32_MASK64) };
++    return { h: Number((n >> _32n) & U32_MASK64) | 0, l: Number(n & U32_MASK64) | 0 };
++}
++function split(lst, le = false) {
++    let Ah = new Uint32Array(lst.length);
++    let Al = new Uint32Array(lst.length);
++    for (let i = 0; i < lst.length; i++) {
++        const { h, l } = fromBig(lst[i], le);
++        [Ah[i], Al[i]] = [h, l];
++    }
++    return [Ah, Al];
++}
++const toBig = (h, l) => (BigInt(h >>> 0) << _32n) | BigInt(l >>> 0);
++// for Shift in [0, 32)
++const shrSH = (h, _l, s) => h >>> s;
++const shrSL = (h, l, s) => (h << (32 - s)) | (l >>> s);
++// Right rotate for Shift in [1, 32)
++const rotrSH = (h, l, s) => (h >>> s) | (l << (32 - s));
++const rotrSL = (h, l, s) => (h << (32 - s)) | (l >>> s);
++// Right rotate for Shift in (32, 64), NOTE: 32 is special case.
++const rotrBH = (h, l, s) => (h << (64 - s)) | (l >>> (s - 32));
++const rotrBL = (h, l, s) => (h >>> (s - 32)) | (l << (64 - s));
++// Right rotate for shift===32 (just swaps l&h)
++const rotr32H = (_h, l) => l;
++const rotr32L = (h, _l) => h;
++// Left rotate for Shift in [1, 32)
++const rotlSH = (h, l, s) => (h << s) | (l >>> (32 - s));
++const rotlSL = (h, l, s) => (l << s) | (h >>> (32 - s));
++// Left rotate for Shift in (32, 64), NOTE: 32 is special case.
++const rotlBH = (h, l, s) => (l << (s - 32)) | (h >>> (64 - s));
++const rotlBL = (h, l, s) => (h << (s - 32)) | (l >>> (64 - s));
++// JS uses 32-bit signed integers for bitwise operations which means we cannot
++// simple take carry out of low bit sum by shift, we need to use division.
++function add(Ah, Al, Bh, Bl) {
++    const l = (Al >>> 0) + (Bl >>> 0);
++    return { h: (Ah + Bh + ((l / 2 ** 32) | 0)) | 0, l: l | 0 };
++}
++// Addition with more than 2 elements
++const add3L = (Al, Bl, Cl) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0);
++const add3H = (low, Ah, Bh, Ch) => (Ah + Bh + Ch + ((low / 2 ** 32) | 0)) | 0;
++const add4L = (Al, Bl, Cl, Dl) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0);
++const add4H = (low, Ah, Bh, Ch, Dh) => (Ah + Bh + Ch + Dh + ((low / 2 ** 32) | 0)) | 0;
++const add5L = (Al, Bl, Cl, Dl, El) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0) + (El >>> 0);
++const add5H = (low, Ah, Bh, Ch, Dh, Eh) => (Ah + Bh + Ch + Dh + Eh + ((low / 2 ** 32) | 0)) | 0;
++// prettier-ignore
++export { fromBig, split, toBig, shrSH, shrSL, rotrSH, rotrSL, rotrBH, rotrBL, rotr32H, rotr32L, rotlSH, rotlSL, rotlBH, rotlBL, add, add3L, add3H, add4L, add4H, add5H, add5L, };
++// prettier-ignore
++const u64 = {
++    fromBig, split, toBig,
++    shrSH, shrSL,
++    rotrSH, rotrSL, rotrBH, rotrBL,
++    rotr32H, rotr32L,
++    rotlSH, rotlSL, rotlBH, rotlBL,
++    add, add3L, add3H, add4L, add4H, add5H, add5L,
++};
++export default u64;
++//# sourceMappingURL=_u64.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.js.map
+new file mode 100644
+index 0000000..ecba77f
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/_u64.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"_u64.js","sourceRoot":"","sources":["../src/_u64.ts"],"names":[],"mappings":"AAAA,MAAM,UAAU,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC,CAAC;AACvD,MAAM,IAAI,GAAG,eAAe,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC;AAExC,+EAA+E;AAC/E,SAAS,OAAO,CAAC,CAAS,EAAE,EAAE,GAAG,KAAK;IACpC,IAAI,EAAE;QAAE,OAAO,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,GAAG,UAAU,CAAC,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC,GAAG,UAAU,CAAC,EAAE,CAAC;IAClF,OAAO,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC,GAAG,UAAU,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,MAAM,CAAC,CAAC,GAAG,UAAU,CAAC,GAAG,CAAC,EAAE,CAAC;AACpF,CAAC;AAED,SAAS,KAAK,CAAC,GAAa,EAAE,EAAE,GAAG,KAAK;IACtC,IAAI,EAAE,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrC,IAAI,EAAE,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACpC,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;QACrC,CAAC,EAAE,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;IAC1B,CAAC;IACD,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAClB,CAAC;AAED,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,MAAM,CAAC,CAAC,KAAK,CAAC,CAAC,IAAI,IAAI,CAAC,GAAG,MAAM,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AACpF,uBAAuB;AACvB,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,EAAU,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,KAAK,CAAC,CAAC;AAC5D,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AAC/E,oCAAoC;AACpC,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AAChF,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AAChF,gEAAgE;AAChE,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC;AACvF,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AACvF,+CAA+C;AAC/C,MAAM,OAAO,GAAG,CAAC,EAAU,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC;AAC7C,MAAM,OAAO,GAAG,CAAC,CAAS,EAAE,EAAU,EAAE,EAAE,CAAC,CAAC,CAAC;AAC7C,mCAAmC;AACnC,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AAChF,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AAChF,+DAA+D;AAC/D,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AACvF,MAAM,MAAM,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;AAEvF,8EAA8E;AAC9E,0EAA0E;AAC1E,SAAS,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;IACzD,MAAM,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;IAClC,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC;AAC9D,CAAC;AACD,qCAAqC;AACrC,MAAM,KAAK,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAAC,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;AAC3F,MAAM,KAAK,GAAG,CAAC,GAAW,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAChE,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,GAAG,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;AAC7C,MAAM,KAAK,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAC/D,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;AACpD,MAAM,KAAK,GAAG,CAAC,GAAW,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAC5E,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,GAAG,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;AAClD,MAAM,KAAK,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CAC3E,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,GAAG,CAAC,EAAE,KAAK,CAAC,CAAC,CAAC;AACjE,MAAM,KAAK,GAAG,CAAC,GAAW,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAE,CACxF,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC,GAAG,GAAG,CAAC,IAAI,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;AAEvD,kBAAkB;AAClB,OAAO,EACL,OAAO,EAAE,KAAK,EAAE,KAAK,EACrB,KAAK,EAAE,KAAK,EACZ,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAC9B,OAAO,EAAE,OAAO,EAChB,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAC9B,GAAG,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,GAC9C,CAAC;AACF,kBAAkB;AAClB,MAAM,GAAG,GAAG;IACV,OAAO,EAAE,KAAK,EAAE,KAAK;IACrB,KAAK,EAAE,KAAK;IACZ,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM;IAC9B,OAAO,EAAE,OAAO;IAChB,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM;IAC9B,GAAG,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK,EAAE,KAAK;CAC9C,CAAC;AACF,eAAe,GAAG,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.d.ts
+new file mode 100644
+index 0000000..9d4139c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.d.ts
+@@ -0,0 +1,17 @@
++import { Input } from './utils.js';
++export type ArgonOpts = {
++    t: number;
++    m: number;
++    p: number;
++    version?: number;
++    key?: Input;
++    personalization?: Input;
++    dkLen?: number;
++    asyncTick?: number;
++    maxmem?: number;
++    onProgress?: (progress: number) => void;
++};
++export declare const argon2d: (password: Input, salt: Input, opts: ArgonOpts) => Uint8Array;
++export declare const argon2i: (password: Input, salt: Input, opts: ArgonOpts) => Uint8Array;
++export declare const argon2id: (password: Input, salt: Input, opts: ArgonOpts) => Uint8Array;
++//# sourceMappingURL=argon2.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.d.ts.map
+new file mode 100644
+index 0000000..8035207
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"argon2.d.ts","sourceRoot":"","sources":["../src/argon2.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,KAAK,EAAoB,MAAM,YAAY,CAAC;AAkKrD,MAAM,MAAM,SAAS,GAAG;IACtB,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,OAAO,CAAC,EAAE,MAAM,CAAC;IACjB,GAAG,CAAC,EAAE,KAAK,CAAC;IACZ,eAAe,CAAC,EAAE,KAAK,CAAC;IACxB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,SAAS,CAAC,EAAE,MAAM,CAAC;IACnB,MAAM,CAAC,EAAE,MAAM,CAAC;IAChB,UAAU,CAAC,EAAE,CAAC,QAAQ,EAAE,MAAM,KAAK,IAAI,CAAC;CACzC,CAAC;AAkMF,eAAO,MAAM,OAAO,aAAc,KAAK,QAAQ,KAAK,QAAQ,SAAS,eACvB,CAAC;AAC/C,eAAO,MAAM,OAAO,aAAc,KAAK,QAAQ,KAAK,QAAQ,SAAS,eACxB,CAAC;AAC9C,eAAO,MAAM,QAAQ,aAAc,KAAK,QAAQ,KAAK,QAAQ,SAAS,eACxB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.js
+new file mode 100644
+index 0000000..682eb34
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.js
+@@ -0,0 +1,297 @@
++import { number as assertNumber } from './_assert.js';
++import { toBytes, u8, u32 } from './utils.js';
++import { blake2b } from './blake2b.js';
++import { add3H, add3L, rotr32H, rotr32L, rotrBH, rotrBL, rotrSH, rotrSL } from './_u64.js';
++const ARGON2_SYNC_POINTS = 4;
++const toBytesOptional = (buf) => (buf !== undefined ? toBytes(buf) : new Uint8Array([]));
++function mul(a, b) {
++    const aL = a & 0xffff;
++    const aH = a >>> 16;
++    const bL = b & 0xffff;
++    const bH = b >>> 16;
++    const ll = Math.imul(aL, bL);
++    const hl = Math.imul(aH, bL);
++    const lh = Math.imul(aL, bH);
++    const hh = Math.imul(aH, bH);
++    const BUF = ((ll >>> 16) + (hl & 0xffff) + lh) | 0;
++    const h = ((hl >>> 16) + (BUF >>> 16) + hh) | 0;
++    return { h, l: (BUF << 16) | (ll & 0xffff) };
++}
++function relPos(areaSize, relativePos) {
++    // areaSize - 1 - ((areaSize * ((relativePos ** 2) >>> 32)) >>> 32)
++    return areaSize - 1 - mul(areaSize, mul(relativePos, relativePos).h).h;
++}
++function mul2(a, b) {
++    // 2 * a * b (via shifts)
++    const { h, l } = mul(a, b);
++    return { h: ((h << 1) | (l >>> 31)) & 4294967295, l: (l << 1) & 4294967295 };
++}
++function blamka(Ah, Al, Bh, Bl) {
++    const { h: Ch, l: Cl } = mul2(Al, Bl);
++    // A + B + (2 * A * B)
++    const Rll = add3L(Al, Bl, Cl);
++    return { h: add3H(Rll, Ah, Bh, Ch), l: Rll | 0 };
++}
++// Temporary block buffer
++const A2_BUF = new Uint32Array(256);
++function G(a, b, c, d) {
++    let Al = A2_BUF[2 * a], Ah = A2_BUF[2 * a + 1]; // prettier-ignore
++    let Bl = A2_BUF[2 * b], Bh = A2_BUF[2 * b + 1]; // prettier-ignore
++    let Cl = A2_BUF[2 * c], Ch = A2_BUF[2 * c + 1]; // prettier-ignore
++    let Dl = A2_BUF[2 * d], Dh = A2_BUF[2 * d + 1]; // prettier-ignore
++    ({ h: Ah, l: Al } = blamka(Ah, Al, Bh, Bl));
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: rotr32H(Dh, Dl), Dl: rotr32L(Dh, Dl) });
++    ({ h: Ch, l: Cl } = blamka(Ch, Cl, Dh, Dl));
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: rotrSH(Bh, Bl, 24), Bl: rotrSL(Bh, Bl, 24) });
++    ({ h: Ah, l: Al } = blamka(Ah, Al, Bh, Bl));
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: rotrSH(Dh, Dl, 16), Dl: rotrSL(Dh, Dl, 16) });
++    ({ h: Ch, l: Cl } = blamka(Ch, Cl, Dh, Dl));
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: rotrBH(Bh, Bl, 63), Bl: rotrBL(Bh, Bl, 63) });
++    (A2_BUF[2 * a] = Al), (A2_BUF[2 * a + 1] = Ah);
++    (A2_BUF[2 * b] = Bl), (A2_BUF[2 * b + 1] = Bh);
++    (A2_BUF[2 * c] = Cl), (A2_BUF[2 * c + 1] = Ch);
++    (A2_BUF[2 * d] = Dl), (A2_BUF[2 * d + 1] = Dh);
++}
++// prettier-ignore
++function P(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15) {
++    G(v00, v04, v08, v12);
++    G(v01, v05, v09, v13);
++    G(v02, v06, v10, v14);
++    G(v03, v07, v11, v15);
++    G(v00, v05, v10, v15);
++    G(v01, v06, v11, v12);
++    G(v02, v07, v08, v13);
++    G(v03, v04, v09, v14);
++}
++function block(x, xPos, yPos, outPos, needXor) {
++    for (let i = 0; i < 256; i++)
++        A2_BUF[i] = x[xPos + i] ^ x[yPos + i];
++    // columns
++    for (let i = 0; i < 128; i += 16) {
++        // prettier-ignore
++        P(i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7, i + 8, i + 9, i + 10, i + 11, i + 12, i + 13, i + 14, i + 15);
++    }
++    // rows
++    for (let i = 0; i < 16; i += 2) {
++        // prettier-ignore
++        P(i, i + 1, i + 16, i + 17, i + 32, i + 33, i + 48, i + 49, i + 64, i + 65, i + 80, i + 81, i + 96, i + 97, i + 112, i + 113);
++    }
++    if (needXor)
++        for (let i = 0; i < 256; i++)
++            x[outPos + i] ^= A2_BUF[i] ^ x[xPos + i] ^ x[yPos + i];
++    else
++        for (let i = 0; i < 256; i++)
++            x[outPos + i] = A2_BUF[i] ^ x[xPos + i] ^ x[yPos + i];
++}
++// Variable-Length Hash Function H'
++function Hp(A, dkLen) {
++    const A8 = u8(A);
++    const T = new Uint32Array(1);
++    const T8 = u8(T);
++    T[0] = dkLen;
++    // Fast path
++    if (dkLen <= 64)
++        return blake2b.create({ dkLen }).update(T8).update(A8).digest();
++    const out = new Uint8Array(dkLen);
++    let V = blake2b.create({}).update(T8).update(A8).digest();
++    let pos = 0;
++    // First block
++    out.set(V.subarray(0, 32));
++    pos += 32;
++    // Rest blocks
++    for (; dkLen - pos > 64; pos += 32)
++        out.set((V = blake2b(V)).subarray(0, 32), pos);
++    // Last block
++    out.set(blake2b(V, { dkLen: dkLen - pos }), pos);
++    return u32(out);
++}
++function indexAlpha(r, s, laneLen, segmentLen, index, randL, sameLane = false) {
++    let area;
++    if (0 == r) {
++        if (0 == s)
++            area = index - 1;
++        else if (sameLane)
++            area = s * segmentLen + index - 1;
++        else
++            area = s * segmentLen + (index == 0 ? -1 : 0);
++    }
++    else if (sameLane)
++        area = laneLen - segmentLen + index - 1;
++    else
++        area = laneLen - segmentLen + (index == 0 ? -1 : 0);
++    const startPos = r !== 0 && s !== ARGON2_SYNC_POINTS - 1 ? (s + 1) * segmentLen : 0;
++    const rel = relPos(area, randL);
++    // NOTE: check about overflows here
++    //     absPos = (startPos + relPos) % laneLength;
++    return (startPos + rel) % laneLen;
++}
++function argon2Init(type, password, salt, opts) {
++    password = toBytes(password);
++    salt = toBytes(salt);
++    let { p, dkLen, m, t, version, key, personalization, maxmem, onProgress } = {
++        ...opts,
++        version: opts.version || 0x13,
++        dkLen: opts.dkLen || 32,
++        maxmem: 2 ** 32,
++    };
++    // Validation
++    assertNumber(p);
++    assertNumber(dkLen);
++    assertNumber(m);
++    assertNumber(t);
++    assertNumber(version);
++    if (dkLen < 4 || dkLen >= 2 ** 32)
++        throw new Error('Argon2: dkLen should be at least 4 bytes');
++    if (p < 1 || p >= 2 ** 32)
++        throw new Error('Argon2: p (parallelism) should be at least 1');
++    if (t < 1 || t >= 2 ** 32)
++        throw new Error('Argon2: t (iterations) should be at least 1');
++    if (m < 8 * p)
++        throw new Error(`Argon2: memory should be at least 8*p bytes`);
++    if (version !== 16 && version !== 19)
++        throw new Error(`Argon2: unknown version=${version}`);
++    password = toBytes(password);
++    if (password.length < 0 || password.length >= 2 ** 32)
++        throw new Error('Argon2: password should be less than 4 GB');
++    salt = toBytes(salt);
++    if (salt.length < 8)
++        throw new Error('Argon2: salt should be at least 8 bytes');
++    key = toBytesOptional(key);
++    personalization = toBytesOptional(personalization);
++    if (onProgress !== undefined && typeof onProgress !== 'function')
++        throw new Error('progressCb should be function');
++    // Params
++    const lanes = p;
++    // m' = 4 * p * floor (m / 4p)
++    const mP = 4 * p * Math.floor(m / (ARGON2_SYNC_POINTS * p));
++    //q = m' / p columns
++    const laneLen = Math.floor(mP / p);
++    const segmentLen = Math.floor(laneLen / ARGON2_SYNC_POINTS);
++    // H0
++    const h = blake2b.create({});
++    const BUF = new Uint32Array(1);
++    const BUF8 = u8(BUF);
++    for (const i of [p, dkLen, m, t, version, type]) {
++        if (i < 0 || i >= 2 ** 32)
++            throw new Error(`Argon2: wrong parameter=${i}, expected uint32`);
++        BUF[0] = i;
++        h.update(BUF8);
++    }
++    for (let i of [password, salt, key, personalization]) {
++        BUF[0] = i.length;
++        h.update(BUF8).update(i);
++    }
++    const H0 = new Uint32Array(18);
++    const H0_8 = u8(H0);
++    h.digestInto(H0_8);
++    // 256 u32 = 1024 (BLOCK_SIZE)
++    const memUsed = mP * 256;
++    if (memUsed < 0 || memUsed >= 2 ** 32 || memUsed > maxmem) {
++        throw new Error(`Argon2: wrong params (memUsed=${memUsed} maxmem=${maxmem}), should be less than 2**32`);
++    }
++    const B = new Uint32Array(memUsed);
++    // Fill first blocks
++    for (let l = 0; l < p; l++) {
++        const i = 256 * laneLen * l;
++        // B[i][0] = H'^(1024)(H_0 || LE32(0) || LE32(i))
++        H0[17] = l;
++        H0[16] = 0;
++        B.set(Hp(H0, 1024), i);
++        // B[i][1] = H'^(1024)(H_0 || LE32(1) || LE32(i))
++        H0[16] = 1;
++        B.set(Hp(H0, 1024), i + 256);
++    }
++    let perBlock = () => { };
++    if (onProgress) {
++        const totalBlock = t * ARGON2_SYNC_POINTS * p * segmentLen;
++        // Invoke callback if progress changes from 10.01 to 10.02
++        // Allows to draw smooth progress bar on up to 8K screen
++        const callbackPer = Math.max(Math.floor(totalBlock / 10000), 1);
++        let blockCnt = 0;
++        perBlock = () => {
++            blockCnt++;
++            if (onProgress && (!(blockCnt % callbackPer) || blockCnt === totalBlock))
++                onProgress(blockCnt / totalBlock);
++        };
++    }
++    return { type, mP, p, t, version, B, laneLen, lanes, segmentLen, dkLen, perBlock };
++}
++function argon2Output(B, p, laneLen, dkLen) {
++    const B_final = new Uint32Array(256);
++    for (let l = 0; l < p; l++)
++        for (let j = 0; j < 256; j++)
++            B_final[j] ^= B[256 * (laneLen * l + laneLen - 1) + j];
++    return u8(Hp(B_final, dkLen));
++}
++function processBlock(B, address, l, r, s, index, laneLen, segmentLen, lanes, offset, prev, dataIndependent, needXor) {
++    if (offset % laneLen)
++        prev = offset - 1;
++    let randL, randH;
++    if (dataIndependent) {
++        if (index % 128 === 0) {
++            address[256 + 12]++;
++            block(address, 256, 2 * 256, 0, false);
++            block(address, 0, 2 * 256, 0, false);
++        }
++        randL = address[2 * (index % 128)];
++        randH = address[2 * (index % 128) + 1];
++    }
++    else {
++        const T = 256 * prev;
++        randL = B[T];
++        randH = B[T + 1];
++    }
++    // address block
++    const refLane = r === 0 && s === 0 ? l : randH % lanes;
++    const refPos = indexAlpha(r, s, laneLen, segmentLen, index, randL, refLane == l);
++    const refBlock = laneLen * refLane + refPos;
++    // B[i][j] = G(B[i][j-1], B[l][z])
++    block(B, 256 * prev, 256 * refBlock, offset * 256, needXor);
++}
++function argon2(type, password, salt, opts) {
++    const { mP, p, t, version, B, laneLen, lanes, segmentLen, dkLen, perBlock } = argon2Init(type, password, salt, opts);
++    // Pre-loop setup
++    // [address, input, zero_block] format so we can pass single U32 to block function
++    const address = new Uint32Array(3 * 256);
++    address[256 + 6] = mP;
++    address[256 + 8] = t;
++    address[256 + 10] = type;
++    for (let r = 0; r < t; r++) {
++        const needXor = r !== 0 && version === 0x13;
++        address[256 + 0] = r;
++        for (let s = 0; s < ARGON2_SYNC_POINTS; s++) {
++            address[256 + 4] = s;
++            const dataIndependent = type == 1 /* Types.Argon2i */ || (type == 2 /* Types.Argon2id */ && r === 0 && s < 2);
++            for (let l = 0; l < p; l++) {
++                address[256 + 2] = l;
++                address[256 + 12] = 0;
++                let startPos = 0;
++                if (r === 0 && s === 0) {
++                    startPos = 2;
++                    if (dataIndependent) {
++                        address[256 + 12]++;
++                        block(address, 256, 2 * 256, 0, false);
++                        block(address, 0, 2 * 256, 0, false);
++                    }
++                }
++                // current block postion
++                let offset = l * laneLen + s * segmentLen + startPos;
++                // previous block position
++                let prev = offset % laneLen ? offset - 1 : offset + laneLen - 1;
++                for (let index = startPos; index < segmentLen; index++, offset++, prev++) {
++                    perBlock();
++                    processBlock(B, address, l, r, s, index, laneLen, segmentLen, lanes, offset, prev, dataIndependent, needXor);
++                }
++            }
++        }
++    }
++    return argon2Output(B, p, laneLen, dkLen);
++}
++export const argon2d = (password, salt, opts) => argon2(0 /* Types.Argond2d */, password, salt, opts);
++export const argon2i = (password, salt, opts) => argon2(1 /* Types.Argon2i */, password, salt, opts);
++export const argon2id = (password, salt, opts) => argon2(2 /* Types.Argon2id */, password, salt, opts);
++//# sourceMappingURL=argon2.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.js.map
+new file mode 100644
+index 0000000..4a51e8a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/argon2.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"argon2.js","sourceRoot":"","sources":["../src/argon2.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,IAAI,YAAY,EAAE,MAAM,cAAc,CAAC;AACtD,OAAO,EAAS,OAAO,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,YAAY,CAAC;AACrD,OAAO,EAAE,OAAO,EAAE,MAAM,cAAc,CAAC;AACvC,OAAO,EAAE,KAAK,EAAE,KAAK,EAAE,OAAO,EAAE,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,WAAW,CAAC;AAS3F,MAAM,kBAAkB,GAAG,CAAC,CAAC;AAE7B,MAAM,eAAe,GAAG,CAAC,GAAW,EAAE,EAAE,CAAC,CAAC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC,CAAC;AAEjG,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS;IAC/B,MAAM,EAAE,GAAG,CAAC,GAAG,MAAM,CAAC;IACtB,MAAM,EAAE,GAAG,CAAC,KAAK,EAAE,CAAC;IACpB,MAAM,EAAE,GAAG,CAAC,GAAG,MAAM,CAAC;IACtB,MAAM,EAAE,GAAG,CAAC,KAAK,EAAE,CAAC;IACpB,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,IAAI,CAAC,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IAC7B,MAAM,GAAG,GAAG,CAAC,CAAC,EAAE,KAAK,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,MAAM,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;IACnD,MAAM,CAAC,GAAG,CAAC,CAAC,EAAE,KAAK,EAAE,CAAC,GAAG,CAAC,GAAG,KAAK,EAAE,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;IAChD,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,IAAI,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,MAAM,CAAC,EAAE,CAAC;AAC/C,CAAC;AAED,SAAS,MAAM,CAAC,QAAgB,EAAE,WAAmB;IACnD,mEAAmE;IACnE,OAAO,QAAQ,GAAG,CAAC,GAAG,GAAG,CAAC,QAAQ,EAAE,GAAG,CAAC,WAAW,EAAE,WAAW,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACzE,CAAC;AAED,SAAS,IAAI,CAAC,CAAS,EAAE,CAAS;IAChC,yBAAyB;IACzB,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;IAC3B,OAAO,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,CAAC,CAAC,GAAG,UAAW,EAAE,CAAC,EAAE,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,UAAW,EAAE,CAAC;AACjF,CAAC;AAED,SAAS,MAAM,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;IAC5D,MAAM,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;IACtC,sBAAsB;IACtB,MAAM,GAAG,GAAG,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC9B,OAAO,EAAE,CAAC,EAAE,KAAK,CAAC,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,CAAC;AACnD,CAAC;AAED,yBAAyB;AACzB,MAAM,MAAM,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,CAAC;AAEpC,SAAS,CAAC,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IACnD,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,CAAC,EAAE,EAAE,GAAG,MAAM,CAAC,CAAC,GAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAE9D,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAE5D,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAElE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAElE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAElE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC/C,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC/C,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC/C,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AACjD,CAAC;AAED,kBAAkB;AAClB,SAAS,CAAC,CACR,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EACtG,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW;IAEtG,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACtB,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;AACxB,CAAC;AAED,SAAS,KAAK,CAAC,CAAc,EAAE,IAAY,EAAE,IAAY,EAAE,MAAc,EAAE,OAAgB;IACzF,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;QAAE,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;IAEpE,UAAU;IACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,IAAI,EAAE,EAAE,CAAC;QACjC,kBAAkB;QAClB,CAAC,CACC,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAClD,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,CAC7D,CAAC;IACJ,CAAC;IACD,OAAO;IACP,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC;QAC/B,kBAAkB;QAClB,CAAC,CACC,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EACxD,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,GAAG,CACjE,CAAC;IACJ,CAAC;IAED,IAAI,OAAO;QAAE,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,IAAI,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;;QAC7F,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;AAC3F,CAAC;AAED,mCAAmC;AACnC,SAAS,EAAE,CAAC,CAAc,EAAE,KAAa;IACvC,MAAM,EAAE,GAAG,EAAE,CAAC,CAAC,CAAC,CAAC;IACjB,MAAM,CAAC,GAAG,IAAI,WAAW,CAAC,CAAC,CAAC,CAAC;IAC7B,MAAM,EAAE,GAAG,EAAE,CAAC,CAAC,CAAC,CAAC;IACjB,CAAC,CAAC,CAAC,CAAC,GAAG,KAAK,CAAC;IACb,YAAY;IACZ,IAAI,KAAK,IAAI,EAAE;QAAE,OAAO,OAAO,CAAC,MAAM,CAAC,EAAE,KAAK,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,EAAE,CAAC;IACjF,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC;IAClC,IAAI,CAAC,GAAG,OAAO,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,EAAE,CAAC;IAC1D,IAAI,GAAG,GAAG,CAAC,CAAC;IACZ,cAAc;IACd,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC;IAC3B,GAAG,IAAI,EAAE,CAAC;IACV,cAAc;IACd,OAAO,KAAK,GAAG,GAAG,GAAG,EAAE,EAAE,GAAG,IAAI,EAAE;QAAE,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,OAAO,CAAC,CAAC,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;IACnF,aAAa;IACb,GAAG,CAAC,GAAG,CAAC,OAAO,CAAC,CAAC,EAAE,EAAE,KAAK,EAAE,KAAK,GAAG,GAAG,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;IACjD,OAAO,GAAG,CAAC,GAAG,CAAC,CAAC;AAClB,CAAC;AAED,SAAS,UAAU,CACjB,CAAS,EACT,CAAS,EACT,OAAe,EACf,UAAkB,EAClB,KAAa,EACb,KAAa,EACb,WAAoB,KAAK;IAEzB,IAAI,IAAI,CAAC;IACT,IAAI,CAAC,IAAI,CAAC,EAAE,CAAC;QACX,IAAI,CAAC,IAAI,CAAC;YAAE,IAAI,GAAG,KAAK,GAAG,CAAC,CAAC;aACxB,IAAI,QAAQ;YAAE,IAAI,GAAG,CAAC,GAAG,UAAU,GAAG,KAAK,GAAG,CAAC,CAAC;;YAChD,IAAI,GAAG,CAAC,GAAG,UAAU,GAAG,CAAC,KAAK,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACrD,CAAC;SAAM,IAAI,QAAQ;QAAE,IAAI,GAAG,OAAO,GAAG,UAAU,GAAG,KAAK,GAAG,CAAC,CAAC;;QACxD,IAAI,GAAG,OAAO,GAAG,UAAU,GAAG,CAAC,KAAK,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;IACzD,MAAM,QAAQ,GAAG,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,kBAAkB,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;IACpF,MAAM,GAAG,GAAG,MAAM,CAAC,IAAI,EAAE,KAAK,CAAC,CAAC;IAChC,mCAAmC;IACnC,iDAAiD;IACjD,OAAO,CAAC,QAAQ,GAAG,GAAG,CAAC,GAAG,OAAO,CAAC;AACpC,CAAC;AAgBD,SAAS,UAAU,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IAC5E,QAAQ,GAAG,OAAO,CAAC,QAAQ,CAAC,CAAC;IAC7B,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;IACrB,IAAI,EAAE,CAAC,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,GAAG,EAAE,eAAe,EAAE,MAAM,EAAE,UAAU,EAAE,GAAG;QAC1E,GAAG,IAAI;QACP,OAAO,EAAE,IAAI,CAAC,OAAO,IAAI,IAAI;QAC7B,KAAK,EAAE,IAAI,CAAC,KAAK,IAAI,EAAE;QACvB,MAAM,EAAE,CAAC,IAAI,EAAE;KAChB,CAAC;IACF,aAAa;IACb,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,KAAK,CAAC,CAAC;IACpB,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,OAAO,CAAC,CAAC;IACtB,IAAI,KAAK,GAAG,CAAC,IAAI,KAAK,IAAI,CAAC,IAAI,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,0CAA0C,CAAC,CAAC;IAC/F,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,8CAA8C,CAAC,CAAC;IAC3F,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,CAAC;IAC1F,IAAI,CAAC,GAAG,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,CAAC;IAC9E,IAAI,OAAO,KAAK,EAAE,IAAI,OAAO,KAAK,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,2BAA2B,OAAO,EAAE,CAAC,CAAC;IAC5F,QAAQ,GAAG,OAAO,CAAC,QAAQ,CAAC,CAAC;IAC7B,IAAI,QAAQ,CAAC,MAAM,GAAG,CAAC,IAAI,QAAQ,CAAC,MAAM,IAAI,CAAC,IAAI,EAAE;QACnD,MAAM,IAAI,KAAK,CAAC,2CAA2C,CAAC,CAAC;IAC/D,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;IACrB,IAAI,IAAI,CAAC,MAAM,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,yCAAyC,CAAC,CAAC;IAChF,GAAG,GAAG,eAAe,CAAC,GAAG,CAAC,CAAC;IAC3B,eAAe,GAAG,eAAe,CAAC,eAAe,CAAC,CAAC;IACnD,IAAI,UAAU,KAAK,SAAS,IAAI,OAAO,UAAU,KAAK,UAAU;QAC9D,MAAM,IAAI,KAAK,CAAC,+BAA+B,CAAC,CAAC;IACnD,SAAS;IACT,MAAM,KAAK,GAAG,CAAC,CAAC;IAChB,8BAA8B;IAC9B,MAAM,EAAE,GAAG,CAAC,GAAG,CAAC,GAAG,IAAI,CAAC,KAAK,CAAC,CAAC,GAAG,CAAC,kBAAkB,GAAG,CAAC,CAAC,CAAC,CAAC;IAC5D,oBAAoB;IACpB,MAAM,OAAO,GAAG,IAAI,CAAC,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC;IACnC,MAAM,UAAU,GAAG,IAAI,CAAC,KAAK,CAAC,OAAO,GAAG,kBAAkB,CAAC,CAAC;IAC5D,KAAK;IACL,MAAM,CAAC,GAAG,OAAO,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC;IAC7B,MAAM,GAAG,GAAG,IAAI,WAAW,CAAC,CAAC,CAAC,CAAC;IAC/B,MAAM,IAAI,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;IACrB,KAAK,MAAM,CAAC,IAAI,CAAC,CAAC,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,IAAI,CAAC,EAAE,CAAC;QAChD,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE;YAAE,MAAM,IAAI,KAAK,CAAC,2BAA2B,CAAC,mBAAmB,CAAC,CAAC;QAC5F,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACX,CAAC,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IACjB,CAAC;IACD,KAAK,IAAI,CAAC,IAAI,CAAC,QAAQ,EAAE,IAAI,EAAE,GAAG,EAAE,eAAe,CAAC,EAAE,CAAC;QACrD,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,MAAM,CAAC;QAClB,CAAC,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;IAC3B,CAAC;IACD,MAAM,EAAE,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;IAC/B,MAAM,IAAI,GAAG,EAAE,CAAC,EAAE,CAAC,CAAC;IACpB,CAAC,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC;IAEnB,8BAA8B;IAC9B,MAAM,OAAO,GAAG,EAAE,GAAG,GAAG,CAAC;IACzB,IAAI,OAAO,GAAG,CAAC,IAAI,OAAO,IAAI,CAAC,IAAI,EAAE,IAAI,OAAO,GAAG,MAAM,EAAE,CAAC;QAC1D,MAAM,IAAI,KAAK,CACb,iCAAiC,OAAO,WAAW,MAAM,8BAA8B,CACxF,CAAC;IACJ,CAAC;IACD,MAAM,CAAC,GAAG,IAAI,WAAW,CAAC,OAAO,CAAC,CAAC;IACnC,oBAAoB;IACpB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;QAC3B,MAAM,CAAC,GAAG,GAAG,GAAG,OAAO,GAAG,CAAC,CAAC;QAC5B,iDAAiD;QACjD,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACX,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACX,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,CAAC,CAAC,CAAC;QACvB,iDAAiD;QACjD,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACX,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,CAAC;IAC/B,CAAC;IACD,IAAI,QAAQ,GAAG,GAAG,EAAE,GAAE,CAAC,CAAC;IACxB,IAAI,UAAU,EAAE,CAAC;QACf,MAAM,UAAU,GAAG,CAAC,GAAG,kBAAkB,GAAG,CAAC,GAAG,UAAU,CAAC;QAC3D,0DAA0D;QAC1D,wDAAwD;QACxD,MAAM,WAAW,GAAG,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,KAAK,CAAC,UAAU,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC;QAChE,IAAI,QAAQ,GAAG,CAAC,CAAC;QACjB,QAAQ,GAAG,GAAG,EAAE;YACd,QAAQ,EAAE,CAAC;YACX,IAAI,UAAU,IAAI,CAAC,CAAC,CAAC,QAAQ,GAAG,WAAW,CAAC,IAAI,QAAQ,KAAK,UAAU,CAAC;gBACtE,UAAU,CAAC,QAAQ,GAAG,UAAU,CAAC,CAAC;QACtC,CAAC,CAAC;IACJ,CAAC;IACD,OAAO,EAAE,IAAI,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,CAAC,EAAE,OAAO,EAAE,KAAK,EAAE,UAAU,EAAE,KAAK,EAAE,QAAQ,EAAE,CAAC;AACrF,CAAC;AAED,SAAS,YAAY,CAAC,CAAc,EAAE,CAAS,EAAE,OAAe,EAAE,KAAa;IAC7E,MAAM,OAAO,GAAG,IAAI,WAAW,CAAC,GAAG,CAAC,CAAC;IACrC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE;QACxB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE;YAAE,OAAO,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,GAAG,GAAG,CAAC,OAAO,GAAG,CAAC,GAAG,OAAO,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACvF,OAAO,EAAE,CAAC,EAAE,CAAC,OAAO,EAAE,KAAK,CAAC,CAAC,CAAC;AAChC,CAAC;AAED,SAAS,YAAY,CACnB,CAAc,EACd,OAAoB,EACpB,CAAS,EACT,CAAS,EACT,CAAS,EACT,KAAa,EACb,OAAe,EACf,UAAkB,EAClB,KAAa,EACb,MAAc,EACd,IAAY,EACZ,eAAwB,EACxB,OAAgB;IAEhB,IAAI,MAAM,GAAG,OAAO;QAAE,IAAI,GAAG,MAAM,GAAG,CAAC,CAAC;IACxC,IAAI,KAAK,EAAE,KAAK,CAAC;IACjB,IAAI,eAAe,EAAE,CAAC;QACpB,IAAI,KAAK,GAAG,GAAG,KAAK,CAAC,EAAE,CAAC;YACtB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,CAAC;YACpB,KAAK,CAAC,OAAO,EAAE,GAAG,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;YACvC,KAAK,CAAC,OAAO,EAAE,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;QACvC,CAAC;QACD,KAAK,GAAG,OAAO,CAAC,CAAC,GAAG,CAAC,KAAK,GAAG,GAAG,CAAC,CAAC,CAAC;QACnC,KAAK,GAAG,OAAO,CAAC,CAAC,GAAG,CAAC,KAAK,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC;IACzC,CAAC;SAAM,CAAC;QACN,MAAM,CAAC,GAAG,GAAG,GAAG,IAAI,CAAC;QACrB,KAAK,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;QACb,KAAK,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACnB,CAAC;IACD,gBAAgB;IAChB,MAAM,OAAO,GAAG,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,KAAK,GAAG,KAAK,CAAC;IACvD,MAAM,MAAM,GAAG,UAAU,CAAC,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,UAAU,EAAE,KAAK,EAAE,KAAK,EAAE,OAAO,IAAI,CAAC,CAAC,CAAC;IACjF,MAAM,QAAQ,GAAG,OAAO,GAAG,OAAO,GAAG,MAAM,CAAC;IAC5C,kCAAkC;IAClC,KAAK,CAAC,CAAC,EAAE,GAAG,GAAG,IAAI,EAAE,GAAG,GAAG,QAAQ,EAAE,MAAM,GAAG,GAAG,EAAE,OAAO,CAAC,CAAC;AAC9D,CAAC;AAED,SAAS,MAAM,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IACxE,MAAM,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,CAAC,EAAE,OAAO,EAAE,KAAK,EAAE,UAAU,EAAE,KAAK,EAAE,QAAQ,EAAE,GAAG,UAAU,CACtF,IAAI,EACJ,QAAQ,EACR,IAAI,EACJ,IAAI,CACL,CAAC;IACF,iBAAiB;IACjB,kFAAkF;IAClF,MAAM,OAAO,GAAG,IAAI,WAAW,CAAC,CAAC,GAAG,GAAG,CAAC,CAAC;IACzC,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;IACtB,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IACrB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,IAAI,CAAC;IACzB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;QAC3B,MAAM,OAAO,GAAG,CAAC,KAAK,CAAC,IAAI,OAAO,KAAK,IAAI,CAAC;QAC5C,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,kBAAkB,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5C,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;YACrB,MAAM,eAAe,GAAG,IAAI,yBAAiB,IAAI,CAAC,IAAI,0BAAkB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;YAC9F,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;gBAC3B,OAAO,CAAC,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;gBACrB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;gBACtB,IAAI,QAAQ,GAAG,CAAC,CAAC;gBACjB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,CAAC,EAAE,CAAC;oBACvB,QAAQ,GAAG,CAAC,CAAC;oBACb,IAAI,eAAe,EAAE,CAAC;wBACpB,OAAO,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,CAAC;wBACpB,KAAK,CAAC,OAAO,EAAE,GAAG,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;wBACvC,KAAK,CAAC,OAAO,EAAE,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;oBACvC,CAAC;gBACH,CAAC;gBACD,wBAAwB;gBACxB,IAAI,MAAM,GAAG,CAAC,GAAG,OAAO,GAAG,CAAC,GAAG,UAAU,GAAG,QAAQ,CAAC;gBACrD,0BAA0B;gBAC1B,IAAI,IAAI,GAAG,MAAM,GAAG,OAAO,CAAC,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,CAAC,MAAM,GAAG,OAAO,GAAG,CAAC,CAAC;gBAChE,KAAK,IAAI,KAAK,GAAG,QAAQ,EAAE,KAAK,GAAG,UAAU,EAAE,KAAK,EAAE,EAAE,MAAM,EAAE,EAAE,IAAI,EAAE,EAAE,CAAC;oBACzE,QAAQ,EAAE,CAAC;oBACX,YAAY,CACV,CAAC,EACD,OAAO,EACP,CAAC,EACD,CAAC,EACD,CAAC,EACD,KAAK,EACL,OAAO,EACP,UAAU,EACV,KAAK,EACL,MAAM,EACN,IAAI,EACJ,eAAe,EACf,OAAO,CACR,CAAC;gBACJ,CAAC;YACH,CAAC;QACH,CAAC;IACH,CAAC;IACD,OAAO,YAAY,CAAC,CAAC,EAAE,CAAC,EAAE,OAAO,EAAE,KAAK,CAAC,CAAC;AAC5C,CAAC;AAED,MAAM,CAAC,MAAM,OAAO,GAAG,CAAC,QAAe,EAAE,IAAW,EAAE,IAAe,EAAE,EAAE,CACvE,MAAM,yBAAiB,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;AAC/C,MAAM,CAAC,MAAM,OAAO,GAAG,CAAC,QAAe,EAAE,IAAW,EAAE,IAAe,EAAE,EAAE,CACvE,MAAM,wBAAgB,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;AAC9C,MAAM,CAAC,MAAM,QAAQ,GAAG,CAAC,QAAe,EAAE,IAAW,EAAE,IAAe,EAAE,EAAE,CACxE,MAAM,yBAAiB,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.d.ts
+new file mode 100644
+index 0000000..fa5b7f9
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.d.ts
+@@ -0,0 +1,53 @@
++import { BLAKE, BlakeOpts } from './_blake.js';
++export declare class BLAKE2b extends BLAKE<BLAKE2b> {
++    private v0l;
++    private v0h;
++    private v1l;
++    private v1h;
++    private v2l;
++    private v2h;
++    private v3l;
++    private v3h;
++    private v4l;
++    private v4h;
++    private v5l;
++    private v5h;
++    private v6l;
++    private v6h;
++    private v7l;
++    private v7h;
++    constructor(opts?: BlakeOpts);
++    protected get(): [
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number
++    ];
++    protected set(v0l: number, v0h: number, v1l: number, v1h: number, v2l: number, v2h: number, v3l: number, v3h: number, v4l: number, v4h: number, v5l: number, v5h: number, v6l: number, v6h: number, v7l: number, v7h: number): void;
++    protected compress(msg: Uint32Array, offset: number, isLast: boolean): void;
++    destroy(): void;
++}
++/**
++ * BLAKE2b - optimized for 64-bit platforms. JS doesn't have uint64, so it's slower than BLAKE2s.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++export declare const blake2b: {
++    (msg: import("./utils.js").Input, opts?: BlakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: BlakeOpts): import("./utils.js").Hash<BLAKE2b>;
++};
++//# sourceMappingURL=blake2b.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.d.ts.map
+new file mode 100644
+index 0000000..046c3e0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2b.d.ts","sourceRoot":"","sources":["../src/blake2b.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,SAAS,EAAS,MAAM,aAAa,CAAC;AAgEtD,qBAAa,OAAQ,SAAQ,KAAK,CAAC,OAAO,CAAC;IAEzC,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAiB;IAC5B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;IAC7B,OAAO,CAAC,GAAG,CAAkB;gBAEjB,IAAI,GAAE,SAAc;IA0BhC,SAAS,CAAC,GAAG,IAAI;QACf,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAC9D,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;KAC/D;IAKD,SAAS,CAAC,GAAG,CACX,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAClD,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAClD,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAClD,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM;IAmBpD,SAAS,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,OAAO;IAkDpE,OAAO;CAKR;AAED;;;;GAIG;AACH,eAAO,MAAM,OAAO;;;;;CAEnB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.js
+new file mode 100644
+index 0000000..207b222
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.js
+@@ -0,0 +1,189 @@
++import { BLAKE, SIGMA } from './_blake.js';
++import u64 from './_u64.js';
++import { toBytes, u32, wrapConstructorWithOpts, byteSwapIfBE } from './utils.js';
++// Same as SHA-512 but LE
++// prettier-ignore
++const B2B_IV = /* @__PURE__ */ new Uint32Array([
++    0xf3bcc908, 0x6a09e667, 0x84caa73b, 0xbb67ae85, 0xfe94f82b, 0x3c6ef372, 0x5f1d36f1, 0xa54ff53a,
++    0xade682d1, 0x510e527f, 0x2b3e6c1f, 0x9b05688c, 0xfb41bd6b, 0x1f83d9ab, 0x137e2179, 0x5be0cd19
++]);
++// Temporary buffer
++const BBUF = /* @__PURE__ */ new Uint32Array(32);
++// Mixing function G splitted in two halfs
++function G1b(a, b, c, d, msg, x) {
++    // NOTE: V is LE here
++    const Xl = msg[x], Xh = msg[x + 1]; // prettier-ignore
++    let Al = BBUF[2 * a], Ah = BBUF[2 * a + 1]; // prettier-ignore
++    let Bl = BBUF[2 * b], Bh = BBUF[2 * b + 1]; // prettier-ignore
++    let Cl = BBUF[2 * c], Ch = BBUF[2 * c + 1]; // prettier-ignore
++    let Dl = BBUF[2 * d], Dh = BBUF[2 * d + 1]; // prettier-ignore
++    // v[a] = (v[a] + v[b] + x) | 0;
++    let ll = u64.add3L(Al, Bl, Xl);
++    Ah = u64.add3H(ll, Ah, Bh, Xh);
++    Al = ll | 0;
++    // v[d] = rotr(v[d] ^ v[a], 32)
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: u64.rotr32H(Dh, Dl), Dl: u64.rotr32L(Dh, Dl) });
++    // v[c] = (v[c] + v[d]) | 0;
++    ({ h: Ch, l: Cl } = u64.add(Ch, Cl, Dh, Dl));
++    // v[b] = rotr(v[b] ^ v[c], 24)
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: u64.rotrSH(Bh, Bl, 24), Bl: u64.rotrSL(Bh, Bl, 24) });
++    (BBUF[2 * a] = Al), (BBUF[2 * a + 1] = Ah);
++    (BBUF[2 * b] = Bl), (BBUF[2 * b + 1] = Bh);
++    (BBUF[2 * c] = Cl), (BBUF[2 * c + 1] = Ch);
++    (BBUF[2 * d] = Dl), (BBUF[2 * d + 1] = Dh);
++}
++function G2b(a, b, c, d, msg, x) {
++    // NOTE: V is LE here
++    const Xl = msg[x], Xh = msg[x + 1]; // prettier-ignore
++    let Al = BBUF[2 * a], Ah = BBUF[2 * a + 1]; // prettier-ignore
++    let Bl = BBUF[2 * b], Bh = BBUF[2 * b + 1]; // prettier-ignore
++    let Cl = BBUF[2 * c], Ch = BBUF[2 * c + 1]; // prettier-ignore
++    let Dl = BBUF[2 * d], Dh = BBUF[2 * d + 1]; // prettier-ignore
++    // v[a] = (v[a] + v[b] + x) | 0;
++    let ll = u64.add3L(Al, Bl, Xl);
++    Ah = u64.add3H(ll, Ah, Bh, Xh);
++    Al = ll | 0;
++    // v[d] = rotr(v[d] ^ v[a], 16)
++    ({ Dh, Dl } = { Dh: Dh ^ Ah, Dl: Dl ^ Al });
++    ({ Dh, Dl } = { Dh: u64.rotrSH(Dh, Dl, 16), Dl: u64.rotrSL(Dh, Dl, 16) });
++    // v[c] = (v[c] + v[d]) | 0;
++    ({ h: Ch, l: Cl } = u64.add(Ch, Cl, Dh, Dl));
++    // v[b] = rotr(v[b] ^ v[c], 63)
++    ({ Bh, Bl } = { Bh: Bh ^ Ch, Bl: Bl ^ Cl });
++    ({ Bh, Bl } = { Bh: u64.rotrBH(Bh, Bl, 63), Bl: u64.rotrBL(Bh, Bl, 63) });
++    (BBUF[2 * a] = Al), (BBUF[2 * a + 1] = Ah);
++    (BBUF[2 * b] = Bl), (BBUF[2 * b + 1] = Bh);
++    (BBUF[2 * c] = Cl), (BBUF[2 * c + 1] = Ch);
++    (BBUF[2 * d] = Dl), (BBUF[2 * d + 1] = Dh);
++}
++export class BLAKE2b extends BLAKE {
++    constructor(opts = {}) {
++        super(128, opts.dkLen === undefined ? 64 : opts.dkLen, opts, 64, 16, 16);
++        // Same as SHA-512, but LE
++        this.v0l = B2B_IV[0] | 0;
++        this.v0h = B2B_IV[1] | 0;
++        this.v1l = B2B_IV[2] | 0;
++        this.v1h = B2B_IV[3] | 0;
++        this.v2l = B2B_IV[4] | 0;
++        this.v2h = B2B_IV[5] | 0;
++        this.v3l = B2B_IV[6] | 0;
++        this.v3h = B2B_IV[7] | 0;
++        this.v4l = B2B_IV[8] | 0;
++        this.v4h = B2B_IV[9] | 0;
++        this.v5l = B2B_IV[10] | 0;
++        this.v5h = B2B_IV[11] | 0;
++        this.v6l = B2B_IV[12] | 0;
++        this.v6h = B2B_IV[13] | 0;
++        this.v7l = B2B_IV[14] | 0;
++        this.v7h = B2B_IV[15] | 0;
++        const keyLength = opts.key ? opts.key.length : 0;
++        this.v0l ^= this.outputLen | (keyLength << 8) | (0x01 << 16) | (0x01 << 24);
++        if (opts.salt) {
++            const salt = u32(toBytes(opts.salt));
++            this.v4l ^= byteSwapIfBE(salt[0]);
++            this.v4h ^= byteSwapIfBE(salt[1]);
++            this.v5l ^= byteSwapIfBE(salt[2]);
++            this.v5h ^= byteSwapIfBE(salt[3]);
++        }
++        if (opts.personalization) {
++            const pers = u32(toBytes(opts.personalization));
++            this.v6l ^= byteSwapIfBE(pers[0]);
++            this.v6h ^= byteSwapIfBE(pers[1]);
++            this.v7l ^= byteSwapIfBE(pers[2]);
++            this.v7h ^= byteSwapIfBE(pers[3]);
++        }
++        if (opts.key) {
++            // Pad to blockLen and update
++            const tmp = new Uint8Array(this.blockLen);
++            tmp.set(toBytes(opts.key));
++            this.update(tmp);
++        }
++    }
++    // prettier-ignore
++    get() {
++        let { v0l, v0h, v1l, v1h, v2l, v2h, v3l, v3h, v4l, v4h, v5l, v5h, v6l, v6h, v7l, v7h } = this;
++        return [v0l, v0h, v1l, v1h, v2l, v2h, v3l, v3h, v4l, v4h, v5l, v5h, v6l, v6h, v7l, v7h];
++    }
++    // prettier-ignore
++    set(v0l, v0h, v1l, v1h, v2l, v2h, v3l, v3h, v4l, v4h, v5l, v5h, v6l, v6h, v7l, v7h) {
++        this.v0l = v0l | 0;
++        this.v0h = v0h | 0;
++        this.v1l = v1l | 0;
++        this.v1h = v1h | 0;
++        this.v2l = v2l | 0;
++        this.v2h = v2h | 0;
++        this.v3l = v3l | 0;
++        this.v3h = v3h | 0;
++        this.v4l = v4l | 0;
++        this.v4h = v4h | 0;
++        this.v5l = v5l | 0;
++        this.v5h = v5h | 0;
++        this.v6l = v6l | 0;
++        this.v6h = v6h | 0;
++        this.v7l = v7l | 0;
++        this.v7h = v7h | 0;
++    }
++    compress(msg, offset, isLast) {
++        this.get().forEach((v, i) => (BBUF[i] = v)); // First half from state.
++        BBUF.set(B2B_IV, 16); // Second half from IV.
++        let { h, l } = u64.fromBig(BigInt(this.length));
++        BBUF[24] = B2B_IV[8] ^ l; // Low word of the offset.
++        BBUF[25] = B2B_IV[9] ^ h; // High word.
++        // Invert all bits for last block
++        if (isLast) {
++            BBUF[28] = ~BBUF[28];
++            BBUF[29] = ~BBUF[29];
++        }
++        let j = 0;
++        const s = SIGMA;
++        for (let i = 0; i < 12; i++) {
++            G1b(0, 4, 8, 12, msg, offset + 2 * s[j++]);
++            G2b(0, 4, 8, 12, msg, offset + 2 * s[j++]);
++            G1b(1, 5, 9, 13, msg, offset + 2 * s[j++]);
++            G2b(1, 5, 9, 13, msg, offset + 2 * s[j++]);
++            G1b(2, 6, 10, 14, msg, offset + 2 * s[j++]);
++            G2b(2, 6, 10, 14, msg, offset + 2 * s[j++]);
++            G1b(3, 7, 11, 15, msg, offset + 2 * s[j++]);
++            G2b(3, 7, 11, 15, msg, offset + 2 * s[j++]);
++            G1b(0, 5, 10, 15, msg, offset + 2 * s[j++]);
++            G2b(0, 5, 10, 15, msg, offset + 2 * s[j++]);
++            G1b(1, 6, 11, 12, msg, offset + 2 * s[j++]);
++            G2b(1, 6, 11, 12, msg, offset + 2 * s[j++]);
++            G1b(2, 7, 8, 13, msg, offset + 2 * s[j++]);
++            G2b(2, 7, 8, 13, msg, offset + 2 * s[j++]);
++            G1b(3, 4, 9, 14, msg, offset + 2 * s[j++]);
++            G2b(3, 4, 9, 14, msg, offset + 2 * s[j++]);
++        }
++        this.v0l ^= BBUF[0] ^ BBUF[16];
++        this.v0h ^= BBUF[1] ^ BBUF[17];
++        this.v1l ^= BBUF[2] ^ BBUF[18];
++        this.v1h ^= BBUF[3] ^ BBUF[19];
++        this.v2l ^= BBUF[4] ^ BBUF[20];
++        this.v2h ^= BBUF[5] ^ BBUF[21];
++        this.v3l ^= BBUF[6] ^ BBUF[22];
++        this.v3h ^= BBUF[7] ^ BBUF[23];
++        this.v4l ^= BBUF[8] ^ BBUF[24];
++        this.v4h ^= BBUF[9] ^ BBUF[25];
++        this.v5l ^= BBUF[10] ^ BBUF[26];
++        this.v5h ^= BBUF[11] ^ BBUF[27];
++        this.v6l ^= BBUF[12] ^ BBUF[28];
++        this.v6h ^= BBUF[13] ^ BBUF[29];
++        this.v7l ^= BBUF[14] ^ BBUF[30];
++        this.v7h ^= BBUF[15] ^ BBUF[31];
++        BBUF.fill(0);
++    }
++    destroy() {
++        this.destroyed = true;
++        this.buffer32.fill(0);
++        this.set(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
++    }
++}
++/**
++ * BLAKE2b - optimized for 64-bit platforms. JS doesn't have uint64, so it's slower than BLAKE2s.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++export const blake2b = /* @__PURE__ */ wrapConstructorWithOpts((opts) => new BLAKE2b(opts));
++//# sourceMappingURL=blake2b.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.js.map
+new file mode 100644
+index 0000000..8b51057
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2b.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2b.js","sourceRoot":"","sources":["../src/blake2b.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAa,KAAK,EAAE,MAAM,aAAa,CAAC;AACtD,OAAO,GAAG,MAAM,WAAW,CAAC;AAC5B,OAAO,EAAE,OAAO,EAAE,GAAG,EAAE,uBAAuB,EAAE,YAAY,EAAE,MAAM,YAAY,CAAC;AAEjF,yBAAyB;AACzB,kBAAkB;AAClB,MAAM,MAAM,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAC7C,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AACH,mBAAmB;AACnB,MAAM,IAAI,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AAEjD,0CAA0C;AAC1C,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,GAAgB,EAAE,CAAS;IAClF,qBAAqB;IACrB,MAAM,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IACtD,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,gCAAgC;IAChC,IAAI,EAAE,GAAG,GAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,GAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACZ,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,CAAC,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,CAAC,OAAO,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IACpE,4BAA4B;IAC5B,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC7C,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAC1E,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AAC7C,CAAC;AAED,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,GAAgB,EAAE,CAAS;IAClF,qBAAqB;IACrB,MAAM,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IACtD,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,IAAI,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,kBAAkB;IAC9D,gCAAgC;IAChC,IAAI,EAAE,GAAG,GAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,GAAG,CAAC,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC/B,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACZ,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAC1E,4BAA4B;IAC5B,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC;IAC7C,+BAA+B;IAC/B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC;IAC5C,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC;IAC1E,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IAC3C,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AAC7C,CAAC;AAED,MAAM,OAAO,OAAQ,SAAQ,KAAc;IAmBzC,YAAY,OAAkB,EAAE;QAC9B,KAAK,CAAC,GAAG,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;QAnB3E,0BAA0B;QAClB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACpB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QACrB,QAAG,GAAG,MAAM,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC;QAI3B,MAAM,SAAS,GAAG,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;QACjD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,SAAS,GAAG,CAAC,SAAS,IAAI,CAAC,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,CAAC;QAC5E,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;YACd,MAAM,IAAI,GAAG,GAAG,CAAC,OAAO,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC;YACrC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpC,CAAC;QACD,IAAI,IAAI,CAAC,eAAe,EAAE,CAAC;YACzB,MAAM,IAAI,GAAG,GAAG,CAAC,OAAO,CAAC,IAAI,CAAC,eAAe,CAAC,CAAC,CAAC;YAChD,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YAClC,IAAI,CAAC,GAAG,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpC,CAAC;QACD,IAAI,IAAI,CAAC,GAAG,EAAE,CAAC;YACb,6BAA6B;YAC7B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YAC1C,GAAG,CAAC,GAAG,CAAC,OAAO,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;YAC3B,IAAI,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACnB,CAAC;IACH,CAAC;IACD,kBAAkB;IACR,GAAG;QAIX,IAAI,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QAC9F,OAAO,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IAC1F,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAClD,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAClD,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAClD,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW;QAElD,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;QACnB,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,CAAC;IACrB,CAAC;IACS,QAAQ,CAAC,GAAgB,EAAE,MAAc,EAAE,MAAe;QAClE,IAAI,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,yBAAyB;QACtE,IAAI,CAAC,GAAG,CAAC,MAAM,EAAE,EAAE,CAAC,CAAC,CAAC,uBAAuB;QAC7C,IAAI,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,GAAG,CAAC,OAAO,CAAC,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC,CAAC;QAChD,IAAI,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,0BAA0B;QACpD,IAAI,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,aAAa;QACvC,iCAAiC;QACjC,IAAI,MAAM,EAAE,CAAC;YACX,IAAI,CAAC,EAAE,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YACrB,IAAI,CAAC,EAAE,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;QACvB,CAAC;QACD,IAAI,CAAC,GAAG,CAAC,CAAC;QACV,MAAM,CAAC,GAAG,KAAK,CAAC;QAChB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAE5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC5C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;YAC3C,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,EAAE,MAAM,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;QAC7C,CAAC;QACD,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAC/B,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC,CAAC;QAChC,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACf,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACtB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC3D,CAAC;CACF;AAED;;;;GAIG;AACH,MAAM,CAAC,MAAM,OAAO,GAAG,eAAe,CAAC,uBAAuB,CAC5D,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,OAAO,CAAC,IAAI,CAAC,CAC5B,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.d.ts
+new file mode 100644
+index 0000000..29d4b2f
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.d.ts
+@@ -0,0 +1,47 @@
++import { BLAKE, BlakeOpts } from './_blake.js';
++export declare const B2S_IV: Uint32Array;
++export declare function compress(s: Uint8Array, offset: number, msg: Uint32Array, rounds: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number): {
++    v0: number;
++    v1: number;
++    v2: number;
++    v3: number;
++    v4: number;
++    v5: number;
++    v6: number;
++    v7: number;
++    v8: number;
++    v9: number;
++    v10: number;
++    v11: number;
++    v12: number;
++    v13: number;
++    v14: number;
++    v15: number;
++};
++export declare class BLAKE2s extends BLAKE<BLAKE2s> {
++    private v0;
++    private v1;
++    private v2;
++    private v3;
++    private v4;
++    private v5;
++    private v6;
++    private v7;
++    constructor(opts?: BlakeOpts);
++    protected get(): [number, number, number, number, number, number, number, number];
++    protected set(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number): void;
++    protected compress(msg: Uint32Array, offset: number, isLast: boolean): void;
++    destroy(): void;
++}
++/**
++ * BLAKE2s - optimized for 32-bit platforms. JS doesn't have uint64, so it's faster than BLAKE2b.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++export declare const blake2s: {
++    (msg: import("./utils.js").Input, opts?: BlakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: BlakeOpts): import("./utils.js").Hash<BLAKE2s>;
++};
++//# sourceMappingURL=blake2s.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.d.ts.map
+new file mode 100644
+index 0000000..c092a23
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2s.d.ts","sourceRoot":"","sources":["../src/blake2s.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,SAAS,EAAS,MAAM,aAAa,CAAC;AAOtD,eAAO,MAAM,MAAM,aAEjB,CAAC;AAoBH,wBAAgB,QAAQ,CAAC,CAAC,EAAE,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EACtF,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAC9F,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM,EAAE,GAAG,EAAE,MAAM;;;;;;;;;;;;;;;;;EAuBrG;AAED,qBAAa,OAAQ,SAAQ,KAAK,CAAC,OAAO,CAAC;IAEzC,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;IAC3B,OAAO,CAAC,EAAE,CAAiB;gBAEf,IAAI,GAAE,SAAc;IAqBhC,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAKjF,SAAS,CAAC,GAAG,CACX,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;IAWhG,SAAS,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,OAAO;IAkBpE,OAAO;CAKR;AAED;;;;GAIG;AACH,eAAO,MAAM,OAAO;;;;;CAEnB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.js
+new file mode 100644
+index 0000000..d601eeb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.js
+@@ -0,0 +1,119 @@
++import { BLAKE, SIGMA } from './_blake.js';
++import { fromBig } from './_u64.js';
++import { rotr, toBytes, wrapConstructorWithOpts, u32, byteSwapIfBE } from './utils.js';
++// Initial state: same as SHA256
++// first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19
++// prettier-ignore
++export const B2S_IV = /* @__PURE__ */ new Uint32Array([
++    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
++]);
++// Mixing function G splitted in two halfs
++function G1s(a, b, c, d, x) {
++    a = (a + b + x) | 0;
++    d = rotr(d ^ a, 16);
++    c = (c + d) | 0;
++    b = rotr(b ^ c, 12);
++    return { a, b, c, d };
++}
++function G2s(a, b, c, d, x) {
++    a = (a + b + x) | 0;
++    d = rotr(d ^ a, 8);
++    c = (c + d) | 0;
++    b = rotr(b ^ c, 7);
++    return { a, b, c, d };
++}
++// prettier-ignore
++export function compress(s, offset, msg, rounds, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) {
++    let j = 0;
++    for (let i = 0; i < rounds; i++) {
++        ({ a: v0, b: v4, c: v8, d: v12 } = G1s(v0, v4, v8, v12, msg[offset + s[j++]]));
++        ({ a: v0, b: v4, c: v8, d: v12 } = G2s(v0, v4, v8, v12, msg[offset + s[j++]]));
++        ({ a: v1, b: v5, c: v9, d: v13 } = G1s(v1, v5, v9, v13, msg[offset + s[j++]]));
++        ({ a: v1, b: v5, c: v9, d: v13 } = G2s(v1, v5, v9, v13, msg[offset + s[j++]]));
++        ({ a: v2, b: v6, c: v10, d: v14 } = G1s(v2, v6, v10, v14, msg[offset + s[j++]]));
++        ({ a: v2, b: v6, c: v10, d: v14 } = G2s(v2, v6, v10, v14, msg[offset + s[j++]]));
++        ({ a: v3, b: v7, c: v11, d: v15 } = G1s(v3, v7, v11, v15, msg[offset + s[j++]]));
++        ({ a: v3, b: v7, c: v11, d: v15 } = G2s(v3, v7, v11, v15, msg[offset + s[j++]]));
++        ({ a: v0, b: v5, c: v10, d: v15 } = G1s(v0, v5, v10, v15, msg[offset + s[j++]]));
++        ({ a: v0, b: v5, c: v10, d: v15 } = G2s(v0, v5, v10, v15, msg[offset + s[j++]]));
++        ({ a: v1, b: v6, c: v11, d: v12 } = G1s(v1, v6, v11, v12, msg[offset + s[j++]]));
++        ({ a: v1, b: v6, c: v11, d: v12 } = G2s(v1, v6, v11, v12, msg[offset + s[j++]]));
++        ({ a: v2, b: v7, c: v8, d: v13 } = G1s(v2, v7, v8, v13, msg[offset + s[j++]]));
++        ({ a: v2, b: v7, c: v8, d: v13 } = G2s(v2, v7, v8, v13, msg[offset + s[j++]]));
++        ({ a: v3, b: v4, c: v9, d: v14 } = G1s(v3, v4, v9, v14, msg[offset + s[j++]]));
++        ({ a: v3, b: v4, c: v9, d: v14 } = G2s(v3, v4, v9, v14, msg[offset + s[j++]]));
++    }
++    return { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
++}
++export class BLAKE2s extends BLAKE {
++    constructor(opts = {}) {
++        super(64, opts.dkLen === undefined ? 32 : opts.dkLen, opts, 32, 8, 8);
++        // Internal state, same as SHA-256
++        this.v0 = B2S_IV[0] | 0;
++        this.v1 = B2S_IV[1] | 0;
++        this.v2 = B2S_IV[2] | 0;
++        this.v3 = B2S_IV[3] | 0;
++        this.v4 = B2S_IV[4] | 0;
++        this.v5 = B2S_IV[5] | 0;
++        this.v6 = B2S_IV[6] | 0;
++        this.v7 = B2S_IV[7] | 0;
++        const keyLength = opts.key ? opts.key.length : 0;
++        this.v0 ^= this.outputLen | (keyLength << 8) | (0x01 << 16) | (0x01 << 24);
++        if (opts.salt) {
++            const salt = u32(toBytes(opts.salt));
++            this.v4 ^= byteSwapIfBE(salt[0]);
++            this.v5 ^= byteSwapIfBE(salt[1]);
++        }
++        if (opts.personalization) {
++            const pers = u32(toBytes(opts.personalization));
++            this.v6 ^= byteSwapIfBE(pers[0]);
++            this.v7 ^= byteSwapIfBE(pers[1]);
++        }
++        if (opts.key) {
++            // Pad to blockLen and update
++            const tmp = new Uint8Array(this.blockLen);
++            tmp.set(toBytes(opts.key));
++            this.update(tmp);
++        }
++    }
++    get() {
++        const { v0, v1, v2, v3, v4, v5, v6, v7 } = this;
++        return [v0, v1, v2, v3, v4, v5, v6, v7];
++    }
++    // prettier-ignore
++    set(v0, v1, v2, v3, v4, v5, v6, v7) {
++        this.v0 = v0 | 0;
++        this.v1 = v1 | 0;
++        this.v2 = v2 | 0;
++        this.v3 = v3 | 0;
++        this.v4 = v4 | 0;
++        this.v5 = v5 | 0;
++        this.v6 = v6 | 0;
++        this.v7 = v7 | 0;
++    }
++    compress(msg, offset, isLast) {
++        const { h, l } = fromBig(BigInt(this.length));
++        // prettier-ignore
++        const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = compress(SIGMA, offset, msg, 10, this.v0, this.v1, this.v2, this.v3, this.v4, this.v5, this.v6, this.v7, B2S_IV[0], B2S_IV[1], B2S_IV[2], B2S_IV[3], l ^ B2S_IV[4], h ^ B2S_IV[5], isLast ? ~B2S_IV[6] : B2S_IV[6], B2S_IV[7]);
++        this.v0 ^= v0 ^ v8;
++        this.v1 ^= v1 ^ v9;
++        this.v2 ^= v2 ^ v10;
++        this.v3 ^= v3 ^ v11;
++        this.v4 ^= v4 ^ v12;
++        this.v5 ^= v5 ^ v13;
++        this.v6 ^= v6 ^ v14;
++        this.v7 ^= v7 ^ v15;
++    }
++    destroy() {
++        this.destroyed = true;
++        this.buffer32.fill(0);
++        this.set(0, 0, 0, 0, 0, 0, 0, 0);
++    }
++}
++/**
++ * BLAKE2s - optimized for 32-bit platforms. JS doesn't have uint64, so it's faster than BLAKE2b.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, salt, personalization
++ */
++export const blake2s = /* @__PURE__ */ wrapConstructorWithOpts((opts) => new BLAKE2s(opts));
++//# sourceMappingURL=blake2s.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.js.map
+new file mode 100644
+index 0000000..ddd4acd
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake2s.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake2s.js","sourceRoot":"","sources":["../src/blake2s.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAa,KAAK,EAAE,MAAM,aAAa,CAAC;AACtD,OAAO,EAAE,OAAO,EAAE,MAAM,WAAW,CAAC;AACpC,OAAO,EAAE,IAAI,EAAE,OAAO,EAAE,uBAAuB,EAAE,GAAG,EAAE,YAAY,EAAE,MAAM,YAAY,CAAC;AAEvF,gCAAgC;AAChC,wFAAwF;AACxF,kBAAkB;AAClB,MAAM,CAAC,MAAM,MAAM,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IACpD,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AAEH,0CAA0C;AAC1C,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IAChE,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IACpB,CAAC,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;IACpB,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IAChB,CAAC,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;IACpB,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;AACxB,CAAC;AAED,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IAChE,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IACpB,CAAC,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC,CAAC;IACnB,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;IAChB,CAAC,GAAG,IAAI,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC,CAAC;IACnB,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC;AACxB,CAAC;AAED,kBAAkB;AAClB,MAAM,UAAU,QAAQ,CAAC,CAAa,EAAE,MAAc,EAAE,GAAgB,EAAE,MAAc,EACtF,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAC9F,EAAU,EAAE,EAAU,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW,EAAE,GAAW;IAEpG,IAAI,CAAC,GAAG,CAAC,CAAC;IACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QAChC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAEjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QACjF,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;QAC/E,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;IACjF,CAAC;IACD,OAAO,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC;AAClF,CAAC;AAED,MAAM,OAAO,OAAQ,SAAQ,KAAc;IAWzC,YAAY,OAAkB,EAAE;QAC9B,KAAK,CAAC,EAAE,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QAXxE,kCAAkC;QAC1B,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,OAAE,GAAG,MAAM,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QAIzB,MAAM,SAAS,GAAG,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC;QACjD,IAAI,CAAC,EAAE,IAAI,IAAI,CAAC,SAAS,GAAG,CAAC,SAAS,IAAI,CAAC,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,GAAG,CAAC,IAAI,IAAI,EAAE,CAAC,CAAC;QAC3E,IAAI,IAAI,CAAC,IAAI,EAAE,CAAC;YACd,MAAM,IAAI,GAAG,GAAG,CAAC,OAAO,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC;YACrC,IAAI,CAAC,EAAE,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YACjC,IAAI,CAAC,EAAE,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACnC,CAAC;QACD,IAAI,IAAI,CAAC,eAAe,EAAE,CAAC;YACzB,MAAM,IAAI,GAAG,GAAG,CAAC,OAAO,CAAC,IAAI,CAAC,eAAe,CAAC,CAAC,CAAC;YAChD,IAAI,CAAC,EAAE,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;YACjC,IAAI,CAAC,EAAE,IAAI,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACnC,CAAC;QACD,IAAI,IAAI,CAAC,GAAG,EAAE,CAAC;YACb,6BAA6B;YAC7B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YAC1C,GAAG,CAAC,GAAG,CAAC,OAAO,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;YAC3B,IAAI,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACnB,CAAC;IACH,CAAC;IACS,GAAG;QACX,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QAChD,OAAO,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC1C,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;QAE9F,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACnB,CAAC;IACS,QAAQ,CAAC,GAAgB,EAAE,MAAc,EAAE,MAAe;QAClE,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,OAAO,CAAC,MAAM,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC,CAAC;QAC9C,kBAAkB;QAClB,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAC5E,QAAQ,CACN,KAAK,EAAE,MAAM,EAAE,GAAG,EAAE,EAAE,EACtB,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EAAE,IAAI,CAAC,EAAE,EACtE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,CACrH,CAAC;QACJ,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,EAAE,CAAC;QACnB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,EAAE,CAAC;QACnB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;QACpB,IAAI,CAAC,EAAE,IAAI,EAAE,GAAG,GAAG,CAAC;IACtB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACtB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IACnC,CAAC;CACF;AAED;;;;GAIG;AACH,MAAM,CAAC,MAAM,OAAO,GAAG,eAAe,CAAC,uBAAuB,CAC5D,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,OAAO,CAAC,IAAI,CAAC,CAC5B,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.d.ts
+new file mode 100644
+index 0000000..701b389
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.d.ts
+@@ -0,0 +1,46 @@
++import { BLAKE } from './_blake.js';
++import { Input, HashXOF } from './utils.js';
++export type Blake3Opts = {
++    dkLen?: number;
++    key?: Input;
++    context?: Input;
++};
++export declare class BLAKE3 extends BLAKE<BLAKE3> implements HashXOF<BLAKE3> {
++    private IV;
++    private flags;
++    private state;
++    private chunkPos;
++    private chunksDone;
++    private stack;
++    private posOut;
++    private bufferOut32;
++    private bufferOut;
++    private chunkOut;
++    private enableXOF;
++    constructor(opts?: Blake3Opts, flags?: number);
++    protected get(): never[];
++    protected set(): void;
++    private b2Compress;
++    protected compress(buf: Uint32Array, bufPos?: number, isLast?: boolean): void;
++    _cloneInto(to?: BLAKE3): BLAKE3;
++    destroy(): void;
++    private b2CompressOut;
++    protected finish(): void;
++    private writeInto;
++    xofInto(out: Uint8Array): Uint8Array;
++    xof(bytes: number): Uint8Array;
++    digestInto(out: Uint8Array): Uint8Array;
++    digest(): Uint8Array;
++}
++/**
++ * BLAKE3 hash function.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, context
++ */
++export declare const blake3: {
++    (msg: Input, opts?: Blake3Opts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: Blake3Opts): HashXOF<BLAKE3>;
++};
++//# sourceMappingURL=blake3.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.d.ts.map
+new file mode 100644
+index 0000000..8eced0b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake3.d.ts","sourceRoot":"","sources":["../src/blake3.ts"],"names":[],"mappings":"AAEA,OAAO,EAAE,KAAK,EAAE,MAAM,aAAa,CAAC;AAEpC,OAAO,EACL,KAAK,EAIL,OAAO,EAIR,MAAM,YAAY,CAAC;AA4BpB,MAAM,MAAM,UAAU,GAAG;IAAE,KAAK,CAAC,EAAE,MAAM,CAAC;IAAC,GAAG,CAAC,EAAE,KAAK,CAAC;IAAC,OAAO,CAAC,EAAE,KAAK,CAAA;CAAE,CAAC;AAU1E,qBAAa,MAAO,SAAQ,KAAK,CAAC,MAAM,CAAE,YAAW,OAAO,CAAC,MAAM,CAAC;IAClE,OAAO,CAAC,EAAE,CAAc;IACxB,OAAO,CAAC,KAAK,CAAS;IACtB,OAAO,CAAC,KAAK,CAAc;IAC3B,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,UAAU,CAAK;IACvB,OAAO,CAAC,KAAK,CAAqB;IAElC,OAAO,CAAC,MAAM,CAAK;IACnB,OAAO,CAAC,WAAW,CAAuB;IAC1C,OAAO,CAAC,SAAS,CAAa;IAC9B,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,SAAS,CAAQ;gBAEb,IAAI,GAAE,UAAe,EAAE,KAAK,SAAI;IA2B5C,SAAS,CAAC,GAAG;IAGb,SAAS,CAAC,GAAG;IACb,OAAO,CAAC,UAAU;IAmBlB,SAAS,CAAC,QAAQ,CAAC,GAAG,EAAE,WAAW,EAAE,MAAM,GAAE,MAAU,EAAE,MAAM,GAAE,OAAe;IAiChF,UAAU,CAAC,EAAE,CAAC,EAAE,MAAM,GAAG,MAAM;IAe/B,OAAO;IASP,OAAO,CAAC,aAAa;IAiCrB,SAAS,CAAC,MAAM;IAoBhB,OAAO,CAAC,SAAS;IAcjB,OAAO,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU;IAIpC,GAAG,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU;IAI9B,UAAU,CAAC,GAAG,EAAE,UAAU;IAQ1B,MAAM;CAGP;AAED;;;;GAIG;AACH,eAAO,MAAM,MAAM;;;;;CAElB,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.js
+new file mode 100644
+index 0000000..3577963
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.js
+@@ -0,0 +1,240 @@
++import { bytes, exists, number, output } from './_assert.js';
++import { fromBig } from './_u64.js';
++import { BLAKE } from './_blake.js';
++import { compress, B2S_IV } from './blake2s.js';
++import { u8, u32, toBytes, wrapXOFConstructorWithOpts, isLE, byteSwap32, } from './utils.js';
++const SIGMA = /* @__PURE__ */ (() => {
++    const Id = Array.from({ length: 16 }, (_, i) => i);
++    const permute = (arr) => [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8].map((i) => arr[i]);
++    const res = [];
++    for (let i = 0, v = Id; i < 7; i++, v = permute(v))
++        res.push(...v);
++    return Uint8Array.from(res);
++})();
++// Why is this so slow? It should be 6x faster than blake2b.
++// - There is only 30% reduction in number of rounds from blake2s
++// - This function uses tree mode to achive parallelisation via SIMD and threading,
++//   however in JS we don't have threads and SIMD, so we get only overhead from tree structure
++// - It is possible to speed it up via Web Workers, hovewer it will make code singnificantly more
++//   complicated, which we are trying to avoid, since this library is intended to be used
++//   for cryptographic purposes. Also, parallelization happens only on chunk level (1024 bytes),
++//   which won't really benefit small inputs.
++export class BLAKE3 extends BLAKE {
++    constructor(opts = {}, flags = 0) {
++        super(64, opts.dkLen === undefined ? 32 : opts.dkLen, {}, Number.MAX_SAFE_INTEGER, 0, 0);
++        this.flags = 0 | 0;
++        this.chunkPos = 0; // Position of current block in chunk
++        this.chunksDone = 0; // How many chunks we already have
++        this.stack = [];
++        // Output
++        this.posOut = 0;
++        this.bufferOut32 = new Uint32Array(16);
++        this.chunkOut = 0; // index of output chunk
++        this.enableXOF = true;
++        this.outputLen = opts.dkLen === undefined ? 32 : opts.dkLen;
++        number(this.outputLen);
++        if (opts.key !== undefined && opts.context !== undefined)
++            throw new Error('Blake3: only key or context can be specified at same time');
++        else if (opts.key !== undefined) {
++            const key = toBytes(opts.key).slice();
++            if (key.length !== 32)
++                throw new Error('Blake3: key should be 32 byte');
++            this.IV = u32(key);
++            if (!isLE)
++                byteSwap32(this.IV);
++            this.flags = flags | 16 /* B3_Flags.KEYED_HASH */;
++        }
++        else if (opts.context !== undefined) {
++            const context_key = new BLAKE3({ dkLen: 32 }, 32 /* B3_Flags.DERIVE_KEY_CONTEXT */)
++                .update(opts.context)
++                .digest();
++            this.IV = u32(context_key);
++            if (!isLE)
++                byteSwap32(this.IV);
++            this.flags = flags | 64 /* B3_Flags.DERIVE_KEY_MATERIAL */;
++        }
++        else {
++            this.IV = B2S_IV.slice();
++            this.flags = flags;
++        }
++        this.state = this.IV.slice();
++        this.bufferOut = u8(this.bufferOut32);
++    }
++    // Unused
++    get() {
++        return [];
++    }
++    set() { }
++    b2Compress(counter, flags, buf, bufPos = 0) {
++        const { state: s, pos } = this;
++        const { h, l } = fromBig(BigInt(counter), true);
++        // prettier-ignore
++        const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = compress(SIGMA, bufPos, buf, 7, s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], B2S_IV[0], B2S_IV[1], B2S_IV[2], B2S_IV[3], h, l, pos, flags);
++        s[0] = v0 ^ v8;
++        s[1] = v1 ^ v9;
++        s[2] = v2 ^ v10;
++        s[3] = v3 ^ v11;
++        s[4] = v4 ^ v12;
++        s[5] = v5 ^ v13;
++        s[6] = v6 ^ v14;
++        s[7] = v7 ^ v15;
++    }
++    compress(buf, bufPos = 0, isLast = false) {
++        // Compress last block
++        let flags = this.flags;
++        if (!this.chunkPos)
++            flags |= 1 /* B3_Flags.CHUNK_START */;
++        if (this.chunkPos === 15 || isLast)
++            flags |= 2 /* B3_Flags.CHUNK_END */;
++        if (!isLast)
++            this.pos = this.blockLen;
++        this.b2Compress(this.chunksDone, flags, buf, bufPos);
++        this.chunkPos += 1;
++        // If current block is last in chunk (16 blocks), then compress chunks
++        if (this.chunkPos === 16 || isLast) {
++            let chunk = this.state;
++            this.state = this.IV.slice();
++            // If not the last one, compress only when there are trailing zeros in chunk counter
++            // chunks used as binary tree where current stack is path. Zero means current leaf is finished and can be compressed.
++            // 1 (001) - leaf not finished (just push current chunk to stack)
++            // 2 (010) - leaf finished at depth=1 (merge with last elm on stack and push back)
++            // 3 (011) - last leaf not finished
++            // 4 (100) - leafs finished at depth=1 and depth=2
++            for (let last, chunks = this.chunksDone + 1; isLast || !(chunks & 1); chunks >>= 1) {
++                if (!(last = this.stack.pop()))
++                    break;
++                this.buffer32.set(last, 0);
++                this.buffer32.set(chunk, 8);
++                this.pos = this.blockLen;
++                this.b2Compress(0, this.flags | 4 /* B3_Flags.PARENT */, this.buffer32, 0);
++                chunk = this.state;
++                this.state = this.IV.slice();
++            }
++            this.chunksDone++;
++            this.chunkPos = 0;
++            this.stack.push(chunk);
++        }
++        this.pos = 0;
++    }
++    _cloneInto(to) {
++        to = super._cloneInto(to);
++        const { IV, flags, state, chunkPos, posOut, chunkOut, stack, chunksDone } = this;
++        to.state.set(state.slice());
++        to.stack = stack.map((i) => Uint32Array.from(i));
++        to.IV.set(IV);
++        to.flags = flags;
++        to.chunkPos = chunkPos;
++        to.chunksDone = chunksDone;
++        to.posOut = posOut;
++        to.chunkOut = chunkOut;
++        to.enableXOF = this.enableXOF;
++        to.bufferOut32.set(this.bufferOut32);
++        return to;
++    }
++    destroy() {
++        this.destroyed = true;
++        this.state.fill(0);
++        this.buffer32.fill(0);
++        this.IV.fill(0);
++        this.bufferOut32.fill(0);
++        for (let i of this.stack)
++            i.fill(0);
++    }
++    // Same as b2Compress, but doesn't modify state and returns 16 u32 array (instead of 8)
++    b2CompressOut() {
++        const { state: s, pos, flags, buffer32, bufferOut32: out32 } = this;
++        const { h, l } = fromBig(BigInt(this.chunkOut++));
++        if (!isLE)
++            byteSwap32(buffer32);
++        // prettier-ignore
++        const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = compress(SIGMA, 0, buffer32, 7, s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], B2S_IV[0], B2S_IV[1], B2S_IV[2], B2S_IV[3], l, h, pos, flags);
++        out32[0] = v0 ^ v8;
++        out32[1] = v1 ^ v9;
++        out32[2] = v2 ^ v10;
++        out32[3] = v3 ^ v11;
++        out32[4] = v4 ^ v12;
++        out32[5] = v5 ^ v13;
++        out32[6] = v6 ^ v14;
++        out32[7] = v7 ^ v15;
++        out32[8] = s[0] ^ v8;
++        out32[9] = s[1] ^ v9;
++        out32[10] = s[2] ^ v10;
++        out32[11] = s[3] ^ v11;
++        out32[12] = s[4] ^ v12;
++        out32[13] = s[5] ^ v13;
++        out32[14] = s[6] ^ v14;
++        out32[15] = s[7] ^ v15;
++        if (!isLE) {
++            byteSwap32(buffer32);
++            byteSwap32(out32);
++        }
++        this.posOut = 0;
++    }
++    finish() {
++        if (this.finished)
++            return;
++        this.finished = true;
++        // Padding
++        this.buffer.fill(0, this.pos);
++        // Process last chunk
++        let flags = this.flags | 8 /* B3_Flags.ROOT */;
++        if (this.stack.length) {
++            flags |= 4 /* B3_Flags.PARENT */;
++            if (!isLE)
++                byteSwap32(this.buffer32);
++            this.compress(this.buffer32, 0, true);
++            if (!isLE)
++                byteSwap32(this.buffer32);
++            this.chunksDone = 0;
++            this.pos = this.blockLen;
++        }
++        else {
++            flags |= (!this.chunkPos ? 1 /* B3_Flags.CHUNK_START */ : 0) | 2 /* B3_Flags.CHUNK_END */;
++        }
++        this.flags = flags;
++        this.b2CompressOut();
++    }
++    writeInto(out) {
++        exists(this, false);
++        bytes(out);
++        this.finish();
++        const { blockLen, bufferOut } = this;
++        for (let pos = 0, len = out.length; pos < len;) {
++            if (this.posOut >= blockLen)
++                this.b2CompressOut();
++            const take = Math.min(blockLen - this.posOut, len - pos);
++            out.set(bufferOut.subarray(this.posOut, this.posOut + take), pos);
++            this.posOut += take;
++            pos += take;
++        }
++        return out;
++    }
++    xofInto(out) {
++        if (!this.enableXOF)
++            throw new Error('XOF is not possible after digest call');
++        return this.writeInto(out);
++    }
++    xof(bytes) {
++        number(bytes);
++        return this.xofInto(new Uint8Array(bytes));
++    }
++    digestInto(out) {
++        output(out, this);
++        if (this.finished)
++            throw new Error('digest() was already called');
++        this.enableXOF = false;
++        this.writeInto(out);
++        this.destroy();
++        return out;
++    }
++    digest() {
++        return this.digestInto(new Uint8Array(this.outputLen));
++    }
++}
++/**
++ * BLAKE3 hash function.
++ * @param msg - message that would be hashed
++ * @param opts - dkLen, key, context
++ */
++export const blake3 = /* @__PURE__ */ wrapXOFConstructorWithOpts((opts) => new BLAKE3(opts));
++//# sourceMappingURL=blake3.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.js.map
+new file mode 100644
+index 0000000..c82019a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/blake3.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"blake3.js","sourceRoot":"","sources":["../src/blake3.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,cAAc,CAAC;AAC7D,OAAO,EAAE,OAAO,EAAE,MAAM,WAAW,CAAC;AACpC,OAAO,EAAE,KAAK,EAAE,MAAM,aAAa,CAAC;AACpC,OAAO,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,cAAc,CAAC;AAChD,OAAO,EAEL,EAAE,EACF,GAAG,EACH,OAAO,EAEP,0BAA0B,EAC1B,IAAI,EACJ,UAAU,GACX,MAAM,YAAY,CAAC;AAepB,MAAM,KAAK,GAAe,eAAe,CAAC,CAAC,GAAG,EAAE;IAC9C,MAAM,EAAE,GAAG,KAAK,CAAC,IAAI,CAAC,EAAE,MAAM,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC;IACnD,MAAM,OAAO,GAAG,CAAC,GAAa,EAAE,EAAE,CAChC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;IAC5E,MAAM,GAAG,GAAa,EAAE,CAAC;IACzB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,GAAG,OAAO,CAAC,CAAC,CAAC;QAAE,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC;IACnE,OAAO,UAAU,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC;AAC9B,CAAC,CAAC,EAAE,CAAC;AAQL,4DAA4D;AAC5D,iEAAiE;AACjE,mFAAmF;AACnF,8FAA8F;AAC9F,iGAAiG;AACjG,yFAAyF;AACzF,gGAAgG;AAChG,6CAA6C;AAC7C,MAAM,OAAO,MAAO,SAAQ,KAAa;IAcvC,YAAY,OAAmB,EAAE,EAAE,KAAK,GAAG,CAAC;QAC1C,KAAK,CAAC,EAAE,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,EAAE,EAAE,MAAM,CAAC,gBAAgB,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QAbnF,UAAK,GAAG,CAAC,GAAG,CAAC,CAAC;QAEd,aAAQ,GAAG,CAAC,CAAC,CAAC,qCAAqC;QACnD,eAAU,GAAG,CAAC,CAAC,CAAC,kCAAkC;QAClD,UAAK,GAAkB,EAAE,CAAC;QAClC,SAAS;QACD,WAAM,GAAG,CAAC,CAAC;QACX,gBAAW,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;QAElC,aAAQ,GAAG,CAAC,CAAC,CAAC,wBAAwB;QACtC,cAAS,GAAG,IAAI,CAAC;QAIvB,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC;QAC5D,MAAM,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC;QACvB,IAAI,IAAI,CAAC,GAAG,KAAK,SAAS,IAAI,IAAI,CAAC,OAAO,KAAK,SAAS;YACtD,MAAM,IAAI,KAAK,CAAC,2DAA2D,CAAC,CAAC;aAC1E,IAAI,IAAI,CAAC,GAAG,KAAK,SAAS,EAAE,CAAC;YAChC,MAAM,GAAG,GAAG,OAAO,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,KAAK,EAAE,CAAC;YACtC,IAAI,GAAG,CAAC,MAAM,KAAK,EAAE;gBAAE,MAAM,IAAI,KAAK,CAAC,+BAA+B,CAAC,CAAC;YACxE,IAAI,CAAC,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;YACnB,IAAI,CAAC,IAAI;gBAAE,UAAU,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAC/B,IAAI,CAAC,KAAK,GAAG,KAAK,+BAAsB,CAAC;QAC3C,CAAC;aAAM,IAAI,IAAI,CAAC,OAAO,KAAK,SAAS,EAAE,CAAC;YACtC,MAAM,WAAW,GAAG,IAAI,MAAM,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,uCAA8B;iBACvE,MAAM,CAAC,IAAI,CAAC,OAAO,CAAC;iBACpB,MAAM,EAAE,CAAC;YACZ,IAAI,CAAC,EAAE,GAAG,GAAG,CAAC,WAAW,CAAC,CAAC;YAC3B,IAAI,CAAC,IAAI;gBAAE,UAAU,CAAC,IAAI,CAAC,EAAE,CAAC,CAAC;YAC/B,IAAI,CAAC,KAAK,GAAG,KAAK,wCAA+B,CAAC;QACpD,CAAC;aAAM,CAAC;YACN,IAAI,CAAC,EAAE,GAAG,MAAM,CAAC,KAAK,EAAE,CAAC;YACzB,IAAI,CAAC,KAAK,GAAG,KAAK,CAAC;QACrB,CAAC;QACD,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,EAAE,CAAC,KAAK,EAAE,CAAC;QAC7B,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC,IAAI,CAAC,WAAW,CAAC,CAAC;IACxC,CAAC;IACD,SAAS;IACC,GAAG;QACX,OAAO,EAAE,CAAC;IACZ,CAAC;IACS,GAAG,KAAI,CAAC;IACV,UAAU,CAAC,OAAe,EAAE,KAAa,EAAE,GAAgB,EAAE,SAAiB,CAAC;QACrF,MAAM,EAAE,KAAK,EAAE,CAAC,EAAE,GAAG,EAAE,GAAG,IAAI,CAAC;QAC/B,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,OAAO,CAAC,MAAM,CAAC,OAAO,CAAC,EAAE,IAAI,CAAC,CAAC;QAChD,kBAAkB;QAClB,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAC5E,QAAQ,CACN,KAAK,EAAE,MAAM,EAAE,GAAG,EAAE,CAAC,EACrB,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAC9C,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,EAAE,KAAK,CAC7D,CAAC;QACJ,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACf,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACf,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QAChB,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;IAClB,CAAC;IACS,QAAQ,CAAC,GAAgB,EAAE,SAAiB,CAAC,EAAE,SAAkB,KAAK;QAC9E,sBAAsB;QACtB,IAAI,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC;QACvB,IAAI,CAAC,IAAI,CAAC,QAAQ;YAAE,KAAK,gCAAwB,CAAC;QAClD,IAAI,IAAI,CAAC,QAAQ,KAAK,EAAE,IAAI,MAAM;YAAE,KAAK,8BAAsB,CAAC;QAChE,IAAI,CAAC,MAAM;YAAE,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;QACtC,IAAI,CAAC,UAAU,CAAC,IAAI,CAAC,UAAU,EAAE,KAAK,EAAE,GAAG,EAAE,MAAM,CAAC,CAAC;QACrD,IAAI,CAAC,QAAQ,IAAI,CAAC,CAAC;QACnB,sEAAsE;QACtE,IAAI,IAAI,CAAC,QAAQ,KAAK,EAAE,IAAI,MAAM,EAAE,CAAC;YACnC,IAAI,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC;YACvB,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,EAAE,CAAC,KAAK,EAAE,CAAC;YAC7B,oFAAoF;YACpF,qHAAqH;YACrH,iEAAiE;YACjE,kFAAkF;YAClF,mCAAmC;YACnC,kDAAkD;YAClD,KAAK,IAAI,IAAI,EAAE,MAAM,GAAG,IAAI,CAAC,UAAU,GAAG,CAAC,EAAE,MAAM,IAAI,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,EAAE,MAAM,KAAK,CAAC,EAAE,CAAC;gBACnF,IAAI,CAAC,CAAC,IAAI,GAAG,IAAI,CAAC,KAAK,CAAC,GAAG,EAAE,CAAC;oBAAE,MAAM;gBACtC,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC,IAAI,EAAE,CAAC,CAAC,CAAC;gBAC3B,IAAI,CAAC,QAAQ,CAAC,GAAG,CAAC,KAAK,EAAE,CAAC,CAAC,CAAC;gBAC5B,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;gBACzB,IAAI,CAAC,UAAU,CAAC,CAAC,EAAE,IAAI,CAAC,KAAK,0BAAkB,EAAE,IAAI,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC;gBACnE,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC;gBACnB,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,EAAE,CAAC,KAAK,EAAE,CAAC;YAC/B,CAAC;YACD,IAAI,CAAC,UAAU,EAAE,CAAC;YAClB,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;YAClB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC;QACzB,CAAC;QACD,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;IACf,CAAC;IACD,UAAU,CAAC,EAAW;QACpB,EAAE,GAAG,KAAK,CAAC,UAAU,CAAC,EAAE,CAAW,CAAC;QACpC,MAAM,EAAE,EAAE,EAAE,KAAK,EAAE,KAAK,EAAE,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,KAAK,EAAE,UAAU,EAAE,GAAG,IAAI,CAAC;QACjF,EAAE,CAAC,KAAK,CAAC,GAAG,CAAC,KAAK,CAAC,KAAK,EAAE,CAAC,CAAC;QAC5B,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,WAAW,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACjD,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,CAAC;QACd,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC;QACjB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,UAAU,GAAG,UAAU,CAAC;QAC3B,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,IAAI,CAAC,SAAS,CAAC;QAC9B,EAAE,CAAC,WAAW,CAAC,GAAG,CAAC,IAAI,CAAC,WAAW,CAAC,CAAC;QACrC,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACnB,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACtB,IAAI,CAAC,EAAE,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QAChB,IAAI,CAAC,WAAW,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACzB,KAAK,IAAI,CAAC,IAAI,IAAI,CAAC,KAAK;YAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACtC,CAAC;IACD,uFAAuF;IAC/E,aAAa;QACnB,MAAM,EAAE,KAAK,EAAE,CAAC,EAAE,GAAG,EAAE,KAAK,EAAE,QAAQ,EAAE,WAAW,EAAE,KAAK,EAAE,GAAG,IAAI,CAAC;QACpE,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,OAAO,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,EAAE,CAAC,CAAC,CAAC;QAClD,IAAI,CAAC,IAAI;YAAE,UAAU,CAAC,QAAQ,CAAC,CAAC;QAChC,kBAAkB;QAClB,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,GAC5E,QAAQ,CACN,KAAK,EAAE,CAAC,EAAE,QAAQ,EAAE,CAAC,EACrB,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,EAC9C,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,EAAE,KAAK,CAC7D,CAAC;QACJ,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACnB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QACnB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC;QACpB,KAAK,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC;QACrB,KAAK,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC;QACrB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,KAAK,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC;QACvB,IAAI,CAAC,IAAI,EAAE,CAAC;YACV,UAAU,CAAC,QAAQ,CAAC,CAAC;YACrB,UAAU,CAAC,KAAK,CAAC,CAAC;QACpB,CAAC;QACD,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC;IAClB,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,UAAU;QACV,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,EAAE,IAAI,CAAC,GAAG,CAAC,CAAC;QAC9B,qBAAqB;QACrB,IAAI,KAAK,GAAG,IAAI,CAAC,KAAK,wBAAgB,CAAC;QACvC,IAAI,IAAI,CAAC,KAAK,CAAC,MAAM,EAAE,CAAC;YACtB,KAAK,2BAAmB,CAAC;YACzB,IAAI,CAAC,IAAI;gBAAE,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YACrC,IAAI,CAAC,QAAQ,CAAC,IAAI,CAAC,QAAQ,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;YACtC,IAAI,CAAC,IAAI;gBAAE,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;YACrC,IAAI,CAAC,UAAU,GAAG,CAAC,CAAC;YACpB,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC3B,CAAC;aAAM,CAAC;YACN,KAAK,IAAI,CAAC,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC,8BAAsB,CAAC,CAAC,CAAC,CAAC,6BAAqB,CAAC;QAC5E,CAAC;QACD,IAAI,CAAC,KAAK,GAAG,KAAK,CAAC;QACnB,IAAI,CAAC,aAAa,EAAE,CAAC;IACvB,CAAC;IACO,SAAS,CAAC,GAAe;QAC/B,MAAM,CAAC,IAAI,EAAE,KAAK,CAAC,CAAC;QACpB,KAAK,CAAC,GAAG,CAAC,CAAC;QACX,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,MAAM,EAAE,QAAQ,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACrC,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAChD,IAAI,IAAI,CAAC,MAAM,IAAI,QAAQ;gBAAE,IAAI,CAAC,aAAa,EAAE,CAAC;YAClD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACzD,GAAG,CAAC,GAAG,CAAC,SAAS,CAAC,QAAQ,CAAC,IAAI,CAAC,MAAM,EAAE,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC;YAClE,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC;YACpB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,GAAG,CAAC;IACb,CAAC;IACD,OAAO,CAAC,GAAe;QACrB,IAAI,CAAC,IAAI,CAAC,SAAS;YAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;QAC9E,OAAO,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;IAC7B,CAAC;IACD,GAAG,CAAC,KAAa;QACf,MAAM,CAAC,KAAK,CAAC,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,CAAC,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;IAC7C,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,MAAM,CAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,IAAI,IAAI,CAAC,QAAQ;YAAE,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;QAClE,IAAI,CAAC,SAAS,GAAG,KAAK,CAAC;QACvB,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;QACpB,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,MAAM;QACJ,OAAO,IAAI,CAAC,UAAU,CAAC,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC;IACzD,CAAC;CACF;AAED;;;;GAIG;AACH,MAAM,CAAC,MAAM,MAAM,GAAG,eAAe,CAAC,0BAA0B,CAC9D,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,MAAM,CAAC,IAAI,CAAC,CAC3B,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.d.ts
+new file mode 100644
+index 0000000..ac181a0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.d.ts
+@@ -0,0 +1,2 @@
++export declare const crypto: any;
++//# sourceMappingURL=crypto.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.d.ts.map
+new file mode 100644
+index 0000000..d31325e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"crypto.d.ts","sourceRoot":"","sources":["../src/crypto.ts"],"names":[],"mappings":"AAGA,eAAO,MAAM,MAAM,KACuE,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.js
+new file mode 100644
+index 0000000..8d499a0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.js
+@@ -0,0 +1,2 @@
++export const crypto = typeof globalThis === 'object' && 'crypto' in globalThis ? globalThis.crypto : undefined;
++//# sourceMappingURL=crypto.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.js.map
+new file mode 100644
+index 0000000..4b4fd3d
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/crypto.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"crypto.js","sourceRoot":"","sources":["../src/crypto.ts"],"names":[],"mappings":"AAGA,MAAM,CAAC,MAAM,MAAM,GACjB,OAAO,UAAU,KAAK,QAAQ,IAAI,QAAQ,IAAI,UAAU,CAAC,CAAC,CAAC,UAAU,CAAC,MAAM,CAAC,CAAC,CAAC,SAAS,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.d.ts
+new file mode 100644
+index 0000000..98bda7b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.d.ts
+@@ -0,0 +1,2 @@
++export declare const crypto: any;
++//# sourceMappingURL=cryptoNode.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.d.ts.map
+new file mode 100644
+index 0000000..75df3e3
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"cryptoNode.d.ts","sourceRoot":"","sources":["../src/cryptoNode.ts"],"names":[],"mappings":"AAKA,eAAO,MAAM,MAAM,KACoE,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.js
+new file mode 100644
+index 0000000..241f1da
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.js
+@@ -0,0 +1,7 @@
++// We use WebCrypto aka globalThis.crypto, which exists in browsers and node.js 16+.
++// See utils.ts for details.
++// The file will throw on node.js 14 and earlier.
++// @ts-ignore
++import * as nc from 'node:crypto';
++export const crypto = nc && typeof nc === 'object' && 'webcrypto' in nc ? nc.webcrypto : undefined;
++//# sourceMappingURL=cryptoNode.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.js.map
+new file mode 100644
+index 0000000..f7ab75e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/cryptoNode.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"cryptoNode.js","sourceRoot":"","sources":["../src/cryptoNode.ts"],"names":[],"mappings":"AAAA,oFAAoF;AACpF,4BAA4B;AAC5B,iDAAiD;AACjD,aAAa;AACb,OAAO,KAAK,EAAE,MAAM,aAAa,CAAC;AAClC,MAAM,CAAC,MAAM,MAAM,GACjB,EAAE,IAAI,OAAO,EAAE,KAAK,QAAQ,IAAI,WAAW,IAAI,EAAE,CAAC,CAAC,CAAE,EAAE,CAAC,SAAiB,CAAC,CAAC,CAAC,SAAS,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.d.ts
+new file mode 100644
+index 0000000..66721eb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.d.ts
+@@ -0,0 +1,47 @@
++export declare function scrypt(password: string, salt: string): Uint8Array;
++export declare function pbkdf2(password: string, salt: string): Uint8Array;
++/**
++ * Derives main seed. Takes a lot of time. Prefer `eskdf` method instead.
++ */
++export declare function deriveMainSeed(username: string, password: string): Uint8Array;
++type AccountID = number | string;
++type OptsLength = {
++    keyLength: number;
++};
++type OptsMod = {
++    modulus: bigint;
++};
++type KeyOpts = undefined | OptsLength | OptsMod;
++export interface ESKDF {
++    /**
++     * Derives a child key. Child key will not be associated with any
++     * other child key because of properties of underlying KDF.
++     *
++     * @param protocol - 3-15 character protocol name
++     * @param accountId - numeric identifier of account
++     * @param options - `keyLength: 64` or `modulus: 41920438n`
++     * @example deriveChildKey('aes', 0)
++     */
++    deriveChildKey: (protocol: string, accountId: AccountID, options?: KeyOpts) => Uint8Array;
++    /**
++     * Deletes the main seed from eskdf instance
++     */
++    expire: () => void;
++    /**
++     * Account fingerprint
++     */
++    fingerprint: string;
++}
++/**
++ * ESKDF
++ * @param username - username, email, or identifier, min: 8 characters, should have enough entropy
++ * @param password - password, min: 8 characters, should have enough entropy
++ * @example
++ * const kdf = await eskdf('example-university', 'beginning-new-example');
++ * const key = kdf.deriveChildKey('aes', 0);
++ * console.log(kdf.fingerprint);
++ * kdf.expire();
++ */
++export declare function eskdf(username: string, password: string): Promise<ESKDF>;
++export {};
++//# sourceMappingURL=eskdf.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.d.ts.map
+new file mode 100644
+index 0000000..9236618
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"eskdf.d.ts","sourceRoot":"","sources":["../src/eskdf.ts"],"names":[],"mappings":"AAeA,wBAAgB,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,IAAI,EAAE,MAAM,GAAG,UAAU,CAEjE;AAGD,wBAAgB,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,IAAI,EAAE,MAAM,GAAG,UAAU,CAEjE;AAiBD;;GAEG;AACH,wBAAgB,cAAc,CAAC,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,GAAG,UAAU,CAS7E;AAED,KAAK,SAAS,GAAG,MAAM,GAAG,MAAM,CAAC;AA+BjC,KAAK,UAAU,GAAG;IAAE,SAAS,EAAE,MAAM,CAAA;CAAE,CAAC;AACxC,KAAK,OAAO,GAAG;IAAE,OAAO,EAAE,MAAM,CAAA;CAAE,CAAC;AACnC,KAAK,OAAO,GAAG,SAAS,GAAG,UAAU,GAAG,OAAO,CAAC;AAwChD,MAAM,WAAW,KAAK;IACpB;;;;;;;;OAQG;IACH,cAAc,EAAE,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,SAAS,EAAE,OAAO,CAAC,EAAE,OAAO,KAAK,UAAU,CAAC;IAC1F;;OAEG;IACH,MAAM,EAAE,MAAM,IAAI,CAAC;IACnB;;OAEG;IACH,WAAW,EAAE,MAAM,CAAC;CACrB;AAED;;;;;;;;;GASG;AACH,wBAAsB,KAAK,CAAC,QAAQ,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,GAAG,OAAO,CAAC,KAAK,CAAC,CAuB9E"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.js
+new file mode 100644
+index 0000000..13253eb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.js
+@@ -0,0 +1,155 @@
++import { bytes as assertBytes } from './_assert.js';
++import { hkdf } from './hkdf.js';
++import { sha256 } from './sha256.js';
++import { pbkdf2 as _pbkdf2 } from './pbkdf2.js';
++import { scrypt as _scrypt } from './scrypt.js';
++import { bytesToHex, createView, hexToBytes, toBytes } from './utils.js';
++// A tiny KDF for various applications like AES key-gen.
++// Uses HKDF in a non-standard way, so it's not "KDF-secure", only "PRF-secure".
++// Which is good enough: assume sha2-256 retained preimage resistance.
++const SCRYPT_FACTOR = 2 ** 19;
++const PBKDF2_FACTOR = 2 ** 17;
++// Scrypt KDF
++export function scrypt(password, salt) {
++    return _scrypt(password, salt, { N: SCRYPT_FACTOR, r: 8, p: 1, dkLen: 32 });
++}
++// PBKDF2-HMAC-SHA256
++export function pbkdf2(password, salt) {
++    return _pbkdf2(sha256, password, salt, { c: PBKDF2_FACTOR, dkLen: 32 });
++}
++// Combines two 32-byte byte arrays
++function xor32(a, b) {
++    assertBytes(a, 32);
++    assertBytes(b, 32);
++    const arr = new Uint8Array(32);
++    for (let i = 0; i < 32; i++) {
++        arr[i] = a[i] ^ b[i];
++    }
++    return arr;
++}
++function strHasLength(str, min, max) {
++    return typeof str === 'string' && str.length >= min && str.length <= max;
++}
++/**
++ * Derives main seed. Takes a lot of time. Prefer `eskdf` method instead.
++ */
++export function deriveMainSeed(username, password) {
++    if (!strHasLength(username, 8, 255))
++        throw new Error('invalid username');
++    if (!strHasLength(password, 8, 255))
++        throw new Error('invalid password');
++    const scr = scrypt(password + '\u{1}', username + '\u{1}');
++    const pbk = pbkdf2(password + '\u{2}', username + '\u{2}');
++    const res = xor32(scr, pbk);
++    scr.fill(0);
++    pbk.fill(0);
++    return res;
++}
++/**
++ * Converts protocol & accountId pair to HKDF salt & info params.
++ */
++function getSaltInfo(protocol, accountId = 0) {
++    // Note that length here also repeats two lines below
++    // We do an additional length check here to reduce the scope of DoS attacks
++    if (!(strHasLength(protocol, 3, 15) && /^[a-z0-9]{3,15}$/.test(protocol))) {
++        throw new Error('invalid protocol');
++    }
++    // Allow string account ids for some protocols
++    const allowsStr = /^password\d{0,3}|ssh|tor|file$/.test(protocol);
++    let salt; // Extract salt. Default is undefined.
++    if (typeof accountId === 'string') {
++        if (!allowsStr)
++            throw new Error('accountId must be a number');
++        if (!strHasLength(accountId, 1, 255))
++            throw new Error('accountId must be valid string');
++        salt = toBytes(accountId);
++    }
++    else if (Number.isSafeInteger(accountId)) {
++        if (accountId < 0 || accountId > 2 ** 32 - 1)
++            throw new Error('invalid accountId');
++        // Convert to Big Endian Uint32
++        salt = new Uint8Array(4);
++        createView(salt).setUint32(0, accountId, false);
++    }
++    else {
++        throw new Error(`accountId must be a number${allowsStr ? ' or string' : ''}`);
++    }
++    const info = toBytes(protocol);
++    return { salt, info };
++}
++function countBytes(num) {
++    if (typeof num !== 'bigint' || num <= BigInt(128))
++        throw new Error('invalid number');
++    return Math.ceil(num.toString(2).length / 8);
++}
++/**
++ * Parses keyLength and modulus options to extract length of result key.
++ * If modulus is used, adds 64 bits to it as per FIPS 186 B.4.1 to combat modulo bias.
++ */
++function getKeyLength(options) {
++    if (!options || typeof options !== 'object')
++        return 32;
++    const hasLen = 'keyLength' in options;
++    const hasMod = 'modulus' in options;
++    if (hasLen && hasMod)
++        throw new Error('cannot combine keyLength and modulus options');
++    if (!hasLen && !hasMod)
++        throw new Error('must have either keyLength or modulus option');
++    // FIPS 186 B.4.1 requires at least 64 more bits
++    const l = hasMod ? countBytes(options.modulus) + 8 : options.keyLength;
++    if (!(typeof l === 'number' && l >= 16 && l <= 8192))
++        throw new Error('invalid keyLength');
++    return l;
++}
++/**
++ * Converts key to bigint and divides it by modulus. Big Endian.
++ * Implements FIPS 186 B.4.1, which removes 0 and modulo bias from output.
++ */
++function modReduceKey(key, modulus) {
++    const _1 = BigInt(1);
++    const num = BigInt('0x' + bytesToHex(key)); // check for ui8a, then bytesToNumber()
++    const res = (num % (modulus - _1)) + _1; // Remove 0 from output
++    if (res < _1)
++        throw new Error('expected positive number'); // Guard against bad values
++    const len = key.length - 8; // FIPS requires 64 more bits = 8 bytes
++    const hex = res.toString(16).padStart(len * 2, '0'); // numberToHex()
++    const bytes = hexToBytes(hex);
++    if (bytes.length !== len)
++        throw new Error('invalid length of result key');
++    return bytes;
++}
++/**
++ * ESKDF
++ * @param username - username, email, or identifier, min: 8 characters, should have enough entropy
++ * @param password - password, min: 8 characters, should have enough entropy
++ * @example
++ * const kdf = await eskdf('example-university', 'beginning-new-example');
++ * const key = kdf.deriveChildKey('aes', 0);
++ * console.log(kdf.fingerprint);
++ * kdf.expire();
++ */
++export async function eskdf(username, password) {
++    // We are using closure + object instead of class because
++    // we want to make `seed` non-accessible for any external function.
++    let seed = deriveMainSeed(username, password);
++    function deriveCK(protocol, accountId = 0, options) {
++        assertBytes(seed, 32);
++        const { salt, info } = getSaltInfo(protocol, accountId); // validate protocol & accountId
++        const keyLength = getKeyLength(options); // validate options
++        const key = hkdf(sha256, seed, salt, info, keyLength);
++        // Modulus has already been validated
++        return options && 'modulus' in options ? modReduceKey(key, options.modulus) : key;
++    }
++    function expire() {
++        if (seed)
++            seed.fill(1);
++        seed = undefined;
++    }
++    // prettier-ignore
++    const fingerprint = Array.from(deriveCK('fingerprint', 0))
++        .slice(0, 6)
++        .map((char) => char.toString(16).padStart(2, '0').toUpperCase())
++        .join(':');
++    return Object.freeze({ deriveChildKey: deriveCK, expire, fingerprint });
++}
++//# sourceMappingURL=eskdf.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.js.map
+new file mode 100644
+index 0000000..1a7c815
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/eskdf.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"eskdf.js","sourceRoot":"","sources":["../src/eskdf.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,IAAI,WAAW,EAAE,MAAM,cAAc,CAAC;AACpD,OAAO,EAAE,IAAI,EAAE,MAAM,WAAW,CAAC;AACjC,OAAO,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC;AACrC,OAAO,EAAE,MAAM,IAAI,OAAO,EAAE,MAAM,aAAa,CAAC;AAChD,OAAO,EAAE,MAAM,IAAI,OAAO,EAAE,MAAM,aAAa,CAAC;AAChD,OAAO,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,OAAO,EAAE,MAAM,YAAY,CAAC;AAEzE,wDAAwD;AACxD,gFAAgF;AAChF,sEAAsE;AAEtE,MAAM,aAAa,GAAG,CAAC,IAAI,EAAE,CAAC;AAC9B,MAAM,aAAa,GAAG,CAAC,IAAI,EAAE,CAAC;AAE9B,aAAa;AACb,MAAM,UAAU,MAAM,CAAC,QAAgB,EAAE,IAAY;IACnD,OAAO,OAAO,CAAC,QAAQ,EAAE,IAAI,EAAE,EAAE,CAAC,EAAE,aAAa,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,CAAC,CAAC;AAC9E,CAAC;AAED,qBAAqB;AACrB,MAAM,UAAU,MAAM,CAAC,QAAgB,EAAE,IAAY;IACnD,OAAO,OAAO,CAAC,MAAM,EAAE,QAAQ,EAAE,IAAI,EAAE,EAAE,CAAC,EAAE,aAAa,EAAE,KAAK,EAAE,EAAE,EAAE,CAAC,CAAC;AAC1E,CAAC;AAED,mCAAmC;AACnC,SAAS,KAAK,CAAC,CAAa,EAAE,CAAa;IACzC,WAAW,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;IACnB,WAAW,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;IACnB,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC;IAC/B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;QAC5B,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;IACvB,CAAC;IACD,OAAO,GAAG,CAAC;AACb,CAAC;AAED,SAAS,YAAY,CAAC,GAAW,EAAE,GAAW,EAAE,GAAW;IACzD,OAAO,OAAO,GAAG,KAAK,QAAQ,IAAI,GAAG,CAAC,MAAM,IAAI,GAAG,IAAI,GAAG,CAAC,MAAM,IAAI,GAAG,CAAC;AAC3E,CAAC;AAED;;GAEG;AACH,MAAM,UAAU,cAAc,CAAC,QAAgB,EAAE,QAAgB;IAC/D,IAAI,CAAC,YAAY,CAAC,QAAQ,EAAE,CAAC,EAAE,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,kBAAkB,CAAC,CAAC;IACzE,IAAI,CAAC,YAAY,CAAC,QAAQ,EAAE,CAAC,EAAE,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,kBAAkB,CAAC,CAAC;IACzE,MAAM,GAAG,GAAG,MAAM,CAAC,QAAQ,GAAG,OAAO,EAAE,QAAQ,GAAG,OAAO,CAAC,CAAC;IAC3D,MAAM,GAAG,GAAG,MAAM,CAAC,QAAQ,GAAG,OAAO,EAAE,QAAQ,GAAG,OAAO,CAAC,CAAC;IAC3D,MAAM,GAAG,GAAG,KAAK,CAAC,GAAG,EAAE,GAAG,CAAC,CAAC;IAC5B,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACZ,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACZ,OAAO,GAAG,CAAC;AACb,CAAC;AAID;;GAEG;AACH,SAAS,WAAW,CAAC,QAAgB,EAAE,YAAuB,CAAC;IAC7D,qDAAqD;IACrD,2EAA2E;IAC3E,IAAI,CAAC,CAAC,YAAY,CAAC,QAAQ,EAAE,CAAC,EAAE,EAAE,CAAC,IAAI,kBAAkB,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC,EAAE,CAAC;QAC1E,MAAM,IAAI,KAAK,CAAC,kBAAkB,CAAC,CAAC;IACtC,CAAC;IAED,8CAA8C;IAC9C,MAAM,SAAS,GAAG,gCAAgC,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;IAClE,IAAI,IAAgB,CAAC,CAAC,sCAAsC;IAC5D,IAAI,OAAO,SAAS,KAAK,QAAQ,EAAE,CAAC;QAClC,IAAI,CAAC,SAAS;YAAE,MAAM,IAAI,KAAK,CAAC,4BAA4B,CAAC,CAAC;QAC9D,IAAI,CAAC,YAAY,CAAC,SAAS,EAAE,CAAC,EAAE,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,gCAAgC,CAAC,CAAC;QACxF,IAAI,GAAG,OAAO,CAAC,SAAS,CAAC,CAAC;IAC5B,CAAC;SAAM,IAAI,MAAM,CAAC,aAAa,CAAC,SAAS,CAAC,EAAE,CAAC;QAC3C,IAAI,SAAS,GAAG,CAAC,IAAI,SAAS,GAAG,CAAC,IAAI,EAAE,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,mBAAmB,CAAC,CAAC;QACnF,+BAA+B;QAC/B,IAAI,GAAG,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC;QACzB,UAAU,CAAC,IAAI,CAAC,CAAC,SAAS,CAAC,CAAC,EAAE,SAAS,EAAE,KAAK,CAAC,CAAC;IAClD,CAAC;SAAM,CAAC;QACN,MAAM,IAAI,KAAK,CAAC,6BAA6B,SAAS,CAAC,CAAC,CAAC,YAAY,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;IAChF,CAAC;IACD,MAAM,IAAI,GAAG,OAAO,CAAC,QAAQ,CAAC,CAAC;IAC/B,OAAO,EAAE,IAAI,EAAE,IAAI,EAAE,CAAC;AACxB,CAAC;AAMD,SAAS,UAAU,CAAC,GAAW;IAC7B,IAAI,OAAO,GAAG,KAAK,QAAQ,IAAI,GAAG,IAAI,MAAM,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,gBAAgB,CAAC,CAAC;IACrF,OAAO,IAAI,CAAC,IAAI,CAAC,GAAG,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC;AAC/C,CAAC;AAED;;;GAGG;AACH,SAAS,YAAY,CAAC,OAAgB;IACpC,IAAI,CAAC,OAAO,IAAI,OAAO,OAAO,KAAK,QAAQ;QAAE,OAAO,EAAE,CAAC;IACvD,MAAM,MAAM,GAAG,WAAW,IAAI,OAAO,CAAC;IACtC,MAAM,MAAM,GAAG,SAAS,IAAI,OAAO,CAAC;IACpC,IAAI,MAAM,IAAI,MAAM;QAAE,MAAM,IAAI,KAAK,CAAC,8CAA8C,CAAC,CAAC;IACtF,IAAI,CAAC,MAAM,IAAI,CAAC,MAAM;QAAE,MAAM,IAAI,KAAK,CAAC,8CAA8C,CAAC,CAAC;IACxF,gDAAgD;IAChD,MAAM,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,UAAU,CAAC,OAAO,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,OAAO,CAAC,SAAS,CAAC;IACvE,IAAI,CAAC,CAAC,OAAO,CAAC,KAAK,QAAQ,IAAI,CAAC,IAAI,EAAE,IAAI,CAAC,IAAI,IAAI,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,mBAAmB,CAAC,CAAC;IAC3F,OAAO,CAAC,CAAC;AACX,CAAC;AAED;;;GAGG;AACH,SAAS,YAAY,CAAC,GAAe,EAAE,OAAe;IACpD,MAAM,EAAE,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC;IACrB,MAAM,GAAG,GAAG,MAAM,CAAC,IAAI,GAAG,UAAU,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,uCAAuC;IACnF,MAAM,GAAG,GAAG,CAAC,GAAG,GAAG,CAAC,OAAO,GAAG,EAAE,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,uBAAuB;IAChE,IAAI,GAAG,GAAG,EAAE;QAAE,MAAM,IAAI,KAAK,CAAC,0BAA0B,CAAC,CAAC,CAAC,2BAA2B;IACtF,MAAM,GAAG,GAAG,GAAG,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,uCAAuC;IACnE,MAAM,GAAG,GAAG,GAAG,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,gBAAgB;IACrE,MAAM,KAAK,GAAG,UAAU,CAAC,GAAG,CAAC,CAAC;IAC9B,IAAI,KAAK,CAAC,MAAM,KAAK,GAAG;QAAE,MAAM,IAAI,KAAK,CAAC,8BAA8B,CAAC,CAAC;IAC1E,OAAO,KAAK,CAAC;AACf,CAAC;AAwBD;;;;;;;;;GASG;AACH,MAAM,CAAC,KAAK,UAAU,KAAK,CAAC,QAAgB,EAAE,QAAgB;IAC5D,yDAAyD;IACzD,mEAAmE;IACnE,IAAI,IAAI,GAA2B,cAAc,CAAC,QAAQ,EAAE,QAAQ,CAAC,CAAC;IAEtE,SAAS,QAAQ,CAAC,QAAgB,EAAE,YAAuB,CAAC,EAAE,OAAiB;QAC7E,WAAW,CAAC,IAAI,EAAE,EAAE,CAAC,CAAC;QACtB,MAAM,EAAE,IAAI,EAAE,IAAI,EAAE,GAAG,WAAW,CAAC,QAAQ,EAAE,SAAS,CAAC,CAAC,CAAC,gCAAgC;QACzF,MAAM,SAAS,GAAG,YAAY,CAAC,OAAO,CAAC,CAAC,CAAC,mBAAmB;QAC5D,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,EAAE,IAAK,EAAE,IAAI,EAAE,IAAI,EAAE,SAAS,CAAC,CAAC;QACvD,qCAAqC;QACrC,OAAO,OAAO,IAAI,SAAS,IAAI,OAAO,CAAC,CAAC,CAAC,YAAY,CAAC,GAAG,EAAE,OAAO,CAAC,OAAO,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC;IACpF,CAAC;IACD,SAAS,MAAM;QACb,IAAI,IAAI;YAAE,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACvB,IAAI,GAAG,SAAS,CAAC;IACnB,CAAC;IACD,kBAAkB;IAClB,MAAM,WAAW,GAAG,KAAK,CAAC,IAAI,CAAC,QAAQ,CAAC,aAAa,EAAE,CAAC,CAAC,CAAC;SACvD,KAAK,CAAC,CAAC,EAAE,CAAC,CAAC;SACX,GAAG,CAAC,CAAC,IAAI,EAAE,EAAE,CAAC,IAAI,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,WAAW,EAAE,CAAC;SAC/D,IAAI,CAAC,GAAG,CAAC,CAAC;IACb,OAAO,MAAM,CAAC,MAAM,CAAC,EAAE,cAAc,EAAE,QAAQ,EAAE,MAAM,EAAE,WAAW,EAAE,CAAC,CAAC;AAC1E,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.d.ts
+new file mode 100644
+index 0000000..f2ff770
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.d.ts
+@@ -0,0 +1,27 @@
++import { CHash, Input } from './utils.js';
++/**
++ * HKDF-Extract(IKM, salt) -> PRK
++ * Arguments position differs from spec (IKM is first one, since it is not optional)
++ * @param hash
++ * @param ikm
++ * @param salt
++ * @returns
++ */
++export declare function extract(hash: CHash, ikm: Input, salt?: Input): Uint8Array;
++/**
++ * HKDF-expand from the spec.
++ * @param prk - a pseudorandom key of at least HashLen octets (usually, the output from the extract step)
++ * @param info - optional context and application specific information (can be a zero-length string)
++ * @param length - length of output keying material in octets
++ */
++export declare function expand(hash: CHash, prk: Input, info?: Input, length?: number): Uint8Array;
++/**
++ * HKDF (RFC 5869): extract + expand in one step.
++ * @param hash - hash function that would be used (e.g. sha256)
++ * @param ikm - input keying material, the initial key
++ * @param salt - optional salt value (a non-secret random value)
++ * @param info - optional context and application specific information
++ * @param length - length of output keying material in octets
++ */
++export declare const hkdf: (hash: CHash, ikm: Input, salt: Input | undefined, info: Input | undefined, length: number) => Uint8Array;
++//# sourceMappingURL=hkdf.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.d.ts.map
+new file mode 100644
+index 0000000..e5b6be0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hkdf.d.ts","sourceRoot":"","sources":["../src/hkdf.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,KAAK,EAAE,KAAK,EAAW,MAAM,YAAY,CAAC;AAMnD;;;;;;;GAOG;AACH,wBAAgB,OAAO,CAAC,IAAI,EAAE,KAAK,EAAE,GAAG,EAAE,KAAK,EAAE,IAAI,CAAC,EAAE,KAAK,cAO5D;AAMD;;;;;GAKG;AACH,wBAAgB,MAAM,CAAC,IAAI,EAAE,KAAK,EAAE,GAAG,EAAE,KAAK,EAAE,IAAI,CAAC,EAAE,KAAK,EAAE,MAAM,GAAE,MAAW,cA4BhF;AAED;;;;;;;GAOG;AACH,eAAO,MAAM,IAAI,SACT,KAAK,OACN,KAAK,QACJ,KAAK,GAAG,SAAS,QACjB,KAAK,GAAG,SAAS,UACf,MAAM,eACyC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.js
+new file mode 100644
+index 0000000..8fbdac8
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.js
+@@ -0,0 +1,72 @@
++import { hash as assertHash, number as assertNumber } from './_assert.js';
++import { toBytes } from './utils.js';
++import { hmac } from './hmac.js';
++// HKDF (RFC 5869)
++// https://soatok.blog/2021/11/17/understanding-hkdf/
++/**
++ * HKDF-Extract(IKM, salt) -> PRK
++ * Arguments position differs from spec (IKM is first one, since it is not optional)
++ * @param hash
++ * @param ikm
++ * @param salt
++ * @returns
++ */
++export function extract(hash, ikm, salt) {
++    assertHash(hash);
++    // NOTE: some libraries treat zero-length array as 'not provided';
++    // we don't, since we have undefined as 'not provided'
++    // https://github.com/RustCrypto/KDFs/issues/15
++    if (salt === undefined)
++        salt = new Uint8Array(hash.outputLen); // if not provided, it is set to a string of HashLen zeros
++    return hmac(hash, toBytes(salt), toBytes(ikm));
++}
++// HKDF-Expand(PRK, info, L) -> OKM
++const HKDF_COUNTER = /* @__PURE__ */ new Uint8Array([0]);
++const EMPTY_BUFFER = /* @__PURE__ */ new Uint8Array();
++/**
++ * HKDF-expand from the spec.
++ * @param prk - a pseudorandom key of at least HashLen octets (usually, the output from the extract step)
++ * @param info - optional context and application specific information (can be a zero-length string)
++ * @param length - length of output keying material in octets
++ */
++export function expand(hash, prk, info, length = 32) {
++    assertHash(hash);
++    assertNumber(length);
++    if (length > 255 * hash.outputLen)
++        throw new Error('Length should be <= 255*HashLen');
++    const blocks = Math.ceil(length / hash.outputLen);
++    if (info === undefined)
++        info = EMPTY_BUFFER;
++    // first L(ength) octets of T
++    const okm = new Uint8Array(blocks * hash.outputLen);
++    // Re-use HMAC instance between blocks
++    const HMAC = hmac.create(hash, prk);
++    const HMACTmp = HMAC._cloneInto();
++    const T = new Uint8Array(HMAC.outputLen);
++    for (let counter = 0; counter < blocks; counter++) {
++        HKDF_COUNTER[0] = counter + 1;
++        // T(0) = empty string (zero length)
++        // T(N) = HMAC-Hash(PRK, T(N-1) | info | N)
++        HMACTmp.update(counter === 0 ? EMPTY_BUFFER : T)
++            .update(info)
++            .update(HKDF_COUNTER)
++            .digestInto(T);
++        okm.set(T, hash.outputLen * counter);
++        HMAC._cloneInto(HMACTmp);
++    }
++    HMAC.destroy();
++    HMACTmp.destroy();
++    T.fill(0);
++    HKDF_COUNTER.fill(0);
++    return okm.slice(0, length);
++}
++/**
++ * HKDF (RFC 5869): extract + expand in one step.
++ * @param hash - hash function that would be used (e.g. sha256)
++ * @param ikm - input keying material, the initial key
++ * @param salt - optional salt value (a non-secret random value)
++ * @param info - optional context and application specific information
++ * @param length - length of output keying material in octets
++ */
++export const hkdf = (hash, ikm, salt, info, length) => expand(hash, extract(hash, ikm, salt), info, length);
++//# sourceMappingURL=hkdf.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.js.map
+new file mode 100644
+index 0000000..f8fd588
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hkdf.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hkdf.js","sourceRoot":"","sources":["../src/hkdf.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,IAAI,IAAI,UAAU,EAAE,MAAM,IAAI,YAAY,EAAE,MAAM,cAAc,CAAC;AAC1E,OAAO,EAAgB,OAAO,EAAE,MAAM,YAAY,CAAC;AACnD,OAAO,EAAE,IAAI,EAAE,MAAM,WAAW,CAAC;AAEjC,kBAAkB;AAClB,qDAAqD;AAErD;;;;;;;GAOG;AACH,MAAM,UAAU,OAAO,CAAC,IAAW,EAAE,GAAU,EAAE,IAAY;IAC3D,UAAU,CAAC,IAAI,CAAC,CAAC;IACjB,kEAAkE;IAClE,sDAAsD;IACtD,+CAA+C;IAC/C,IAAI,IAAI,KAAK,SAAS;QAAE,IAAI,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,0DAA0D;IACzH,OAAO,IAAI,CAAC,IAAI,EAAE,OAAO,CAAC,IAAI,CAAC,EAAE,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC;AACjD,CAAC;AAED,mCAAmC;AACnC,MAAM,YAAY,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACzD,MAAM,YAAY,GAAG,eAAe,CAAC,IAAI,UAAU,EAAE,CAAC;AAEtD;;;;;GAKG;AACH,MAAM,UAAU,MAAM,CAAC,IAAW,EAAE,GAAU,EAAE,IAAY,EAAE,SAAiB,EAAE;IAC/E,UAAU,CAAC,IAAI,CAAC,CAAC;IACjB,YAAY,CAAC,MAAM,CAAC,CAAC;IACrB,IAAI,MAAM,GAAG,GAAG,GAAG,IAAI,CAAC,SAAS;QAAE,MAAM,IAAI,KAAK,CAAC,iCAAiC,CAAC,CAAC;IACtF,MAAM,MAAM,GAAG,IAAI,CAAC,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,SAAS,CAAC,CAAC;IAClD,IAAI,IAAI,KAAK,SAAS;QAAE,IAAI,GAAG,YAAY,CAAC;IAC5C,6BAA6B;IAC7B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,MAAM,GAAG,IAAI,CAAC,SAAS,CAAC,CAAC;IACpD,sCAAsC;IACtC,MAAM,IAAI,GAAG,IAAI,CAAC,MAAM,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC;IACpC,MAAM,OAAO,GAAG,IAAI,CAAC,UAAU,EAAE,CAAC;IAClC,MAAM,CAAC,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC;IACzC,KAAK,IAAI,OAAO,GAAG,CAAC,EAAE,OAAO,GAAG,MAAM,EAAE,OAAO,EAAE,EAAE,CAAC;QAClD,YAAY,CAAC,CAAC,CAAC,GAAG,OAAO,GAAG,CAAC,CAAC;QAC9B,oCAAoC;QACpC,2CAA2C;QAC3C,OAAO,CAAC,MAAM,CAAC,OAAO,KAAK,CAAC,CAAC,CAAC,CAAC,YAAY,CAAC,CAAC,CAAC,CAAC,CAAC;aAC7C,MAAM,CAAC,IAAI,CAAC;aACZ,MAAM,CAAC,YAAY,CAAC;aACpB,UAAU,CAAC,CAAC,CAAC,CAAC;QACjB,GAAG,CAAC,GAAG,CAAC,CAAC,EAAE,IAAI,CAAC,SAAS,GAAG,OAAO,CAAC,CAAC;QACrC,IAAI,CAAC,UAAU,CAAC,OAAO,CAAC,CAAC;IAC3B,CAAC;IACD,IAAI,CAAC,OAAO,EAAE,CAAC;IACf,OAAO,CAAC,OAAO,EAAE,CAAC;IAClB,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACrB,OAAO,GAAG,CAAC,KAAK,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC;AAC9B,CAAC;AAED;;;;;;;GAOG;AACH,MAAM,CAAC,MAAM,IAAI,GAAG,CAClB,IAAW,EACX,GAAU,EACV,IAAuB,EACvB,IAAuB,EACvB,MAAc,EACd,EAAE,CAAC,MAAM,CAAC,IAAI,EAAE,OAAO,CAAC,IAAI,EAAE,GAAG,EAAE,IAAI,CAAC,EAAE,IAAI,EAAE,MAAM,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.d.ts
+new file mode 100644
+index 0000000..5a9f896
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.d.ts
+@@ -0,0 +1,30 @@
++import { Hash, CHash, Input } from './utils.js';
++export declare class HMAC<T extends Hash<T>> extends Hash<HMAC<T>> {
++    oHash: T;
++    iHash: T;
++    blockLen: number;
++    outputLen: number;
++    private finished;
++    private destroyed;
++    constructor(hash: CHash, _key: Input);
++    update(buf: Input): this;
++    digestInto(out: Uint8Array): void;
++    digest(): Uint8Array;
++    _cloneInto(to?: HMAC<T>): HMAC<T>;
++    destroy(): void;
++}
++/**
++ * HMAC: RFC2104 message authentication code.
++ * @param hash - function that would be used e.g. sha256
++ * @param key - message key
++ * @param message - message data
++ * @example
++ * import { hmac } from '@noble/hashes/hmac';
++ * import { sha256 } from '@noble/hashes/sha2';
++ * const mac1 = hmac(sha256, 'key', 'message');
++ */
++export declare const hmac: {
++    (hash: CHash, key: Input, message: Input): Uint8Array;
++    create(hash: CHash, key: Input): HMAC<any>;
++};
++//# sourceMappingURL=hmac.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.d.ts.map
+new file mode 100644
+index 0000000..f6b4aa6
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hmac.d.ts","sourceRoot":"","sources":["../src/hmac.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAE,KAAK,EAAE,KAAK,EAAW,MAAM,YAAY,CAAC;AAEzD,qBAAa,IAAI,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,CAAE,SAAQ,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACxD,KAAK,EAAE,CAAC,CAAC;IACT,KAAK,EAAE,CAAC,CAAC;IACT,QAAQ,EAAE,MAAM,CAAC;IACjB,SAAS,EAAE,MAAM,CAAC;IAClB,OAAO,CAAC,QAAQ,CAAS;IACzB,OAAO,CAAC,SAAS,CAAS;gBAEd,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK;IAsBpC,MAAM,CAAC,GAAG,EAAE,KAAK;IAKjB,UAAU,CAAC,GAAG,EAAE,UAAU;IAS1B,MAAM;IAKN,UAAU,CAAC,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC;IAajC,OAAO;CAKR;AAED;;;;;;;;;GASG;AACH,eAAO,MAAM,IAAI;WAAU,KAAK,OAAO,KAAK,WAAW,KAAK,GAAG,UAAU;iBAEpD,KAAK,OAAO,KAAK;CADa,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.js
+new file mode 100644
+index 0000000..02f6975
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.js
+@@ -0,0 +1,81 @@
++import { hash as assertHash, bytes as assertBytes, exists as assertExists } from './_assert.js';
++import { Hash, toBytes } from './utils.js';
++// HMAC (RFC 2104)
++export class HMAC extends Hash {
++    constructor(hash, _key) {
++        super();
++        this.finished = false;
++        this.destroyed = false;
++        assertHash(hash);
++        const key = toBytes(_key);
++        this.iHash = hash.create();
++        if (typeof this.iHash.update !== 'function')
++            throw new Error('Expected instance of class which extends utils.Hash');
++        this.blockLen = this.iHash.blockLen;
++        this.outputLen = this.iHash.outputLen;
++        const blockLen = this.blockLen;
++        const pad = new Uint8Array(blockLen);
++        // blockLen can be bigger than outputLen
++        pad.set(key.length > blockLen ? hash.create().update(key).digest() : key);
++        for (let i = 0; i < pad.length; i++)
++            pad[i] ^= 0x36;
++        this.iHash.update(pad);
++        // By doing update (processing of first block) of outer hash here we can re-use it between multiple calls via clone
++        this.oHash = hash.create();
++        // Undo internal XOR && apply outer XOR
++        for (let i = 0; i < pad.length; i++)
++            pad[i] ^= 0x36 ^ 0x5c;
++        this.oHash.update(pad);
++        pad.fill(0);
++    }
++    update(buf) {
++        assertExists(this);
++        this.iHash.update(buf);
++        return this;
++    }
++    digestInto(out) {
++        assertExists(this);
++        assertBytes(out, this.outputLen);
++        this.finished = true;
++        this.iHash.digestInto(out);
++        this.oHash.update(out);
++        this.oHash.digestInto(out);
++        this.destroy();
++    }
++    digest() {
++        const out = new Uint8Array(this.oHash.outputLen);
++        this.digestInto(out);
++        return out;
++    }
++    _cloneInto(to) {
++        // Create new instance without calling constructor since key already in state and we don't know it.
++        to || (to = Object.create(Object.getPrototypeOf(this), {}));
++        const { oHash, iHash, finished, destroyed, blockLen, outputLen } = this;
++        to = to;
++        to.finished = finished;
++        to.destroyed = destroyed;
++        to.blockLen = blockLen;
++        to.outputLen = outputLen;
++        to.oHash = oHash._cloneInto(to.oHash);
++        to.iHash = iHash._cloneInto(to.iHash);
++        return to;
++    }
++    destroy() {
++        this.destroyed = true;
++        this.oHash.destroy();
++        this.iHash.destroy();
++    }
++}
++/**
++ * HMAC: RFC2104 message authentication code.
++ * @param hash - function that would be used e.g. sha256
++ * @param key - message key
++ * @param message - message data
++ * @example
++ * import { hmac } from '@noble/hashes/hmac';
++ * import { sha256 } from '@noble/hashes/sha2';
++ * const mac1 = hmac(sha256, 'key', 'message');
++ */
++export const hmac = (hash, key, message) => new HMAC(hash, key).update(message).digest();
++hmac.create = (hash, key) => new HMAC(hash, key);
++//# sourceMappingURL=hmac.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.js.map
+new file mode 100644
+index 0000000..6a8bb0b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/hmac.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hmac.js","sourceRoot":"","sources":["../src/hmac.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,IAAI,IAAI,UAAU,EAAE,KAAK,IAAI,WAAW,EAAE,MAAM,IAAI,YAAY,EAAE,MAAM,cAAc,CAAC;AAChG,OAAO,EAAE,IAAI,EAAgB,OAAO,EAAE,MAAM,YAAY,CAAC;AACzD,kBAAkB;AAClB,MAAM,OAAO,IAAwB,SAAQ,IAAa;IAQxD,YAAY,IAAW,EAAE,IAAW;QAClC,KAAK,EAAE,CAAC;QAJF,aAAQ,GAAG,KAAK,CAAC;QACjB,cAAS,GAAG,KAAK,CAAC;QAIxB,UAAU,CAAC,IAAI,CAAC,CAAC;QACjB,MAAM,GAAG,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;QAC1B,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,MAAM,EAAO,CAAC;QAChC,IAAI,OAAO,IAAI,CAAC,KAAK,CAAC,MAAM,KAAK,UAAU;YACzC,MAAM,IAAI,KAAK,CAAC,qDAAqD,CAAC,CAAC;QACzE,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC,KAAK,CAAC,QAAQ,CAAC;QACpC,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC,KAAK,CAAC,SAAS,CAAC;QACtC,MAAM,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC/B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,QAAQ,CAAC,CAAC;QACrC,wCAAwC;QACxC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,MAAM,GAAG,QAAQ,CAAC,CAAC,CAAC,IAAI,CAAC,MAAM,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,MAAM,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QAC1E,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE;YAAE,GAAG,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC;QACpD,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,mHAAmH;QACnH,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,MAAM,EAAO,CAAC;QAChC,uCAAuC;QACvC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE;YAAE,GAAG,CAAC,CAAC,CAAC,IAAI,IAAI,GAAG,IAAI,CAAC;QAC3D,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACd,CAAC;IACD,MAAM,CAAC,GAAU;QACf,YAAY,CAAC,IAAI,CAAC,CAAC;QACnB,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,OAAO,IAAI,CAAC;IACd,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,YAAY,CAAC,IAAI,CAAC,CAAC;QACnB,WAAW,CAAC,GAAG,EAAE,IAAI,CAAC,SAAS,CAAC,CAAC;QACjC,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,IAAI,CAAC,KAAK,CAAC,UAAU,CAAC,GAAG,CAAC,CAAC;QAC3B,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,IAAI,CAAC,KAAK,CAAC,UAAU,CAAC,GAAG,CAAC,CAAC;QAC3B,IAAI,CAAC,OAAO,EAAE,CAAC;IACjB,CAAC;IACD,MAAM;QACJ,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;QACjD,IAAI,CAAC,UAAU,CAAC,GAAG,CAAC,CAAC;QACrB,OAAO,GAAG,CAAC;IACb,CAAC;IACD,UAAU,CAAC,EAAY;QACrB,mGAAmG;QACnG,EAAE,KAAF,EAAE,GAAK,MAAM,CAAC,MAAM,CAAC,MAAM,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,EAAE,CAAC,EAAC;QACtD,MAAM,EAAE,KAAK,EAAE,KAAK,EAAE,QAAQ,EAAE,SAAS,EAAE,QAAQ,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACxE,EAAE,GAAG,EAAU,CAAC;QAChB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,KAAK,CAAC,CAAC;QACtC,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,KAAK,CAAC,CAAC;QACtC,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,KAAK,CAAC,OAAO,EAAE,CAAC;QACrB,IAAI,CAAC,KAAK,CAAC,OAAO,EAAE,CAAC;IACvB,CAAC;CACF;AAED;;;;;;;;;GASG;AACH,MAAM,CAAC,MAAM,IAAI,GAAG,CAAC,IAAW,EAAE,GAAU,EAAE,OAAc,EAAc,EAAE,CAC1E,IAAI,IAAI,CAAM,IAAI,EAAE,GAAG,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;AACpD,IAAI,CAAC,MAAM,GAAG,CAAC,IAAW,EAAE,GAAU,EAAE,EAAE,CAAC,IAAI,IAAI,CAAM,IAAI,EAAE,GAAG,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.d.ts
+new file mode 100644
+index 0000000..e26a57a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.d.ts
+@@ -0,0 +1,2 @@
++export {};
++//# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.d.ts.map
+new file mode 100644
+index 0000000..535b86d
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":""}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.js
+new file mode 100644
+index 0000000..d02dc7a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.js
+@@ -0,0 +1,3 @@
++throw new Error('root module cannot be imported: import submodules instead. Check out README');
++export {};
++//# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.js.map
+new file mode 100644
+index 0000000..d17f53a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/index.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,MAAM,IAAI,KAAK,CAAC,6EAA6E,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.d.ts
+new file mode 100644
+index 0000000..1fb1b27
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.d.ts
+@@ -0,0 +1,16 @@
++import { CHash, Input } from './utils.js';
++export type Pbkdf2Opt = {
++    c: number;
++    dkLen?: number;
++    asyncTick?: number;
++};
++/**
++ * PBKDF2-HMAC: RFC 2898 key derivation function
++ * @param hash - hash function that would be used e.g. sha256
++ * @param password - password from which a derived key is generated
++ * @param salt - cryptographic salt
++ * @param opts - {c, dkLen} where c is work factor and dkLen is output message size
++ */
++export declare function pbkdf2(hash: CHash, password: Input, salt: Input, opts: Pbkdf2Opt): Uint8Array;
++export declare function pbkdf2Async(hash: CHash, password: Input, salt: Input, opts: Pbkdf2Opt): Promise<Uint8Array>;
++//# sourceMappingURL=pbkdf2.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.d.ts.map
+new file mode 100644
+index 0000000..2556fc4
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"pbkdf2.d.ts","sourceRoot":"","sources":["../src/pbkdf2.ts"],"names":[],"mappings":"AAEA,OAAO,EAAQ,KAAK,EAAE,KAAK,EAA6C,MAAM,YAAY,CAAC;AAG3F,MAAM,MAAM,SAAS,GAAG;IACtB,CAAC,EAAE,MAAM,CAAC;IACV,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,SAAS,CAAC,EAAE,MAAM,CAAC;CACpB,CAAC;AAkCF;;;;;;GAMG;AACH,wBAAgB,MAAM,CAAC,IAAI,EAAE,KAAK,EAAE,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,SAAS,cAsBhF;AAED,wBAAsB,WAAW,CAAC,IAAI,EAAE,KAAK,EAAE,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,SAAS,uBAsB3F"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.js
+new file mode 100644
+index 0000000..3f0c11f
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.js
+@@ -0,0 +1,86 @@
++import { hash as assertHash, number as assertNumber } from './_assert.js';
++import { hmac } from './hmac.js';
++import { createView, toBytes, checkOpts, asyncLoop } from './utils.js';
++// Common prologue and epilogue for sync/async functions
++function pbkdf2Init(hash, _password, _salt, _opts) {
++    assertHash(hash);
++    const opts = checkOpts({ dkLen: 32, asyncTick: 10 }, _opts);
++    const { c, dkLen, asyncTick } = opts;
++    assertNumber(c);
++    assertNumber(dkLen);
++    assertNumber(asyncTick);
++    if (c < 1)
++        throw new Error('PBKDF2: iterations (c) should be >= 1');
++    const password = toBytes(_password);
++    const salt = toBytes(_salt);
++    // DK = PBKDF2(PRF, Password, Salt, c, dkLen);
++    const DK = new Uint8Array(dkLen);
++    // U1 = PRF(Password, Salt + INT_32_BE(i))
++    const PRF = hmac.create(hash, password);
++    const PRFSalt = PRF._cloneInto().update(salt);
++    return { c, dkLen, asyncTick, DK, PRF, PRFSalt };
++}
++function pbkdf2Output(PRF, PRFSalt, DK, prfW, u) {
++    PRF.destroy();
++    PRFSalt.destroy();
++    if (prfW)
++        prfW.destroy();
++    u.fill(0);
++    return DK;
++}
++/**
++ * PBKDF2-HMAC: RFC 2898 key derivation function
++ * @param hash - hash function that would be used e.g. sha256
++ * @param password - password from which a derived key is generated
++ * @param salt - cryptographic salt
++ * @param opts - {c, dkLen} where c is work factor and dkLen is output message size
++ */
++export function pbkdf2(hash, password, salt, opts) {
++    const { c, dkLen, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
++    let prfW; // Working copy
++    const arr = new Uint8Array(4);
++    const view = createView(arr);
++    const u = new Uint8Array(PRF.outputLen);
++    // DK = T1 + T2 + ⋯ + Tdklen/hlen
++    for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
++        // Ti = F(Password, Salt, c, i)
++        const Ti = DK.subarray(pos, pos + PRF.outputLen);
++        view.setInt32(0, ti, false);
++        // F(Password, Salt, c, i) = U1 ^ U2 ^ ⋯ ^ Uc
++        // U1 = PRF(Password, Salt + INT_32_BE(i))
++        (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
++        Ti.set(u.subarray(0, Ti.length));
++        for (let ui = 1; ui < c; ui++) {
++            // Uc = PRF(Password, Uc−1)
++            PRF._cloneInto(prfW).update(u).digestInto(u);
++            for (let i = 0; i < Ti.length; i++)
++                Ti[i] ^= u[i];
++        }
++    }
++    return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
++}
++export async function pbkdf2Async(hash, password, salt, opts) {
++    const { c, dkLen, asyncTick, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
++    let prfW; // Working copy
++    const arr = new Uint8Array(4);
++    const view = createView(arr);
++    const u = new Uint8Array(PRF.outputLen);
++    // DK = T1 + T2 + ⋯ + Tdklen/hlen
++    for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
++        // Ti = F(Password, Salt, c, i)
++        const Ti = DK.subarray(pos, pos + PRF.outputLen);
++        view.setInt32(0, ti, false);
++        // F(Password, Salt, c, i) = U1 ^ U2 ^ ⋯ ^ Uc
++        // U1 = PRF(Password, Salt + INT_32_BE(i))
++        (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
++        Ti.set(u.subarray(0, Ti.length));
++        await asyncLoop(c - 1, asyncTick, () => {
++            // Uc = PRF(Password, Uc−1)
++            PRF._cloneInto(prfW).update(u).digestInto(u);
++            for (let i = 0; i < Ti.length; i++)
++                Ti[i] ^= u[i];
++        });
++    }
++    return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
++}
++//# sourceMappingURL=pbkdf2.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.js.map
+new file mode 100644
+index 0000000..989dcbb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/pbkdf2.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"pbkdf2.js","sourceRoot":"","sources":["../src/pbkdf2.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,IAAI,IAAI,UAAU,EAAE,MAAM,IAAI,YAAY,EAAE,MAAM,cAAc,CAAC;AAC1E,OAAO,EAAE,IAAI,EAAE,MAAM,WAAW,CAAC;AACjC,OAAO,EAAsB,UAAU,EAAE,OAAO,EAAE,SAAS,EAAE,SAAS,EAAE,MAAM,YAAY,CAAC;AAQ3F,wDAAwD;AACxD,SAAS,UAAU,CAAC,IAAW,EAAE,SAAgB,EAAE,KAAY,EAAE,KAAgB;IAC/E,UAAU,CAAC,IAAI,CAAC,CAAC;IACjB,MAAM,IAAI,GAAG,SAAS,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,SAAS,EAAE,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;IAC5D,MAAM,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;IACrC,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,KAAK,CAAC,CAAC;IACpB,YAAY,CAAC,SAAS,CAAC,CAAC;IACxB,IAAI,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;IACpE,MAAM,QAAQ,GAAG,OAAO,CAAC,SAAS,CAAC,CAAC;IACpC,MAAM,IAAI,GAAG,OAAO,CAAC,KAAK,CAAC,CAAC;IAC5B,8CAA8C;IAC9C,MAAM,EAAE,GAAG,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC;IACjC,0CAA0C;IAC1C,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC,IAAI,EAAE,QAAQ,CAAC,CAAC;IACxC,MAAM,OAAO,GAAG,GAAG,CAAC,UAAU,EAAE,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IAC9C,OAAO,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,EAAE,EAAE,GAAG,EAAE,OAAO,EAAE,CAAC;AACnD,CAAC;AAED,SAAS,YAAY,CACnB,GAAY,EACZ,OAAgB,EAChB,EAAc,EACd,IAAa,EACb,CAAa;IAEb,GAAG,CAAC,OAAO,EAAE,CAAC;IACd,OAAO,CAAC,OAAO,EAAE,CAAC;IAClB,IAAI,IAAI;QAAE,IAAI,CAAC,OAAO,EAAE,CAAC;IACzB,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,OAAO,EAAE,CAAC;AACZ,CAAC;AAED;;;;;;GAMG;AACH,MAAM,UAAU,MAAM,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IAC/E,MAAM,EAAE,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,GAAG,EAAE,OAAO,EAAE,GAAG,UAAU,CAAC,IAAI,EAAE,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;IAC9E,IAAI,IAAS,CAAC,CAAC,eAAe;IAC9B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC;IAC9B,MAAM,IAAI,GAAG,UAAU,CAAC,GAAG,CAAC,CAAC;IAC7B,MAAM,CAAC,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IACxC,iCAAiC;IACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,KAAK,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,GAAG,CAAC,SAAS,EAAE,CAAC;QAClE,+BAA+B;QAC/B,MAAM,EAAE,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,SAAS,CAAC,CAAC;QACjD,IAAI,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;QAC5B,6CAA6C;QAC7C,0CAA0C;QAC1C,CAAC,IAAI,GAAG,OAAO,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;QAC5D,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC;QACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC;YAC9B,2BAA2B;YAC3B,GAAG,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;YAC7C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,CAAC,MAAM,EAAE,CAAC,EAAE;gBAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpD,CAAC;IACH,CAAC;IACD,OAAO,YAAY,CAAC,GAAG,EAAE,OAAO,EAAE,EAAE,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;AACjD,CAAC;AAED,MAAM,CAAC,KAAK,UAAU,WAAW,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IAC1F,MAAM,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,EAAE,EAAE,GAAG,EAAE,OAAO,EAAE,GAAG,UAAU,CAAC,IAAI,EAAE,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;IACzF,IAAI,IAAS,CAAC,CAAC,eAAe;IAC9B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC;IAC9B,MAAM,IAAI,GAAG,UAAU,CAAC,GAAG,CAAC,CAAC;IAC7B,MAAM,CAAC,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IACxC,iCAAiC;IACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,KAAK,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,GAAG,CAAC,SAAS,EAAE,CAAC;QAClE,+BAA+B;QAC/B,MAAM,EAAE,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,SAAS,CAAC,CAAC;QACjD,IAAI,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;QAC5B,6CAA6C;QAC7C,0CAA0C;QAC1C,CAAC,IAAI,GAAG,OAAO,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;QAC5D,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC;QACjC,MAAM,SAAS,CAAC,CAAC,GAAG,CAAC,EAAE,SAAS,EAAE,GAAG,EAAE;YACrC,2BAA2B;YAC3B,GAAG,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;YAC7C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,CAAC,MAAM,EAAE,CAAC,EAAE;gBAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpD,CAAC,CAAC,CAAC;IACL,CAAC;IACD,OAAO,YAAY,CAAC,GAAG,EAAE,OAAO,EAAE,EAAE,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;AACjD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.d.ts
+new file mode 100644
+index 0000000..1320a14
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.d.ts
+@@ -0,0 +1,25 @@
++import { HashMD } from './_md.js';
++export declare class RIPEMD160 extends HashMD<RIPEMD160> {
++    private h0;
++    private h1;
++    private h2;
++    private h3;
++    private h4;
++    constructor();
++    protected get(): [number, number, number, number, number];
++    protected set(h0: number, h1: number, h2: number, h3: number, h4: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++/**
++ * RIPEMD-160 - a hash function from 1990s.
++ * @param message - msg that would be hashed
++ */
++export declare const ripemd160: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<RIPEMD160>;
++};
++//# sourceMappingURL=ripemd160.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.d.ts.map
+new file mode 100644
+index 0000000..bf78e18
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"ripemd160.d.ts","sourceRoot":"","sources":["../src/ripemd160.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,UAAU,CAAC;AAqClC,qBAAa,SAAU,SAAQ,MAAM,CAAC,SAAS,CAAC;IAC9C,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;;IAK5B,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAIzD,SAAS,CAAC,GAAG,CAAC,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;IAOxE,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAmCvD,SAAS,CAAC,UAAU;IAGpB,OAAO;CAKR;AAED;;;GAGG;AACH,eAAO,MAAM,SAAS;;;;;CAAyD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.js
+new file mode 100644
+index 0000000..c8e7100
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.js
+@@ -0,0 +1,102 @@
++import { HashMD } from './_md.js';
++import { rotl, wrapConstructor } from './utils.js';
++// https://homes.esat.kuleuven.be/~bosselae/ripemd160.html
++// https://homes.esat.kuleuven.be/~bosselae/ripemd160/pdf/AB-9601/AB-9601.pdf
++const Rho = /* @__PURE__ */ new Uint8Array([7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8]);
++const Id = /* @__PURE__ */ new Uint8Array(new Array(16).fill(0).map((_, i) => i));
++const Pi = /* @__PURE__ */ Id.map((i) => (9 * i + 5) % 16);
++let idxL = [Id];
++let idxR = [Pi];
++for (let i = 0; i < 4; i++)
++    for (let j of [idxL, idxR])
++        j.push(j[i].map((k) => Rho[k]));
++const shifts = /* @__PURE__ */ [
++    [11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8],
++    [12, 13, 11, 15, 6, 9, 9, 7, 12, 15, 11, 13, 7, 8, 7, 7],
++    [13, 15, 14, 11, 7, 7, 6, 8, 13, 14, 13, 12, 5, 5, 6, 9],
++    [14, 11, 12, 14, 8, 6, 5, 5, 15, 12, 15, 14, 9, 9, 8, 6],
++    [15, 12, 13, 13, 9, 5, 8, 6, 14, 11, 12, 11, 8, 6, 5, 5],
++].map((i) => new Uint8Array(i));
++const shiftsL = /* @__PURE__ */ idxL.map((idx, i) => idx.map((j) => shifts[i][j]));
++const shiftsR = /* @__PURE__ */ idxR.map((idx, i) => idx.map((j) => shifts[i][j]));
++const Kl = /* @__PURE__ */ new Uint32Array([
++    0x00000000, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e,
++]);
++const Kr = /* @__PURE__ */ new Uint32Array([
++    0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0x00000000,
++]);
++// It's called f() in spec.
++function f(group, x, y, z) {
++    if (group === 0)
++        return x ^ y ^ z;
++    else if (group === 1)
++        return (x & y) | (~x & z);
++    else if (group === 2)
++        return (x | ~y) ^ z;
++    else if (group === 3)
++        return (x & z) | (y & ~z);
++    else
++        return x ^ (y | ~z);
++}
++// Temporary buffer, not used to store anything between runs
++const R_BUF = /* @__PURE__ */ new Uint32Array(16);
++export class RIPEMD160 extends HashMD {
++    constructor() {
++        super(64, 20, 8, true);
++        this.h0 = 0x67452301 | 0;
++        this.h1 = 0xefcdab89 | 0;
++        this.h2 = 0x98badcfe | 0;
++        this.h3 = 0x10325476 | 0;
++        this.h4 = 0xc3d2e1f0 | 0;
++    }
++    get() {
++        const { h0, h1, h2, h3, h4 } = this;
++        return [h0, h1, h2, h3, h4];
++    }
++    set(h0, h1, h2, h3, h4) {
++        this.h0 = h0 | 0;
++        this.h1 = h1 | 0;
++        this.h2 = h2 | 0;
++        this.h3 = h3 | 0;
++        this.h4 = h4 | 0;
++    }
++    process(view, offset) {
++        for (let i = 0; i < 16; i++, offset += 4)
++            R_BUF[i] = view.getUint32(offset, true);
++        // prettier-ignore
++        let al = this.h0 | 0, ar = al, bl = this.h1 | 0, br = bl, cl = this.h2 | 0, cr = cl, dl = this.h3 | 0, dr = dl, el = this.h4 | 0, er = el;
++        // Instead of iterating 0 to 80, we split it into 5 groups
++        // And use the groups in constants, functions, etc. Much simpler
++        for (let group = 0; group < 5; group++) {
++            const rGroup = 4 - group;
++            const hbl = Kl[group], hbr = Kr[group]; // prettier-ignore
++            const rl = idxL[group], rr = idxR[group]; // prettier-ignore
++            const sl = shiftsL[group], sr = shiftsR[group]; // prettier-ignore
++            for (let i = 0; i < 16; i++) {
++                const tl = (rotl(al + f(group, bl, cl, dl) + R_BUF[rl[i]] + hbl, sl[i]) + el) | 0;
++                al = el, el = dl, dl = rotl(cl, 10) | 0, cl = bl, bl = tl; // prettier-ignore
++            }
++            // 2 loops are 10% faster
++            for (let i = 0; i < 16; i++) {
++                const tr = (rotl(ar + f(rGroup, br, cr, dr) + R_BUF[rr[i]] + hbr, sr[i]) + er) | 0;
++                ar = er, er = dr, dr = rotl(cr, 10) | 0, cr = br, br = tr; // prettier-ignore
++            }
++        }
++        // Add the compressed chunk to the current hash value
++        this.set((this.h1 + cl + dr) | 0, (this.h2 + dl + er) | 0, (this.h3 + el + ar) | 0, (this.h4 + al + br) | 0, (this.h0 + bl + cr) | 0);
++    }
++    roundClean() {
++        R_BUF.fill(0);
++    }
++    destroy() {
++        this.destroyed = true;
++        this.buffer.fill(0);
++        this.set(0, 0, 0, 0, 0);
++    }
++}
++/**
++ * RIPEMD-160 - a hash function from 1990s.
++ * @param message - msg that would be hashed
++ */
++export const ripemd160 = /* @__PURE__ */ wrapConstructor(() => new RIPEMD160());
++//# sourceMappingURL=ripemd160.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.js.map
+new file mode 100644
+index 0000000..343c7c0
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/ripemd160.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"ripemd160.js","sourceRoot":"","sources":["../src/ripemd160.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,UAAU,CAAC;AAClC,OAAO,EAAE,IAAI,EAAE,eAAe,EAAE,MAAM,YAAY,CAAC;AAEnD,0DAA0D;AAC1D,6EAA6E;AAC7E,MAAM,GAAG,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC;AACnG,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC,IAAI,KAAK,CAAC,EAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;AAClF,MAAM,EAAE,GAAG,eAAe,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AAC3D,IAAI,IAAI,GAAG,CAAC,EAAE,CAAC,CAAC;AAChB,IAAI,IAAI,GAAG,CAAC,EAAE,CAAC,CAAC;AAChB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE;IAAE,KAAK,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE,IAAI,CAAC;QAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AAExF,MAAM,MAAM,GAAG,eAAe,CAAC;IAC7B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;CACzD,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;AAChC,MAAM,OAAO,GAAG,eAAe,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACnF,MAAM,OAAO,GAAG,eAAe,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACnF,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IACzC,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC3D,CAAC,CAAC;AACH,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IACzC,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC3D,CAAC,CAAC;AACH,2BAA2B;AAC3B,SAAS,CAAC,CAAC,KAAa,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IACvD,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;SAC7B,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;SAC3C,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;SACrC,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;;QAC3C,OAAO,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AAC3B,CAAC;AACD,4DAA4D;AAC5D,MAAM,KAAK,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AAClD,MAAM,OAAO,SAAU,SAAQ,MAAiB;IAO9C;QACE,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;QAPjB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;IAI5B,CAAC;IACS,GAAG;QACX,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QACpC,OAAO,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC9B,CAAC;IACS,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;QACtE,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACnB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC;YAAE,KAAK,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,EAAE,IAAI,CAAC,CAAC;QAClF,kBAAkB;QAClB,IAAI,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,CAAC;QAE9B,0DAA0D;QAC1D,gEAAgE;QAChE,KAAK,IAAI,KAAK,GAAG,CAAC,EAAE,KAAK,GAAG,CAAC,EAAE,KAAK,EAAE,EAAE,CAAC;YACvC,MAAM,MAAM,GAAG,CAAC,GAAG,KAAK,CAAC;YACzB,MAAM,GAAG,GAAG,EAAE,CAAC,KAAK,CAAC,EAAE,GAAG,GAAG,EAAE,CAAC,KAAK,CAAC,CAAC,CAAC,kBAAkB;YAC1D,MAAM,EAAE,GAAG,IAAI,CAAC,KAAK,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,kBAAkB;YAC5D,MAAM,EAAE,GAAG,OAAO,CAAC,KAAK,CAAC,EAAE,EAAE,GAAG,OAAO,CAAC,KAAK,CAAC,CAAC,CAAC,kBAAkB;YAClE,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;gBAC5B,MAAM,EAAE,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;gBAClF,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,CAAC,CAAC,kBAAkB;YAC/E,CAAC;YACD,yBAAyB;YACzB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;gBAC5B,MAAM,EAAE,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;gBACnF,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,CAAC,CAAC,kBAAkB;YAC/E,CAAC;QACH,CAAC;QACD,qDAAqD;QACrD,IAAI,CAAC,GAAG,CACN,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CACxB,CAAC;IACJ,CAAC;IACS,UAAU;QAClB,KAAK,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IAChB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACpB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC1B,CAAC;CACF;AAED;;;GAGG;AACH,MAAM,CAAC,MAAM,SAAS,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,SAAS,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.d.ts
+new file mode 100644
+index 0000000..68368e6
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.d.ts
+@@ -0,0 +1,30 @@
++import { Input } from './utils.js';
++export type ScryptOpts = {
++    N: number;
++    r: number;
++    p: number;
++    dkLen?: number;
++    asyncTick?: number;
++    maxmem?: number;
++    onProgress?: (progress: number) => void;
++};
++/**
++ * Scrypt KDF from RFC 7914.
++ * @param password - pass
++ * @param salt - salt
++ * @param opts - parameters
++ * - `N` is cpu/mem work factor (power of 2 e.g. 2**18)
++ * - `r` is block size (8 is common), fine-tunes sequential memory read size and performance
++ * - `p` is parallelization factor (1 is common)
++ * - `dkLen` is output key length in bytes e.g. 32.
++ * - `asyncTick` - (default: 10) max time in ms for which async function can block execution
++ * - `maxmem` - (default: `1024 ** 3 + 1024` aka 1GB+1KB). A limit that the app could use for scrypt
++ * - `onProgress` - callback function that would be executed for progress report
++ * @returns Derived key
++ */
++export declare function scrypt(password: Input, salt: Input, opts: ScryptOpts): Uint8Array;
++/**
++ * Scrypt KDF from RFC 7914.
++ */
++export declare function scryptAsync(password: Input, salt: Input, opts: ScryptOpts): Promise<Uint8Array>;
++//# sourceMappingURL=scrypt.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.d.ts.map
+new file mode 100644
+index 0000000..a16a176
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"scrypt.d.ts","sourceRoot":"","sources":["../src/scrypt.ts"],"names":[],"mappings":"AAGA,OAAO,EAA8B,KAAK,EAAyB,MAAM,YAAY,CAAC;AAyEtF,MAAM,MAAM,UAAU,GAAG;IACvB,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,SAAS,CAAC,EAAE,MAAM,CAAC;IACnB,MAAM,CAAC,EAAE,MAAM,CAAC;IAChB,UAAU,CAAC,EAAE,CAAC,QAAQ,EAAE,MAAM,KAAK,IAAI,CAAC;CACzC,CAAC;AAoFF;;;;;;;;;;;;;GAaG;AACH,wBAAgB,MAAM,CAAC,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,UAAU,cA0BpE;AAED;;GAEG;AACH,wBAAsB,WAAW,CAAC,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,UAAU,uBA2B/E"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.js
+new file mode 100644
+index 0000000..d24decf
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.js
+@@ -0,0 +1,224 @@
++import { number as assertNumber } from './_assert.js';
++import { sha256 } from './sha256.js';
++import { pbkdf2 } from './pbkdf2.js';
++import { rotl, asyncLoop, checkOpts, u32, isLE, byteSwap32 } from './utils.js';
++// RFC 7914 Scrypt KDF
++// The main Scrypt loop: uses Salsa extensively.
++// Six versions of the function were tried, this is the fastest one.
++// prettier-ignore
++function XorAndSalsa(prev, pi, input, ii, out, oi) {
++    // Based on https://cr.yp.to/salsa20.html
++    // Xor blocks
++    let y00 = prev[pi++] ^ input[ii++], y01 = prev[pi++] ^ input[ii++];
++    let y02 = prev[pi++] ^ input[ii++], y03 = prev[pi++] ^ input[ii++];
++    let y04 = prev[pi++] ^ input[ii++], y05 = prev[pi++] ^ input[ii++];
++    let y06 = prev[pi++] ^ input[ii++], y07 = prev[pi++] ^ input[ii++];
++    let y08 = prev[pi++] ^ input[ii++], y09 = prev[pi++] ^ input[ii++];
++    let y10 = prev[pi++] ^ input[ii++], y11 = prev[pi++] ^ input[ii++];
++    let y12 = prev[pi++] ^ input[ii++], y13 = prev[pi++] ^ input[ii++];
++    let y14 = prev[pi++] ^ input[ii++], y15 = prev[pi++] ^ input[ii++];
++    // Save state to temporary variables (salsa)
++    let x00 = y00, x01 = y01, x02 = y02, x03 = y03, x04 = y04, x05 = y05, x06 = y06, x07 = y07, x08 = y08, x09 = y09, x10 = y10, x11 = y11, x12 = y12, x13 = y13, x14 = y14, x15 = y15;
++    // Main loop (salsa)
++    for (let i = 0; i < 8; i += 2) {
++        x04 ^= rotl(x00 + x12 | 0, 7);
++        x08 ^= rotl(x04 + x00 | 0, 9);
++        x12 ^= rotl(x08 + x04 | 0, 13);
++        x00 ^= rotl(x12 + x08 | 0, 18);
++        x09 ^= rotl(x05 + x01 | 0, 7);
++        x13 ^= rotl(x09 + x05 | 0, 9);
++        x01 ^= rotl(x13 + x09 | 0, 13);
++        x05 ^= rotl(x01 + x13 | 0, 18);
++        x14 ^= rotl(x10 + x06 | 0, 7);
++        x02 ^= rotl(x14 + x10 | 0, 9);
++        x06 ^= rotl(x02 + x14 | 0, 13);
++        x10 ^= rotl(x06 + x02 | 0, 18);
++        x03 ^= rotl(x15 + x11 | 0, 7);
++        x07 ^= rotl(x03 + x15 | 0, 9);
++        x11 ^= rotl(x07 + x03 | 0, 13);
++        x15 ^= rotl(x11 + x07 | 0, 18);
++        x01 ^= rotl(x00 + x03 | 0, 7);
++        x02 ^= rotl(x01 + x00 | 0, 9);
++        x03 ^= rotl(x02 + x01 | 0, 13);
++        x00 ^= rotl(x03 + x02 | 0, 18);
++        x06 ^= rotl(x05 + x04 | 0, 7);
++        x07 ^= rotl(x06 + x05 | 0, 9);
++        x04 ^= rotl(x07 + x06 | 0, 13);
++        x05 ^= rotl(x04 + x07 | 0, 18);
++        x11 ^= rotl(x10 + x09 | 0, 7);
++        x08 ^= rotl(x11 + x10 | 0, 9);
++        x09 ^= rotl(x08 + x11 | 0, 13);
++        x10 ^= rotl(x09 + x08 | 0, 18);
++        x12 ^= rotl(x15 + x14 | 0, 7);
++        x13 ^= rotl(x12 + x15 | 0, 9);
++        x14 ^= rotl(x13 + x12 | 0, 13);
++        x15 ^= rotl(x14 + x13 | 0, 18);
++    }
++    // Write output (salsa)
++    out[oi++] = (y00 + x00) | 0;
++    out[oi++] = (y01 + x01) | 0;
++    out[oi++] = (y02 + x02) | 0;
++    out[oi++] = (y03 + x03) | 0;
++    out[oi++] = (y04 + x04) | 0;
++    out[oi++] = (y05 + x05) | 0;
++    out[oi++] = (y06 + x06) | 0;
++    out[oi++] = (y07 + x07) | 0;
++    out[oi++] = (y08 + x08) | 0;
++    out[oi++] = (y09 + x09) | 0;
++    out[oi++] = (y10 + x10) | 0;
++    out[oi++] = (y11 + x11) | 0;
++    out[oi++] = (y12 + x12) | 0;
++    out[oi++] = (y13 + x13) | 0;
++    out[oi++] = (y14 + x14) | 0;
++    out[oi++] = (y15 + x15) | 0;
++}
++function BlockMix(input, ii, out, oi, r) {
++    // The block B is r 128-byte chunks (which is equivalent of 2r 64-byte chunks)
++    let head = oi + 0;
++    let tail = oi + 16 * r;
++    for (let i = 0; i < 16; i++)
++        out[tail + i] = input[ii + (2 * r - 1) * 16 + i]; // X ← B[2r−1]
++    for (let i = 0; i < r; i++, head += 16, ii += 16) {
++        // We write odd & even Yi at same time. Even: 0bXXXXX0 Odd:  0bXXXXX1
++        XorAndSalsa(out, tail, input, ii, out, head); // head[i] = Salsa(blockIn[2*i] ^ tail[i-1])
++        if (i > 0)
++            tail += 16; // First iteration overwrites tmp value in tail
++        XorAndSalsa(out, head, input, (ii += 16), out, tail); // tail[i] = Salsa(blockIn[2*i+1] ^ head[i])
++    }
++}
++// Common prologue and epilogue for sync/async functions
++function scryptInit(password, salt, _opts) {
++    // Maxmem - 1GB+1KB by default
++    const opts = checkOpts({
++        dkLen: 32,
++        asyncTick: 10,
++        maxmem: 1024 ** 3 + 1024,
++    }, _opts);
++    const { N, r, p, dkLen, asyncTick, maxmem, onProgress } = opts;
++    assertNumber(N);
++    assertNumber(r);
++    assertNumber(p);
++    assertNumber(dkLen);
++    assertNumber(asyncTick);
++    assertNumber(maxmem);
++    if (onProgress !== undefined && typeof onProgress !== 'function')
++        throw new Error('progressCb should be function');
++    const blockSize = 128 * r;
++    const blockSize32 = blockSize / 4;
++    if (N <= 1 || (N & (N - 1)) !== 0 || N >= 2 ** (blockSize / 8) || N > 2 ** 32) {
++        // NOTE: we limit N to be less than 2**32 because of 32 bit variant of Integrify function
++        // There is no JS engines that allows alocate more than 4GB per single Uint8Array for now, but can change in future.
++        throw new Error('Scrypt: N must be larger than 1, a power of 2, less than 2^(128 * r / 8) and less than 2^32');
++    }
++    if (p < 0 || p > ((2 ** 32 - 1) * 32) / blockSize) {
++        throw new Error('Scrypt: p must be a positive integer less than or equal to ((2^32 - 1) * 32) / (128 * r)');
++    }
++    if (dkLen < 0 || dkLen > (2 ** 32 - 1) * 32) {
++        throw new Error('Scrypt: dkLen should be positive integer less than or equal to (2^32 - 1) * 32');
++    }
++    const memUsed = blockSize * (N + p);
++    if (memUsed > maxmem) {
++        throw new Error(`Scrypt: parameters too large, ${memUsed} (128 * r * (N + p)) > ${maxmem} (maxmem)`);
++    }
++    // [B0...Bp−1] ← PBKDF2HMAC-SHA256(Passphrase, Salt, 1, blockSize*ParallelizationFactor)
++    // Since it has only one iteration there is no reason to use async variant
++    const B = pbkdf2(sha256, password, salt, { c: 1, dkLen: blockSize * p });
++    const B32 = u32(B);
++    // Re-used between parallel iterations. Array(iterations) of B
++    const V = u32(new Uint8Array(blockSize * N));
++    const tmp = u32(new Uint8Array(blockSize));
++    let blockMixCb = () => { };
++    if (onProgress) {
++        const totalBlockMix = 2 * N * p;
++        // Invoke callback if progress changes from 10.01 to 10.02
++        // Allows to draw smooth progress bar on up to 8K screen
++        const callbackPer = Math.max(Math.floor(totalBlockMix / 10000), 1);
++        let blockMixCnt = 0;
++        blockMixCb = () => {
++            blockMixCnt++;
++            if (onProgress && (!(blockMixCnt % callbackPer) || blockMixCnt === totalBlockMix))
++                onProgress(blockMixCnt / totalBlockMix);
++        };
++    }
++    return { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick };
++}
++function scryptOutput(password, dkLen, B, V, tmp) {
++    const res = pbkdf2(sha256, password, B, { c: 1, dkLen });
++    B.fill(0);
++    V.fill(0);
++    tmp.fill(0);
++    return res;
++}
++/**
++ * Scrypt KDF from RFC 7914.
++ * @param password - pass
++ * @param salt - salt
++ * @param opts - parameters
++ * - `N` is cpu/mem work factor (power of 2 e.g. 2**18)
++ * - `r` is block size (8 is common), fine-tunes sequential memory read size and performance
++ * - `p` is parallelization factor (1 is common)
++ * - `dkLen` is output key length in bytes e.g. 32.
++ * - `asyncTick` - (default: 10) max time in ms for which async function can block execution
++ * - `maxmem` - (default: `1024 ** 3 + 1024` aka 1GB+1KB). A limit that the app could use for scrypt
++ * - `onProgress` - callback function that would be executed for progress report
++ * @returns Derived key
++ */
++export function scrypt(password, salt, opts) {
++    const { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb } = scryptInit(password, salt, opts);
++    if (!isLE)
++        byteSwap32(B32);
++    for (let pi = 0; pi < p; pi++) {
++        const Pi = blockSize32 * pi;
++        for (let i = 0; i < blockSize32; i++)
++            V[i] = B32[Pi + i]; // V[0] = B[i]
++        for (let i = 0, pos = 0; i < N - 1; i++) {
++            BlockMix(V, pos, V, (pos += blockSize32), r); // V[i] = BlockMix(V[i-1]);
++            blockMixCb();
++        }
++        BlockMix(V, (N - 1) * blockSize32, B32, Pi, r); // Process last element
++        blockMixCb();
++        for (let i = 0; i < N; i++) {
++            // First u32 of the last 64-byte block (u32 is LE)
++            const j = B32[Pi + blockSize32 - 16] % N; // j = Integrify(X) % iterations
++            for (let k = 0; k < blockSize32; k++)
++                tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
++            BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])
++            blockMixCb();
++        }
++    }
++    if (!isLE)
++        byteSwap32(B32);
++    return scryptOutput(password, dkLen, B, V, tmp);
++}
++/**
++ * Scrypt KDF from RFC 7914.
++ */
++export async function scryptAsync(password, salt, opts) {
++    const { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick } = scryptInit(password, salt, opts);
++    if (!isLE)
++        byteSwap32(B32);
++    for (let pi = 0; pi < p; pi++) {
++        const Pi = blockSize32 * pi;
++        for (let i = 0; i < blockSize32; i++)
++            V[i] = B32[Pi + i]; // V[0] = B[i]
++        let pos = 0;
++        await asyncLoop(N - 1, asyncTick, () => {
++            BlockMix(V, pos, V, (pos += blockSize32), r); // V[i] = BlockMix(V[i-1]);
++            blockMixCb();
++        });
++        BlockMix(V, (N - 1) * blockSize32, B32, Pi, r); // Process last element
++        blockMixCb();
++        await asyncLoop(N, asyncTick, () => {
++            // First u32 of the last 64-byte block (u32 is LE)
++            const j = B32[Pi + blockSize32 - 16] % N; // j = Integrify(X) % iterations
++            for (let k = 0; k < blockSize32; k++)
++                tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
++            BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])
++            blockMixCb();
++        });
++    }
++    if (!isLE)
++        byteSwap32(B32);
++    return scryptOutput(password, dkLen, B, V, tmp);
++}
++//# sourceMappingURL=scrypt.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.js.map
+new file mode 100644
+index 0000000..ce40ca7
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/scrypt.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"scrypt.js","sourceRoot":"","sources":["../src/scrypt.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,IAAI,YAAY,EAAE,MAAM,cAAc,CAAC;AACtD,OAAO,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC;AACrC,OAAO,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC;AACrC,OAAO,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,EAAS,GAAG,EAAE,IAAI,EAAE,UAAU,EAAE,MAAM,YAAY,CAAC;AAEtF,sBAAsB;AAEtB,gDAAgD;AAChD,oEAAoE;AACpE,kBAAkB;AAClB,SAAS,WAAW,CAClB,IAAiB,EACjB,EAAU,EACV,KAAkB,EAClB,EAAU,EACV,GAAgB,EAChB,EAAU;IAEV,yCAAyC;IACzC,aAAa;IACb,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,4CAA4C;IAC5C,IAAI,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAC1C,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAC1C,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAC1C,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC;IAC/C,oBAAoB;IACpB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC;QAC9B,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAI,CAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;IACjE,CAAC;IACD,uBAAuB;IACvB,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;AAC3D,CAAC;AAED,SAAS,QAAQ,CAAC,KAAkB,EAAE,EAAU,EAAE,GAAgB,EAAE,EAAU,EAAE,CAAS;IACvF,8EAA8E;IAC9E,IAAI,IAAI,GAAG,EAAE,GAAG,CAAC,CAAC;IAClB,IAAI,IAAI,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACvB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;QAAE,GAAG,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC,cAAc;IAC7F,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,IAAI,IAAI,EAAE,EAAE,EAAE,IAAI,EAAE,EAAE,CAAC;QACjD,qEAAqE;QACrE,WAAW,CAAC,GAAG,EAAE,IAAI,EAAE,KAAK,EAAE,EAAE,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC,CAAC,4CAA4C;QAC1F,IAAI,CAAC,GAAG,CAAC;YAAE,IAAI,IAAI,EAAE,CAAC,CAAC,+CAA+C;QACtE,WAAW,CAAC,GAAG,EAAE,IAAI,EAAE,KAAK,EAAE,CAAC,EAAE,IAAI,EAAE,CAAC,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC,CAAC,4CAA4C;IACpG,CAAC;AACH,CAAC;AAYD,wDAAwD;AACxD,SAAS,UAAU,CAAC,QAAe,EAAE,IAAW,EAAE,KAAkB;IAClE,8BAA8B;IAC9B,MAAM,IAAI,GAAG,SAAS,CACpB;QACE,KAAK,EAAE,EAAE;QACT,SAAS,EAAE,EAAE;QACb,MAAM,EAAE,IAAI,IAAI,CAAC,GAAG,IAAI;KACzB,EACD,KAAK,CACN,CAAC;IACF,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,MAAM,EAAE,UAAU,EAAE,GAAG,IAAI,CAAC;IAC/D,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,CAAC,CAAC,CAAC;IAChB,YAAY,CAAC,KAAK,CAAC,CAAC;IACpB,YAAY,CAAC,SAAS,CAAC,CAAC;IACxB,YAAY,CAAC,MAAM,CAAC,CAAC;IACrB,IAAI,UAAU,KAAK,SAAS,IAAI,OAAO,UAAU,KAAK,UAAU;QAC9D,MAAM,IAAI,KAAK,CAAC,+BAA+B,CAAC,CAAC;IACnD,MAAM,SAAS,GAAG,GAAG,GAAG,CAAC,CAAC;IAC1B,MAAM,WAAW,GAAG,SAAS,GAAG,CAAC,CAAC;IAClC,IAAI,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,KAAK,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC,IAAI,EAAE,EAAE,CAAC;QAC9E,yFAAyF;QACzF,oHAAoH;QACpH,MAAM,IAAI,KAAK,CACb,6FAA6F,CAC9F,CAAC;IACJ,CAAC;IACD,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,SAAS,EAAE,CAAC;QAClD,MAAM,IAAI,KAAK,CACb,0FAA0F,CAC3F,CAAC;IACJ,CAAC;IACD,IAAI,KAAK,GAAG,CAAC,IAAI,KAAK,GAAG,CAAC,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC,GAAG,EAAE,EAAE,CAAC;QAC5C,MAAM,IAAI,KAAK,CACb,gFAAgF,CACjF,CAAC;IACJ,CAAC;IACD,MAAM,OAAO,GAAG,SAAS,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACpC,IAAI,OAAO,GAAG,MAAM,EAAE,CAAC;QACrB,MAAM,IAAI,KAAK,CACb,iCAAiC,OAAO,0BAA0B,MAAM,WAAW,CACpF,CAAC;IACJ,CAAC;IACD,wFAAwF;IACxF,0EAA0E;IAC1E,MAAM,CAAC,GAAG,MAAM,CAAC,MAAM,EAAE,QAAQ,EAAE,IAAI,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,GAAG,CAAC,EAAE,CAAC,CAAC;IACzE,MAAM,GAAG,GAAG,GAAG,CAAC,CAAC,CAAC,CAAC;IACnB,8DAA8D;IAC9D,MAAM,CAAC,GAAG,GAAG,CAAC,IAAI,UAAU,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC;IAC7C,MAAM,GAAG,GAAG,GAAG,CAAC,IAAI,UAAU,CAAC,SAAS,CAAC,CAAC,CAAC;IAC3C,IAAI,UAAU,GAAG,GAAG,EAAE,GAAE,CAAC,CAAC;IAC1B,IAAI,UAAU,EAAE,CAAC;QACf,MAAM,aAAa,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QAChC,0DAA0D;QAC1D,wDAAwD;QACxD,MAAM,WAAW,GAAG,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,KAAK,CAAC,aAAa,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC;QACnE,IAAI,WAAW,GAAG,CAAC,CAAC;QACpB,UAAU,GAAG,GAAG,EAAE;YAChB,WAAW,EAAE,CAAC;YACd,IAAI,UAAU,IAAI,CAAC,CAAC,CAAC,WAAW,GAAG,WAAW,CAAC,IAAI,WAAW,KAAK,aAAa,CAAC;gBAC/E,UAAU,CAAC,WAAW,GAAG,aAAa,CAAC,CAAC;QAC5C,CAAC,CAAC;IACJ,CAAC;IACD,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,WAAW,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,UAAU,EAAE,SAAS,EAAE,CAAC;AAChF,CAAC;AAED,SAAS,YAAY,CACnB,QAAe,EACf,KAAa,EACb,CAAa,EACb,CAAc,EACd,GAAgB;IAEhB,MAAM,GAAG,GAAG,MAAM,CAAC,MAAM,EAAE,QAAQ,EAAE,CAAC,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,CAAC,CAAC;IACzD,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACZ,OAAO,GAAG,CAAC;AACb,CAAC;AAED;;;;;;;;;;;;;GAaG;AACH,MAAM,UAAU,MAAM,CAAC,QAAe,EAAE,IAAW,EAAE,IAAgB;IACnE,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,WAAW,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,UAAU,EAAE,GAAG,UAAU,CAC5E,QAAQ,EACR,IAAI,EACJ,IAAI,CACL,CAAC;IACF,IAAI,CAAC,IAAI;QAAE,UAAU,CAAC,GAAG,CAAC,CAAC;IAC3B,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC;QAC9B,MAAM,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC;QAC5B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC,cAAc;QACxE,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;YACxC,QAAQ,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,CAAC,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,2BAA2B;YACzE,UAAU,EAAE,CAAC;QACf,CAAC;QACD,QAAQ,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,WAAW,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,uBAAuB;QACvE,UAAU,EAAE,CAAC;QACb,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;YAC3B,kDAAkD;YAClD,MAAM,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,gCAAgC;YAC1E,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;gBAAE,GAAG,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,WAAW,GAAG,CAAC,CAAC,CAAC,CAAC,iBAAiB;YACtG,QAAQ,CAAC,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,yBAAyB;YACvD,UAAU,EAAE,CAAC;QACf,CAAC;IACH,CAAC;IACD,IAAI,CAAC,IAAI;QAAE,UAAU,CAAC,GAAG,CAAC,CAAC;IAC3B,OAAO,YAAY,CAAC,QAAQ,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;AAClD,CAAC;AAED;;GAEG;AACH,MAAM,CAAC,KAAK,UAAU,WAAW,CAAC,QAAe,EAAE,IAAW,EAAE,IAAgB;IAC9E,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,WAAW,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,UAAU,EAAE,SAAS,EAAE,GAAG,UAAU,CACvF,QAAQ,EACR,IAAI,EACJ,IAAI,CACL,CAAC;IACF,IAAI,CAAC,IAAI;QAAE,UAAU,CAAC,GAAG,CAAC,CAAC;IAC3B,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC;QAC9B,MAAM,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC;QAC5B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC,cAAc;QACxE,IAAI,GAAG,GAAG,CAAC,CAAC;QACZ,MAAM,SAAS,CAAC,CAAC,GAAG,CAAC,EAAE,SAAS,EAAE,GAAG,EAAE;YACrC,QAAQ,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,CAAC,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,2BAA2B;YACzE,UAAU,EAAE,CAAC;QACf,CAAC,CAAC,CAAC;QACH,QAAQ,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,WAAW,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,uBAAuB;QACvE,UAAU,EAAE,CAAC;QACb,MAAM,SAAS,CAAC,CAAC,EAAE,SAAS,EAAE,GAAG,EAAE;YACjC,kDAAkD;YAClD,MAAM,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,gCAAgC;YAC1E,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;gBAAE,GAAG,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,WAAW,GAAG,CAAC,CAAC,CAAC,CAAC,iBAAiB;YACtG,QAAQ,CAAC,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,yBAAyB;YACvD,UAAU,EAAE,CAAC;QACf,CAAC,CAAC,CAAC;IACL,CAAC;IACD,IAAI,CAAC,IAAI;QAAE,UAAU,CAAC,GAAG,CAAC,CAAC;IAC3B,OAAO,YAAY,CAAC,QAAQ,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;AAClD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.d.ts
+new file mode 100644
+index 0000000..f210c5c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.d.ts
+@@ -0,0 +1,26 @@
++import { HashMD } from './_md.js';
++export declare class SHA1 extends HashMD<SHA1> {
++    private A;
++    private B;
++    private C;
++    private D;
++    private E;
++    constructor();
++    protected get(): [number, number, number, number, number];
++    protected set(A: number, B: number, C: number, D: number, E: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++/**
++ * SHA1 (RFC 3174) hash function.
++ * It was cryptographically broken: prefer newer algorithms.
++ * @param message - data that would be hashed
++ */
++export declare const sha1: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA1>;
++};
++//# sourceMappingURL=sha1.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.d.ts.map
+new file mode 100644
+index 0000000..a2bcda2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha1.d.ts","sourceRoot":"","sources":["../src/sha1.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAY,MAAM,UAAU,CAAC;AAa5C,qBAAa,IAAK,SAAQ,MAAM,CAAC,IAAI,CAAC;IACpC,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;;IAK3B,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAIzD,SAAS,CAAC,GAAG,CAAC,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM;IAOnE,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAoCvD,SAAS,CAAC,UAAU;IAGpB,OAAO;CAIR;AAED;;;;GAIG;AACH,eAAO,MAAM,IAAI;;;;;CAAoD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.js
+new file mode 100644
+index 0000000..8975407
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.js
+@@ -0,0 +1,85 @@
++import { HashMD, Chi, Maj } from './_md.js';
++import { rotl, wrapConstructor } from './utils.js';
++// SHA1 (RFC 3174). It was cryptographically broken: prefer newer algorithms.
++// Initial state
++const SHA1_IV = /* @__PURE__ */ new Uint32Array([
++    0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0,
++]);
++// Temporary buffer, not used to store anything between runs
++// Named this way because it matches specification.
++const SHA1_W = /* @__PURE__ */ new Uint32Array(80);
++export class SHA1 extends HashMD {
++    constructor() {
++        super(64, 20, 8, false);
++        this.A = SHA1_IV[0] | 0;
++        this.B = SHA1_IV[1] | 0;
++        this.C = SHA1_IV[2] | 0;
++        this.D = SHA1_IV[3] | 0;
++        this.E = SHA1_IV[4] | 0;
++    }
++    get() {
++        const { A, B, C, D, E } = this;
++        return [A, B, C, D, E];
++    }
++    set(A, B, C, D, E) {
++        this.A = A | 0;
++        this.B = B | 0;
++        this.C = C | 0;
++        this.D = D | 0;
++        this.E = E | 0;
++    }
++    process(view, offset) {
++        for (let i = 0; i < 16; i++, offset += 4)
++            SHA1_W[i] = view.getUint32(offset, false);
++        for (let i = 16; i < 80; i++)
++            SHA1_W[i] = rotl(SHA1_W[i - 3] ^ SHA1_W[i - 8] ^ SHA1_W[i - 14] ^ SHA1_W[i - 16], 1);
++        // Compression function main loop, 80 rounds
++        let { A, B, C, D, E } = this;
++        for (let i = 0; i < 80; i++) {
++            let F, K;
++            if (i < 20) {
++                F = Chi(B, C, D);
++                K = 0x5a827999;
++            }
++            else if (i < 40) {
++                F = B ^ C ^ D;
++                K = 0x6ed9eba1;
++            }
++            else if (i < 60) {
++                F = Maj(B, C, D);
++                K = 0x8f1bbcdc;
++            }
++            else {
++                F = B ^ C ^ D;
++                K = 0xca62c1d6;
++            }
++            const T = (rotl(A, 5) + F + E + K + SHA1_W[i]) | 0;
++            E = D;
++            D = C;
++            C = rotl(B, 30);
++            B = A;
++            A = T;
++        }
++        // Add the compressed chunk to the current hash value
++        A = (A + this.A) | 0;
++        B = (B + this.B) | 0;
++        C = (C + this.C) | 0;
++        D = (D + this.D) | 0;
++        E = (E + this.E) | 0;
++        this.set(A, B, C, D, E);
++    }
++    roundClean() {
++        SHA1_W.fill(0);
++    }
++    destroy() {
++        this.set(0, 0, 0, 0, 0);
++        this.buffer.fill(0);
++    }
++}
++/**
++ * SHA1 (RFC 3174) hash function.
++ * It was cryptographically broken: prefer newer algorithms.
++ * @param message - data that would be hashed
++ */
++export const sha1 = /* @__PURE__ */ wrapConstructor(() => new SHA1());
++//# sourceMappingURL=sha1.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.js.map
+new file mode 100644
+index 0000000..4ca21c2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha1.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha1.js","sourceRoot":"","sources":["../src/sha1.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,GAAG,EAAE,GAAG,EAAE,MAAM,UAAU,CAAC;AAC5C,OAAO,EAAE,IAAI,EAAE,eAAe,EAAE,MAAM,YAAY,CAAC;AAEnD,6EAA6E;AAE7E,gBAAgB;AAChB,MAAM,OAAO,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAC9C,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC3D,CAAC,CAAC;AAEH,4DAA4D;AAC5D,mDAAmD;AACnD,MAAM,MAAM,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACnD,MAAM,OAAO,IAAK,SAAQ,MAAY;IAOpC;QACE,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;QAPlB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;IAI3B,CAAC;IACS,GAAG;QACX,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QAC/B,OAAO,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IACzB,CAAC;IACS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;QACjE,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;IACjB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC;YAAE,MAAM,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;QACpF,KAAK,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;YAC1B,MAAM,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QACvF,4CAA4C;QAC5C,IAAI,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QAC7B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,IAAI,CAAC,EAAE,CAAC,CAAC;YACT,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC;gBACX,CAAC,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;gBACjB,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;iBAAM,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC;gBAClB,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;gBACd,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;iBAAM,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC;gBAClB,CAAC,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;gBACjB,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;iBAAM,CAAC;gBACN,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;gBACd,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;YACD,MAAM,CAAC,GAAG,CAAC,IAAI,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;YACnD,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,IAAI,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;YAChB,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;QACR,CAAC;QACD,qDAAqD;QACrD,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC1B,CAAC;IACS,UAAU;QAClB,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACjB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QACxB,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACtB,CAAC;CACF;AAED;;;;GAIG;AACH,MAAM,CAAC,MAAM,IAAI,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,IAAI,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.d.ts
+new file mode 100644
+index 0000000..6052a2a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.d.ts
+@@ -0,0 +1,3 @@
++export { sha256, sha224 } from './sha256.js';
++export { sha512, sha512_224, sha512_256, sha384 } from './sha512.js';
++//# sourceMappingURL=sha2.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.d.ts.map
+new file mode 100644
+index 0000000..dc32e7a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha2.d.ts","sourceRoot":"","sources":["../src/sha2.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC;AAC7C,OAAO,EAAE,MAAM,EAAE,UAAU,EAAE,UAAU,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.js
+new file mode 100644
+index 0000000..780eb18
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.js
+@@ -0,0 +1,4 @@
++// Usually you either use sha256, or sha512. We re-export them as sha2 for naming consistency.
++export { sha256, sha224 } from './sha256.js';
++export { sha512, sha512_224, sha512_256, sha384 } from './sha512.js';
++//# sourceMappingURL=sha2.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.js.map
+new file mode 100644
+index 0000000..b77fde8
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha2.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha2.js","sourceRoot":"","sources":["../src/sha2.ts"],"names":[],"mappings":"AAAA,8FAA8F;AAC9F,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC;AAC7C,OAAO,EAAE,MAAM,EAAE,UAAU,EAAE,UAAU,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.d.ts
+new file mode 100644
+index 0000000..b31a842
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.d.ts
+@@ -0,0 +1,37 @@
++import { HashMD } from './_md.js';
++export declare class SHA256 extends HashMD<SHA256> {
++    A: number;
++    B: number;
++    C: number;
++    D: number;
++    E: number;
++    F: number;
++    G: number;
++    H: number;
++    constructor();
++    protected get(): [number, number, number, number, number, number, number, number];
++    protected set(A: number, B: number, C: number, D: number, E: number, F: number, G: number, H: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++/**
++ * SHA2-256 hash function
++ * @param message - data that would be hashed
++ */
++export declare const sha256: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA256>;
++};
++/**
++ * SHA2-224 hash function
++ */
++export declare const sha224: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA256>;
++};
++//# sourceMappingURL=sha256.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.d.ts.map
+new file mode 100644
+index 0000000..2969d86
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha256.d.ts","sourceRoot":"","sources":["../src/sha256.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAY,MAAM,UAAU,CAAC;AA8B5C,qBAAa,MAAO,SAAQ,MAAM,CAAC,MAAM,CAAC;IAGxC,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;;IAKrB,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAKjF,SAAS,CAAC,GAAG,CACX,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM;IAWxF,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAqCvD,SAAS,CAAC,UAAU;IAGpB,OAAO;CAIR;AAiBD;;;GAGG;AACH,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC;AAC1E;;GAEG;AACH,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.js
+new file mode 100644
+index 0000000..91dbe12
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.js
+@@ -0,0 +1,126 @@
++import { HashMD, Chi, Maj } from './_md.js';
++import { rotr, wrapConstructor } from './utils.js';
++// SHA2-256 need to try 2^128 hashes to execute birthday attack.
++// BTC network is doing 2^67 hashes/sec as per early 2023.
++// Round constants:
++// first 32 bits of the fractional parts of the cube roots of the first 64 primes 2..311)
++// prettier-ignore
++const SHA256_K = /* @__PURE__ */ new Uint32Array([
++    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
++    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
++    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
++    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
++    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
++    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
++    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
++    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
++]);
++// Initial state:
++// first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19
++// prettier-ignore
++const SHA256_IV = /* @__PURE__ */ new Uint32Array([
++    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
++]);
++// Temporary buffer, not used to store anything between runs
++// Named this way because it matches specification.
++const SHA256_W = /* @__PURE__ */ new Uint32Array(64);
++export class SHA256 extends HashMD {
++    constructor() {
++        super(64, 32, 8, false);
++        // We cannot use array here since array allows indexing by variable
++        // which means optimizer/compiler cannot use registers.
++        this.A = SHA256_IV[0] | 0;
++        this.B = SHA256_IV[1] | 0;
++        this.C = SHA256_IV[2] | 0;
++        this.D = SHA256_IV[3] | 0;
++        this.E = SHA256_IV[4] | 0;
++        this.F = SHA256_IV[5] | 0;
++        this.G = SHA256_IV[6] | 0;
++        this.H = SHA256_IV[7] | 0;
++    }
++    get() {
++        const { A, B, C, D, E, F, G, H } = this;
++        return [A, B, C, D, E, F, G, H];
++    }
++    // prettier-ignore
++    set(A, B, C, D, E, F, G, H) {
++        this.A = A | 0;
++        this.B = B | 0;
++        this.C = C | 0;
++        this.D = D | 0;
++        this.E = E | 0;
++        this.F = F | 0;
++        this.G = G | 0;
++        this.H = H | 0;
++    }
++    process(view, offset) {
++        // Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array
++        for (let i = 0; i < 16; i++, offset += 4)
++            SHA256_W[i] = view.getUint32(offset, false);
++        for (let i = 16; i < 64; i++) {
++            const W15 = SHA256_W[i - 15];
++            const W2 = SHA256_W[i - 2];
++            const s0 = rotr(W15, 7) ^ rotr(W15, 18) ^ (W15 >>> 3);
++            const s1 = rotr(W2, 17) ^ rotr(W2, 19) ^ (W2 >>> 10);
++            SHA256_W[i] = (s1 + SHA256_W[i - 7] + s0 + SHA256_W[i - 16]) | 0;
++        }
++        // Compression function main loop, 64 rounds
++        let { A, B, C, D, E, F, G, H } = this;
++        for (let i = 0; i < 64; i++) {
++            const sigma1 = rotr(E, 6) ^ rotr(E, 11) ^ rotr(E, 25);
++            const T1 = (H + sigma1 + Chi(E, F, G) + SHA256_K[i] + SHA256_W[i]) | 0;
++            const sigma0 = rotr(A, 2) ^ rotr(A, 13) ^ rotr(A, 22);
++            const T2 = (sigma0 + Maj(A, B, C)) | 0;
++            H = G;
++            G = F;
++            F = E;
++            E = (D + T1) | 0;
++            D = C;
++            C = B;
++            B = A;
++            A = (T1 + T2) | 0;
++        }
++        // Add the compressed chunk to the current hash value
++        A = (A + this.A) | 0;
++        B = (B + this.B) | 0;
++        C = (C + this.C) | 0;
++        D = (D + this.D) | 0;
++        E = (E + this.E) | 0;
++        F = (F + this.F) | 0;
++        G = (G + this.G) | 0;
++        H = (H + this.H) | 0;
++        this.set(A, B, C, D, E, F, G, H);
++    }
++    roundClean() {
++        SHA256_W.fill(0);
++    }
++    destroy() {
++        this.set(0, 0, 0, 0, 0, 0, 0, 0);
++        this.buffer.fill(0);
++    }
++}
++// Constants from https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
++class SHA224 extends SHA256 {
++    constructor() {
++        super();
++        this.A = 0xc1059ed8 | 0;
++        this.B = 0x367cd507 | 0;
++        this.C = 0x3070dd17 | 0;
++        this.D = 0xf70e5939 | 0;
++        this.E = 0xffc00b31 | 0;
++        this.F = 0x68581511 | 0;
++        this.G = 0x64f98fa7 | 0;
++        this.H = 0xbefa4fa4 | 0;
++        this.outputLen = 28;
++    }
++}
++/**
++ * SHA2-256 hash function
++ * @param message - data that would be hashed
++ */
++export const sha256 = /* @__PURE__ */ wrapConstructor(() => new SHA256());
++/**
++ * SHA2-224 hash function
++ */
++export const sha224 = /* @__PURE__ */ wrapConstructor(() => new SHA224());
++//# sourceMappingURL=sha256.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.js.map
+new file mode 100644
+index 0000000..d785c23
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha256.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha256.js","sourceRoot":"","sources":["../src/sha256.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,GAAG,EAAE,GAAG,EAAE,MAAM,UAAU,CAAC;AAC5C,OAAO,EAAE,IAAI,EAAE,eAAe,EAAE,MAAM,YAAY,CAAC;AAEnD,gEAAgE;AAChE,0DAA0D;AAE1D,mBAAmB;AACnB,yFAAyF;AACzF,kBAAkB;AAClB,MAAM,QAAQ,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAC/C,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AAEH,iBAAiB;AACjB,wFAAwF;AACxF,kBAAkB;AAClB,MAAM,SAAS,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAChD,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AAEH,4DAA4D;AAC5D,mDAAmD;AACnD,MAAM,QAAQ,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACrD,MAAM,OAAO,MAAO,SAAQ,MAAc;IAYxC;QACE,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;QAZ1B,mEAAmE;QACnE,uDAAuD;QACvD,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;IAIrB,CAAC;IACS,GAAG;QACX,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QACxC,OAAO,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAClC,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;QAEtF,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;IACjB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,gGAAgG;QAChG,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC;YAAE,QAAQ,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;QACtF,KAAK,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC7B,MAAM,GAAG,GAAG,QAAQ,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;YAC7B,MAAM,EAAE,GAAG,QAAQ,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;YAC3B,MAAM,EAAE,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,KAAK,CAAC,CAAC,CAAC;YACtD,MAAM,EAAE,GAAG,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,GAAG,IAAI,CAAC,EAAE,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,KAAK,EAAE,CAAC,CAAC;YACrD,QAAQ,CAAC,CAAC,CAAC,GAAG,CAAC,EAAE,GAAG,QAAQ,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,GAAG,QAAQ,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC;QACnE,CAAC;QACD,4CAA4C;QAC5C,IAAI,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QACtC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,MAAM,MAAM,GAAG,IAAI,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,EAAE,EAAE,CAAC,GAAG,IAAI,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;YACtD,MAAM,EAAE,GAAG,CAAC,CAAC,GAAG,MAAM,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,GAAG,QAAQ,CAAC,CAAC,CAAC,GAAG,QAAQ,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;YACvE,MAAM,MAAM,GAAG,IAAI,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,EAAE,EAAE,CAAC,GAAG,IAAI,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC;YACtD,MAAM,EAAE,GAAG,CAAC,MAAM,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;YACvC,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;YACjB,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;QACpB,CAAC;QACD,qDAAqD;QACrD,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IACnC,CAAC;IACS,UAAU;QAClB,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACnB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QACjC,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACtB,CAAC;CACF;AACD,4EAA4E;AAC5E,MAAM,MAAO,SAAQ,MAAM;IASzB;QACE,KAAK,EAAE,CAAC;QATV,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QAGjB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAED;;;GAGG;AACH,MAAM,CAAC,MAAM,MAAM,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC;AAC1E;;GAEG;AACH,MAAM,CAAC,MAAM,MAAM,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.d.ts
+new file mode 100644
+index 0000000..151cdf2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.d.ts
+@@ -0,0 +1,154 @@
++import { Input, Hash, HashXOF } from './utils.js';
++import { Keccak, ShakeOpts } from './sha3.js';
++export type cShakeOpts = ShakeOpts & {
++    personalization?: Input;
++    NISTfn?: Input;
++};
++export declare const cshake128: {
++    (msg: Input, opts?: cShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: cShakeOpts): HashXOF<Keccak>;
++};
++export declare const cshake256: {
++    (msg: Input, opts?: cShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: cShakeOpts): HashXOF<Keccak>;
++};
++export declare class KMAC extends Keccak implements HashXOF<KMAC> {
++    constructor(blockLen: number, outputLen: number, enableXOF: boolean, key: Input, opts?: cShakeOpts);
++    protected finish(): void;
++    _cloneInto(to?: KMAC): KMAC;
++    clone(): KMAC;
++}
++export declare const kmac128: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare const kmac256: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare const kmac128xof: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare const kmac256xof: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare class TupleHash extends Keccak implements HashXOF<TupleHash> {
++    constructor(blockLen: number, outputLen: number, enableXOF: boolean, opts?: cShakeOpts);
++    protected finish(): void;
++    _cloneInto(to?: TupleHash): TupleHash;
++    clone(): TupleHash;
++}
++export declare const tuplehash128: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++export declare const tuplehash256: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++export declare const tuplehash128xof: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++export declare const tuplehash256xof: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++type ParallelOpts = cShakeOpts & {
++    blockLen?: number;
++};
++export declare class ParallelHash extends Keccak implements HashXOF<ParallelHash> {
++    protected leafCons: () => Hash<Keccak>;
++    private leafHash?;
++    private chunkPos;
++    private chunksDone;
++    private chunkLen;
++    constructor(blockLen: number, outputLen: number, leafCons: () => Hash<Keccak>, enableXOF: boolean, opts?: ParallelOpts);
++    protected finish(): void;
++    _cloneInto(to?: ParallelHash): ParallelHash;
++    destroy(): void;
++    clone(): ParallelHash;
++}
++export declare const parallelhash128: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export declare const parallelhash256: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export declare const parallelhash128xof: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export declare const parallelhash256xof: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export type TurboshakeOpts = ShakeOpts & {
++    D?: number;
++};
++export declare const turboshake128: {
++    (msg: Input, opts?: TurboshakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: TurboshakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++export declare const turboshake256: {
++    (msg: Input, opts?: TurboshakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: TurboshakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++export type KangarooOpts = {
++    dkLen?: number;
++    personalization?: Input;
++};
++export declare class KangarooTwelve extends Keccak implements HashXOF<KangarooTwelve> {
++    protected leafLen: number;
++    readonly chunkLen = 8192;
++    private leafHash?;
++    private personalization;
++    private chunkPos;
++    private chunksDone;
++    constructor(blockLen: number, leafLen: number, outputLen: number, rounds: number, opts: KangarooOpts);
++    update(data: Input): this;
++    protected finish(): void;
++    destroy(): void;
++    _cloneInto(to?: KangarooTwelve): KangarooTwelve;
++    clone(): KangarooTwelve;
++}
++export declare const k12: {
++    (msg: Input, opts?: KangarooOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: KangarooOpts): Hash<KangarooTwelve>;
++};
++export declare const m14: {
++    (msg: Input, opts?: KangarooOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: KangarooOpts): Hash<KangarooTwelve>;
++};
++export declare class KeccakPRG extends Keccak {
++    protected rate: number;
++    constructor(capacity: number);
++    keccak(): void;
++    update(data: Input): this;
++    feed(data: Input): this;
++    protected finish(): void;
++    digestInto(_out: Uint8Array): Uint8Array;
++    fetch(bytes: number): Uint8Array;
++    forget(): void;
++    _cloneInto(to?: KeccakPRG): KeccakPRG;
++    clone(): KeccakPRG;
++}
++export declare const keccakprg: (capacity?: number) => KeccakPRG;
++export {};
++//# sourceMappingURL=sha3-addons.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.d.ts.map
+new file mode 100644
+index 0000000..ace68ec
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3-addons.d.ts","sourceRoot":"","sources":["../src/sha3-addons.ts"],"names":[],"mappings":"AACA,OAAO,EACL,KAAK,EAIL,IAAI,EACJ,OAAO,EAER,MAAM,YAAY,CAAC;AACpB,OAAO,EAAE,MAAM,EAAE,SAAS,EAAE,MAAM,WAAW,CAAC;AAyB9C,MAAM,MAAM,UAAU,GAAG,SAAS,GAAG;IAAE,eAAe,CAAC,EAAE,KAAK,CAAC;IAAC,MAAM,CAAC,EAAE,KAAK,CAAA;CAAE,CAAC;AAyBjF,eAAO,MAAM,SAAS;;;;;CAA0D,CAAC;AACjF,eAAO,MAAM,SAAS;;;;;CAA0D,CAAC;AAEjF,qBAAa,IAAK,SAAQ,MAAO,YAAW,OAAO,CAAC,IAAI,CAAC;gBAErD,QAAQ,EAAE,MAAM,EAChB,SAAS,EAAE,MAAM,EACjB,SAAS,EAAE,OAAO,EAClB,GAAG,EAAE,KAAK,EACV,IAAI,GAAE,UAAe;IAYvB,SAAS,CAAC,MAAM;IAIhB,UAAU,CAAC,EAAE,CAAC,EAAE,IAAI,GAAG,IAAI;IAW3B,KAAK,IAAI,IAAI;CAGd;AAUD,eAAO,MAAM,OAAO;UAPC,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAKyB,CAAC;AACvE,eAAO,MAAM,OAAO;UARC,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAMyB,CAAC;AACvE,eAAO,MAAM,UAAU;UATF,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAOkC,CAAC;AAChF,eAAO,MAAM,UAAU;UAVF,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAQkC,CAAC;AAIhF,qBAAa,SAAU,SAAQ,MAAO,YAAW,OAAO,CAAC,SAAS,CAAC;gBACrD,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,SAAS,EAAE,OAAO,EAAE,IAAI,GAAE,UAAe;IAW1F,SAAS,CAAC,MAAM;IAIhB,UAAU,CAAC,EAAE,CAAC,EAAE,SAAS,GAAG,SAAS;IAIrC,KAAK,IAAI,SAAS;CAGnB;AAaD,eAAO,MAAM,YAAY;eAVE,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAK0C,CAAC;AAC7E,eAAO,MAAM,YAAY;eAXE,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAM0C,CAAC;AAC7E,eAAO,MAAM,eAAe;eAZD,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAOmD,CAAC;AACtF,eAAO,MAAM,eAAe;eAbD,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAQmD,CAAC;AAGtF,KAAK,YAAY,GAAG,UAAU,GAAG;IAAE,QAAQ,CAAC,EAAE,MAAM,CAAA;CAAE,CAAC;AAEvD,qBAAa,YAAa,SAAQ,MAAO,YAAW,OAAO,CAAC,YAAY,CAAC;IAQrE,SAAS,CAAC,QAAQ,EAAE,MAAM,IAAI,CAAC,MAAM,CAAC;IAPxC,OAAO,CAAC,QAAQ,CAAC,CAAe;IAChC,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,UAAU,CAAK;IACvB,OAAO,CAAC,QAAQ,CAAS;gBAEvB,QAAQ,EAAE,MAAM,EAChB,SAAS,EAAE,MAAM,EACP,QAAQ,EAAE,MAAM,IAAI,CAAC,MAAM,CAAC,EACtC,SAAS,EAAE,OAAO,EAClB,IAAI,GAAE,YAAiB;IA8BzB,SAAS,CAAC,MAAM;IAUhB,UAAU,CAAC,EAAE,CAAC,EAAE,YAAY,GAAG,YAAY;IAQ3C,OAAO;IAIP,KAAK,IAAI,YAAY;CAGtB;AAqBD,eAAO,MAAM,eAAe;cAbC,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAWiD,CAAC;AACzF,eAAO,MAAM,eAAe;cAdC,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAYiD,CAAC;AACzF,eAAO,MAAM,kBAAkB;cAfF,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAa0D,CAAC;AAClG,eAAO,MAAM,kBAAkB;cAhBF,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAc0D,CAAC;AAGlG,MAAM,MAAM,cAAc,GAAG,SAAS,GAAG;IACvC,CAAC,CAAC,EAAE,MAAM,CAAC;CACZ,CAAC;AAWF,eAAO,MAAM,aAAa;;;;;CAA8C,CAAC;AACzE,eAAO,MAAM,aAAa;;;;;CAA8C,CAAC;AAWzE,MAAM,MAAM,YAAY,GAAG;IAAE,KAAK,CAAC,EAAE,MAAM,CAAC;IAAC,eAAe,CAAC,EAAE,KAAK,CAAA;CAAE,CAAC;AAGvE,qBAAa,cAAe,SAAQ,MAAO,YAAW,OAAO,CAAC,cAAc,CAAC;IAQzE,SAAS,CAAC,OAAO,EAAE,MAAM;IAP3B,QAAQ,CAAC,QAAQ,QAAQ;IACzB,OAAO,CAAC,QAAQ,CAAC,CAAS;IAC1B,OAAO,CAAC,eAAe,CAAa;IACpC,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,UAAU,CAAK;gBAErB,QAAQ,EAAE,MAAM,EACN,OAAO,EAAE,MAAM,EACzB,SAAS,EAAE,MAAM,EACjB,MAAM,EAAE,MAAM,EACd,IAAI,EAAE,YAAY;IAMpB,MAAM,CAAC,IAAI,EAAE,KAAK;IAuBlB,SAAS,CAAC,MAAM;IAYhB,OAAO;IAMP,UAAU,CAAC,EAAE,CAAC,EAAE,cAAc,GAAG,cAAc;IAW/C,KAAK,IAAI,cAAc;CAGxB;AAED,eAAO,MAAM,GAAG;;;;;CAGV,CAAC;AAEP,eAAO,MAAM,GAAG;;;;;CAGV,CAAC;AAIP,qBAAa,SAAU,SAAQ,MAAM;IACnC,SAAS,CAAC,IAAI,EAAE,MAAM,CAAC;gBACX,QAAQ,EAAE,MAAM;IAU5B,MAAM;IAQN,MAAM,CAAC,IAAI,EAAE,KAAK;IAKlB,IAAI,CAAC,IAAI,EAAE,KAAK;IAGhB,SAAS,CAAC,MAAM;IAChB,UAAU,CAAC,IAAI,EAAE,UAAU,GAAG,UAAU;IAGxC,KAAK,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU;IAIhC,MAAM;IAQN,UAAU,CAAC,EAAE,CAAC,EAAE,SAAS,GAAG,SAAS;IAOrC,KAAK,IAAI,SAAS;CAGnB;AAED,eAAO,MAAM,SAAS,kCAA8C,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.js
+new file mode 100644
+index 0000000..533cfaf
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.js
+@@ -0,0 +1,356 @@
++import { number as assertNumber } from './_assert.js';
++import { toBytes, wrapConstructorWithOpts, u32, wrapXOFConstructorWithOpts, } from './utils.js';
++import { Keccak } from './sha3.js';
++// cSHAKE && KMAC (NIST SP800-185)
++function leftEncode(n) {
++    const res = [n & 0xff];
++    n >>= 8;
++    for (; n > 0; n >>= 8)
++        res.unshift(n & 0xff);
++    res.unshift(res.length);
++    return new Uint8Array(res);
++}
++function rightEncode(n) {
++    const res = [n & 0xff];
++    n >>= 8;
++    for (; n > 0; n >>= 8)
++        res.unshift(n & 0xff);
++    res.push(res.length);
++    return new Uint8Array(res);
++}
++function chooseLen(opts, outputLen) {
++    return opts.dkLen === undefined ? outputLen : opts.dkLen;
++}
++const toBytesOptional = (buf) => (buf !== undefined ? toBytes(buf) : new Uint8Array([]));
++// NOTE: second modulo is necessary since we don't need to add padding if current element takes whole block
++const getPadding = (len, block) => new Uint8Array((block - (len % block)) % block);
++// Personalization
++function cshakePers(hash, opts = {}) {
++    if (!opts || (!opts.personalization && !opts.NISTfn))
++        return hash;
++    // Encode and pad inplace to avoid unneccesary memory copies/slices (so we don't need to zero them later)
++    // bytepad(encode_string(N) || encode_string(S), 168)
++    const blockLenBytes = leftEncode(hash.blockLen);
++    const fn = toBytesOptional(opts.NISTfn);
++    const fnLen = leftEncode(8 * fn.length); // length in bits
++    const pers = toBytesOptional(opts.personalization);
++    const persLen = leftEncode(8 * pers.length); // length in bits
++    if (!fn.length && !pers.length)
++        return hash;
++    hash.suffix = 0x04;
++    hash.update(blockLenBytes).update(fnLen).update(fn).update(persLen).update(pers);
++    let totalLen = blockLenBytes.length + fnLen.length + fn.length + persLen.length + pers.length;
++    hash.update(getPadding(totalLen, hash.blockLen));
++    return hash;
++}
++const gencShake = (suffix, blockLen, outputLen) => wrapXOFConstructorWithOpts((opts = {}) => cshakePers(new Keccak(blockLen, suffix, chooseLen(opts, outputLen), true), opts));
++export const cshake128 = /* @__PURE__ */ (() => gencShake(0x1f, 168, 128 / 8))();
++export const cshake256 = /* @__PURE__ */ (() => gencShake(0x1f, 136, 256 / 8))();
++export class KMAC extends Keccak {
++    constructor(blockLen, outputLen, enableXOF, key, opts = {}) {
++        super(blockLen, 0x1f, outputLen, enableXOF);
++        cshakePers(this, { NISTfn: 'KMAC', personalization: opts.personalization });
++        key = toBytes(key);
++        // 1. newX = bytepad(encode_string(K), 168) || X || right_encode(L).
++        const blockLenBytes = leftEncode(this.blockLen);
++        const keyLen = leftEncode(8 * key.length);
++        this.update(blockLenBytes).update(keyLen).update(key);
++        const totalLen = blockLenBytes.length + keyLen.length + key.length;
++        this.update(getPadding(totalLen, this.blockLen));
++    }
++    finish() {
++        if (!this.finished)
++            this.update(rightEncode(this.enableXOF ? 0 : this.outputLen * 8)); // outputLen in bits
++        super.finish();
++    }
++    _cloneInto(to) {
++        // Create new instance without calling constructor since key already in state and we don't know it.
++        // Force "to" to be instance of KMAC instead of Sha3.
++        if (!to) {
++            to = Object.create(Object.getPrototypeOf(this), {});
++            to.state = this.state.slice();
++            to.blockLen = this.blockLen;
++            to.state32 = u32(to.state);
++        }
++        return super._cloneInto(to);
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++function genKmac(blockLen, outputLen, xof = false) {
++    const kmac = (key, message, opts) => kmac.create(key, opts).update(message).digest();
++    kmac.create = (key, opts = {}) => new KMAC(blockLen, chooseLen(opts, outputLen), xof, key, opts);
++    return kmac;
++}
++export const kmac128 = /* @__PURE__ */ (() => genKmac(168, 128 / 8))();
++export const kmac256 = /* @__PURE__ */ (() => genKmac(136, 256 / 8))();
++export const kmac128xof = /* @__PURE__ */ (() => genKmac(168, 128 / 8, true))();
++export const kmac256xof = /* @__PURE__ */ (() => genKmac(136, 256 / 8, true))();
++// TupleHash
++// Usage: tuple(['ab', 'cd']) != tuple(['a', 'bcd'])
++export class TupleHash extends Keccak {
++    constructor(blockLen, outputLen, enableXOF, opts = {}) {
++        super(blockLen, 0x1f, outputLen, enableXOF);
++        cshakePers(this, { NISTfn: 'TupleHash', personalization: opts.personalization });
++        // Change update after cshake processed
++        this.update = (data) => {
++            data = toBytes(data);
++            super.update(leftEncode(data.length * 8));
++            super.update(data);
++            return this;
++        };
++    }
++    finish() {
++        if (!this.finished)
++            super.update(rightEncode(this.enableXOF ? 0 : this.outputLen * 8)); // outputLen in bits
++        super.finish();
++    }
++    _cloneInto(to) {
++        to || (to = new TupleHash(this.blockLen, this.outputLen, this.enableXOF));
++        return super._cloneInto(to);
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++function genTuple(blockLen, outputLen, xof = false) {
++    const tuple = (messages, opts) => {
++        const h = tuple.create(opts);
++        for (const msg of messages)
++            h.update(msg);
++        return h.digest();
++    };
++    tuple.create = (opts = {}) => new TupleHash(blockLen, chooseLen(opts, outputLen), xof, opts);
++    return tuple;
++}
++export const tuplehash128 = /* @__PURE__ */ (() => genTuple(168, 128 / 8))();
++export const tuplehash256 = /* @__PURE__ */ (() => genTuple(136, 256 / 8))();
++export const tuplehash128xof = /* @__PURE__ */ (() => genTuple(168, 128 / 8, true))();
++export const tuplehash256xof = /* @__PURE__ */ (() => genTuple(136, 256 / 8, true))();
++export class ParallelHash extends Keccak {
++    constructor(blockLen, outputLen, leafCons, enableXOF, opts = {}) {
++        super(blockLen, 0x1f, outputLen, enableXOF);
++        this.leafCons = leafCons;
++        this.chunkPos = 0; // Position of current block in chunk
++        this.chunksDone = 0; // How many chunks we already have
++        cshakePers(this, { NISTfn: 'ParallelHash', personalization: opts.personalization });
++        let { blockLen: B } = opts;
++        B || (B = 8);
++        assertNumber(B);
++        this.chunkLen = B;
++        super.update(leftEncode(B));
++        // Change update after cshake processed
++        this.update = (data) => {
++            data = toBytes(data);
++            const { chunkLen, leafCons } = this;
++            for (let pos = 0, len = data.length; pos < len;) {
++                if (this.chunkPos == chunkLen || !this.leafHash) {
++                    if (this.leafHash) {
++                        super.update(this.leafHash.digest());
++                        this.chunksDone++;
++                    }
++                    this.leafHash = leafCons();
++                    this.chunkPos = 0;
++                }
++                const take = Math.min(chunkLen - this.chunkPos, len - pos);
++                this.leafHash.update(data.subarray(pos, pos + take));
++                this.chunkPos += take;
++                pos += take;
++            }
++            return this;
++        };
++    }
++    finish() {
++        if (this.finished)
++            return;
++        if (this.leafHash) {
++            super.update(this.leafHash.digest());
++            this.chunksDone++;
++        }
++        super.update(rightEncode(this.chunksDone));
++        super.update(rightEncode(this.enableXOF ? 0 : this.outputLen * 8)); // outputLen in bits
++        super.finish();
++    }
++    _cloneInto(to) {
++        to || (to = new ParallelHash(this.blockLen, this.outputLen, this.leafCons, this.enableXOF));
++        if (this.leafHash)
++            to.leafHash = this.leafHash._cloneInto(to.leafHash);
++        to.chunkPos = this.chunkPos;
++        to.chunkLen = this.chunkLen;
++        to.chunksDone = this.chunksDone;
++        return super._cloneInto(to);
++    }
++    destroy() {
++        super.destroy.call(this);
++        if (this.leafHash)
++            this.leafHash.destroy();
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++function genPrl(blockLen, outputLen, leaf, xof = false) {
++    const parallel = (message, opts) => parallel.create(opts).update(message).digest();
++    parallel.create = (opts = {}) => new ParallelHash(blockLen, chooseLen(opts, outputLen), () => leaf.create({ dkLen: 2 * outputLen }), xof, opts);
++    return parallel;
++}
++export const parallelhash128 = /* @__PURE__ */ (() => genPrl(168, 128 / 8, cshake128))();
++export const parallelhash256 = /* @__PURE__ */ (() => genPrl(136, 256 / 8, cshake256))();
++export const parallelhash128xof = /* @__PURE__ */ (() => genPrl(168, 128 / 8, cshake128, true))();
++export const parallelhash256xof = /* @__PURE__ */ (() => genPrl(136, 256 / 8, cshake256, true))();
++const genTurboshake = (blockLen, outputLen) => wrapXOFConstructorWithOpts((opts = {}) => {
++    const D = opts.D === undefined ? 0x1f : opts.D;
++    // Section 2.1 of https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve/
++    if (!Number.isSafeInteger(D) || D < 0x01 || D > 0x7f)
++        throw new Error(`turboshake: wrong domain separation byte: ${D}, should be 0x01..0x7f`);
++    return new Keccak(blockLen, D, opts.dkLen === undefined ? outputLen : opts.dkLen, true, 12);
++});
++export const turboshake128 = /* @__PURE__ */ genTurboshake(168, 256 / 8);
++export const turboshake256 = /* @__PURE__ */ genTurboshake(136, 512 / 8);
++// Kangaroo
++// Same as NIST rightEncode, but returns [0] for zero string
++function rightEncodeK12(n) {
++    const res = [];
++    for (; n > 0; n >>= 8)
++        res.unshift(n & 0xff);
++    res.push(res.length);
++    return new Uint8Array(res);
++}
++const EMPTY = new Uint8Array([]);
++export class KangarooTwelve extends Keccak {
++    constructor(blockLen, leafLen, outputLen, rounds, opts) {
++        super(blockLen, 0x07, outputLen, true, rounds);
++        this.leafLen = leafLen;
++        this.chunkLen = 8192;
++        this.chunkPos = 0; // Position of current block in chunk
++        this.chunksDone = 0; // How many chunks we already have
++        const { personalization } = opts;
++        this.personalization = toBytesOptional(personalization);
++    }
++    update(data) {
++        data = toBytes(data);
++        const { chunkLen, blockLen, leafLen, rounds } = this;
++        for (let pos = 0, len = data.length; pos < len;) {
++            if (this.chunkPos == chunkLen) {
++                if (this.leafHash)
++                    super.update(this.leafHash.digest());
++                else {
++                    this.suffix = 0x06; // Its safe to change suffix here since its used only in digest()
++                    super.update(new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0]));
++                }
++                this.leafHash = new Keccak(blockLen, 0x0b, leafLen, false, rounds);
++                this.chunksDone++;
++                this.chunkPos = 0;
++            }
++            const take = Math.min(chunkLen - this.chunkPos, len - pos);
++            const chunk = data.subarray(pos, pos + take);
++            if (this.leafHash)
++                this.leafHash.update(chunk);
++            else
++                super.update(chunk);
++            this.chunkPos += take;
++            pos += take;
++        }
++        return this;
++    }
++    finish() {
++        if (this.finished)
++            return;
++        const { personalization } = this;
++        this.update(personalization).update(rightEncodeK12(personalization.length));
++        // Leaf hash
++        if (this.leafHash) {
++            super.update(this.leafHash.digest());
++            super.update(rightEncodeK12(this.chunksDone));
++            super.update(new Uint8Array([0xff, 0xff]));
++        }
++        super.finish.call(this);
++    }
++    destroy() {
++        super.destroy.call(this);
++        if (this.leafHash)
++            this.leafHash.destroy();
++        // We cannot zero personalization buffer since it is user provided and we don't want to mutate user input
++        this.personalization = EMPTY;
++    }
++    _cloneInto(to) {
++        const { blockLen, leafLen, leafHash, outputLen, rounds } = this;
++        to || (to = new KangarooTwelve(blockLen, leafLen, outputLen, rounds, {}));
++        super._cloneInto(to);
++        if (leafHash)
++            to.leafHash = leafHash._cloneInto(to.leafHash);
++        to.personalization.set(this.personalization);
++        to.leafLen = this.leafLen;
++        to.chunkPos = this.chunkPos;
++        to.chunksDone = this.chunksDone;
++        return to;
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++// Default to 32 bytes, so it can be used without opts
++export const k12 = /* @__PURE__ */ (() => wrapConstructorWithOpts((opts = {}) => new KangarooTwelve(168, 32, chooseLen(opts, 32), 12, opts)))();
++// MarsupilamiFourteen
++export const m14 = /* @__PURE__ */ (() => wrapConstructorWithOpts((opts = {}) => new KangarooTwelve(136, 64, chooseLen(opts, 64), 14, opts)))();
++// https://keccak.team/files/CSF-0.1.pdf
++// + https://github.com/XKCP/XKCP/tree/master/lib/high/Keccak/PRG
++export class KeccakPRG extends Keccak {
++    constructor(capacity) {
++        assertNumber(capacity);
++        // Rho should be full bytes
++        if (capacity < 0 || capacity > 1600 - 10 || (1600 - capacity - 2) % 8)
++            throw new Error('KeccakPRG: Invalid capacity');
++        // blockLen = rho in bytes
++        super((1600 - capacity - 2) / 8, 0, 0, true);
++        this.rate = 1600 - capacity;
++        this.posOut = Math.floor((this.rate + 7) / 8);
++    }
++    keccak() {
++        // Duplex padding
++        this.state[this.pos] ^= 0x01;
++        this.state[this.blockLen] ^= 0x02; // Rho is full bytes
++        super.keccak();
++        this.pos = 0;
++        this.posOut = 0;
++    }
++    update(data) {
++        super.update(data);
++        this.posOut = this.blockLen;
++        return this;
++    }
++    feed(data) {
++        return this.update(data);
++    }
++    finish() { }
++    digestInto(_out) {
++        throw new Error('KeccakPRG: digest is not allowed, please use .fetch instead.');
++    }
++    fetch(bytes) {
++        return this.xof(bytes);
++    }
++    // Ensure irreversibility (even if state leaked previous outputs cannot be computed)
++    forget() {
++        if (this.rate < 1600 / 2 + 1)
++            throw new Error('KeccakPRG: rate too low to use forget');
++        this.keccak();
++        for (let i = 0; i < this.blockLen; i++)
++            this.state[i] = 0;
++        this.pos = this.blockLen;
++        this.keccak();
++        this.posOut = this.blockLen;
++    }
++    _cloneInto(to) {
++        const { rate } = this;
++        to || (to = new KeccakPRG(1600 - rate));
++        super._cloneInto(to);
++        to.rate = rate;
++        return to;
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++export const keccakprg = (capacity = 254) => new KeccakPRG(capacity);
++//# sourceMappingURL=sha3-addons.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.js.map
+new file mode 100644
+index 0000000..257310e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3-addons.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3-addons.js","sourceRoot":"","sources":["../src/sha3-addons.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,IAAI,YAAY,EAAE,MAAM,cAAc,CAAC;AACtD,OAAO,EAEL,OAAO,EACP,uBAAuB,EACvB,GAAG,EAGH,0BAA0B,GAC3B,MAAM,YAAY,CAAC;AACpB,OAAO,EAAE,MAAM,EAAa,MAAM,WAAW,CAAC;AAC9C,kCAAkC;AAClC,SAAS,UAAU,CAAC,CAAS;IAC3B,MAAM,GAAG,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IACvB,CAAC,KAAK,CAAC,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC;QAAE,GAAG,CAAC,OAAO,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IAC7C,GAAG,CAAC,OAAO,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACxB,OAAO,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;AAC7B,CAAC;AAED,SAAS,WAAW,CAAC,CAAS;IAC5B,MAAM,GAAG,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IACvB,CAAC,KAAK,CAAC,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC;QAAE,GAAG,CAAC,OAAO,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IAC7C,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrB,OAAO,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;AAC7B,CAAC;AAED,SAAS,SAAS,CAAC,IAAe,EAAE,SAAiB;IACnD,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC;AAC3D,CAAC;AAED,MAAM,eAAe,GAAG,CAAC,GAAW,EAAE,EAAE,CAAC,CAAC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC,CAAC;AACjG,2GAA2G;AAC3G,MAAM,UAAU,GAAG,CAAC,GAAW,EAAE,KAAa,EAAE,EAAE,CAAC,IAAI,UAAU,CAAC,CAAC,KAAK,GAAG,CAAC,GAAG,GAAG,KAAK,CAAC,CAAC,GAAG,KAAK,CAAC,CAAC;AAGnG,kBAAkB;AAClB,SAAS,UAAU,CAAC,IAAY,EAAE,OAAmB,EAAE;IACrD,IAAI,CAAC,IAAI,IAAI,CAAC,CAAC,IAAI,CAAC,eAAe,IAAI,CAAC,IAAI,CAAC,MAAM,CAAC;QAAE,OAAO,IAAI,CAAC;IAClE,yGAAyG;IACzG,qDAAqD;IACrD,MAAM,aAAa,GAAG,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;IAChD,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC;IACxC,MAAM,KAAK,GAAG,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,iBAAiB;IAC1D,MAAM,IAAI,GAAG,eAAe,CAAC,IAAI,CAAC,eAAe,CAAC,CAAC;IACnD,MAAM,OAAO,GAAG,UAAU,CAAC,CAAC,GAAG,IAAI,CAAC,MAAM,CAAC,CAAC,CAAC,iBAAiB;IAC9D,IAAI,CAAC,EAAE,CAAC,MAAM,IAAI,CAAC,IAAI,CAAC,MAAM;QAAE,OAAO,IAAI,CAAC;IAC5C,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC;IACnB,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,MAAM,CAAC,KAAK,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IACjF,IAAI,QAAQ,GAAG,aAAa,CAAC,MAAM,GAAG,KAAK,CAAC,MAAM,GAAG,EAAE,CAAC,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,MAAM,CAAC;IAC9F,IAAI,CAAC,MAAM,CAAC,UAAU,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC,CAAC,CAAC;IACjD,OAAO,IAAI,CAAC;AACd,CAAC;AAED,MAAM,SAAS,GAAG,CAAC,MAAc,EAAE,QAAgB,EAAE,SAAiB,EAAE,EAAE,CACxE,0BAA0B,CAAqB,CAAC,OAAmB,EAAE,EAAE,EAAE,CACvE,UAAU,CAAC,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAAE,IAAI,CAAC,EAAE,IAAI,CAAC,CACjF,CAAC;AAEJ,MAAM,CAAC,MAAM,SAAS,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,SAAS,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AACjF,MAAM,CAAC,MAAM,SAAS,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,SAAS,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAEjF,MAAM,OAAO,IAAK,SAAQ,MAAM;IAC9B,YACE,QAAgB,EAChB,SAAiB,EACjB,SAAkB,EAClB,GAAU,EACV,OAAmB,EAAE;QAErB,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,CAAC,CAAC;QAC5C,UAAU,CAAC,IAAI,EAAE,EAAE,MAAM,EAAE,MAAM,EAAE,eAAe,EAAE,IAAI,CAAC,eAAe,EAAE,CAAC,CAAC;QAC5E,GAAG,GAAG,OAAO,CAAC,GAAG,CAAC,CAAC;QACnB,oEAAoE;QACpE,MAAM,aAAa,GAAG,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;QAChD,MAAM,MAAM,GAAG,UAAU,CAAC,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,CAAC;QAC1C,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,MAAM,CAAC,MAAM,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACtD,MAAM,QAAQ,GAAG,aAAa,CAAC,MAAM,GAAG,MAAM,CAAC,MAAM,GAAG,GAAG,CAAC,MAAM,CAAC;QACnE,IAAI,CAAC,MAAM,CAAC,UAAU,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC,CAAC,CAAC;IACnD,CAAC;IACS,MAAM;QACd,IAAI,CAAC,IAAI,CAAC,QAAQ;YAAE,IAAI,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,oBAAoB;QAC3G,KAAK,CAAC,MAAM,EAAE,CAAC;IACjB,CAAC;IACD,UAAU,CAAC,EAAS;QAClB,mGAAmG;QACnG,qDAAqD;QACrD,IAAI,CAAC,EAAE,EAAE,CAAC;YACR,EAAE,GAAG,MAAM,CAAC,MAAM,CAAC,MAAM,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,EAAE,CAAS,CAAC;YAC5D,EAAE,CAAC,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC,KAAK,EAAE,CAAC;YAC9B,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;YAC5B,EAAE,CAAC,OAAO,GAAG,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC,CAAC;QAC7B,CAAC;QACD,OAAO,KAAK,CAAC,UAAU,CAAC,EAAE,CAAS,CAAC;IACtC,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAED,SAAS,OAAO,CAAC,QAAgB,EAAE,SAAiB,EAAE,GAAG,GAAG,KAAK;IAC/D,MAAM,IAAI,GAAG,CAAC,GAAU,EAAE,OAAc,EAAE,IAAiB,EAAc,EAAE,CACzE,IAAI,CAAC,MAAM,CAAC,GAAG,EAAE,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;IAClD,IAAI,CAAC,MAAM,GAAG,CAAC,GAAU,EAAE,OAAmB,EAAE,EAAE,EAAE,CAClD,IAAI,IAAI,CAAC,QAAQ,EAAE,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC;IACjE,OAAO,IAAI,CAAC;AACd,CAAC;AAED,MAAM,CAAC,MAAM,OAAO,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AACvE,MAAM,CAAC,MAAM,OAAO,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AACvE,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAChF,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAEhF,YAAY;AACZ,oDAAoD;AACpD,MAAM,OAAO,SAAU,SAAQ,MAAM;IACnC,YAAY,QAAgB,EAAE,SAAiB,EAAE,SAAkB,EAAE,OAAmB,EAAE;QACxF,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,CAAC,CAAC;QAC5C,UAAU,CAAC,IAAI,EAAE,EAAE,MAAM,EAAE,WAAW,EAAE,eAAe,EAAE,IAAI,CAAC,eAAe,EAAE,CAAC,CAAC;QACjF,uCAAuC;QACvC,IAAI,CAAC,MAAM,GAAG,CAAC,IAAW,EAAE,EAAE;YAC5B,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;YACrB,KAAK,CAAC,MAAM,CAAC,UAAU,CAAC,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,CAAC;YAC1C,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;YACnB,OAAO,IAAI,CAAC;QACd,CAAC,CAAC;IACJ,CAAC;IACS,MAAM;QACd,IAAI,CAAC,IAAI,CAAC,QAAQ;YAAE,KAAK,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,oBAAoB;QAC5G,KAAK,CAAC,MAAM,EAAE,CAAC;IACjB,CAAC;IACD,UAAU,CAAC,EAAc;QACvB,EAAE,KAAF,EAAE,GAAK,IAAI,SAAS,CAAC,IAAI,CAAC,QAAQ,EAAE,IAAI,CAAC,SAAS,EAAE,IAAI,CAAC,SAAS,CAAC,EAAC;QACpE,OAAO,KAAK,CAAC,UAAU,CAAC,EAAE,CAAc,CAAC;IAC3C,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAED,SAAS,QAAQ,CAAC,QAAgB,EAAE,SAAiB,EAAE,GAAG,GAAG,KAAK;IAChE,MAAM,KAAK,GAAG,CAAC,QAAiB,EAAE,IAAiB,EAAc,EAAE;QACjE,MAAM,CAAC,GAAG,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;QAC7B,KAAK,MAAM,GAAG,IAAI,QAAQ;YAAE,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QAC1C,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;IACpB,CAAC,CAAC;IACF,KAAK,CAAC,MAAM,GAAG,CAAC,OAAmB,EAAE,EAAE,EAAE,CACvC,IAAI,SAAS,CAAC,QAAQ,EAAE,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC;IACjE,OAAO,KAAK,CAAC;AACf,CAAC;AAED,MAAM,CAAC,MAAM,YAAY,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAC7E,MAAM,CAAC,MAAM,YAAY,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAC7E,MAAM,CAAC,MAAM,eAAe,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AACtF,MAAM,CAAC,MAAM,eAAe,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAKtF,MAAM,OAAO,YAAa,SAAQ,MAAM;IAKtC,YACE,QAAgB,EAChB,SAAiB,EACP,QAA4B,EACtC,SAAkB,EAClB,OAAqB,EAAE;QAEvB,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,CAAC,CAAC;QAJlC,aAAQ,GAAR,QAAQ,CAAoB;QANhC,aAAQ,GAAG,CAAC,CAAC,CAAC,qCAAqC;QACnD,eAAU,GAAG,CAAC,CAAC,CAAC,kCAAkC;QAUxD,UAAU,CAAC,IAAI,EAAE,EAAE,MAAM,EAAE,cAAc,EAAE,eAAe,EAAE,IAAI,CAAC,eAAe,EAAE,CAAC,CAAC;QACpF,IAAI,EAAE,QAAQ,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QAC3B,CAAC,KAAD,CAAC,GAAK,CAAC,EAAC;QACR,YAAY,CAAC,CAAC,CAAC,CAAC;QAChB,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;QAClB,KAAK,CAAC,MAAM,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;QAC5B,uCAAuC;QACvC,IAAI,CAAC,MAAM,GAAG,CAAC,IAAW,EAAE,EAAE;YAC5B,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;YACrB,MAAM,EAAE,QAAQ,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;YACpC,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;gBACjD,IAAI,IAAI,CAAC,QAAQ,IAAI,QAAQ,IAAI,CAAC,IAAI,CAAC,QAAQ,EAAE,CAAC;oBAChD,IAAI,IAAI,CAAC,QAAQ,EAAE,CAAC;wBAClB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;wBACrC,IAAI,CAAC,UAAU,EAAE,CAAC;oBACpB,CAAC;oBACD,IAAI,CAAC,QAAQ,GAAG,QAAQ,EAAE,CAAC;oBAC3B,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;gBACpB,CAAC;gBACD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;gBAC3D,IAAI,CAAC,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,CAAC,CAAC;gBACrD,IAAI,CAAC,QAAQ,IAAI,IAAI,CAAC;gBACtB,GAAG,IAAI,IAAI,CAAC;YACd,CAAC;YACD,OAAO,IAAI,CAAC;QACd,CAAC,CAAC;IACJ,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,IAAI,IAAI,CAAC,QAAQ,EAAE,CAAC;YAClB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;YACrC,IAAI,CAAC,UAAU,EAAE,CAAC;QACpB,CAAC;QACD,KAAK,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,UAAU,CAAC,CAAC,CAAC;QAC3C,KAAK,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,oBAAoB;QACxF,KAAK,CAAC,MAAM,EAAE,CAAC;IACjB,CAAC;IACD,UAAU,CAAC,EAAiB;QAC1B,EAAE,KAAF,EAAE,GAAK,IAAI,YAAY,CAAC,IAAI,CAAC,QAAQ,EAAE,IAAI,CAAC,SAAS,EAAE,IAAI,CAAC,QAAQ,EAAE,IAAI,CAAC,SAAS,CAAC,EAAC;QACtF,IAAI,IAAI,CAAC,QAAQ;YAAE,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC,UAAU,CAAC,EAAE,CAAC,QAAkB,CAAC,CAAC;QACjF,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,UAAU,GAAG,IAAI,CAAC,UAAU,CAAC;QAChC,OAAO,KAAK,CAAC,UAAU,CAAC,EAAE,CAAiB,CAAC;IAC9C,CAAC;IACD,OAAO;QACL,KAAK,CAAC,OAAO,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC;QACzB,IAAI,IAAI,CAAC,QAAQ;YAAE,IAAI,CAAC,QAAQ,CAAC,OAAO,EAAE,CAAC;IAC7C,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAED,SAAS,MAAM,CACb,QAAgB,EAChB,SAAiB,EACjB,IAAkC,EAClC,GAAG,GAAG,KAAK;IAEX,MAAM,QAAQ,GAAG,CAAC,OAAc,EAAE,IAAmB,EAAc,EAAE,CACnE,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;IACjD,QAAQ,CAAC,MAAM,GAAG,CAAC,OAAqB,EAAE,EAAE,EAAE,CAC5C,IAAI,YAAY,CACd,QAAQ,EACR,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAC1B,GAAG,EAAE,CAAC,IAAI,CAAC,MAAM,CAAC,EAAE,KAAK,EAAE,CAAC,GAAG,SAAS,EAAE,CAAC,EAC3C,GAAG,EACH,IAAI,CACL,CAAC;IACJ,OAAO,QAAQ,CAAC;AAClB,CAAC;AAED,MAAM,CAAC,MAAM,eAAe,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,SAAS,CAAC,CAAC,EAAE,CAAC;AACzF,MAAM,CAAC,MAAM,eAAe,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,SAAS,CAAC,CAAC,EAAE,CAAC;AACzF,MAAM,CAAC,MAAM,kBAAkB,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,SAAS,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAClG,MAAM,CAAC,MAAM,kBAAkB,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,SAAS,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAOlG,MAAM,aAAa,GAAG,CAAC,QAAgB,EAAE,SAAiB,EAAE,EAAE,CAC5D,0BAA0B,CAAkC,CAAC,OAAuB,EAAE,EAAE,EAAE;IACxF,MAAM,CAAC,GAAG,IAAI,CAAC,CAAC,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC;IAC/C,kFAAkF;IAClF,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,GAAG,IAAI;QAClD,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,wBAAwB,CAAC,CAAC;IAC1F,OAAO,IAAI,MAAM,CAAC,QAAQ,EAAE,CAAC,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,EAAE,EAAE,CAAC,CAAC;AAC9F,CAAC,CAAC,CAAC;AAEL,MAAM,CAAC,MAAM,aAAa,GAAG,eAAe,CAAC,aAAa,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACzE,MAAM,CAAC,MAAM,aAAa,GAAG,eAAe,CAAC,aAAa,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAEzE,WAAW;AACX,4DAA4D;AAC5D,SAAS,cAAc,CAAC,CAAS;IAC/B,MAAM,GAAG,GAAG,EAAE,CAAC;IACf,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC;QAAE,GAAG,CAAC,OAAO,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IAC7C,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrB,OAAO,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;AAC7B,CAAC;AAGD,MAAM,KAAK,GAAG,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC;AAEjC,MAAM,OAAO,cAAe,SAAQ,MAAM;IAMxC,YACE,QAAgB,EACN,OAAe,EACzB,SAAiB,EACjB,MAAc,EACd,IAAkB;QAElB,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,IAAI,EAAE,MAAM,CAAC,CAAC;QALrC,YAAO,GAAP,OAAO,CAAQ;QAPlB,aAAQ,GAAG,IAAI,CAAC;QAGjB,aAAQ,GAAG,CAAC,CAAC,CAAC,qCAAqC;QACnD,eAAU,GAAG,CAAC,CAAC,CAAC,kCAAkC;QASxD,MAAM,EAAE,eAAe,EAAE,GAAG,IAAI,CAAC;QACjC,IAAI,CAAC,eAAe,GAAG,eAAe,CAAC,eAAe,CAAC,CAAC;IAC1D,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;QACrB,MAAM,EAAE,QAAQ,EAAE,QAAQ,EAAE,OAAO,EAAE,MAAM,EAAE,GAAG,IAAI,CAAC;QACrD,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YACjD,IAAI,IAAI,CAAC,QAAQ,IAAI,QAAQ,EAAE,CAAC;gBAC9B,IAAI,IAAI,CAAC,QAAQ;oBAAE,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;qBACnD,CAAC;oBACJ,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,CAAC,iEAAiE;oBACrF,KAAK,CAAC,MAAM,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;gBACzD,CAAC;gBACD,IAAI,CAAC,QAAQ,GAAG,IAAI,MAAM,CAAC,QAAQ,EAAE,IAAI,EAAE,OAAO,EAAE,KAAK,EAAE,MAAM,CAAC,CAAC;gBACnE,IAAI,CAAC,UAAU,EAAE,CAAC;gBAClB,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;YACpB,CAAC;YACD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YAC3D,MAAM,KAAK,GAAG,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,CAAC;YAC7C,IAAI,IAAI,CAAC,QAAQ;gBAAE,IAAI,CAAC,QAAQ,CAAC,MAAM,CAAC,KAAK,CAAC,CAAC;;gBAC1C,KAAK,CAAC,MAAM,CAAC,KAAK,CAAC,CAAC;YACzB,IAAI,CAAC,QAAQ,IAAI,IAAI,CAAC;YACtB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,IAAI,CAAC;IACd,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,MAAM,EAAE,eAAe,EAAE,GAAG,IAAI,CAAC;QACjC,IAAI,CAAC,MAAM,CAAC,eAAe,CAAC,CAAC,MAAM,CAAC,cAAc,CAAC,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC;QAC5E,YAAY;QACZ,IAAI,IAAI,CAAC,QAAQ,EAAE,CAAC;YAClB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;YACrC,KAAK,CAAC,MAAM,CAAC,cAAc,CAAC,IAAI,CAAC,UAAU,CAAC,CAAC,CAAC;YAC9C,KAAK,CAAC,MAAM,CAAC,IAAI,UAAU,CAAC,CAAC,IAAI,EAAE,IAAI,CAAC,CAAC,CAAC,CAAC;QAC7C,CAAC;QACD,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC;IAC1B,CAAC;IACD,OAAO;QACL,KAAK,CAAC,OAAO,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC;QACzB,IAAI,IAAI,CAAC,QAAQ;YAAE,IAAI,CAAC,QAAQ,CAAC,OAAO,EAAE,CAAC;QAC3C,yGAAyG;QACzG,IAAI,CAAC,eAAe,GAAG,KAAK,CAAC;IAC/B,CAAC;IACD,UAAU,CAAC,EAAmB;QAC5B,MAAM,EAAE,QAAQ,EAAE,OAAO,EAAE,QAAQ,EAAE,SAAS,EAAE,MAAM,EAAE,GAAG,IAAI,CAAC;QAChE,EAAE,KAAF,EAAE,GAAK,IAAI,cAAc,CAAC,QAAQ,EAAE,OAAO,EAAE,SAAS,EAAE,MAAM,EAAE,EAAE,CAAC,EAAC;QACpE,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;QACrB,IAAI,QAAQ;YAAE,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC,UAAU,CAAC,EAAE,CAAC,QAAQ,CAAC,CAAC;QAC7D,EAAE,CAAC,eAAe,CAAC,GAAG,CAAC,IAAI,CAAC,eAAe,CAAC,CAAC;QAC7C,EAAE,CAAC,OAAO,GAAG,IAAI,CAAC,OAAO,CAAC;QAC1B,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,UAAU,GAAG,IAAI,CAAC,UAAU,CAAC;QAChC,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AACD,sDAAsD;AACtD,MAAM,CAAC,MAAM,GAAG,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CACvC,uBAAuB,CACrB,CAAC,OAAqB,EAAE,EAAE,EAAE,CAAC,IAAI,cAAc,CAAC,GAAG,EAAE,EAAE,EAAE,SAAS,CAAC,IAAI,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CACxF,CAAC,EAAE,CAAC;AACP,sBAAsB;AACtB,MAAM,CAAC,MAAM,GAAG,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CACvC,uBAAuB,CACrB,CAAC,OAAqB,EAAE,EAAE,EAAE,CAAC,IAAI,cAAc,CAAC,GAAG,EAAE,EAAE,EAAE,SAAS,CAAC,IAAI,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CACxF,CAAC,EAAE,CAAC;AAEP,wCAAwC;AACxC,iEAAiE;AACjE,MAAM,OAAO,SAAU,SAAQ,MAAM;IAEnC,YAAY,QAAgB;QAC1B,YAAY,CAAC,QAAQ,CAAC,CAAC;QACvB,2BAA2B;QAC3B,IAAI,QAAQ,GAAG,CAAC,IAAI,QAAQ,GAAG,IAAI,GAAG,EAAE,IAAI,CAAC,IAAI,GAAG,QAAQ,GAAG,CAAC,CAAC,GAAG,CAAC;YACnE,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;QACjD,0BAA0B;QAC1B,KAAK,CAAC,CAAC,IAAI,GAAG,QAAQ,GAAG,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;QAC7C,IAAI,CAAC,IAAI,GAAG,IAAI,GAAG,QAAQ,CAAC;QAC5B,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,KAAK,CAAC,CAAC,IAAI,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IAChD,CAAC;IACD,MAAM;QACJ,iBAAiB;QACjB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,GAAG,CAAC,IAAI,IAAI,CAAC;QAC7B,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,QAAQ,CAAC,IAAI,IAAI,CAAC,CAAC,oBAAoB;QACvD,KAAK,CAAC,MAAM,EAAE,CAAC;QACf,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;QACb,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC;IAClB,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;QACnB,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,OAAO,IAAI,CAAC;IACd,CAAC;IACD,IAAI,CAAC,IAAW;QACd,OAAO,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IAC3B,CAAC;IACS,MAAM,KAAI,CAAC;IACrB,UAAU,CAAC,IAAgB;QACzB,MAAM,IAAI,KAAK,CAAC,8DAA8D,CAAC,CAAC;IAClF,CAAC;IACD,KAAK,CAAC,KAAa;QACjB,OAAO,IAAI,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC;IACzB,CAAC;IACD,oFAAoF;IACpF,MAAM;QACJ,IAAI,IAAI,CAAC,IAAI,GAAG,IAAI,GAAG,CAAC,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;QACvF,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,QAAQ,EAAE,CAAC,EAAE;YAAE,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QAC1D,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;QACzB,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC;IAC9B,CAAC;IACD,UAAU,CAAC,EAAc;QACvB,MAAM,EAAE,IAAI,EAAE,GAAG,IAAI,CAAC;QACtB,EAAE,KAAF,EAAE,GAAK,IAAI,SAAS,CAAC,IAAI,GAAG,IAAI,CAAC,EAAC;QAClC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;QACrB,EAAE,CAAC,IAAI,GAAG,IAAI,CAAC;QACf,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAED,MAAM,CAAC,MAAM,SAAS,GAAG,CAAC,QAAQ,GAAG,GAAG,EAAE,EAAE,CAAC,IAAI,SAAS,CAAC,QAAQ,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.d.ts
+new file mode 100644
+index 0000000..82b88a8
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.d.ts
+@@ -0,0 +1,98 @@
++import { Hash, Input, HashXOF } from './utils.js';
++export declare function keccakP(s: Uint32Array, rounds?: number): void;
++export declare class Keccak extends Hash<Keccak> implements HashXOF<Keccak> {
++    blockLen: number;
++    suffix: number;
++    outputLen: number;
++    protected enableXOF: boolean;
++    protected rounds: number;
++    protected state: Uint8Array;
++    protected pos: number;
++    protected posOut: number;
++    protected finished: boolean;
++    protected state32: Uint32Array;
++    protected destroyed: boolean;
++    constructor(blockLen: number, suffix: number, outputLen: number, enableXOF?: boolean, rounds?: number);
++    protected keccak(): void;
++    update(data: Input): this;
++    protected finish(): void;
++    protected writeInto(out: Uint8Array): Uint8Array;
++    xofInto(out: Uint8Array): Uint8Array;
++    xof(bytes: number): Uint8Array;
++    digestInto(out: Uint8Array): Uint8Array;
++    digest(): Uint8Array;
++    destroy(): void;
++    _cloneInto(to?: Keccak): Keccak;
++}
++export declare const sha3_224: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++/**
++ * SHA3-256 hash function
++ * @param message - that would be hashed
++ */
++export declare const sha3_256: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const sha3_384: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const sha3_512: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const keccak_224: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++/**
++ * keccak-256 hash function. Different from SHA3-256.
++ * @param message - that would be hashed
++ */
++export declare const keccak_256: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const keccak_384: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const keccak_512: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export type ShakeOpts = {
++    dkLen?: number;
++};
++export declare const shake128: {
++    (msg: Input, opts?: ShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: ShakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++export declare const shake256: {
++    (msg: Input, opts?: ShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: ShakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++//# sourceMappingURL=sha3.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.d.ts.map
+new file mode 100644
+index 0000000..18faedf
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3.d.ts","sourceRoot":"","sources":["../src/sha3.ts"],"names":[],"mappings":"AAEA,OAAO,EACL,IAAI,EAEJ,KAAK,EAIL,OAAO,EAGR,MAAM,YAAY,CAAC;AAoCpB,wBAAgB,OAAO,CAAC,CAAC,EAAE,WAAW,EAAE,MAAM,GAAE,MAAW,QAyC1D;AAED,qBAAa,MAAO,SAAQ,IAAI,CAAC,MAAM,CAAE,YAAW,OAAO,CAAC,MAAM,CAAC;IASxD,QAAQ,EAAE,MAAM;IAChB,MAAM,EAAE,MAAM;IACd,SAAS,EAAE,MAAM;IACxB,SAAS,CAAC,SAAS;IACnB,SAAS,CAAC,MAAM,EAAE,MAAM;IAZ1B,SAAS,CAAC,KAAK,EAAE,UAAU,CAAC;IAC5B,SAAS,CAAC,GAAG,SAAK;IAClB,SAAS,CAAC,MAAM,SAAK;IACrB,SAAS,CAAC,QAAQ,UAAS;IAC3B,SAAS,CAAC,OAAO,EAAE,WAAW,CAAC;IAC/B,SAAS,CAAC,SAAS,UAAS;gBAGnB,QAAQ,EAAE,MAAM,EAChB,MAAM,EAAE,MAAM,EACd,SAAS,EAAE,MAAM,EACd,SAAS,UAAQ,EACjB,MAAM,GAAE,MAAW;IAW/B,SAAS,CAAC,MAAM;IAOhB,MAAM,CAAC,IAAI,EAAE,KAAK;IAYlB,SAAS,CAAC,MAAM;IAUhB,SAAS,CAAC,SAAS,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU;IAehD,OAAO,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU;IAKpC,GAAG,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU;IAI9B,UAAU,CAAC,GAAG,EAAE,UAAU;IAO1B,MAAM;IAGN,OAAO;IAIP,UAAU,CAAC,EAAE,CAAC,EAAE,MAAM,GAAG,MAAM;CAehC;AAKD,eAAO,MAAM,QAAQ;;;;;CAA0C,CAAC;AAChE;;;GAGG;AACH,eAAO,MAAM,QAAQ;;;;;CAA0C,CAAC;AAChE,eAAO,MAAM,QAAQ;;;;;CAA0C,CAAC;AAChE,eAAO,MAAM,QAAQ;;;;;CAAyC,CAAC;AAC/D,eAAO,MAAM,UAAU;;;;;CAA0C,CAAC;AAClE;;;GAGG;AACH,eAAO,MAAM,UAAU;;;;;CAA0C,CAAC;AAClE,eAAO,MAAM,UAAU;;;;;CAA0C,CAAC;AAClE,eAAO,MAAM,UAAU;;;;;CAAyC,CAAC;AAEjE,MAAM,MAAM,SAAS,GAAG;IAAE,KAAK,CAAC,EAAE,MAAM,CAAA;CAAE,CAAC;AAQ3C,eAAO,MAAM,QAAQ;;;;;CAA+C,CAAC;AACrE,eAAO,MAAM,QAAQ;;;;;CAA+C,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.js
+new file mode 100644
+index 0000000..4809ba7
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.js
+@@ -0,0 +1,214 @@
++import { bytes, exists, number, output } from './_assert.js';
++import { rotlBH, rotlBL, rotlSH, rotlSL, split } from './_u64.js';
++import { Hash, u32, toBytes, wrapConstructor, wrapXOFConstructorWithOpts, isLE, byteSwap32, } from './utils.js';
++// SHA3 (keccak) is based on a new design: basically, the internal state is bigger than output size.
++// It's called a sponge function.
++// Various per round constants calculations
++const SHA3_PI = [];
++const SHA3_ROTL = [];
++const _SHA3_IOTA = [];
++const _0n = /* @__PURE__ */ BigInt(0);
++const _1n = /* @__PURE__ */ BigInt(1);
++const _2n = /* @__PURE__ */ BigInt(2);
++const _7n = /* @__PURE__ */ BigInt(7);
++const _256n = /* @__PURE__ */ BigInt(256);
++const _0x71n = /* @__PURE__ */ BigInt(0x71);
++for (let round = 0, R = _1n, x = 1, y = 0; round < 24; round++) {
++    // Pi
++    [x, y] = [y, (2 * x + 3 * y) % 5];
++    SHA3_PI.push(2 * (5 * y + x));
++    // Rotational
++    SHA3_ROTL.push((((round + 1) * (round + 2)) / 2) % 64);
++    // Iota
++    let t = _0n;
++    for (let j = 0; j < 7; j++) {
++        R = ((R << _1n) ^ ((R >> _7n) * _0x71n)) % _256n;
++        if (R & _2n)
++            t ^= _1n << ((_1n << /* @__PURE__ */ BigInt(j)) - _1n);
++    }
++    _SHA3_IOTA.push(t);
++}
++const [SHA3_IOTA_H, SHA3_IOTA_L] = /* @__PURE__ */ split(_SHA3_IOTA, true);
++// Left rotation (without 0, 32, 64)
++const rotlH = (h, l, s) => (s > 32 ? rotlBH(h, l, s) : rotlSH(h, l, s));
++const rotlL = (h, l, s) => (s > 32 ? rotlBL(h, l, s) : rotlSL(h, l, s));
++// Same as keccakf1600, but allows to skip some rounds
++export function keccakP(s, rounds = 24) {
++    const B = new Uint32Array(5 * 2);
++    // NOTE: all indices are x2 since we store state as u32 instead of u64 (bigints to slow in js)
++    for (let round = 24 - rounds; round < 24; round++) {
++        // Theta θ
++        for (let x = 0; x < 10; x++)
++            B[x] = s[x] ^ s[x + 10] ^ s[x + 20] ^ s[x + 30] ^ s[x + 40];
++        for (let x = 0; x < 10; x += 2) {
++            const idx1 = (x + 8) % 10;
++            const idx0 = (x + 2) % 10;
++            const B0 = B[idx0];
++            const B1 = B[idx0 + 1];
++            const Th = rotlH(B0, B1, 1) ^ B[idx1];
++            const Tl = rotlL(B0, B1, 1) ^ B[idx1 + 1];
++            for (let y = 0; y < 50; y += 10) {
++                s[x + y] ^= Th;
++                s[x + y + 1] ^= Tl;
++            }
++        }
++        // Rho (ρ) and Pi (π)
++        let curH = s[2];
++        let curL = s[3];
++        for (let t = 0; t < 24; t++) {
++            const shift = SHA3_ROTL[t];
++            const Th = rotlH(curH, curL, shift);
++            const Tl = rotlL(curH, curL, shift);
++            const PI = SHA3_PI[t];
++            curH = s[PI];
++            curL = s[PI + 1];
++            s[PI] = Th;
++            s[PI + 1] = Tl;
++        }
++        // Chi (χ)
++        for (let y = 0; y < 50; y += 10) {
++            for (let x = 0; x < 10; x++)
++                B[x] = s[y + x];
++            for (let x = 0; x < 10; x++)
++                s[y + x] ^= ~B[(x + 2) % 10] & B[(x + 4) % 10];
++        }
++        // Iota (ι)
++        s[0] ^= SHA3_IOTA_H[round];
++        s[1] ^= SHA3_IOTA_L[round];
++    }
++    B.fill(0);
++}
++export class Keccak extends Hash {
++    // NOTE: we accept arguments in bytes instead of bits here.
++    constructor(blockLen, suffix, outputLen, enableXOF = false, rounds = 24) {
++        super();
++        this.blockLen = blockLen;
++        this.suffix = suffix;
++        this.outputLen = outputLen;
++        this.enableXOF = enableXOF;
++        this.rounds = rounds;
++        this.pos = 0;
++        this.posOut = 0;
++        this.finished = false;
++        this.destroyed = false;
++        // Can be passed from user as dkLen
++        number(outputLen);
++        // 1600 = 5x5 matrix of 64bit.  1600 bits === 200 bytes
++        if (0 >= this.blockLen || this.blockLen >= 200)
++            throw new Error('Sha3 supports only keccak-f1600 function');
++        this.state = new Uint8Array(200);
++        this.state32 = u32(this.state);
++    }
++    keccak() {
++        if (!isLE)
++            byteSwap32(this.state32);
++        keccakP(this.state32, this.rounds);
++        if (!isLE)
++            byteSwap32(this.state32);
++        this.posOut = 0;
++        this.pos = 0;
++    }
++    update(data) {
++        exists(this);
++        const { blockLen, state } = this;
++        data = toBytes(data);
++        const len = data.length;
++        for (let pos = 0; pos < len;) {
++            const take = Math.min(blockLen - this.pos, len - pos);
++            for (let i = 0; i < take; i++)
++                state[this.pos++] ^= data[pos++];
++            if (this.pos === blockLen)
++                this.keccak();
++        }
++        return this;
++    }
++    finish() {
++        if (this.finished)
++            return;
++        this.finished = true;
++        const { state, suffix, pos, blockLen } = this;
++        // Do the padding
++        state[pos] ^= suffix;
++        if ((suffix & 0x80) !== 0 && pos === blockLen - 1)
++            this.keccak();
++        state[blockLen - 1] ^= 0x80;
++        this.keccak();
++    }
++    writeInto(out) {
++        exists(this, false);
++        bytes(out);
++        this.finish();
++        const bufferOut = this.state;
++        const { blockLen } = this;
++        for (let pos = 0, len = out.length; pos < len;) {
++            if (this.posOut >= blockLen)
++                this.keccak();
++            const take = Math.min(blockLen - this.posOut, len - pos);
++            out.set(bufferOut.subarray(this.posOut, this.posOut + take), pos);
++            this.posOut += take;
++            pos += take;
++        }
++        return out;
++    }
++    xofInto(out) {
++        // Sha3/Keccak usage with XOF is probably mistake, only SHAKE instances can do XOF
++        if (!this.enableXOF)
++            throw new Error('XOF is not possible for this instance');
++        return this.writeInto(out);
++    }
++    xof(bytes) {
++        number(bytes);
++        return this.xofInto(new Uint8Array(bytes));
++    }
++    digestInto(out) {
++        output(out, this);
++        if (this.finished)
++            throw new Error('digest() was already called');
++        this.writeInto(out);
++        this.destroy();
++        return out;
++    }
++    digest() {
++        return this.digestInto(new Uint8Array(this.outputLen));
++    }
++    destroy() {
++        this.destroyed = true;
++        this.state.fill(0);
++    }
++    _cloneInto(to) {
++        const { blockLen, suffix, outputLen, rounds, enableXOF } = this;
++        to || (to = new Keccak(blockLen, suffix, outputLen, enableXOF, rounds));
++        to.state32.set(this.state32);
++        to.pos = this.pos;
++        to.posOut = this.posOut;
++        to.finished = this.finished;
++        to.rounds = rounds;
++        // Suffix can change in cSHAKE
++        to.suffix = suffix;
++        to.outputLen = outputLen;
++        to.enableXOF = enableXOF;
++        to.destroyed = this.destroyed;
++        return to;
++    }
++}
++const gen = (suffix, blockLen, outputLen) => wrapConstructor(() => new Keccak(blockLen, suffix, outputLen));
++export const sha3_224 = /* @__PURE__ */ gen(0x06, 144, 224 / 8);
++/**
++ * SHA3-256 hash function
++ * @param message - that would be hashed
++ */
++export const sha3_256 = /* @__PURE__ */ gen(0x06, 136, 256 / 8);
++export const sha3_384 = /* @__PURE__ */ gen(0x06, 104, 384 / 8);
++export const sha3_512 = /* @__PURE__ */ gen(0x06, 72, 512 / 8);
++export const keccak_224 = /* @__PURE__ */ gen(0x01, 144, 224 / 8);
++/**
++ * keccak-256 hash function. Different from SHA3-256.
++ * @param message - that would be hashed
++ */
++export const keccak_256 = /* @__PURE__ */ gen(0x01, 136, 256 / 8);
++export const keccak_384 = /* @__PURE__ */ gen(0x01, 104, 384 / 8);
++export const keccak_512 = /* @__PURE__ */ gen(0x01, 72, 512 / 8);
++const genShake = (suffix, blockLen, outputLen) => wrapXOFConstructorWithOpts((opts = {}) => new Keccak(blockLen, suffix, opts.dkLen === undefined ? outputLen : opts.dkLen, true));
++export const shake128 = /* @__PURE__ */ genShake(0x1f, 168, 128 / 8);
++export const shake256 = /* @__PURE__ */ genShake(0x1f, 136, 256 / 8);
++//# sourceMappingURL=sha3.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.js.map
+new file mode 100644
+index 0000000..e73a11c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha3.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3.js","sourceRoot":"","sources":["../src/sha3.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,cAAc,CAAC;AAC7D,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,KAAK,EAAE,MAAM,WAAW,CAAC;AAClE,OAAO,EACL,IAAI,EACJ,GAAG,EAEH,OAAO,EACP,eAAe,EACf,0BAA0B,EAE1B,IAAI,EACJ,UAAU,GACX,MAAM,YAAY,CAAC;AAEpB,oGAAoG;AACpG,iCAAiC;AAEjC,2CAA2C;AAC3C,MAAM,OAAO,GAAa,EAAE,CAAC;AAC7B,MAAM,SAAS,GAAa,EAAE,CAAC;AAC/B,MAAM,UAAU,GAAa,EAAE,CAAC;AAChC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,KAAK,GAAG,eAAe,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;AAC1C,MAAM,MAAM,GAAG,eAAe,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;AAC5C,KAAK,IAAI,KAAK,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,KAAK,GAAG,EAAE,EAAE,KAAK,EAAE,EAAE,CAAC;IAC/D,KAAK;IACL,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IAClC,OAAO,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;IAC9B,aAAa;IACb,SAAS,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,KAAK,GAAG,CAAC,CAAC,GAAG,CAAC,KAAK,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IACvD,OAAO;IACP,IAAI,CAAC,GAAG,GAAG,CAAC;IACZ,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;QAC3B,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,GAAG,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,KAAK,CAAC;QACjD,IAAI,CAAC,GAAG,GAAG;YAAE,CAAC,IAAI,GAAG,IAAI,CAAC,CAAC,GAAG,IAAI,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,CAAC;IACtE,CAAC;IACD,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;AACrB,CAAC;AACD,MAAM,CAAC,WAAW,EAAE,WAAW,CAAC,GAAG,eAAe,CAAC,KAAK,CAAC,UAAU,EAAE,IAAI,CAAC,CAAC;AAE3E,oCAAoC;AACpC,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;AAChG,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;AAEhG,sDAAsD;AACtD,MAAM,UAAU,OAAO,CAAC,CAAc,EAAE,SAAiB,EAAE;IACzD,MAAM,CAAC,GAAG,IAAI,WAAW,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACjC,8FAA8F;IAC9F,KAAK,IAAI,KAAK,GAAG,EAAE,GAAG,MAAM,EAAE,KAAK,GAAG,EAAE,EAAE,KAAK,EAAE,EAAE,CAAC;QAClD,UAAU;QACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;QACzF,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC;YAC/B,MAAM,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;YAC1B,MAAM,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;YAC1B,MAAM,EAAE,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC;YACnB,MAAM,EAAE,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;YACvB,MAAM,EAAE,GAAG,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC;YACtC,MAAM,EAAE,GAAG,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;YAC1C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,EAAE,EAAE,CAAC;gBAChC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,EAAE,CAAC;gBACf,CAAC,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,IAAI,EAAE,CAAC;YACrB,CAAC;QACH,CAAC;QACD,qBAAqB;QACrB,IAAI,IAAI,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;QAChB,IAAI,IAAI,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;QAChB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,MAAM,KAAK,GAAG,SAAS,CAAC,CAAC,CAAC,CAAC;YAC3B,MAAM,EAAE,GAAG,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,KAAK,CAAC,CAAC;YACpC,MAAM,EAAE,GAAG,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,KAAK,CAAC,CAAC;YACpC,MAAM,EAAE,GAAG,OAAO,CAAC,CAAC,CAAC,CAAC;YACtB,IAAI,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;YACb,IAAI,GAAG,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC;YACjB,CAAC,CAAC,EAAE,CAAC,GAAG,EAAE,CAAC;YACX,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;QACjB,CAAC;QACD,UAAU;QACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,EAAE,EAAE,CAAC;YAChC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;gBAAE,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;YAC7C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;gBAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;QAC9E,CAAC;QACD,WAAW;QACX,CAAC,CAAC,CAAC,CAAC,IAAI,WAAW,CAAC,KAAK,CAAC,CAAC;QAC3B,CAAC,CAAC,CAAC,CAAC,IAAI,WAAW,CAAC,KAAK,CAAC,CAAC;IAC7B,CAAC;IACD,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;AACZ,CAAC;AAED,MAAM,OAAO,MAAO,SAAQ,IAAY;IAOtC,2DAA2D;IAC3D,YACS,QAAgB,EAChB,MAAc,EACd,SAAiB,EACd,YAAY,KAAK,EACjB,SAAiB,EAAE;QAE7B,KAAK,EAAE,CAAC;QAND,aAAQ,GAAR,QAAQ,CAAQ;QAChB,WAAM,GAAN,MAAM,CAAQ;QACd,cAAS,GAAT,SAAS,CAAQ;QACd,cAAS,GAAT,SAAS,CAAQ;QACjB,WAAM,GAAN,MAAM,CAAa;QAXrB,QAAG,GAAG,CAAC,CAAC;QACR,WAAM,GAAG,CAAC,CAAC;QACX,aAAQ,GAAG,KAAK,CAAC;QAEjB,cAAS,GAAG,KAAK,CAAC;QAU1B,mCAAmC;QACnC,MAAM,CAAC,SAAS,CAAC,CAAC;QAClB,uDAAuD;QACvD,IAAI,CAAC,IAAI,IAAI,CAAC,QAAQ,IAAI,IAAI,CAAC,QAAQ,IAAI,GAAG;YAC5C,MAAM,IAAI,KAAK,CAAC,0CAA0C,CAAC,CAAC;QAC9D,IAAI,CAAC,KAAK,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;QACjC,IAAI,CAAC,OAAO,GAAG,GAAG,CAAC,IAAI,CAAC,KAAK,CAAC,CAAC;IACjC,CAAC;IACS,MAAM;QACd,IAAI,CAAC,IAAI;YAAE,UAAU,CAAC,IAAI,CAAC,OAAO,CAAC,CAAC;QACpC,OAAO,CAAC,IAAI,CAAC,OAAO,EAAE,IAAI,CAAC,MAAM,CAAC,CAAC;QACnC,IAAI,CAAC,IAAI;YAAE,UAAU,CAAC,IAAI,CAAC,OAAO,CAAC,CAAC;QACpC,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC;QAChB,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;IACf,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,MAAM,CAAC,IAAI,CAAC,CAAC;QACb,MAAM,EAAE,QAAQ,EAAE,KAAK,EAAE,GAAG,IAAI,CAAC;QACjC,IAAI,GAAG,OAAO,CAAC,IAAI,CAAC,CAAC;QACrB,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAC9B,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACtD,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,IAAI,EAAE,CAAC,EAAE;gBAAE,KAAK,CAAC,IAAI,CAAC,GAAG,EAAE,CAAC,IAAI,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC;YAChE,IAAI,IAAI,CAAC,GAAG,KAAK,QAAQ;gBAAE,IAAI,CAAC,MAAM,EAAE,CAAC;QAC3C,CAAC;QACD,OAAO,IAAI,CAAC;IACd,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,MAAM,EAAE,KAAK,EAAE,MAAM,EAAE,GAAG,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC9C,iBAAiB;QACjB,KAAK,CAAC,GAAG,CAAC,IAAI,MAAM,CAAC;QACrB,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,KAAK,CAAC,IAAI,GAAG,KAAK,QAAQ,GAAG,CAAC;YAAE,IAAI,CAAC,MAAM,EAAE,CAAC;QACjE,KAAK,CAAC,QAAQ,GAAG,CAAC,CAAC,IAAI,IAAI,CAAC;QAC5B,IAAI,CAAC,MAAM,EAAE,CAAC;IAChB,CAAC;IACS,SAAS,CAAC,GAAe;QACjC,MAAM,CAAC,IAAI,EAAE,KAAK,CAAC,CAAC;QACpB,KAAK,CAAC,GAAG,CAAC,CAAC;QACX,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,MAAM,SAAS,GAAG,IAAI,CAAC,KAAK,CAAC;QAC7B,MAAM,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC1B,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAChD,IAAI,IAAI,CAAC,MAAM,IAAI,QAAQ;gBAAE,IAAI,CAAC,MAAM,EAAE,CAAC;YAC3C,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACzD,GAAG,CAAC,GAAG,CAAC,SAAS,CAAC,QAAQ,CAAC,IAAI,CAAC,MAAM,EAAE,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC;YAClE,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC;YACpB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,GAAG,CAAC;IACb,CAAC;IACD,OAAO,CAAC,GAAe;QACrB,kFAAkF;QAClF,IAAI,CAAC,IAAI,CAAC,SAAS;YAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;QAC9E,OAAO,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;IAC7B,CAAC;IACD,GAAG,CAAC,KAAa;QACf,MAAM,CAAC,KAAK,CAAC,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,CAAC,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;IAC7C,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,MAAM,CAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,IAAI,IAAI,CAAC,QAAQ;YAAE,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;QAClE,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;QACpB,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,MAAM;QACJ,OAAO,IAAI,CAAC,UAAU,CAAC,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC;IACzD,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACrB,CAAC;IACD,UAAU,CAAC,EAAW;QACpB,MAAM,EAAE,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QAChE,EAAE,KAAF,EAAE,GAAK,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,SAAS,EAAE,MAAM,CAAC,EAAC;QAClE,EAAE,CAAC,OAAO,CAAC,GAAG,CAAC,IAAI,CAAC,OAAO,CAAC,CAAC;QAC7B,EAAE,CAAC,GAAG,GAAG,IAAI,CAAC,GAAG,CAAC;QAClB,EAAE,CAAC,MAAM,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,8BAA8B;QAC9B,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,SAAS,GAAG,IAAI,CAAC,SAAS,CAAC;QAC9B,OAAO,EAAE,CAAC;IACZ,CAAC;CACF;AAED,MAAM,GAAG,GAAG,CAAC,MAAc,EAAE,QAAgB,EAAE,SAAiB,EAAE,EAAE,CAClE,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,CAAC,CAAC,CAAC;AAEjE,MAAM,CAAC,MAAM,QAAQ,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAChE;;;GAGG;AACH,MAAM,CAAC,MAAM,QAAQ,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAChE,MAAM,CAAC,MAAM,QAAQ,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAChE,MAAM,CAAC,MAAM,QAAQ,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAC/D,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAClE;;;GAGG;AACH,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAClE,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAClE,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,GAAG,CAAC,IAAI,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAIjE,MAAM,QAAQ,GAAG,CAAC,MAAc,EAAE,QAAgB,EAAE,SAAiB,EAAE,EAAE,CACvE,0BAA0B,CACxB,CAAC,OAAkB,EAAE,EAAE,EAAE,CACvB,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,CAAC,CACxF,CAAC;AAEJ,MAAM,CAAC,MAAM,QAAQ,GAAG,eAAe,CAAC,QAAQ,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACrE,MAAM,CAAC,MAAM,QAAQ,GAAG,eAAe,CAAC,QAAQ,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.d.ts
+new file mode 100644
+index 0000000..2282d2b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.d.ts
+@@ -0,0 +1,124 @@
++import { HashMD } from './_md.js';
++export declare class SHA512 extends HashMD<SHA512> {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++    protected get(): [
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number
++    ];
++    protected set(Ah: number, Al: number, Bh: number, Bl: number, Ch: number, Cl: number, Dh: number, Dl: number, Eh: number, El: number, Fh: number, Fl: number, Gh: number, Gl: number, Hh: number, Hl: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++export declare class SHA512_224 extends SHA512 {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++}
++export declare class SHA512_256 extends SHA512 {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++}
++export declare class SHA384 extends SHA512 {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++}
++export declare const sha512: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++export declare const sha512_224: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++export declare const sha512_256: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++export declare const sha384: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++//# sourceMappingURL=sha512.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.d.ts.map
+new file mode 100644
+index 0000000..0a0b9fd
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha512.d.ts","sourceRoot":"","sources":["../src/sha512.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,UAAU,CAAC;AAgClC,qBAAa,MAAO,SAAQ,MAAM,CAAC,MAAM,CAAC;IAKxC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;IAMpB,SAAS,CAAC,GAAG,IAAI;QACf,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAC9D,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;KAC/D;IAKD,SAAS,CAAC,GAAG,CACX,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAC9F,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;IAmBhG,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM;IAsEhD,SAAS,CAAC,UAAU;IAIpB,OAAO;CAIR;AAED,qBAAa,UAAW,SAAQ,MAAM;IAEpC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;CAMrB;AAED,qBAAa,UAAW,SAAQ,MAAM;IAEpC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;CAMrB;AAED,qBAAa,MAAO,SAAQ,MAAM;IAEhC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;CAMrB;AAED,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC;AAC1E,eAAO,MAAM,UAAU;;;;;CAA0D,CAAC;AAClF,eAAO,MAAM,UAAU;;;;;CAA0D,CAAC;AAClF,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.js
+new file mode 100644
+index 0000000..6ea9be1
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.js
+@@ -0,0 +1,231 @@
++import { HashMD } from './_md.js';
++import u64 from './_u64.js';
++import { wrapConstructor } from './utils.js';
++// Round contants (first 32 bits of the fractional parts of the cube roots of the first 80 primes 2..409):
++// prettier-ignore
++const [SHA512_Kh, SHA512_Kl] = /* @__PURE__ */ (() => u64.split([
++    '0x428a2f98d728ae22', '0x7137449123ef65cd', '0xb5c0fbcfec4d3b2f', '0xe9b5dba58189dbbc',
++    '0x3956c25bf348b538', '0x59f111f1b605d019', '0x923f82a4af194f9b', '0xab1c5ed5da6d8118',
++    '0xd807aa98a3030242', '0x12835b0145706fbe', '0x243185be4ee4b28c', '0x550c7dc3d5ffb4e2',
++    '0x72be5d74f27b896f', '0x80deb1fe3b1696b1', '0x9bdc06a725c71235', '0xc19bf174cf692694',
++    '0xe49b69c19ef14ad2', '0xefbe4786384f25e3', '0x0fc19dc68b8cd5b5', '0x240ca1cc77ac9c65',
++    '0x2de92c6f592b0275', '0x4a7484aa6ea6e483', '0x5cb0a9dcbd41fbd4', '0x76f988da831153b5',
++    '0x983e5152ee66dfab', '0xa831c66d2db43210', '0xb00327c898fb213f', '0xbf597fc7beef0ee4',
++    '0xc6e00bf33da88fc2', '0xd5a79147930aa725', '0x06ca6351e003826f', '0x142929670a0e6e70',
++    '0x27b70a8546d22ffc', '0x2e1b21385c26c926', '0x4d2c6dfc5ac42aed', '0x53380d139d95b3df',
++    '0x650a73548baf63de', '0x766a0abb3c77b2a8', '0x81c2c92e47edaee6', '0x92722c851482353b',
++    '0xa2bfe8a14cf10364', '0xa81a664bbc423001', '0xc24b8b70d0f89791', '0xc76c51a30654be30',
++    '0xd192e819d6ef5218', '0xd69906245565a910', '0xf40e35855771202a', '0x106aa07032bbd1b8',
++    '0x19a4c116b8d2d0c8', '0x1e376c085141ab53', '0x2748774cdf8eeb99', '0x34b0bcb5e19b48a8',
++    '0x391c0cb3c5c95a63', '0x4ed8aa4ae3418acb', '0x5b9cca4f7763e373', '0x682e6ff3d6b2b8a3',
++    '0x748f82ee5defb2fc', '0x78a5636f43172f60', '0x84c87814a1f0ab72', '0x8cc702081a6439ec',
++    '0x90befffa23631e28', '0xa4506cebde82bde9', '0xbef9a3f7b2c67915', '0xc67178f2e372532b',
++    '0xca273eceea26619c', '0xd186b8c721c0c207', '0xeada7dd6cde0eb1e', '0xf57d4f7fee6ed178',
++    '0x06f067aa72176fba', '0x0a637dc5a2c898a6', '0x113f9804bef90dae', '0x1b710b35131c471b',
++    '0x28db77f523047d84', '0x32caab7b40c72493', '0x3c9ebe0a15c9bebc', '0x431d67c49c100d4c',
++    '0x4cc5d4becb3e42b6', '0x597f299cfc657e2a', '0x5fcb6fab3ad6faec', '0x6c44198c4a475817'
++].map(n => BigInt(n))))();
++// Temporary buffer, not used to store anything between runs
++const SHA512_W_H = /* @__PURE__ */ new Uint32Array(80);
++const SHA512_W_L = /* @__PURE__ */ new Uint32Array(80);
++export class SHA512 extends HashMD {
++    constructor() {
++        super(128, 64, 16, false);
++        // We cannot use array here since array allows indexing by variable which means optimizer/compiler cannot use registers.
++        // Also looks cleaner and easier to verify with spec.
++        // Initial state (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0x6a09e667 | 0;
++        this.Al = 0xf3bcc908 | 0;
++        this.Bh = 0xbb67ae85 | 0;
++        this.Bl = 0x84caa73b | 0;
++        this.Ch = 0x3c6ef372 | 0;
++        this.Cl = 0xfe94f82b | 0;
++        this.Dh = 0xa54ff53a | 0;
++        this.Dl = 0x5f1d36f1 | 0;
++        this.Eh = 0x510e527f | 0;
++        this.El = 0xade682d1 | 0;
++        this.Fh = 0x9b05688c | 0;
++        this.Fl = 0x2b3e6c1f | 0;
++        this.Gh = 0x1f83d9ab | 0;
++        this.Gl = 0xfb41bd6b | 0;
++        this.Hh = 0x5be0cd19 | 0;
++        this.Hl = 0x137e2179 | 0;
++    }
++    // prettier-ignore
++    get() {
++        const { Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl } = this;
++        return [Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl];
++    }
++    // prettier-ignore
++    set(Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl) {
++        this.Ah = Ah | 0;
++        this.Al = Al | 0;
++        this.Bh = Bh | 0;
++        this.Bl = Bl | 0;
++        this.Ch = Ch | 0;
++        this.Cl = Cl | 0;
++        this.Dh = Dh | 0;
++        this.Dl = Dl | 0;
++        this.Eh = Eh | 0;
++        this.El = El | 0;
++        this.Fh = Fh | 0;
++        this.Fl = Fl | 0;
++        this.Gh = Gh | 0;
++        this.Gl = Gl | 0;
++        this.Hh = Hh | 0;
++        this.Hl = Hl | 0;
++    }
++    process(view, offset) {
++        // Extend the first 16 words into the remaining 64 words w[16..79] of the message schedule array
++        for (let i = 0; i < 16; i++, offset += 4) {
++            SHA512_W_H[i] = view.getUint32(offset);
++            SHA512_W_L[i] = view.getUint32((offset += 4));
++        }
++        for (let i = 16; i < 80; i++) {
++            // s0 := (w[i-15] rightrotate 1) xor (w[i-15] rightrotate 8) xor (w[i-15] rightshift 7)
++            const W15h = SHA512_W_H[i - 15] | 0;
++            const W15l = SHA512_W_L[i - 15] | 0;
++            const s0h = u64.rotrSH(W15h, W15l, 1) ^ u64.rotrSH(W15h, W15l, 8) ^ u64.shrSH(W15h, W15l, 7);
++            const s0l = u64.rotrSL(W15h, W15l, 1) ^ u64.rotrSL(W15h, W15l, 8) ^ u64.shrSL(W15h, W15l, 7);
++            // s1 := (w[i-2] rightrotate 19) xor (w[i-2] rightrotate 61) xor (w[i-2] rightshift 6)
++            const W2h = SHA512_W_H[i - 2] | 0;
++            const W2l = SHA512_W_L[i - 2] | 0;
++            const s1h = u64.rotrSH(W2h, W2l, 19) ^ u64.rotrBH(W2h, W2l, 61) ^ u64.shrSH(W2h, W2l, 6);
++            const s1l = u64.rotrSL(W2h, W2l, 19) ^ u64.rotrBL(W2h, W2l, 61) ^ u64.shrSL(W2h, W2l, 6);
++            // SHA256_W[i] = s0 + s1 + SHA256_W[i - 7] + SHA256_W[i - 16];
++            const SUMl = u64.add4L(s0l, s1l, SHA512_W_L[i - 7], SHA512_W_L[i - 16]);
++            const SUMh = u64.add4H(SUMl, s0h, s1h, SHA512_W_H[i - 7], SHA512_W_H[i - 16]);
++            SHA512_W_H[i] = SUMh | 0;
++            SHA512_W_L[i] = SUMl | 0;
++        }
++        let { Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl } = this;
++        // Compression function main loop, 80 rounds
++        for (let i = 0; i < 80; i++) {
++            // S1 := (e rightrotate 14) xor (e rightrotate 18) xor (e rightrotate 41)
++            const sigma1h = u64.rotrSH(Eh, El, 14) ^ u64.rotrSH(Eh, El, 18) ^ u64.rotrBH(Eh, El, 41);
++            const sigma1l = u64.rotrSL(Eh, El, 14) ^ u64.rotrSL(Eh, El, 18) ^ u64.rotrBL(Eh, El, 41);
++            //const T1 = (H + sigma1 + Chi(E, F, G) + SHA256_K[i] + SHA256_W[i]) | 0;
++            const CHIh = (Eh & Fh) ^ (~Eh & Gh);
++            const CHIl = (El & Fl) ^ (~El & Gl);
++            // T1 = H + sigma1 + Chi(E, F, G) + SHA512_K[i] + SHA512_W[i]
++            // prettier-ignore
++            const T1ll = u64.add5L(Hl, sigma1l, CHIl, SHA512_Kl[i], SHA512_W_L[i]);
++            const T1h = u64.add5H(T1ll, Hh, sigma1h, CHIh, SHA512_Kh[i], SHA512_W_H[i]);
++            const T1l = T1ll | 0;
++            // S0 := (a rightrotate 28) xor (a rightrotate 34) xor (a rightrotate 39)
++            const sigma0h = u64.rotrSH(Ah, Al, 28) ^ u64.rotrBH(Ah, Al, 34) ^ u64.rotrBH(Ah, Al, 39);
++            const sigma0l = u64.rotrSL(Ah, Al, 28) ^ u64.rotrBL(Ah, Al, 34) ^ u64.rotrBL(Ah, Al, 39);
++            const MAJh = (Ah & Bh) ^ (Ah & Ch) ^ (Bh & Ch);
++            const MAJl = (Al & Bl) ^ (Al & Cl) ^ (Bl & Cl);
++            Hh = Gh | 0;
++            Hl = Gl | 0;
++            Gh = Fh | 0;
++            Gl = Fl | 0;
++            Fh = Eh | 0;
++            Fl = El | 0;
++            ({ h: Eh, l: El } = u64.add(Dh | 0, Dl | 0, T1h | 0, T1l | 0));
++            Dh = Ch | 0;
++            Dl = Cl | 0;
++            Ch = Bh | 0;
++            Cl = Bl | 0;
++            Bh = Ah | 0;
++            Bl = Al | 0;
++            const All = u64.add3L(T1l, sigma0l, MAJl);
++            Ah = u64.add3H(All, T1h, sigma0h, MAJh);
++            Al = All | 0;
++        }
++        // Add the compressed chunk to the current hash value
++        ({ h: Ah, l: Al } = u64.add(this.Ah | 0, this.Al | 0, Ah | 0, Al | 0));
++        ({ h: Bh, l: Bl } = u64.add(this.Bh | 0, this.Bl | 0, Bh | 0, Bl | 0));
++        ({ h: Ch, l: Cl } = u64.add(this.Ch | 0, this.Cl | 0, Ch | 0, Cl | 0));
++        ({ h: Dh, l: Dl } = u64.add(this.Dh | 0, this.Dl | 0, Dh | 0, Dl | 0));
++        ({ h: Eh, l: El } = u64.add(this.Eh | 0, this.El | 0, Eh | 0, El | 0));
++        ({ h: Fh, l: Fl } = u64.add(this.Fh | 0, this.Fl | 0, Fh | 0, Fl | 0));
++        ({ h: Gh, l: Gl } = u64.add(this.Gh | 0, this.Gl | 0, Gh | 0, Gl | 0));
++        ({ h: Hh, l: Hl } = u64.add(this.Hh | 0, this.Hl | 0, Hh | 0, Hl | 0));
++        this.set(Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl);
++    }
++    roundClean() {
++        SHA512_W_H.fill(0);
++        SHA512_W_L.fill(0);
++    }
++    destroy() {
++        this.buffer.fill(0);
++        this.set(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
++    }
++}
++export class SHA512_224 extends SHA512 {
++    constructor() {
++        super();
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0x8c3d37c8 | 0;
++        this.Al = 0x19544da2 | 0;
++        this.Bh = 0x73e19966 | 0;
++        this.Bl = 0x89dcd4d6 | 0;
++        this.Ch = 0x1dfab7ae | 0;
++        this.Cl = 0x32ff9c82 | 0;
++        this.Dh = 0x679dd514 | 0;
++        this.Dl = 0x582f9fcf | 0;
++        this.Eh = 0x0f6d2b69 | 0;
++        this.El = 0x7bd44da8 | 0;
++        this.Fh = 0x77e36f73 | 0;
++        this.Fl = 0x04c48942 | 0;
++        this.Gh = 0x3f9d85a8 | 0;
++        this.Gl = 0x6a1d36c8 | 0;
++        this.Hh = 0x1112e6ad | 0;
++        this.Hl = 0x91d692a1 | 0;
++        this.outputLen = 28;
++    }
++}
++export class SHA512_256 extends SHA512 {
++    constructor() {
++        super();
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0x22312194 | 0;
++        this.Al = 0xfc2bf72c | 0;
++        this.Bh = 0x9f555fa3 | 0;
++        this.Bl = 0xc84c64c2 | 0;
++        this.Ch = 0x2393b86b | 0;
++        this.Cl = 0x6f53b151 | 0;
++        this.Dh = 0x96387719 | 0;
++        this.Dl = 0x5940eabd | 0;
++        this.Eh = 0x96283ee2 | 0;
++        this.El = 0xa88effe3 | 0;
++        this.Fh = 0xbe5e1e25 | 0;
++        this.Fl = 0x53863992 | 0;
++        this.Gh = 0x2b0199fc | 0;
++        this.Gl = 0x2c85b8aa | 0;
++        this.Hh = 0x0eb72ddc | 0;
++        this.Hl = 0x81c52ca2 | 0;
++        this.outputLen = 32;
++    }
++}
++export class SHA384 extends SHA512 {
++    constructor() {
++        super();
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0xcbbb9d5d | 0;
++        this.Al = 0xc1059ed8 | 0;
++        this.Bh = 0x629a292a | 0;
++        this.Bl = 0x367cd507 | 0;
++        this.Ch = 0x9159015a | 0;
++        this.Cl = 0x3070dd17 | 0;
++        this.Dh = 0x152fecd8 | 0;
++        this.Dl = 0xf70e5939 | 0;
++        this.Eh = 0x67332667 | 0;
++        this.El = 0xffc00b31 | 0;
++        this.Fh = 0x8eb44a87 | 0;
++        this.Fl = 0x68581511 | 0;
++        this.Gh = 0xdb0c2e0d | 0;
++        this.Gl = 0x64f98fa7 | 0;
++        this.Hh = 0x47b5481d | 0;
++        this.Hl = 0xbefa4fa4 | 0;
++        this.outputLen = 48;
++    }
++}
++export const sha512 = /* @__PURE__ */ wrapConstructor(() => new SHA512());
++export const sha512_224 = /* @__PURE__ */ wrapConstructor(() => new SHA512_224());
++export const sha512_256 = /* @__PURE__ */ wrapConstructor(() => new SHA512_256());
++export const sha384 = /* @__PURE__ */ wrapConstructor(() => new SHA384());
++//# sourceMappingURL=sha512.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.js.map
+new file mode 100644
+index 0000000..7bc2e75
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/sha512.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha512.js","sourceRoot":"","sources":["../src/sha512.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,UAAU,CAAC;AAClC,OAAO,GAAG,MAAM,WAAW,CAAC;AAC5B,OAAO,EAAE,eAAe,EAAE,MAAM,YAAY,CAAC;AAE7C,0GAA0G;AAC1G,kBAAkB;AAClB,MAAM,CAAC,SAAS,EAAE,SAAS,CAAC,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,KAAK,CAAC;IAC9D,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;CACvF,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC;AAE1B,4DAA4D;AAC5D,MAAM,UAAU,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACvD,MAAM,UAAU,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACvD,MAAM,OAAO,MAAO,SAAQ,MAAc;IAsBxC;QACE,KAAK,CAAC,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;QAtB5B,wHAAwH;QACxH,qDAAqD;QACrD,yGAAyG;QACzG,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;IAIpB,CAAC;IACD,kBAAkB;IACR,GAAG;QAIX,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QAChF,OAAO,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC1E,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAC9F,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;QAE9F,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACnB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,gGAAgG;QAChG,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC,EAAE,CAAC;YACzC,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,CAAC,CAAC;YACvC,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,CAAC,MAAM,IAAI,CAAC,CAAC,CAAC,CAAC;QAChD,CAAC;QACD,KAAK,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC7B,uFAAuF;YACvF,MAAM,IAAI,GAAG,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;YACpC,MAAM,IAAI,GAAG,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;YACpC,MAAM,GAAG,GAAG,GAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,GAAG,CAAC,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;YAC7F,MAAM,GAAG,GAAG,GAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,GAAG,CAAC,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;YAC7F,sFAAsF;YACtF,MAAM,GAAG,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;YAClC,MAAM,GAAG,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;YAClC,MAAM,GAAG,GAAG,GAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC,CAAC,CAAC;YACzF,MAAM,GAAG,GAAG,GAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC,CAAC,CAAC;YACzF,8DAA8D;YAC9D,MAAM,IAAI,GAAG,GAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC;YACxE,MAAM,IAAI,GAAG,GAAG,CAAC,KAAK,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,EAAE,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC;YAC9E,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,GAAG,CAAC,CAAC;YACzB,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,GAAG,CAAC,CAAC;QAC3B,CAAC;QACD,IAAI,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QAC9E,4CAA4C;QAC5C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,yEAAyE;YACzE,MAAM,OAAO,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,MAAM,OAAO,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,yEAAyE;YACzE,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YACpC,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YACpC,6DAA6D;YAC7D,kBAAkB;YAClB,MAAM,IAAI,GAAG,GAAG,CAAC,KAAK,CAAC,EAAE,EAAE,OAAO,EAAE,IAAI,EAAE,SAAS,CAAC,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;YACvE,MAAM,GAAG,GAAG,GAAG,CAAC,KAAK,CAAC,IAAI,EAAE,EAAE,EAAE,OAAO,EAAE,IAAI,EAAE,SAAS,CAAC,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;YAC5E,MAAM,GAAG,GAAG,IAAI,GAAG,CAAC,CAAC;YACrB,yEAAyE;YACzE,MAAM,OAAO,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,MAAM,OAAO,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YAC/C,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YAC/C,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,CAAC;YAC/D,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,MAAM,GAAG,GAAG,GAAG,CAAC,KAAK,CAAC,GAAG,EAAE,OAAO,EAAE,IAAI,CAAC,CAAC;YAC1C,EAAE,GAAG,GAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,OAAO,EAAE,IAAI,CAAC,CAAC;YACxC,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;QACf,CAAC;QACD,qDAAqD;QACrD,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,IAAI,CAAC,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC3E,CAAC;IACS,UAAU;QAClB,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACnB,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACrB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACpB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC3D,CAAC;CACF;AAED,MAAM,OAAO,UAAW,SAAQ,MAAM;IAmBpC;QACE,KAAK,EAAE,CAAC;QAnBV,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QAIlB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAED,MAAM,OAAO,UAAW,SAAQ,MAAM;IAmBpC;QACE,KAAK,EAAE,CAAC;QAnBV,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QAIlB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAED,MAAM,OAAO,MAAO,SAAQ,MAAM;IAmBhC;QACE,KAAK,EAAE,CAAC;QAnBV,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QAIlB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAED,MAAM,CAAC,MAAM,MAAM,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC;AAC1E,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,UAAU,EAAE,CAAC,CAAC;AAClF,MAAM,CAAC,MAAM,UAAU,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,UAAU,EAAE,CAAC,CAAC;AAClF,MAAM,CAAC,MAAM,MAAM,GAAG,eAAe,CAAC,eAAe,CAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.d.ts
+new file mode 100644
+index 0000000..21254c4
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.d.ts
+@@ -0,0 +1,96 @@
++/*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) */
++export declare function isBytes(a: unknown): a is Uint8Array;
++export type TypedArray = Int8Array | Uint8ClampedArray | Uint8Array | Uint16Array | Int16Array | Uint32Array | Int32Array;
++export declare const u8: (arr: TypedArray) => Uint8Array;
++export declare const u32: (arr: TypedArray) => Uint32Array;
++export declare const createView: (arr: TypedArray) => DataView;
++export declare const rotr: (word: number, shift: number) => number;
++export declare const rotl: (word: number, shift: number) => number;
++export declare const isLE: boolean;
++export declare const byteSwap: (word: number) => number;
++export declare const byteSwapIfBE: (n: number) => number;
++export declare function byteSwap32(arr: Uint32Array): void;
++/**
++ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
++ */
++export declare function bytesToHex(bytes: Uint8Array): string;
++/**
++ * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
++ */
++export declare function hexToBytes(hex: string): Uint8Array;
++export declare const nextTick: () => Promise<void>;
++export declare function asyncLoop(iters: number, tick: number, cb: (i: number) => void): Promise<void>;
++/**
++ * @example utf8ToBytes('abc') // new Uint8Array([97, 98, 99])
++ */
++export declare function utf8ToBytes(str: string): Uint8Array;
++export type Input = Uint8Array | string;
++/**
++ * Normalizes (non-hex) string or Uint8Array to Uint8Array.
++ * Warning: when Uint8Array is passed, it would NOT get copied.
++ * Keep in mind for future mutable operations.
++ */
++export declare function toBytes(data: Input): Uint8Array;
++/**
++ * Copies several Uint8Arrays into one.
++ */
++export declare function concatBytes(...arrays: Uint8Array[]): Uint8Array;
++export declare abstract class Hash<T extends Hash<T>> {
++    abstract blockLen: number;
++    abstract outputLen: number;
++    abstract update(buf: Input): this;
++    abstract digestInto(buf: Uint8Array): void;
++    abstract digest(): Uint8Array;
++    /**
++     * Resets internal state. Makes Hash instance unusable.
++     * Reset is impossible for keyed hashes if key is consumed into state. If digest is not consumed
++     * by user, they will need to manually call `destroy()` when zeroing is necessary.
++     */
++    abstract destroy(): void;
++    /**
++     * Clones hash instance. Unsafe: doesn't check whether `to` is valid. Can be used as `clone()`
++     * when no options are passed.
++     * Reasons to use `_cloneInto` instead of clone: 1) performance 2) reuse instance => all internal
++     * buffers are overwritten => causes buffer overwrite which is used for digest in some cases.
++     * There are no guarantees for clean-up because it's impossible in JS.
++     */
++    abstract _cloneInto(to?: T): T;
++    clone(): T;
++}
++/**
++ * XOF: streaming API to read digest in chunks.
++ * Same as 'squeeze' in keccak/k12 and 'seek' in blake3, but more generic name.
++ * When hash used in XOF mode it is up to user to call '.destroy' afterwards, since we cannot
++ * destroy state, next call can require more bytes.
++ */
++export type HashXOF<T extends Hash<T>> = Hash<T> & {
++    xof(bytes: number): Uint8Array;
++    xofInto(buf: Uint8Array): Uint8Array;
++};
++type EmptyObj = {};
++export declare function checkOpts<T1 extends EmptyObj, T2 extends EmptyObj>(defaults: T1, opts?: T2): T1 & T2;
++export type CHash = ReturnType<typeof wrapConstructor>;
++export declare function wrapConstructor<T extends Hash<T>>(hashCons: () => Hash<T>): {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<T>;
++};
++export declare function wrapConstructorWithOpts<H extends Hash<H>, T extends Object>(hashCons: (opts?: T) => Hash<H>): {
++    (msg: Input, opts?: T): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: T): Hash<H>;
++};
++export declare function wrapXOFConstructorWithOpts<H extends HashXOF<H>, T extends Object>(hashCons: (opts?: T) => HashXOF<H>): {
++    (msg: Input, opts?: T): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: T): HashXOF<H>;
++};
++/**
++ * Secure PRNG. Uses `crypto.getRandomValues`, which defers to OS.
++ */
++export declare function randomBytes(bytesLength?: number): Uint8Array;
++export {};
++//# sourceMappingURL=utils.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.d.ts.map
+new file mode 100644
+index 0000000..0e0456b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"utils.d.ts","sourceRoot":"","sources":["../src/utils.ts"],"names":[],"mappings":"AAAA,sEAAsE;AAYtE,wBAAgB,OAAO,CAAC,CAAC,EAAE,OAAO,GAAG,CAAC,IAAI,UAAU,CAKnD;AAGD,MAAM,MAAM,UAAU,GAAG,SAAS,GAAG,iBAAiB,GAAG,UAAU,GACjE,WAAW,GAAG,UAAU,GAAG,WAAW,GAAG,UAAU,CAAC;AAGtD,eAAO,MAAM,EAAE,QAAS,UAAU,eAA+D,CAAC;AAClG,eAAO,MAAM,GAAG,QAAS,UAAU,gBAC0C,CAAC;AAG9E,eAAO,MAAM,UAAU,QAAS,UAAU,aACgB,CAAC;AAG3D,eAAO,MAAM,IAAI,SAAU,MAAM,SAAS,MAAM,WAA8C,CAAC;AAE/F,eAAO,MAAM,IAAI,SAAU,MAAM,SAAS,MAAM,WACG,CAAC;AAEpD,eAAO,MAAM,IAAI,SAAmE,CAAC;AAErF,eAAO,MAAM,QAAQ,SAAU,MAAM,WAIb,CAAC;AAEzB,eAAO,MAAM,YAAY,MAAc,MAAM,WAAmC,CAAC;AAGjF,wBAAgB,UAAU,CAAC,GAAG,EAAE,WAAW,QAI1C;AAMD;;GAEG;AACH,wBAAgB,UAAU,CAAC,KAAK,EAAE,UAAU,GAAG,MAAM,CAQpD;AAWD;;GAEG;AACH,wBAAgB,UAAU,CAAC,GAAG,EAAE,MAAM,GAAG,UAAU,CAgBlD;AAKD,eAAO,MAAM,QAAQ,qBAAiB,CAAC;AAGvC,wBAAsB,SAAS,CAAC,KAAK,EAAE,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,EAAE,EAAE,CAAC,CAAC,EAAE,MAAM,KAAK,IAAI,iBAUnF;AAMD;;GAEG;AACH,wBAAgB,WAAW,CAAC,GAAG,EAAE,MAAM,GAAG,UAAU,CAGnD;AAED,MAAM,MAAM,KAAK,GAAG,UAAU,GAAG,MAAM,CAAC;AACxC;;;;GAIG;AACH,wBAAgB,OAAO,CAAC,IAAI,EAAE,KAAK,GAAG,UAAU,CAI/C;AAED;;GAEG;AACH,wBAAgB,WAAW,CAAC,GAAG,MAAM,EAAE,UAAU,EAAE,GAAG,UAAU,CAc/D;AAGD,8BAAsB,IAAI,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC;IAC1C,QAAQ,CAAC,QAAQ,EAAE,MAAM,CAAC;IAC1B,QAAQ,CAAC,SAAS,EAAE,MAAM,CAAC;IAC3B,QAAQ,CAAC,MAAM,CAAC,GAAG,EAAE,KAAK,GAAG,IAAI;IAEjC,QAAQ,CAAC,UAAU,CAAC,GAAG,EAAE,UAAU,GAAG,IAAI;IAC1C,QAAQ,CAAC,MAAM,IAAI,UAAU;IAC7B;;;;OAIG;IACH,QAAQ,CAAC,OAAO,IAAI,IAAI;IACxB;;;;;;OAMG;IACH,QAAQ,CAAC,UAAU,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC;IAE9B,KAAK,IAAI,CAAC;CAGX;AAED;;;;;GAKG;AACH,MAAM,MAAM,OAAO,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG;IACjD,GAAG,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU,CAAC;IAC/B,OAAO,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU,CAAC;CACtC,CAAC;AAGF,KAAK,QAAQ,GAAG,EAAE,CAAC;AACnB,wBAAgB,SAAS,CAAC,EAAE,SAAS,QAAQ,EAAE,EAAE,SAAS,QAAQ,EAChE,QAAQ,EAAE,EAAE,EACZ,IAAI,CAAC,EAAE,EAAE,GACR,EAAE,GAAG,EAAE,CAKT;AAED,MAAM,MAAM,KAAK,GAAG,UAAU,CAAC,OAAO,eAAe,CAAC,CAAC;AAEvD,wBAAgB,eAAe,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,EAAE,QAAQ,EAAE,MAAM,IAAI,CAAC,CAAC,CAAC;UACpD,KAAK,GAAG,UAAU;;;;EAMvC;AAED,wBAAgB,uBAAuB,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,EAAE,CAAC,SAAS,MAAM,EACzE,QAAQ,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,KAAK,IAAI,CAAC,CAAC,CAAC;UAEX,KAAK,SAAS,CAAC,GAAG,UAAU;;;iBAI1B,CAAC;EAExB;AAED,wBAAgB,0BAA0B,CAAC,CAAC,SAAS,OAAO,CAAC,CAAC,CAAC,EAAE,CAAC,SAAS,MAAM,EAC/E,QAAQ,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,KAAK,OAAO,CAAC,CAAC,CAAC;UAEd,KAAK,SAAS,CAAC,GAAG,UAAU;;;iBAI1B,CAAC;EAExB;AAED;;GAEG;AACH,wBAAgB,WAAW,CAAC,WAAW,SAAK,GAAG,UAAU,CAKxD"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.js
+new file mode 100644
+index 0000000..da75f64
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.js
+@@ -0,0 +1,187 @@
++/*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) */
++// We use WebCrypto aka globalThis.crypto, which exists in browsers and node.js 16+.
++// node.js versions earlier than v19 don't declare it in global scope.
++// For node.js, package.json#exports field mapping rewrites import
++// from `crypto` to `cryptoNode`, which imports native module.
++// Makes the utils un-importable in browsers without a bundler.
++// Once node.js 18 is deprecated (2025-04-30), we can just drop the import.
++import { crypto } from '@noble/hashes/crypto';
++import { bytes as abytes } from './_assert.js';
++// export { isBytes } from './_assert.js';
++// We can't reuse isBytes from _assert, because somehow this causes huge perf issues
++export function isBytes(a) {
++    return (a instanceof Uint8Array ||
++        (a != null && typeof a === 'object' && a.constructor.name === 'Uint8Array'));
++}
++// Cast array to different type
++export const u8 = (arr) => new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
++export const u32 = (arr) => new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
++// Cast array to view
++export const createView = (arr) => new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
++// The rotate right (circular right shift) operation for uint32
++export const rotr = (word, shift) => (word << (32 - shift)) | (word >>> shift);
++// The rotate left (circular left shift) operation for uint32
++export const rotl = (word, shift) => (word << shift) | ((word >>> (32 - shift)) >>> 0);
++export const isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
++// The byte swap operation for uint32
++export const byteSwap = (word) => ((word << 24) & 0xff000000) |
++    ((word << 8) & 0xff0000) |
++    ((word >>> 8) & 0xff00) |
++    ((word >>> 24) & 0xff);
++// Conditionally byte swap if on a big-endian platform
++export const byteSwapIfBE = isLE ? (n) => n : (n) => byteSwap(n);
++// In place byte swap for Uint32Array
++export function byteSwap32(arr) {
++    for (let i = 0; i < arr.length; i++) {
++        arr[i] = byteSwap(arr[i]);
++    }
++}
++// Array where index 0xf0 (240) is mapped to string 'f0'
++const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'));
++/**
++ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
++ */
++export function bytesToHex(bytes) {
++    abytes(bytes);
++    // pre-caching improves the speed 6x
++    let hex = '';
++    for (let i = 0; i < bytes.length; i++) {
++        hex += hexes[bytes[i]];
++    }
++    return hex;
++}
++// We use optimized technique to convert hex string to byte array
++const asciis = { _0: 48, _9: 57, _A: 65, _F: 70, _a: 97, _f: 102 };
++function asciiToBase16(char) {
++    if (char >= asciis._0 && char <= asciis._9)
++        return char - asciis._0;
++    if (char >= asciis._A && char <= asciis._F)
++        return char - (asciis._A - 10);
++    if (char >= asciis._a && char <= asciis._f)
++        return char - (asciis._a - 10);
++    return;
++}
++/**
++ * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
++ */
++export function hexToBytes(hex) {
++    if (typeof hex !== 'string')
++        throw new Error('hex string expected, got ' + typeof hex);
++    const hl = hex.length;
++    const al = hl / 2;
++    if (hl % 2)
++        throw new Error('padded hex string expected, got unpadded hex of length ' + hl);
++    const array = new Uint8Array(al);
++    for (let ai = 0, hi = 0; ai < al; ai++, hi += 2) {
++        const n1 = asciiToBase16(hex.charCodeAt(hi));
++        const n2 = asciiToBase16(hex.charCodeAt(hi + 1));
++        if (n1 === undefined || n2 === undefined) {
++            const char = hex[hi] + hex[hi + 1];
++            throw new Error('hex string expected, got non-hex character "' + char + '" at index ' + hi);
++        }
++        array[ai] = n1 * 16 + n2;
++    }
++    return array;
++}
++// There is no setImmediate in browser and setTimeout is slow.
++// call of async fn will return Promise, which will be fullfiled only on
++// next scheduler queue processing step and this is exactly what we need.
++export const nextTick = async () => { };
++// Returns control to thread each 'tick' ms to avoid blocking
++export async function asyncLoop(iters, tick, cb) {
++    let ts = Date.now();
++    for (let i = 0; i < iters; i++) {
++        cb(i);
++        // Date.now() is not monotonic, so in case if clock goes backwards we return return control too
++        const diff = Date.now() - ts;
++        if (diff >= 0 && diff < tick)
++            continue;
++        await nextTick();
++        ts += diff;
++    }
++}
++/**
++ * @example utf8ToBytes('abc') // new Uint8Array([97, 98, 99])
++ */
++export function utf8ToBytes(str) {
++    if (typeof str !== 'string')
++        throw new Error(`utf8ToBytes expected string, got ${typeof str}`);
++    return new Uint8Array(new TextEncoder().encode(str)); // https://bugzil.la/1681809
++}
++/**
++ * Normalizes (non-hex) string or Uint8Array to Uint8Array.
++ * Warning: when Uint8Array is passed, it would NOT get copied.
++ * Keep in mind for future mutable operations.
++ */
++export function toBytes(data) {
++    if (typeof data === 'string')
++        data = utf8ToBytes(data);
++    abytes(data);
++    return data;
++}
++/**
++ * Copies several Uint8Arrays into one.
++ */
++export function concatBytes(...arrays) {
++    let sum = 0;
++    for (let i = 0; i < arrays.length; i++) {
++        const a = arrays[i];
++        abytes(a);
++        sum += a.length;
++    }
++    const res = new Uint8Array(sum);
++    for (let i = 0, pad = 0; i < arrays.length; i++) {
++        const a = arrays[i];
++        res.set(a, pad);
++        pad += a.length;
++    }
++    return res;
++}
++// For runtime check if class implements interface
++export class Hash {
++    // Safe version that clones internal state
++    clone() {
++        return this._cloneInto();
++    }
++}
++const toStr = {}.toString;
++export function checkOpts(defaults, opts) {
++    if (opts !== undefined && toStr.call(opts) !== '[object Object]')
++        throw new Error('Options should be object or undefined');
++    const merged = Object.assign(defaults, opts);
++    return merged;
++}
++export function wrapConstructor(hashCons) {
++    const hashC = (msg) => hashCons().update(toBytes(msg)).digest();
++    const tmp = hashCons();
++    hashC.outputLen = tmp.outputLen;
++    hashC.blockLen = tmp.blockLen;
++    hashC.create = () => hashCons();
++    return hashC;
++}
++export function wrapConstructorWithOpts(hashCons) {
++    const hashC = (msg, opts) => hashCons(opts).update(toBytes(msg)).digest();
++    const tmp = hashCons({});
++    hashC.outputLen = tmp.outputLen;
++    hashC.blockLen = tmp.blockLen;
++    hashC.create = (opts) => hashCons(opts);
++    return hashC;
++}
++export function wrapXOFConstructorWithOpts(hashCons) {
++    const hashC = (msg, opts) => hashCons(opts).update(toBytes(msg)).digest();
++    const tmp = hashCons({});
++    hashC.outputLen = tmp.outputLen;
++    hashC.blockLen = tmp.blockLen;
++    hashC.create = (opts) => hashCons(opts);
++    return hashC;
++}
++/**
++ * Secure PRNG. Uses `crypto.getRandomValues`, which defers to OS.
++ */
++export function randomBytes(bytesLength = 32) {
++    if (crypto && typeof crypto.getRandomValues === 'function') {
++        return crypto.getRandomValues(new Uint8Array(bytesLength));
++    }
++    throw new Error('crypto.getRandomValues must be defined');
++}
++//# sourceMappingURL=utils.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.js.map
+new file mode 100644
+index 0000000..742bafa
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/esm/utils.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"utils.js","sourceRoot":"","sources":["../src/utils.ts"],"names":[],"mappings":"AAAA,sEAAsE;AAEtE,oFAAoF;AACpF,sEAAsE;AACtE,kEAAkE;AAClE,8DAA8D;AAC9D,+DAA+D;AAC/D,2EAA2E;AAC3E,OAAO,EAAE,MAAM,EAAE,MAAM,sBAAsB,CAAC;AAC9C,OAAO,EAAE,KAAK,IAAI,MAAM,EAAE,MAAM,cAAc,CAAC;AAC/C,0CAA0C;AAC1C,oFAAoF;AACpF,MAAM,UAAU,OAAO,CAAC,CAAU;IAChC,OAAO,CACL,CAAC,YAAY,UAAU;QACvB,CAAC,CAAC,IAAI,IAAI,IAAI,OAAO,CAAC,KAAK,QAAQ,IAAI,CAAC,CAAC,WAAW,CAAC,IAAI,KAAK,YAAY,CAAC,CAC5E,CAAC;AACJ,CAAC;AAMD,+BAA+B;AAC/B,MAAM,CAAC,MAAM,EAAE,GAAG,CAAC,GAAe,EAAE,EAAE,CAAC,IAAI,UAAU,CAAC,GAAG,CAAC,MAAM,EAAE,GAAG,CAAC,UAAU,EAAE,GAAG,CAAC,UAAU,CAAC,CAAC;AAClG,MAAM,CAAC,MAAM,GAAG,GAAG,CAAC,GAAe,EAAE,EAAE,CACrC,IAAI,WAAW,CAAC,GAAG,CAAC,MAAM,EAAE,GAAG,CAAC,UAAU,EAAE,IAAI,CAAC,KAAK,CAAC,GAAG,CAAC,UAAU,GAAG,CAAC,CAAC,CAAC,CAAC;AAE9E,qBAAqB;AACrB,MAAM,CAAC,MAAM,UAAU,GAAG,CAAC,GAAe,EAAE,EAAE,CAC5C,IAAI,QAAQ,CAAC,GAAG,CAAC,MAAM,EAAE,GAAG,CAAC,UAAU,EAAE,GAAG,CAAC,UAAU,CAAC,CAAC;AAE3D,+DAA+D;AAC/D,MAAM,CAAC,MAAM,IAAI,GAAG,CAAC,IAAY,EAAE,KAAa,EAAE,EAAE,CAAC,CAAC,IAAI,IAAI,CAAC,EAAE,GAAG,KAAK,CAAC,CAAC,GAAG,CAAC,IAAI,KAAK,KAAK,CAAC,CAAC;AAC/F,6DAA6D;AAC7D,MAAM,CAAC,MAAM,IAAI,GAAG,CAAC,IAAY,EAAE,KAAa,EAAE,EAAE,CAClD,CAAC,IAAI,IAAI,KAAK,CAAC,GAAG,CAAC,CAAC,IAAI,KAAK,CAAC,EAAE,GAAG,KAAK,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AAEpD,MAAM,CAAC,MAAM,IAAI,GAAG,IAAI,UAAU,CAAC,IAAI,WAAW,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,KAAK,IAAI,CAAC;AACrF,qCAAqC;AACrC,MAAM,CAAC,MAAM,QAAQ,GAAG,CAAC,IAAY,EAAE,EAAE,CACvC,CAAC,CAAC,IAAI,IAAI,EAAE,CAAC,GAAG,UAAU,CAAC;IAC3B,CAAC,CAAC,IAAI,IAAI,CAAC,CAAC,GAAG,QAAQ,CAAC;IACxB,CAAC,CAAC,IAAI,KAAK,CAAC,CAAC,GAAG,MAAM,CAAC;IACvB,CAAC,CAAC,IAAI,KAAK,EAAE,CAAC,GAAG,IAAI,CAAC,CAAC;AACzB,sDAAsD;AACtD,MAAM,CAAC,MAAM,YAAY,GAAG,IAAI,CAAC,CAAC,CAAC,CAAC,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAS,EAAE,EAAE,CAAC,QAAQ,CAAC,CAAC,CAAC,CAAC;AAEjF,qCAAqC;AACrC,MAAM,UAAU,UAAU,CAAC,GAAgB;IACzC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACpC,GAAG,CAAC,CAAC,CAAC,GAAG,QAAQ,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;IAC5B,CAAC;AACH,CAAC;AAED,wDAAwD;AACxD,MAAM,KAAK,GAAG,eAAe,CAAC,KAAK,CAAC,IAAI,CAAC,EAAE,MAAM,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CACjE,CAAC,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAChC,CAAC;AACF;;GAEG;AACH,MAAM,UAAU,UAAU,CAAC,KAAiB;IAC1C,MAAM,CAAC,KAAK,CAAC,CAAC;IACd,oCAAoC;IACpC,IAAI,GAAG,GAAG,EAAE,CAAC;IACb,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,KAAK,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACtC,GAAG,IAAI,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,CAAC;IACzB,CAAC;IACD,OAAO,GAAG,CAAC;AACb,CAAC;AAED,iEAAiE;AACjE,MAAM,MAAM,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAW,CAAC;AAC5E,SAAS,aAAa,CAAC,IAAY;IACjC,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE;QAAE,OAAO,IAAI,GAAG,MAAM,CAAC,EAAE,CAAC;IACpE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE;QAAE,OAAO,IAAI,GAAG,CAAC,MAAM,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;IAC3E,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE;QAAE,OAAO,IAAI,GAAG,CAAC,MAAM,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;IAC3E,OAAO;AACT,CAAC;AAED;;GAEG;AACH,MAAM,UAAU,UAAU,CAAC,GAAW;IACpC,IAAI,OAAO,GAAG,KAAK,QAAQ;QAAE,MAAM,IAAI,KAAK,CAAC,2BAA2B,GAAG,OAAO,GAAG,CAAC,CAAC;IACvF,MAAM,EAAE,GAAG,GAAG,CAAC,MAAM,CAAC;IACtB,MAAM,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IAClB,IAAI,EAAE,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,yDAAyD,GAAG,EAAE,CAAC,CAAC;IAC5F,MAAM,KAAK,GAAG,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC;IACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,IAAI,CAAC,EAAE,CAAC;QAChD,MAAM,EAAE,GAAG,aAAa,CAAC,GAAG,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC,CAAC;QAC7C,MAAM,EAAE,GAAG,aAAa,CAAC,GAAG,CAAC,UAAU,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACjD,IAAI,EAAE,KAAK,SAAS,IAAI,EAAE,KAAK,SAAS,EAAE,CAAC;YACzC,MAAM,IAAI,GAAG,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC;YACnC,MAAM,IAAI,KAAK,CAAC,8CAA8C,GAAG,IAAI,GAAG,aAAa,GAAG,EAAE,CAAC,CAAC;QAC9F,CAAC;QACD,KAAK,CAAC,EAAE,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC;IAC3B,CAAC;IACD,OAAO,KAAK,CAAC;AACf,CAAC;AAED,8DAA8D;AAC9D,wEAAwE;AACxE,yEAAyE;AACzE,MAAM,CAAC,MAAM,QAAQ,GAAG,KAAK,IAAI,EAAE,GAAE,CAAC,CAAC;AAEvC,6DAA6D;AAC7D,MAAM,CAAC,KAAK,UAAU,SAAS,CAAC,KAAa,EAAE,IAAY,EAAE,EAAuB;IAClF,IAAI,EAAE,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC;IACpB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,KAAK,EAAE,CAAC,EAAE,EAAE,CAAC;QAC/B,EAAE,CAAC,CAAC,CAAC,CAAC;QACN,+FAA+F;QAC/F,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QAC7B,IAAI,IAAI,IAAI,CAAC,IAAI,IAAI,GAAG,IAAI;YAAE,SAAS;QACvC,MAAM,QAAQ,EAAE,CAAC;QACjB,EAAE,IAAI,IAAI,CAAC;IACb,CAAC;AACH,CAAC;AAMD;;GAEG;AACH,MAAM,UAAU,WAAW,CAAC,GAAW;IACrC,IAAI,OAAO,GAAG,KAAK,QAAQ;QAAE,MAAM,IAAI,KAAK,CAAC,oCAAoC,OAAO,GAAG,EAAE,CAAC,CAAC;IAC/F,OAAO,IAAI,UAAU,CAAC,IAAI,WAAW,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,4BAA4B;AACpF,CAAC;AAGD;;;;GAIG;AACH,MAAM,UAAU,OAAO,CAAC,IAAW;IACjC,IAAI,OAAO,IAAI,KAAK,QAAQ;QAAE,IAAI,GAAG,WAAW,CAAC,IAAI,CAAC,CAAC;IACvD,MAAM,CAAC,IAAI,CAAC,CAAC;IACb,OAAO,IAAI,CAAC;AACd,CAAC;AAED;;GAEG;AACH,MAAM,UAAU,WAAW,CAAC,GAAG,MAAoB;IACjD,IAAI,GAAG,GAAG,CAAC,CAAC;IACZ,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACvC,MAAM,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC;QACpB,MAAM,CAAC,CAAC,CAAC,CAAC;QACV,GAAG,IAAI,CAAC,CAAC,MAAM,CAAC;IAClB,CAAC;IACD,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;IAChC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QAChD,MAAM,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC;QACpB,GAAG,CAAC,GAAG,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC;QAChB,GAAG,IAAI,CAAC,CAAC,MAAM,CAAC;IAClB,CAAC;IACD,OAAO,GAAG,CAAC;AACb,CAAC;AAED,kDAAkD;AAClD,MAAM,OAAgB,IAAI;IAqBxB,0CAA0C;IAC1C,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAaD,MAAM,KAAK,GAAG,EAAE,CAAC,QAAQ,CAAC;AAE1B,MAAM,UAAU,SAAS,CACvB,QAAY,EACZ,IAAS;IAET,IAAI,IAAI,KAAK,SAAS,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,CAAC,KAAK,iBAAiB;QAC9D,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;IAC3D,MAAM,MAAM,GAAG,MAAM,CAAC,MAAM,CAAC,QAAQ,EAAE,IAAI,CAAC,CAAC;IAC7C,OAAO,MAAiB,CAAC;AAC3B,CAAC;AAID,MAAM,UAAU,eAAe,CAAoB,QAAuB;IACxE,MAAM,KAAK,GAAG,CAAC,GAAU,EAAc,EAAE,CAAC,QAAQ,EAAE,CAAC,MAAM,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,MAAM,EAAE,CAAC;IACnF,MAAM,GAAG,GAAG,QAAQ,EAAE,CAAC;IACvB,KAAK,CAAC,SAAS,GAAG,GAAG,CAAC,SAAS,CAAC;IAChC,KAAK,CAAC,QAAQ,GAAG,GAAG,CAAC,QAAQ,CAAC;IAC9B,KAAK,CAAC,MAAM,GAAG,GAAG,EAAE,CAAC,QAAQ,EAAE,CAAC;IAChC,OAAO,KAAK,CAAC;AACf,CAAC;AAED,MAAM,UAAU,uBAAuB,CACrC,QAA+B;IAE/B,MAAM,KAAK,GAAG,CAAC,GAAU,EAAE,IAAQ,EAAc,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,MAAM,EAAE,CAAC;IACjG,MAAM,GAAG,GAAG,QAAQ,CAAC,EAAO,CAAC,CAAC;IAC9B,KAAK,CAAC,SAAS,GAAG,GAAG,CAAC,SAAS,CAAC;IAChC,KAAK,CAAC,QAAQ,GAAG,GAAG,CAAC,QAAQ,CAAC;IAC9B,KAAK,CAAC,MAAM,GAAG,CAAC,IAAO,EAAE,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC;IAC3C,OAAO,KAAK,CAAC;AACf,CAAC;AAED,MAAM,UAAU,0BAA0B,CACxC,QAAkC;IAElC,MAAM,KAAK,GAAG,CAAC,GAAU,EAAE,IAAQ,EAAc,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,MAAM,EAAE,CAAC;IACjG,MAAM,GAAG,GAAG,QAAQ,CAAC,EAAO,CAAC,CAAC;IAC9B,KAAK,CAAC,SAAS,GAAG,GAAG,CAAC,SAAS,CAAC;IAChC,KAAK,CAAC,QAAQ,GAAG,GAAG,CAAC,QAAQ,CAAC;IAC9B,KAAK,CAAC,MAAM,GAAG,CAAC,IAAO,EAAE,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC;IAC3C,OAAO,KAAK,CAAC;AACf,CAAC;AAED;;GAEG;AACH,MAAM,UAAU,WAAW,CAAC,WAAW,GAAG,EAAE;IAC1C,IAAI,MAAM,IAAI,OAAO,MAAM,CAAC,eAAe,KAAK,UAAU,EAAE,CAAC;QAC3D,OAAO,MAAM,CAAC,eAAe,CAAC,IAAI,UAAU,CAAC,WAAW,CAAC,CAAC,CAAC;IAC7D,CAAC;IACD,MAAM,IAAI,KAAK,CAAC,wCAAwC,CAAC,CAAC;AAC5D,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.d.ts
+new file mode 100644
+index 0000000..f2ff770
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.d.ts
+@@ -0,0 +1,27 @@
++import { CHash, Input } from './utils.js';
++/**
++ * HKDF-Extract(IKM, salt) -> PRK
++ * Arguments position differs from spec (IKM is first one, since it is not optional)
++ * @param hash
++ * @param ikm
++ * @param salt
++ * @returns
++ */
++export declare function extract(hash: CHash, ikm: Input, salt?: Input): Uint8Array;
++/**
++ * HKDF-expand from the spec.
++ * @param prk - a pseudorandom key of at least HashLen octets (usually, the output from the extract step)
++ * @param info - optional context and application specific information (can be a zero-length string)
++ * @param length - length of output keying material in octets
++ */
++export declare function expand(hash: CHash, prk: Input, info?: Input, length?: number): Uint8Array;
++/**
++ * HKDF (RFC 5869): extract + expand in one step.
++ * @param hash - hash function that would be used (e.g. sha256)
++ * @param ikm - input keying material, the initial key
++ * @param salt - optional salt value (a non-secret random value)
++ * @param info - optional context and application specific information
++ * @param length - length of output keying material in octets
++ */
++export declare const hkdf: (hash: CHash, ikm: Input, salt: Input | undefined, info: Input | undefined, length: number) => Uint8Array;
++//# sourceMappingURL=hkdf.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.d.ts.map
+new file mode 100644
+index 0000000..d27f938
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hkdf.d.ts","sourceRoot":"","sources":["src/hkdf.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,KAAK,EAAE,KAAK,EAAW,MAAM,YAAY,CAAC;AAMnD;;;;;;;GAOG;AACH,wBAAgB,OAAO,CAAC,IAAI,EAAE,KAAK,EAAE,GAAG,EAAE,KAAK,EAAE,IAAI,CAAC,EAAE,KAAK,cAO5D;AAMD;;;;;GAKG;AACH,wBAAgB,MAAM,CAAC,IAAI,EAAE,KAAK,EAAE,GAAG,EAAE,KAAK,EAAE,IAAI,CAAC,EAAE,KAAK,EAAE,MAAM,GAAE,MAAW,cA4BhF;AAED;;;;;;;GAOG;AACH,eAAO,MAAM,IAAI,SACT,KAAK,OACN,KAAK,QACJ,KAAK,GAAG,SAAS,QACjB,KAAK,GAAG,SAAS,UACf,MAAM,eACyC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.js
+new file mode 100644
+index 0000000..1a3a82b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.js
+@@ -0,0 +1,78 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.hkdf = void 0;
++exports.extract = extract;
++exports.expand = expand;
++const _assert_js_1 = require("./_assert.js");
++const utils_js_1 = require("./utils.js");
++const hmac_js_1 = require("./hmac.js");
++// HKDF (RFC 5869)
++// https://soatok.blog/2021/11/17/understanding-hkdf/
++/**
++ * HKDF-Extract(IKM, salt) -> PRK
++ * Arguments position differs from spec (IKM is first one, since it is not optional)
++ * @param hash
++ * @param ikm
++ * @param salt
++ * @returns
++ */
++function extract(hash, ikm, salt) {
++    (0, _assert_js_1.hash)(hash);
++    // NOTE: some libraries treat zero-length array as 'not provided';
++    // we don't, since we have undefined as 'not provided'
++    // https://github.com/RustCrypto/KDFs/issues/15
++    if (salt === undefined)
++        salt = new Uint8Array(hash.outputLen); // if not provided, it is set to a string of HashLen zeros
++    return (0, hmac_js_1.hmac)(hash, (0, utils_js_1.toBytes)(salt), (0, utils_js_1.toBytes)(ikm));
++}
++// HKDF-Expand(PRK, info, L) -> OKM
++const HKDF_COUNTER = /* @__PURE__ */ new Uint8Array([0]);
++const EMPTY_BUFFER = /* @__PURE__ */ new Uint8Array();
++/**
++ * HKDF-expand from the spec.
++ * @param prk - a pseudorandom key of at least HashLen octets (usually, the output from the extract step)
++ * @param info - optional context and application specific information (can be a zero-length string)
++ * @param length - length of output keying material in octets
++ */
++function expand(hash, prk, info, length = 32) {
++    (0, _assert_js_1.hash)(hash);
++    (0, _assert_js_1.number)(length);
++    if (length > 255 * hash.outputLen)
++        throw new Error('Length should be <= 255*HashLen');
++    const blocks = Math.ceil(length / hash.outputLen);
++    if (info === undefined)
++        info = EMPTY_BUFFER;
++    // first L(ength) octets of T
++    const okm = new Uint8Array(blocks * hash.outputLen);
++    // Re-use HMAC instance between blocks
++    const HMAC = hmac_js_1.hmac.create(hash, prk);
++    const HMACTmp = HMAC._cloneInto();
++    const T = new Uint8Array(HMAC.outputLen);
++    for (let counter = 0; counter < blocks; counter++) {
++        HKDF_COUNTER[0] = counter + 1;
++        // T(0) = empty string (zero length)
++        // T(N) = HMAC-Hash(PRK, T(N-1) | info | N)
++        HMACTmp.update(counter === 0 ? EMPTY_BUFFER : T)
++            .update(info)
++            .update(HKDF_COUNTER)
++            .digestInto(T);
++        okm.set(T, hash.outputLen * counter);
++        HMAC._cloneInto(HMACTmp);
++    }
++    HMAC.destroy();
++    HMACTmp.destroy();
++    T.fill(0);
++    HKDF_COUNTER.fill(0);
++    return okm.slice(0, length);
++}
++/**
++ * HKDF (RFC 5869): extract + expand in one step.
++ * @param hash - hash function that would be used (e.g. sha256)
++ * @param ikm - input keying material, the initial key
++ * @param salt - optional salt value (a non-secret random value)
++ * @param info - optional context and application specific information
++ * @param length - length of output keying material in octets
++ */
++const hkdf = (hash, ikm, salt, info, length) => expand(hash, extract(hash, ikm, salt), info, length);
++exports.hkdf = hkdf;
++//# sourceMappingURL=hkdf.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.js.map
+new file mode 100644
+index 0000000..58b39d2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hkdf.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hkdf.js","sourceRoot":"","sources":["src/hkdf.ts"],"names":[],"mappings":";;;AAeA,0BAOC;AAYD,wBA4BC;AA9DD,6CAA0E;AAC1E,yCAAmD;AACnD,uCAAiC;AAEjC,kBAAkB;AAClB,qDAAqD;AAErD;;;;;;;GAOG;AACH,SAAgB,OAAO,CAAC,IAAW,EAAE,GAAU,EAAE,IAAY;IAC3D,IAAA,iBAAU,EAAC,IAAI,CAAC,CAAC;IACjB,kEAAkE;IAClE,sDAAsD;IACtD,+CAA+C;IAC/C,IAAI,IAAI,KAAK,SAAS;QAAE,IAAI,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,0DAA0D;IACzH,OAAO,IAAA,cAAI,EAAC,IAAI,EAAE,IAAA,kBAAO,EAAC,IAAI,CAAC,EAAE,IAAA,kBAAO,EAAC,GAAG,CAAC,CAAC,CAAC;AACjD,CAAC;AAED,mCAAmC;AACnC,MAAM,YAAY,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACzD,MAAM,YAAY,GAAG,eAAe,CAAC,IAAI,UAAU,EAAE,CAAC;AAEtD;;;;;GAKG;AACH,SAAgB,MAAM,CAAC,IAAW,EAAE,GAAU,EAAE,IAAY,EAAE,SAAiB,EAAE;IAC/E,IAAA,iBAAU,EAAC,IAAI,CAAC,CAAC;IACjB,IAAA,mBAAY,EAAC,MAAM,CAAC,CAAC;IACrB,IAAI,MAAM,GAAG,GAAG,GAAG,IAAI,CAAC,SAAS;QAAE,MAAM,IAAI,KAAK,CAAC,iCAAiC,CAAC,CAAC;IACtF,MAAM,MAAM,GAAG,IAAI,CAAC,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,SAAS,CAAC,CAAC;IAClD,IAAI,IAAI,KAAK,SAAS;QAAE,IAAI,GAAG,YAAY,CAAC;IAC5C,6BAA6B;IAC7B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,MAAM,GAAG,IAAI,CAAC,SAAS,CAAC,CAAC;IACpD,sCAAsC;IACtC,MAAM,IAAI,GAAG,cAAI,CAAC,MAAM,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC;IACpC,MAAM,OAAO,GAAG,IAAI,CAAC,UAAU,EAAE,CAAC;IAClC,MAAM,CAAC,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC;IACzC,KAAK,IAAI,OAAO,GAAG,CAAC,EAAE,OAAO,GAAG,MAAM,EAAE,OAAO,EAAE,EAAE,CAAC;QAClD,YAAY,CAAC,CAAC,CAAC,GAAG,OAAO,GAAG,CAAC,CAAC;QAC9B,oCAAoC;QACpC,2CAA2C;QAC3C,OAAO,CAAC,MAAM,CAAC,OAAO,KAAK,CAAC,CAAC,CAAC,CAAC,YAAY,CAAC,CAAC,CAAC,CAAC,CAAC;aAC7C,MAAM,CAAC,IAAI,CAAC;aACZ,MAAM,CAAC,YAAY,CAAC;aACpB,UAAU,CAAC,CAAC,CAAC,CAAC;QACjB,GAAG,CAAC,GAAG,CAAC,CAAC,EAAE,IAAI,CAAC,SAAS,GAAG,OAAO,CAAC,CAAC;QACrC,IAAI,CAAC,UAAU,CAAC,OAAO,CAAC,CAAC;IAC3B,CAAC;IACD,IAAI,CAAC,OAAO,EAAE,CAAC;IACf,OAAO,CAAC,OAAO,EAAE,CAAC;IAClB,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,YAAY,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACrB,OAAO,GAAG,CAAC,KAAK,CAAC,CAAC,EAAE,MAAM,CAAC,CAAC;AAC9B,CAAC;AAED;;;;;;;GAOG;AACI,MAAM,IAAI,GAAG,CAClB,IAAW,EACX,GAAU,EACV,IAAuB,EACvB,IAAuB,EACvB,MAAc,EACd,EAAE,CAAC,MAAM,CAAC,IAAI,EAAE,OAAO,CAAC,IAAI,EAAE,GAAG,EAAE,IAAI,CAAC,EAAE,IAAI,EAAE,MAAM,CAAC,CAAC;AAN7C,QAAA,IAAI,QAMyC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.d.ts
+new file mode 100644
+index 0000000..5a9f896
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.d.ts
+@@ -0,0 +1,30 @@
++import { Hash, CHash, Input } from './utils.js';
++export declare class HMAC<T extends Hash<T>> extends Hash<HMAC<T>> {
++    oHash: T;
++    iHash: T;
++    blockLen: number;
++    outputLen: number;
++    private finished;
++    private destroyed;
++    constructor(hash: CHash, _key: Input);
++    update(buf: Input): this;
++    digestInto(out: Uint8Array): void;
++    digest(): Uint8Array;
++    _cloneInto(to?: HMAC<T>): HMAC<T>;
++    destroy(): void;
++}
++/**
++ * HMAC: RFC2104 message authentication code.
++ * @param hash - function that would be used e.g. sha256
++ * @param key - message key
++ * @param message - message data
++ * @example
++ * import { hmac } from '@noble/hashes/hmac';
++ * import { sha256 } from '@noble/hashes/sha2';
++ * const mac1 = hmac(sha256, 'key', 'message');
++ */
++export declare const hmac: {
++    (hash: CHash, key: Input, message: Input): Uint8Array;
++    create(hash: CHash, key: Input): HMAC<any>;
++};
++//# sourceMappingURL=hmac.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.d.ts.map
+new file mode 100644
+index 0000000..797ea17
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hmac.d.ts","sourceRoot":"","sources":["src/hmac.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAE,KAAK,EAAE,KAAK,EAAW,MAAM,YAAY,CAAC;AAEzD,qBAAa,IAAI,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,CAAE,SAAQ,IAAI,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACxD,KAAK,EAAE,CAAC,CAAC;IACT,KAAK,EAAE,CAAC,CAAC;IACT,QAAQ,EAAE,MAAM,CAAC;IACjB,SAAS,EAAE,MAAM,CAAC;IAClB,OAAO,CAAC,QAAQ,CAAS;IACzB,OAAO,CAAC,SAAS,CAAS;gBAEd,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK;IAsBpC,MAAM,CAAC,GAAG,EAAE,KAAK;IAKjB,UAAU,CAAC,GAAG,EAAE,UAAU;IAS1B,MAAM;IAKN,UAAU,CAAC,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC;IAajC,OAAO;CAKR;AAED;;;;;;;;;GASG;AACH,eAAO,MAAM,IAAI;WAAU,KAAK,OAAO,KAAK,WAAW,KAAK,GAAG,UAAU;iBAEpD,KAAK,OAAO,KAAK;CADa,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.js
+new file mode 100644
+index 0000000..74f1f48
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.js
+@@ -0,0 +1,86 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.hmac = exports.HMAC = void 0;
++const _assert_js_1 = require("./_assert.js");
++const utils_js_1 = require("./utils.js");
++// HMAC (RFC 2104)
++class HMAC extends utils_js_1.Hash {
++    constructor(hash, _key) {
++        super();
++        this.finished = false;
++        this.destroyed = false;
++        (0, _assert_js_1.hash)(hash);
++        const key = (0, utils_js_1.toBytes)(_key);
++        this.iHash = hash.create();
++        if (typeof this.iHash.update !== 'function')
++            throw new Error('Expected instance of class which extends utils.Hash');
++        this.blockLen = this.iHash.blockLen;
++        this.outputLen = this.iHash.outputLen;
++        const blockLen = this.blockLen;
++        const pad = new Uint8Array(blockLen);
++        // blockLen can be bigger than outputLen
++        pad.set(key.length > blockLen ? hash.create().update(key).digest() : key);
++        for (let i = 0; i < pad.length; i++)
++            pad[i] ^= 0x36;
++        this.iHash.update(pad);
++        // By doing update (processing of first block) of outer hash here we can re-use it between multiple calls via clone
++        this.oHash = hash.create();
++        // Undo internal XOR && apply outer XOR
++        for (let i = 0; i < pad.length; i++)
++            pad[i] ^= 0x36 ^ 0x5c;
++        this.oHash.update(pad);
++        pad.fill(0);
++    }
++    update(buf) {
++        (0, _assert_js_1.exists)(this);
++        this.iHash.update(buf);
++        return this;
++    }
++    digestInto(out) {
++        (0, _assert_js_1.exists)(this);
++        (0, _assert_js_1.bytes)(out, this.outputLen);
++        this.finished = true;
++        this.iHash.digestInto(out);
++        this.oHash.update(out);
++        this.oHash.digestInto(out);
++        this.destroy();
++    }
++    digest() {
++        const out = new Uint8Array(this.oHash.outputLen);
++        this.digestInto(out);
++        return out;
++    }
++    _cloneInto(to) {
++        // Create new instance without calling constructor since key already in state and we don't know it.
++        to || (to = Object.create(Object.getPrototypeOf(this), {}));
++        const { oHash, iHash, finished, destroyed, blockLen, outputLen } = this;
++        to = to;
++        to.finished = finished;
++        to.destroyed = destroyed;
++        to.blockLen = blockLen;
++        to.outputLen = outputLen;
++        to.oHash = oHash._cloneInto(to.oHash);
++        to.iHash = iHash._cloneInto(to.iHash);
++        return to;
++    }
++    destroy() {
++        this.destroyed = true;
++        this.oHash.destroy();
++        this.iHash.destroy();
++    }
++}
++exports.HMAC = HMAC;
++/**
++ * HMAC: RFC2104 message authentication code.
++ * @param hash - function that would be used e.g. sha256
++ * @param key - message key
++ * @param message - message data
++ * @example
++ * import { hmac } from '@noble/hashes/hmac';
++ * import { sha256 } from '@noble/hashes/sha2';
++ * const mac1 = hmac(sha256, 'key', 'message');
++ */
++const hmac = (hash, key, message) => new HMAC(hash, key).update(message).digest();
++exports.hmac = hmac;
++exports.hmac.create = (hash, key) => new HMAC(hash, key);
++//# sourceMappingURL=hmac.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.js.map
+new file mode 100644
+index 0000000..3612e23
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/hmac.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"hmac.js","sourceRoot":"","sources":["src/hmac.ts"],"names":[],"mappings":";;;AAAA,6CAAgG;AAChG,yCAAyD;AACzD,kBAAkB;AAClB,MAAa,IAAwB,SAAQ,eAAa;IAQxD,YAAY,IAAW,EAAE,IAAW;QAClC,KAAK,EAAE,CAAC;QAJF,aAAQ,GAAG,KAAK,CAAC;QACjB,cAAS,GAAG,KAAK,CAAC;QAIxB,IAAA,iBAAU,EAAC,IAAI,CAAC,CAAC;QACjB,MAAM,GAAG,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;QAC1B,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,MAAM,EAAO,CAAC;QAChC,IAAI,OAAO,IAAI,CAAC,KAAK,CAAC,MAAM,KAAK,UAAU;YACzC,MAAM,IAAI,KAAK,CAAC,qDAAqD,CAAC,CAAC;QACzE,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC,KAAK,CAAC,QAAQ,CAAC;QACpC,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC,KAAK,CAAC,SAAS,CAAC;QACtC,MAAM,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC/B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,QAAQ,CAAC,CAAC;QACrC,wCAAwC;QACxC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,MAAM,GAAG,QAAQ,CAAC,CAAC,CAAC,IAAI,CAAC,MAAM,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,MAAM,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QAC1E,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE;YAAE,GAAG,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC;QACpD,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,mHAAmH;QACnH,IAAI,CAAC,KAAK,GAAG,IAAI,CAAC,MAAM,EAAO,CAAC;QAChC,uCAAuC;QACvC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE;YAAE,GAAG,CAAC,CAAC,CAAC,IAAI,IAAI,GAAG,IAAI,CAAC;QAC3D,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACd,CAAC;IACD,MAAM,CAAC,GAAU;QACf,IAAA,mBAAY,EAAC,IAAI,CAAC,CAAC;QACnB,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,OAAO,IAAI,CAAC;IACd,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,IAAA,mBAAY,EAAC,IAAI,CAAC,CAAC;QACnB,IAAA,kBAAW,EAAC,GAAG,EAAE,IAAI,CAAC,SAAS,CAAC,CAAC;QACjC,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,IAAI,CAAC,KAAK,CAAC,UAAU,CAAC,GAAG,CAAC,CAAC;QAC3B,IAAI,CAAC,KAAK,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACvB,IAAI,CAAC,KAAK,CAAC,UAAU,CAAC,GAAG,CAAC,CAAC;QAC3B,IAAI,CAAC,OAAO,EAAE,CAAC;IACjB,CAAC;IACD,MAAM;QACJ,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,IAAI,CAAC,KAAK,CAAC,SAAS,CAAC,CAAC;QACjD,IAAI,CAAC,UAAU,CAAC,GAAG,CAAC,CAAC;QACrB,OAAO,GAAG,CAAC;IACb,CAAC;IACD,UAAU,CAAC,EAAY;QACrB,mGAAmG;QACnG,EAAE,KAAF,EAAE,GAAK,MAAM,CAAC,MAAM,CAAC,MAAM,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,EAAE,CAAC,EAAC;QACtD,MAAM,EAAE,KAAK,EAAE,KAAK,EAAE,QAAQ,EAAE,SAAS,EAAE,QAAQ,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QACxE,EAAE,GAAG,EAAU,CAAC;QAChB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC;QACvB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,KAAK,CAAC,CAAC;QACtC,EAAE,CAAC,KAAK,GAAG,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,KAAK,CAAC,CAAC;QACtC,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,KAAK,CAAC,OAAO,EAAE,CAAC;QACrB,IAAI,CAAC,KAAK,CAAC,OAAO,EAAE,CAAC;IACvB,CAAC;CACF;AAnED,oBAmEC;AAED;;;;;;;;;GASG;AACI,MAAM,IAAI,GAAG,CAAC,IAAW,EAAE,GAAU,EAAE,OAAc,EAAc,EAAE,CAC1E,IAAI,IAAI,CAAM,IAAI,EAAE,GAAG,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;AADvC,QAAA,IAAI,QACmC;AACpD,YAAI,CAAC,MAAM,GAAG,CAAC,IAAW,EAAE,GAAU,EAAE,EAAE,CAAC,IAAI,IAAI,CAAM,IAAI,EAAE,GAAG,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.d.ts
+new file mode 100644
+index 0000000..f36479a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.d.ts
+@@ -0,0 +1 @@
++//# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.d.ts.map
+new file mode 100644
+index 0000000..4e8c581
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["src/index.ts"],"names":[],"mappings":""}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.js
+new file mode 100644
+index 0000000..da92182
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.js
+@@ -0,0 +1,3 @@
++"use strict";
++throw new Error('root module cannot be imported: import submodules instead. Check out README');
++//# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.js.map
+new file mode 100644
+index 0000000..b6e5db7
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/index.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"index.js","sourceRoot":"","sources":["src/index.ts"],"names":[],"mappings":";AAAA,MAAM,IAAI,KAAK,CAAC,6EAA6E,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.d.ts
+new file mode 100644
+index 0000000..1fb1b27
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.d.ts
+@@ -0,0 +1,16 @@
++import { CHash, Input } from './utils.js';
++export type Pbkdf2Opt = {
++    c: number;
++    dkLen?: number;
++    asyncTick?: number;
++};
++/**
++ * PBKDF2-HMAC: RFC 2898 key derivation function
++ * @param hash - hash function that would be used e.g. sha256
++ * @param password - password from which a derived key is generated
++ * @param salt - cryptographic salt
++ * @param opts - {c, dkLen} where c is work factor and dkLen is output message size
++ */
++export declare function pbkdf2(hash: CHash, password: Input, salt: Input, opts: Pbkdf2Opt): Uint8Array;
++export declare function pbkdf2Async(hash: CHash, password: Input, salt: Input, opts: Pbkdf2Opt): Promise<Uint8Array>;
++//# sourceMappingURL=pbkdf2.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.d.ts.map
+new file mode 100644
+index 0000000..830ceeb
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"pbkdf2.d.ts","sourceRoot":"","sources":["src/pbkdf2.ts"],"names":[],"mappings":"AAEA,OAAO,EAAQ,KAAK,EAAE,KAAK,EAA6C,MAAM,YAAY,CAAC;AAG3F,MAAM,MAAM,SAAS,GAAG;IACtB,CAAC,EAAE,MAAM,CAAC;IACV,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,SAAS,CAAC,EAAE,MAAM,CAAC;CACpB,CAAC;AAkCF;;;;;;GAMG;AACH,wBAAgB,MAAM,CAAC,IAAI,EAAE,KAAK,EAAE,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,SAAS,cAsBhF;AAED,wBAAsB,WAAW,CAAC,IAAI,EAAE,KAAK,EAAE,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,SAAS,uBAsB3F"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.js
+new file mode 100644
+index 0000000..40b919a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.js
+@@ -0,0 +1,90 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.pbkdf2 = pbkdf2;
++exports.pbkdf2Async = pbkdf2Async;
++const _assert_js_1 = require("./_assert.js");
++const hmac_js_1 = require("./hmac.js");
++const utils_js_1 = require("./utils.js");
++// Common prologue and epilogue for sync/async functions
++function pbkdf2Init(hash, _password, _salt, _opts) {
++    (0, _assert_js_1.hash)(hash);
++    const opts = (0, utils_js_1.checkOpts)({ dkLen: 32, asyncTick: 10 }, _opts);
++    const { c, dkLen, asyncTick } = opts;
++    (0, _assert_js_1.number)(c);
++    (0, _assert_js_1.number)(dkLen);
++    (0, _assert_js_1.number)(asyncTick);
++    if (c < 1)
++        throw new Error('PBKDF2: iterations (c) should be >= 1');
++    const password = (0, utils_js_1.toBytes)(_password);
++    const salt = (0, utils_js_1.toBytes)(_salt);
++    // DK = PBKDF2(PRF, Password, Salt, c, dkLen);
++    const DK = new Uint8Array(dkLen);
++    // U1 = PRF(Password, Salt + INT_32_BE(i))
++    const PRF = hmac_js_1.hmac.create(hash, password);
++    const PRFSalt = PRF._cloneInto().update(salt);
++    return { c, dkLen, asyncTick, DK, PRF, PRFSalt };
++}
++function pbkdf2Output(PRF, PRFSalt, DK, prfW, u) {
++    PRF.destroy();
++    PRFSalt.destroy();
++    if (prfW)
++        prfW.destroy();
++    u.fill(0);
++    return DK;
++}
++/**
++ * PBKDF2-HMAC: RFC 2898 key derivation function
++ * @param hash - hash function that would be used e.g. sha256
++ * @param password - password from which a derived key is generated
++ * @param salt - cryptographic salt
++ * @param opts - {c, dkLen} where c is work factor and dkLen is output message size
++ */
++function pbkdf2(hash, password, salt, opts) {
++    const { c, dkLen, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
++    let prfW; // Working copy
++    const arr = new Uint8Array(4);
++    const view = (0, utils_js_1.createView)(arr);
++    const u = new Uint8Array(PRF.outputLen);
++    // DK = T1 + T2 + ⋯ + Tdklen/hlen
++    for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
++        // Ti = F(Password, Salt, c, i)
++        const Ti = DK.subarray(pos, pos + PRF.outputLen);
++        view.setInt32(0, ti, false);
++        // F(Password, Salt, c, i) = U1 ^ U2 ^ ⋯ ^ Uc
++        // U1 = PRF(Password, Salt + INT_32_BE(i))
++        (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
++        Ti.set(u.subarray(0, Ti.length));
++        for (let ui = 1; ui < c; ui++) {
++            // Uc = PRF(Password, Uc−1)
++            PRF._cloneInto(prfW).update(u).digestInto(u);
++            for (let i = 0; i < Ti.length; i++)
++                Ti[i] ^= u[i];
++        }
++    }
++    return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
++}
++async function pbkdf2Async(hash, password, salt, opts) {
++    const { c, dkLen, asyncTick, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
++    let prfW; // Working copy
++    const arr = new Uint8Array(4);
++    const view = (0, utils_js_1.createView)(arr);
++    const u = new Uint8Array(PRF.outputLen);
++    // DK = T1 + T2 + ⋯ + Tdklen/hlen
++    for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
++        // Ti = F(Password, Salt, c, i)
++        const Ti = DK.subarray(pos, pos + PRF.outputLen);
++        view.setInt32(0, ti, false);
++        // F(Password, Salt, c, i) = U1 ^ U2 ^ ⋯ ^ Uc
++        // U1 = PRF(Password, Salt + INT_32_BE(i))
++        (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
++        Ti.set(u.subarray(0, Ti.length));
++        await (0, utils_js_1.asyncLoop)(c - 1, asyncTick, () => {
++            // Uc = PRF(Password, Uc−1)
++            PRF._cloneInto(prfW).update(u).digestInto(u);
++            for (let i = 0; i < Ti.length; i++)
++                Ti[i] ^= u[i];
++        });
++    }
++    return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
++}
++//# sourceMappingURL=pbkdf2.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.js.map
+new file mode 100644
+index 0000000..c2da67a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/pbkdf2.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"pbkdf2.js","sourceRoot":"","sources":["src/pbkdf2.ts"],"names":[],"mappings":";;AAkDA,wBAsBC;AAED,kCAsBC;AAhGD,6CAA0E;AAC1E,uCAAiC;AACjC,yCAA2F;AAQ3F,wDAAwD;AACxD,SAAS,UAAU,CAAC,IAAW,EAAE,SAAgB,EAAE,KAAY,EAAE,KAAgB;IAC/E,IAAA,iBAAU,EAAC,IAAI,CAAC,CAAC;IACjB,MAAM,IAAI,GAAG,IAAA,oBAAS,EAAC,EAAE,KAAK,EAAE,EAAE,EAAE,SAAS,EAAE,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;IAC5D,MAAM,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;IACrC,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,KAAK,CAAC,CAAC;IACpB,IAAA,mBAAY,EAAC,SAAS,CAAC,CAAC;IACxB,IAAI,CAAC,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;IACpE,MAAM,QAAQ,GAAG,IAAA,kBAAO,EAAC,SAAS,CAAC,CAAC;IACpC,MAAM,IAAI,GAAG,IAAA,kBAAO,EAAC,KAAK,CAAC,CAAC;IAC5B,8CAA8C;IAC9C,MAAM,EAAE,GAAG,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC;IACjC,0CAA0C;IAC1C,MAAM,GAAG,GAAG,cAAI,CAAC,MAAM,CAAC,IAAI,EAAE,QAAQ,CAAC,CAAC;IACxC,MAAM,OAAO,GAAG,GAAG,CAAC,UAAU,EAAE,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IAC9C,OAAO,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,EAAE,EAAE,GAAG,EAAE,OAAO,EAAE,CAAC;AACnD,CAAC;AAED,SAAS,YAAY,CACnB,GAAY,EACZ,OAAgB,EAChB,EAAc,EACd,IAAa,EACb,CAAa;IAEb,GAAG,CAAC,OAAO,EAAE,CAAC;IACd,OAAO,CAAC,OAAO,EAAE,CAAC;IAClB,IAAI,IAAI;QAAE,IAAI,CAAC,OAAO,EAAE,CAAC;IACzB,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,OAAO,EAAE,CAAC;AACZ,CAAC;AAED;;;;;;GAMG;AACH,SAAgB,MAAM,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IAC/E,MAAM,EAAE,CAAC,EAAE,KAAK,EAAE,EAAE,EAAE,GAAG,EAAE,OAAO,EAAE,GAAG,UAAU,CAAC,IAAI,EAAE,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;IAC9E,IAAI,IAAS,CAAC,CAAC,eAAe;IAC9B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC;IAC9B,MAAM,IAAI,GAAG,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC7B,MAAM,CAAC,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IACxC,iCAAiC;IACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,KAAK,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,GAAG,CAAC,SAAS,EAAE,CAAC;QAClE,+BAA+B;QAC/B,MAAM,EAAE,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,SAAS,CAAC,CAAC;QACjD,IAAI,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;QAC5B,6CAA6C;QAC7C,0CAA0C;QAC1C,CAAC,IAAI,GAAG,OAAO,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;QAC5D,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC;QACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC;YAC9B,2BAA2B;YAC3B,GAAG,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;YAC7C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,CAAC,MAAM,EAAE,CAAC,EAAE;gBAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpD,CAAC;IACH,CAAC;IACD,OAAO,YAAY,CAAC,GAAG,EAAE,OAAO,EAAE,EAAE,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;AACjD,CAAC;AAEM,KAAK,UAAU,WAAW,CAAC,IAAW,EAAE,QAAe,EAAE,IAAW,EAAE,IAAe;IAC1F,MAAM,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,EAAE,EAAE,GAAG,EAAE,OAAO,EAAE,GAAG,UAAU,CAAC,IAAI,EAAE,QAAQ,EAAE,IAAI,EAAE,IAAI,CAAC,CAAC;IACzF,IAAI,IAAS,CAAC,CAAC,eAAe;IAC9B,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC;IAC9B,MAAM,IAAI,GAAG,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC7B,MAAM,CAAC,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IACxC,iCAAiC;IACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,KAAK,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,GAAG,CAAC,SAAS,EAAE,CAAC;QAClE,+BAA+B;QAC/B,MAAM,EAAE,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,SAAS,CAAC,CAAC;QACjD,IAAI,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;QAC5B,6CAA6C;QAC7C,0CAA0C;QAC1C,CAAC,IAAI,GAAG,OAAO,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;QAC5D,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC;QACjC,MAAM,IAAA,oBAAS,EAAC,CAAC,GAAG,CAAC,EAAE,SAAS,EAAE,GAAG,EAAE;YACrC,2BAA2B;YAC3B,GAAG,CAAC,UAAU,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC;YAC7C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,CAAC,MAAM,EAAE,CAAC,EAAE;gBAAE,EAAE,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC;QACpD,CAAC,CAAC,CAAC;IACL,CAAC;IACD,OAAO,YAAY,CAAC,GAAG,EAAE,OAAO,EAAE,EAAE,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;AACjD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.d.ts
+new file mode 100644
+index 0000000..1320a14
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.d.ts
+@@ -0,0 +1,25 @@
++import { HashMD } from './_md.js';
++export declare class RIPEMD160 extends HashMD<RIPEMD160> {
++    private h0;
++    private h1;
++    private h2;
++    private h3;
++    private h4;
++    constructor();
++    protected get(): [number, number, number, number, number];
++    protected set(h0: number, h1: number, h2: number, h3: number, h4: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++/**
++ * RIPEMD-160 - a hash function from 1990s.
++ * @param message - msg that would be hashed
++ */
++export declare const ripemd160: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<RIPEMD160>;
++};
++//# sourceMappingURL=ripemd160.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.d.ts.map
+new file mode 100644
+index 0000000..00a3aa2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"ripemd160.d.ts","sourceRoot":"","sources":["src/ripemd160.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,UAAU,CAAC;AAqClC,qBAAa,SAAU,SAAQ,MAAM,CAAC,SAAS,CAAC;IAC9C,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;IAC5B,OAAO,CAAC,EAAE,CAAkB;;IAK5B,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAIzD,SAAS,CAAC,GAAG,CAAC,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;IAOxE,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAmCvD,SAAS,CAAC,UAAU;IAGpB,OAAO;CAKR;AAED;;;GAGG;AACH,eAAO,MAAM,SAAS;;;;;CAAyD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.js
+new file mode 100644
+index 0000000..244744e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.js
+@@ -0,0 +1,106 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.ripemd160 = exports.RIPEMD160 = void 0;
++const _md_js_1 = require("./_md.js");
++const utils_js_1 = require("./utils.js");
++// https://homes.esat.kuleuven.be/~bosselae/ripemd160.html
++// https://homes.esat.kuleuven.be/~bosselae/ripemd160/pdf/AB-9601/AB-9601.pdf
++const Rho = /* @__PURE__ */ new Uint8Array([7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8]);
++const Id = /* @__PURE__ */ new Uint8Array(new Array(16).fill(0).map((_, i) => i));
++const Pi = /* @__PURE__ */ Id.map((i) => (9 * i + 5) % 16);
++let idxL = [Id];
++let idxR = [Pi];
++for (let i = 0; i < 4; i++)
++    for (let j of [idxL, idxR])
++        j.push(j[i].map((k) => Rho[k]));
++const shifts = /* @__PURE__ */ [
++    [11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8],
++    [12, 13, 11, 15, 6, 9, 9, 7, 12, 15, 11, 13, 7, 8, 7, 7],
++    [13, 15, 14, 11, 7, 7, 6, 8, 13, 14, 13, 12, 5, 5, 6, 9],
++    [14, 11, 12, 14, 8, 6, 5, 5, 15, 12, 15, 14, 9, 9, 8, 6],
++    [15, 12, 13, 13, 9, 5, 8, 6, 14, 11, 12, 11, 8, 6, 5, 5],
++].map((i) => new Uint8Array(i));
++const shiftsL = /* @__PURE__ */ idxL.map((idx, i) => idx.map((j) => shifts[i][j]));
++const shiftsR = /* @__PURE__ */ idxR.map((idx, i) => idx.map((j) => shifts[i][j]));
++const Kl = /* @__PURE__ */ new Uint32Array([
++    0x00000000, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e,
++]);
++const Kr = /* @__PURE__ */ new Uint32Array([
++    0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0x00000000,
++]);
++// It's called f() in spec.
++function f(group, x, y, z) {
++    if (group === 0)
++        return x ^ y ^ z;
++    else if (group === 1)
++        return (x & y) | (~x & z);
++    else if (group === 2)
++        return (x | ~y) ^ z;
++    else if (group === 3)
++        return (x & z) | (y & ~z);
++    else
++        return x ^ (y | ~z);
++}
++// Temporary buffer, not used to store anything between runs
++const R_BUF = /* @__PURE__ */ new Uint32Array(16);
++class RIPEMD160 extends _md_js_1.HashMD {
++    constructor() {
++        super(64, 20, 8, true);
++        this.h0 = 0x67452301 | 0;
++        this.h1 = 0xefcdab89 | 0;
++        this.h2 = 0x98badcfe | 0;
++        this.h3 = 0x10325476 | 0;
++        this.h4 = 0xc3d2e1f0 | 0;
++    }
++    get() {
++        const { h0, h1, h2, h3, h4 } = this;
++        return [h0, h1, h2, h3, h4];
++    }
++    set(h0, h1, h2, h3, h4) {
++        this.h0 = h0 | 0;
++        this.h1 = h1 | 0;
++        this.h2 = h2 | 0;
++        this.h3 = h3 | 0;
++        this.h4 = h4 | 0;
++    }
++    process(view, offset) {
++        for (let i = 0; i < 16; i++, offset += 4)
++            R_BUF[i] = view.getUint32(offset, true);
++        // prettier-ignore
++        let al = this.h0 | 0, ar = al, bl = this.h1 | 0, br = bl, cl = this.h2 | 0, cr = cl, dl = this.h3 | 0, dr = dl, el = this.h4 | 0, er = el;
++        // Instead of iterating 0 to 80, we split it into 5 groups
++        // And use the groups in constants, functions, etc. Much simpler
++        for (let group = 0; group < 5; group++) {
++            const rGroup = 4 - group;
++            const hbl = Kl[group], hbr = Kr[group]; // prettier-ignore
++            const rl = idxL[group], rr = idxR[group]; // prettier-ignore
++            const sl = shiftsL[group], sr = shiftsR[group]; // prettier-ignore
++            for (let i = 0; i < 16; i++) {
++                const tl = ((0, utils_js_1.rotl)(al + f(group, bl, cl, dl) + R_BUF[rl[i]] + hbl, sl[i]) + el) | 0;
++                al = el, el = dl, dl = (0, utils_js_1.rotl)(cl, 10) | 0, cl = bl, bl = tl; // prettier-ignore
++            }
++            // 2 loops are 10% faster
++            for (let i = 0; i < 16; i++) {
++                const tr = ((0, utils_js_1.rotl)(ar + f(rGroup, br, cr, dr) + R_BUF[rr[i]] + hbr, sr[i]) + er) | 0;
++                ar = er, er = dr, dr = (0, utils_js_1.rotl)(cr, 10) | 0, cr = br, br = tr; // prettier-ignore
++            }
++        }
++        // Add the compressed chunk to the current hash value
++        this.set((this.h1 + cl + dr) | 0, (this.h2 + dl + er) | 0, (this.h3 + el + ar) | 0, (this.h4 + al + br) | 0, (this.h0 + bl + cr) | 0);
++    }
++    roundClean() {
++        R_BUF.fill(0);
++    }
++    destroy() {
++        this.destroyed = true;
++        this.buffer.fill(0);
++        this.set(0, 0, 0, 0, 0);
++    }
++}
++exports.RIPEMD160 = RIPEMD160;
++/**
++ * RIPEMD-160 - a hash function from 1990s.
++ * @param message - msg that would be hashed
++ */
++exports.ripemd160 = (0, utils_js_1.wrapConstructor)(() => new RIPEMD160());
++//# sourceMappingURL=ripemd160.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.js.map
+new file mode 100644
+index 0000000..f8ee722
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/ripemd160.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"ripemd160.js","sourceRoot":"","sources":["src/ripemd160.ts"],"names":[],"mappings":";;;AAAA,qCAAkC;AAClC,yCAAmD;AAEnD,0DAA0D;AAC1D,6EAA6E;AAC7E,MAAM,GAAG,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC;AACnG,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,UAAU,CAAC,IAAI,KAAK,CAAC,EAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;AAClF,MAAM,EAAE,GAAG,eAAe,CAAC,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;AAC3D,IAAI,IAAI,GAAG,CAAC,EAAE,CAAC,CAAC;AAChB,IAAI,IAAI,GAAG,CAAC,EAAE,CAAC,CAAC;AAChB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE;IAAE,KAAK,IAAI,CAAC,IAAI,CAAC,IAAI,EAAE,IAAI,CAAC;QAAE,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AAExF,MAAM,MAAM,GAAG,eAAe,CAAC;IAC7B,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;IACxD,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC;CACzD,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;AAChC,MAAM,OAAO,GAAG,eAAe,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACnF,MAAM,OAAO,GAAG,eAAe,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACnF,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IACzC,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC3D,CAAC,CAAC;AACH,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IACzC,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC3D,CAAC,CAAC;AACH,2BAA2B;AAC3B,SAAS,CAAC,CAAC,KAAa,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;IACvD,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;SAC7B,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;SAC3C,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;SACrC,IAAI,KAAK,KAAK,CAAC;QAAE,OAAO,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;;QAC3C,OAAO,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AAC3B,CAAC;AACD,4DAA4D;AAC5D,MAAM,KAAK,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AAClD,MAAa,SAAU,SAAQ,eAAiB;IAO9C;QACE,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;QAPjB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;IAI5B,CAAC;IACS,GAAG;QACX,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QACpC,OAAO,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC9B,CAAC;IACS,GAAG,CAAC,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;QACtE,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACnB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC;YAAE,KAAK,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,EAAE,IAAI,CAAC,CAAC;QAClF,kBAAkB;QAClB,IAAI,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EACzB,EAAE,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,CAAC;QAE9B,0DAA0D;QAC1D,gEAAgE;QAChE,KAAK,IAAI,KAAK,GAAG,CAAC,EAAE,KAAK,GAAG,CAAC,EAAE,KAAK,EAAE,EAAE,CAAC;YACvC,MAAM,MAAM,GAAG,CAAC,GAAG,KAAK,CAAC;YACzB,MAAM,GAAG,GAAG,EAAE,CAAC,KAAK,CAAC,EAAE,GAAG,GAAG,EAAE,CAAC,KAAK,CAAC,CAAC,CAAC,kBAAkB;YAC1D,MAAM,EAAE,GAAG,IAAI,CAAC,KAAK,CAAC,EAAE,EAAE,GAAG,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,kBAAkB;YAC5D,MAAM,EAAE,GAAG,OAAO,CAAC,KAAK,CAAC,EAAE,EAAE,GAAG,OAAO,CAAC,KAAK,CAAC,CAAC,CAAC,kBAAkB;YAClE,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;gBAC5B,MAAM,EAAE,GAAG,CAAC,IAAA,eAAI,EAAC,EAAE,GAAG,CAAC,CAAC,KAAK,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;gBAClF,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,IAAA,eAAI,EAAC,EAAE,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,CAAC,CAAC,kBAAkB;YAC/E,CAAC;YACD,yBAAyB;YACzB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;gBAC5B,MAAM,EAAE,GAAG,CAAC,IAAA,eAAI,EAAC,EAAE,GAAG,CAAC,CAAC,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;gBACnF,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,IAAA,eAAI,EAAC,EAAE,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,GAAG,EAAE,CAAC,CAAC,kBAAkB;YAC/E,CAAC;QACH,CAAC;QACD,qDAAqD;QACrD,IAAI,CAAC,GAAG,CACN,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EACvB,CAAC,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CACxB,CAAC;IACJ,CAAC;IACS,UAAU;QAClB,KAAK,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IAChB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACpB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC1B,CAAC;CACF;AAhED,8BAgEC;AAED;;;GAGG;AACU,QAAA,SAAS,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,SAAS,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.d.ts
+new file mode 100644
+index 0000000..68368e6
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.d.ts
+@@ -0,0 +1,30 @@
++import { Input } from './utils.js';
++export type ScryptOpts = {
++    N: number;
++    r: number;
++    p: number;
++    dkLen?: number;
++    asyncTick?: number;
++    maxmem?: number;
++    onProgress?: (progress: number) => void;
++};
++/**
++ * Scrypt KDF from RFC 7914.
++ * @param password - pass
++ * @param salt - salt
++ * @param opts - parameters
++ * - `N` is cpu/mem work factor (power of 2 e.g. 2**18)
++ * - `r` is block size (8 is common), fine-tunes sequential memory read size and performance
++ * - `p` is parallelization factor (1 is common)
++ * - `dkLen` is output key length in bytes e.g. 32.
++ * - `asyncTick` - (default: 10) max time in ms for which async function can block execution
++ * - `maxmem` - (default: `1024 ** 3 + 1024` aka 1GB+1KB). A limit that the app could use for scrypt
++ * - `onProgress` - callback function that would be executed for progress report
++ * @returns Derived key
++ */
++export declare function scrypt(password: Input, salt: Input, opts: ScryptOpts): Uint8Array;
++/**
++ * Scrypt KDF from RFC 7914.
++ */
++export declare function scryptAsync(password: Input, salt: Input, opts: ScryptOpts): Promise<Uint8Array>;
++//# sourceMappingURL=scrypt.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.d.ts.map
+new file mode 100644
+index 0000000..ab45209
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"scrypt.d.ts","sourceRoot":"","sources":["src/scrypt.ts"],"names":[],"mappings":"AAGA,OAAO,EAA8B,KAAK,EAAyB,MAAM,YAAY,CAAC;AAyEtF,MAAM,MAAM,UAAU,GAAG;IACvB,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,CAAC,EAAE,MAAM,CAAC;IACV,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,SAAS,CAAC,EAAE,MAAM,CAAC;IACnB,MAAM,CAAC,EAAE,MAAM,CAAC;IAChB,UAAU,CAAC,EAAE,CAAC,QAAQ,EAAE,MAAM,KAAK,IAAI,CAAC;CACzC,CAAC;AAoFF;;;;;;;;;;;;;GAaG;AACH,wBAAgB,MAAM,CAAC,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,UAAU,cA0BpE;AAED;;GAEG;AACH,wBAAsB,WAAW,CAAC,QAAQ,EAAE,KAAK,EAAE,IAAI,EAAE,KAAK,EAAE,IAAI,EAAE,UAAU,uBA2B/E"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.js
+new file mode 100644
+index 0000000..30cfc0e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.js
+@@ -0,0 +1,228 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.scrypt = scrypt;
++exports.scryptAsync = scryptAsync;
++const _assert_js_1 = require("./_assert.js");
++const sha256_js_1 = require("./sha256.js");
++const pbkdf2_js_1 = require("./pbkdf2.js");
++const utils_js_1 = require("./utils.js");
++// RFC 7914 Scrypt KDF
++// The main Scrypt loop: uses Salsa extensively.
++// Six versions of the function were tried, this is the fastest one.
++// prettier-ignore
++function XorAndSalsa(prev, pi, input, ii, out, oi) {
++    // Based on https://cr.yp.to/salsa20.html
++    // Xor blocks
++    let y00 = prev[pi++] ^ input[ii++], y01 = prev[pi++] ^ input[ii++];
++    let y02 = prev[pi++] ^ input[ii++], y03 = prev[pi++] ^ input[ii++];
++    let y04 = prev[pi++] ^ input[ii++], y05 = prev[pi++] ^ input[ii++];
++    let y06 = prev[pi++] ^ input[ii++], y07 = prev[pi++] ^ input[ii++];
++    let y08 = prev[pi++] ^ input[ii++], y09 = prev[pi++] ^ input[ii++];
++    let y10 = prev[pi++] ^ input[ii++], y11 = prev[pi++] ^ input[ii++];
++    let y12 = prev[pi++] ^ input[ii++], y13 = prev[pi++] ^ input[ii++];
++    let y14 = prev[pi++] ^ input[ii++], y15 = prev[pi++] ^ input[ii++];
++    // Save state to temporary variables (salsa)
++    let x00 = y00, x01 = y01, x02 = y02, x03 = y03, x04 = y04, x05 = y05, x06 = y06, x07 = y07, x08 = y08, x09 = y09, x10 = y10, x11 = y11, x12 = y12, x13 = y13, x14 = y14, x15 = y15;
++    // Main loop (salsa)
++    for (let i = 0; i < 8; i += 2) {
++        x04 ^= (0, utils_js_1.rotl)(x00 + x12 | 0, 7);
++        x08 ^= (0, utils_js_1.rotl)(x04 + x00 | 0, 9);
++        x12 ^= (0, utils_js_1.rotl)(x08 + x04 | 0, 13);
++        x00 ^= (0, utils_js_1.rotl)(x12 + x08 | 0, 18);
++        x09 ^= (0, utils_js_1.rotl)(x05 + x01 | 0, 7);
++        x13 ^= (0, utils_js_1.rotl)(x09 + x05 | 0, 9);
++        x01 ^= (0, utils_js_1.rotl)(x13 + x09 | 0, 13);
++        x05 ^= (0, utils_js_1.rotl)(x01 + x13 | 0, 18);
++        x14 ^= (0, utils_js_1.rotl)(x10 + x06 | 0, 7);
++        x02 ^= (0, utils_js_1.rotl)(x14 + x10 | 0, 9);
++        x06 ^= (0, utils_js_1.rotl)(x02 + x14 | 0, 13);
++        x10 ^= (0, utils_js_1.rotl)(x06 + x02 | 0, 18);
++        x03 ^= (0, utils_js_1.rotl)(x15 + x11 | 0, 7);
++        x07 ^= (0, utils_js_1.rotl)(x03 + x15 | 0, 9);
++        x11 ^= (0, utils_js_1.rotl)(x07 + x03 | 0, 13);
++        x15 ^= (0, utils_js_1.rotl)(x11 + x07 | 0, 18);
++        x01 ^= (0, utils_js_1.rotl)(x00 + x03 | 0, 7);
++        x02 ^= (0, utils_js_1.rotl)(x01 + x00 | 0, 9);
++        x03 ^= (0, utils_js_1.rotl)(x02 + x01 | 0, 13);
++        x00 ^= (0, utils_js_1.rotl)(x03 + x02 | 0, 18);
++        x06 ^= (0, utils_js_1.rotl)(x05 + x04 | 0, 7);
++        x07 ^= (0, utils_js_1.rotl)(x06 + x05 | 0, 9);
++        x04 ^= (0, utils_js_1.rotl)(x07 + x06 | 0, 13);
++        x05 ^= (0, utils_js_1.rotl)(x04 + x07 | 0, 18);
++        x11 ^= (0, utils_js_1.rotl)(x10 + x09 | 0, 7);
++        x08 ^= (0, utils_js_1.rotl)(x11 + x10 | 0, 9);
++        x09 ^= (0, utils_js_1.rotl)(x08 + x11 | 0, 13);
++        x10 ^= (0, utils_js_1.rotl)(x09 + x08 | 0, 18);
++        x12 ^= (0, utils_js_1.rotl)(x15 + x14 | 0, 7);
++        x13 ^= (0, utils_js_1.rotl)(x12 + x15 | 0, 9);
++        x14 ^= (0, utils_js_1.rotl)(x13 + x12 | 0, 13);
++        x15 ^= (0, utils_js_1.rotl)(x14 + x13 | 0, 18);
++    }
++    // Write output (salsa)
++    out[oi++] = (y00 + x00) | 0;
++    out[oi++] = (y01 + x01) | 0;
++    out[oi++] = (y02 + x02) | 0;
++    out[oi++] = (y03 + x03) | 0;
++    out[oi++] = (y04 + x04) | 0;
++    out[oi++] = (y05 + x05) | 0;
++    out[oi++] = (y06 + x06) | 0;
++    out[oi++] = (y07 + x07) | 0;
++    out[oi++] = (y08 + x08) | 0;
++    out[oi++] = (y09 + x09) | 0;
++    out[oi++] = (y10 + x10) | 0;
++    out[oi++] = (y11 + x11) | 0;
++    out[oi++] = (y12 + x12) | 0;
++    out[oi++] = (y13 + x13) | 0;
++    out[oi++] = (y14 + x14) | 0;
++    out[oi++] = (y15 + x15) | 0;
++}
++function BlockMix(input, ii, out, oi, r) {
++    // The block B is r 128-byte chunks (which is equivalent of 2r 64-byte chunks)
++    let head = oi + 0;
++    let tail = oi + 16 * r;
++    for (let i = 0; i < 16; i++)
++        out[tail + i] = input[ii + (2 * r - 1) * 16 + i]; // X ← B[2r−1]
++    for (let i = 0; i < r; i++, head += 16, ii += 16) {
++        // We write odd & even Yi at same time. Even: 0bXXXXX0 Odd:  0bXXXXX1
++        XorAndSalsa(out, tail, input, ii, out, head); // head[i] = Salsa(blockIn[2*i] ^ tail[i-1])
++        if (i > 0)
++            tail += 16; // First iteration overwrites tmp value in tail
++        XorAndSalsa(out, head, input, (ii += 16), out, tail); // tail[i] = Salsa(blockIn[2*i+1] ^ head[i])
++    }
++}
++// Common prologue and epilogue for sync/async functions
++function scryptInit(password, salt, _opts) {
++    // Maxmem - 1GB+1KB by default
++    const opts = (0, utils_js_1.checkOpts)({
++        dkLen: 32,
++        asyncTick: 10,
++        maxmem: 1024 ** 3 + 1024,
++    }, _opts);
++    const { N, r, p, dkLen, asyncTick, maxmem, onProgress } = opts;
++    (0, _assert_js_1.number)(N);
++    (0, _assert_js_1.number)(r);
++    (0, _assert_js_1.number)(p);
++    (0, _assert_js_1.number)(dkLen);
++    (0, _assert_js_1.number)(asyncTick);
++    (0, _assert_js_1.number)(maxmem);
++    if (onProgress !== undefined && typeof onProgress !== 'function')
++        throw new Error('progressCb should be function');
++    const blockSize = 128 * r;
++    const blockSize32 = blockSize / 4;
++    if (N <= 1 || (N & (N - 1)) !== 0 || N >= 2 ** (blockSize / 8) || N > 2 ** 32) {
++        // NOTE: we limit N to be less than 2**32 because of 32 bit variant of Integrify function
++        // There is no JS engines that allows alocate more than 4GB per single Uint8Array for now, but can change in future.
++        throw new Error('Scrypt: N must be larger than 1, a power of 2, less than 2^(128 * r / 8) and less than 2^32');
++    }
++    if (p < 0 || p > ((2 ** 32 - 1) * 32) / blockSize) {
++        throw new Error('Scrypt: p must be a positive integer less than or equal to ((2^32 - 1) * 32) / (128 * r)');
++    }
++    if (dkLen < 0 || dkLen > (2 ** 32 - 1) * 32) {
++        throw new Error('Scrypt: dkLen should be positive integer less than or equal to (2^32 - 1) * 32');
++    }
++    const memUsed = blockSize * (N + p);
++    if (memUsed > maxmem) {
++        throw new Error(`Scrypt: parameters too large, ${memUsed} (128 * r * (N + p)) > ${maxmem} (maxmem)`);
++    }
++    // [B0...Bp−1] ← PBKDF2HMAC-SHA256(Passphrase, Salt, 1, blockSize*ParallelizationFactor)
++    // Since it has only one iteration there is no reason to use async variant
++    const B = (0, pbkdf2_js_1.pbkdf2)(sha256_js_1.sha256, password, salt, { c: 1, dkLen: blockSize * p });
++    const B32 = (0, utils_js_1.u32)(B);
++    // Re-used between parallel iterations. Array(iterations) of B
++    const V = (0, utils_js_1.u32)(new Uint8Array(blockSize * N));
++    const tmp = (0, utils_js_1.u32)(new Uint8Array(blockSize));
++    let blockMixCb = () => { };
++    if (onProgress) {
++        const totalBlockMix = 2 * N * p;
++        // Invoke callback if progress changes from 10.01 to 10.02
++        // Allows to draw smooth progress bar on up to 8K screen
++        const callbackPer = Math.max(Math.floor(totalBlockMix / 10000), 1);
++        let blockMixCnt = 0;
++        blockMixCb = () => {
++            blockMixCnt++;
++            if (onProgress && (!(blockMixCnt % callbackPer) || blockMixCnt === totalBlockMix))
++                onProgress(blockMixCnt / totalBlockMix);
++        };
++    }
++    return { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick };
++}
++function scryptOutput(password, dkLen, B, V, tmp) {
++    const res = (0, pbkdf2_js_1.pbkdf2)(sha256_js_1.sha256, password, B, { c: 1, dkLen });
++    B.fill(0);
++    V.fill(0);
++    tmp.fill(0);
++    return res;
++}
++/**
++ * Scrypt KDF from RFC 7914.
++ * @param password - pass
++ * @param salt - salt
++ * @param opts - parameters
++ * - `N` is cpu/mem work factor (power of 2 e.g. 2**18)
++ * - `r` is block size (8 is common), fine-tunes sequential memory read size and performance
++ * - `p` is parallelization factor (1 is common)
++ * - `dkLen` is output key length in bytes e.g. 32.
++ * - `asyncTick` - (default: 10) max time in ms for which async function can block execution
++ * - `maxmem` - (default: `1024 ** 3 + 1024` aka 1GB+1KB). A limit that the app could use for scrypt
++ * - `onProgress` - callback function that would be executed for progress report
++ * @returns Derived key
++ */
++function scrypt(password, salt, opts) {
++    const { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb } = scryptInit(password, salt, opts);
++    if (!utils_js_1.isLE)
++        (0, utils_js_1.byteSwap32)(B32);
++    for (let pi = 0; pi < p; pi++) {
++        const Pi = blockSize32 * pi;
++        for (let i = 0; i < blockSize32; i++)
++            V[i] = B32[Pi + i]; // V[0] = B[i]
++        for (let i = 0, pos = 0; i < N - 1; i++) {
++            BlockMix(V, pos, V, (pos += blockSize32), r); // V[i] = BlockMix(V[i-1]);
++            blockMixCb();
++        }
++        BlockMix(V, (N - 1) * blockSize32, B32, Pi, r); // Process last element
++        blockMixCb();
++        for (let i = 0; i < N; i++) {
++            // First u32 of the last 64-byte block (u32 is LE)
++            const j = B32[Pi + blockSize32 - 16] % N; // j = Integrify(X) % iterations
++            for (let k = 0; k < blockSize32; k++)
++                tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
++            BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])
++            blockMixCb();
++        }
++    }
++    if (!utils_js_1.isLE)
++        (0, utils_js_1.byteSwap32)(B32);
++    return scryptOutput(password, dkLen, B, V, tmp);
++}
++/**
++ * Scrypt KDF from RFC 7914.
++ */
++async function scryptAsync(password, salt, opts) {
++    const { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick } = scryptInit(password, salt, opts);
++    if (!utils_js_1.isLE)
++        (0, utils_js_1.byteSwap32)(B32);
++    for (let pi = 0; pi < p; pi++) {
++        const Pi = blockSize32 * pi;
++        for (let i = 0; i < blockSize32; i++)
++            V[i] = B32[Pi + i]; // V[0] = B[i]
++        let pos = 0;
++        await (0, utils_js_1.asyncLoop)(N - 1, asyncTick, () => {
++            BlockMix(V, pos, V, (pos += blockSize32), r); // V[i] = BlockMix(V[i-1]);
++            blockMixCb();
++        });
++        BlockMix(V, (N - 1) * blockSize32, B32, Pi, r); // Process last element
++        blockMixCb();
++        await (0, utils_js_1.asyncLoop)(N, asyncTick, () => {
++            // First u32 of the last 64-byte block (u32 is LE)
++            const j = B32[Pi + blockSize32 - 16] % N; // j = Integrify(X) % iterations
++            for (let k = 0; k < blockSize32; k++)
++                tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
++            BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])
++            blockMixCb();
++        });
++    }
++    if (!utils_js_1.isLE)
++        (0, utils_js_1.byteSwap32)(B32);
++    return scryptOutput(password, dkLen, B, V, tmp);
++}
++//# sourceMappingURL=scrypt.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.js.map
+new file mode 100644
+index 0000000..060d6b6
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/scrypt.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"scrypt.js","sourceRoot":"","sources":["src/scrypt.ts"],"names":[],"mappings":";;AAsLA,wBA0BC;AAKD,kCA2BC;AAhPD,6CAAsD;AACtD,2CAAqC;AACrC,2CAAqC;AACrC,yCAAsF;AAEtF,sBAAsB;AAEtB,gDAAgD;AAChD,oEAAoE;AACpE,kBAAkB;AAClB,SAAS,WAAW,CAClB,IAAiB,EACjB,EAAU,EACV,KAAkB,EAClB,EAAU,EACV,GAAgB,EAChB,EAAU;IAEV,yCAAyC;IACzC,aAAa;IACb,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,IAAI,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,EAAE,EAAE,CAAC,GAAG,KAAK,CAAC,EAAE,EAAE,CAAC,CAAC;IACnE,4CAA4C;IAC5C,IAAI,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAC1C,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAC1C,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAC1C,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC;IAC/C,oBAAoB;IACpB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC;QAC9B,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAG,CAAC,CAAC,CAAC;QAC/D,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;QAAC,GAAG,IAAI,IAAA,eAAI,EAAC,GAAG,GAAG,GAAG,GAAG,CAAC,EAAE,EAAE,CAAC,CAAC;IACjE,CAAC;IACD,uBAAuB;IACvB,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IACzD,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;IAAC,GAAG,CAAC,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,GAAG,GAAG,CAAC,GAAG,CAAC,CAAC;AAC3D,CAAC;AAED,SAAS,QAAQ,CAAC,KAAkB,EAAE,EAAU,EAAE,GAAgB,EAAE,EAAU,EAAE,CAAS;IACvF,8EAA8E;IAC9E,IAAI,IAAI,GAAG,EAAE,GAAG,CAAC,CAAC;IAClB,IAAI,IAAI,GAAG,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACvB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;QAAE,GAAG,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,KAAK,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC,cAAc;IAC7F,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,IAAI,IAAI,EAAE,EAAE,EAAE,IAAI,EAAE,EAAE,CAAC;QACjD,qEAAqE;QACrE,WAAW,CAAC,GAAG,EAAE,IAAI,EAAE,KAAK,EAAE,EAAE,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC,CAAC,4CAA4C;QAC1F,IAAI,CAAC,GAAG,CAAC;YAAE,IAAI,IAAI,EAAE,CAAC,CAAC,+CAA+C;QACtE,WAAW,CAAC,GAAG,EAAE,IAAI,EAAE,KAAK,EAAE,CAAC,EAAE,IAAI,EAAE,CAAC,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC,CAAC,4CAA4C;IACpG,CAAC;AACH,CAAC;AAYD,wDAAwD;AACxD,SAAS,UAAU,CAAC,QAAe,EAAE,IAAW,EAAE,KAAkB;IAClE,8BAA8B;IAC9B,MAAM,IAAI,GAAG,IAAA,oBAAS,EACpB;QACE,KAAK,EAAE,EAAE;QACT,SAAS,EAAE,EAAE;QACb,MAAM,EAAE,IAAI,IAAI,CAAC,GAAG,IAAI;KACzB,EACD,KAAK,CACN,CAAC;IACF,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,EAAE,MAAM,EAAE,UAAU,EAAE,GAAG,IAAI,CAAC;IAC/D,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;IAChB,IAAA,mBAAY,EAAC,KAAK,CAAC,CAAC;IACpB,IAAA,mBAAY,EAAC,SAAS,CAAC,CAAC;IACxB,IAAA,mBAAY,EAAC,MAAM,CAAC,CAAC;IACrB,IAAI,UAAU,KAAK,SAAS,IAAI,OAAO,UAAU,KAAK,UAAU;QAC9D,MAAM,IAAI,KAAK,CAAC,+BAA+B,CAAC,CAAC;IACnD,MAAM,SAAS,GAAG,GAAG,GAAG,CAAC,CAAC;IAC1B,MAAM,WAAW,GAAG,SAAS,GAAG,CAAC,CAAC;IAClC,IAAI,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,KAAK,CAAC,IAAI,CAAC,IAAI,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,IAAI,CAAC,GAAG,CAAC,IAAI,EAAE,EAAE,CAAC;QAC9E,yFAAyF;QACzF,oHAAoH;QACpH,MAAM,IAAI,KAAK,CACb,6FAA6F,CAC9F,CAAC;IACJ,CAAC;IACD,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,SAAS,EAAE,CAAC;QAClD,MAAM,IAAI,KAAK,CACb,0FAA0F,CAC3F,CAAC;IACJ,CAAC;IACD,IAAI,KAAK,GAAG,CAAC,IAAI,KAAK,GAAG,CAAC,CAAC,IAAI,EAAE,GAAG,CAAC,CAAC,GAAG,EAAE,EAAE,CAAC;QAC5C,MAAM,IAAI,KAAK,CACb,gFAAgF,CACjF,CAAC;IACJ,CAAC;IACD,MAAM,OAAO,GAAG,SAAS,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACpC,IAAI,OAAO,GAAG,MAAM,EAAE,CAAC;QACrB,MAAM,IAAI,KAAK,CACb,iCAAiC,OAAO,0BAA0B,MAAM,WAAW,CACpF,CAAC;IACJ,CAAC;IACD,wFAAwF;IACxF,0EAA0E;IAC1E,MAAM,CAAC,GAAG,IAAA,kBAAM,EAAC,kBAAM,EAAE,QAAQ,EAAE,IAAI,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,SAAS,GAAG,CAAC,EAAE,CAAC,CAAC;IACzE,MAAM,GAAG,GAAG,IAAA,cAAG,EAAC,CAAC,CAAC,CAAC;IACnB,8DAA8D;IAC9D,MAAM,CAAC,GAAG,IAAA,cAAG,EAAC,IAAI,UAAU,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC;IAC7C,MAAM,GAAG,GAAG,IAAA,cAAG,EAAC,IAAI,UAAU,CAAC,SAAS,CAAC,CAAC,CAAC;IAC3C,IAAI,UAAU,GAAG,GAAG,EAAE,GAAE,CAAC,CAAC;IAC1B,IAAI,UAAU,EAAE,CAAC;QACf,MAAM,aAAa,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QAChC,0DAA0D;QAC1D,wDAAwD;QACxD,MAAM,WAAW,GAAG,IAAI,CAAC,GAAG,CAAC,IAAI,CAAC,KAAK,CAAC,aAAa,GAAG,KAAK,CAAC,EAAE,CAAC,CAAC,CAAC;QACnE,IAAI,WAAW,GAAG,CAAC,CAAC;QACpB,UAAU,GAAG,GAAG,EAAE;YAChB,WAAW,EAAE,CAAC;YACd,IAAI,UAAU,IAAI,CAAC,CAAC,CAAC,WAAW,GAAG,WAAW,CAAC,IAAI,WAAW,KAAK,aAAa,CAAC;gBAC/E,UAAU,CAAC,WAAW,GAAG,aAAa,CAAC,CAAC;QAC5C,CAAC,CAAC;IACJ,CAAC;IACD,OAAO,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,WAAW,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,UAAU,EAAE,SAAS,EAAE,CAAC;AAChF,CAAC;AAED,SAAS,YAAY,CACnB,QAAe,EACf,KAAa,EACb,CAAa,EACb,CAAc,EACd,GAAgB;IAEhB,MAAM,GAAG,GAAG,IAAA,kBAAM,EAAC,kBAAM,EAAE,QAAQ,EAAE,CAAC,EAAE,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,CAAC,CAAC;IACzD,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACV,GAAG,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACZ,OAAO,GAAG,CAAC;AACb,CAAC;AAED;;;;;;;;;;;;;GAaG;AACH,SAAgB,MAAM,CAAC,QAAe,EAAE,IAAW,EAAE,IAAgB;IACnE,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,WAAW,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,UAAU,EAAE,GAAG,UAAU,CAC5E,QAAQ,EACR,IAAI,EACJ,IAAI,CACL,CAAC;IACF,IAAI,CAAC,eAAI;QAAE,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC3B,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC;QAC9B,MAAM,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC;QAC5B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC,cAAc;QACxE,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;YACxC,QAAQ,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,CAAC,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,2BAA2B;YACzE,UAAU,EAAE,CAAC;QACf,CAAC;QACD,QAAQ,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,WAAW,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,uBAAuB;QACvE,UAAU,EAAE,CAAC;QACb,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;YAC3B,kDAAkD;YAClD,MAAM,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,gCAAgC;YAC1E,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;gBAAE,GAAG,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,WAAW,GAAG,CAAC,CAAC,CAAC,CAAC,iBAAiB;YACtG,QAAQ,CAAC,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,yBAAyB;YACvD,UAAU,EAAE,CAAC;QACf,CAAC;IACH,CAAC;IACD,IAAI,CAAC,eAAI;QAAE,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC3B,OAAO,YAAY,CAAC,QAAQ,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;AAClD,CAAC;AAED;;GAEG;AACI,KAAK,UAAU,WAAW,CAAC,QAAe,EAAE,IAAW,EAAE,IAAgB;IAC9E,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,KAAK,EAAE,WAAW,EAAE,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,UAAU,EAAE,SAAS,EAAE,GAAG,UAAU,CACvF,QAAQ,EACR,IAAI,EACJ,IAAI,CACL,CAAC;IACF,IAAI,CAAC,eAAI;QAAE,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC3B,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC;QAC9B,MAAM,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC;QAC5B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC,cAAc;QACxE,IAAI,GAAG,GAAG,CAAC,CAAC;QACZ,MAAM,IAAA,oBAAS,EAAC,CAAC,GAAG,CAAC,EAAE,SAAS,EAAE,GAAG,EAAE;YACrC,QAAQ,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,EAAE,CAAC,GAAG,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,2BAA2B;YACzE,UAAU,EAAE,CAAC;QACf,CAAC,CAAC,CAAC;QACH,QAAQ,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,WAAW,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,uBAAuB;QACvE,UAAU,EAAE,CAAC;QACb,MAAM,IAAA,oBAAS,EAAC,CAAC,EAAE,SAAS,EAAE,GAAG,EAAE;YACjC,kDAAkD;YAClD,MAAM,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,WAAW,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,gCAAgC;YAC1E,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,WAAW,EAAE,CAAC,EAAE;gBAAE,GAAG,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,WAAW,GAAG,CAAC,CAAC,CAAC,CAAC,iBAAiB;YACtG,QAAQ,CAAC,GAAG,EAAE,CAAC,EAAE,GAAG,EAAE,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,yBAAyB;YACvD,UAAU,EAAE,CAAC;QACf,CAAC,CAAC,CAAC;IACL,CAAC;IACD,IAAI,CAAC,eAAI;QAAE,IAAA,qBAAU,EAAC,GAAG,CAAC,CAAC;IAC3B,OAAO,YAAY,CAAC,QAAQ,EAAE,KAAK,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,CAAC,CAAC;AAClD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.d.ts
+new file mode 100644
+index 0000000..f210c5c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.d.ts
+@@ -0,0 +1,26 @@
++import { HashMD } from './_md.js';
++export declare class SHA1 extends HashMD<SHA1> {
++    private A;
++    private B;
++    private C;
++    private D;
++    private E;
++    constructor();
++    protected get(): [number, number, number, number, number];
++    protected set(A: number, B: number, C: number, D: number, E: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++/**
++ * SHA1 (RFC 3174) hash function.
++ * It was cryptographically broken: prefer newer algorithms.
++ * @param message - data that would be hashed
++ */
++export declare const sha1: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA1>;
++};
++//# sourceMappingURL=sha1.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.d.ts.map
+new file mode 100644
+index 0000000..ea42f9e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha1.d.ts","sourceRoot":"","sources":["src/sha1.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAY,MAAM,UAAU,CAAC;AAa5C,qBAAa,IAAK,SAAQ,MAAM,CAAC,IAAI,CAAC;IACpC,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;IAC3B,OAAO,CAAC,CAAC,CAAkB;;IAK3B,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAIzD,SAAS,CAAC,GAAG,CAAC,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM;IAOnE,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAoCvD,SAAS,CAAC,UAAU;IAGpB,OAAO;CAIR;AAED;;;;GAIG;AACH,eAAO,MAAM,IAAI;;;;;CAAoD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.js
+new file mode 100644
+index 0000000..a6dca1b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.js
+@@ -0,0 +1,89 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.sha1 = exports.SHA1 = void 0;
++const _md_js_1 = require("./_md.js");
++const utils_js_1 = require("./utils.js");
++// SHA1 (RFC 3174). It was cryptographically broken: prefer newer algorithms.
++// Initial state
++const SHA1_IV = /* @__PURE__ */ new Uint32Array([
++    0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0,
++]);
++// Temporary buffer, not used to store anything between runs
++// Named this way because it matches specification.
++const SHA1_W = /* @__PURE__ */ new Uint32Array(80);
++class SHA1 extends _md_js_1.HashMD {
++    constructor() {
++        super(64, 20, 8, false);
++        this.A = SHA1_IV[0] | 0;
++        this.B = SHA1_IV[1] | 0;
++        this.C = SHA1_IV[2] | 0;
++        this.D = SHA1_IV[3] | 0;
++        this.E = SHA1_IV[4] | 0;
++    }
++    get() {
++        const { A, B, C, D, E } = this;
++        return [A, B, C, D, E];
++    }
++    set(A, B, C, D, E) {
++        this.A = A | 0;
++        this.B = B | 0;
++        this.C = C | 0;
++        this.D = D | 0;
++        this.E = E | 0;
++    }
++    process(view, offset) {
++        for (let i = 0; i < 16; i++, offset += 4)
++            SHA1_W[i] = view.getUint32(offset, false);
++        for (let i = 16; i < 80; i++)
++            SHA1_W[i] = (0, utils_js_1.rotl)(SHA1_W[i - 3] ^ SHA1_W[i - 8] ^ SHA1_W[i - 14] ^ SHA1_W[i - 16], 1);
++        // Compression function main loop, 80 rounds
++        let { A, B, C, D, E } = this;
++        for (let i = 0; i < 80; i++) {
++            let F, K;
++            if (i < 20) {
++                F = (0, _md_js_1.Chi)(B, C, D);
++                K = 0x5a827999;
++            }
++            else if (i < 40) {
++                F = B ^ C ^ D;
++                K = 0x6ed9eba1;
++            }
++            else if (i < 60) {
++                F = (0, _md_js_1.Maj)(B, C, D);
++                K = 0x8f1bbcdc;
++            }
++            else {
++                F = B ^ C ^ D;
++                K = 0xca62c1d6;
++            }
++            const T = ((0, utils_js_1.rotl)(A, 5) + F + E + K + SHA1_W[i]) | 0;
++            E = D;
++            D = C;
++            C = (0, utils_js_1.rotl)(B, 30);
++            B = A;
++            A = T;
++        }
++        // Add the compressed chunk to the current hash value
++        A = (A + this.A) | 0;
++        B = (B + this.B) | 0;
++        C = (C + this.C) | 0;
++        D = (D + this.D) | 0;
++        E = (E + this.E) | 0;
++        this.set(A, B, C, D, E);
++    }
++    roundClean() {
++        SHA1_W.fill(0);
++    }
++    destroy() {
++        this.set(0, 0, 0, 0, 0);
++        this.buffer.fill(0);
++    }
++}
++exports.SHA1 = SHA1;
++/**
++ * SHA1 (RFC 3174) hash function.
++ * It was cryptographically broken: prefer newer algorithms.
++ * @param message - data that would be hashed
++ */
++exports.sha1 = (0, utils_js_1.wrapConstructor)(() => new SHA1());
++//# sourceMappingURL=sha1.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.js.map
+new file mode 100644
+index 0000000..d0e4764
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha1.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha1.js","sourceRoot":"","sources":["src/sha1.ts"],"names":[],"mappings":";;;AAAA,qCAA4C;AAC5C,yCAAmD;AAEnD,6EAA6E;AAE7E,gBAAgB;AAChB,MAAM,OAAO,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAC9C,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC3D,CAAC,CAAC;AAEH,4DAA4D;AAC5D,mDAAmD;AACnD,MAAM,MAAM,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACnD,MAAa,IAAK,SAAQ,eAAY;IAOpC;QACE,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;QAPlB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,OAAO,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;IAI3B,CAAC;IACS,GAAG;QACX,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QAC/B,OAAO,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IACzB,CAAC;IACS,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;QACjE,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;IACjB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC;YAAE,MAAM,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;QACpF,KAAK,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;YAC1B,MAAM,CAAC,CAAC,CAAC,GAAG,IAAA,eAAI,EAAC,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QACvF,4CAA4C;QAC5C,IAAI,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QAC7B,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,IAAI,CAAC,EAAE,CAAC,CAAC;YACT,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC;gBACX,CAAC,GAAG,IAAA,YAAG,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;gBACjB,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;iBAAM,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC;gBAClB,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;gBACd,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;iBAAM,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC;gBAClB,CAAC,GAAG,IAAA,YAAG,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;gBACjB,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;iBAAM,CAAC;gBACN,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;gBACd,CAAC,GAAG,UAAU,CAAC;YACjB,CAAC;YACD,MAAM,CAAC,GAAG,CAAC,IAAA,eAAI,EAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;YACnD,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,EAAE,CAAC,CAAC;YAChB,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;QACR,CAAC;QACD,qDAAqD;QACrD,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC1B,CAAC;IACS,UAAU;QAClB,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACjB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QACxB,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACtB,CAAC;CACF;AAhED,oBAgEC;AAED;;;;GAIG;AACU,QAAA,IAAI,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,IAAI,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.d.ts
+new file mode 100644
+index 0000000..6052a2a
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.d.ts
+@@ -0,0 +1,3 @@
++export { sha256, sha224 } from './sha256.js';
++export { sha512, sha512_224, sha512_256, sha384 } from './sha512.js';
++//# sourceMappingURL=sha2.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.d.ts.map
+new file mode 100644
+index 0000000..588445d
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha2.d.ts","sourceRoot":"","sources":["src/sha2.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC;AAC7C,OAAO,EAAE,MAAM,EAAE,UAAU,EAAE,UAAU,EAAE,MAAM,EAAE,MAAM,aAAa,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.js
+new file mode 100644
+index 0000000..651b9e4
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.js
+@@ -0,0 +1,13 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.sha384 = exports.sha512_256 = exports.sha512_224 = exports.sha512 = exports.sha224 = exports.sha256 = void 0;
++// Usually you either use sha256, or sha512. We re-export them as sha2 for naming consistency.
++var sha256_js_1 = require("./sha256.js");
++Object.defineProperty(exports, "sha256", { enumerable: true, get: function () { return sha256_js_1.sha256; } });
++Object.defineProperty(exports, "sha224", { enumerable: true, get: function () { return sha256_js_1.sha224; } });
++var sha512_js_1 = require("./sha512.js");
++Object.defineProperty(exports, "sha512", { enumerable: true, get: function () { return sha512_js_1.sha512; } });
++Object.defineProperty(exports, "sha512_224", { enumerable: true, get: function () { return sha512_js_1.sha512_224; } });
++Object.defineProperty(exports, "sha512_256", { enumerable: true, get: function () { return sha512_js_1.sha512_256; } });
++Object.defineProperty(exports, "sha384", { enumerable: true, get: function () { return sha512_js_1.sha384; } });
++//# sourceMappingURL=sha2.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.js.map
+new file mode 100644
+index 0000000..a0c2748
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha2.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha2.js","sourceRoot":"","sources":["src/sha2.ts"],"names":[],"mappings":";;;AAAA,8FAA8F;AAC9F,yCAA6C;AAApC,mGAAA,MAAM,OAAA;AAAE,mGAAA,MAAM,OAAA;AACvB,yCAAqE;AAA5D,mGAAA,MAAM,OAAA;AAAE,uGAAA,UAAU,OAAA;AAAE,uGAAA,UAAU,OAAA;AAAE,mGAAA,MAAM,OAAA"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.d.ts
+new file mode 100644
+index 0000000..b31a842
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.d.ts
+@@ -0,0 +1,37 @@
++import { HashMD } from './_md.js';
++export declare class SHA256 extends HashMD<SHA256> {
++    A: number;
++    B: number;
++    C: number;
++    D: number;
++    E: number;
++    F: number;
++    G: number;
++    H: number;
++    constructor();
++    protected get(): [number, number, number, number, number, number, number, number];
++    protected set(A: number, B: number, C: number, D: number, E: number, F: number, G: number, H: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++/**
++ * SHA2-256 hash function
++ * @param message - data that would be hashed
++ */
++export declare const sha256: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA256>;
++};
++/**
++ * SHA2-224 hash function
++ */
++export declare const sha224: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA256>;
++};
++//# sourceMappingURL=sha256.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.d.ts.map
+new file mode 100644
+index 0000000..0c59b17
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha256.d.ts","sourceRoot":"","sources":["src/sha256.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAY,MAAM,UAAU,CAAC;AA8B5C,qBAAa,MAAO,SAAQ,MAAM,CAAC,MAAM,CAAC;IAGxC,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;IACrB,CAAC,SAAoB;;IAKrB,SAAS,CAAC,GAAG,IAAI,CAAC,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,CAAC;IAKjF,SAAS,CAAC,GAAG,CACX,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM;IAWxF,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM,GAAG,IAAI;IAqCvD,SAAS,CAAC,UAAU;IAGpB,OAAO;CAIR;AAiBD;;;GAGG;AACH,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC;AAC1E;;GAEG;AACH,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.js
+new file mode 100644
+index 0000000..3e21558
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.js
+@@ -0,0 +1,130 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.sha224 = exports.sha256 = exports.SHA256 = void 0;
++const _md_js_1 = require("./_md.js");
++const utils_js_1 = require("./utils.js");
++// SHA2-256 need to try 2^128 hashes to execute birthday attack.
++// BTC network is doing 2^67 hashes/sec as per early 2023.
++// Round constants:
++// first 32 bits of the fractional parts of the cube roots of the first 64 primes 2..311)
++// prettier-ignore
++const SHA256_K = /* @__PURE__ */ new Uint32Array([
++    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
++    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
++    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
++    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
++    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
++    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
++    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
++    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
++]);
++// Initial state:
++// first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19
++// prettier-ignore
++const SHA256_IV = /* @__PURE__ */ new Uint32Array([
++    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
++]);
++// Temporary buffer, not used to store anything between runs
++// Named this way because it matches specification.
++const SHA256_W = /* @__PURE__ */ new Uint32Array(64);
++class SHA256 extends _md_js_1.HashMD {
++    constructor() {
++        super(64, 32, 8, false);
++        // We cannot use array here since array allows indexing by variable
++        // which means optimizer/compiler cannot use registers.
++        this.A = SHA256_IV[0] | 0;
++        this.B = SHA256_IV[1] | 0;
++        this.C = SHA256_IV[2] | 0;
++        this.D = SHA256_IV[3] | 0;
++        this.E = SHA256_IV[4] | 0;
++        this.F = SHA256_IV[5] | 0;
++        this.G = SHA256_IV[6] | 0;
++        this.H = SHA256_IV[7] | 0;
++    }
++    get() {
++        const { A, B, C, D, E, F, G, H } = this;
++        return [A, B, C, D, E, F, G, H];
++    }
++    // prettier-ignore
++    set(A, B, C, D, E, F, G, H) {
++        this.A = A | 0;
++        this.B = B | 0;
++        this.C = C | 0;
++        this.D = D | 0;
++        this.E = E | 0;
++        this.F = F | 0;
++        this.G = G | 0;
++        this.H = H | 0;
++    }
++    process(view, offset) {
++        // Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array
++        for (let i = 0; i < 16; i++, offset += 4)
++            SHA256_W[i] = view.getUint32(offset, false);
++        for (let i = 16; i < 64; i++) {
++            const W15 = SHA256_W[i - 15];
++            const W2 = SHA256_W[i - 2];
++            const s0 = (0, utils_js_1.rotr)(W15, 7) ^ (0, utils_js_1.rotr)(W15, 18) ^ (W15 >>> 3);
++            const s1 = (0, utils_js_1.rotr)(W2, 17) ^ (0, utils_js_1.rotr)(W2, 19) ^ (W2 >>> 10);
++            SHA256_W[i] = (s1 + SHA256_W[i - 7] + s0 + SHA256_W[i - 16]) | 0;
++        }
++        // Compression function main loop, 64 rounds
++        let { A, B, C, D, E, F, G, H } = this;
++        for (let i = 0; i < 64; i++) {
++            const sigma1 = (0, utils_js_1.rotr)(E, 6) ^ (0, utils_js_1.rotr)(E, 11) ^ (0, utils_js_1.rotr)(E, 25);
++            const T1 = (H + sigma1 + (0, _md_js_1.Chi)(E, F, G) + SHA256_K[i] + SHA256_W[i]) | 0;
++            const sigma0 = (0, utils_js_1.rotr)(A, 2) ^ (0, utils_js_1.rotr)(A, 13) ^ (0, utils_js_1.rotr)(A, 22);
++            const T2 = (sigma0 + (0, _md_js_1.Maj)(A, B, C)) | 0;
++            H = G;
++            G = F;
++            F = E;
++            E = (D + T1) | 0;
++            D = C;
++            C = B;
++            B = A;
++            A = (T1 + T2) | 0;
++        }
++        // Add the compressed chunk to the current hash value
++        A = (A + this.A) | 0;
++        B = (B + this.B) | 0;
++        C = (C + this.C) | 0;
++        D = (D + this.D) | 0;
++        E = (E + this.E) | 0;
++        F = (F + this.F) | 0;
++        G = (G + this.G) | 0;
++        H = (H + this.H) | 0;
++        this.set(A, B, C, D, E, F, G, H);
++    }
++    roundClean() {
++        SHA256_W.fill(0);
++    }
++    destroy() {
++        this.set(0, 0, 0, 0, 0, 0, 0, 0);
++        this.buffer.fill(0);
++    }
++}
++exports.SHA256 = SHA256;
++// Constants from https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
++class SHA224 extends SHA256 {
++    constructor() {
++        super();
++        this.A = 0xc1059ed8 | 0;
++        this.B = 0x367cd507 | 0;
++        this.C = 0x3070dd17 | 0;
++        this.D = 0xf70e5939 | 0;
++        this.E = 0xffc00b31 | 0;
++        this.F = 0x68581511 | 0;
++        this.G = 0x64f98fa7 | 0;
++        this.H = 0xbefa4fa4 | 0;
++        this.outputLen = 28;
++    }
++}
++/**
++ * SHA2-256 hash function
++ * @param message - data that would be hashed
++ */
++exports.sha256 = (0, utils_js_1.wrapConstructor)(() => new SHA256());
++/**
++ * SHA2-224 hash function
++ */
++exports.sha224 = (0, utils_js_1.wrapConstructor)(() => new SHA224());
++//# sourceMappingURL=sha256.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.js.map
+new file mode 100644
+index 0000000..2b14c2e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha256.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha256.js","sourceRoot":"","sources":["src/sha256.ts"],"names":[],"mappings":";;;AAAA,qCAA4C;AAC5C,yCAAmD;AAEnD,gEAAgE;AAChE,0DAA0D;AAE1D,mBAAmB;AACnB,yFAAyF;AACzF,kBAAkB;AAClB,MAAM,QAAQ,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAC/C,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;IAC9F,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AAEH,iBAAiB;AACjB,wFAAwF;AACxF,kBAAkB;AAClB,MAAM,SAAS,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC;IAChD,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU,EAAE,UAAU;CAC/F,CAAC,CAAC;AAEH,4DAA4D;AAC5D,mDAAmD;AACnD,MAAM,QAAQ,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACrD,MAAa,MAAO,SAAQ,eAAc;IAYxC;QACE,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,EAAE,KAAK,CAAC,CAAC;QAZ1B,mEAAmE;QACnE,uDAAuD;QACvD,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,MAAC,GAAG,SAAS,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;IAIrB,CAAC;IACS,GAAG;QACX,MAAM,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QACxC,OAAO,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAClC,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,CAAS;QAEtF,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;QACf,IAAI,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;IACjB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,gGAAgG;QAChG,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC;YAAE,QAAQ,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;QACtF,KAAK,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC7B,MAAM,GAAG,GAAG,QAAQ,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;YAC7B,MAAM,EAAE,GAAG,QAAQ,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;YAC3B,MAAM,EAAE,GAAG,IAAA,eAAI,EAAC,GAAG,EAAE,CAAC,CAAC,GAAG,IAAA,eAAI,EAAC,GAAG,EAAE,EAAE,CAAC,GAAG,CAAC,GAAG,KAAK,CAAC,CAAC,CAAC;YACtD,MAAM,EAAE,GAAG,IAAA,eAAI,EAAC,EAAE,EAAE,EAAE,CAAC,GAAG,IAAA,eAAI,EAAC,EAAE,EAAE,EAAE,CAAC,GAAG,CAAC,EAAE,KAAK,EAAE,CAAC,CAAC;YACrD,QAAQ,CAAC,CAAC,CAAC,GAAG,CAAC,EAAE,GAAG,QAAQ,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,GAAG,QAAQ,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC;QACnE,CAAC;QACD,4CAA4C;QAC5C,IAAI,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QACtC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,MAAM,MAAM,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,CAAC,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,EAAE,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,EAAE,CAAC,CAAC;YACtD,MAAM,EAAE,GAAG,CAAC,CAAC,GAAG,MAAM,GAAG,IAAA,YAAG,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,GAAG,QAAQ,CAAC,CAAC,CAAC,GAAG,QAAQ,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;YACvE,MAAM,MAAM,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,CAAC,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,EAAE,CAAC,GAAG,IAAA,eAAI,EAAC,CAAC,EAAE,EAAE,CAAC,CAAC;YACtD,MAAM,EAAE,GAAG,CAAC,MAAM,GAAG,IAAA,YAAG,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;YACvC,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;YACjB,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,CAAC;YACN,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;QACpB,CAAC;QACD,qDAAqD;QACrD,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,CAAC,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QACrB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IACnC,CAAC;IACS,UAAU;QAClB,QAAQ,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACnB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;QACjC,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACtB,CAAC;CACF;AA5ED,wBA4EC;AACD,4EAA4E;AAC5E,MAAM,MAAO,SAAQ,MAAM;IASzB;QACE,KAAK,EAAE,CAAC;QATV,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QACnB,MAAC,GAAG,UAAU,GAAG,CAAC,CAAC;QAGjB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAED;;;GAGG;AACU,QAAA,MAAM,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC;AAC1E;;GAEG;AACU,QAAA,MAAM,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.d.ts
+new file mode 100644
+index 0000000..151cdf2
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.d.ts
+@@ -0,0 +1,154 @@
++import { Input, Hash, HashXOF } from './utils.js';
++import { Keccak, ShakeOpts } from './sha3.js';
++export type cShakeOpts = ShakeOpts & {
++    personalization?: Input;
++    NISTfn?: Input;
++};
++export declare const cshake128: {
++    (msg: Input, opts?: cShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: cShakeOpts): HashXOF<Keccak>;
++};
++export declare const cshake256: {
++    (msg: Input, opts?: cShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: cShakeOpts): HashXOF<Keccak>;
++};
++export declare class KMAC extends Keccak implements HashXOF<KMAC> {
++    constructor(blockLen: number, outputLen: number, enableXOF: boolean, key: Input, opts?: cShakeOpts);
++    protected finish(): void;
++    _cloneInto(to?: KMAC): KMAC;
++    clone(): KMAC;
++}
++export declare const kmac128: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare const kmac256: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare const kmac128xof: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare const kmac256xof: {
++    (key: Input, message: Input, opts?: cShakeOpts): Uint8Array;
++    create(key: Input, opts?: cShakeOpts): KMAC;
++};
++export declare class TupleHash extends Keccak implements HashXOF<TupleHash> {
++    constructor(blockLen: number, outputLen: number, enableXOF: boolean, opts?: cShakeOpts);
++    protected finish(): void;
++    _cloneInto(to?: TupleHash): TupleHash;
++    clone(): TupleHash;
++}
++export declare const tuplehash128: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++export declare const tuplehash256: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++export declare const tuplehash128xof: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++export declare const tuplehash256xof: {
++    (messages: Input[], opts?: cShakeOpts): Uint8Array;
++    create(opts?: cShakeOpts): TupleHash;
++};
++type ParallelOpts = cShakeOpts & {
++    blockLen?: number;
++};
++export declare class ParallelHash extends Keccak implements HashXOF<ParallelHash> {
++    protected leafCons: () => Hash<Keccak>;
++    private leafHash?;
++    private chunkPos;
++    private chunksDone;
++    private chunkLen;
++    constructor(blockLen: number, outputLen: number, leafCons: () => Hash<Keccak>, enableXOF: boolean, opts?: ParallelOpts);
++    protected finish(): void;
++    _cloneInto(to?: ParallelHash): ParallelHash;
++    destroy(): void;
++    clone(): ParallelHash;
++}
++export declare const parallelhash128: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export declare const parallelhash256: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export declare const parallelhash128xof: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export declare const parallelhash256xof: {
++    (message: Input, opts?: ParallelOpts): Uint8Array;
++    create(opts?: ParallelOpts): ParallelHash;
++};
++export type TurboshakeOpts = ShakeOpts & {
++    D?: number;
++};
++export declare const turboshake128: {
++    (msg: Input, opts?: TurboshakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: TurboshakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++export declare const turboshake256: {
++    (msg: Input, opts?: TurboshakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: TurboshakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++export type KangarooOpts = {
++    dkLen?: number;
++    personalization?: Input;
++};
++export declare class KangarooTwelve extends Keccak implements HashXOF<KangarooTwelve> {
++    protected leafLen: number;
++    readonly chunkLen = 8192;
++    private leafHash?;
++    private personalization;
++    private chunkPos;
++    private chunksDone;
++    constructor(blockLen: number, leafLen: number, outputLen: number, rounds: number, opts: KangarooOpts);
++    update(data: Input): this;
++    protected finish(): void;
++    destroy(): void;
++    _cloneInto(to?: KangarooTwelve): KangarooTwelve;
++    clone(): KangarooTwelve;
++}
++export declare const k12: {
++    (msg: Input, opts?: KangarooOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: KangarooOpts): Hash<KangarooTwelve>;
++};
++export declare const m14: {
++    (msg: Input, opts?: KangarooOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: KangarooOpts): Hash<KangarooTwelve>;
++};
++export declare class KeccakPRG extends Keccak {
++    protected rate: number;
++    constructor(capacity: number);
++    keccak(): void;
++    update(data: Input): this;
++    feed(data: Input): this;
++    protected finish(): void;
++    digestInto(_out: Uint8Array): Uint8Array;
++    fetch(bytes: number): Uint8Array;
++    forget(): void;
++    _cloneInto(to?: KeccakPRG): KeccakPRG;
++    clone(): KeccakPRG;
++}
++export declare const keccakprg: (capacity?: number) => KeccakPRG;
++export {};
++//# sourceMappingURL=sha3-addons.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.d.ts.map
+new file mode 100644
+index 0000000..c2def57
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3-addons.d.ts","sourceRoot":"","sources":["src/sha3-addons.ts"],"names":[],"mappings":"AACA,OAAO,EACL,KAAK,EAIL,IAAI,EACJ,OAAO,EAER,MAAM,YAAY,CAAC;AACpB,OAAO,EAAE,MAAM,EAAE,SAAS,EAAE,MAAM,WAAW,CAAC;AAyB9C,MAAM,MAAM,UAAU,GAAG,SAAS,GAAG;IAAE,eAAe,CAAC,EAAE,KAAK,CAAC;IAAC,MAAM,CAAC,EAAE,KAAK,CAAA;CAAE,CAAC;AAyBjF,eAAO,MAAM,SAAS;;;;;CAA0D,CAAC;AACjF,eAAO,MAAM,SAAS;;;;;CAA0D,CAAC;AAEjF,qBAAa,IAAK,SAAQ,MAAO,YAAW,OAAO,CAAC,IAAI,CAAC;gBAErD,QAAQ,EAAE,MAAM,EAChB,SAAS,EAAE,MAAM,EACjB,SAAS,EAAE,OAAO,EAClB,GAAG,EAAE,KAAK,EACV,IAAI,GAAE,UAAe;IAYvB,SAAS,CAAC,MAAM;IAIhB,UAAU,CAAC,EAAE,CAAC,EAAE,IAAI,GAAG,IAAI;IAW3B,KAAK,IAAI,IAAI;CAGd;AAUD,eAAO,MAAM,OAAO;UAPC,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAKyB,CAAC;AACvE,eAAO,MAAM,OAAO;UARC,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAMyB,CAAC;AACvE,eAAO,MAAM,UAAU;UATF,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAOkC,CAAC;AAChF,eAAO,MAAM,UAAU;UAVF,KAAK,WAAW,KAAK,SAAS,UAAU,GAAG,UAAU;gBAEpD,KAAK,SAAQ,UAAU;CAQkC,CAAC;AAIhF,qBAAa,SAAU,SAAQ,MAAO,YAAW,OAAO,CAAC,SAAS,CAAC;gBACrD,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,SAAS,EAAE,OAAO,EAAE,IAAI,GAAE,UAAe;IAW1F,SAAS,CAAC,MAAM;IAIhB,UAAU,CAAC,EAAE,CAAC,EAAE,SAAS,GAAG,SAAS;IAIrC,KAAK,IAAI,SAAS;CAGnB;AAaD,eAAO,MAAM,YAAY;eAVE,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAK0C,CAAC;AAC7E,eAAO,MAAM,YAAY;eAXE,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAM0C,CAAC;AAC7E,eAAO,MAAM,eAAe;eAZD,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAOmD,CAAC;AACtF,eAAO,MAAM,eAAe;eAbD,KAAK,EAAE,SAAS,UAAU,GAAG,UAAU;kBAK1C,UAAU;CAQmD,CAAC;AAGtF,KAAK,YAAY,GAAG,UAAU,GAAG;IAAE,QAAQ,CAAC,EAAE,MAAM,CAAA;CAAE,CAAC;AAEvD,qBAAa,YAAa,SAAQ,MAAO,YAAW,OAAO,CAAC,YAAY,CAAC;IAQrE,SAAS,CAAC,QAAQ,EAAE,MAAM,IAAI,CAAC,MAAM,CAAC;IAPxC,OAAO,CAAC,QAAQ,CAAC,CAAe;IAChC,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,UAAU,CAAK;IACvB,OAAO,CAAC,QAAQ,CAAS;gBAEvB,QAAQ,EAAE,MAAM,EAChB,SAAS,EAAE,MAAM,EACP,QAAQ,EAAE,MAAM,IAAI,CAAC,MAAM,CAAC,EACtC,SAAS,EAAE,OAAO,EAClB,IAAI,GAAE,YAAiB;IA8BzB,SAAS,CAAC,MAAM;IAUhB,UAAU,CAAC,EAAE,CAAC,EAAE,YAAY,GAAG,YAAY;IAQ3C,OAAO;IAIP,KAAK,IAAI,YAAY;CAGtB;AAqBD,eAAO,MAAM,eAAe;cAbC,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAWiD,CAAC;AACzF,eAAO,MAAM,eAAe;cAdC,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAYiD,CAAC;AACzF,eAAO,MAAM,kBAAkB;cAfF,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAa0D,CAAC;AAClG,eAAO,MAAM,kBAAkB;cAhBF,KAAK,SAAS,YAAY,GAAG,UAAU;kBAEzC,YAAY;CAc0D,CAAC;AAGlG,MAAM,MAAM,cAAc,GAAG,SAAS,GAAG;IACvC,CAAC,CAAC,EAAE,MAAM,CAAC;CACZ,CAAC;AAWF,eAAO,MAAM,aAAa;;;;;CAA8C,CAAC;AACzE,eAAO,MAAM,aAAa;;;;;CAA8C,CAAC;AAWzE,MAAM,MAAM,YAAY,GAAG;IAAE,KAAK,CAAC,EAAE,MAAM,CAAC;IAAC,eAAe,CAAC,EAAE,KAAK,CAAA;CAAE,CAAC;AAGvE,qBAAa,cAAe,SAAQ,MAAO,YAAW,OAAO,CAAC,cAAc,CAAC;IAQzE,SAAS,CAAC,OAAO,EAAE,MAAM;IAP3B,QAAQ,CAAC,QAAQ,QAAQ;IACzB,OAAO,CAAC,QAAQ,CAAC,CAAS;IAC1B,OAAO,CAAC,eAAe,CAAa;IACpC,OAAO,CAAC,QAAQ,CAAK;IACrB,OAAO,CAAC,UAAU,CAAK;gBAErB,QAAQ,EAAE,MAAM,EACN,OAAO,EAAE,MAAM,EACzB,SAAS,EAAE,MAAM,EACjB,MAAM,EAAE,MAAM,EACd,IAAI,EAAE,YAAY;IAMpB,MAAM,CAAC,IAAI,EAAE,KAAK;IAuBlB,SAAS,CAAC,MAAM;IAYhB,OAAO;IAMP,UAAU,CAAC,EAAE,CAAC,EAAE,cAAc,GAAG,cAAc;IAW/C,KAAK,IAAI,cAAc;CAGxB;AAED,eAAO,MAAM,GAAG;;;;;CAGV,CAAC;AAEP,eAAO,MAAM,GAAG;;;;;CAGV,CAAC;AAIP,qBAAa,SAAU,SAAQ,MAAM;IACnC,SAAS,CAAC,IAAI,EAAE,MAAM,CAAC;gBACX,QAAQ,EAAE,MAAM;IAU5B,MAAM;IAQN,MAAM,CAAC,IAAI,EAAE,KAAK;IAKlB,IAAI,CAAC,IAAI,EAAE,KAAK;IAGhB,SAAS,CAAC,MAAM;IAChB,UAAU,CAAC,IAAI,EAAE,UAAU,GAAG,UAAU;IAGxC,KAAK,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU;IAIhC,MAAM;IAQN,UAAU,CAAC,EAAE,CAAC,EAAE,SAAS,GAAG,SAAS;IAOrC,KAAK,IAAI,SAAS;CAGnB;AAED,eAAO,MAAM,SAAS,kCAA8C,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.js
+new file mode 100644
+index 0000000..5f2a4d4
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.js
+@@ -0,0 +1,365 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.keccakprg = exports.KeccakPRG = exports.m14 = exports.k12 = exports.KangarooTwelve = exports.turboshake256 = exports.turboshake128 = exports.parallelhash256xof = exports.parallelhash128xof = exports.parallelhash256 = exports.parallelhash128 = exports.ParallelHash = exports.tuplehash256xof = exports.tuplehash128xof = exports.tuplehash256 = exports.tuplehash128 = exports.TupleHash = exports.kmac256xof = exports.kmac128xof = exports.kmac256 = exports.kmac128 = exports.KMAC = exports.cshake256 = exports.cshake128 = void 0;
++const _assert_js_1 = require("./_assert.js");
++const utils_js_1 = require("./utils.js");
++const sha3_js_1 = require("./sha3.js");
++// cSHAKE && KMAC (NIST SP800-185)
++function leftEncode(n) {
++    const res = [n & 0xff];
++    n >>= 8;
++    for (; n > 0; n >>= 8)
++        res.unshift(n & 0xff);
++    res.unshift(res.length);
++    return new Uint8Array(res);
++}
++function rightEncode(n) {
++    const res = [n & 0xff];
++    n >>= 8;
++    for (; n > 0; n >>= 8)
++        res.unshift(n & 0xff);
++    res.push(res.length);
++    return new Uint8Array(res);
++}
++function chooseLen(opts, outputLen) {
++    return opts.dkLen === undefined ? outputLen : opts.dkLen;
++}
++const toBytesOptional = (buf) => (buf !== undefined ? (0, utils_js_1.toBytes)(buf) : new Uint8Array([]));
++// NOTE: second modulo is necessary since we don't need to add padding if current element takes whole block
++const getPadding = (len, block) => new Uint8Array((block - (len % block)) % block);
++// Personalization
++function cshakePers(hash, opts = {}) {
++    if (!opts || (!opts.personalization && !opts.NISTfn))
++        return hash;
++    // Encode and pad inplace to avoid unneccesary memory copies/slices (so we don't need to zero them later)
++    // bytepad(encode_string(N) || encode_string(S), 168)
++    const blockLenBytes = leftEncode(hash.blockLen);
++    const fn = toBytesOptional(opts.NISTfn);
++    const fnLen = leftEncode(8 * fn.length); // length in bits
++    const pers = toBytesOptional(opts.personalization);
++    const persLen = leftEncode(8 * pers.length); // length in bits
++    if (!fn.length && !pers.length)
++        return hash;
++    hash.suffix = 0x04;
++    hash.update(blockLenBytes).update(fnLen).update(fn).update(persLen).update(pers);
++    let totalLen = blockLenBytes.length + fnLen.length + fn.length + persLen.length + pers.length;
++    hash.update(getPadding(totalLen, hash.blockLen));
++    return hash;
++}
++const gencShake = (suffix, blockLen, outputLen) => (0, utils_js_1.wrapXOFConstructorWithOpts)((opts = {}) => cshakePers(new sha3_js_1.Keccak(blockLen, suffix, chooseLen(opts, outputLen), true), opts));
++exports.cshake128 = (() => gencShake(0x1f, 168, 128 / 8))();
++exports.cshake256 = (() => gencShake(0x1f, 136, 256 / 8))();
++class KMAC extends sha3_js_1.Keccak {
++    constructor(blockLen, outputLen, enableXOF, key, opts = {}) {
++        super(blockLen, 0x1f, outputLen, enableXOF);
++        cshakePers(this, { NISTfn: 'KMAC', personalization: opts.personalization });
++        key = (0, utils_js_1.toBytes)(key);
++        // 1. newX = bytepad(encode_string(K), 168) || X || right_encode(L).
++        const blockLenBytes = leftEncode(this.blockLen);
++        const keyLen = leftEncode(8 * key.length);
++        this.update(blockLenBytes).update(keyLen).update(key);
++        const totalLen = blockLenBytes.length + keyLen.length + key.length;
++        this.update(getPadding(totalLen, this.blockLen));
++    }
++    finish() {
++        if (!this.finished)
++            this.update(rightEncode(this.enableXOF ? 0 : this.outputLen * 8)); // outputLen in bits
++        super.finish();
++    }
++    _cloneInto(to) {
++        // Create new instance without calling constructor since key already in state and we don't know it.
++        // Force "to" to be instance of KMAC instead of Sha3.
++        if (!to) {
++            to = Object.create(Object.getPrototypeOf(this), {});
++            to.state = this.state.slice();
++            to.blockLen = this.blockLen;
++            to.state32 = (0, utils_js_1.u32)(to.state);
++        }
++        return super._cloneInto(to);
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++exports.KMAC = KMAC;
++function genKmac(blockLen, outputLen, xof = false) {
++    const kmac = (key, message, opts) => kmac.create(key, opts).update(message).digest();
++    kmac.create = (key, opts = {}) => new KMAC(blockLen, chooseLen(opts, outputLen), xof, key, opts);
++    return kmac;
++}
++exports.kmac128 = (() => genKmac(168, 128 / 8))();
++exports.kmac256 = (() => genKmac(136, 256 / 8))();
++exports.kmac128xof = (() => genKmac(168, 128 / 8, true))();
++exports.kmac256xof = (() => genKmac(136, 256 / 8, true))();
++// TupleHash
++// Usage: tuple(['ab', 'cd']) != tuple(['a', 'bcd'])
++class TupleHash extends sha3_js_1.Keccak {
++    constructor(blockLen, outputLen, enableXOF, opts = {}) {
++        super(blockLen, 0x1f, outputLen, enableXOF);
++        cshakePers(this, { NISTfn: 'TupleHash', personalization: opts.personalization });
++        // Change update after cshake processed
++        this.update = (data) => {
++            data = (0, utils_js_1.toBytes)(data);
++            super.update(leftEncode(data.length * 8));
++            super.update(data);
++            return this;
++        };
++    }
++    finish() {
++        if (!this.finished)
++            super.update(rightEncode(this.enableXOF ? 0 : this.outputLen * 8)); // outputLen in bits
++        super.finish();
++    }
++    _cloneInto(to) {
++        to || (to = new TupleHash(this.blockLen, this.outputLen, this.enableXOF));
++        return super._cloneInto(to);
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++exports.TupleHash = TupleHash;
++function genTuple(blockLen, outputLen, xof = false) {
++    const tuple = (messages, opts) => {
++        const h = tuple.create(opts);
++        for (const msg of messages)
++            h.update(msg);
++        return h.digest();
++    };
++    tuple.create = (opts = {}) => new TupleHash(blockLen, chooseLen(opts, outputLen), xof, opts);
++    return tuple;
++}
++exports.tuplehash128 = (() => genTuple(168, 128 / 8))();
++exports.tuplehash256 = (() => genTuple(136, 256 / 8))();
++exports.tuplehash128xof = (() => genTuple(168, 128 / 8, true))();
++exports.tuplehash256xof = (() => genTuple(136, 256 / 8, true))();
++class ParallelHash extends sha3_js_1.Keccak {
++    constructor(blockLen, outputLen, leafCons, enableXOF, opts = {}) {
++        super(blockLen, 0x1f, outputLen, enableXOF);
++        this.leafCons = leafCons;
++        this.chunkPos = 0; // Position of current block in chunk
++        this.chunksDone = 0; // How many chunks we already have
++        cshakePers(this, { NISTfn: 'ParallelHash', personalization: opts.personalization });
++        let { blockLen: B } = opts;
++        B || (B = 8);
++        (0, _assert_js_1.number)(B);
++        this.chunkLen = B;
++        super.update(leftEncode(B));
++        // Change update after cshake processed
++        this.update = (data) => {
++            data = (0, utils_js_1.toBytes)(data);
++            const { chunkLen, leafCons } = this;
++            for (let pos = 0, len = data.length; pos < len;) {
++                if (this.chunkPos == chunkLen || !this.leafHash) {
++                    if (this.leafHash) {
++                        super.update(this.leafHash.digest());
++                        this.chunksDone++;
++                    }
++                    this.leafHash = leafCons();
++                    this.chunkPos = 0;
++                }
++                const take = Math.min(chunkLen - this.chunkPos, len - pos);
++                this.leafHash.update(data.subarray(pos, pos + take));
++                this.chunkPos += take;
++                pos += take;
++            }
++            return this;
++        };
++    }
++    finish() {
++        if (this.finished)
++            return;
++        if (this.leafHash) {
++            super.update(this.leafHash.digest());
++            this.chunksDone++;
++        }
++        super.update(rightEncode(this.chunksDone));
++        super.update(rightEncode(this.enableXOF ? 0 : this.outputLen * 8)); // outputLen in bits
++        super.finish();
++    }
++    _cloneInto(to) {
++        to || (to = new ParallelHash(this.blockLen, this.outputLen, this.leafCons, this.enableXOF));
++        if (this.leafHash)
++            to.leafHash = this.leafHash._cloneInto(to.leafHash);
++        to.chunkPos = this.chunkPos;
++        to.chunkLen = this.chunkLen;
++        to.chunksDone = this.chunksDone;
++        return super._cloneInto(to);
++    }
++    destroy() {
++        super.destroy.call(this);
++        if (this.leafHash)
++            this.leafHash.destroy();
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++exports.ParallelHash = ParallelHash;
++function genPrl(blockLen, outputLen, leaf, xof = false) {
++    const parallel = (message, opts) => parallel.create(opts).update(message).digest();
++    parallel.create = (opts = {}) => new ParallelHash(blockLen, chooseLen(opts, outputLen), () => leaf.create({ dkLen: 2 * outputLen }), xof, opts);
++    return parallel;
++}
++exports.parallelhash128 = (() => genPrl(168, 128 / 8, exports.cshake128))();
++exports.parallelhash256 = (() => genPrl(136, 256 / 8, exports.cshake256))();
++exports.parallelhash128xof = (() => genPrl(168, 128 / 8, exports.cshake128, true))();
++exports.parallelhash256xof = (() => genPrl(136, 256 / 8, exports.cshake256, true))();
++const genTurboshake = (blockLen, outputLen) => (0, utils_js_1.wrapXOFConstructorWithOpts)((opts = {}) => {
++    const D = opts.D === undefined ? 0x1f : opts.D;
++    // Section 2.1 of https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve/
++    if (!Number.isSafeInteger(D) || D < 0x01 || D > 0x7f)
++        throw new Error(`turboshake: wrong domain separation byte: ${D}, should be 0x01..0x7f`);
++    return new sha3_js_1.Keccak(blockLen, D, opts.dkLen === undefined ? outputLen : opts.dkLen, true, 12);
++});
++exports.turboshake128 = genTurboshake(168, 256 / 8);
++exports.turboshake256 = genTurboshake(136, 512 / 8);
++// Kangaroo
++// Same as NIST rightEncode, but returns [0] for zero string
++function rightEncodeK12(n) {
++    const res = [];
++    for (; n > 0; n >>= 8)
++        res.unshift(n & 0xff);
++    res.push(res.length);
++    return new Uint8Array(res);
++}
++const EMPTY = new Uint8Array([]);
++class KangarooTwelve extends sha3_js_1.Keccak {
++    constructor(blockLen, leafLen, outputLen, rounds, opts) {
++        super(blockLen, 0x07, outputLen, true, rounds);
++        this.leafLen = leafLen;
++        this.chunkLen = 8192;
++        this.chunkPos = 0; // Position of current block in chunk
++        this.chunksDone = 0; // How many chunks we already have
++        const { personalization } = opts;
++        this.personalization = toBytesOptional(personalization);
++    }
++    update(data) {
++        data = (0, utils_js_1.toBytes)(data);
++        const { chunkLen, blockLen, leafLen, rounds } = this;
++        for (let pos = 0, len = data.length; pos < len;) {
++            if (this.chunkPos == chunkLen) {
++                if (this.leafHash)
++                    super.update(this.leafHash.digest());
++                else {
++                    this.suffix = 0x06; // Its safe to change suffix here since its used only in digest()
++                    super.update(new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0]));
++                }
++                this.leafHash = new sha3_js_1.Keccak(blockLen, 0x0b, leafLen, false, rounds);
++                this.chunksDone++;
++                this.chunkPos = 0;
++            }
++            const take = Math.min(chunkLen - this.chunkPos, len - pos);
++            const chunk = data.subarray(pos, pos + take);
++            if (this.leafHash)
++                this.leafHash.update(chunk);
++            else
++                super.update(chunk);
++            this.chunkPos += take;
++            pos += take;
++        }
++        return this;
++    }
++    finish() {
++        if (this.finished)
++            return;
++        const { personalization } = this;
++        this.update(personalization).update(rightEncodeK12(personalization.length));
++        // Leaf hash
++        if (this.leafHash) {
++            super.update(this.leafHash.digest());
++            super.update(rightEncodeK12(this.chunksDone));
++            super.update(new Uint8Array([0xff, 0xff]));
++        }
++        super.finish.call(this);
++    }
++    destroy() {
++        super.destroy.call(this);
++        if (this.leafHash)
++            this.leafHash.destroy();
++        // We cannot zero personalization buffer since it is user provided and we don't want to mutate user input
++        this.personalization = EMPTY;
++    }
++    _cloneInto(to) {
++        const { blockLen, leafLen, leafHash, outputLen, rounds } = this;
++        to || (to = new KangarooTwelve(blockLen, leafLen, outputLen, rounds, {}));
++        super._cloneInto(to);
++        if (leafHash)
++            to.leafHash = leafHash._cloneInto(to.leafHash);
++        to.personalization.set(this.personalization);
++        to.leafLen = this.leafLen;
++        to.chunkPos = this.chunkPos;
++        to.chunksDone = this.chunksDone;
++        return to;
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++exports.KangarooTwelve = KangarooTwelve;
++// Default to 32 bytes, so it can be used without opts
++exports.k12 = (() => (0, utils_js_1.wrapConstructorWithOpts)((opts = {}) => new KangarooTwelve(168, 32, chooseLen(opts, 32), 12, opts)))();
++// MarsupilamiFourteen
++exports.m14 = (() => (0, utils_js_1.wrapConstructorWithOpts)((opts = {}) => new KangarooTwelve(136, 64, chooseLen(opts, 64), 14, opts)))();
++// https://keccak.team/files/CSF-0.1.pdf
++// + https://github.com/XKCP/XKCP/tree/master/lib/high/Keccak/PRG
++class KeccakPRG extends sha3_js_1.Keccak {
++    constructor(capacity) {
++        (0, _assert_js_1.number)(capacity);
++        // Rho should be full bytes
++        if (capacity < 0 || capacity > 1600 - 10 || (1600 - capacity - 2) % 8)
++            throw new Error('KeccakPRG: Invalid capacity');
++        // blockLen = rho in bytes
++        super((1600 - capacity - 2) / 8, 0, 0, true);
++        this.rate = 1600 - capacity;
++        this.posOut = Math.floor((this.rate + 7) / 8);
++    }
++    keccak() {
++        // Duplex padding
++        this.state[this.pos] ^= 0x01;
++        this.state[this.blockLen] ^= 0x02; // Rho is full bytes
++        super.keccak();
++        this.pos = 0;
++        this.posOut = 0;
++    }
++    update(data) {
++        super.update(data);
++        this.posOut = this.blockLen;
++        return this;
++    }
++    feed(data) {
++        return this.update(data);
++    }
++    finish() { }
++    digestInto(_out) {
++        throw new Error('KeccakPRG: digest is not allowed, please use .fetch instead.');
++    }
++    fetch(bytes) {
++        return this.xof(bytes);
++    }
++    // Ensure irreversibility (even if state leaked previous outputs cannot be computed)
++    forget() {
++        if (this.rate < 1600 / 2 + 1)
++            throw new Error('KeccakPRG: rate too low to use forget');
++        this.keccak();
++        for (let i = 0; i < this.blockLen; i++)
++            this.state[i] = 0;
++        this.pos = this.blockLen;
++        this.keccak();
++        this.posOut = this.blockLen;
++    }
++    _cloneInto(to) {
++        const { rate } = this;
++        to || (to = new KeccakPRG(1600 - rate));
++        super._cloneInto(to);
++        to.rate = rate;
++        return to;
++    }
++    clone() {
++        return this._cloneInto();
++    }
++}
++exports.KeccakPRG = KeccakPRG;
++const keccakprg = (capacity = 254) => new KeccakPRG(capacity);
++exports.keccakprg = keccakprg;
++//# sourceMappingURL=sha3-addons.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.js.map
+new file mode 100644
+index 0000000..589e3e5
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3-addons.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3-addons.js","sourceRoot":"","sources":["src/sha3-addons.ts"],"names":[],"mappings":";;;AAAA,6CAAsD;AACtD,yCAQoB;AACpB,uCAA8C;AAC9C,kCAAkC;AAClC,SAAS,UAAU,CAAC,CAAS;IAC3B,MAAM,GAAG,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IACvB,CAAC,KAAK,CAAC,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC;QAAE,GAAG,CAAC,OAAO,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IAC7C,GAAG,CAAC,OAAO,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACxB,OAAO,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;AAC7B,CAAC;AAED,SAAS,WAAW,CAAC,CAAS;IAC5B,MAAM,GAAG,GAAG,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IACvB,CAAC,KAAK,CAAC,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC;QAAE,GAAG,CAAC,OAAO,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IAC7C,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrB,OAAO,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;AAC7B,CAAC;AAED,SAAS,SAAS,CAAC,IAAe,EAAE,SAAiB;IACnD,OAAO,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,CAAC;AAC3D,CAAC;AAED,MAAM,eAAe,GAAG,CAAC,GAAW,EAAE,EAAE,CAAC,CAAC,GAAG,KAAK,SAAS,CAAC,CAAC,CAAC,IAAA,kBAAO,EAAC,GAAG,CAAC,CAAC,CAAC,CAAC,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC,CAAC;AACjG,2GAA2G;AAC3G,MAAM,UAAU,GAAG,CAAC,GAAW,EAAE,KAAa,EAAE,EAAE,CAAC,IAAI,UAAU,CAAC,CAAC,KAAK,GAAG,CAAC,GAAG,GAAG,KAAK,CAAC,CAAC,GAAG,KAAK,CAAC,CAAC;AAGnG,kBAAkB;AAClB,SAAS,UAAU,CAAC,IAAY,EAAE,OAAmB,EAAE;IACrD,IAAI,CAAC,IAAI,IAAI,CAAC,CAAC,IAAI,CAAC,eAAe,IAAI,CAAC,IAAI,CAAC,MAAM,CAAC;QAAE,OAAO,IAAI,CAAC;IAClE,yGAAyG;IACzG,qDAAqD;IACrD,MAAM,aAAa,GAAG,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;IAChD,MAAM,EAAE,GAAG,eAAe,CAAC,IAAI,CAAC,MAAM,CAAC,CAAC;IACxC,MAAM,KAAK,GAAG,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,iBAAiB;IAC1D,MAAM,IAAI,GAAG,eAAe,CAAC,IAAI,CAAC,eAAe,CAAC,CAAC;IACnD,MAAM,OAAO,GAAG,UAAU,CAAC,CAAC,GAAG,IAAI,CAAC,MAAM,CAAC,CAAC,CAAC,iBAAiB;IAC9D,IAAI,CAAC,EAAE,CAAC,MAAM,IAAI,CAAC,IAAI,CAAC,MAAM;QAAE,OAAO,IAAI,CAAC;IAC5C,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC;IACnB,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,MAAM,CAAC,KAAK,CAAC,CAAC,MAAM,CAAC,EAAE,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IACjF,IAAI,QAAQ,GAAG,aAAa,CAAC,MAAM,GAAG,KAAK,CAAC,MAAM,GAAG,EAAE,CAAC,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,MAAM,CAAC;IAC9F,IAAI,CAAC,MAAM,CAAC,UAAU,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC,CAAC,CAAC;IACjD,OAAO,IAAI,CAAC;AACd,CAAC;AAED,MAAM,SAAS,GAAG,CAAC,MAAc,EAAE,QAAgB,EAAE,SAAiB,EAAE,EAAE,CACxE,IAAA,qCAA0B,EAAqB,CAAC,OAAmB,EAAE,EAAE,EAAE,CACvE,UAAU,CAAC,IAAI,gBAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAAE,IAAI,CAAC,EAAE,IAAI,CAAC,CACjF,CAAC;AAES,QAAA,SAAS,GAAmB,CAAC,GAAG,EAAE,CAAC,SAAS,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AACpE,QAAA,SAAS,GAAmB,CAAC,GAAG,EAAE,CAAC,SAAS,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAEjF,MAAa,IAAK,SAAQ,gBAAM;IAC9B,YACE,QAAgB,EAChB,SAAiB,EACjB,SAAkB,EAClB,GAAU,EACV,OAAmB,EAAE;QAErB,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,CAAC,CAAC;QAC5C,UAAU,CAAC,IAAI,EAAE,EAAE,MAAM,EAAE,MAAM,EAAE,eAAe,EAAE,IAAI,CAAC,eAAe,EAAE,CAAC,CAAC;QAC5E,GAAG,GAAG,IAAA,kBAAO,EAAC,GAAG,CAAC,CAAC;QACnB,oEAAoE;QACpE,MAAM,aAAa,GAAG,UAAU,CAAC,IAAI,CAAC,QAAQ,CAAC,CAAC;QAChD,MAAM,MAAM,GAAG,UAAU,CAAC,CAAC,GAAG,GAAG,CAAC,MAAM,CAAC,CAAC;QAC1C,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,MAAM,CAAC,MAAM,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QACtD,MAAM,QAAQ,GAAG,aAAa,CAAC,MAAM,GAAG,MAAM,CAAC,MAAM,GAAG,GAAG,CAAC,MAAM,CAAC;QACnE,IAAI,CAAC,MAAM,CAAC,UAAU,CAAC,QAAQ,EAAE,IAAI,CAAC,QAAQ,CAAC,CAAC,CAAC;IACnD,CAAC;IACS,MAAM;QACd,IAAI,CAAC,IAAI,CAAC,QAAQ;YAAE,IAAI,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,oBAAoB;QAC3G,KAAK,CAAC,MAAM,EAAE,CAAC;IACjB,CAAC;IACD,UAAU,CAAC,EAAS;QAClB,mGAAmG;QACnG,qDAAqD;QACrD,IAAI,CAAC,EAAE,EAAE,CAAC;YACR,EAAE,GAAG,MAAM,CAAC,MAAM,CAAC,MAAM,CAAC,cAAc,CAAC,IAAI,CAAC,EAAE,EAAE,CAAS,CAAC;YAC5D,EAAE,CAAC,KAAK,GAAG,IAAI,CAAC,KAAK,CAAC,KAAK,EAAE,CAAC;YAC9B,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;YAC5B,EAAE,CAAC,OAAO,GAAG,IAAA,cAAG,EAAC,EAAE,CAAC,KAAK,CAAC,CAAC;QAC7B,CAAC;QACD,OAAO,KAAK,CAAC,UAAU,CAAC,EAAE,CAAS,CAAC;IACtC,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AApCD,oBAoCC;AAED,SAAS,OAAO,CAAC,QAAgB,EAAE,SAAiB,EAAE,GAAG,GAAG,KAAK;IAC/D,MAAM,IAAI,GAAG,CAAC,GAAU,EAAE,OAAc,EAAE,IAAiB,EAAc,EAAE,CACzE,IAAI,CAAC,MAAM,CAAC,GAAG,EAAE,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;IAClD,IAAI,CAAC,MAAM,GAAG,CAAC,GAAU,EAAE,OAAmB,EAAE,EAAE,EAAE,CAClD,IAAI,IAAI,CAAC,QAAQ,EAAE,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAAE,GAAG,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC;IACjE,OAAO,IAAI,CAAC;AACd,CAAC;AAEY,QAAA,OAAO,GAAmB,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAC1D,QAAA,OAAO,GAAmB,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAC1D,QAAA,UAAU,GAAmB,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AACnE,QAAA,UAAU,GAAmB,CAAC,GAAG,EAAE,CAAC,OAAO,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAEhF,YAAY;AACZ,oDAAoD;AACpD,MAAa,SAAU,SAAQ,gBAAM;IACnC,YAAY,QAAgB,EAAE,SAAiB,EAAE,SAAkB,EAAE,OAAmB,EAAE;QACxF,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,CAAC,CAAC;QAC5C,UAAU,CAAC,IAAI,EAAE,EAAE,MAAM,EAAE,WAAW,EAAE,eAAe,EAAE,IAAI,CAAC,eAAe,EAAE,CAAC,CAAC;QACjF,uCAAuC;QACvC,IAAI,CAAC,MAAM,GAAG,CAAC,IAAW,EAAE,EAAE;YAC5B,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;YACrB,KAAK,CAAC,MAAM,CAAC,UAAU,CAAC,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC,CAAC,CAAC;YAC1C,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;YACnB,OAAO,IAAI,CAAC;QACd,CAAC,CAAC;IACJ,CAAC;IACS,MAAM;QACd,IAAI,CAAC,IAAI,CAAC,QAAQ;YAAE,KAAK,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,oBAAoB;QAC5G,KAAK,CAAC,MAAM,EAAE,CAAC;IACjB,CAAC;IACD,UAAU,CAAC,EAAc;QACvB,EAAE,KAAF,EAAE,GAAK,IAAI,SAAS,CAAC,IAAI,CAAC,QAAQ,EAAE,IAAI,CAAC,SAAS,EAAE,IAAI,CAAC,SAAS,CAAC,EAAC;QACpE,OAAO,KAAK,CAAC,UAAU,CAAC,EAAE,CAAc,CAAC;IAC3C,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAvBD,8BAuBC;AAED,SAAS,QAAQ,CAAC,QAAgB,EAAE,SAAiB,EAAE,GAAG,GAAG,KAAK;IAChE,MAAM,KAAK,GAAG,CAAC,QAAiB,EAAE,IAAiB,EAAc,EAAE;QACjE,MAAM,CAAC,GAAG,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;QAC7B,KAAK,MAAM,GAAG,IAAI,QAAQ;YAAE,CAAC,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;QAC1C,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;IACpB,CAAC,CAAC;IACF,KAAK,CAAC,MAAM,GAAG,CAAC,OAAmB,EAAE,EAAE,EAAE,CACvC,IAAI,SAAS,CAAC,QAAQ,EAAE,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAAE,GAAG,EAAE,IAAI,CAAC,CAAC;IACjE,OAAO,KAAK,CAAC;AACf,CAAC;AAEY,QAAA,YAAY,GAAmB,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAChE,QAAA,YAAY,GAAmB,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC;AAChE,QAAA,eAAe,GAAmB,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AACzE,QAAA,eAAe,GAAmB,CAAC,GAAG,EAAE,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAKtF,MAAa,YAAa,SAAQ,gBAAM;IAKtC,YACE,QAAgB,EAChB,SAAiB,EACP,QAA4B,EACtC,SAAkB,EAClB,OAAqB,EAAE;QAEvB,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,SAAS,CAAC,CAAC;QAJlC,aAAQ,GAAR,QAAQ,CAAoB;QANhC,aAAQ,GAAG,CAAC,CAAC,CAAC,qCAAqC;QACnD,eAAU,GAAG,CAAC,CAAC,CAAC,kCAAkC;QAUxD,UAAU,CAAC,IAAI,EAAE,EAAE,MAAM,EAAE,cAAc,EAAE,eAAe,EAAE,IAAI,CAAC,eAAe,EAAE,CAAC,CAAC;QACpF,IAAI,EAAE,QAAQ,EAAE,CAAC,EAAE,GAAG,IAAI,CAAC;QAC3B,CAAC,KAAD,CAAC,GAAK,CAAC,EAAC;QACR,IAAA,mBAAY,EAAC,CAAC,CAAC,CAAC;QAChB,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;QAClB,KAAK,CAAC,MAAM,CAAC,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;QAC5B,uCAAuC;QACvC,IAAI,CAAC,MAAM,GAAG,CAAC,IAAW,EAAE,EAAE;YAC5B,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;YACrB,MAAM,EAAE,QAAQ,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;YACpC,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;gBACjD,IAAI,IAAI,CAAC,QAAQ,IAAI,QAAQ,IAAI,CAAC,IAAI,CAAC,QAAQ,EAAE,CAAC;oBAChD,IAAI,IAAI,CAAC,QAAQ,EAAE,CAAC;wBAClB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;wBACrC,IAAI,CAAC,UAAU,EAAE,CAAC;oBACpB,CAAC;oBACD,IAAI,CAAC,QAAQ,GAAG,QAAQ,EAAE,CAAC;oBAC3B,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;gBACpB,CAAC;gBACD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;gBAC3D,IAAI,CAAC,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,CAAC,CAAC;gBACrD,IAAI,CAAC,QAAQ,IAAI,IAAI,CAAC;gBACtB,GAAG,IAAI,IAAI,CAAC;YACd,CAAC;YACD,OAAO,IAAI,CAAC;QACd,CAAC,CAAC;IACJ,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,IAAI,IAAI,CAAC,QAAQ,EAAE,CAAC;YAClB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;YACrC,IAAI,CAAC,UAAU,EAAE,CAAC;QACpB,CAAC;QACD,KAAK,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,UAAU,CAAC,CAAC,CAAC;QAC3C,KAAK,CAAC,MAAM,CAAC,WAAW,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,IAAI,CAAC,SAAS,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC,oBAAoB;QACxF,KAAK,CAAC,MAAM,EAAE,CAAC;IACjB,CAAC;IACD,UAAU,CAAC,EAAiB;QAC1B,EAAE,KAAF,EAAE,GAAK,IAAI,YAAY,CAAC,IAAI,CAAC,QAAQ,EAAE,IAAI,CAAC,SAAS,EAAE,IAAI,CAAC,QAAQ,EAAE,IAAI,CAAC,SAAS,CAAC,EAAC;QACtF,IAAI,IAAI,CAAC,QAAQ;YAAE,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC,UAAU,CAAC,EAAE,CAAC,QAAkB,CAAC,CAAC;QACjF,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,UAAU,GAAG,IAAI,CAAC,UAAU,CAAC;QAChC,OAAO,KAAK,CAAC,UAAU,CAAC,EAAE,CAAiB,CAAC;IAC9C,CAAC;IACD,OAAO;QACL,KAAK,CAAC,OAAO,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC;QACzB,IAAI,IAAI,CAAC,QAAQ;YAAE,IAAI,CAAC,QAAQ,CAAC,OAAO,EAAE,CAAC;IAC7C,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAjED,oCAiEC;AAED,SAAS,MAAM,CACb,QAAgB,EAChB,SAAiB,EACjB,IAAkC,EAClC,GAAG,GAAG,KAAK;IAEX,MAAM,QAAQ,GAAG,CAAC,OAAc,EAAE,IAAmB,EAAc,EAAE,CACnE,QAAQ,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,CAAC,MAAM,EAAE,CAAC;IACjD,QAAQ,CAAC,MAAM,GAAG,CAAC,OAAqB,EAAE,EAAE,EAAE,CAC5C,IAAI,YAAY,CACd,QAAQ,EACR,SAAS,CAAC,IAAI,EAAE,SAAS,CAAC,EAC1B,GAAG,EAAE,CAAC,IAAI,CAAC,MAAM,CAAC,EAAE,KAAK,EAAE,CAAC,GAAG,SAAS,EAAE,CAAC,EAC3C,GAAG,EACH,IAAI,CACL,CAAC;IACJ,OAAO,QAAQ,CAAC;AAClB,CAAC;AAEY,QAAA,eAAe,GAAmB,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,iBAAS,CAAC,CAAC,EAAE,CAAC;AAC5E,QAAA,eAAe,GAAmB,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,iBAAS,CAAC,CAAC,EAAE,CAAC;AAC5E,QAAA,kBAAkB,GAAmB,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,iBAAS,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AACrF,QAAA,kBAAkB,GAAmB,CAAC,GAAG,EAAE,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,EAAE,iBAAS,EAAE,IAAI,CAAC,CAAC,EAAE,CAAC;AAOlG,MAAM,aAAa,GAAG,CAAC,QAAgB,EAAE,SAAiB,EAAE,EAAE,CAC5D,IAAA,qCAA0B,EAAkC,CAAC,OAAuB,EAAE,EAAE,EAAE;IACxF,MAAM,CAAC,GAAG,IAAI,CAAC,CAAC,KAAK,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC;IAC/C,kFAAkF;IAClF,IAAI,CAAC,MAAM,CAAC,aAAa,CAAC,CAAC,CAAC,IAAI,CAAC,GAAG,IAAI,IAAI,CAAC,GAAG,IAAI;QAClD,MAAM,IAAI,KAAK,CAAC,6CAA6C,CAAC,wBAAwB,CAAC,CAAC;IAC1F,OAAO,IAAI,gBAAM,CAAC,QAAQ,EAAE,CAAC,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,EAAE,EAAE,CAAC,CAAC;AAC9F,CAAC,CAAC,CAAC;AAEQ,QAAA,aAAa,GAAmB,aAAa,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAC5D,QAAA,aAAa,GAAmB,aAAa,CAAC,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAEzE,WAAW;AACX,4DAA4D;AAC5D,SAAS,cAAc,CAAC,CAAS;IAC/B,MAAM,GAAG,GAAG,EAAE,CAAC;IACf,OAAO,CAAC,GAAG,CAAC,EAAE,CAAC,KAAK,CAAC;QAAE,GAAG,CAAC,OAAO,CAAC,CAAC,GAAG,IAAI,CAAC,CAAC;IAC7C,GAAG,CAAC,IAAI,CAAC,GAAG,CAAC,MAAM,CAAC,CAAC;IACrB,OAAO,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;AAC7B,CAAC;AAGD,MAAM,KAAK,GAAG,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC;AAEjC,MAAa,cAAe,SAAQ,gBAAM;IAMxC,YACE,QAAgB,EACN,OAAe,EACzB,SAAiB,EACjB,MAAc,EACd,IAAkB;QAElB,KAAK,CAAC,QAAQ,EAAE,IAAI,EAAE,SAAS,EAAE,IAAI,EAAE,MAAM,CAAC,CAAC;QALrC,YAAO,GAAP,OAAO,CAAQ;QAPlB,aAAQ,GAAG,IAAI,CAAC;QAGjB,aAAQ,GAAG,CAAC,CAAC,CAAC,qCAAqC;QACnD,eAAU,GAAG,CAAC,CAAC,CAAC,kCAAkC;QASxD,MAAM,EAAE,eAAe,EAAE,GAAG,IAAI,CAAC;QACjC,IAAI,CAAC,eAAe,GAAG,eAAe,CAAC,eAAe,CAAC,CAAC;IAC1D,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;QACrB,MAAM,EAAE,QAAQ,EAAE,QAAQ,EAAE,OAAO,EAAE,MAAM,EAAE,GAAG,IAAI,CAAC;QACrD,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YACjD,IAAI,IAAI,CAAC,QAAQ,IAAI,QAAQ,EAAE,CAAC;gBAC9B,IAAI,IAAI,CAAC,QAAQ;oBAAE,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;qBACnD,CAAC;oBACJ,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,CAAC,iEAAiE;oBACrF,KAAK,CAAC,MAAM,CAAC,IAAI,UAAU,CAAC,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC;gBACzD,CAAC;gBACD,IAAI,CAAC,QAAQ,GAAG,IAAI,gBAAM,CAAC,QAAQ,EAAE,IAAI,EAAE,OAAO,EAAE,KAAK,EAAE,MAAM,CAAC,CAAC;gBACnE,IAAI,CAAC,UAAU,EAAE,CAAC;gBAClB,IAAI,CAAC,QAAQ,GAAG,CAAC,CAAC;YACpB,CAAC;YACD,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YAC3D,MAAM,KAAK,GAAG,IAAI,CAAC,QAAQ,CAAC,GAAG,EAAE,GAAG,GAAG,IAAI,CAAC,CAAC;YAC7C,IAAI,IAAI,CAAC,QAAQ;gBAAE,IAAI,CAAC,QAAQ,CAAC,MAAM,CAAC,KAAK,CAAC,CAAC;;gBAC1C,KAAK,CAAC,MAAM,CAAC,KAAK,CAAC,CAAC;YACzB,IAAI,CAAC,QAAQ,IAAI,IAAI,CAAC;YACtB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,IAAI,CAAC;IACd,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,MAAM,EAAE,eAAe,EAAE,GAAG,IAAI,CAAC;QACjC,IAAI,CAAC,MAAM,CAAC,eAAe,CAAC,CAAC,MAAM,CAAC,cAAc,CAAC,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC;QAC5E,YAAY;QACZ,IAAI,IAAI,CAAC,QAAQ,EAAE,CAAC;YAClB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,QAAQ,CAAC,MAAM,EAAE,CAAC,CAAC;YACrC,KAAK,CAAC,MAAM,CAAC,cAAc,CAAC,IAAI,CAAC,UAAU,CAAC,CAAC,CAAC;YAC9C,KAAK,CAAC,MAAM,CAAC,IAAI,UAAU,CAAC,CAAC,IAAI,EAAE,IAAI,CAAC,CAAC,CAAC,CAAC;QAC7C,CAAC;QACD,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC;IAC1B,CAAC;IACD,OAAO;QACL,KAAK,CAAC,OAAO,CAAC,IAAI,CAAC,IAAI,CAAC,CAAC;QACzB,IAAI,IAAI,CAAC,QAAQ;YAAE,IAAI,CAAC,QAAQ,CAAC,OAAO,EAAE,CAAC;QAC3C,yGAAyG;QACzG,IAAI,CAAC,eAAe,GAAG,KAAK,CAAC;IAC/B,CAAC;IACD,UAAU,CAAC,EAAmB;QAC5B,MAAM,EAAE,QAAQ,EAAE,OAAO,EAAE,QAAQ,EAAE,SAAS,EAAE,MAAM,EAAE,GAAG,IAAI,CAAC;QAChE,EAAE,KAAF,EAAE,GAAK,IAAI,cAAc,CAAC,QAAQ,EAAE,OAAO,EAAE,SAAS,EAAE,MAAM,EAAE,EAAE,CAAC,EAAC;QACpE,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;QACrB,IAAI,QAAQ;YAAE,EAAE,CAAC,QAAQ,GAAG,QAAQ,CAAC,UAAU,CAAC,EAAE,CAAC,QAAQ,CAAC,CAAC;QAC7D,EAAE,CAAC,eAAe,CAAC,GAAG,CAAC,IAAI,CAAC,eAAe,CAAC,CAAC;QAC7C,EAAE,CAAC,OAAO,GAAG,IAAI,CAAC,OAAO,CAAC;QAC1B,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,UAAU,GAAG,IAAI,CAAC,UAAU,CAAC;QAChC,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAxED,wCAwEC;AACD,sDAAsD;AACzC,QAAA,GAAG,GAAmB,CAAC,GAAG,EAAE,CACvC,IAAA,kCAAuB,EACrB,CAAC,OAAqB,EAAE,EAAE,EAAE,CAAC,IAAI,cAAc,CAAC,GAAG,EAAE,EAAE,EAAE,SAAS,CAAC,IAAI,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CACxF,CAAC,EAAE,CAAC;AACP,sBAAsB;AACT,QAAA,GAAG,GAAmB,CAAC,GAAG,EAAE,CACvC,IAAA,kCAAuB,EACrB,CAAC,OAAqB,EAAE,EAAE,EAAE,CAAC,IAAI,cAAc,CAAC,GAAG,EAAE,EAAE,EAAE,SAAS,CAAC,IAAI,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,IAAI,CAAC,CACxF,CAAC,EAAE,CAAC;AAEP,wCAAwC;AACxC,iEAAiE;AACjE,MAAa,SAAU,SAAQ,gBAAM;IAEnC,YAAY,QAAgB;QAC1B,IAAA,mBAAY,EAAC,QAAQ,CAAC,CAAC;QACvB,2BAA2B;QAC3B,IAAI,QAAQ,GAAG,CAAC,IAAI,QAAQ,GAAG,IAAI,GAAG,EAAE,IAAI,CAAC,IAAI,GAAG,QAAQ,GAAG,CAAC,CAAC,GAAG,CAAC;YACnE,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;QACjD,0BAA0B;QAC1B,KAAK,CAAC,CAAC,IAAI,GAAG,QAAQ,GAAG,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,IAAI,CAAC,CAAC;QAC7C,IAAI,CAAC,IAAI,GAAG,IAAI,GAAG,QAAQ,CAAC;QAC5B,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,KAAK,CAAC,CAAC,IAAI,CAAC,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IAChD,CAAC;IACD,MAAM;QACJ,iBAAiB;QACjB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,GAAG,CAAC,IAAI,IAAI,CAAC;QAC7B,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,QAAQ,CAAC,IAAI,IAAI,CAAC,CAAC,oBAAoB;QACvD,KAAK,CAAC,MAAM,EAAE,CAAC;QACf,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;QACb,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC;IAClB,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,KAAK,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;QACnB,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,OAAO,IAAI,CAAC;IACd,CAAC;IACD,IAAI,CAAC,IAAW;QACd,OAAO,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;IAC3B,CAAC;IACS,MAAM,KAAI,CAAC;IACrB,UAAU,CAAC,IAAgB;QACzB,MAAM,IAAI,KAAK,CAAC,8DAA8D,CAAC,CAAC;IAClF,CAAC;IACD,KAAK,CAAC,KAAa;QACjB,OAAO,IAAI,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC;IACzB,CAAC;IACD,oFAAoF;IACpF,MAAM;QACJ,IAAI,IAAI,CAAC,IAAI,GAAG,IAAI,GAAG,CAAC,GAAG,CAAC;YAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;QACvF,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,IAAI,CAAC,QAAQ,EAAE,CAAC,EAAE;YAAE,IAAI,CAAC,KAAK,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC;QAC1D,IAAI,CAAC,GAAG,GAAG,IAAI,CAAC,QAAQ,CAAC;QACzB,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,QAAQ,CAAC;IAC9B,CAAC;IACD,UAAU,CAAC,EAAc;QACvB,MAAM,EAAE,IAAI,EAAE,GAAG,IAAI,CAAC;QACtB,EAAE,KAAF,EAAE,GAAK,IAAI,SAAS,CAAC,IAAI,GAAG,IAAI,CAAC,EAAC;QAClC,KAAK,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC;QACrB,EAAE,CAAC,IAAI,GAAG,IAAI,CAAC;QACf,OAAO,EAAE,CAAC;IACZ,CAAC;IACD,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAtDD,8BAsDC;AAEM,MAAM,SAAS,GAAG,CAAC,QAAQ,GAAG,GAAG,EAAE,EAAE,CAAC,IAAI,SAAS,CAAC,QAAQ,CAAC,CAAC;AAAxD,QAAA,SAAS,aAA+C"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.d.ts
+new file mode 100644
+index 0000000..82b88a8
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.d.ts
+@@ -0,0 +1,98 @@
++import { Hash, Input, HashXOF } from './utils.js';
++export declare function keccakP(s: Uint32Array, rounds?: number): void;
++export declare class Keccak extends Hash<Keccak> implements HashXOF<Keccak> {
++    blockLen: number;
++    suffix: number;
++    outputLen: number;
++    protected enableXOF: boolean;
++    protected rounds: number;
++    protected state: Uint8Array;
++    protected pos: number;
++    protected posOut: number;
++    protected finished: boolean;
++    protected state32: Uint32Array;
++    protected destroyed: boolean;
++    constructor(blockLen: number, suffix: number, outputLen: number, enableXOF?: boolean, rounds?: number);
++    protected keccak(): void;
++    update(data: Input): this;
++    protected finish(): void;
++    protected writeInto(out: Uint8Array): Uint8Array;
++    xofInto(out: Uint8Array): Uint8Array;
++    xof(bytes: number): Uint8Array;
++    digestInto(out: Uint8Array): Uint8Array;
++    digest(): Uint8Array;
++    destroy(): void;
++    _cloneInto(to?: Keccak): Keccak;
++}
++export declare const sha3_224: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++/**
++ * SHA3-256 hash function
++ * @param message - that would be hashed
++ */
++export declare const sha3_256: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const sha3_384: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const sha3_512: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const keccak_224: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++/**
++ * keccak-256 hash function. Different from SHA3-256.
++ * @param message - that would be hashed
++ */
++export declare const keccak_256: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const keccak_384: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export declare const keccak_512: {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<Keccak>;
++};
++export type ShakeOpts = {
++    dkLen?: number;
++};
++export declare const shake128: {
++    (msg: Input, opts?: ShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: ShakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++export declare const shake256: {
++    (msg: Input, opts?: ShakeOpts | undefined): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: ShakeOpts): HashXOF<HashXOF<Keccak>>;
++};
++//# sourceMappingURL=sha3.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.d.ts.map
+new file mode 100644
+index 0000000..3644f6e
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3.d.ts","sourceRoot":"","sources":["src/sha3.ts"],"names":[],"mappings":"AAEA,OAAO,EACL,IAAI,EAEJ,KAAK,EAIL,OAAO,EAGR,MAAM,YAAY,CAAC;AAoCpB,wBAAgB,OAAO,CAAC,CAAC,EAAE,WAAW,EAAE,MAAM,GAAE,MAAW,QAyC1D;AAED,qBAAa,MAAO,SAAQ,IAAI,CAAC,MAAM,CAAE,YAAW,OAAO,CAAC,MAAM,CAAC;IASxD,QAAQ,EAAE,MAAM;IAChB,MAAM,EAAE,MAAM;IACd,SAAS,EAAE,MAAM;IACxB,SAAS,CAAC,SAAS;IACnB,SAAS,CAAC,MAAM,EAAE,MAAM;IAZ1B,SAAS,CAAC,KAAK,EAAE,UAAU,CAAC;IAC5B,SAAS,CAAC,GAAG,SAAK;IAClB,SAAS,CAAC,MAAM,SAAK;IACrB,SAAS,CAAC,QAAQ,UAAS;IAC3B,SAAS,CAAC,OAAO,EAAE,WAAW,CAAC;IAC/B,SAAS,CAAC,SAAS,UAAS;gBAGnB,QAAQ,EAAE,MAAM,EAChB,MAAM,EAAE,MAAM,EACd,SAAS,EAAE,MAAM,EACd,SAAS,UAAQ,EACjB,MAAM,GAAE,MAAW;IAW/B,SAAS,CAAC,MAAM;IAOhB,MAAM,CAAC,IAAI,EAAE,KAAK;IAYlB,SAAS,CAAC,MAAM;IAUhB,SAAS,CAAC,SAAS,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU;IAehD,OAAO,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU;IAKpC,GAAG,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU;IAI9B,UAAU,CAAC,GAAG,EAAE,UAAU;IAO1B,MAAM;IAGN,OAAO;IAIP,UAAU,CAAC,EAAE,CAAC,EAAE,MAAM,GAAG,MAAM;CAehC;AAKD,eAAO,MAAM,QAAQ;;;;;CAA0C,CAAC;AAChE;;;GAGG;AACH,eAAO,MAAM,QAAQ;;;;;CAA0C,CAAC;AAChE,eAAO,MAAM,QAAQ;;;;;CAA0C,CAAC;AAChE,eAAO,MAAM,QAAQ;;;;;CAAyC,CAAC;AAC/D,eAAO,MAAM,UAAU;;;;;CAA0C,CAAC;AAClE;;;GAGG;AACH,eAAO,MAAM,UAAU;;;;;CAA0C,CAAC;AAClE,eAAO,MAAM,UAAU;;;;;CAA0C,CAAC;AAClE,eAAO,MAAM,UAAU;;;;;CAAyC,CAAC;AAEjE,MAAM,MAAM,SAAS,GAAG;IAAE,KAAK,CAAC,EAAE,MAAM,CAAA;CAAE,CAAC;AAQ3C,eAAO,MAAM,QAAQ;;;;;CAA+C,CAAC;AACrE,eAAO,MAAM,QAAQ;;;;;CAA+C,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.js
+new file mode 100644
+index 0000000..cb0b719
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.js
+@@ -0,0 +1,219 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.shake256 = exports.shake128 = exports.keccak_512 = exports.keccak_384 = exports.keccak_256 = exports.keccak_224 = exports.sha3_512 = exports.sha3_384 = exports.sha3_256 = exports.sha3_224 = exports.Keccak = void 0;
++exports.keccakP = keccakP;
++const _assert_js_1 = require("./_assert.js");
++const _u64_js_1 = require("./_u64.js");
++const utils_js_1 = require("./utils.js");
++// SHA3 (keccak) is based on a new design: basically, the internal state is bigger than output size.
++// It's called a sponge function.
++// Various per round constants calculations
++const SHA3_PI = [];
++const SHA3_ROTL = [];
++const _SHA3_IOTA = [];
++const _0n = /* @__PURE__ */ BigInt(0);
++const _1n = /* @__PURE__ */ BigInt(1);
++const _2n = /* @__PURE__ */ BigInt(2);
++const _7n = /* @__PURE__ */ BigInt(7);
++const _256n = /* @__PURE__ */ BigInt(256);
++const _0x71n = /* @__PURE__ */ BigInt(0x71);
++for (let round = 0, R = _1n, x = 1, y = 0; round < 24; round++) {
++    // Pi
++    [x, y] = [y, (2 * x + 3 * y) % 5];
++    SHA3_PI.push(2 * (5 * y + x));
++    // Rotational
++    SHA3_ROTL.push((((round + 1) * (round + 2)) / 2) % 64);
++    // Iota
++    let t = _0n;
++    for (let j = 0; j < 7; j++) {
++        R = ((R << _1n) ^ ((R >> _7n) * _0x71n)) % _256n;
++        if (R & _2n)
++            t ^= _1n << ((_1n << /* @__PURE__ */ BigInt(j)) - _1n);
++    }
++    _SHA3_IOTA.push(t);
++}
++const [SHA3_IOTA_H, SHA3_IOTA_L] = /* @__PURE__ */ (0, _u64_js_1.split)(_SHA3_IOTA, true);
++// Left rotation (without 0, 32, 64)
++const rotlH = (h, l, s) => (s > 32 ? (0, _u64_js_1.rotlBH)(h, l, s) : (0, _u64_js_1.rotlSH)(h, l, s));
++const rotlL = (h, l, s) => (s > 32 ? (0, _u64_js_1.rotlBL)(h, l, s) : (0, _u64_js_1.rotlSL)(h, l, s));
++// Same as keccakf1600, but allows to skip some rounds
++function keccakP(s, rounds = 24) {
++    const B = new Uint32Array(5 * 2);
++    // NOTE: all indices are x2 since we store state as u32 instead of u64 (bigints to slow in js)
++    for (let round = 24 - rounds; round < 24; round++) {
++        // Theta θ
++        for (let x = 0; x < 10; x++)
++            B[x] = s[x] ^ s[x + 10] ^ s[x + 20] ^ s[x + 30] ^ s[x + 40];
++        for (let x = 0; x < 10; x += 2) {
++            const idx1 = (x + 8) % 10;
++            const idx0 = (x + 2) % 10;
++            const B0 = B[idx0];
++            const B1 = B[idx0 + 1];
++            const Th = rotlH(B0, B1, 1) ^ B[idx1];
++            const Tl = rotlL(B0, B1, 1) ^ B[idx1 + 1];
++            for (let y = 0; y < 50; y += 10) {
++                s[x + y] ^= Th;
++                s[x + y + 1] ^= Tl;
++            }
++        }
++        // Rho (ρ) and Pi (π)
++        let curH = s[2];
++        let curL = s[3];
++        for (let t = 0; t < 24; t++) {
++            const shift = SHA3_ROTL[t];
++            const Th = rotlH(curH, curL, shift);
++            const Tl = rotlL(curH, curL, shift);
++            const PI = SHA3_PI[t];
++            curH = s[PI];
++            curL = s[PI + 1];
++            s[PI] = Th;
++            s[PI + 1] = Tl;
++        }
++        // Chi (χ)
++        for (let y = 0; y < 50; y += 10) {
++            for (let x = 0; x < 10; x++)
++                B[x] = s[y + x];
++            for (let x = 0; x < 10; x++)
++                s[y + x] ^= ~B[(x + 2) % 10] & B[(x + 4) % 10];
++        }
++        // Iota (ι)
++        s[0] ^= SHA3_IOTA_H[round];
++        s[1] ^= SHA3_IOTA_L[round];
++    }
++    B.fill(0);
++}
++class Keccak extends utils_js_1.Hash {
++    // NOTE: we accept arguments in bytes instead of bits here.
++    constructor(blockLen, suffix, outputLen, enableXOF = false, rounds = 24) {
++        super();
++        this.blockLen = blockLen;
++        this.suffix = suffix;
++        this.outputLen = outputLen;
++        this.enableXOF = enableXOF;
++        this.rounds = rounds;
++        this.pos = 0;
++        this.posOut = 0;
++        this.finished = false;
++        this.destroyed = false;
++        // Can be passed from user as dkLen
++        (0, _assert_js_1.number)(outputLen);
++        // 1600 = 5x5 matrix of 64bit.  1600 bits === 200 bytes
++        if (0 >= this.blockLen || this.blockLen >= 200)
++            throw new Error('Sha3 supports only keccak-f1600 function');
++        this.state = new Uint8Array(200);
++        this.state32 = (0, utils_js_1.u32)(this.state);
++    }
++    keccak() {
++        if (!utils_js_1.isLE)
++            (0, utils_js_1.byteSwap32)(this.state32);
++        keccakP(this.state32, this.rounds);
++        if (!utils_js_1.isLE)
++            (0, utils_js_1.byteSwap32)(this.state32);
++        this.posOut = 0;
++        this.pos = 0;
++    }
++    update(data) {
++        (0, _assert_js_1.exists)(this);
++        const { blockLen, state } = this;
++        data = (0, utils_js_1.toBytes)(data);
++        const len = data.length;
++        for (let pos = 0; pos < len;) {
++            const take = Math.min(blockLen - this.pos, len - pos);
++            for (let i = 0; i < take; i++)
++                state[this.pos++] ^= data[pos++];
++            if (this.pos === blockLen)
++                this.keccak();
++        }
++        return this;
++    }
++    finish() {
++        if (this.finished)
++            return;
++        this.finished = true;
++        const { state, suffix, pos, blockLen } = this;
++        // Do the padding
++        state[pos] ^= suffix;
++        if ((suffix & 0x80) !== 0 && pos === blockLen - 1)
++            this.keccak();
++        state[blockLen - 1] ^= 0x80;
++        this.keccak();
++    }
++    writeInto(out) {
++        (0, _assert_js_1.exists)(this, false);
++        (0, _assert_js_1.bytes)(out);
++        this.finish();
++        const bufferOut = this.state;
++        const { blockLen } = this;
++        for (let pos = 0, len = out.length; pos < len;) {
++            if (this.posOut >= blockLen)
++                this.keccak();
++            const take = Math.min(blockLen - this.posOut, len - pos);
++            out.set(bufferOut.subarray(this.posOut, this.posOut + take), pos);
++            this.posOut += take;
++            pos += take;
++        }
++        return out;
++    }
++    xofInto(out) {
++        // Sha3/Keccak usage with XOF is probably mistake, only SHAKE instances can do XOF
++        if (!this.enableXOF)
++            throw new Error('XOF is not possible for this instance');
++        return this.writeInto(out);
++    }
++    xof(bytes) {
++        (0, _assert_js_1.number)(bytes);
++        return this.xofInto(new Uint8Array(bytes));
++    }
++    digestInto(out) {
++        (0, _assert_js_1.output)(out, this);
++        if (this.finished)
++            throw new Error('digest() was already called');
++        this.writeInto(out);
++        this.destroy();
++        return out;
++    }
++    digest() {
++        return this.digestInto(new Uint8Array(this.outputLen));
++    }
++    destroy() {
++        this.destroyed = true;
++        this.state.fill(0);
++    }
++    _cloneInto(to) {
++        const { blockLen, suffix, outputLen, rounds, enableXOF } = this;
++        to || (to = new Keccak(blockLen, suffix, outputLen, enableXOF, rounds));
++        to.state32.set(this.state32);
++        to.pos = this.pos;
++        to.posOut = this.posOut;
++        to.finished = this.finished;
++        to.rounds = rounds;
++        // Suffix can change in cSHAKE
++        to.suffix = suffix;
++        to.outputLen = outputLen;
++        to.enableXOF = enableXOF;
++        to.destroyed = this.destroyed;
++        return to;
++    }
++}
++exports.Keccak = Keccak;
++const gen = (suffix, blockLen, outputLen) => (0, utils_js_1.wrapConstructor)(() => new Keccak(blockLen, suffix, outputLen));
++exports.sha3_224 = gen(0x06, 144, 224 / 8);
++/**
++ * SHA3-256 hash function
++ * @param message - that would be hashed
++ */
++exports.sha3_256 = gen(0x06, 136, 256 / 8);
++exports.sha3_384 = gen(0x06, 104, 384 / 8);
++exports.sha3_512 = gen(0x06, 72, 512 / 8);
++exports.keccak_224 = gen(0x01, 144, 224 / 8);
++/**
++ * keccak-256 hash function. Different from SHA3-256.
++ * @param message - that would be hashed
++ */
++exports.keccak_256 = gen(0x01, 136, 256 / 8);
++exports.keccak_384 = gen(0x01, 104, 384 / 8);
++exports.keccak_512 = gen(0x01, 72, 512 / 8);
++const genShake = (suffix, blockLen, outputLen) => (0, utils_js_1.wrapXOFConstructorWithOpts)((opts = {}) => new Keccak(blockLen, suffix, opts.dkLen === undefined ? outputLen : opts.dkLen, true));
++exports.shake128 = genShake(0x1f, 168, 128 / 8);
++exports.shake256 = genShake(0x1f, 136, 256 / 8);
++//# sourceMappingURL=sha3.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.js.map
+new file mode 100644
+index 0000000..1dc4d71
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha3.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha3.js","sourceRoot":"","sources":["src/sha3.ts"],"names":[],"mappings":";;;AAgDA,0BAyCC;AAzFD,6CAA6D;AAC7D,uCAAkE;AAClE,yCAUoB;AAEpB,oGAAoG;AACpG,iCAAiC;AAEjC,2CAA2C;AAC3C,MAAM,OAAO,GAAa,EAAE,CAAC;AAC7B,MAAM,SAAS,GAAa,EAAE,CAAC;AAC/B,MAAM,UAAU,GAAa,EAAE,CAAC;AAChC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,GAAG,GAAG,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC;AACtC,MAAM,KAAK,GAAG,eAAe,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC;AAC1C,MAAM,MAAM,GAAG,eAAe,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC;AAC5C,KAAK,IAAI,KAAK,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,KAAK,GAAG,EAAE,EAAE,KAAK,EAAE,EAAE,CAAC;IAC/D,KAAK;IACL,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IAClC,OAAO,CAAC,IAAI,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;IAC9B,aAAa;IACb,SAAS,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,KAAK,GAAG,CAAC,CAAC,GAAG,CAAC,KAAK,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;IACvD,OAAO;IACP,IAAI,CAAC,GAAG,GAAG,CAAC;IACZ,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,CAAC,EAAE,CAAC,EAAE,EAAE,CAAC;QAC3B,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,GAAG,CAAC,GAAG,CAAC,CAAC,CAAC,IAAI,GAAG,CAAC,GAAG,MAAM,CAAC,CAAC,GAAG,KAAK,CAAC;QACjD,IAAI,CAAC,GAAG,GAAG;YAAE,CAAC,IAAI,GAAG,IAAI,CAAC,CAAC,GAAG,IAAI,eAAe,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,GAAG,GAAG,CAAC,CAAC;IACtE,CAAC;IACD,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;AACrB,CAAC;AACD,MAAM,CAAC,WAAW,EAAE,WAAW,CAAC,GAAG,eAAe,CAAC,IAAA,eAAK,EAAC,UAAU,EAAE,IAAI,CAAC,CAAC;AAE3E,oCAAoC;AACpC,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC,IAAA,gBAAM,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC,IAAA,gBAAM,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;AAChG,MAAM,KAAK,GAAG,CAAC,CAAS,EAAE,CAAS,EAAE,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC,IAAA,gBAAM,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC,IAAA,gBAAM,EAAC,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;AAEhG,sDAAsD;AACtD,SAAgB,OAAO,CAAC,CAAc,EAAE,SAAiB,EAAE;IACzD,MAAM,CAAC,GAAG,IAAI,WAAW,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;IACjC,8FAA8F;IAC9F,KAAK,IAAI,KAAK,GAAG,EAAE,GAAG,MAAM,EAAE,KAAK,GAAG,EAAE,EAAE,KAAK,EAAE,EAAE,CAAC;QAClD,UAAU;QACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;YAAE,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;QACzF,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC;YAC/B,MAAM,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;YAC1B,MAAM,IAAI,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;YAC1B,MAAM,EAAE,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC;YACnB,MAAM,EAAE,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;YACvB,MAAM,EAAE,GAAG,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC;YACtC,MAAM,EAAE,GAAG,KAAK,CAAC,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,GAAG,CAAC,CAAC,CAAC;YAC1C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,EAAE,EAAE,CAAC;gBAChC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,EAAE,CAAC;gBACf,CAAC,CAAC,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC,IAAI,EAAE,CAAC;YACrB,CAAC;QACH,CAAC;QACD,qBAAqB;QACrB,IAAI,IAAI,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;QAChB,IAAI,IAAI,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;QAChB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,MAAM,KAAK,GAAG,SAAS,CAAC,CAAC,CAAC,CAAC;YAC3B,MAAM,EAAE,GAAG,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,KAAK,CAAC,CAAC;YACpC,MAAM,EAAE,GAAG,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,KAAK,CAAC,CAAC;YACpC,MAAM,EAAE,GAAG,OAAO,CAAC,CAAC,CAAC,CAAC;YACtB,IAAI,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;YACb,IAAI,GAAG,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC;YACjB,CAAC,CAAC,EAAE,CAAC,GAAG,EAAE,CAAC;YACX,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC;QACjB,CAAC;QACD,UAAU;QACV,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,IAAI,EAAE,EAAE,CAAC;YAChC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;gBAAE,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,CAAC;YAC7C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE;gBAAE,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC;QAC9E,CAAC;QACD,WAAW;QACX,CAAC,CAAC,CAAC,CAAC,IAAI,WAAW,CAAC,KAAK,CAAC,CAAC;QAC3B,CAAC,CAAC,CAAC,CAAC,IAAI,WAAW,CAAC,KAAK,CAAC,CAAC;IAC7B,CAAC;IACD,CAAC,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;AACZ,CAAC;AAED,MAAa,MAAO,SAAQ,eAAY;IAOtC,2DAA2D;IAC3D,YACS,QAAgB,EAChB,MAAc,EACd,SAAiB,EACd,YAAY,KAAK,EACjB,SAAiB,EAAE;QAE7B,KAAK,EAAE,CAAC;QAND,aAAQ,GAAR,QAAQ,CAAQ;QAChB,WAAM,GAAN,MAAM,CAAQ;QACd,cAAS,GAAT,SAAS,CAAQ;QACd,cAAS,GAAT,SAAS,CAAQ;QACjB,WAAM,GAAN,MAAM,CAAa;QAXrB,QAAG,GAAG,CAAC,CAAC;QACR,WAAM,GAAG,CAAC,CAAC;QACX,aAAQ,GAAG,KAAK,CAAC;QAEjB,cAAS,GAAG,KAAK,CAAC;QAU1B,mCAAmC;QACnC,IAAA,mBAAM,EAAC,SAAS,CAAC,CAAC;QAClB,uDAAuD;QACvD,IAAI,CAAC,IAAI,IAAI,CAAC,QAAQ,IAAI,IAAI,CAAC,QAAQ,IAAI,GAAG;YAC5C,MAAM,IAAI,KAAK,CAAC,0CAA0C,CAAC,CAAC;QAC9D,IAAI,CAAC,KAAK,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;QACjC,IAAI,CAAC,OAAO,GAAG,IAAA,cAAG,EAAC,IAAI,CAAC,KAAK,CAAC,CAAC;IACjC,CAAC;IACS,MAAM;QACd,IAAI,CAAC,eAAI;YAAE,IAAA,qBAAU,EAAC,IAAI,CAAC,OAAO,CAAC,CAAC;QACpC,OAAO,CAAC,IAAI,CAAC,OAAO,EAAE,IAAI,CAAC,MAAM,CAAC,CAAC;QACnC,IAAI,CAAC,eAAI;YAAE,IAAA,qBAAU,EAAC,IAAI,CAAC,OAAO,CAAC,CAAC;QACpC,IAAI,CAAC,MAAM,GAAG,CAAC,CAAC;QAChB,IAAI,CAAC,GAAG,GAAG,CAAC,CAAC;IACf,CAAC;IACD,MAAM,CAAC,IAAW;QAChB,IAAA,mBAAM,EAAC,IAAI,CAAC,CAAC;QACb,MAAM,EAAE,QAAQ,EAAE,KAAK,EAAE,GAAG,IAAI,CAAC;QACjC,IAAI,GAAG,IAAA,kBAAO,EAAC,IAAI,CAAC,CAAC;QACrB,MAAM,GAAG,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAC9B,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACtD,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,IAAI,EAAE,CAAC,EAAE;gBAAE,KAAK,CAAC,IAAI,CAAC,GAAG,EAAE,CAAC,IAAI,IAAI,CAAC,GAAG,EAAE,CAAC,CAAC;YAChE,IAAI,IAAI,CAAC,GAAG,KAAK,QAAQ;gBAAE,IAAI,CAAC,MAAM,EAAE,CAAC;QAC3C,CAAC;QACD,OAAO,IAAI,CAAC;IACd,CAAC;IACS,MAAM;QACd,IAAI,IAAI,CAAC,QAAQ;YAAE,OAAO;QAC1B,IAAI,CAAC,QAAQ,GAAG,IAAI,CAAC;QACrB,MAAM,EAAE,KAAK,EAAE,MAAM,EAAE,GAAG,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC9C,iBAAiB;QACjB,KAAK,CAAC,GAAG,CAAC,IAAI,MAAM,CAAC;QACrB,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,KAAK,CAAC,IAAI,GAAG,KAAK,QAAQ,GAAG,CAAC;YAAE,IAAI,CAAC,MAAM,EAAE,CAAC;QACjE,KAAK,CAAC,QAAQ,GAAG,CAAC,CAAC,IAAI,IAAI,CAAC;QAC5B,IAAI,CAAC,MAAM,EAAE,CAAC;IAChB,CAAC;IACS,SAAS,CAAC,GAAe;QACjC,IAAA,mBAAM,EAAC,IAAI,EAAE,KAAK,CAAC,CAAC;QACpB,IAAA,kBAAK,EAAC,GAAG,CAAC,CAAC;QACX,IAAI,CAAC,MAAM,EAAE,CAAC;QACd,MAAM,SAAS,GAAG,IAAI,CAAC,KAAK,CAAC;QAC7B,MAAM,EAAE,QAAQ,EAAE,GAAG,IAAI,CAAC;QAC1B,KAAK,IAAI,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,GAAG,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,GAAI,CAAC;YAChD,IAAI,IAAI,CAAC,MAAM,IAAI,QAAQ;gBAAE,IAAI,CAAC,MAAM,EAAE,CAAC;YAC3C,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,CAAC,QAAQ,GAAG,IAAI,CAAC,MAAM,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;YACzD,GAAG,CAAC,GAAG,CAAC,SAAS,CAAC,QAAQ,CAAC,IAAI,CAAC,MAAM,EAAE,IAAI,CAAC,MAAM,GAAG,IAAI,CAAC,EAAE,GAAG,CAAC,CAAC;YAClE,IAAI,CAAC,MAAM,IAAI,IAAI,CAAC;YACpB,GAAG,IAAI,IAAI,CAAC;QACd,CAAC;QACD,OAAO,GAAG,CAAC;IACb,CAAC;IACD,OAAO,CAAC,GAAe;QACrB,kFAAkF;QAClF,IAAI,CAAC,IAAI,CAAC,SAAS;YAAE,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;QAC9E,OAAO,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;IAC7B,CAAC;IACD,GAAG,CAAC,KAAa;QACf,IAAA,mBAAM,EAAC,KAAK,CAAC,CAAC;QACd,OAAO,IAAI,CAAC,OAAO,CAAC,IAAI,UAAU,CAAC,KAAK,CAAC,CAAC,CAAC;IAC7C,CAAC;IACD,UAAU,CAAC,GAAe;QACxB,IAAA,mBAAM,EAAC,GAAG,EAAE,IAAI,CAAC,CAAC;QAClB,IAAI,IAAI,CAAC,QAAQ;YAAE,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;QAClE,IAAI,CAAC,SAAS,CAAC,GAAG,CAAC,CAAC;QACpB,IAAI,CAAC,OAAO,EAAE,CAAC;QACf,OAAO,GAAG,CAAC;IACb,CAAC;IACD,MAAM;QACJ,OAAO,IAAI,CAAC,UAAU,CAAC,IAAI,UAAU,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC,CAAC;IACzD,CAAC;IACD,OAAO;QACL,IAAI,CAAC,SAAS,GAAG,IAAI,CAAC;QACtB,IAAI,CAAC,KAAK,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACrB,CAAC;IACD,UAAU,CAAC,EAAW;QACpB,MAAM,EAAE,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,SAAS,EAAE,GAAG,IAAI,CAAC;QAChE,EAAE,KAAF,EAAE,GAAK,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,EAAE,SAAS,EAAE,MAAM,CAAC,EAAC;QAClE,EAAE,CAAC,OAAO,CAAC,GAAG,CAAC,IAAI,CAAC,OAAO,CAAC,CAAC;QAC7B,EAAE,CAAC,GAAG,GAAG,IAAI,CAAC,GAAG,CAAC;QAClB,EAAE,CAAC,MAAM,GAAG,IAAI,CAAC,MAAM,CAAC;QACxB,EAAE,CAAC,QAAQ,GAAG,IAAI,CAAC,QAAQ,CAAC;QAC5B,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,8BAA8B;QAC9B,EAAE,CAAC,MAAM,GAAG,MAAM,CAAC;QACnB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,SAAS,GAAG,SAAS,CAAC;QACzB,EAAE,CAAC,SAAS,GAAG,IAAI,CAAC,SAAS,CAAC;QAC9B,OAAO,EAAE,CAAC;IACZ,CAAC;CACF;AA1GD,wBA0GC;AAED,MAAM,GAAG,GAAG,CAAC,MAAc,EAAE,QAAgB,EAAE,SAAiB,EAAE,EAAE,CAClE,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,SAAS,CAAC,CAAC,CAAC;AAEpD,QAAA,QAAQ,GAAmB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAChE;;;GAGG;AACU,QAAA,QAAQ,GAAmB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACnD,QAAA,QAAQ,GAAmB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACnD,QAAA,QAAQ,GAAmB,GAAG,CAAC,IAAI,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAClD,QAAA,UAAU,GAAmB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAClE;;;GAGG;AACU,QAAA,UAAU,GAAmB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACrD,QAAA,UAAU,GAAmB,GAAG,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACrD,QAAA,UAAU,GAAmB,GAAG,CAAC,IAAI,EAAE,EAAE,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AAIjE,MAAM,QAAQ,GAAG,CAAC,MAAc,EAAE,QAAgB,EAAE,SAAiB,EAAE,EAAE,CACvE,IAAA,qCAA0B,EACxB,CAAC,OAAkB,EAAE,EAAE,EAAE,CACvB,IAAI,MAAM,CAAC,QAAQ,EAAE,MAAM,EAAE,IAAI,CAAC,KAAK,KAAK,SAAS,CAAC,CAAC,CAAC,SAAS,CAAC,CAAC,CAAC,IAAI,CAAC,KAAK,EAAE,IAAI,CAAC,CACxF,CAAC;AAES,QAAA,QAAQ,GAAmB,QAAQ,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC;AACxD,QAAA,QAAQ,GAAmB,QAAQ,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.d.ts
+new file mode 100644
+index 0000000..2282d2b
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.d.ts
+@@ -0,0 +1,124 @@
++import { HashMD } from './_md.js';
++export declare class SHA512 extends HashMD<SHA512> {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++    protected get(): [
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number,
++        number
++    ];
++    protected set(Ah: number, Al: number, Bh: number, Bl: number, Ch: number, Cl: number, Dh: number, Dl: number, Eh: number, El: number, Fh: number, Fl: number, Gh: number, Gl: number, Hh: number, Hl: number): void;
++    protected process(view: DataView, offset: number): void;
++    protected roundClean(): void;
++    destroy(): void;
++}
++export declare class SHA512_224 extends SHA512 {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++}
++export declare class SHA512_256 extends SHA512 {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++}
++export declare class SHA384 extends SHA512 {
++    Ah: number;
++    Al: number;
++    Bh: number;
++    Bl: number;
++    Ch: number;
++    Cl: number;
++    Dh: number;
++    Dl: number;
++    Eh: number;
++    El: number;
++    Fh: number;
++    Fl: number;
++    Gh: number;
++    Gl: number;
++    Hh: number;
++    Hl: number;
++    constructor();
++}
++export declare const sha512: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++export declare const sha512_224: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++export declare const sha512_256: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++export declare const sha384: {
++    (msg: import("./utils.js").Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): import("./utils.js").Hash<SHA512>;
++};
++//# sourceMappingURL=sha512.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.d.ts.map
+new file mode 100644
+index 0000000..efa0211
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha512.d.ts","sourceRoot":"","sources":["src/sha512.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,MAAM,EAAE,MAAM,UAAU,CAAC;AAgClC,qBAAa,MAAO,SAAQ,MAAM,CAAC,MAAM,CAAC;IAKxC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;IAMpB,SAAS,CAAC,GAAG,IAAI;QACf,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAC9D,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;QAAE,MAAM;KAC/D;IAKD,SAAS,CAAC,GAAG,CACX,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAC9F,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM,EAAE,EAAE,EAAE,MAAM;IAmBhG,SAAS,CAAC,OAAO,CAAC,IAAI,EAAE,QAAQ,EAAE,MAAM,EAAE,MAAM;IAsEhD,SAAS,CAAC,UAAU;IAIpB,OAAO;CAIR;AAED,qBAAa,UAAW,SAAQ,MAAM;IAEpC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;CAMrB;AAED,qBAAa,UAAW,SAAQ,MAAM;IAEpC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;CAMrB;AAED,qBAAa,MAAO,SAAQ,MAAM;IAEhC,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;IACpB,EAAE,SAAkB;;CAMrB;AAED,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC;AAC1E,eAAO,MAAM,UAAU;;;;;CAA0D,CAAC;AAClF,eAAO,MAAM,UAAU;;;;;CAA0D,CAAC;AAClF,eAAO,MAAM,MAAM;;;;;CAAsD,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.js
+new file mode 100644
+index 0000000..a793ba6
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.js
+@@ -0,0 +1,238 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.sha384 = exports.sha512_256 = exports.sha512_224 = exports.sha512 = exports.SHA384 = exports.SHA512_256 = exports.SHA512_224 = exports.SHA512 = void 0;
++const _md_js_1 = require("./_md.js");
++const _u64_js_1 = require("./_u64.js");
++const utils_js_1 = require("./utils.js");
++// Round contants (first 32 bits of the fractional parts of the cube roots of the first 80 primes 2..409):
++// prettier-ignore
++const [SHA512_Kh, SHA512_Kl] = /* @__PURE__ */ (() => _u64_js_1.default.split([
++    '0x428a2f98d728ae22', '0x7137449123ef65cd', '0xb5c0fbcfec4d3b2f', '0xe9b5dba58189dbbc',
++    '0x3956c25bf348b538', '0x59f111f1b605d019', '0x923f82a4af194f9b', '0xab1c5ed5da6d8118',
++    '0xd807aa98a3030242', '0x12835b0145706fbe', '0x243185be4ee4b28c', '0x550c7dc3d5ffb4e2',
++    '0x72be5d74f27b896f', '0x80deb1fe3b1696b1', '0x9bdc06a725c71235', '0xc19bf174cf692694',
++    '0xe49b69c19ef14ad2', '0xefbe4786384f25e3', '0x0fc19dc68b8cd5b5', '0x240ca1cc77ac9c65',
++    '0x2de92c6f592b0275', '0x4a7484aa6ea6e483', '0x5cb0a9dcbd41fbd4', '0x76f988da831153b5',
++    '0x983e5152ee66dfab', '0xa831c66d2db43210', '0xb00327c898fb213f', '0xbf597fc7beef0ee4',
++    '0xc6e00bf33da88fc2', '0xd5a79147930aa725', '0x06ca6351e003826f', '0x142929670a0e6e70',
++    '0x27b70a8546d22ffc', '0x2e1b21385c26c926', '0x4d2c6dfc5ac42aed', '0x53380d139d95b3df',
++    '0x650a73548baf63de', '0x766a0abb3c77b2a8', '0x81c2c92e47edaee6', '0x92722c851482353b',
++    '0xa2bfe8a14cf10364', '0xa81a664bbc423001', '0xc24b8b70d0f89791', '0xc76c51a30654be30',
++    '0xd192e819d6ef5218', '0xd69906245565a910', '0xf40e35855771202a', '0x106aa07032bbd1b8',
++    '0x19a4c116b8d2d0c8', '0x1e376c085141ab53', '0x2748774cdf8eeb99', '0x34b0bcb5e19b48a8',
++    '0x391c0cb3c5c95a63', '0x4ed8aa4ae3418acb', '0x5b9cca4f7763e373', '0x682e6ff3d6b2b8a3',
++    '0x748f82ee5defb2fc', '0x78a5636f43172f60', '0x84c87814a1f0ab72', '0x8cc702081a6439ec',
++    '0x90befffa23631e28', '0xa4506cebde82bde9', '0xbef9a3f7b2c67915', '0xc67178f2e372532b',
++    '0xca273eceea26619c', '0xd186b8c721c0c207', '0xeada7dd6cde0eb1e', '0xf57d4f7fee6ed178',
++    '0x06f067aa72176fba', '0x0a637dc5a2c898a6', '0x113f9804bef90dae', '0x1b710b35131c471b',
++    '0x28db77f523047d84', '0x32caab7b40c72493', '0x3c9ebe0a15c9bebc', '0x431d67c49c100d4c',
++    '0x4cc5d4becb3e42b6', '0x597f299cfc657e2a', '0x5fcb6fab3ad6faec', '0x6c44198c4a475817'
++].map(n => BigInt(n))))();
++// Temporary buffer, not used to store anything between runs
++const SHA512_W_H = /* @__PURE__ */ new Uint32Array(80);
++const SHA512_W_L = /* @__PURE__ */ new Uint32Array(80);
++class SHA512 extends _md_js_1.HashMD {
++    constructor() {
++        super(128, 64, 16, false);
++        // We cannot use array here since array allows indexing by variable which means optimizer/compiler cannot use registers.
++        // Also looks cleaner and easier to verify with spec.
++        // Initial state (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0x6a09e667 | 0;
++        this.Al = 0xf3bcc908 | 0;
++        this.Bh = 0xbb67ae85 | 0;
++        this.Bl = 0x84caa73b | 0;
++        this.Ch = 0x3c6ef372 | 0;
++        this.Cl = 0xfe94f82b | 0;
++        this.Dh = 0xa54ff53a | 0;
++        this.Dl = 0x5f1d36f1 | 0;
++        this.Eh = 0x510e527f | 0;
++        this.El = 0xade682d1 | 0;
++        this.Fh = 0x9b05688c | 0;
++        this.Fl = 0x2b3e6c1f | 0;
++        this.Gh = 0x1f83d9ab | 0;
++        this.Gl = 0xfb41bd6b | 0;
++        this.Hh = 0x5be0cd19 | 0;
++        this.Hl = 0x137e2179 | 0;
++    }
++    // prettier-ignore
++    get() {
++        const { Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl } = this;
++        return [Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl];
++    }
++    // prettier-ignore
++    set(Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl) {
++        this.Ah = Ah | 0;
++        this.Al = Al | 0;
++        this.Bh = Bh | 0;
++        this.Bl = Bl | 0;
++        this.Ch = Ch | 0;
++        this.Cl = Cl | 0;
++        this.Dh = Dh | 0;
++        this.Dl = Dl | 0;
++        this.Eh = Eh | 0;
++        this.El = El | 0;
++        this.Fh = Fh | 0;
++        this.Fl = Fl | 0;
++        this.Gh = Gh | 0;
++        this.Gl = Gl | 0;
++        this.Hh = Hh | 0;
++        this.Hl = Hl | 0;
++    }
++    process(view, offset) {
++        // Extend the first 16 words into the remaining 64 words w[16..79] of the message schedule array
++        for (let i = 0; i < 16; i++, offset += 4) {
++            SHA512_W_H[i] = view.getUint32(offset);
++            SHA512_W_L[i] = view.getUint32((offset += 4));
++        }
++        for (let i = 16; i < 80; i++) {
++            // s0 := (w[i-15] rightrotate 1) xor (w[i-15] rightrotate 8) xor (w[i-15] rightshift 7)
++            const W15h = SHA512_W_H[i - 15] | 0;
++            const W15l = SHA512_W_L[i - 15] | 0;
++            const s0h = _u64_js_1.default.rotrSH(W15h, W15l, 1) ^ _u64_js_1.default.rotrSH(W15h, W15l, 8) ^ _u64_js_1.default.shrSH(W15h, W15l, 7);
++            const s0l = _u64_js_1.default.rotrSL(W15h, W15l, 1) ^ _u64_js_1.default.rotrSL(W15h, W15l, 8) ^ _u64_js_1.default.shrSL(W15h, W15l, 7);
++            // s1 := (w[i-2] rightrotate 19) xor (w[i-2] rightrotate 61) xor (w[i-2] rightshift 6)
++            const W2h = SHA512_W_H[i - 2] | 0;
++            const W2l = SHA512_W_L[i - 2] | 0;
++            const s1h = _u64_js_1.default.rotrSH(W2h, W2l, 19) ^ _u64_js_1.default.rotrBH(W2h, W2l, 61) ^ _u64_js_1.default.shrSH(W2h, W2l, 6);
++            const s1l = _u64_js_1.default.rotrSL(W2h, W2l, 19) ^ _u64_js_1.default.rotrBL(W2h, W2l, 61) ^ _u64_js_1.default.shrSL(W2h, W2l, 6);
++            // SHA256_W[i] = s0 + s1 + SHA256_W[i - 7] + SHA256_W[i - 16];
++            const SUMl = _u64_js_1.default.add4L(s0l, s1l, SHA512_W_L[i - 7], SHA512_W_L[i - 16]);
++            const SUMh = _u64_js_1.default.add4H(SUMl, s0h, s1h, SHA512_W_H[i - 7], SHA512_W_H[i - 16]);
++            SHA512_W_H[i] = SUMh | 0;
++            SHA512_W_L[i] = SUMl | 0;
++        }
++        let { Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl } = this;
++        // Compression function main loop, 80 rounds
++        for (let i = 0; i < 80; i++) {
++            // S1 := (e rightrotate 14) xor (e rightrotate 18) xor (e rightrotate 41)
++            const sigma1h = _u64_js_1.default.rotrSH(Eh, El, 14) ^ _u64_js_1.default.rotrSH(Eh, El, 18) ^ _u64_js_1.default.rotrBH(Eh, El, 41);
++            const sigma1l = _u64_js_1.default.rotrSL(Eh, El, 14) ^ _u64_js_1.default.rotrSL(Eh, El, 18) ^ _u64_js_1.default.rotrBL(Eh, El, 41);
++            //const T1 = (H + sigma1 + Chi(E, F, G) + SHA256_K[i] + SHA256_W[i]) | 0;
++            const CHIh = (Eh & Fh) ^ (~Eh & Gh);
++            const CHIl = (El & Fl) ^ (~El & Gl);
++            // T1 = H + sigma1 + Chi(E, F, G) + SHA512_K[i] + SHA512_W[i]
++            // prettier-ignore
++            const T1ll = _u64_js_1.default.add5L(Hl, sigma1l, CHIl, SHA512_Kl[i], SHA512_W_L[i]);
++            const T1h = _u64_js_1.default.add5H(T1ll, Hh, sigma1h, CHIh, SHA512_Kh[i], SHA512_W_H[i]);
++            const T1l = T1ll | 0;
++            // S0 := (a rightrotate 28) xor (a rightrotate 34) xor (a rightrotate 39)
++            const sigma0h = _u64_js_1.default.rotrSH(Ah, Al, 28) ^ _u64_js_1.default.rotrBH(Ah, Al, 34) ^ _u64_js_1.default.rotrBH(Ah, Al, 39);
++            const sigma0l = _u64_js_1.default.rotrSL(Ah, Al, 28) ^ _u64_js_1.default.rotrBL(Ah, Al, 34) ^ _u64_js_1.default.rotrBL(Ah, Al, 39);
++            const MAJh = (Ah & Bh) ^ (Ah & Ch) ^ (Bh & Ch);
++            const MAJl = (Al & Bl) ^ (Al & Cl) ^ (Bl & Cl);
++            Hh = Gh | 0;
++            Hl = Gl | 0;
++            Gh = Fh | 0;
++            Gl = Fl | 0;
++            Fh = Eh | 0;
++            Fl = El | 0;
++            ({ h: Eh, l: El } = _u64_js_1.default.add(Dh | 0, Dl | 0, T1h | 0, T1l | 0));
++            Dh = Ch | 0;
++            Dl = Cl | 0;
++            Ch = Bh | 0;
++            Cl = Bl | 0;
++            Bh = Ah | 0;
++            Bl = Al | 0;
++            const All = _u64_js_1.default.add3L(T1l, sigma0l, MAJl);
++            Ah = _u64_js_1.default.add3H(All, T1h, sigma0h, MAJh);
++            Al = All | 0;
++        }
++        // Add the compressed chunk to the current hash value
++        ({ h: Ah, l: Al } = _u64_js_1.default.add(this.Ah | 0, this.Al | 0, Ah | 0, Al | 0));
++        ({ h: Bh, l: Bl } = _u64_js_1.default.add(this.Bh | 0, this.Bl | 0, Bh | 0, Bl | 0));
++        ({ h: Ch, l: Cl } = _u64_js_1.default.add(this.Ch | 0, this.Cl | 0, Ch | 0, Cl | 0));
++        ({ h: Dh, l: Dl } = _u64_js_1.default.add(this.Dh | 0, this.Dl | 0, Dh | 0, Dl | 0));
++        ({ h: Eh, l: El } = _u64_js_1.default.add(this.Eh | 0, this.El | 0, Eh | 0, El | 0));
++        ({ h: Fh, l: Fl } = _u64_js_1.default.add(this.Fh | 0, this.Fl | 0, Fh | 0, Fl | 0));
++        ({ h: Gh, l: Gl } = _u64_js_1.default.add(this.Gh | 0, this.Gl | 0, Gh | 0, Gl | 0));
++        ({ h: Hh, l: Hl } = _u64_js_1.default.add(this.Hh | 0, this.Hl | 0, Hh | 0, Hl | 0));
++        this.set(Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl);
++    }
++    roundClean() {
++        SHA512_W_H.fill(0);
++        SHA512_W_L.fill(0);
++    }
++    destroy() {
++        this.buffer.fill(0);
++        this.set(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
++    }
++}
++exports.SHA512 = SHA512;
++class SHA512_224 extends SHA512 {
++    constructor() {
++        super();
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0x8c3d37c8 | 0;
++        this.Al = 0x19544da2 | 0;
++        this.Bh = 0x73e19966 | 0;
++        this.Bl = 0x89dcd4d6 | 0;
++        this.Ch = 0x1dfab7ae | 0;
++        this.Cl = 0x32ff9c82 | 0;
++        this.Dh = 0x679dd514 | 0;
++        this.Dl = 0x582f9fcf | 0;
++        this.Eh = 0x0f6d2b69 | 0;
++        this.El = 0x7bd44da8 | 0;
++        this.Fh = 0x77e36f73 | 0;
++        this.Fl = 0x04c48942 | 0;
++        this.Gh = 0x3f9d85a8 | 0;
++        this.Gl = 0x6a1d36c8 | 0;
++        this.Hh = 0x1112e6ad | 0;
++        this.Hl = 0x91d692a1 | 0;
++        this.outputLen = 28;
++    }
++}
++exports.SHA512_224 = SHA512_224;
++class SHA512_256 extends SHA512 {
++    constructor() {
++        super();
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0x22312194 | 0;
++        this.Al = 0xfc2bf72c | 0;
++        this.Bh = 0x9f555fa3 | 0;
++        this.Bl = 0xc84c64c2 | 0;
++        this.Ch = 0x2393b86b | 0;
++        this.Cl = 0x6f53b151 | 0;
++        this.Dh = 0x96387719 | 0;
++        this.Dl = 0x5940eabd | 0;
++        this.Eh = 0x96283ee2 | 0;
++        this.El = 0xa88effe3 | 0;
++        this.Fh = 0xbe5e1e25 | 0;
++        this.Fl = 0x53863992 | 0;
++        this.Gh = 0x2b0199fc | 0;
++        this.Gl = 0x2c85b8aa | 0;
++        this.Hh = 0x0eb72ddc | 0;
++        this.Hl = 0x81c52ca2 | 0;
++        this.outputLen = 32;
++    }
++}
++exports.SHA512_256 = SHA512_256;
++class SHA384 extends SHA512 {
++    constructor() {
++        super();
++        // h -- high 32 bits, l -- low 32 bits
++        this.Ah = 0xcbbb9d5d | 0;
++        this.Al = 0xc1059ed8 | 0;
++        this.Bh = 0x629a292a | 0;
++        this.Bl = 0x367cd507 | 0;
++        this.Ch = 0x9159015a | 0;
++        this.Cl = 0x3070dd17 | 0;
++        this.Dh = 0x152fecd8 | 0;
++        this.Dl = 0xf70e5939 | 0;
++        this.Eh = 0x67332667 | 0;
++        this.El = 0xffc00b31 | 0;
++        this.Fh = 0x8eb44a87 | 0;
++        this.Fl = 0x68581511 | 0;
++        this.Gh = 0xdb0c2e0d | 0;
++        this.Gl = 0x64f98fa7 | 0;
++        this.Hh = 0x47b5481d | 0;
++        this.Hl = 0xbefa4fa4 | 0;
++        this.outputLen = 48;
++    }
++}
++exports.SHA384 = SHA384;
++exports.sha512 = (0, utils_js_1.wrapConstructor)(() => new SHA512());
++exports.sha512_224 = (0, utils_js_1.wrapConstructor)(() => new SHA512_224());
++exports.sha512_256 = (0, utils_js_1.wrapConstructor)(() => new SHA512_256());
++exports.sha384 = (0, utils_js_1.wrapConstructor)(() => new SHA384());
++//# sourceMappingURL=sha512.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.js.map
+new file mode 100644
+index 0000000..7836e7c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/sha512.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"sha512.js","sourceRoot":"","sources":["src/sha512.ts"],"names":[],"mappings":";;;AAAA,qCAAkC;AAClC,uCAA4B;AAC5B,yCAA6C;AAE7C,0GAA0G;AAC1G,kBAAkB;AAClB,MAAM,CAAC,SAAS,EAAE,SAAS,CAAC,GAAG,eAAe,CAAC,CAAC,GAAG,EAAE,CAAC,iBAAG,CAAC,KAAK,CAAC;IAC9D,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;IACtF,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB,EAAE,oBAAoB;CACvF,CAAC,GAAG,CAAC,CAAC,CAAC,EAAE,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,EAAE,CAAC;AAE1B,4DAA4D;AAC5D,MAAM,UAAU,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACvD,MAAM,UAAU,GAAG,eAAe,CAAC,IAAI,WAAW,CAAC,EAAE,CAAC,CAAC;AACvD,MAAa,MAAO,SAAQ,eAAc;IAsBxC;QACE,KAAK,CAAC,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,KAAK,CAAC,CAAC;QAtB5B,wHAAwH;QACxH,qDAAqD;QACrD,yGAAyG;QACzG,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;IAIpB,CAAC;IACD,kBAAkB;IACR,GAAG;QAIX,MAAM,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QAChF,OAAO,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC1E,CAAC;IACD,kBAAkB;IACR,GAAG,CACX,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAC9F,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU,EAAE,EAAU;QAE9F,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;QACjB,IAAI,CAAC,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IACnB,CAAC;IACS,OAAO,CAAC,IAAc,EAAE,MAAc;QAC9C,gGAAgG;QAChG,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,MAAM,IAAI,CAAC,EAAE,CAAC;YACzC,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,MAAM,CAAC,CAAC;YACvC,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,CAAC,SAAS,CAAC,CAAC,MAAM,IAAI,CAAC,CAAC,CAAC,CAAC;QAChD,CAAC;QACD,KAAK,IAAI,CAAC,GAAG,EAAE,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC7B,uFAAuF;YACvF,MAAM,IAAI,GAAG,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;YACpC,MAAM,IAAI,GAAG,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC;YACpC,MAAM,GAAG,GAAG,iBAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,iBAAG,CAAC,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;YAC7F,MAAM,GAAG,GAAG,iBAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,GAAG,iBAAG,CAAC,KAAK,CAAC,IAAI,EAAE,IAAI,EAAE,CAAC,CAAC,CAAC;YAC7F,sFAAsF;YACtF,MAAM,GAAG,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;YAClC,MAAM,GAAG,GAAG,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC,CAAC;YAClC,MAAM,GAAG,GAAG,iBAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC,CAAC,CAAC;YACzF,MAAM,GAAG,GAAG,iBAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,GAAG,EAAE,GAAG,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC,CAAC,CAAC;YACzF,8DAA8D;YAC9D,MAAM,IAAI,GAAG,iBAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC;YACxE,MAAM,IAAI,GAAG,iBAAG,CAAC,KAAK,CAAC,IAAI,EAAE,GAAG,EAAE,GAAG,EAAE,UAAU,CAAC,CAAC,GAAG,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,GAAG,EAAE,CAAC,CAAC,CAAC;YAC9E,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,GAAG,CAAC,CAAC;YACzB,UAAU,CAAC,CAAC,CAAC,GAAG,IAAI,GAAG,CAAC,CAAC;QAC3B,CAAC;QACD,IAAI,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,IAAI,CAAC;QAC9E,4CAA4C;QAC5C,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,EAAE,EAAE,CAAC,EAAE,EAAE,CAAC;YAC5B,yEAAyE;YACzE,MAAM,OAAO,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,MAAM,OAAO,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,yEAAyE;YACzE,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YACpC,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YACpC,6DAA6D;YAC7D,kBAAkB;YAClB,MAAM,IAAI,GAAG,iBAAG,CAAC,KAAK,CAAC,EAAE,EAAE,OAAO,EAAE,IAAI,EAAE,SAAS,CAAC,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;YACvE,MAAM,GAAG,GAAG,iBAAG,CAAC,KAAK,CAAC,IAAI,EAAE,EAAE,EAAE,OAAO,EAAE,IAAI,EAAE,SAAS,CAAC,CAAC,CAAC,EAAE,UAAU,CAAC,CAAC,CAAC,CAAC,CAAC;YAC5E,MAAM,GAAG,GAAG,IAAI,GAAG,CAAC,CAAC;YACrB,yEAAyE;YACzE,MAAM,OAAO,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,MAAM,OAAO,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,GAAG,iBAAG,CAAC,MAAM,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;YACzF,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YAC/C,MAAM,IAAI,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,GAAG,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;YAC/C,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,CAAC,CAAC,CAAC;YAC/D,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;YACZ,MAAM,GAAG,GAAG,iBAAG,CAAC,KAAK,CAAC,GAAG,EAAE,OAAO,EAAE,IAAI,CAAC,CAAC;YAC1C,EAAE,GAAG,iBAAG,CAAC,KAAK,CAAC,GAAG,EAAE,GAAG,EAAE,OAAO,EAAE,IAAI,CAAC,CAAC;YACxC,EAAE,GAAG,GAAG,GAAG,CAAC,CAAC;QACf,CAAC;QACD,qDAAqD;QACrD,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,CAAC,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,GAAG,iBAAG,CAAC,GAAG,CAAC,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,IAAI,CAAC,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACvE,IAAI,CAAC,GAAG,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,CAAC,CAAC;IAC3E,CAAC;IACS,UAAU;QAClB,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACnB,UAAU,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;IACrB,CAAC;IACD,OAAO;QACL,IAAI,CAAC,MAAM,CAAC,IAAI,CAAC,CAAC,CAAC,CAAC;QACpB,IAAI,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,EAAE,CAAC,CAAC,CAAC;IAC3D,CAAC;CACF;AArID,wBAqIC;AAED,MAAa,UAAW,SAAQ,MAAM;IAmBpC;QACE,KAAK,EAAE,CAAC;QAnBV,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QAIlB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAvBD,gCAuBC;AAED,MAAa,UAAW,SAAQ,MAAM;IAmBpC;QACE,KAAK,EAAE,CAAC;QAnBV,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QAIlB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAvBD,gCAuBC;AAED,MAAa,MAAO,SAAQ,MAAM;IAmBhC;QACE,KAAK,EAAE,CAAC;QAnBV,sCAAsC;QACtC,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QACpB,OAAE,GAAG,UAAU,GAAG,CAAC,CAAC;QAIlB,IAAI,CAAC,SAAS,GAAG,EAAE,CAAC;IACtB,CAAC;CACF;AAvBD,wBAuBC;AAEY,QAAA,MAAM,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC;AAC7D,QAAA,UAAU,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,UAAU,EAAE,CAAC,CAAC;AACrE,QAAA,UAAU,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,UAAU,EAAE,CAAC,CAAC;AACrE,QAAA,MAAM,GAAmB,IAAA,0BAAe,EAAC,GAAG,EAAE,CAAC,IAAI,MAAM,EAAE,CAAC,CAAC"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.d.ts b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.d.ts
+new file mode 100644
+index 0000000..21254c4
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.d.ts
+@@ -0,0 +1,96 @@
++/*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) */
++export declare function isBytes(a: unknown): a is Uint8Array;
++export type TypedArray = Int8Array | Uint8ClampedArray | Uint8Array | Uint16Array | Int16Array | Uint32Array | Int32Array;
++export declare const u8: (arr: TypedArray) => Uint8Array;
++export declare const u32: (arr: TypedArray) => Uint32Array;
++export declare const createView: (arr: TypedArray) => DataView;
++export declare const rotr: (word: number, shift: number) => number;
++export declare const rotl: (word: number, shift: number) => number;
++export declare const isLE: boolean;
++export declare const byteSwap: (word: number) => number;
++export declare const byteSwapIfBE: (n: number) => number;
++export declare function byteSwap32(arr: Uint32Array): void;
++/**
++ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
++ */
++export declare function bytesToHex(bytes: Uint8Array): string;
++/**
++ * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
++ */
++export declare function hexToBytes(hex: string): Uint8Array;
++export declare const nextTick: () => Promise<void>;
++export declare function asyncLoop(iters: number, tick: number, cb: (i: number) => void): Promise<void>;
++/**
++ * @example utf8ToBytes('abc') // new Uint8Array([97, 98, 99])
++ */
++export declare function utf8ToBytes(str: string): Uint8Array;
++export type Input = Uint8Array | string;
++/**
++ * Normalizes (non-hex) string or Uint8Array to Uint8Array.
++ * Warning: when Uint8Array is passed, it would NOT get copied.
++ * Keep in mind for future mutable operations.
++ */
++export declare function toBytes(data: Input): Uint8Array;
++/**
++ * Copies several Uint8Arrays into one.
++ */
++export declare function concatBytes(...arrays: Uint8Array[]): Uint8Array;
++export declare abstract class Hash<T extends Hash<T>> {
++    abstract blockLen: number;
++    abstract outputLen: number;
++    abstract update(buf: Input): this;
++    abstract digestInto(buf: Uint8Array): void;
++    abstract digest(): Uint8Array;
++    /**
++     * Resets internal state. Makes Hash instance unusable.
++     * Reset is impossible for keyed hashes if key is consumed into state. If digest is not consumed
++     * by user, they will need to manually call `destroy()` when zeroing is necessary.
++     */
++    abstract destroy(): void;
++    /**
++     * Clones hash instance. Unsafe: doesn't check whether `to` is valid. Can be used as `clone()`
++     * when no options are passed.
++     * Reasons to use `_cloneInto` instead of clone: 1) performance 2) reuse instance => all internal
++     * buffers are overwritten => causes buffer overwrite which is used for digest in some cases.
++     * There are no guarantees for clean-up because it's impossible in JS.
++     */
++    abstract _cloneInto(to?: T): T;
++    clone(): T;
++}
++/**
++ * XOF: streaming API to read digest in chunks.
++ * Same as 'squeeze' in keccak/k12 and 'seek' in blake3, but more generic name.
++ * When hash used in XOF mode it is up to user to call '.destroy' afterwards, since we cannot
++ * destroy state, next call can require more bytes.
++ */
++export type HashXOF<T extends Hash<T>> = Hash<T> & {
++    xof(bytes: number): Uint8Array;
++    xofInto(buf: Uint8Array): Uint8Array;
++};
++type EmptyObj = {};
++export declare function checkOpts<T1 extends EmptyObj, T2 extends EmptyObj>(defaults: T1, opts?: T2): T1 & T2;
++export type CHash = ReturnType<typeof wrapConstructor>;
++export declare function wrapConstructor<T extends Hash<T>>(hashCons: () => Hash<T>): {
++    (msg: Input): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(): Hash<T>;
++};
++export declare function wrapConstructorWithOpts<H extends Hash<H>, T extends Object>(hashCons: (opts?: T) => Hash<H>): {
++    (msg: Input, opts?: T): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: T): Hash<H>;
++};
++export declare function wrapXOFConstructorWithOpts<H extends HashXOF<H>, T extends Object>(hashCons: (opts?: T) => HashXOF<H>): {
++    (msg: Input, opts?: T): Uint8Array;
++    outputLen: number;
++    blockLen: number;
++    create(opts: T): HashXOF<H>;
++};
++/**
++ * Secure PRNG. Uses `crypto.getRandomValues`, which defers to OS.
++ */
++export declare function randomBytes(bytesLength?: number): Uint8Array;
++export {};
++//# sourceMappingURL=utils.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.d.ts.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.d.ts.map
+new file mode 100644
+index 0000000..ce9133c
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.d.ts.map
+@@ -0,0 +1 @@
++{"version":3,"file":"utils.d.ts","sourceRoot":"","sources":["src/utils.ts"],"names":[],"mappings":"AAAA,sEAAsE;AAYtE,wBAAgB,OAAO,CAAC,CAAC,EAAE,OAAO,GAAG,CAAC,IAAI,UAAU,CAKnD;AAGD,MAAM,MAAM,UAAU,GAAG,SAAS,GAAG,iBAAiB,GAAG,UAAU,GACjE,WAAW,GAAG,UAAU,GAAG,WAAW,GAAG,UAAU,CAAC;AAGtD,eAAO,MAAM,EAAE,QAAS,UAAU,eAA+D,CAAC;AAClG,eAAO,MAAM,GAAG,QAAS,UAAU,gBAC0C,CAAC;AAG9E,eAAO,MAAM,UAAU,QAAS,UAAU,aACgB,CAAC;AAG3D,eAAO,MAAM,IAAI,SAAU,MAAM,SAAS,MAAM,WAA8C,CAAC;AAE/F,eAAO,MAAM,IAAI,SAAU,MAAM,SAAS,MAAM,WACG,CAAC;AAEpD,eAAO,MAAM,IAAI,SAAmE,CAAC;AAErF,eAAO,MAAM,QAAQ,SAAU,MAAM,WAIb,CAAC;AAEzB,eAAO,MAAM,YAAY,MAAc,MAAM,WAAmC,CAAC;AAGjF,wBAAgB,UAAU,CAAC,GAAG,EAAE,WAAW,QAI1C;AAMD;;GAEG;AACH,wBAAgB,UAAU,CAAC,KAAK,EAAE,UAAU,GAAG,MAAM,CAQpD;AAWD;;GAEG;AACH,wBAAgB,UAAU,CAAC,GAAG,EAAE,MAAM,GAAG,UAAU,CAgBlD;AAKD,eAAO,MAAM,QAAQ,qBAAiB,CAAC;AAGvC,wBAAsB,SAAS,CAAC,KAAK,EAAE,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,EAAE,EAAE,CAAC,CAAC,EAAE,MAAM,KAAK,IAAI,iBAUnF;AAMD;;GAEG;AACH,wBAAgB,WAAW,CAAC,GAAG,EAAE,MAAM,GAAG,UAAU,CAGnD;AAED,MAAM,MAAM,KAAK,GAAG,UAAU,GAAG,MAAM,CAAC;AACxC;;;;GAIG;AACH,wBAAgB,OAAO,CAAC,IAAI,EAAE,KAAK,GAAG,UAAU,CAI/C;AAED;;GAEG;AACH,wBAAgB,WAAW,CAAC,GAAG,MAAM,EAAE,UAAU,EAAE,GAAG,UAAU,CAc/D;AAGD,8BAAsB,IAAI,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC;IAC1C,QAAQ,CAAC,QAAQ,EAAE,MAAM,CAAC;IAC1B,QAAQ,CAAC,SAAS,EAAE,MAAM,CAAC;IAC3B,QAAQ,CAAC,MAAM,CAAC,GAAG,EAAE,KAAK,GAAG,IAAI;IAEjC,QAAQ,CAAC,UAAU,CAAC,GAAG,EAAE,UAAU,GAAG,IAAI;IAC1C,QAAQ,CAAC,MAAM,IAAI,UAAU;IAC7B;;;;OAIG;IACH,QAAQ,CAAC,OAAO,IAAI,IAAI;IACxB;;;;;;OAMG;IACH,QAAQ,CAAC,UAAU,CAAC,EAAE,CAAC,EAAE,CAAC,GAAG,CAAC;IAE9B,KAAK,IAAI,CAAC;CAGX;AAED;;;;;GAKG;AACH,MAAM,MAAM,OAAO,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,IAAI,IAAI,CAAC,CAAC,CAAC,GAAG;IACjD,GAAG,CAAC,KAAK,EAAE,MAAM,GAAG,UAAU,CAAC;IAC/B,OAAO,CAAC,GAAG,EAAE,UAAU,GAAG,UAAU,CAAC;CACtC,CAAC;AAGF,KAAK,QAAQ,GAAG,EAAE,CAAC;AACnB,wBAAgB,SAAS,CAAC,EAAE,SAAS,QAAQ,EAAE,EAAE,SAAS,QAAQ,EAChE,QAAQ,EAAE,EAAE,EACZ,IAAI,CAAC,EAAE,EAAE,GACR,EAAE,GAAG,EAAE,CAKT;AAED,MAAM,MAAM,KAAK,GAAG,UAAU,CAAC,OAAO,eAAe,CAAC,CAAC;AAEvD,wBAAgB,eAAe,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,EAAE,QAAQ,EAAE,MAAM,IAAI,CAAC,CAAC,CAAC;UACpD,KAAK,GAAG,UAAU;;;;EAMvC;AAED,wBAAgB,uBAAuB,CAAC,CAAC,SAAS,IAAI,CAAC,CAAC,CAAC,EAAE,CAAC,SAAS,MAAM,EACzE,QAAQ,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,KAAK,IAAI,CAAC,CAAC,CAAC;UAEX,KAAK,SAAS,CAAC,GAAG,UAAU;;;iBAI1B,CAAC;EAExB;AAED,wBAAgB,0BAA0B,CAAC,CAAC,SAAS,OAAO,CAAC,CAAC,CAAC,EAAE,CAAC,SAAS,MAAM,EAC/E,QAAQ,EAAE,CAAC,IAAI,CAAC,EAAE,CAAC,KAAK,OAAO,CAAC,CAAC,CAAC;UAEd,KAAK,SAAS,CAAC,GAAG,UAAU;;;iBAI1B,CAAC;EAExB;AAED;;GAEG;AACH,wBAAgB,WAAW,CAAC,WAAW,SAAK,GAAG,UAAU,CAKxD"}
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.js b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.js
+new file mode 100644
+index 0000000..19078da
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.js
+@@ -0,0 +1,211 @@
++"use strict";
++/*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) */
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.Hash = exports.nextTick = exports.byteSwapIfBE = exports.byteSwap = exports.isLE = exports.rotl = exports.rotr = exports.createView = exports.u32 = exports.u8 = void 0;
++exports.isBytes = isBytes;
++exports.byteSwap32 = byteSwap32;
++exports.bytesToHex = bytesToHex;
++exports.hexToBytes = hexToBytes;
++exports.asyncLoop = asyncLoop;
++exports.utf8ToBytes = utf8ToBytes;
++exports.toBytes = toBytes;
++exports.concatBytes = concatBytes;
++exports.checkOpts = checkOpts;
++exports.wrapConstructor = wrapConstructor;
++exports.wrapConstructorWithOpts = wrapConstructorWithOpts;
++exports.wrapXOFConstructorWithOpts = wrapXOFConstructorWithOpts;
++exports.randomBytes = randomBytes;
++// We use WebCrypto aka globalThis.crypto, which exists in browsers and node.js 16+.
++// node.js versions earlier than v19 don't declare it in global scope.
++// For node.js, package.json#exports field mapping rewrites import
++// from `crypto` to `cryptoNode`, which imports native module.
++// Makes the utils un-importable in browsers without a bundler.
++// Once node.js 18 is deprecated (2025-04-30), we can just drop the import.
++const crypto_1 = require("@noble/hashes/crypto");
++const _assert_js_1 = require("./_assert.js");
++// export { isBytes } from './_assert.js';
++// We can't reuse isBytes from _assert, because somehow this causes huge perf issues
++function isBytes(a) {
++    return (a instanceof Uint8Array ||
++        (a != null && typeof a === 'object' && a.constructor.name === 'Uint8Array'));
++}
++// Cast array to different type
++const u8 = (arr) => new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
++exports.u8 = u8;
++const u32 = (arr) => new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
++exports.u32 = u32;
++// Cast array to view
++const createView = (arr) => new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
++exports.createView = createView;
++// The rotate right (circular right shift) operation for uint32
++const rotr = (word, shift) => (word << (32 - shift)) | (word >>> shift);
++exports.rotr = rotr;
++// The rotate left (circular left shift) operation for uint32
++const rotl = (word, shift) => (word << shift) | ((word >>> (32 - shift)) >>> 0);
++exports.rotl = rotl;
++exports.isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
++// The byte swap operation for uint32
++const byteSwap = (word) => ((word << 24) & 0xff000000) |
++    ((word << 8) & 0xff0000) |
++    ((word >>> 8) & 0xff00) |
++    ((word >>> 24) & 0xff);
++exports.byteSwap = byteSwap;
++// Conditionally byte swap if on a big-endian platform
++exports.byteSwapIfBE = exports.isLE ? (n) => n : (n) => (0, exports.byteSwap)(n);
++// In place byte swap for Uint32Array
++function byteSwap32(arr) {
++    for (let i = 0; i < arr.length; i++) {
++        arr[i] = (0, exports.byteSwap)(arr[i]);
++    }
++}
++// Array where index 0xf0 (240) is mapped to string 'f0'
++const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'));
++/**
++ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
++ */
++function bytesToHex(bytes) {
++    (0, _assert_js_1.bytes)(bytes);
++    // pre-caching improves the speed 6x
++    let hex = '';
++    for (let i = 0; i < bytes.length; i++) {
++        hex += hexes[bytes[i]];
++    }
++    return hex;
++}
++// We use optimized technique to convert hex string to byte array
++const asciis = { _0: 48, _9: 57, _A: 65, _F: 70, _a: 97, _f: 102 };
++function asciiToBase16(char) {
++    if (char >= asciis._0 && char <= asciis._9)
++        return char - asciis._0;
++    if (char >= asciis._A && char <= asciis._F)
++        return char - (asciis._A - 10);
++    if (char >= asciis._a && char <= asciis._f)
++        return char - (asciis._a - 10);
++    return;
++}
++/**
++ * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
++ */
++function hexToBytes(hex) {
++    if (typeof hex !== 'string')
++        throw new Error('hex string expected, got ' + typeof hex);
++    const hl = hex.length;
++    const al = hl / 2;
++    if (hl % 2)
++        throw new Error('padded hex string expected, got unpadded hex of length ' + hl);
++    const array = new Uint8Array(al);
++    for (let ai = 0, hi = 0; ai < al; ai++, hi += 2) {
++        const n1 = asciiToBase16(hex.charCodeAt(hi));
++        const n2 = asciiToBase16(hex.charCodeAt(hi + 1));
++        if (n1 === undefined || n2 === undefined) {
++            const char = hex[hi] + hex[hi + 1];
++            throw new Error('hex string expected, got non-hex character "' + char + '" at index ' + hi);
++        }
++        array[ai] = n1 * 16 + n2;
++    }
++    return array;
++}
++// There is no setImmediate in browser and setTimeout is slow.
++// call of async fn will return Promise, which will be fullfiled only on
++// next scheduler queue processing step and this is exactly what we need.
++const nextTick = async () => { };
++exports.nextTick = nextTick;
++// Returns control to thread each 'tick' ms to avoid blocking
++async function asyncLoop(iters, tick, cb) {
++    let ts = Date.now();
++    for (let i = 0; i < iters; i++) {
++        cb(i);
++        // Date.now() is not monotonic, so in case if clock goes backwards we return return control too
++        const diff = Date.now() - ts;
++        if (diff >= 0 && diff < tick)
++            continue;
++        await (0, exports.nextTick)();
++        ts += diff;
++    }
++}
++/**
++ * @example utf8ToBytes('abc') // new Uint8Array([97, 98, 99])
++ */
++function utf8ToBytes(str) {
++    if (typeof str !== 'string')
++        throw new Error(`utf8ToBytes expected string, got ${typeof str}`);
++    return new Uint8Array(new TextEncoder().encode(str)); // https://bugzil.la/1681809
++}
++/**
++ * Normalizes (non-hex) string or Uint8Array to Uint8Array.
++ * Warning: when Uint8Array is passed, it would NOT get copied.
++ * Keep in mind for future mutable operations.
++ */
++function toBytes(data) {
++    if (typeof data === 'string')
++        data = utf8ToBytes(data);
++    (0, _assert_js_1.bytes)(data);
++    return data;
++}
++/**
++ * Copies several Uint8Arrays into one.
++ */
++function concatBytes(...arrays) {
++    let sum = 0;
++    for (let i = 0; i < arrays.length; i++) {
++        const a = arrays[i];
++        (0, _assert_js_1.bytes)(a);
++        sum += a.length;
++    }
++    const res = new Uint8Array(sum);
++    for (let i = 0, pad = 0; i < arrays.length; i++) {
++        const a = arrays[i];
++        res.set(a, pad);
++        pad += a.length;
++    }
++    return res;
++}
++// For runtime check if class implements interface
++class Hash {
++    // Safe version that clones internal state
++    clone() {
++        return this._cloneInto();
++    }
++}
++exports.Hash = Hash;
++const toStr = {}.toString;
++function checkOpts(defaults, opts) {
++    if (opts !== undefined && toStr.call(opts) !== '[object Object]')
++        throw new Error('Options should be object or undefined');
++    const merged = Object.assign(defaults, opts);
++    return merged;
++}
++function wrapConstructor(hashCons) {
++    const hashC = (msg) => hashCons().update(toBytes(msg)).digest();
++    const tmp = hashCons();
++    hashC.outputLen = tmp.outputLen;
++    hashC.blockLen = tmp.blockLen;
++    hashC.create = () => hashCons();
++    return hashC;
++}
++function wrapConstructorWithOpts(hashCons) {
++    const hashC = (msg, opts) => hashCons(opts).update(toBytes(msg)).digest();
++    const tmp = hashCons({});
++    hashC.outputLen = tmp.outputLen;
++    hashC.blockLen = tmp.blockLen;
++    hashC.create = (opts) => hashCons(opts);
++    return hashC;
++}
++function wrapXOFConstructorWithOpts(hashCons) {
++    const hashC = (msg, opts) => hashCons(opts).update(toBytes(msg)).digest();
++    const tmp = hashCons({});
++    hashC.outputLen = tmp.outputLen;
++    hashC.blockLen = tmp.blockLen;
++    hashC.create = (opts) => hashCons(opts);
++    return hashC;
++}
++/**
++ * Secure PRNG. Uses `crypto.getRandomValues`, which defers to OS.
++ */
++function randomBytes(bytesLength = 32) {
++    if (crypto_1.crypto && typeof crypto_1.crypto.getRandomValues === 'function') {
++        return crypto_1.crypto.getRandomValues(new Uint8Array(bytesLength));
++    }
++    throw new Error('crypto.getRandomValues must be defined');
++}
++//# sourceMappingURL=utils.js.map
+\ No newline at end of file
+diff --git a/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.js.map b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.js.map
+new file mode 100644
+index 0000000..27240de
+--- /dev/null
++++ b/node_modules/@agoric/orchestration/node_modules/@noble/hashes/utils.js.map
+@@ -0,0 +1 @@
++{"version":3,"file":"utils.js","sourceRoot":"","sources":["src/utils.ts"],"names":[],"mappings":";AAAA,sEAAsE;;;AAYtE,0BAKC;AAgCD,gCAIC;AASD,gCAQC;AAcD,gCAgBC;AAQD,8BAUC;AASD,kCAGC;AAQD,0BAIC;AAKD,kCAcC;AA2CD,8BAQC;AAID,0CAOC;AAED,0DASC;AAED,gEASC;AAKD,kCAKC;AA7PD,oFAAoF;AACpF,sEAAsE;AACtE,kEAAkE;AAClE,8DAA8D;AAC9D,+DAA+D;AAC/D,2EAA2E;AAC3E,iDAA8C;AAC9C,6CAA+C;AAC/C,0CAA0C;AAC1C,oFAAoF;AACpF,SAAgB,OAAO,CAAC,CAAU;IAChC,OAAO,CACL,CAAC,YAAY,UAAU;QACvB,CAAC,CAAC,IAAI,IAAI,IAAI,OAAO,CAAC,KAAK,QAAQ,IAAI,CAAC,CAAC,WAAW,CAAC,IAAI,KAAK,YAAY,CAAC,CAC5E,CAAC;AACJ,CAAC;AAMD,+BAA+B;AACxB,MAAM,EAAE,GAAG,CAAC,GAAe,EAAE,EAAE,CAAC,IAAI,UAAU,CAAC,GAAG,CAAC,MAAM,EAAE,GAAG,CAAC,UAAU,EAAE,GAAG,CAAC,UAAU,CAAC,CAAC;AAArF,QAAA,EAAE,MAAmF;AAC3F,MAAM,GAAG,GAAG,CAAC,GAAe,EAAE,EAAE,CACrC,IAAI,WAAW,CAAC,GAAG,CAAC,MAAM,EAAE,GAAG,CAAC,UAAU,EAAE,IAAI,CAAC,KAAK,CAAC,GAAG,CAAC,UAAU,GAAG,CAAC,CAAC,CAAC,CAAC;AADjE,QAAA,GAAG,OAC8D;AAE9E,qBAAqB;AACd,MAAM,UAAU,GAAG,CAAC,GAAe,EAAE,EAAE,CAC5C,IAAI,QAAQ,CAAC,GAAG,CAAC,MAAM,EAAE,GAAG,CAAC,UAAU,EAAE,GAAG,CAAC,UAAU,CAAC,CAAC;AAD9C,QAAA,UAAU,cACoC;AAE3D,+DAA+D;AACxD,MAAM,IAAI,GAAG,CAAC,IAAY,EAAE,KAAa,EAAE,EAAE,CAAC,CAAC,IAAI,IAAI,CAAC,EAAE,GAAG,KAAK,CAAC,CAAC,GAAG,CAAC,IAAI,KAAK,KAAK,CAAC,CAAC;AAAlF,QAAA,IAAI,QAA8E;AAC/F,6DAA6D;AACtD,MAAM,IAAI,GAAG,CAAC,IAAY,EAAE,KAAa,EAAE,EAAE,CAClD,CAAC,IAAI,IAAI,KAAK,CAAC,GAAG,CAAC,CAAC,IAAI,KAAK,CAAC,EAAE,GAAG,KAAK,CAAC,CAAC,KAAK,CAAC,CAAC,CAAC;AADvC,QAAA,IAAI,QACmC;AAEvC,QAAA,IAAI,GAAG,IAAI,UAAU,CAAC,IAAI,WAAW,CAAC,CAAC,UAAU,CAAC,CAAC,CAAC,MAAM,CAAC,CAAC,CAAC,CAAC,KAAK,IAAI,CAAC;AACrF,qCAAqC;AAC9B,MAAM,QAAQ,GAAG,CAAC,IAAY,EAAE,EAAE,CACvC,CAAC,CAAC,IAAI,IAAI,EAAE,CAAC,GAAG,UAAU,CAAC;IAC3B,CAAC,CAAC,IAAI,IAAI,CAAC,CAAC,GAAG,QAAQ,CAAC;IACxB,CAAC,CAAC,IAAI,KAAK,CAAC,CAAC,GAAG,MAAM,CAAC;IACvB,CAAC,CAAC,IAAI,KAAK,EAAE,CAAC,GAAG,IAAI,CAAC,CAAC;AAJZ,QAAA,QAAQ,YAII;AACzB,sDAAsD;AACzC,QAAA,YAAY,GAAG,YAAI,CAAC,CAAC,CAAC,CAAC,CAAS,EAAE,EAAE,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAS,EAAE,EAAE,CAAC,IAAA,gBAAQ,EAAC,CAAC,CAAC,CAAC;AAEjF,qCAAqC;AACrC,SAAgB,UAAU,CAAC,GAAgB;IACzC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACpC,GAAG,CAAC,CAAC,CAAC,GAAG,IAAA,gBAAQ,EAAC,GAAG,CAAC,CAAC,CAAC,CAAC,CAAC;IAC5B,CAAC;AACH,CAAC;AAED,wDAAwD;AACxD,MAAM,KAAK,GAAG,eAAe,CAAC,KAAK,CAAC,IAAI,CAAC,EAAE,MAAM,EAAE,GAAG,EAAE,EAAE,CAAC,CAAC,EAAE,CAAC,EAAE,EAAE,CACjE,CAAC,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,QAAQ,CAAC,CAAC,EAAE,GAAG,CAAC,CAChC,CAAC;AACF;;GAEG;AACH,SAAgB,UAAU,CAAC,KAAiB;IAC1C,IAAA,kBAAM,EAAC,KAAK,CAAC,CAAC;IACd,oCAAoC;IACpC,IAAI,GAAG,GAAG,EAAE,CAAC;IACb,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,KAAK,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACtC,GAAG,IAAI,KAAK,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC,CAAC;IACzB,CAAC;IACD,OAAO,GAAG,CAAC;AACb,CAAC;AAED,iEAAiE;AACjE,MAAM,MAAM,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,GAAG,EAAW,CAAC;AAC5E,SAAS,aAAa,CAAC,IAAY;IACjC,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE;QAAE,OAAO,IAAI,GAAG,MAAM,CAAC,EAAE,CAAC;IACpE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE;QAAE,OAAO,IAAI,GAAG,CAAC,MAAM,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;IAC3E,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE,IAAI,IAAI,IAAI,MAAM,CAAC,EAAE;QAAE,OAAO,IAAI,GAAG,CAAC,MAAM,CAAC,EAAE,GAAG,EAAE,CAAC,CAAC;IAC3E,OAAO;AACT,CAAC;AAED;;GAEG;AACH,SAAgB,UAAU,CAAC,GAAW;IACpC,IAAI,OAAO,GAAG,KAAK,QAAQ;QAAE,MAAM,IAAI,KAAK,CAAC,2BAA2B,GAAG,OAAO,GAAG,CAAC,CAAC;IACvF,MAAM,EAAE,GAAG,GAAG,CAAC,MAAM,CAAC;IACtB,MAAM,EAAE,GAAG,EAAE,GAAG,CAAC,CAAC;IAClB,IAAI,EAAE,GAAG,CAAC;QAAE,MAAM,IAAI,KAAK,CAAC,yDAAyD,GAAG,EAAE,CAAC,CAAC;IAC5F,MAAM,KAAK,GAAG,IAAI,UAAU,CAAC,EAAE,CAAC,CAAC;IACjC,KAAK,IAAI,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,CAAC,EAAE,EAAE,GAAG,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,IAAI,CAAC,EAAE,CAAC;QAChD,MAAM,EAAE,GAAG,aAAa,CAAC,GAAG,CAAC,UAAU,CAAC,EAAE,CAAC,CAAC,CAAC;QAC7C,MAAM,EAAE,GAAG,aAAa,CAAC,GAAG,CAAC,UAAU,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC,CAAC;QACjD,IAAI,EAAE,KAAK,SAAS,IAAI,EAAE,KAAK,SAAS,EAAE,CAAC;YACzC,MAAM,IAAI,GAAG,GAAG,CAAC,EAAE,CAAC,GAAG,GAAG,CAAC,EAAE,GAAG,CAAC,CAAC,CAAC;YACnC,MAAM,IAAI,KAAK,CAAC,8CAA8C,GAAG,IAAI,GAAG,aAAa,GAAG,EAAE,CAAC,CAAC;QAC9F,CAAC;QACD,KAAK,CAAC,EAAE,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG,EAAE,CAAC;IAC3B,CAAC;IACD,OAAO,KAAK,CAAC;AACf,CAAC;AAED,8DAA8D;AAC9D,wEAAwE;AACxE,yEAAyE;AAClE,MAAM,QAAQ,GAAG,KAAK,IAAI,EAAE,GAAE,CAAC,CAAC;AAA1B,QAAA,QAAQ,YAAkB;AAEvC,6DAA6D;AACtD,KAAK,UAAU,SAAS,CAAC,KAAa,EAAE,IAAY,EAAE,EAAuB;IAClF,IAAI,EAAE,GAAG,IAAI,CAAC,GAAG,EAAE,CAAC;IACpB,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,KAAK,EAAE,CAAC,EAAE,EAAE,CAAC;QAC/B,EAAE,CAAC,CAAC,CAAC,CAAC;QACN,+FAA+F;QAC/F,MAAM,IAAI,GAAG,IAAI,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;QAC7B,IAAI,IAAI,IAAI,CAAC,IAAI,IAAI,GAAG,IAAI;YAAE,SAAS;QACvC,MAAM,IAAA,gBAAQ,GAAE,CAAC;QACjB,EAAE,IAAI,IAAI,CAAC;IACb,CAAC;AACH,CAAC;AAMD;;GAEG;AACH,SAAgB,WAAW,CAAC,GAAW;IACrC,IAAI,OAAO,GAAG,KAAK,QAAQ;QAAE,MAAM,IAAI,KAAK,CAAC,oCAAoC,OAAO,GAAG,EAAE,CAAC,CAAC;IAC/F,OAAO,IAAI,UAAU,CAAC,IAAI,WAAW,EAAE,CAAC,MAAM,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,4BAA4B;AACpF,CAAC;AAGD;;;;GAIG;AACH,SAAgB,OAAO,CAAC,IAAW;IACjC,IAAI,OAAO,IAAI,KAAK,QAAQ;QAAE,IAAI,GAAG,WAAW,CAAC,IAAI,CAAC,CAAC;IACvD,IAAA,kBAAM,EAAC,IAAI,CAAC,CAAC;IACb,OAAO,IAAI,CAAC;AACd,CAAC;AAED;;GAEG;AACH,SAAgB,WAAW,CAAC,GAAG,MAAoB;IACjD,IAAI,GAAG,GAAG,CAAC,CAAC;IACZ,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QACvC,MAAM,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC;QACpB,IAAA,kBAAM,EAAC,CAAC,CAAC,CAAC;QACV,GAAG,IAAI,CAAC,CAAC,MAAM,CAAC;IAClB,CAAC;IACD,MAAM,GAAG,GAAG,IAAI,UAAU,CAAC,GAAG,CAAC,CAAC;IAChC,KAAK,IAAI,CAAC,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC,EAAE,CAAC,GAAG,MAAM,CAAC,MAAM,EAAE,CAAC,EAAE,EAAE,CAAC;QAChD,MAAM,CAAC,GAAG,MAAM,CAAC,CAAC,CAAC,CAAC;QACpB,GAAG,CAAC,GAAG,CAAC,CAAC,EAAE,GAAG,CAAC,CAAC;QAChB,GAAG,IAAI,CAAC,CAAC,MAAM,CAAC;IAClB,CAAC;IACD,OAAO,GAAG,CAAC;AACb,CAAC;AAED,kDAAkD;AAClD,MAAsB,IAAI;IAqBxB,0CAA0C;IAC1C,KAAK;QACH,OAAO,IAAI,CAAC,UAAU,EAAE,CAAC;IAC3B,CAAC;CACF;AAzBD,oBAyBC;AAaD,MAAM,KAAK,GAAG,EAAE,CAAC,QAAQ,CAAC;AAE1B,SAAgB,SAAS,CACvB,QAAY,EACZ,IAAS;IAET,IAAI,IAAI,KAAK,SAAS,IAAI,KAAK,CAAC,IAAI,CAAC,IAAI,CAAC,KAAK,iBAAiB;QAC9D,MAAM,IAAI,KAAK,CAAC,uCAAuC,CAAC,CAAC;IAC3D,MAAM,MAAM,GAAG,MAAM,CAAC,MAAM,CAAC,QAAQ,EAAE,IAAI,CAAC,CAAC;IAC7C,OAAO,MAAiB,CAAC;AAC3B,CAAC;AAID,SAAgB,eAAe,CAAoB,QAAuB;IACxE,MAAM,KAAK,GAAG,CAAC,GAAU,EAAc,EAAE,CAAC,QAAQ,EAAE,CAAC,MAAM,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,MAAM,EAAE,CAAC;IACnF,MAAM,GAAG,GAAG,QAAQ,EAAE,CAAC;IACvB,KAAK,CAAC,SAAS,GAAG,GAAG,CAAC,SAAS,CAAC;IAChC,KAAK,CAAC,QAAQ,GAAG,GAAG,CAAC,QAAQ,CAAC;IAC9B,KAAK,CAAC,MAAM,GAAG,GAAG,EAAE,CAAC,QAAQ,EAAE,CAAC;IAChC,OAAO,KAAK,CAAC;AACf,CAAC;AAED,SAAgB,uBAAuB,CACrC,QAA+B;IAE/B,MAAM,KAAK,GAAG,CAAC,GAAU,EAAE,IAAQ,EAAc,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,MAAM,EAAE,CAAC;IACjG,MAAM,GAAG,GAAG,QAAQ,CAAC,EAAO,CAAC,CAAC;IAC9B,KAAK,CAAC,SAAS,GAAG,GAAG,CAAC,SAAS,CAAC;IAChC,KAAK,CAAC,QAAQ,GAAG,GAAG,CAAC,QAAQ,CAAC;IAC9B,KAAK,CAAC,MAAM,GAAG,CAAC,IAAO,EAAE,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC;IAC3C,OAAO,KAAK,CAAC;AACf,CAAC;AAED,SAAgB,0BAA0B,CACxC,QAAkC;IAElC,MAAM,KAAK,GAAG,CAAC,GAAU,EAAE,IAAQ,EAAc,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC,MAAM,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,MAAM,EAAE,CAAC;IACjG,MAAM,GAAG,GAAG,QAAQ,CAAC,EAAO,CAAC,CAAC;IAC9B,KAAK,CAAC,SAAS,GAAG,GAAG,CAAC,SAAS,CAAC;IAChC,KAAK,CAAC,QAAQ,GAAG,GAAG,CAAC,QAAQ,CAAC;IAC9B,KAAK,CAAC,MAAM,GAAG,CAAC,IAAO,EAAE,EAAE,CAAC,QAAQ,CAAC,IAAI,CAAC,CAAC;IAC3C,OAAO,KAAK,CAAC;AACf,CAAC;AAED;;GAEG;AACH,SAAgB,WAAW,CAAC,WAAW,GAAG,EAAE;IAC1C,IAAI,eAAM,IAAI,OAAO,eAAM,CAAC,eAAe,KAAK,UAAU,EAAE,CAAC;QAC3D,OAAO,eAAM,CAAC,eAAe,CAAC,IAAI,UAAU,CAAC,WAAW,CAAC,CAAC,CAAC;IAC7D,CAAC;IACD,MAAM,IAAI,KAAK,CAAC,wCAAwC,CAAC,CAAC;AAC5D,CAAC"}
+\ No newline at end of file

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,6 +2780,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
 
+"@noble/hashes@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,10 +2780,9 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
 
-"@noble/hashes@^1.4.0":
+"@noble/hashes@github:paulmillr/noble-hashes#ae060da":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
-  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+  resolved "https://codeload.github.com/paulmillr/noble-hashes/tar.gz/ae060daa6252f3ff2aa2f84e887de0aab491281d"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
refs: #9211

## Description

Prototyping for #9211 suggests we'll want to be [derive IBC denoms](https://tutorials.cosmos.network/tutorials/6-ibc-dev/#how-are-ibc-denoms-derived) using a hash of a path such as `transfer/channel-0/uatom` -> `ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2`.

I tried to use the sha256 function from `@cosmjs/crypto`, but I got error's about node's `crypto` module. `@cosmjs/crypto` imports an old version of `@noble/hashes`. The current version seems to be vat-safe.

### Scaling Considerations

Compute performance: Doing a sha256 computation on XS in pure JS seems a little whacky. We could consider dropping down to C like we do for base64. But since this is a constant time operation, it doesn't seem worthwhile.

Bundle size: A base64 encoded bundle with just this module seems to be around 500k.

```
┌──────────────────────────────┬────────┐
│           (index)            │ Values │
├──────────────────────────────┼────────┤
│ @agoric/orchestration-v0.1.0 │  1702  │
│     @noble/hashes-v1.4.0     │ 18820  │
└──────────────────────────────┴────────┘
total size: 36623
```

### Security Considerations

supply chain: this adds a dependency on the current [@noble/hashes](https://www.npmjs.com/package/@noble/hashes), which is reasonably popular (3m weekly downloads) and seems to be well audited.

### Documentation Considerations

I'm not sure where this shows up in the orchestration API yet.

### Testing Considerations

A test that it works in a compartment is included.

### Upgrade Considerations

Unrelated to any deployed code.