### PR TITLE
fix: typescript-estree does not support Node.js LTS

### DIFF
--- a/patches/@typescript-eslint+typescript-estree+7.13.0.patch
+++ b/patches/@typescript-eslint+typescript-estree+7.13.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@typescript-eslint/typescript-estree/package.json b/node_modules/@typescript-eslint/typescript-estree/package.json
+index 3a1b7a2..8c8c9f2 100644
+--- a/node_modules/@typescript-eslint/typescript-estree/package.json
++++ b/node_modules/@typescript-eslint/typescript-estree/package.json
+@@ -22,7 +22,7 @@
+   },
+   "types": "./dist/index.d.ts",
+   "engines": {
+-    "node": "^18.18.0 || >=20.0.0"
++    "node": "^18.12 || >=20.0.0"
+   },
+   "repository": {
+     "type": "git",


### PR DESCRIPTION
## Description

Patch `@typescript-eslint/typescript-estree` to support node 18.12 (LTS)
