### PR TITLE
chore: contractState.account type alignment

### DIFF
--- a/packages/async-flow/src/endowments.js
+++ b/packages/async-flow/src/endowments.js
@@ -59,8 +59,10 @@ export const forwardingMethods = rem => {
  * gets and sets, but is implemented using accessors, so it will be recognized
  * as a state record.
  *
- * @param {object} dataRecord
- * @returns {object}
+ * @template { string | number | symbol } K
+ * @template {Record<K, any>} R
+ * @param {R} dataRecord
+ * @returns {R}
  */
 export const makeStateRecord = dataRecord =>
   harden(

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -38,7 +38,7 @@ const { entries } = Object;
  * @param {object} ctx
  * @param {ZCF} ctx.zcf
  * @param {any} ctx.agoricNamesTools TODO Give this a better type
- * @param {{ account: OrchestrationAccount<any> }} ctx.contractState
+ * @param {{ account: OrchestrationAccount<any> | undefined }} ctx.contractState
  * @param {ZCFSeat} seat
  * @param {object} offerArgs
  * @param {string} offerArgs.chainName
@@ -68,8 +68,8 @@ const sendItFn = async (
   const { chainId } = info;
   assert(typeof chainId === 'string', 'bad chainId');
   const { [kw]: pmtP } = await withdrawFromSeat(zcf, seat, give);
-  await E.when(pmtP, pmt => contractState.account.deposit(pmt));
-  await contractState.account.transfer(
+  await E.when(pmtP, pmt => contractState.account?.deposit(pmt));
+  await contractState.account?.transfer(
     { denom, value: amt.value },
     {
       address: destAddr,


### PR DESCRIPTION
refs: #9566

## Description

address a type error from #9566:

```
Error: src/examples/sendAnywhere.contract.js(112,9): error TS2741: Property 'account' is missing in type '{}' but required in type '{ account: OrchestrationAccount<any> | undefined; }'.
```

