### PR TITLE
refactor(orchestration): simplify example guest code

### DIFF
--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -4,7 +4,6 @@ import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js'
 import { Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M, objectMap } from '@endo/patterns';
-import { heapVowTools } from '@agoric/vow/vat.js';
 import { orcUtils } from '../utils/orc.js';
 import { provideOrchestration } from '../utils/start-helper.js';
 
@@ -34,10 +33,8 @@ const stackAndSwapFn = async (orch, { zcf }, seat, offerArgs) => {
   const agoric = await orch.getChain('agoric');
 
   const [omniAccount, localAccount] = await Promise.all([
-    // XXX when() until membrane
-    heapVowTools.when(omni.makeAccount()),
-    // XXX when() until membrane
-    heapVowTools.when(agoric.makeAccount()),
+    omni.makeAccount(),
+    agoric.makeAccount(),
   ]);
 
   const omniAddress = omniAccount.getAddress();


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/9566/files#r1653602477

## Description

At https://github.com/Agoric/agoric-sdk/pull/9566/files#r1653602477 @dckc commented on a cleanup that I thought I did and marked as done, but was not done. 

Before #9566, the code that would be guest code had several workarounds marked `// XXX when() until membrane` that correctly indicated that they should be cleaned up as of #9566, which introduces exactly that membrane.

In addition, guest code has no need for `heapVowE` since it doesn't see vows. It should just use the normal `E`. To keep this distinct, I stopped renaming `hostVowE` where host code needs it in the same file.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
examples are now more like what we want to teach
### Testing Considerations
I believe this PR is a pure refactor that should not have any observable effects. Thus, it should not affect any tests. We'll see soon.
### Upgrade Considerations
none