### PR TITLE
Remove scaled price authority upgrade

### DIFF
--- a/a3p-integration/proposals/a:upgrade-next/agd-tools.js
+++ b/a3p-integration/proposals/a:upgrade-next/agd-tools.js
@@ -162,6 +162,12 @@ export const getAuctionCollateral = async index => {
   return body.collateralAvailable.value;
 };
 
+export const getVaultPrices = async index => {
+  const path = `published.vaultFactory.managers.manager${index}.quotes`;
+  const body = await getQuoteBody(path);
+  return body.quoteAmount;
+};
+
 export const bankSend = (addr, wanted) => {
   const chain = ['--chain-id', CHAINID];
   const from = ['--from', VALIDATORADDR];

--- a/a3p-integration/proposals/a:upgrade-next/upgradeVaults.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/upgradeVaults.test.js
@@ -17,6 +17,7 @@ import {
   generateOracleMap,
   getLiveOffers,
   getPriceQuote,
+  getVaultPrices,
   pushPrices,
 } from './agd-tools.js';
 import { getDetailsMatchingVats } from './vatDetails.js';
@@ -95,6 +96,15 @@ const checkAuctionVat = async t => {
   t.true(Object.keys(details).length > 2);
 };
 
+const verifyVaultPriceUpdate = async t => {
+  const quote = await getVaultPrices(0);
+
+  t.true(quote.value[0].amountIn.brand.includes(' ATOM '));
+
+  // FAIL, should be +5200000
+  t.is(quote.value[0].amountOut.value, '12010000');
+};
+
 // test.serial() isn't guaranteed to run tests in order, so we run the intended tests here
 test('liquidation post upgrade', async t => {
   t.log('starting upgrade vaults test');
@@ -114,4 +124,7 @@ test('liquidation post upgrade', async t => {
 
   t.log('make new auction');
   await checkAuctionVat(t);
+
+  t.log('vault price updated');
+  await verifyVaultPriceUpdate(t);
 });

--- a/a3p-integration/proposals/a:upgrade-next/upgradeVaults.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/upgradeVaults.test.js
@@ -100,9 +100,7 @@ const verifyVaultPriceUpdate = async t => {
   const quote = await getVaultPrices(0);
 
   t.true(quote.value[0].amountIn.brand.includes(' ATOM '));
-
-  // FAIL, should be +5200000
-  t.is(quote.value[0].amountOut.value, '12010000');
+  t.is(quote.value[0].amountOut.value, '+5200000');
 };
 
 // test.serial() isn't guaranteed to run tests in order, so we run the intended tests here

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -959,8 +959,6 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/add-auction.js"),
 				// upgrade vaultFactory.
 				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/upgradeVaults.js"),
-				// upgrade scaledPriceAuthorities.
-				vm.CoreProposalStepForModules("@agoric/builders/scripts/vats/upgradeScaledPriceAuthorities.js"),
 			}
 		}
 


### PR DESCRIPTION
refs: #9382
refs: #9584

## Description

Add a test that was supposed to be in #9283, where it says 

> A3P tests that verify that vaultFactory has been upgraded, that a new Auctioneer is running and is receiving prices. Verify that when prices drop, assets are sold via the auction, the bidder gets the proceeds, and the vaults are liquidated or reconstituted appropriately.

It was too hard to verify the results of the auction, because of the timing of vault liquidations and auction runs, so the actual check was dropped. 

The subsequent PR (#9371) that upgraded scaledPriceAuthorities seems to have broken the upgrade, and the missing test failed to warn us.

Here we test that vaultFactory was actually upgraded by verifying that it's getting prices from the new price feeds, and drop the upgrade of scaledPriceAuthority until we can figure out how to make that upgrade compatible.

### Security Considerations

Not relevant

### Scaling Considerations

Drops the upgrade of scaledPriceAuthority, which fixed part of the memory growth. This was the smaller portion of the growth, so it's more important to get the rest of the fixes in than to also include this.

### Documentation Considerations

None.

### Testing Considerations

Replaces a missing test.

### Upgrade Considerations

Repairs upgrade.