### PR TITLE
feat(vows): improve handling of ephemeral values

### DIFF
--- a/packages/base-zone/src/watch-promise.js
+++ b/packages/base-zone/src/watch-promise.js
@@ -9,7 +9,7 @@ const { apply } = Reflect;
 /**
  * A PromiseWatcher method guard callable with or more arguments, returning void.
  */
-export const PromiseWatcherHandler = M.call(M.any()).rest(M.any()).returns();
+export const PromiseWatcherHandler = M.call(M.raw()).rest(M.raw()).returns();
 
 /**
  * A PromiseWatcher interface that has both onFulfilled and onRejected handlers.

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -7,7 +7,7 @@ import { makeAsVow } from './vow-utils.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
- * @import {IsRetryableReason, AsPromiseFunction, Vow, EVow} from './types.js';
+ * @import {IsRetryableReason, AsPromiseFunction, EVow} from './types.js';
  */
 
 /**

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -5,8 +5,10 @@ import { prepareWatch } from './watch.js';
 import { prepareWatchUtils } from './watch-utils.js';
 import { makeAsVow } from './vow-utils.js';
 
-/** @import {Zone} from '@agoric/base-zone' */
-/** @import {IsRetryableReason, AsPromiseFunction} from './types.js' */
+/**
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {IsRetryableReason, AsPromiseFunction} from './types.js';
+ */
 
 /**
  * @param {Zone} zone

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -7,7 +7,7 @@ import { makeAsVow } from './vow-utils.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
- * @import {IsRetryableReason, AsPromiseFunction} from './types.js';
+ * @import {IsRetryableReason, AsPromiseFunction, Vow, EVow} from './types.js';
  */
 
 /**
@@ -33,9 +33,9 @@ export const prepareVowTools = (zone, powers = {}) => {
   /**
    * Vow-tolerant implementation of Promise.all.
    *
-   * @param {unknown[]} vows
+   * @param {EVow<unknown>[]} maybeVows
    */
-  const allVows = vows => watchUtils.all(vows);
+  const allVows = maybeVows => watchUtils.all(maybeVows);
 
   /** @type {AsPromiseFunction} */
   const asPromise = (specimenP, ...watcherArgs) =>

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -6,7 +6,7 @@ import { prepareWatchUtils } from './watch-utils.js';
 import { makeAsVow } from './vow-utils.js';
 
 /** @import {Zone} from '@agoric/base-zone' */
-/** @import {IsRetryableReason} from './types.js' */
+/** @import {IsRetryableReason, AsPromiseFunction} from './types.js' */
 
 /**
  * @param {Zone} zone
@@ -35,7 +35,11 @@ export const prepareVowTools = (zone, powers = {}) => {
    */
   const allVows = vows => watchUtils.all(vows);
 
-  return harden({ when, watch, makeVowKit, allVows, asVow });
+  /** @type {AsPromiseFunction} */
+  const asPromise = (specimenP, ...watcherArgs) =>
+    watchUtils.asPromise(specimenP, ...watcherArgs);
+
+  return harden({ when, watch, makeVowKit, allVows, asVow, asPromise });
 };
 harden(prepareVowTools);
 

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -19,7 +19,12 @@ export const prepareVowTools = (zone, powers = {}) => {
   const makeVowKit = prepareVowKit(zone);
   const when = makeWhen(isRetryableReason);
   const watch = prepareWatch(zone, makeVowKit, isRetryableReason);
-  const makeWatchUtils = prepareWatchUtils(zone, watch, makeVowKit);
+  const makeWatchUtils = prepareWatchUtils(zone, {
+    watch,
+    when,
+    makeVowKit,
+    isRetryableReason,
+  });
   const watchUtils = makeWatchUtils();
   const asVow = makeAsVow(makeVowKit);
 

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -30,6 +30,12 @@ export {};
  */
 
 /**
+ * Eventually a value T or Vow for it.
+ * @template T
+ * @typedef {ERef<T | Vow<T>>} EVow
+ */
+
+/**
  * Follow the chain of vow shortening to the end, returning the final value.
  * This is used within E, so we must narrow the type to its remote form.
  * @template T

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -86,3 +86,17 @@ export {};
  * @property {(value: T, ...args: C) => Vow<TResult1> | PromiseVow<TResult1> | TResult1} [onFulfilled]
  * @property {(reason: any, ...args: C) => Vow<TResult2> | PromiseVow<TResult2> | TResult2} [onRejected]
  */
+
+/**
+ * Converts a vow or promise to a promise, ensuring proper handling of ephemeral promises.
+ *
+ * @template [T=any]
+ * @template [TResult1=T]
+ * @template [TResult2=never]
+ * @template {any[]} [C=any[]]
+ * @callback AsPromiseFunction
+ * @param {ERef<T | Vow<T>>} specimenP
+ * @param {Watcher<T, TResult1, TResult2, C>} [watcher]
+ * @param {C} [watcherArgs]
+ * @returns {Promise<TResult1 | TResult2>}
+ */

--- a/packages/vow/src/vow.js
+++ b/packages/vow/src/vow.js
@@ -9,6 +9,7 @@ const { details: X } = assert;
 /**
  * @import {PromiseKit} from '@endo/promise-kit';
  * @import {Zone} from '@agoric/base-zone';
+ * @import {MapStore} from '@agoric/store';
  * @import {VowResolver, VowKit} from './types.js';
  */
 
@@ -78,6 +79,12 @@ export const prepareVowKit = zone => {
         null
       ),
       isStoredValue: /** @type {boolean} */ (false),
+      /**
+       * Map for future properties that aren't in the schema.
+       * UNTIL https://github.com/Agoric/agoric-sdk/issues/7407
+       * @type {MapStore<any, any> | undefined}
+       */
+      extra: undefined,
     }),
     {
       vowV0: {

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -6,12 +6,11 @@ import { PromiseWatcherI } from '@agoric/base-zone';
 const { Fail, bare, details: X } = assert;
 
 /**
- * @import {MapStore} from '@agoric/store/src/types.js'
- * @import { Zone } from '@agoric/base-zone'
- * @import { Watch } from './watch.js'
- * @import { When } from './when.js'
- * @import {VowKit, AsPromiseFunction} from './types.js'
- * @import {IsRetryableReason} from './types.js'
+ * @import {MapStore} from '@agoric/store/src/types.js';
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {Watch} from './watch.js';
+ * @import {When} from './when.js';
+ * @import {VowKit, AsPromiseFunction, IsRetryableReason, Vow, EVow} from './types.js';
  */
 
 const VowShape = M.tagged(
@@ -81,7 +80,7 @@ export const prepareWatchUtils = (
     {
       utils: {
         /**
-         * @param {unknown[]} vows
+         * @param {EVow<unknown>[]} vows
          */
         all(vows) {
           const { nextId: id, idToVowState } = this.state;

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -88,24 +88,22 @@ export const prepareWatchUtils = (
           const kit = makeVowKit();
 
           // Preserve the order of the vow results.
-          let index = 0;
-          for (const vow of vows) {
-            watch(vow, this.facets.watcher, {
+          for (let index = 0; index < vows.length; index += 1) {
+            watch(vows[index], this.facets.watcher, {
               id,
               index,
               numResults: vows.length,
             });
-            index += 1;
           }
 
-          if (index > 0) {
+          if (vows.length > 0) {
             // Save the state until rejection or all fulfilled.
             this.state.nextId += 1n;
             idToVowState.init(
               id,
               harden({
                 resolver: kit.resolver,
-                remaining: index,
+                remaining: vows.length,
                 resultsMap: detached.mapStore('resultsMap'),
               }),
             );

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -10,7 +10,7 @@ const { Fail, bare, details: X } = assert;
  * @import {Zone} from '@agoric/base-zone';
  * @import {Watch} from './watch.js';
  * @import {When} from './when.js';
- * @import {VowKit, AsPromiseFunction, IsRetryableReason, Vow, EVow} from './types.js';
+ * @import {VowKit, AsPromiseFunction, IsRetryableReason, EVow} from './types.js';
  */
 
 const VowShape = M.tagged(

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -10,7 +10,7 @@ const { Fail, bare } = assert;
  * @import { Zone } from '@agoric/base-zone'
  * @import { Watch } from './watch.js'
  * @import { When } from './when.js'
- * @import {VowKit} from './types.js'
+ * @import {VowKit, AsPromiseFunction} from './types.js'
  * @import {IsRetryableReason} from './types.js'
  */
 
@@ -96,6 +96,7 @@ export const prepareWatchUtils = (
           }
           return kit.vow;
         },
+        /** @type {AsPromiseFunction} */
         asPromise(specimenP, ...watcherArgs) {
           // Watch the specimen in case it is an ephemeral promise.
           const vow = watch(specimenP, ...watcherArgs);

--- a/packages/vow/src/watch.js
+++ b/packages/vow/src/watch.js
@@ -6,7 +6,7 @@ const { apply } = Reflect;
 
 /**
  * @import { PromiseWatcher, Zone } from '@agoric/base-zone';
- * @import { ERef, IsRetryableReason, Vow, VowKit, VowResolver, Watcher } from './types.js';
+ * @import { ERef, EVow, IsRetryableReason, Vow, VowKit, VowResolver, Watcher } from './types.js';
  */
 
 /**
@@ -170,7 +170,7 @@ export const prepareWatch = (
    * @template [TResult1=T]
    * @template [TResult2=never]
    * @template {any[]} [C=any[]] watcher args
-   * @param {ERef<T | Vow<T>>} specimenP
+   * @param {EVow<T>} specimenP
    * @param {Watcher<T, TResult1, TResult2, C>} [watcher]
    * @param {C} watcherArgs
    */

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -247,6 +247,7 @@ test('asPromise handles watcher arguments', async t => {
     },
   };
 
+  // XXX fix type: `watcherContext` doesn't need to be an array
   const result = await asPromise(vow, watcher, ['ctx']);
   t.is(result, 'watcher test');
   t.true(watcherCalled);

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -199,3 +199,55 @@ test('allVows does NOT support Vow pipelining', async t => {
     message: 'target has no method "getAddress", has []',
   });
 });
+
+test('asPromise converts a vow to a promise', async t => {
+  const zone = makeHeapZone();
+  const { watch, asPromise } = prepareVowTools(zone);
+
+  const testPromiseP = Promise.resolve('test value');
+  const vow = watch(testPromiseP);
+
+  const result = await asPromise(vow);
+  t.is(result, 'test value');
+});
+
+test('asPromise handles vow rejection', async t => {
+  const zone = makeHeapZone();
+  const { watch, asPromise } = prepareVowTools(zone);
+
+  const testPromiseP = Promise.reject(new Error('test error'));
+  const vow = watch(testPromiseP);
+
+  await t.throwsAsync(asPromise(vow), { message: 'test error' });
+});
+
+test('asPromise accepts and resolves promises', async t => {
+  const zone = makeHeapZone();
+  const { asPromise } = prepareVowTools(zone);
+
+  const p = Promise.resolve('a promise');
+  const result = await asPromise(p);
+  t.is(result, 'a promise');
+});
+
+test('asPromise handles watcher arguments', async t => {
+  const zone = makeHeapZone();
+  const { watch, asPromise } = prepareVowTools(zone);
+
+  const testPromiseP = Promise.resolve('watcher test');
+  const vow = watch(testPromiseP);
+
+  let watcherCalled = false;
+  const watcher = {
+    onFulfilled(value, ctx) {
+      watcherCalled = true;
+      t.is(value, 'watcher test');
+      t.deepEqual(ctx, ['ctx']);
+      return value;
+    },
+  };
+
+  const result = await asPromise(vow, watcher, ['ctx']);
+  t.is(result, 'watcher test');
+  t.true(watcherCalled);
+});


### PR DESCRIPTION
refs: #9308

## Description
- adds `asPromise` helper to `VowTools` for unwrapping `Vow|Promise`, ensuring proper handling of ephemeral promises
- updates watch-utils to better handle values that are not storable durably, such as promises

### Testing Considerations
This does not include tests that simulate an upgrade - only a heap zone is used in the included tests. See https://github.com/Agoric/agoric-sdk/issues/9631

### Upgrade Considerations
This PR includes changes we'd like to be in the initial release of vows.
