### PR TITLE
fix(swingset): retire unreachable orphans

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -974,11 +974,8 @@ export default function buildKernel(
     const abandonedObjects = [
       ...kernelKeeper.enumerateNonDurableObjectExports(vatID),
     ];
-    for (const { kref, vref } of abandonedObjects) {
-      /** @see translateAbandonExports in {@link ./vatTranslator.js} */
-      vatKeeper.deleteCListEntry(kref, vref);
-      /** @see abandonExports in {@link ./kernelSyscall.js} */
-      kernelKeeper.orphanKernelObject(kref, vatID);
+    for (const { kref } of abandonedObjects) {
+      kernelKeeper.abandonKernelObject(kref, vatID);
     }
 
     // cleanup done, now we reset the worker to a clean state with no

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -187,7 +187,7 @@ export function makeKernelSyscallHandler(tools) {
     for (const koid of koids) {
       // note that this is effectful and also performed outside of a syscall
       // by processUpgradeVat in {@link ./kernel.js}
-      kernelKeeper.orphanKernelObject(koid, vatID);
+      kernelKeeper.abandonKernelObject(koid, vatID);
     }
     return OKNULL;
   }

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -178,16 +178,7 @@ export function makeKernelSyscallHandler(tools) {
 
   function retireExports(koids) {
     Array.isArray(koids) || Fail`retireExports given non-Array ${koids}`;
-    const newActions = [];
-    for (const koid of koids) {
-      const importers = kernelKeeper.getImporters(koid);
-      for (const vatID of importers) {
-        newActions.push(`${vatID} retireImport ${koid}`);
-      }
-      // TODO: decref and delete any #2069 auxdata
-      kernelKeeper.deleteKernelObject(koid);
-    }
-    kernelKeeper.addGCActions(newActions);
+    kernelKeeper.retireKernelObjects(koids);
     return OKNULL;
   }
 

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1462,7 +1462,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
 
   function processRefcounts() {
     if (enableKernelGC) {
-      const actions = getGCActions(); // local cache
+      const actions = new Set();
       // TODO (else buggy): change the iteration to handle krefs that get
       // added multiple times (while we're iterating), because we might do
       // different work the second time around. Something like an ordered
@@ -1510,7 +1510,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
           }
         }
       }
-      setGCActions(actions);
+      addGCActions([...actions]);
     }
     maybeFreeKrefs.clear();
   }

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -102,7 +102,6 @@ export { DEFAULT_REAP_DIRT_THRESHOLD_KEY };
 //   $vatSlot is one of: o+$NN/o-$NN/p+$NN/p-$NN/d+$NN/d-$NN
 // v$NN.c.$vatSlot = $kernelSlot = ko$NN/kp$NN/kd$NN
 // v$NN.vs.$key = string
-// v$NN.meter = m$NN // XXX does this exist?
 // old (v0): v$NN.reapInterval = $NN or 'never'
 // old (v0): v$NN.reapCountdown = $NN or 'never'
 // v$NN.reapDirt = JSON({ deliveries, gcKrefs, computrons }) // missing keys treated as zero

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -679,6 +679,19 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     return owner;
   }
 
+  function retireKernelObjects(koids) {
+    Array.isArray(koids) || Fail`retireExports given non-Array ${koids}`;
+    const newActions = [];
+    for (const koid of koids) {
+      const importers = getImporters(koid);
+      for (const vatID of importers) {
+        newActions.push(`${vatID} retireImport ${koid}`);
+      }
+      deleteKernelObject(koid);
+    }
+    addGCActions(newActions);
+  }
+
   function orphanKernelObject(kref, oldVat) {
     const ownerKey = `${kref}.owner`;
     const ownerVat = kvStore.get(ownerKey);
@@ -1793,6 +1806,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     kernelObjectExists,
     getImporters,
     orphanKernelObject,
+    retireKernelObjects,
     deleteKernelObject,
     pinObject,
 

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -692,13 +692,19 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     addGCActions(newActions);
   }
 
-  function orphanKernelObject(kref, oldVat) {
+  function abandonKernelObject(kref, oldVat) {
+    // termination orphans all exports, upgrade orphans non-durable
+    // exports, and syscall.abandonExports orphans specific ones
     const ownerKey = `${kref}.owner`;
     const ownerVat = kvStore.get(ownerKey);
     ownerVat === oldVat || Fail`export ${kref} not owned by old vat`;
     kvStore.delete(ownerKey);
+    const { vatSlot: vref } = getReachableAndVatSlot(oldVat, kref);
+    kvStore.delete(`${oldVat}.c.${kref}`);
+    kvStore.delete(`${oldVat}.c.${vref}`);
+    addMaybeFreeKref(kref);
     // note that we do not delete the object here: it will be
-    // collected if/when all other references are dropped
+    // retired if/when all other references are dropped
   }
 
   function deleteKernelObject(koid) {
@@ -986,19 +992,8 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
       const vref = k.slice(`${vatID}.c.`.length);
       assert(vref.startsWith('o+'), vref);
       const kref = kvStore.get(k);
-      // we must delete the c-list entry, but we don't need to
-      // manipulate refcounts like the way vatKeeper/deleteCListEntry
-      // does, so just delete the keys directly
-      // vatKeeper.deleteCListEntry(kref, vref);
-      kvStore.delete(`${vatID}.c.${kref}`);
-      kvStore.delete(`${vatID}.c.${vref}`);
-      // if this object became unreferenced, processRefcounts will
-      // delete it, so don't be surprised. TODO: this results in an
-      // extra get() for each delete(), see if there's a way to avoid
-      // this. TODO: think carefully about other such races.
-      if (kvStore.has(`${kref}.owner`)) {
-        orphanKernelObject(kref, vatID);
-      }
+      // note: adds to maybeFreeKrefs, deletes c-list and .owner
+      abandonKernelObject(kref, vatID);
       work.exports += 1;
       if (spend()) {
         logWork();
@@ -1805,7 +1800,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     ownerOfKernelDevice,
     kernelObjectExists,
     getImporters,
-    orphanKernelObject,
+    abandonKernelObject,
     retireKernelObjects,
     deleteKernelObject,
     pinObject,

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -481,9 +481,6 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       assert.equal(allocatedByVat, true); // abandon *exports*, not imports
       // kref must already be in the clist
       const kref = mapVatSlotToKernelSlot(vref, gcSyscallMapOpts);
-      // note that this is effectful and also performed outside of a syscall
-      // by processUpgradeVat in {@link ./kernel.js}
-      vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
     kdebug(`syscall[${vatID}].abandonExports(${krefs.join(' ')})`);

--- a/packages/SwingSet/test/gc-dead-vat/bootstrap.js
+++ b/packages/SwingSet/test/gc-dead-vat/bootstrap.js
@@ -1,5 +1,6 @@
 import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeScalarBigWeakSetStore } from '@agoric/vat-data';
 
 async function sendExport(doomedRoot) {
   const exportToDoomed = Far('exportToDoomed', {});
@@ -11,6 +12,7 @@ export function buildRootObject() {
   let doomedRoot;
   const pin = [];
   const pk1 = makePromiseKit();
+  const wh = makeScalarBigWeakSetStore('weak-holder');
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
@@ -19,6 +21,8 @@ export function buildRootObject() {
       await sendExport(doomedRoot);
       const doomedExport1Presence = await E(doomedRoot).getDoomedExport1();
       pin.push(doomedExport1Presence);
+      const doomedExport3Presence = await E(doomedRoot).getDoomedExport3();
+      wh.add(doomedExport3Presence);
     },
     async stash() {
       // Give vat-doomed a target that doesn't resolve one() right away.

--- a/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
+++ b/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
@@ -4,6 +4,7 @@ export function buildRootObject(vatPowers) {
   const pin = [];
   const doomedExport1 = Far('doomedExport1', {});
   const doomedExport2 = Far('doomedExport2', {});
+  const doomedExport3 = Far('doomedExport3', {});
   return Far('root', {
     accept(exportToDoomedPresence) {
       pin.push(exportToDoomedPresence);
@@ -13,6 +14,9 @@ export function buildRootObject(vatPowers) {
     },
     stashDoomedExport2(target) {
       E(E(target).one()).neverCalled(doomedExport2);
+    },
+    getDoomedExport3() {
+      return doomedExport3;
     },
     terminate() {
       vatPowers.exitVat('completion');

--- a/packages/SwingSet/test/gc-kernel-orphan.test.js
+++ b/packages/SwingSet/test/gc-kernel-orphan.test.js
@@ -1,0 +1,342 @@
+// @ts-nocheck
+/* global WeakRef, FinalizationRegistry */
+
+import anylogger from 'anylogger';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava.js';
+
+import { assert } from '@agoric/assert';
+import { kser, kunser, kslot } from '@agoric/kmarshal';
+import { initSwingStore } from '@agoric/swing-store';
+import { waitUntilQuiescent } from '@agoric/internal/src/lib-nodejs/waitUntilQuiescent.js';
+import buildKernel from '../src/kernel/index.js';
+import { initializeKernel } from '../src/controller/initializeKernel.js';
+
+function makeConsole(tag) {
+  const log = anylogger(tag);
+  const cons = {};
+  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+    cons[level] = log[level];
+  }
+  return harden(cons);
+}
+
+function writeSlogObject(o) {
+  function bigintReplacer(_, arg) {
+    if (typeof arg === 'bigint') {
+      return Number(arg);
+    }
+    return arg;
+  }
+  0 && console.log(JSON.stringify(o, bigintReplacer));
+}
+
+function makeEndowments() {
+  return {
+    waitUntilQuiescent,
+    kernelStorage: initSwingStore().kernelStorage,
+    runEndOfCrank: () => {},
+    makeConsole,
+    writeSlogObject,
+    WeakRef,
+    FinalizationRegistry,
+  };
+}
+
+async function makeKernel() {
+  const endowments = makeEndowments();
+  const { kvStore } = endowments.kernelStorage;
+  await initializeKernel({}, endowments.kernelStorage);
+  const kernel = buildKernel(endowments, {}, {});
+  return { kernel, kvStore };
+}
+
+const orphanTest = test.macro(async (t, cause, when, amyState) => {
+  assert(['reachable', 'recognizable', 'none'].includes(amyState));
+  assert(['abandon', 'terminate'].includes(cause));
+  // There is a third case (vatA gets upgraded, and the object wasn't
+  // durable), but we can't upgrade vats created by createTestVat().
+  assert(['before', 'after'].includes(when));
+  const retireImmediately = false;
+  const { kernel, kvStore } = await makeKernel();
+  await kernel.start();
+
+  const vrefs = {}; // track vrefs within vats
+
+  // Our two root objects (alice and bob) are pinned so they don't disappear
+  // while the test is talking to them. So we make alice introduce "amy" as a
+  // new object that's doomed to be collected. Bob first drops amy, then
+  // retires her, provoking first a dropExports then a retireImports on
+  // alice.
+
+  vrefs.aliceForA = 'o+100';
+  vrefs.amyForA = 'o+101';
+  function setupA(syscall, _state, _helpers, _vatPowers) {
+    let exportingAmy = false;
+    function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
+      let method;
+      if (vd[0] === 'message') {
+        const methargs = kunser(vd[2].methargs);
+        [method] = methargs;
+        if (method === 'init') {
+          // initial conditions: bob holds a reference to amy
+          vrefs.bobForA = vd[2].methargs.slots[0];
+          syscall.send(
+            vrefs.bobForA,
+            kser(['accept-amy', [kslot(vrefs.amyForA)]]),
+          );
+          exportingAmy = true;
+        }
+        if (method === 'abandon') {
+          if (exportingAmy) {
+            syscall.abandonExports([vrefs.amyForA]);
+          }
+        }
+        if (method === 'terminate') {
+          syscall.exit(false, kser('terminated'));
+        }
+      }
+      if (vd[0] === 'dropExports') {
+        if (retireImmediately) {
+          // pretend there are no local strongrefs, and as soon as liveslots
+          // drops it's claim, the object goes away completely
+          syscall.retireExports(vd[1]);
+        }
+      }
+      if (vd[0] === 'retireExports') {
+        exportingAmy = false;
+      }
+    }
+    return dispatch;
+  }
+  await kernel.createTestVat('vatA', setupA);
+  const vatA = kernel.vatNameToID('vatA');
+  const alice = kernel.addExport(vatA, vrefs.aliceForA);
+
+  let amyRetiredToB = false;
+  function setupB(syscall, _state, _helpers, _vatPowers) {
+    function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
+      let method;
+      if (vd[0] === 'message') {
+        [method] = kunser(vd[2].methargs);
+        if (method === 'accept-amy') {
+          vrefs.amyForB = vd[2].methargs.slots[0];
+        }
+        if (method === 'drop') {
+          syscall.dropImports([vrefs.amyForB]);
+        }
+        if (method === 'drop and retire') {
+          syscall.dropImports([vrefs.amyForB]);
+          syscall.retireImports([vrefs.amyForB]);
+        }
+        if (method === 'retire') {
+          // it would be an error for bob to do this before or without
+          // dropImports
+          syscall.retireImports([vrefs.amyForB]);
+        }
+      }
+      if (vd[0] === 'retireImports') {
+        t.deepEqual(vd[1], [vrefs.amyForB]);
+        amyRetiredToB = true;
+      }
+    }
+    return dispatch;
+  }
+  await kernel.createTestVat('vatB', setupB);
+  const vatB = kernel.vatNameToID('vatB');
+  vrefs.bobForB = 'o+200';
+  const bob = kernel.addExport(vatB, vrefs.bobForB);
+
+  // we always start with bob importing an object from alice
+  kernel.queueToKref(alice, 'init', [kslot(bob)], 'none');
+  await kernel.run();
+
+  const amy = kvStore.get(`${vatA}.c.${vrefs.amyForA}`);
+  t.is(amy, 'ko22'); // probably
+
+  if (when === 'before') {
+    // the object is abandoned before vatB drops anything
+    if (cause === 'abandon') {
+      kernel.queueToKref(alice, 'abandon', [], 'none');
+    } else if (cause === 'terminate') {
+      kernel.queueToKref(alice, 'terminate', [], 'none');
+    }
+    await kernel.run();
+    t.is(kvStore.get(`${amy}.owner`), undefined);
+  }
+
+  t.is(kvStore.get(`${amy}.refCount`), '1,1');
+  t.is(kvStore.get(`${vatB}.c.${amy}`), `R ${vrefs.amyForB}`);
+
+  // vatB now drops/retires/neither the "amy" object
+
+  if (amyState === 'reachable') {
+    // no change
+  } else if (amyState === 'recognizable') {
+    kernel.queueToKref(bob, 'drop', [], 'none');
+    await kernel.run();
+    if (when === 'before') {
+      // dropping an abandoned object should also retire it
+      t.true(amyRetiredToB); // fixed by #7212
+      t.is(kvStore.get(`${vatB}.c.${amy}`), undefined);
+      t.is(kvStore.get(`${amy}.refCount`), undefined);
+    } else {
+      // dropping a living object should merely drop it
+      t.is(kvStore.get(`${vatB}.c.${amy}`), `_ ${vrefs.amyForB}`);
+      t.is(kvStore.get(`${amy}.refCount`), '0,1');
+    }
+  } else if (amyState === 'none') {
+    kernel.queueToKref(bob, 'drop and retire', [], 'none');
+    await kernel.run();
+    t.is(kvStore.get(`${vatB}.c.${amy}`), undefined);
+    t.is(kvStore.get(`${amy}.refCount`), undefined);
+  }
+
+  if (when === 'after') {
+    // the object is abandoned *after* vatB drops anything
+    if (cause === 'abandon') {
+      kernel.queueToKref(alice, 'abandon', [], 'none');
+    } else if (cause === 'terminate') {
+      kernel.queueToKref(alice, 'terminate', [], 'none');
+    }
+    await kernel.run();
+  }
+
+  t.is(kvStore.get(`${amy}.owner`), undefined);
+
+  if (amyState === 'reachable') {
+    // amy should remain defined and reachable, just lacking an owner
+    t.is(kvStore.get(`${vatB}.c.${amy}`), `R ${vrefs.amyForB}`);
+    t.is(kvStore.get(`${amy}.refCount`), '1,1');
+  } else if (amyState === 'recognizable') {
+    // an unreachable koid should be retired upon abandonment
+    t.true(amyRetiredToB); // fixed by #7212
+    t.is(kvStore.get(`${vatB}.c.${amy}`), undefined);
+    t.is(kvStore.get(`${amy}.refCount`), undefined);
+  } else if (amyState === 'none') {
+    // no change
+  }
+});
+
+for (const cause of ['abandon', 'terminate']) {
+  for (const when of ['before', 'after']) {
+    for (const amyState of ['reachable', 'recognizable', 'none']) {
+      test(
+        `orphan test ${cause}-${when}-${amyState}`,
+        orphanTest,
+        cause,
+        when,
+        amyState,
+      );
+    }
+  }
+}
+
+// exercise a failure case I saw in the zoe tests (zoe -
+// secondPriceAuction - valid inputs):
+// * vatB is exporting an object ko120 to vatA
+// * vatA does E(ko120).wake(), then drops the reference
+//   (vatA can still recognize ko120)
+// * vatA gets a BOYD, does syscall.dropImport(ko120)
+// * ko120.refCount = 1,2  (0,1 from vatA, 1,1 from the run-queue wake())
+// * wake() is delivered to vatB
+//   * removing it from the run-queue drops refCount to 0,1
+//   * and adds ko120 to maybeFreeKrefs
+//   * wake() provokes vatB to syscall.exit
+//   * post-crank terminateVat() orphans ko120, then retires it
+//     * deleting both .owner and .refCount
+//   * post-er-crank processRefcounts sees ko120 in maybeFreeKrefs
+//     * tries to look up .refCount, fails, panics
+
+// the fix was to change kernelKeeper.getRefCounts to handle a missing
+// koNN.refCounts by just returning 0,0
+
+test('termination plus maybeFreeKrefs', async t => {
+  const { kernel, kvStore } = await makeKernel();
+  await kernel.start();
+
+  const vrefs = {}; // track vrefs within vats
+
+  // vatB exports an object to vatA, vatA sends it a message and drops
+  // it (but doesn't retire it), vatB will self-terminate upon
+  // receiving that message, creating two places that try to retire it
+
+  // Our two root objects (alice and bob) are pinned so they don't
+  // disappear while the test is talking to them, so vatB exports
+  // "billy".
+
+  vrefs.aliceForA = 'o+100';
+  vrefs.bobForB = 'o+200';
+  vrefs.billyForB = 'o+201';
+  let billyKref;
+
+  let vatA;
+  function setupA(syscall, _state, _helpers, _vatPowers) {
+    function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
+      // console.log(`deliverA:`, JSON.stringify(vd));
+      if (vd[0] === 'message') {
+        const methargs = kunser(vd[2].methargs);
+        const [method] = methargs;
+        if (method === 'call-billy') {
+          t.is(vd[2].methargs.slots.length, 1);
+          vrefs.billyForA = vd[2].methargs.slots[0];
+          t.is(vrefs.billyForA, 'o-50'); // probably
+          billyKref = kvStore.get(`${vatA}.c.${vrefs.billyForA}`);
+          syscall.send(
+            vrefs.billyForA,
+            kser(['terminate', [kslot(vrefs.billyForA, 'billy-A')]]),
+          );
+          syscall.dropImports([vrefs.billyForA]);
+        }
+      }
+    }
+    return dispatch;
+  }
+  await kernel.createTestVat('vatA', setupA);
+  vatA = kernel.vatNameToID('vatA');
+  const alice = kernel.addExport(vatA, vrefs.aliceForA);
+
+  function setupB(syscall, _state, _helpers, _vatPowers) {
+    function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
+      // console.log(`deliverB:`, JSON.stringify(vd));
+      if (vd[0] === 'message') {
+        const [method] = kunser(vd[2].methargs);
+        if (method === 'init') {
+          vrefs.aliceForB = vd[2].methargs.slots[0];
+          syscall.send(
+            vrefs.aliceForB,
+            kser(['call-billy', [kslot(vrefs.billyForB, 'billy-B')]]),
+          );
+        }
+        if (method === 'terminate') {
+          t.is(vd[2].methargs.slots.length, 1);
+          assert.equal(vd[2].methargs.slots[0], vrefs.billyForB);
+          syscall.exit(false, kser('reason'));
+        }
+      }
+    }
+    return dispatch;
+  }
+  await kernel.createTestVat('vatB', setupB);
+  const vatB = kernel.vatNameToID('vatB');
+  const bob = kernel.addExport(vatB, vrefs.bobForB);
+
+  // this triggers everything, the bug was a kernel crash
+  kernel.queueToKref(bob, 'init', [kslot(alice, 'alice')], 'none');
+  await kernel.run();
+
+  t.is(kvStore.get(`${billyKref}.owner`), undefined);
+  t.is(kvStore.get(`${billyKref}.refCounts`), undefined);
+});

--- a/packages/SwingSet/test/gc-kernel.test.js
+++ b/packages/SwingSet/test/gc-kernel.test.js
@@ -1091,12 +1091,15 @@ test('terminated vat', async t => {
   // we'll watch for this to be deleted when the vat is terminated
   // console.log(`pinKref`, pinKref);
 
-  // find the highest export: doomedExport1 / doomedExport1Presence
+  // find the two highest exports: doomedExport[13] / doomedExport[13]Presence
   let exports = Object.keys(vrefs).filter(vref => vref.startsWith('o+'));
   sortVrefs(exports);
-  const doomedExport1Vref = exports[exports.length - 1];
+  const doomedExport1Vref = exports[exports.length - 2];
+  const doomedExport3Vref = exports[exports.length - 1];
   t.is(doomedExport1Vref, 'o+10'); // arbitrary
+  t.is(doomedExport3Vref, 'o+11'); // arbitrary
   const doomedExport1Kref = vrefs[doomedExport1Vref];
+  const doomedExport3Kref = vrefs[doomedExport3Vref];
   // this should also be deleted
   // console.log(`doomedExport1Kref`, doomedExport1Kref);
 
@@ -1105,6 +1108,8 @@ test('terminated vat', async t => {
   t.is(owners[pinKref], bootstrapVat);
   t.deepEqual(refcounts[doomedExport1Kref], [1, 1]);
   t.is(owners[doomedExport1Kref], doomedVat);
+  t.deepEqual(refcounts[doomedExport3Kref], [0, 1]);
+  t.is(owners[doomedExport3Kref], doomedVat);
 
   // Tell bootstrap to give a promise to the doomed vat. The doomed vat will
   // send a second export in a message to this promise, so the only
@@ -1117,7 +1122,7 @@ test('terminated vat', async t => {
   exports = Object.keys(vrefs).filter(vref => vref.startsWith('o+'));
   sortVrefs(exports);
   const doomedExport2Vref = exports[exports.length - 1];
-  t.is(doomedExport2Vref, 'o+11'); // arbitrary
+  t.is(doomedExport2Vref, 'o+12'); // arbitrary
   const doomedExport2Kref = vrefs[doomedExport2Vref];
   [refcounts, owners] = getRefCountsAndOwners();
   t.deepEqual(refcounts[doomedExport2Kref], [1, 1]); // from promise queue
@@ -1137,6 +1142,9 @@ test('terminated vat', async t => {
   t.deepEqual(refcounts[doomedExport2Kref], [1, 1]);
   t.falsy(owners[doomedExport1Kref]);
   t.falsy(owners[doomedExport2Kref]);
+  // but the merely-recognizable export should be deleted
+  t.falsy(owners[doomedExport3Kref]);
+  t.deepEqual(refcounts[doomedExport3Kref], undefined);
 
   // send a message to the orphan, to wiggle refcounts some more
   const r = c.queueToVatRoot('bootstrap', 'callOrphan', [], 'panic');

--- a/packages/SwingSet/test/gc-kernel.test.js
+++ b/packages/SwingSet/test/gc-kernel.test.js
@@ -1157,12 +1157,8 @@ test('terminated vat', async t => {
   c.queueToVatRoot('bootstrap', 'drop', [], 'panic');
   await c.run();
 
-  // TODO: however, for some reason neither Node.js nor XS actually drops
-  // 'doomedExport1Presence', despite it clearly going out of scope. I don't
-  // know why. Until we can find way to make it drop, this check is commented
-  // out.
   [refcounts, owners] = getRefCountsAndOwners();
-  // t.is(refcounts[doomedExport1Kref], undefined);
+  t.is(refcounts[doomedExport1Kref], undefined);
   t.falsy(owners[doomedExport1Kref]);
 
   t.is(refcounts[doomedExport2Kref], undefined);

--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -707,20 +707,11 @@ test('non-durable exports are abandoned by upgrade of non-liveslots vat', async 
     '1,1',
     'strong observation of abandoned object retains ref counts',
   );
-  // TODO: Expect and verify observer receipt of dispatch.retireExports
-  // and corresponding removal of weakKref ref counts.
-  // https://github.com/Agoric/agoric-sdk/issues/7212
   t.is(
     kvStore.get(`${weakKref}.refCount`),
-    '0,1',
-    'weak observation of abandoned object retains ref counts before #7212',
+    undefined,
+    'unreachable abandoned object is forgotten',
   );
-  // t.is(
-  //   kvStore.get(`${weakKref}.refCount`),
-  //   undefined,
-  //   'unreachable abandoned object is forgotten',
-  // );
-  // const observerLog = await messageToVat('observer', 'getDispatchLog');
 });
 
 // No longer valid as of removing stopVat per #6650


### PR DESCRIPTION
fix(swingset): retire unreachable orphans

If a kernel object ("koid", the object subset of krefs) is
unreachable, and then becomes orphaned (either because the owning vat
was terminated, or called `syscall.abandonExports`, or was upgraded
and the koid was ephemeral), then retire it immediately.

The argument is that the previously-owning vat can never again talk
about the object, so it can never become reachable again, which is
normally the point at which the owning vat would retire it. But
because the owning vat can't retire it by itself, the kernel needs to
do the retirement on its behalf.

We now consolidate retirement responsibilities into
processRefcounts(): when terminateVat or syscall.abandonExports use
abandonKernelObjects() to mark a kref as orphaned, it also adds the
kref to maybeFreeKrefs, and then processRefcounts() is responsible for
noticing the kref is both orphaned and unreachable, and then notifying
any importers of its retirement.

I double-checked that cleanupAfterTerminatedVat will always be
followed by a processRefcounts(), by virtue of either being called
from processDeliveryMessage (in the crankResults.terminate clause), or
from within a device invocation syscall (which only happens during a
delivery, so follows the same path). We need this to ensure that any
maybeFreeKrefs created by the cleanup's abandonKernelObjects() will
get processed promptly.

Changes getObjectRefCount to tolerate deleted krefs (missing
`koNN.refCount`) by just returning 0,0. This fixes a potential kernel
panic in the new approach, when a kref is recognizable by one vat but
only reachable by a send-message on the run-queue, then becomes
unreachable as that message is delivered (the run-queue held the last
strong reference), if the target vat does syscall.exit during the
delivery. The decref pushes the kref onto maybeFreeKrefs, the
terminateVat retires the merely-recognizable now-orphaned kref, then
processRefcounts used getObjectRefCount() to grab the refcount for the
now-retired (and deleted) kref, which asserted that the koNN.refCount
key still existed, which didn't.

This occured in zoe - secondPriceAuction -- valid input , where the
contract did syscall.exit in response to a timer wake() message sent
to a single-use wakeObj.

closes #7212
