### PR TITLE
Proposal to reset fluxAggregator roundIDs for stTIA/stkATOM

### DIFF
--- a/packages/builders/scripts/vats/resetRoundIds.js
+++ b/packages/builders/scripts/vats/resetRoundIds.js
@@ -1,0 +1,13 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async () =>
+  harden({
+    sourceSpec: '@agoric/vats/src/proposals/resetRoundIds.js',
+    getManifestCall: ['getManifestForResetRoundIds'],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('reest-round-ids', defaultProposalBuilder);
+};

--- a/packages/builders/scripts/vats/resetRoundIds.js
+++ b/packages/builders/scripts/vats/resetRoundIds.js
@@ -9,5 +9,5 @@ export const defaultProposalBuilder = async () =>
 
 export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
-  await writeCoreEval('reest-round-ids', defaultProposalBuilder);
+  await writeCoreEval('reset-round-ids', defaultProposalBuilder);
 };

--- a/packages/vats/src/proposals/resetRoundIds.js
+++ b/packages/vats/src/proposals/resetRoundIds.js
@@ -1,0 +1,47 @@
+import { E } from '@endo/far';
+import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
+import { makeMarshal } from '@endo/marshal';
+import { Fail } from '@agoric/assert';
+
+/**
+ * @param {BootstrapPowers & {
+ *   consume: { chainStorage: any };
+ * }} powers
+ */
+export const resetRoundId = async ({
+  consume: { chainStorage, chainTimerService },
+}) => {
+  const TOKENS = ['stTIA', 'stkATOM'];
+
+  const priceFeedStorageNode = await makeStorageNodeChild(
+    chainStorage,
+    'priceFeed',
+  );
+  for (const token of TOKENS) {
+    const name = `${token}-USD_price_feed`;
+    const tokenStorageNode = await makeStorageNodeChild(
+      priceFeedStorageNode,
+      name,
+    );
+    const marshalData = makeMarshal(_val => Fail`data only`);
+
+    const now = await E(chainTimerService).getCurrentTimestamp();
+    const latestRound = harden({
+      roundId: '0',
+      startedAt: now,
+      startedBy: 'someoneElse',
+    });
+
+    const aux = marshalData.toCapData(harden({ latestRound }));
+
+    await E(tokenStorageNode).setValue(JSON.stringify(aux));
+  }
+};
+
+export const getManifestForResetRoundIds = _powers => ({
+  manifest: {
+    [resetRoundId.name]: {
+      consume: { chainStorage: true, chainTimerService: true },
+    },
+  },
+});

--- a/packages/vats/src/proposals/resetRoundIds.js
+++ b/packages/vats/src/proposals/resetRoundIds.js
@@ -7,35 +7,38 @@ import { Fail } from '@agoric/assert';
  * @param {BootstrapPowers & {
  *   consume: { chainStorage: any };
  * }} powers
+ * @param {object} options
+ * @param {{ tokenName: string }} options.options
  */
-export const resetRoundId = async ({
-  consume: { chainStorage, chainTimerService },
-}) => {
-  const TOKENS = ['stTIA', 'stkATOM'];
-
+export const resetRoundId = async (
+  { consume: { chainStorage, chainTimerService } },
+  options,
+) => {
+  const tokenName = options.options;
   const priceFeedStorageNode = await makeStorageNodeChild(
     chainStorage,
     'priceFeed',
   );
-  for (const token of TOKENS) {
-    const name = `${token}-USD_price_feed`;
-    const tokenStorageNode = await makeStorageNodeChild(
-      priceFeedStorageNode,
-      name,
-    );
-    const marshalData = makeMarshal(_val => Fail`data only`);
+  const tokenStorageNode = await makeStorageNodeChild(
+    priceFeedStorageNode,
+    `${tokenName}-USD_price_feed`,
+  );
+  const latestRoundStorageNode = await makeStorageNodeChild(
+    tokenStorageNode,
+    'latestRound',
+  );
+  const marshalData = makeMarshal(_val => Fail`data only`);
 
-    const now = await E(chainTimerService).getCurrentTimestamp();
-    const latestRound = harden({
-      roundId: '0',
-      startedAt: now,
-      startedBy: 'someoneElse',
-    });
+  const now = await E(chainTimerService).getCurrentTimestamp();
+  const latestRound = harden({
+    roundId: '0',
+    startedAt: now,
+    startedBy: 'someoneElse',
+  });
 
-    const aux = marshalData.toCapData(harden({ latestRound }));
+  const aux = marshalData.toCapData(harden({ latestRound }));
 
-    await E(tokenStorageNode).setValue(JSON.stringify(aux));
-  }
+  await E(latestRoundStorageNode).setValue(JSON.stringify(aux));
 };
 
 export const getManifestForResetRoundIds = _powers => ({


### PR DESCRIPTION
## Description
 
When replacing a priceFeed (see #9044), the oracles find it difficult to reset the roundIDs. We can help by overwriting the vstorage `latestRound` record to reset the roundId to zero.

### Security Considerations

see upgrade.

### Scaling Considerations

No impact.

### Documentation Considerations

None.

### Testing Considerations

We will test in various test networks to ensure that this is the right thing for the oracles.

### Upgrade Considerations

When replacing priceFeeds, we need to make it easy for the oracles to know what the current round is. They can read this from vstorage.