### PR TITLE
fix: Disallow Node.js major version >20

### DIFF
--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -20,7 +20,7 @@ golang_version_check() {
 nodejs_version_check() {
   {
     [ "$1" -eq 18 ] && [ "$2" -ge 12 ] && return 0
-    [ "$1" -ge 20 ] && [ "$2" -ge 9 ] && return 0
+    [ "$1" -eq 20 ] && [ "$2" -ge 9 ] && return 0
   } 2> /dev/null
   echo 1>&2 "need Node.js LTS version ^18.12 or ^20.9, found $1.$2.$3"
   return 1


### PR DESCRIPTION
refs: #9622

## Description
#9623 claimed to enforce Node.js versions ^18.12 or ^20.9, but due to a typo allows arbitrarily high versions to pass the check. This corrects it to enforce that the major version is exactly 18 or 20.

### Security Considerations
None.

### Scaling Considerations
n/a

### Documentation Considerations
Matches the [README](https://github.com/Agoric/agoric-sdk?tab=readme-ov-file#prerequisites).

### Testing Considerations
Checked by integration testing in CI.

### Upgrade Considerations
Will need an update for supporting Node.js v22 when that enters LTS (ref #9265).