### PR TITLE
fix(vow): include vat.js in package files

### DIFF
--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -45,6 +45,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "files": [
+    "*.js",
     "src"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Problem

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@agoric/vow/vat.js' imported from .../contract/test/test-contract.js
```

### Testing Considerations

This manual test passes with this PR but fails without it:

```console
~/projects/agoric-sdk/packages/vow$ yarn pack
~/projects/agoric-sdk/packages/vow$ tar tf *.tgz |grep vat
package/vat.js
```
