### PR TITLE
Upgrade-16 cherry-picks round 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@ packages/stat-logger
 **/_agstate
 .vagrant
 endo-sha.txt
+packages/xsnap/build.config.env
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
 packages/xsnap/moddable

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -45,6 +45,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "files": [
+    "*.js",
     "src"
   ],
   "publishConfig": {

--- a/packages/xsnap/.gitignore
+++ b/packages/xsnap/.gitignore
@@ -1,4 +1,5 @@
 build
+build.config.env
 dist
 test/fixture-snap-pool/
 test/fixture-snap-shot.xss

--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,4 @@
 MODDABLE_URL=https://github.com/agoric-labs/moddable.git
 MODDABLE_COMMIT_HASH=f6c5951fc055e4ca592b9166b9ae3cbb9cca6bf0
 XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
-XSNAP_NATIVE_COMMIT_HASH=2d8ccb76b8508e490d9e03972bb4c64f402d5135
+XSNAP_NATIVE_COMMIT_HASH=eef9b67da5517ed18ff9e0073b842db20924eae3

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -16,6 +16,7 @@
     "build:env": "node src/build.js --show-env > build.env",
     "build:from-env": "{ cat build.env; echo node src/build.js; } | xargs env",
     "build": "yarn build:bin && yarn build:env",
+    "check-version": "xsnap_version=$(./scripts/get_xsnap_version.sh); if test \"${npm_package_version}\" != \"${xsnap_version}\"; then echo \"xsnap version mismatch; expected '${npm_package_version}', got '${xsnap_version}'\"; exit 1; fi",
     "postinstall": "npm run build:from-env",
     "clean": "rm -rf xsnap-native/xsnap/build",
     "lint": "run-s --continue-on-error lint:*",
@@ -56,6 +57,7 @@
     "moddable/xs/makefiles",
     "moddable/xs/platforms/*.h",
     "moddable/xs/sources",
+    "scripts",
     "src",
     "xsnap-native/xsnap/makefiles",
     "xsnap-native/xsnap/sources"

--- a/packages/xsnap/scripts/get_xsnap_version.sh
+++ b/packages/xsnap/scripts/get_xsnap_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+# the xsnap binary lives in a platform-specific directory
+unameOut="$(uname -s)"
+case "${unameOut}" in
+  Linux*) platform=lin ;;
+  Darwin*) platform=mac ;;
+  *) platform=win ;;
+esac
+
+# extract the xsnap package version from the long version printed by xsnap-worker
+"./xsnap-native/xsnap/build/bin/${platform}/release/xsnap-worker" -v | sed -e 's/^xsnap \([^ ]*\) (XS [^)]*)$/\1/g'

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -20,7 +20,7 @@ golang_version_check() {
 nodejs_version_check() {
   {
     [ "$1" -eq 18 ] && [ "$2" -ge 12 ] && return 0
-    [ "$1" -ge 20 ] && [ "$2" -ge 9 ] && return 0
+    [ "$1" -eq 20 ] && [ "$2" -ge 9 ] && return 0
   } 2> /dev/null
   echo 1>&2 "need Node.js LTS version ^18.12 or ^20.9, found $1.$2.$3"
   return 1

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -4,7 +4,6 @@ NODEJS_VERSION=v16
 GOLANG_VERSION=1.20.3
 GOLANG_DIR=golang/cosmos
 GOLANG_DAEMON=$GOLANG_DIR/build/agd
-XSNAP_VERSION=agoric-upgrade-10
 
 # Args are major, minor and patch version numbers
 golang_version_check() {
@@ -12,7 +11,7 @@ golang_version_check() {
     [ "$1" -eq 1 ] && [ "$2" -eq 20 ] && [ "$3" -ge 2 ] && return 0
     [ "$1" -eq 1 ] && [ "$2" -ge 21 ] && return 0
     [ "$1" -ge 2 ] && return 0
-  } 2>/dev/null
+  } 2> /dev/null
   echo 1>&2 "need go version 1.20.2+, 1.21+, or 2+"
   return 1
 }

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 # shellcheck disable=SC2034
-NODEJS_VERSION=v16
+NODEJS_VERSION=v20
 GOLANG_VERSION=1.20.3
 GOLANG_DIR=golang/cosmos
 GOLANG_DAEMON=$GOLANG_DIR/build/agd
@@ -13,5 +13,15 @@ golang_version_check() {
     [ "$1" -ge 2 ] && return 0
   } 2> /dev/null
   echo 1>&2 "need go version 1.20.2+, 1.21+, or 2+"
+  return 1
+}
+
+# Args are major, minor and patch version numbers
+nodejs_version_check() {
+  {
+    [ "$1" -eq 18 ] && [ "$2" -ge 12 ] && return 0
+    [ "$1" -ge 20 ] && [ "$2" -ge 9 ] && return 0
+  } 2> /dev/null
+  echo 1>&2 "need Node.js LTS version ^18.12 or ^20.9, found $1.$2.$3"
   return 1
 }

--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -106,6 +106,12 @@ if $need_nodejs; then
       } 1>&2
       ;;
   esac
+
+  if nodeversion=$(node --version 2> /dev/null); then
+    noderegexp='v([0-9]+)\.([0-9]+)\.([0-9]+)'
+    [[ "$nodeversion" =~ $noderegexp ]] || fatal "illegible node version '$nodeversion'"
+    nodejs_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" || exit 1
+  fi
 fi
 
 $do_not_build || (
@@ -194,7 +200,9 @@ $do_not_build || (
     test -z "$src" || {
       echo "At least $src is newer than node_modules"
       rm -f "$STAMPS/yarn-built"
-      lazy_yarn install
+      # Ignore engines since we already checked officially supported versions above
+      # UNTIL https://github.com/Agoric/agoric-sdk/issues/9622
+      lazy_yarn install --ignore-engines
     }
 
     stamp=$STAMPS/yarn-built

--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -219,20 +219,11 @@ $do_not_build || (
       echo "At least $src is newer than gyp bindings"
       (cd "$GOLANG_DIR" && lazy_yarn build:gyp)
     }
+
+    # check the built xsnap version against the package version it should be using
+    (cd "${thisdir}/../packages/xsnap" && npm run -s check-version) || exit 1
   fi
 )
-
-# the xsnap binary lives in a platform-specific directory
-unameOut="$(uname -s)"
-case "${unameOut}" in
-  Linux*) platform=lin ;;
-  Darwin*) platform=mac ;;
-  *) platform=win ;;
-esac
-
-# check the xsnap version against our baked-in notion of what version we should be using
-xsnap_version=$("${thisdir}/../packages/xsnap/xsnap-native/xsnap/build/bin/${platform}/release/xsnap-worker" -n)
-[[ "${xsnap_version}" == "${XSNAP_VERSION}" ]] || fatal "xsnap version mismatch; expected ${XSNAP_VERSION}, got ${xsnap_version}"
 
 if $only_build; then
   echo "Build complete." 1>&2


### PR DESCRIPTION
Rebase todo

```
# Branch fix-vow-include-vat-js-in-package-files-9607-
label base-fix-vow-include-vat-js-in-package-files-9607-
pick b6ffa6f09e fix(vow): include vat.js in package files
label fix-vow-include-vat-js-in-package-files-9607-
reset base-fix-vow-include-vat-js-in-package-files-9607-
merge -C a3826e91d9 fix-vow-include-vat-js-in-package-files-9607- # fix(vow): include vat.js in package files (#9607)

# Pull Request #9601
pick 6bc363b562 fix(cosmos): only allow snapshot export at latest height (#9601)

# Branch Force-xsnap-rebuild-9618-
label base-Force-xsnap-rebuild-9618-
pick 467435aeea fix(xsnap): force rebuild if build config changes
pick a22772e03e fix(agd): check xsnap was rebuilt
pick 2b53896d5d feat(xsnap): force rebuild if binary version mismatch
label Force-xsnap-rebuild-9618-
reset base-Force-xsnap-rebuild-9618-
merge -C 78b6fec067 Force-xsnap-rebuild-9618- # Force xsnap rebuild (#9618)

# Branch agd-enforce-Node-js-version-9623-
label base-agd-enforce-Node-js-version-9623-
#pick 4b35cafd57 revert fix: typescript-estree does not support Node.js LTS (#9619)
pick 5f01bef764 fix(agd): force own node.js version check
label agd-enforce-Node-js-version-9623-
reset base-agd-enforce-Node-js-version-9623-
merge -C 4f70e66a2f agd-enforce-Node-js-version-9623- # agd enforce Node.js version (#9623)

# Branch gibson-9623-followup
label base-gibson-9623-followup
pick 6102eb9149 fix: Disallow Node.js major version >20
label gibson-9623-followup
reset base-gibson-9623-followup
merge -C caaec0575a gibson-9623-followup # (upstream/master) fix: Disallow Node.js major version >20 (#9630)
```
