### PR TITLE
Patch @cosmjs/math for SES compatibility

### DIFF
--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -133,6 +133,8 @@
     "@agoric/cosmos": "^0.34.1",
     "@ava/typescript": "^4.1.0",
     "@cosmology/telescope": "^1.7.1",
+    "@endo/bundle-source": "^3.2.3",
+    "@endo/import-bundle": "^1.1.2",
     "ava": "^5.3.1",
     "rimraf": "^5.0.0",
     "tsd": "^0.30.7",

--- a/packages/cosmic-proto/test/bundle-cosmjs-math.js
+++ b/packages/cosmic-proto/test/bundle-cosmjs-math.js
@@ -1,0 +1,1 @@
+export { Decimal } from '@cosmjs/math';

--- a/packages/cosmic-proto/test/bundle-cosmjs-math.test.js
+++ b/packages/cosmic-proto/test/bundle-cosmjs-math.test.js
@@ -1,0 +1,18 @@
+// A test to verify that importing @cosmsjs/math into an ESM via bundleSource
+// can see the exported Decimal constructor, which was at time of writing obscured
+// by https://github.com/endojs/endo/pull/2330, temporarily mitigated by a patch.
+// Placed here only because Agoric CLI depends on both bundleSource and CosmJS math.
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import url from 'url';
+import bundleSource from '@endo/bundle-source';
+import { importBundle } from '@endo/import-bundle';
+
+test('bundled @comjs/math exports Decimal', async t => {
+  const entryPath = url.fileURLToPath(
+    new URL('bundle-cosmjs-math.js', import.meta.url),
+  );
+  const bundle = await bundleSource(entryPath);
+  const ns = await importBundle(bundle);
+  t.not(ns.Decimal, undefined);
+});

--- a/patches/@cosmjs+math+0.32.3.patch
+++ b/patches/@cosmjs+math+0.32.3.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@cosmjs/math/build/index.js b/node_modules/@cosmjs/math/build/index.js
+index 1f812f6..6e25ac9 100644
+--- a/node_modules/@cosmjs/math/build/index.js
++++ b/node_modules/@cosmjs/math/build/index.js
+@@ -1,11 +1,10 @@
+-"use strict";
+-Object.defineProperty(exports, "__esModule", { value: true });
+-exports.Uint64 = exports.Uint53 = exports.Uint32 = exports.Int53 = exports.Decimal = void 0;
+-var decimal_1 = require("./decimal");
+-Object.defineProperty(exports, "Decimal", { enumerable: true, get: function () { return decimal_1.Decimal; } });
+-var integers_1 = require("./integers");
+-Object.defineProperty(exports, "Int53", { enumerable: true, get: function () { return integers_1.Int53; } });
+-Object.defineProperty(exports, "Uint32", { enumerable: true, get: function () { return integers_1.Uint32; } });
+-Object.defineProperty(exports, "Uint53", { enumerable: true, get: function () { return integers_1.Uint53; } });
+-Object.defineProperty(exports, "Uint64", { enumerable: true, get: function () { return integers_1.Uint64; } });
++'use strict';
++Object.defineProperty(exports, '__esModule', { value: true });
++var decimal_1 = require('./decimal');
++var integers_1 = require('./integers');
++exports.Uint64 = integers_1.Uint64;
++exports.Uint53 = integers_1.Uint53;
++exports.Uint32 = integers_1.Uint32;
++exports.Int53 = integers_1.Int53;
++exports.Decimal = decimal_1.Decimal;
+ //# sourceMappingURL=index.js.map


### PR DESCRIPTION
closes: #9408

## Description

Pending https://github.com/endojs/endo/pull/2330, we patch `@cosmjs/math` such that imports from ESM reflect the exported types.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

Included test.

### Upgrade Considerations

None.