### PR TITLE
offer result vows in smart wallet 

### DIFF
--- a/a3p-integration/debug-current.sh
+++ b/a3p-integration/debug-current.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Convience script to debug the current proposal being worked on.
+
+scripts/build-submission.sh proposals/b:enable-orchestration testing/start-valueVow.js start-valueVow
+scripts/build-submission.sh proposals/b:enable-orchestration testing/restart-valueVow.js restart-valueVow
+
+yarn test -m orch --debug

--- a/a3p-integration/proposals/b:enable-orchestration/.gitignore
+++ b/a3p-integration/proposals/b:enable-orchestration/.gitignore
@@ -1,1 +1,3 @@
+/restart-valueVow
+/start-valueVow
 /submission

--- a/a3p-integration/proposals/b:enable-orchestration/initial.test.js
+++ b/a3p-integration/proposals/b:enable-orchestration/initial.test.js
@@ -8,7 +8,7 @@ const vats = {
   localchain: { incarnation: 0 },
   orchestration: { incarnation: 0 },
   transfer: { incarnation: 0 },
-  walletFactory: { incarnation: 3 },
+  walletFactory: { incarnation: 4 },
   zoe: { incarnation: 2 },
 };
 

--- a/a3p-integration/proposals/b:enable-orchestration/package.json
+++ b/a3p-integration/proposals/b:enable-orchestration/package.json
@@ -3,6 +3,7 @@
     "type": "/agoric.swingset.CoreEvalProposal",
     "source": "subdir",
     "sdk-generate": [
+      "smart-wallet/build-wallet-factory2-upgrade.js",
       "vats/init-orchestration.js"
     ]
   },

--- a/a3p-integration/proposals/b:enable-orchestration/package.json
+++ b/a3p-integration/proposals/b:enable-orchestration/package.json
@@ -4,14 +4,25 @@
     "source": "subdir",
     "sdk-generate": [
       "smart-wallet/build-wallet-factory2-upgrade.js",
+      "testing/start-valueVow.js start-valueVow",
+      "testing/restart-valueVow.js restart-valueVow",
       "vats/init-orchestration.js"
     ]
   },
   "type": "module",
   "license": "Apache-2.0",
   "dependencies": {
+    "@agoric/internal": "0.3.3-dev-5676146.0",
     "@agoric/synthetic-chain": "^0.1.0",
-    "ava": "^5.3.1"
+    "@cosmjs/stargate": "^0.32.3",
+    "@cosmjs/tendermint-rpc": "^0.32.3",
+    "@endo/errors": "^1.2.2",
+    "@endo/far": "^1.0.4",
+    "@endo/init": "^1.0.4",
+    "agoric": "0.21.2-dev-5676146.0",
+    "ava": "^5.3.1",
+    "execa": "^8.0.1",
+    "node-fetch": "^3.3.2"
   },
   "ava": {
     "concurrency": 1,

--- a/a3p-integration/proposals/b:enable-orchestration/test-lib/chain.js
+++ b/a3p-integration/proposals/b:enable-orchestration/test-lib/chain.js
@@ -1,0 +1,140 @@
+/** @file copied from packages/agoric-cli */
+// TODO DRY in https://github.com/Agoric/agoric-sdk/issues/9109
+// @ts-check
+/* global process */
+
+const agdBinary = 'agd';
+
+/**
+ * @param {ReadonlyArray<string>} swingsetArgs
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
+ *   from: string,
+ *   fees?: string,
+ *   dryRun?: boolean,
+ *   verbose?: boolean,
+ *   keyring?: {home?: string, backend: string}
+ *   stdout?: Pick<import('stream').Writable, 'write'>
+ *   execFileSync: typeof import('child_process').execFileSync
+ * }} opts
+ */
+export const execSwingsetTransaction = (swingsetArgs, opts) => {
+  const {
+    from,
+    fees,
+    dryRun = false,
+    verbose = true,
+    keyring = undefined,
+    chainName,
+    rpcAddrs,
+    stdout = process.stdout,
+    execFileSync,
+  } = opts;
+  const homeOpt = keyring?.home ? [`--home=${keyring.home}`] : [];
+  const backendOpt = keyring?.backend
+    ? [`--keyring-backend=${keyring.backend}`]
+    : [];
+  const feeOpt = fees ? ['--fees', fees] : [];
+  const cmd = [`--node=${rpcAddrs[0]}`, `--chain-id=${chainName}`].concat(
+    homeOpt,
+    backendOpt,
+    feeOpt,
+    [`--from=${from}`, 'tx', 'swingset'],
+    swingsetArgs,
+  );
+
+  if (dryRun) {
+    stdout.write(`Run this interactive command in shell:\n\n`);
+    stdout.write(`${agdBinary} `);
+    stdout.write(cmd.join(' '));
+    stdout.write('\n');
+  } else {
+    const yesCmd = cmd.concat(['--yes']);
+    if (verbose) console.log('Executing ', yesCmd);
+    const out = execFileSync(agdBinary, yesCmd, { encoding: 'utf-8' });
+
+    // agd puts this diagnostic on stdout rather than stderr :-/
+    // "Default sign-mode 'direct' not supported by Ledger, using sign-mode 'amino-json'.
+    if (out.startsWith('Default sign-mode')) {
+      const stripDiagnostic = out.replace(/^Default[^\n]+\n/, '');
+      return stripDiagnostic;
+    }
+    return out;
+  }
+};
+harden(execSwingsetTransaction);
+
+/**
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
+ *   execFileSync: typeof import('child_process').execFileSync,
+ *   delay: (ms: number) => Promise<void>,
+ *   period?: number,
+ *   retryMessage?: string,
+ * }} opts
+ * @returns {<T>(l: (b: { time: string, height: string }) => Promise<T>) => Promise<T>}
+ */
+export const pollBlocks = opts => async lookup => {
+  const { execFileSync, delay, rpcAddrs, period = 3 * 1000 } = opts;
+  assert(execFileSync, 'missing execFileSync');
+  const { retryMessage } = opts;
+
+  const nodeArgs = [`--node=${rpcAddrs[0]}`];
+
+  await null; // separate sync prologue
+
+  for (;;) {
+    const sTxt = execFileSync(agdBinary, ['status', ...nodeArgs]);
+    const status = JSON.parse(sTxt.toString());
+    const {
+      SyncInfo: { latest_block_time: time, latest_block_height: height },
+    } = status;
+    try {
+      // see await null above
+      const result = await lookup({ time, height });
+      return result;
+    } catch (_err) {
+      console.error(
+        time,
+        retryMessage || 'not in block',
+        height,
+        'retrying...',
+      );
+      await delay(period);
+    }
+  }
+};
+
+/**
+ * @param {string} txhash
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
+ *   execFileSync: typeof import('child_process').execFileSync,
+ *   delay: (ms: number) => Promise<void>,
+ *   period?: number,
+ * }} opts
+ */
+export const pollTx = async (txhash, opts) => {
+  const { execFileSync, rpcAddrs, chainName } = opts;
+  assert(execFileSync, 'missing execFileSync in pollTx');
+
+  const nodeArgs = [`--node=${rpcAddrs[0]}`];
+  const outJson = ['--output', 'json'];
+
+  const lookup = async () => {
+    const out = execFileSync(
+      agdBinary,
+      [
+        'query',
+        'tx',
+        txhash,
+        `--chain-id=${chainName}`,
+        ...nodeArgs,
+        ...outJson,
+      ],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    // XXX this type is defined in a .proto file somewhere
+    /** @type {{ height: string, txhash: string, code: number, timestamp: string }} */
+    const info = JSON.parse(out.toString());
+    return info;
+  };
+  return pollBlocks({ ...opts, retryMessage: 'tx not in block' })(lookup);
+};

--- a/a3p-integration/proposals/b:enable-orchestration/test-lib/index.js
+++ b/a3p-integration/proposals/b:enable-orchestration/test-lib/index.js
@@ -1,0 +1,23 @@
+/* global setTimeout */
+import fetch from 'node-fetch';
+import { execFileSync } from 'child_process';
+import { makeWalletUtils } from './wallet.js';
+
+export const networkConfig = {
+  rpcAddrs: ['http://0.0.0.0:26657'],
+  chainName: 'agoriclocal',
+};
+
+/**
+ * Resolve after a delay in milliseconds.
+ *
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+const delay = ms => new Promise(resolve => setTimeout(() => resolve(), ms));
+
+// eslint-disable-next-line @jessie.js/safe-await-separator -- buggy version
+export const walletUtils = await makeWalletUtils(
+  { delay, execFileSync, fetch },
+  networkConfig,
+);

--- a/a3p-integration/proposals/b:enable-orchestration/test-lib/rpc.js
+++ b/a3p-integration/proposals/b:enable-orchestration/test-lib/rpc.js
@@ -1,0 +1,266 @@
+/** @file copied from packages/agoric-cli */
+// TODO DRY in https://github.com/Agoric/agoric-sdk/issues/9109
+// @ts-check
+/* global Buffer */
+
+import {
+  boardSlottingMarshaller,
+  makeBoardRemote,
+} from '@agoric/internal/src/marshal.js';
+import { Fail } from '@endo/errors';
+
+export { boardSlottingMarshaller };
+
+export const boardValToSlot = val => {
+  if ('getBoardId' in val) {
+    return val.getBoardId();
+  }
+  Fail`unknown obj in boardSlottingMarshaller.valToSlot ${val}`;
+};
+
+export const networkConfigUrl = agoricNetSubdomain =>
+  `https://${agoricNetSubdomain}.agoric.net/network-config`;
+export const rpcUrl = agoricNetSubdomain =>
+  `https://${agoricNetSubdomain}.rpc.agoric.net:443`;
+
+/**
+ * @typedef {{ rpcAddrs: string[], chainName: string }} MinimalNetworkConfig
+ */
+
+/** @type {MinimalNetworkConfig} */
+const networkConfig = {
+  rpcAddrs: ['http://0.0.0.0:26657'],
+  chainName: 'agoriclocal',
+};
+export { networkConfig };
+// console.warn('networkConfig', networkConfig);
+
+/**
+ * @param {object} powers
+ * @param {typeof window.fetch} powers.fetch
+ * @param {MinimalNetworkConfig} config
+ */
+export const makeVStorage = (powers, config = networkConfig) => {
+  /** @param {string} path */
+  const getJSON = path => {
+    const url = config.rpcAddrs[0] + path;
+    // console.warn('fetching', url);
+    return powers.fetch(url, { keepalive: true }).then(res => res.json());
+  };
+  // height=0 is the same as omitting height and implies the highest block
+  const url = (path = 'published', { kind = 'children', height = 0 } = {}) =>
+    `/abci_query?path=%22/custom/vstorage/${kind}/${path}%22&height=${height}`;
+
+  const readStorage = (path = 'published', { kind = 'children', height = 0 }) =>
+    getJSON(url(path, { kind, height }))
+      .catch(err => {
+        throw Error(`cannot read ${kind} of ${path}: ${err.message}`);
+      })
+      .then(data => {
+        const {
+          result: { response },
+        } = data;
+        if (response?.code !== 0) {
+          /** @type {any} */
+          const err = Error(
+            `error code ${response?.code} reading ${kind} of ${path}: ${response.log}`,
+          );
+          err.code = response?.code;
+          err.codespace = response?.codespace;
+          throw err;
+        }
+        return data;
+      });
+
+  return {
+    url,
+    decode({ result: { response } }) {
+      const { code } = response;
+      if (code !== 0) {
+        throw response;
+      }
+      const { value } = response;
+      return Buffer.from(value, 'base64').toString();
+    },
+    /**
+     *
+     * @param {string} path
+     * @returns {Promise<string>} latest vstorage value at path
+     */
+    async readLatest(path = 'published') {
+      const raw = await readStorage(path, { kind: 'data' });
+      return this.decode(raw);
+    },
+    async keys(path = 'published') {
+      const raw = await readStorage(path, { kind: 'children' });
+      return JSON.parse(this.decode(raw)).children;
+    },
+    /**
+     * @param {string} path
+     * @param {number} [height] default is highest
+     * @returns {Promise<{blockHeight: number, values: string[]}>}
+     */
+    async readAt(path, height = undefined) {
+      const raw = await readStorage(path, { kind: 'data', height });
+      const txt = this.decode(raw);
+      /** @type {{ value: string }} */
+      const { value } = JSON.parse(txt);
+      return JSON.parse(value);
+    },
+    /**
+     * Read values going back as far as available
+     *
+     * @param {string} path
+     * @param {number | string} [minHeight]
+     * @returns {Promise<string[]>}
+     */
+    async readFully(path, minHeight = undefined) {
+      const parts = [];
+      // undefined the first iteration, to query at the highest
+      let blockHeight;
+      await null;
+      do {
+        // console.debug('READING', { blockHeight });
+        let values;
+        try {
+          ({ blockHeight, values } = await this.readAt(
+            path,
+            blockHeight && Number(blockHeight) - 1,
+          ));
+          // console.debug('readAt returned', { blockHeight });
+        } catch (err) {
+          if (
+            // CosmosSDK ErrNotFound; there is no data at the path
+            (err.codespace === 'sdk' && err.code === 38) ||
+            // CosmosSDK ErrUnknownRequest; misrepresentation of the same until
+            // https://github.com/Agoric/agoric-sdk/commit/dafc7c1708977aaa55e245dc09a73859cf1df192
+            // TODO remove after upgrade-12
+            err.message.match(/unknown request/)
+          ) {
+            // console.error(err);
+            break;
+          }
+          throw err;
+        }
+        parts.push(values);
+        // console.debug('PUSHED', values);
+        // console.debug('NEW', { blockHeight, minHeight });
+        if (minHeight && Number(blockHeight) <= Number(minHeight)) break;
+      } while (blockHeight > 0);
+      return parts.flat();
+    },
+  };
+};
+/** @typedef {ReturnType<typeof makeVStorage>} VStorage */
+
+export const makeFromBoard = () => {
+  const cache = new Map();
+  const convertSlotToVal = (boardId, iface) => {
+    if (cache.has(boardId)) {
+      return cache.get(boardId);
+    }
+    const val = makeBoardRemote({ boardId, iface });
+    cache.set(boardId, val);
+    return val;
+  };
+  return harden({ convertSlotToVal });
+};
+/** @typedef {ReturnType<typeof makeFromBoard>} IdMap */
+
+export const storageHelper = {
+  /** @param { string } txt */
+  parseCapData: txt => {
+    assert(typeof txt === 'string', typeof txt);
+    /** @type {{ value: string }} */
+    const { value } = JSON.parse(txt);
+    const specimen = JSON.parse(value);
+    const { blockHeight, values } = specimen;
+    assert(values, `empty values in specimen ${value}`);
+    const capDatas = storageHelper.parseMany(values);
+    return { blockHeight, capDatas };
+  },
+  /**
+   * @param {string} txt
+   * @param {IdMap} ctx
+   */
+  unserializeTxt: (txt, ctx) => {
+    const { capDatas } = storageHelper.parseCapData(txt);
+    return capDatas.map(capData =>
+      boardSlottingMarshaller(ctx.convertSlotToVal).fromCapData(capData),
+    );
+  },
+  /** @param {string[]} capDataStrings array of stringified capData */
+  parseMany: capDataStrings => {
+    assert(capDataStrings && capDataStrings.length);
+    /** @type {{ body: string, slots: string[] }[]} */
+    const capDatas = capDataStrings.map(s => JSON.parse(s));
+    for (const capData of capDatas) {
+      assert(typeof capData === 'object' && capData !== null);
+      assert('body' in capData && 'slots' in capData);
+      assert(typeof capData.body === 'string');
+      assert(Array.isArray(capData.slots));
+    }
+    return capDatas;
+  },
+};
+harden(storageHelper);
+
+/**
+ * @param {IdMap} ctx
+ * @param {VStorage} vstorage
+ * @returns {Promise<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes>}
+ */
+export const makeAgoricNames = async (ctx, vstorage) => {
+  const reverse = {};
+  const entries = await Promise.all(
+    ['brand', 'instance', 'vbankAsset'].map(async kind => {
+      const content = await vstorage.readLatest(
+        `published.agoricNames.${kind}`,
+      );
+      /** @type {Array<[string, import('@agoric/vats/tools/board-utils.js').BoardRemote]>} */
+      const parts = storageHelper.unserializeTxt(content, ctx).at(-1);
+      for (const [name, remote] of parts) {
+        if ('getBoardId' in remote) {
+          reverse[remote.getBoardId()] = name;
+        }
+      }
+      return [kind, Object.fromEntries(parts)];
+    }),
+  );
+  return { ...Object.fromEntries(entries), reverse };
+};
+
+/**
+ * @param {{ fetch: typeof window.fetch }} io
+ * @param {MinimalNetworkConfig} config
+ */
+export const makeRpcUtils = async ({ fetch }, config = networkConfig) => {
+  await null;
+  try {
+    const vstorage = makeVStorage({ fetch }, config);
+    const fromBoard = makeFromBoard();
+    const agoricNames = await makeAgoricNames(fromBoard, vstorage);
+
+    const marshaller = boardSlottingMarshaller(fromBoard.convertSlotToVal);
+
+    /** @type {(txt: string) => unknown} */
+    const unserializeHead = txt =>
+      storageHelper.unserializeTxt(txt, fromBoard).at(-1);
+
+    /** @type {(path: string) => Promise<unknown>} */
+    const readLatestHead = path =>
+      vstorage.readLatest(path).then(unserializeHead);
+
+    return {
+      agoricNames,
+      fromBoard,
+      marshaller,
+      readLatestHead,
+      unserializeHead,
+      vstorage,
+    };
+  } catch (err) {
+    throw Error(`RPC failure (${config.rpcAddrs}): ${err.message}`);
+  }
+};
+/** @typedef {Awaited<ReturnType<typeof makeRpcUtils>>} RpcUtils */

--- a/a3p-integration/proposals/b:enable-orchestration/test-lib/wallet.js
+++ b/a3p-integration/proposals/b:enable-orchestration/test-lib/wallet.js
@@ -1,0 +1,166 @@
+/**
+ * @file copied from packages/agoric-cli,
+ * removing polling and coalescing features whose dependencies cause import problems here
+ */
+// TODO DRY in https://github.com/Agoric/agoric-sdk/issues/9109
+// @ts-check
+/* global */
+
+import { E, Far } from '@endo/far';
+import { inspect } from 'util';
+import { execSwingsetTransaction, pollTx } from './chain.js';
+import { makeRpcUtils } from './rpc.js';
+
+/** @import {CurrentWalletRecord} from '@agoric/smart-wallet/src/smartWallet.js' */
+/** @import {AgoricNamesRemotes} from '@agoric/vats/tools/board-utils.js' */
+
+/**
+ * @template T
+ * @param follower
+ * @param [options]
+ */
+export const iterateReverse = (follower, options) =>
+  // For now, just pass through the iterable.
+  Far('iterateReverse iterable', {
+    /** @returns {AsyncIterator<T>} */
+    [Symbol.asyncIterator]: () => {
+      const eachIterable = E(follower).getReverseIterable(options);
+      const iterator = E(eachIterable)[Symbol.asyncIterator]();
+      return Far('iterateEach iterator', {
+        next: () => E(iterator).next(),
+      });
+    },
+  });
+
+/** @type {CurrentWalletRecord} */
+const emptyCurrentRecord = {
+  purses: [],
+  offerToUsedInvitation: [],
+  offerToPublicSubscriberPaths: [],
+  liveOffers: [],
+};
+
+/**
+ * @param {string} addr
+ * @param {Pick<import('./rpc.js').RpcUtils, 'readLatestHead'>} io
+ * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>}
+ */
+export const getCurrent = async (addr, { readLatestHead }) => {
+  // Partial because older writes may not have had all properties
+  // NB: assumes changes are only additions
+  let current =
+    /** @type {Partial<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord> | undefined} */ (
+      await readLatestHead(`published.wallet.${addr}.current`)
+    );
+  if (current === undefined) {
+    throw new Error(`undefined current node for ${addr}`);
+  }
+
+  // Repair a type misunderstanding seen in the wild.
+  // See https://github.com/Agoric/agoric-sdk/pull/7139
+  let offerToUsedInvitation = current.offerToUsedInvitation;
+  if (
+    offerToUsedInvitation &&
+    typeof offerToUsedInvitation === 'object' &&
+    !Array.isArray(offerToUsedInvitation)
+  ) {
+    offerToUsedInvitation = Object.entries(offerToUsedInvitation);
+    current = harden({
+      ...current,
+      offerToUsedInvitation,
+    });
+  }
+
+  // override full empty record with defined values from published one
+  return { ...emptyCurrentRecord, ...current };
+};
+
+/**
+ * @param {string} addr
+ * @param {Pick<import('./rpc.js').RpcUtils, 'readLatestHead'>} io
+ * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord>}
+ */
+export const getLastUpdate = (addr, { readLatestHead }) => {
+  // @ts-expect-error cast
+  return readLatestHead(`published.wallet.${addr}`);
+};
+
+/**
+ * Sign and broadcast a wallet-action.
+ *
+ * @throws { Error & { code: number } } if transaction fails
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').BridgeAction} bridgeAction
+ * @param {import('./rpc.js').MinimalNetworkConfig & {
+ *   from: string,
+ *   marshaller: import('@endo/marshal').Marshal<'string'>,
+ *   fees?: string,
+ *   verbose?: boolean,
+ *   keyring?: {home?: string, backend: string},
+ *   stdout: Pick<import('stream').Writable, 'write'>,
+ *   execFileSync: typeof import('child_process').execFileSync,
+ *   delay: (ms: number) => Promise<void>,
+ *   dryRun?: boolean,
+ * }} opts
+ */
+export const sendAction = async (bridgeAction, opts) => {
+  const { marshaller } = opts;
+  const offerBody = JSON.stringify(marshaller.toCapData(harden(bridgeAction)));
+
+  // tryExit should not require --allow-spend
+  // https://github.com/Agoric/agoric-sdk/issues/7291
+  const spendMethods = ['executeOffer', 'tryExitOffer'];
+  const spendArg = spendMethods.includes(bridgeAction.method)
+    ? ['--allow-spend']
+    : [];
+
+  const act = ['wallet-action', ...spendArg, offerBody];
+  const out = execSwingsetTransaction([...act, '--output', 'json'], opts);
+  if (opts.dryRun) {
+    return;
+  }
+
+  assert(out); // not dry run
+  const tx = JSON.parse(out);
+  if (tx.code !== 0) {
+    const err = Error(`failed to send tx: ${tx.raw_log} code: ${tx.code}`);
+    // @ts-expect-error XXX how to add properties to an error?
+    err.code = tx.code;
+    throw err;
+  }
+
+  return pollTx(tx.txhash, opts);
+};
+
+export const makeWalletUtils = async (
+  { delay, execFileSync, fetch },
+  networkConfig,
+) => {
+  const { agoricNames, fromBoard, marshaller, readLatestHead, vstorage } =
+    await makeRpcUtils({ fetch }, networkConfig);
+
+  /**
+   *
+   * @param {string} from
+   * @param {import('@agoric/smart-wallet/src/smartWallet.js').BridgeAction} bridgeAction
+   */
+  const broadcastBridgeAction = async (from, bridgeAction) => {
+    console.log('broadcastBridgeAction', inspect(bridgeAction, { depth: 10 }));
+    return sendAction(bridgeAction, {
+      ...networkConfig,
+      delay,
+      execFileSync,
+      from,
+      marshaller,
+      keyring: { backend: 'test' },
+    });
+  };
+
+  return {
+    agoricNames,
+    broadcastBridgeAction,
+    fromBoard,
+    networkConfig,
+    readLatestHead,
+    vstorage,
+  };
+};

--- a/a3p-integration/proposals/b:enable-orchestration/test.sh
+++ b/a3p-integration/proposals/b:enable-orchestration/test.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
-source /usr/src/upgrade-test-scripts/env_setup.sh
 
-yarn ava
+# Place here any test that should be executed using the executed proposal.
+# The effects of this step are not persisted in further proposal layers.
+
+GLOBIGNORE=initial.test.js
+
+# test the state right after upgrade
+yarn ava initial.test.js
+
+# test more, in ways that change system state
+yarn ava ./*.test.js

--- a/a3p-integration/proposals/b:enable-orchestration/valueVow.test.js
+++ b/a3p-integration/proposals/b:enable-orchestration/valueVow.test.js
@@ -1,0 +1,83 @@
+// @ts-check
+import test from 'ava';
+import { inspect } from 'node:util';
+import '@endo/init';
+
+import {
+  evalBundles,
+  getIncarnation,
+  waitForBlock,
+  GOV1ADDR as GETTER, // not particular to governance, just a handy wallet
+  GOV2ADDR as SETTER, // not particular to governance, just a handy wallet
+} from '@agoric/synthetic-chain';
+import { walletUtils } from './test-lib/index.js';
+
+const START_VALUEVOW_DIR = 'start-valueVow';
+const RESTART_VALUEVOW_DIR = 'restart-valueVow';
+
+test('vow survives restart', async t => {
+  t.log('start valueVow');
+  await evalBundles(START_VALUEVOW_DIR);
+  t.is(await getIncarnation('valueVow'), 0);
+
+  t.log('use wallet to get a vow');
+  await walletUtils.broadcastBridgeAction(GETTER, {
+    method: 'executeOffer',
+    offer: {
+      id: 'get-value',
+      invitationSpec: {
+        source: 'agoricContract',
+        instancePath: ['valueVow'],
+        callPipe: [['makeGetterInvitation']],
+      },
+      proposal: {},
+    },
+  });
+
+  t.log('confirm the value is not in offer results');
+  await waitForBlock(2);
+  {
+    /** @type {any} */
+    const getterStatus = await walletUtils.readLatestHead(
+      `published.wallet.${GETTER}`,
+    );
+    console.log('current: ', inspect(getterStatus, { depth: 10 }));
+    t.like(getterStatus, {
+      status: {
+        id: 'get-value',
+      },
+      updated: 'offerStatus',
+    });
+    t.false('result' in getterStatus.status, 'no result yet');
+  }
+
+  t.log('restart valueVow');
+  await evalBundles(RESTART_VALUEVOW_DIR);
+  t.is(await getIncarnation('valueVow'), 1);
+
+  const offerArgs = { value: 'Ciao, mondo!' };
+
+  t.log('use wallet to set value');
+  await walletUtils.broadcastBridgeAction(SETTER, {
+    method: 'executeOffer',
+    offer: {
+      id: 'set-value',
+      invitationSpec: {
+        source: 'agoricContract',
+        instancePath: ['valueVow'],
+        callPipe: [['makeSetterInvitation']],
+      },
+      offerArgs,
+      proposal: {},
+    },
+  });
+
+  t.log('confirm the value is now in offer results');
+  {
+    const getterStatus = await walletUtils.readLatestHead(
+      `published.wallet.${GETTER}`,
+    );
+
+    t.like(getterStatus, { status: { result: offerArgs.value } });
+  }
+});

--- a/a3p-integration/proposals/b:enable-orchestration/yarn.lock
+++ b/a3p-integration/proposals/b:enable-orchestration/yarn.lock
@@ -5,6 +5,366 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@agoric/access-token@npm:0.4.22-dev-5676146.0+5676146":
+  version: 0.4.22-dev-5676146.0
+  resolution: "@agoric/access-token@npm:0.4.22-dev-5676146.0"
+  dependencies:
+    n-readlines: "npm:^1.0.0"
+    proper-lockfile: "npm:^4.1.2"
+    tmp: "npm:^0.2.1"
+  checksum: 10c0/c1fe4f9f1eaf2e4334ec190099f03d2ccff024e0b06693784230ccac6fbe7a98ebce63f365fade828b9c02c8967239e92c8fa0592d2661086e3b31eecd46e3b0
+  languageName: node
+  linkType: hard
+
+"@agoric/assert@npm:0.6.1-dev-5676146.0+5676146":
+  version: 0.6.1-dev-5676146.0
+  resolution: "@agoric/assert@npm:0.6.1-dev-5676146.0"
+  checksum: 10c0/3391d53d64f4ca74ae5a87b623dc7489a20d91f45716723c33e393cfe6536fb1553344b72d24ac966f49b83d56906140c263778968ff513dfcdbb30e1be68091
+  languageName: node
+  linkType: hard
+
+"@agoric/babel-generator@npm:^7.17.6":
+  version: 7.17.6
+  resolution: "@agoric/babel-generator@npm:7.17.6"
+  dependencies:
+    "@babel/types": "npm:^7.17.0"
+    jsesc: "npm:^2.5.1"
+    source-map: "npm:^0.5.0"
+  checksum: 10c0/59db151ae737bd9b1f21c1589df4c7da9cbf484de5b5cc8352052825c2d977283d975303f55acb54d0210c176cb405da263073ceba1d3a6db65c6e21cc6e663f
+  languageName: node
+  linkType: hard
+
+"@agoric/base-zone@npm:0.1.1-dev-5676146.0+5676146":
+  version: 0.1.1-dev-5676146.0
+  resolution: "@agoric/base-zone@npm:0.1.1-dev-5676146.0"
+  dependencies:
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@endo/common": "npm:^1.1.0"
+    "@endo/exo": "npm:^1.2.1"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/pass-style": "npm:^1.2.0"
+    "@endo/patterns": "npm:^1.2.0"
+  checksum: 10c0/b3dfa47af7cf4a686244e2a31243394b44756f127a7612f5d50c77b1a91f777514386c305866705b46219d2d1e0df2b8d5bff9e08f82275043bb0c198c0601e4
+  languageName: node
+  linkType: hard
+
+"@agoric/cache@npm:0.3.3-dev-5676146.0+5676146":
+  version: 0.3.3-dev-5676146.0
+  resolution: "@agoric/cache@npm:0.3.3-dev-5676146.0"
+  dependencies:
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+  checksum: 10c0/b2967955f99d3cfe9b30700373275290183a5b6284703b6bbfff98246342bd7ff995addc48e31a8b2c52c9330c1aed5566f9e73fc0ae5b753478c961d7cdf258
+  languageName: node
+  linkType: hard
+
+"@agoric/casting@npm:0.4.3-dev-5676146.0+5676146":
+  version: 0.4.3-dev-5676146.0
+  resolution: "@agoric/casting@npm:0.4.3-dev-5676146.0"
+  dependencies:
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/spawner": "npm:0.6.9-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@cosmjs/encoding": "npm:^0.32.3"
+    "@cosmjs/proto-signing": "npm:^0.32.3"
+    "@cosmjs/stargate": "npm:^0.32.3"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.3"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/init": "npm:^1.0.4"
+    "@endo/lockdown": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+    node-fetch: "npm:^2.6.0"
+  checksum: 10c0/548c929c6535aea1d0a8e2cbc7fc3ec57d04dd8fd5b6e62ee565b674f8a87efe82536091e182a71a985244c0459e19b0195fc81b80a22c480859c37a69815367
+  languageName: node
+  linkType: hard
+
+"@agoric/cosmic-proto@npm:0.4.1-dev-5676146.0+5676146":
+  version: 0.4.1-dev-5676146.0
+  resolution: "@agoric/cosmic-proto@npm:0.4.1-dev-5676146.0"
+  dependencies:
+    "@cosmjs/amino": "npm:^0.32.3"
+    "@cosmjs/proto-signing": "npm:^0.32.3"
+    "@cosmjs/stargate": "npm:^0.32.3"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.3"
+    "@endo/init": "npm:^1.0.3"
+    axios: "npm:^1.6.7"
+  checksum: 10c0/dc5a39feebce9209a393c37f6bfe6be550600718b2c841e13750a92d3a734d5ed718beb3d7532829c2da5e0344cf96b82f8d779dfc30d4b2c266d89902e2f4b8
+  languageName: node
+  linkType: hard
+
+"@agoric/ertp@npm:0.16.3-dev-5676146.0+5676146":
+  version: 0.16.3-dev-5676146.0
+  resolution: "@agoric/ertp@npm:0.16.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/zone": "npm:0.2.3-dev-5676146.0+5676146"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+  checksum: 10c0/6a3ef33e6b1052253346a651f6f193dbda9551a2ed3f36f63af0b9da4d27ed80bdf63251f97cc631105c923ac23440ef456198f1b15b56b6aba86ec1a590b6f6
+  languageName: node
+  linkType: hard
+
+"@agoric/governance@npm:0.10.4-dev-5676146.0+5676146":
+  version: 0.10.4-dev-5676146.0
+  resolution: "@agoric/governance@npm:0.10.4-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/ertp": "npm:0.16.3-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/network": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/time": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/zoe": "npm:0.26.3-dev-5676146.0+5676146"
+    "@endo/bundle-source": "npm:^3.1.0"
+    "@endo/captp": "npm:^4.0.4"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/promise-kit": "npm:^1.0.4"
+    import-meta-resolve: "npm:^2.2.1"
+  checksum: 10c0/64a8a0579fde6dd60630175e5d1bd0a370532c993700049352f2cc83dbfde6cac90b1671acf625afadcc3449a8f4872d1dacc194f8724281b5ac82e6c1b887d1
+  languageName: node
+  linkType: hard
+
+"@agoric/inter-protocol@npm:0.16.2-dev-5676146.0+5676146":
+  version: 0.16.2-dev-5676146.0
+  resolution: "@agoric/inter-protocol@npm:0.16.2-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/ertp": "npm:0.16.3-dev-5676146.0+5676146"
+    "@agoric/governance": "npm:0.10.4-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/time": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/vats": "npm:0.15.2-dev-5676146.0+5676146"
+    "@agoric/zoe": "npm:0.26.3-dev-5676146.0+5676146"
+    "@endo/captp": "npm:^4.0.4"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/promise-kit": "npm:^1.0.4"
+    jessie.js: "npm:^0.3.2"
+  checksum: 10c0/6216bb903dc4b292f6b24fdc6121cd3540ebdd402f4c81dded60b00bbf2f8130c25a2565ccb80ffc68dbc2b625d0459df3215cbf69585ed84f101a5d53351e4c
+  languageName: node
+  linkType: hard
+
+"@agoric/internal@npm:0.3.3-dev-5676146.0, @agoric/internal@npm:0.3.3-dev-5676146.0+5676146":
+  version: 0.3.3-dev-5676146.0
+  resolution: "@agoric/internal@npm:0.3.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/base-zone": "npm:0.1.1-dev-5676146.0+5676146"
+    "@endo/common": "npm:^1.1.0"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/init": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+    "@endo/stream": "npm:^1.1.0"
+    anylogger: "npm:^0.21.0"
+    jessie.js: "npm:^0.3.2"
+  checksum: 10c0/cd2a81ff39790a1b333621b3815f0791b70d0822f201d491175e46602697c80814f1fb87a610167e541a9ad431a771cd7348afe24517a15c45d1591d3d494bc2
+  languageName: node
+  linkType: hard
+
+"@agoric/kmarshal@npm:0.1.1-dev-5676146.0+5676146":
+  version: 0.1.1-dev-5676146.0
+  resolution: "@agoric/kmarshal@npm:0.1.1-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+  checksum: 10c0/6acd0de1ad1cb2b4bd6065f13394222476a713be169dd7979a26934f223bcac2222d9e1560327f31417a774501e82703dce3c0cae0a327eae955e2072e8587d7
+  languageName: node
+  linkType: hard
+
+"@agoric/network@npm:0.1.1-dev-5676146.0+5676146":
+  version: 0.1.1-dev-5676146.0
+  resolution: "@agoric/network@npm:0.1.1-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@endo/base64": "npm:^1.0.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/patterns": "npm:^1.1.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+  checksum: 10c0/92207ef3889c53526490de4d62b93788dfb009fb70809b473a50993adc0bc8fbbd2be8da43db78a51b5df9af19d7cbe24aab55c958daf4bdcb86ae1e6e55af95
+  languageName: node
+  linkType: hard
+
+"@agoric/notifier@npm:0.6.3-dev-5676146.0+5676146":
+  version: 0.6.3-dev-5676146.0
+  resolution: "@agoric/notifier@npm:0.6.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+  checksum: 10c0/5357e05ff60d962189658e9476307f5c3a8fd4f6cf82d30dd4526050c5f747f33eafeb8cdb25753c61d91e1390a4c8408424fd6d15ecb103add72e5113b0c4a1
+  languageName: node
+  linkType: hard
+
+"@agoric/smart-wallet@npm:0.5.4-dev-5676146.0+5676146":
+  version: 0.5.4-dev-5676146.0
+  resolution: "@agoric/smart-wallet@npm:0.5.4-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/casting": "npm:0.4.3-dev-5676146.0+5676146"
+    "@agoric/ertp": "npm:0.16.3-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/vats": "npm:0.15.2-dev-5676146.0+5676146"
+    "@agoric/zoe": "npm:0.26.3-dev-5676146.0+5676146"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/promise-kit": "npm:^1.0.4"
+  checksum: 10c0/cc46165846a0d0b3f7290ec4f5fe60030f3272ee7278bd49274634daee5000d96222e2ed3e72f724943100101cee4d2f760e0bf2d5c08620b89930d3fbed5715
+  languageName: node
+  linkType: hard
+
+"@agoric/spawner@npm:0.6.9-dev-5676146.0+5676146":
+  version: 0.6.9-dev-5676146.0
+  resolution: "@agoric/spawner@npm:0.6.9-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/import-bundle": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+  checksum: 10c0/4f605a59a2da5fef37faf8923ebeb237e789f65f678a192c926bb1ccb3ead49eecb75b9120971da9cc4d046de0503087af38814e69811e9d6bfa7d1559b0c510
+  languageName: node
+  linkType: hard
+
+"@agoric/store@npm:0.9.3-dev-5676146.0+5676146":
+  version: 0.9.3-dev-5676146.0
+  resolution: "@agoric/store@npm:0.9.3-dev-5676146.0"
+  dependencies:
+    "@endo/exo": "npm:^1.2.1"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/pass-style": "npm:^1.2.0"
+    "@endo/patterns": "npm:^1.2.0"
+  checksum: 10c0/675e73bbcac024c456b658583ec3fd14a50f69fea5fc07aadf30e593978e5cadbc82d365b13976967b5509614a7adf0adad4e84712f7e0b6c13f2a2a93c9ea63
+  languageName: node
+  linkType: hard
+
+"@agoric/swing-store@npm:0.9.2-dev-5676146.0+5676146":
+  version: 0.9.2-dev-5676146.0
+  resolution: "@agoric/swing-store@npm:0.9.2-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@endo/base64": "npm:^1.0.2"
+    "@endo/bundle-source": "npm:^3.1.0"
+    "@endo/check-bundle": "npm:^1.0.4"
+    "@endo/nat": "npm:^5.0.4"
+    better-sqlite3: "npm:^9.1.1"
+  checksum: 10c0/4f18b4051bc41fb153da4b750144db727f9b59e8fd18196eea1427d12028b47ebf8448b14c47708a2347ed2a4c1ed887fdcf2c0048b5ab4e84869cd17e3dc935
+  languageName: node
+  linkType: hard
+
+"@agoric/swingset-liveslots@npm:0.10.3-dev-5676146.0+5676146":
+  version: 0.10.3-dev-5676146.0
+  resolution: "@agoric/swingset-liveslots@npm:0.10.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@endo/env-options": "npm:^1.1.1"
+    "@endo/errors": "npm:^1.1.0"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/exo": "npm:^1.2.1"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/init": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/pass-style": "npm:^1.2.0"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+  checksum: 10c0/17ff4c6b94992d5532b748b4b20a95d273f8eb9ee7345552b95050de90563f5f2b03416ff60b9ca3ce07564bb4f3aa993fbf7710f6b24dc88d902b701a8b6a91
+  languageName: node
+  linkType: hard
+
+"@agoric/swingset-vat@npm:0.32.3-dev-5676146.0+5676146":
+  version: 0.32.3-dev-5676146.0
+  resolution: "@agoric/swingset-vat@npm:0.32.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/kmarshal": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/swing-store": "npm:0.9.2-dev-5676146.0+5676146"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-5676146.0+5676146"
+    "@agoric/swingset-xsnap-supervisor": "npm:0.10.3-dev-5676146.0+5676146"
+    "@agoric/time": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/xsnap": "npm:0.14.3-dev-5676146.0+5676146"
+    "@agoric/xsnap-lockdown": "npm:0.14.1-dev-5676146.0+5676146"
+    "@endo/base64": "npm:^1.0.2"
+    "@endo/bundle-source": "npm:^3.1.0"
+    "@endo/captp": "npm:^4.0.4"
+    "@endo/check-bundle": "npm:^1.0.4"
+    "@endo/compartment-mapper": "npm:^1.1.2"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/import-bundle": "npm:^1.0.4"
+    "@endo/init": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+    "@endo/ses-ava": "npm:^1.1.2"
+    "@endo/stream": "npm:^1.1.0"
+    "@endo/zip": "npm:^1.0.2"
+    ansi-styles: "npm:^6.2.1"
+    anylogger: "npm:^0.21.0"
+    better-sqlite3: "npm:^9.1.1"
+    import-meta-resolve: "npm:^2.2.1"
+    microtime: "npm:^3.1.0"
+    semver: "npm:^6.3.0"
+    tmp: "npm:^0.2.1"
+    yargs-parser: "npm:^21.1.1"
+  peerDependencies:
+    ava: ^5.3.0
+  bin:
+    vat: bin/vat
+  checksum: 10c0/5eaa97f9e9a71bf20c590d44693c97e12bfbf42e2ce15991d48e3393ff1f9561b8e7717fa63dabc3c0d720795e8922452485003e86b68e307d90bd6aea4c79b0
+  languageName: node
+  linkType: hard
+
+"@agoric/swingset-xsnap-supervisor@npm:0.10.3-dev-5676146.0+5676146":
+  version: 0.10.3-dev-5676146.0
+  resolution: "@agoric/swingset-xsnap-supervisor@npm:0.10.3-dev-5676146.0"
+  checksum: 10c0/495c847ccb69bcfb338e27a2b423ec480e303c52c51e0496aaeea820d17af100c59f2d45e540517c8eba4aea9645ef6c3e200ad3834d46087b4a21671791e077
+  languageName: node
+  linkType: hard
+
 "@agoric/synthetic-chain@npm:^0.1.0":
   version: 0.1.0
   resolution: "@agoric/synthetic-chain@npm:0.1.0"
@@ -19,10 +379,833 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/time@npm:0.3.3-dev-5676146.0+5676146":
+  version: 0.3.3-dev-5676146.0
+  resolution: "@agoric/time@npm:0.3.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/patterns": "npm:^1.2.0"
+  checksum: 10c0/a221f90a327ffaf9eccc6943b1f59b97b200df3a9932b9da7aee484f938e919302069b056182035d6681ebb3b70759841bcf221549f91f172f89848372efe30a
+  languageName: node
+  linkType: hard
+
+"@agoric/vat-data@npm:0.5.3-dev-5676146.0+5676146":
+  version: 0.5.3-dev-5676146.0
+  resolution: "@agoric/vat-data@npm:0.5.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/base-zone": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-5676146.0+5676146"
+    "@agoric/vow": "npm:0.1.1-dev-5676146.0+5676146"
+  checksum: 10c0/2c08e571cf1ab9af2dc1214c1d7fb9b73446ed9ddaca3a10db2b90160138c07728a0d37cfc9748a37dd424a2945da706bfecc152b2b87fbb59e81bdafaba0e77
+  languageName: node
+  linkType: hard
+
+"@agoric/vats@npm:0.15.2-dev-5676146.0+5676146":
+  version: 0.15.2-dev-5676146.0
+  resolution: "@agoric/vats@npm:0.15.2-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/ertp": "npm:0.16.3-dev-5676146.0+5676146"
+    "@agoric/governance": "npm:0.10.4-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/network": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/swingset-vat": "npm:0.32.3-dev-5676146.0+5676146"
+    "@agoric/time": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/zoe": "npm:0.26.3-dev-5676146.0+5676146"
+    "@agoric/zone": "npm:0.2.3-dev-5676146.0+5676146"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/import-bundle": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+    import-meta-resolve: "npm:^2.2.1"
+    jessie.js: "npm:^0.3.2"
+  checksum: 10c0/ac5117f609b112bf8902488d4769c3f6670cc3402cbe8e75db1c8f227f25e4334b5b447d4fa29cfe674e6d3b93554cdfd3d5858dff6c5b48f89b6e24af636da4
+  languageName: node
+  linkType: hard
+
+"@agoric/vow@npm:0.1.1-dev-5676146.0+5676146":
+  version: 0.1.1-dev-5676146.0
+  resolution: "@agoric/vow@npm:0.1.1-dev-5676146.0"
+  dependencies:
+    "@agoric/base-zone": "npm:0.1.1-dev-5676146.0+5676146"
+    "@endo/env-options": "npm:^1.1.1"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/pass-style": "npm:^1.2.0"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+  checksum: 10c0/e0aa219b31e962b784bf4c48a2108b032aecf60c7cf05393e305c0279abee887a81879ca6999eb56cbaedebc656d7d575715ba5c470dd624f62304624475de60
+  languageName: node
+  linkType: hard
+
+"@agoric/xsnap-lockdown@npm:0.14.1-dev-5676146.0+5676146":
+  version: 0.14.1-dev-5676146.0
+  resolution: "@agoric/xsnap-lockdown@npm:0.14.1-dev-5676146.0"
+  checksum: 10c0/8faa700ff6049b9cd29109c42e2ef3b228f18e265a5908e987af4ee32127e9b6451b7299538ec8fa50514c359f2b0b9a60beb6a5d2e126928def1e5232a3d919
+  languageName: node
+  linkType: hard
+
+"@agoric/xsnap@npm:0.14.3-dev-5676146.0+5676146":
+  version: 0.14.3-dev-5676146.0
+  resolution: "@agoric/xsnap@npm:0.14.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/xsnap-lockdown": "npm:0.14.1-dev-5676146.0+5676146"
+    "@endo/bundle-source": "npm:^3.1.0"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/init": "npm:^1.0.4"
+    "@endo/netstring": "npm:^1.0.4"
+    "@endo/promise-kit": "npm:^1.0.4"
+    "@endo/stream": "npm:^1.1.0"
+    "@endo/stream-node": "npm:^1.0.4"
+    glob: "npm:^7.1.6"
+    tmp: "npm:^0.2.1"
+  bin:
+    ava-xs: src/ava-xs.js
+    xsrepl: src/xsrepl
+  checksum: 10c0/0f5461b8c5cafa94388720cdcbd5b9fc65e0f2416d9084e3e90b60728cf050fcd95c009a67fda284cee2471058814ba504e655e0a3de82cbbc36e03c24e9fc50
+  languageName: node
+  linkType: hard
+
+"@agoric/zoe@npm:0.26.3-dev-5676146.0+5676146":
+  version: 0.26.3-dev-5676146.0
+  resolution: "@agoric/zoe@npm:0.26.3-dev-5676146.0"
+  dependencies:
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/base-zone": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/ertp": "npm:0.16.3-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/notifier": "npm:0.6.3-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-5676146.0+5676146"
+    "@agoric/swingset-vat": "npm:0.32.3-dev-5676146.0+5676146"
+    "@agoric/time": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@agoric/zone": "npm:0.2.3-dev-5676146.0+5676146"
+    "@endo/bundle-source": "npm:^3.1.0"
+    "@endo/captp": "npm:^4.0.4"
+    "@endo/common": "npm:^1.1.0"
+    "@endo/eventual-send": "npm:^1.1.2"
+    "@endo/exo": "npm:^1.2.1"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/import-bundle": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10c0/4db929e776483dd41c0453d322fe93d27d35826ab98e31e257314e41f2eb6c86eb2a1da09761790bbc5f2bfa41a348ef5c84534044b6d1de576eca1ecea31a82
+  languageName: node
+  linkType: hard
+
+"@agoric/zone@npm:0.2.3-dev-5676146.0+5676146":
+  version: 0.2.3-dev-5676146.0
+  resolution: "@agoric/zone@npm:0.2.3-dev-5676146.0"
+  dependencies:
+    "@agoric/base-zone": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/vat-data": "npm:0.5.3-dev-5676146.0+5676146"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/pass-style": "npm:^1.2.0"
+  checksum: 10c0/82a7f1c741bb1c6bfca6398686e71b47135ee584f794dbbfc01ecdb37aea37a2607d857532caefd5c61a03f90a3fb7ac02374c189d4510b759209276f631a8d6
+  languageName: node
+  linkType: hard
+
+"@babel/code-frame@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/code-frame@npm:7.24.7"
+  dependencies:
+    "@babel/highlight": "npm:^7.24.7"
+    picocolors: "npm:^1.0.0"
+  checksum: 10c0/ab0af539473a9f5aeaac7047e377cb4f4edd255a81d84a76058595f8540784cc3fbe8acf73f1e073981104562490aabfb23008cd66dc677a456a4ed5390fdde6
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/generator@npm:7.24.7"
+  dependencies:
+    "@babel/types": "npm:^7.24.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    jsesc: "npm:^2.5.1"
+  checksum: 10c0/06b1f3350baf527a3309e50ffd7065f7aee04dd06e1e7db794ddfde7fe9d81f28df64edd587173f8f9295496a7ddb74b9a185d4bf4de7bb619e6d4ec45c8fd35
+  languageName: node
+  linkType: hard
+
+"@babel/helper-environment-visitor@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-environment-visitor@npm:7.24.7"
+  dependencies:
+    "@babel/types": "npm:^7.24.7"
+  checksum: 10c0/36ece78882b5960e2d26abf13cf15ff5689bf7c325b10a2895a74a499e712de0d305f8d78bb382dd3c05cfba7e47ec98fe28aab5674243e0625cd38438dd0b2d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-function-name@npm:7.24.7"
+  dependencies:
+    "@babel/template": "npm:^7.24.7"
+    "@babel/types": "npm:^7.24.7"
+  checksum: 10c0/e5e41e6cf86bd0f8bf272cbb6e7c5ee0f3e9660414174435a46653efba4f2479ce03ce04abff2aa2ef9359cf057c79c06cb7b134a565ad9c0e8a50dcdc3b43c4
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-hoist-variables@npm:7.24.7"
+  dependencies:
+    "@babel/types": "npm:^7.24.7"
+  checksum: 10c0/19ee37563bbd1219f9d98991ad0e9abef77803ee5945fd85aa7aa62a67c69efca9a801696a1b58dda27f211e878b3327789e6fd2a6f6c725ccefe36774b5ce95
+  languageName: node
+  linkType: hard
+
+"@babel/helper-split-export-declaration@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-split-export-declaration@npm:7.24.7"
+  dependencies:
+    "@babel/types": "npm:^7.24.7"
+  checksum: 10c0/0254577d7086bf09b01bbde98f731d4fcf4b7c3fa9634fdb87929801307c1f6202a1352e3faa5492450fa8da4420542d44de604daf540704ff349594a78184f6
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-string-parser@npm:7.24.7"
+  checksum: 10c0/47840c7004e735f3dc93939c77b099bb41a64bf3dda0cae62f60e6f74a5ff80b63e9b7cf77b5ec25a324516381fc994e1f62f922533236a8e3a6af57decb5e1e
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-validator-identifier@npm:7.24.7"
+  checksum: 10c0/87ad608694c9477814093ed5b5c080c2e06d44cb1924ae8320474a74415241223cc2a725eea2640dd783ff1e3390e5f95eede978bc540e870053152e58f1d651
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/highlight@npm:7.24.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.24.7"
+    chalk: "npm:^2.4.2"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.0.0"
+  checksum: 10c0/674334c571d2bb9d1c89bdd87566383f59231e16bcdcf5bb7835babdf03c9ae585ca0887a7b25bdf78f303984af028df52831c7989fecebb5101cc132da9393a
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.23.6, @babel/parser@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/parser@npm:7.24.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/8b244756872185a1c6f14b979b3535e682ff08cb5a2a5fd97cc36c017c7ef431ba76439e95e419d43000c5b07720495b00cf29a7f0d9a483643d08802b58819b
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/template@npm:7.24.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.24.7"
+    "@babel/parser": "npm:^7.24.7"
+    "@babel/types": "npm:^7.24.7"
+  checksum: 10c0/95b0b3ee80fcef685b7f4426f5713a855ea2cd5ac4da829b213f8fb5afe48a2a14683c2ea04d446dbc7f711c33c5cd4a965ef34dcbe5bc387c9e966b67877ae3
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.23.6":
+  version: 7.24.7
+  resolution: "@babel/traverse@npm:7.24.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.24.7"
+    "@babel/generator": "npm:^7.24.7"
+    "@babel/helper-environment-visitor": "npm:^7.24.7"
+    "@babel/helper-function-name": "npm:^7.24.7"
+    "@babel/helper-hoist-variables": "npm:^7.24.7"
+    "@babel/helper-split-export-declaration": "npm:^7.24.7"
+    "@babel/parser": "npm:^7.24.7"
+    "@babel/types": "npm:^7.24.7"
+    debug: "npm:^4.3.1"
+    globals: "npm:^11.1.0"
+  checksum: 10c0/a5135e589c3f1972b8877805f50a084a04865ccb1d68e5e1f3b94a8841b3485da4142e33413d8fd76bc0e6444531d3adf1f59f359c11ffac452b743d835068ab
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.17.0, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.7, @babel/types@npm:^7.8.3":
+  version: 7.24.7
+  resolution: "@babel/types@npm:7.24.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.24.7"
+    "@babel/helper-validator-identifier": "npm:^7.24.7"
+    to-fast-properties: "npm:^2.0.0"
+  checksum: 10c0/d9ecbfc3eb2b05fb1e6eeea546836ac30d990f395ef3fe3f75ced777a222c3cfc4489492f72e0ce3d9a5a28860a1ce5f81e66b88cf5088909068b3ff4fab72c1
+  languageName: node
+  linkType: hard
+
+"@colors/colors@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
+"@confio/ics23@npm:^0.6.8":
+  version: 0.6.8
+  resolution: "@confio/ics23@npm:0.6.8"
+  dependencies:
+    "@noble/hashes": "npm:^1.0.0"
+    protobufjs: "npm:^6.8.8"
+  checksum: 10c0/2f3f5032cd6a34c9b2fbd64bbf7e1cdec75ca71f348a770f7b5474b5027b12202bfbcd404eca931efddb5901f769af035a87cb8bddbf3f23d7e5d93c9d3d7f6f
+  languageName: node
+  linkType: hard
+
+"@confio/relayer@npm:^0.11.3":
+  version: 0.11.3
+  resolution: "@confio/relayer@npm:0.11.3"
+  dependencies:
+    "@cosmjs/cosmwasm-stargate": "npm:^0.32.1"
+    "@cosmjs/crypto": "npm:^0.32.1"
+    "@cosmjs/encoding": "npm:^0.32.1"
+    "@cosmjs/faucet-client": "npm:^0.32.1"
+    "@cosmjs/math": "npm:^0.32.1"
+    "@cosmjs/proto-signing": "npm:^0.32.1"
+    "@cosmjs/stargate": "npm:^0.32.1"
+    "@cosmjs/stream": "npm:^0.32.1"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.1"
+    "@cosmjs/utils": "npm:^0.32.1"
+    ajv: "npm:7.1.1"
+    axios: "npm:^1.6.7"
+    commander: "npm:7.1.0"
+    cosmjs-types: "npm:^0.9.0"
+    fast-safe-stringify: "npm:2.0.4"
+    js-yaml: "npm:4.0.0"
+    lodash: "npm:4.17.21"
+    prom-client: "npm:13.1.0"
+    table: "npm:^6.7.1"
+    triple-beam: "npm:1.3.0"
+    winston: "npm:3.3.3"
+  bin:
+    ibc-relayer: build/binary/ibc-relayer/index.js
+    ibc-setup: build/binary/ibc-setup/index.js
+  checksum: 10c0/f6519a21a7e2b7d79835558305bbac6f6712b90f0e10f2c156ae74583ca170da0b97ec456272c25a2ffdcbe0343ad425e67886b792f2aed1f5303e34b93edf40
+  languageName: node
+  linkType: hard
+
+"@cosmjs/amino@npm:^0.32.3, @cosmjs/amino@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/amino@npm:0.32.4"
+  dependencies:
+    "@cosmjs/crypto": "npm:^0.32.4"
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+  checksum: 10c0/cd8e215b0406f5c7b73ab0a21106d06b6f76b1da12f1ab7b612884e1dd8bc626966dc67d4e7580090ade131546cbec70000f854e6596935299d054b788929a7e
+  languageName: node
+  linkType: hard
+
+"@cosmjs/cosmwasm-stargate@npm:^0.32.1":
+  version: 0.32.4
+  resolution: "@cosmjs/cosmwasm-stargate@npm:0.32.4"
+  dependencies:
+    "@cosmjs/amino": "npm:^0.32.4"
+    "@cosmjs/crypto": "npm:^0.32.4"
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/proto-signing": "npm:^0.32.4"
+    "@cosmjs/stargate": "npm:^0.32.4"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+    cosmjs-types: "npm:^0.9.0"
+    pako: "npm:^2.0.2"
+  checksum: 10c0/f7e285c51ef8b1098a9ea5ca2546a1e226b4fa0a990d95faa6f3b752f3638b6c55f36a56b6f4b11f0a66fd61e3ae8772921d8e99418218df0b2205efe1c82f37
+  languageName: node
+  linkType: hard
+
+"@cosmjs/crypto@npm:^0.32.1, @cosmjs/crypto@npm:^0.32.3, @cosmjs/crypto@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/crypto@npm:0.32.4"
+  dependencies:
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+    "@noble/hashes": "npm:^1"
+    bn.js: "npm:^5.2.0"
+    elliptic: "npm:^6.5.4"
+    libsodium-wrappers-sumo: "npm:^0.7.11"
+  checksum: 10c0/94e742285eb8c7c5393055ba0635f10c06bf87710e953aedc71e3edc2b8e21a12a0d9b5e8eff37e326765f57c9eb3c7fd358f24f639efad4f1a6624eb8189534
+  languageName: node
+  linkType: hard
+
+"@cosmjs/encoding@npm:^0.32.1, @cosmjs/encoding@npm:^0.32.3, @cosmjs/encoding@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/encoding@npm:0.32.4"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    bech32: "npm:^1.1.4"
+    readonly-date: "npm:^1.0.0"
+  checksum: 10c0/4a30d5ae1a2d1247d44bda46101ce208c7666d8801ca9a33de94edc35cc22460c16b4834ec84d5a65ffef5e2a4b58605e0a0a056c46bc0a042979ec84acf20cd
+  languageName: node
+  linkType: hard
+
+"@cosmjs/faucet-client@npm:^0.32.1":
+  version: 0.32.4
+  resolution: "@cosmjs/faucet-client@npm:0.32.4"
+  dependencies:
+    axios: "npm:^1.6.0"
+  checksum: 10c0/1651cb370eb5fa2b12b6f94e06d1dc9a6306e34cad3fc87d9263d8b8a225d500449e10a9f6e326534f65261778208dab7fada6a70efb63195589ad08f58e1008
+  languageName: node
+  linkType: hard
+
+"@cosmjs/json-rpc@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/json-rpc@npm:0.32.4"
+  dependencies:
+    "@cosmjs/stream": "npm:^0.32.4"
+    xstream: "npm:^11.14.0"
+  checksum: 10c0/b3ebd240f4fb21260e284d2e503ecc61bac898842187ab717f0efb9a5f21272f161f267cc145629caeb9735f80946844384e2bd410275a4744147a44518c0fa0
+  languageName: node
+  linkType: hard
+
+"@cosmjs/math@npm:^0.32.1, @cosmjs/math@npm:^0.32.3, @cosmjs/math@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/math@npm:0.32.4"
+  dependencies:
+    bn.js: "npm:^5.2.0"
+  checksum: 10c0/91e47015be5634d27d71d14c5a05899fb4992b69db02cab1558376dedf8254f96d5e24f097c5601804ae18ed33c7c25d023653ac2bf9d20250fd3e5637f6b101
+  languageName: node
+  linkType: hard
+
+"@cosmjs/proto-signing@npm:^0.32.1, @cosmjs/proto-signing@npm:^0.32.3, @cosmjs/proto-signing@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/proto-signing@npm:0.32.4"
+  dependencies:
+    "@cosmjs/amino": "npm:^0.32.4"
+    "@cosmjs/crypto": "npm:^0.32.4"
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+    cosmjs-types: "npm:^0.9.0"
+  checksum: 10c0/6915059d2e6dbe1abda4a747c3b1abd47a9eff4f8cb2cf9a5545f939b656b4a15bbde2bfc1364357f9b2a081a066280c3b469f6d13dd5fc51b429b0f90a54913
+  languageName: node
+  linkType: hard
+
+"@cosmjs/socket@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/socket@npm:0.32.4"
+  dependencies:
+    "@cosmjs/stream": "npm:^0.32.4"
+    isomorphic-ws: "npm:^4.0.1"
+    ws: "npm:^7"
+    xstream: "npm:^11.14.0"
+  checksum: 10c0/2d94c1fb39016bea3c7c145f4565c8a0fed20c805ac569ea604cd3646c15147b82b8db18a4e3c832d6ae0c3dd14363d4db3d91bcacac922679efba164ed49386
+  languageName: node
+  linkType: hard
+
+"@cosmjs/stargate@npm:^0.32.1, @cosmjs/stargate@npm:^0.32.3, @cosmjs/stargate@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/stargate@npm:0.32.4"
+  dependencies:
+    "@confio/ics23": "npm:^0.6.8"
+    "@cosmjs/amino": "npm:^0.32.4"
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/proto-signing": "npm:^0.32.4"
+    "@cosmjs/stream": "npm:^0.32.4"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+    cosmjs-types: "npm:^0.9.0"
+    xstream: "npm:^11.14.0"
+  checksum: 10c0/c30a3519516aaa7eae58ba827c80fcf74c7fe7a9d3aa5cc8138c3a2768f5f241f59c2f5cec27e9037b4df12b1c6605b4fac9eadb4de97bd84edddc3a80a02e24
+  languageName: node
+  linkType: hard
+
+"@cosmjs/stream@npm:^0.32.1, @cosmjs/stream@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/stream@npm:0.32.4"
+  dependencies:
+    xstream: "npm:^11.14.0"
+  checksum: 10c0/c677c53f9101c2a36fa03a475d92dea2fa69c475f896751b5e18a5d07087eeecbf6bca2e62a8940003da53fa235a9b2dd78c8257bf19c3f96e3f69fa8d5f183d
+  languageName: node
+  linkType: hard
+
+"@cosmjs/tendermint-rpc@npm:^0.32.1, @cosmjs/tendermint-rpc@npm:^0.32.3, @cosmjs/tendermint-rpc@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/tendermint-rpc@npm:0.32.4"
+  dependencies:
+    "@cosmjs/crypto": "npm:^0.32.4"
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/json-rpc": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/socket": "npm:^0.32.4"
+    "@cosmjs/stream": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+    axios: "npm:^1.6.0"
+    readonly-date: "npm:^1.0.0"
+    xstream: "npm:^11.14.0"
+  checksum: 10c0/5fae7afcdf98cc7dd36922aa1586254cc8c202cf8fe66804e61d793d31dcff816f40d33f7a0eb72c1b9226c7c361d4848e4ff12d0489f6fa66f47f0c86ae18dd
+  languageName: node
+  linkType: hard
+
+"@cosmjs/utils@npm:^0.32.1, @cosmjs/utils@npm:^0.32.4":
+  version: 0.32.4
+  resolution: "@cosmjs/utils@npm:0.32.4"
+  checksum: 10c0/d5ff8b235094be1150853a715116049f73eb5cdfeea8ce8e22ecccc61ec99792db457404d4307782b1a2f935dcf438f5c485beabfcfbc1dc5df26eb6e6da9062
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: "npm:1.1.x"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: 10c0/a5133df8492802465ed01f2f0a5784585241a1030c362d54a602ed1839816d6c93d71dde05cf2ddb4fd0796238c19774406bd62fa2564b637907b495f52425fe
+  languageName: node
+  linkType: hard
+
+"@endo/base64@npm:^1.0.2, @endo/base64@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@endo/base64@npm:1.0.5"
+  checksum: 10c0/4a47a45b9025cf48542708fddc66314a135a31a1121262690c341f09f58fb6a37b21694461dd0bdc2d24c5b6417da7c42ab336033c38a67f0a4834aa7141d650
+  languageName: node
+  linkType: hard
+
+"@endo/bundle-source@npm:^3.1.0":
+  version: 3.2.3
+  resolution: "@endo/bundle-source@npm:3.2.3"
+  dependencies:
+    "@endo/base64": "npm:^1.0.5"
+    "@endo/compartment-mapper": "npm:^1.1.5"
+    "@endo/evasive-transform": "npm:^1.1.2"
+    "@endo/init": "npm:^1.1.2"
+    "@endo/promise-kit": "npm:^1.1.2"
+    "@endo/where": "npm:^1.0.5"
+    "@rollup/plugin-commonjs": "npm:^19.0.0"
+    "@rollup/plugin-node-resolve": "npm:^13.0.0"
+    acorn: "npm:^8.2.4"
+    rollup: "npm:^2.79.1"
+  bin:
+    bundle-source: src/tool.js
+  checksum: 10c0/6f35953edbb3fe9f2b18d69495c1d04ce5e94bc37ca41662dd424388d42b361e246b7f9759cbf70ad8373c917657f373f9aa5dc14366158e29981994fa7b3fe7
+  languageName: node
+  linkType: hard
+
+"@endo/captp@npm:^4.0.4":
+  version: 4.2.0
+  resolution: "@endo/captp@npm:4.2.0"
+  dependencies:
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/marshal": "npm:^1.5.0"
+    "@endo/nat": "npm:^5.0.7"
+    "@endo/promise-kit": "npm:^1.1.2"
+  checksum: 10c0/968721cc0da15f58d5fadaef4de9194a77f7091d3889970beaa0a27b7546825cc8e1e26ec8636d04ce0232a63f19a9a05a04b6a68a35125a27e22544177f7d50
+  languageName: node
+  linkType: hard
+
+"@endo/check-bundle@npm:^1.0.4":
+  version: 1.0.7
+  resolution: "@endo/check-bundle@npm:1.0.7"
+  dependencies:
+    "@endo/base64": "npm:^1.0.5"
+    "@endo/compartment-mapper": "npm:^1.1.5"
+    "@endo/errors": "npm:^1.2.2"
+  checksum: 10c0/824e476f79e40cdfd459f0e5352a7fd2e57014790cb03d234a3bed1862586513f965fac3f68cb657e4a1091c6e5392029927286eb681a498f705ae70f6413e34
+  languageName: node
+  linkType: hard
+
+"@endo/cjs-module-analyzer@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@endo/cjs-module-analyzer@npm:1.0.5"
+  checksum: 10c0/a9d0eb444f01b9d690624b88828eece23fb994c52712f980b098a6117c9c2520aef514c271db83fd7b944ba362e8aa0629e3f27819e11727ce4435a1c3b82d5f
+  languageName: node
+  linkType: hard
+
+"@endo/common@npm:^1.1.0, @endo/common@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@endo/common@npm:1.2.2"
+  dependencies:
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/promise-kit": "npm:^1.1.2"
+  checksum: 10c0/04a516c12be5146a2b15a31842e8f13a090efb19e674b018c45241ce1c13a9e2480f23df2240105fc6819dc596bac9d2e4746b6a5798b6e7a0b7fc019336e58e
+  languageName: node
+  linkType: hard
+
+"@endo/compartment-mapper@npm:^1.1.2, @endo/compartment-mapper@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "@endo/compartment-mapper@npm:1.1.5"
+  dependencies:
+    "@endo/cjs-module-analyzer": "npm:^1.0.5"
+    "@endo/static-module-record": "npm:^1.1.2"
+    "@endo/zip": "npm:^1.0.5"
+    ses: "npm:^1.5.0"
+  checksum: 10c0/7f06ef852265dd29acde4f41fc749bf29a47ce4d5b1a7977c3d9a979ac3fdfb5de6a02bd86c736d136fd3e2005294bddc578fdb4fe5b0877e558722693ea0b01
+  languageName: node
+  linkType: hard
+
+"@endo/env-options@npm:^1.1.1, @endo/env-options@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@endo/env-options@npm:1.1.4"
+  checksum: 10c0/8816c8fe1332a6f3366e7e4849b000d757fcd181eac011ed8363ccc4e66dfa2f2d975f8d5cbfb3844f3e327c5391e77ee7e234a59a21744c74c945f683b56df1
+  languageName: node
+  linkType: hard
+
+"@endo/errors@npm:^1.1.0, @endo/errors@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@endo/errors@npm:1.2.2"
+  dependencies:
+    ses: "npm:^1.5.0"
+  checksum: 10c0/d90baaf803b17130b83fbc562e253504a6a05e4843d63536e74578503f6bd937fdba3464c4d8eeb9df16b795639cd9c4aad143520525f9e54aa3e91dc5184c17
+  languageName: node
+  linkType: hard
+
+"@endo/evasive-transform@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@endo/evasive-transform@npm:1.1.2"
+  dependencies:
+    "@agoric/babel-generator": "npm:^7.17.6"
+    "@babel/parser": "npm:^7.23.6"
+    "@babel/traverse": "npm:^7.23.6"
+    source-map: "npm:0.7.4"
+  checksum: 10c0/5a5a503ea144e63844d266a0b1713c10cdaf18e2390b3f67c69e57a6f20de1ad299abf55dca85c941ea95a8360ae9afa3d86ee72be2377699a62bc57adccb914
+  languageName: node
+  linkType: hard
+
+"@endo/eventual-send@npm:^1.1.2, @endo/eventual-send@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@endo/eventual-send@npm:1.2.2"
+  dependencies:
+    "@endo/env-options": "npm:^1.1.4"
+  checksum: 10c0/d19fcee64b7113e5ff7fc4886d47bc722c4edd49a107f0952760567a4dd31cabd14abd788cc2c0c9d4b907e2c737944a389fd0ab5b0917809ef47a1df6803642
+  languageName: node
+  linkType: hard
+
+"@endo/exo@npm:^1.2.1":
+  version: 1.5.0
+  resolution: "@endo/exo@npm:1.5.0"
+  dependencies:
+    "@endo/common": "npm:^1.2.2"
+    "@endo/env-options": "npm:^1.1.4"
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/far": "npm:^1.1.2"
+    "@endo/pass-style": "npm:^1.4.0"
+    "@endo/patterns": "npm:^1.4.0"
+  checksum: 10c0/75cebb6771b5e8822fa1b3bf9e8875ed41a60b8d5c6545bee781c115909b71c4e24508c2f3e6465be365470b4c29ea256c4e94482a7dd4ebeaa5c83f0ede0f3a
+  languageName: node
+  linkType: hard
+
+"@endo/far@npm:^1.0.0, @endo/far@npm:^1.0.4, @endo/far@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@endo/far@npm:1.1.2"
+  dependencies:
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/pass-style": "npm:^1.4.0"
+  checksum: 10c0/11a0fa1a1b8d20e9c467f276710756ca81dd88810cd300d5646f462ca4c097616371017c9f59ce9f05ef8dc2a27e7d28185c23b40da69b6bdf77818e2eb457ea
+  languageName: node
+  linkType: hard
+
+"@endo/import-bundle@npm:^1.0.4":
+  version: 1.1.2
+  resolution: "@endo/import-bundle@npm:1.1.2"
+  dependencies:
+    "@endo/base64": "npm:^1.0.5"
+    "@endo/compartment-mapper": "npm:^1.1.5"
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/where": "npm:^1.0.5"
+    ses: "npm:^1.5.0"
+  checksum: 10c0/751aae63b03232061531bcd6a93c82a936f9aa200494e650f197145c9ed47fa1f01803f2b9b7d2e54388d3de79217ac87f8c0dcb9c84cc26d9999a9f1516e0d7
+  languageName: node
+  linkType: hard
+
+"@endo/init@npm:^1.0.3, @endo/init@npm:^1.0.4, @endo/init@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@endo/init@npm:1.1.2"
+  dependencies:
+    "@endo/base64": "npm:^1.0.5"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/lockdown": "npm:^1.0.7"
+    "@endo/promise-kit": "npm:^1.1.2"
+  checksum: 10c0/804c3dfce9880e2424e7a3cee84b82c447b03ce8eb6f6050087c0423420bb7b4f37d1a8655004453f351b80d182054e0329edc0451f213380042f8ce8aa6e83d
+  languageName: node
+  linkType: hard
+
+"@endo/lockdown@npm:^1.0.4, @endo/lockdown@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@endo/lockdown@npm:1.0.7"
+  dependencies:
+    ses: "npm:^1.5.0"
+  checksum: 10c0/a9d8ed2c3feff80741abac0c27f8a2ab9e0d46456b5b3c1d3edcaf81b498c5449b43aaf8ee01b1517452b8be548a1156c172d105469e847b01398df42a428a1b
+  languageName: node
+  linkType: hard
+
+"@endo/marshal@npm:^1.3.0, @endo/marshal@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@endo/marshal@npm:1.5.0"
+  dependencies:
+    "@endo/common": "npm:^1.2.2"
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/nat": "npm:^5.0.7"
+    "@endo/pass-style": "npm:^1.4.0"
+    "@endo/promise-kit": "npm:^1.1.2"
+  checksum: 10c0/1de746affa338e40da61d4a3fecb138724f58bf54a05060efc0996798c4fb2ca508923ac8815c8611741ec6207169517cfb4580dfd24d18e4d144ed412678047
+  languageName: node
+  linkType: hard
+
+"@endo/nat@npm:^5.0.4, @endo/nat@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "@endo/nat@npm:5.0.7"
+  checksum: 10c0/ee7d659a958fa0157767a0aa8a9425c99fe358754d3d1c93f6be169d5d92409427a88d5593da923614b087ad9faf717065ad58c3b4793dfb4049ce59b5bce63a
+  languageName: node
+  linkType: hard
+
+"@endo/netstring@npm:^1.0.4":
+  version: 1.0.7
+  resolution: "@endo/netstring@npm:1.0.7"
+  dependencies:
+    "@endo/init": "npm:^1.1.2"
+    "@endo/promise-kit": "npm:^1.1.2"
+    "@endo/stream": "npm:^1.2.2"
+    ses: "npm:^1.5.0"
+  checksum: 10c0/dd26f84d748bde731a186a433bdc5c2e8f51ca3793b108e0405e4b524709a69d9869a8466b6d703915b6a041156e237cf0f5c8430d5c29de6ca80b8aeb6bfb09
+  languageName: node
+  linkType: hard
+
+"@endo/pass-style@npm:^1.2.0, @endo/pass-style@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@endo/pass-style@npm:1.4.0"
+  dependencies:
+    "@endo/env-options": "npm:^1.1.4"
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/promise-kit": "npm:^1.1.2"
+    "@fast-check/ava": "npm:^1.1.5"
+  checksum: 10c0/28ef4b4293dbae98b17ba8165dddf80edec4a1b7f94664b09adfb5fcd5927f2a4aa0679081b94876c997d4df559a192ef4ec5e8a9444fe671966488f6e098b50
+  languageName: node
+  linkType: hard
+
+"@endo/patterns@npm:^1.1.0, @endo/patterns@npm:^1.2.0, @endo/patterns@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@endo/patterns@npm:1.4.0"
+  dependencies:
+    "@endo/common": "npm:^1.2.2"
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/marshal": "npm:^1.5.0"
+    "@endo/promise-kit": "npm:^1.1.2"
+  checksum: 10c0/c53cc422f3b09bac8b80a7fc406ffd70100ce3e455dd562ebbb0740b4b39cbe3e042d18d43dd48ebdcb4340b77a9ee90c13bc5179634e9ae091a6558fc2a06fc
+  languageName: node
+  linkType: hard
+
+"@endo/promise-kit@npm:^1.0.4, @endo/promise-kit@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@endo/promise-kit@npm:1.1.2"
+  dependencies:
+    ses: "npm:^1.5.0"
+  checksum: 10c0/12bf81d5b3efd77f75c95d4d287a9b46f9f69adc9cb25586d5a25e1d01a5392fe2e268adf5e3f61ef77187f134ffeab9182deb1b9f35598fb14c9a89b38e3a88
+  languageName: node
+  linkType: hard
+
+"@endo/ses-ava@npm:^1.1.2":
+  version: 1.2.2
+  resolution: "@endo/ses-ava@npm:1.2.2"
+  dependencies:
+    "@endo/env-options": "npm:^1.1.4"
+    "@endo/init": "npm:^1.1.2"
+    ses: "npm:^1.5.0"
+  peerDependencies:
+    ava: ^5.3.0 || ^6.1.2
+  checksum: 10c0/62b3747df53d34b986b75d6fd1c25f566448a4e62730afbaa9c4c8e27a7703c267cc6fb233a5e8deb45a68abfa2add048a4b5d4f55fd9790d7b7f0520ab384c4
+  languageName: node
+  linkType: hard
+
+"@endo/static-module-record@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@endo/static-module-record@npm:1.1.2"
+  dependencies:
+    "@agoric/babel-generator": "npm:^7.17.6"
+    "@babel/parser": "npm:^7.23.6"
+    "@babel/traverse": "npm:^7.23.6"
+    "@babel/types": "npm:^7.24.0"
+    ses: "npm:^1.5.0"
+  checksum: 10c0/62809d0bf92721329e0838c0e8278d9ecd376dce36d7fd4b446443e2bad11d15ee7ae1aa79e68acf1498954874014cd71ac26f547cbd9b8aeb904c3cfe4e4e84
+  languageName: node
+  linkType: hard
+
+"@endo/stream-node@npm:^1.0.4":
+  version: 1.1.2
+  resolution: "@endo/stream-node@npm:1.1.2"
+  dependencies:
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/init": "npm:^1.1.2"
+    "@endo/stream": "npm:^1.2.2"
+    ses: "npm:^1.5.0"
+  checksum: 10c0/0c6d3bc991c4cc66c612291663321fd2d2967a8ad894056f9708a3961e5ba1939e818815d6da3970a885b3a2acebd10792c8d2604d879c4529a38cfc02ca1cb0
+  languageName: node
+  linkType: hard
+
+"@endo/stream@npm:^1.1.0, @endo/stream@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@endo/stream@npm:1.2.2"
+  dependencies:
+    "@endo/eventual-send": "npm:^1.2.2"
+    "@endo/promise-kit": "npm:^1.1.2"
+    ses: "npm:^1.5.0"
+  checksum: 10c0/3cc98b2c25aabd79a8005e958b981e5f652fdc8969589f0b67449678abfcdd780b57f0ce96710f6016058b740402c4fc23ddf6e0be7ca683226dcf978094d875
+  languageName: node
+  linkType: hard
+
+"@endo/where@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@endo/where@npm:1.0.5"
+  checksum: 10c0/bff49d4a5c68df24abbe60642afed049a224150803da171b3af51b9e372e9bc4ea741a175221ae1bc574f5e68f4b1782c53028a83f397061f0ab4d442bf5a518
+  languageName: node
+  linkType: hard
+
 "@endo/zip@npm:^1.0.1":
   version: 1.0.1
   resolution: "@endo/zip@npm:1.0.1"
   checksum: 10c0/1074bdc10287f4c94b3423e130da88f9c6ba09c999483c1164b3eed061350a060d2dbe377cfa3b8d4a86b3f1c3aed5cbf0cdd78ee2bf2cb9b837caa2ebbf712f
+  languageName: node
+  linkType: hard
+
+"@endo/zip@npm:^1.0.2, @endo/zip@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@endo/zip@npm:1.0.5"
+  checksum: 10c0/6d03178b66f36b1d39894a84760155219d68ffee975af6381869fc313dc1647464ec40da7a4b50c465a5485ff9f03066ffa0e74f254faa99b46a9fea8852d962
+  languageName: node
+  linkType: hard
+
+"@fast-check/ava@npm:^1.1.5":
+  version: 1.2.1
+  resolution: "@fast-check/ava@npm:1.2.1"
+  dependencies:
+    fast-check: "npm:^3.0.0"
+  peerDependencies:
+    ava: ^4 || ^5 || ^6
+  checksum: 10c0/3800098fd7e8098102544a2f7a595351d063a7ebaeca18ed4901df5ec2679da2330ba8c0db2c820721d4cbb3e23d817ba22fec6d058957930e229f44fa71a684
+  languageName: node
+  linkType: hard
+
+"@iarna/toml@npm:^2.2.3":
+  version: 2.2.5
+  resolution: "@iarna/toml@npm:2.2.5"
+  checksum: 10c0/d095381ad4554aca233b7cf5a91f243ef619e5e15efd3157bc640feac320545450d14b394aebbf6f02a2047437ced778ae598d5879a995441ab7b6c0b2c2f201
   languageName: node
   linkType: hard
 
@@ -37,6 +1220,55 @@ __metadata:
     wrap-ansi: "npm:^8.1.0"
     wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
   checksum: 10c0/b1bf42535d49f11dc137f18d5e4e63a28c5569de438a221c369483731e9dac9fb797af554e8bf02b6192d1e5eba6e6402cf93900c3d0ac86391d00d04876789e
+  languageName: node
+  linkType: hard
+
+"@jridgewell/gen-mapping@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@jridgewell/gen-mapping@npm:0.3.5"
+  dependencies:
+    "@jridgewell/set-array": "npm:^1.2.1"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10c0/1be4fd4a6b0f41337c4f5fdf4afc3bd19e39c3691924817108b82ffcb9c9e609c273f936932b9fba4b3a298ce2eb06d9bff4eb1cc3bd81c4f4ee1b4917e25feb
+  languageName: node
+  linkType: hard
+
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jridgewell/set-array@npm:1.2.1"
+  checksum: 10c0/2a5aa7b4b5c3464c895c802d8ae3f3d2b92fcbe84ad12f8d0bfbb1f5ad006717e7577ee1fd2eac00c088abe486c7adb27976f45d2941ff6b0b92b2c3302c60f4
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: 10c0/0c6b5ae663087558039052a626d2d7ed5208da36cfd707dcc5cea4a07cfc918248403dcb5989a8f7afaf245ce0573b7cc6fd94c4a30453bd10e44d9363940ba5
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1, @noble/hashes@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "@noble/hashes@npm:1.4.0"
+  checksum: 10c0/8c3f005ee72e7b8f9cff756dfae1241485187254e3f743873e22073d63906863df5d4f13d441b7530ea614b7a093f0d889309f28b59850f33b66cb26a779a4a5
   languageName: node
   linkType: hard
 
@@ -96,6 +1328,171 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10c0/a83343a468ff5b5ec6bff36fd788a64c839e48a07ff9f4f813564f58caf44d011cd6504ed2147bf34835bd7a7dd2107052af755961c6b098fd8902b4f6500d0f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10c0/eec925e681081af190b8ee231f9bad3101e189abbc182ff279da6b531e7dbd2a56f1f306f37a80b1be9e00aa2d271690d08dcc5f326f71c9eed8546675c8caf6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+    "@protobufjs/inquire": "npm:^1.1.0"
+  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10c0/cece0a938e7f5dfd2fa03f8c14f2f1cf8b0d6e13ac7326ff4c96ea311effd5fb7ae0bba754fbf505312af2e38500250c90e68506b97c02360a43793d88a0d8b4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10c0/eda2718b7f222ac6e6ad36f758a92ef90d26526026a19f4f17f668f45e0306a5bd734def3f48f51f8134ae0978b6262a5c517c08b115a551756d1a3aadfcf038
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-commonjs@npm:^19.0.0":
+  version: 19.0.2
+  resolution: "@rollup/plugin-commonjs@npm:19.0.2"
+  dependencies:
+    "@rollup/pluginutils": "npm:^3.1.0"
+    commondir: "npm:^1.0.1"
+    estree-walker: "npm:^2.0.1"
+    glob: "npm:^7.1.6"
+    is-reference: "npm:^1.2.1"
+    magic-string: "npm:^0.25.7"
+    resolve: "npm:^1.17.0"
+  peerDependencies:
+    rollup: ^2.38.3
+  checksum: 10c0/9adccf77ad835cbe565da4385212f1e54c3e0dca2be174b5c2cfe89cfaeb240f42c7673e97e49b21b7c66ed901cc1c711552b6727f60b43a953ce996eb2868a7
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-node-resolve@npm:^13.0.0":
+  version: 13.3.0
+  resolution: "@rollup/plugin-node-resolve@npm:13.3.0"
+  dependencies:
+    "@rollup/pluginutils": "npm:^3.1.0"
+    "@types/resolve": "npm:1.17.1"
+    deepmerge: "npm:^4.2.2"
+    is-builtin-module: "npm:^3.1.0"
+    is-module: "npm:^1.0.0"
+    resolve: "npm:^1.19.0"
+  peerDependencies:
+    rollup: ^2.42.0
+  checksum: 10c0/6caa32a8304a20f1c9953111b25e9543f4de7d254958d81ce0158ad909e4493946bc2060c4ace23d9748b560ebc84c920ee7bc1b7d50dbf8ba852ef13c91af58
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@rollup/pluginutils@npm:3.1.0"
+  dependencies:
+    "@types/estree": "npm:0.0.39"
+    estree-walker: "npm:^1.0.1"
+    picomatch: "npm:^2.2.2"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 10c0/7151753160d15ba2b259461a6c25b3932150994ea52dba8fd3144f634c7647c2e56733d986e2c15de67c4d96a9ee7d6278efa6d2e626a7169898fd64adc0f90c
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*":
+  version: 1.0.5
+  resolution: "@types/estree@npm:1.0.5"
+  checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:0.0.39":
+  version: 0.0.39
+  resolution: "@types/estree@npm:0.0.39"
+  checksum: 10c0/f0af6c95ac1988c4827964bd9d3b51d24da442e2188943f6dfcb1e1559103d5d024d564b2e9d3f84c53714a02a0a7435c7441138eb63d9af5de4dfc66cdc0d92
+  languageName: node
+  linkType: hard
+
+"@types/long@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@types/long@npm:4.0.2"
+  checksum: 10c0/42ec66ade1f72ff9d143c5a519a65efc7c1c77be7b1ac5455c530ae9acd87baba065542f8847522af2e3ace2cc999f3ad464ef86e6b7352eece34daf88f8c924
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:*, @types/node@npm:>=13.7.0":
+  version: 20.14.9
+  resolution: "@types/node@npm:20.14.9"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/911ffa444dc032897f4a23ed580c67903bd38ea1c5ec99b1d00fa10b83537a3adddef8e1f29710cbdd8e556a61407ed008e06537d834e48caf449ce59f87d387
+  languageName: node
+  linkType: hard
+
+"@types/resolve@npm:1.17.1":
+  version: 1.17.1
+  resolution: "@types/resolve@npm:1.17.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/6eeb9c27d99bf4b393bf168d43208f63e78cefca5644662a0bdb2bdbf8352386f4f3aca66add138fc41bce5f66fd48a0de430a1473f11b612fbed0375ae78031
+  languageName: node
+  linkType: hard
+
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -107,6 +1504,15 @@ __metadata:
   version: 8.3.2
   resolution: "acorn-walk@npm:8.3.2"
   checksum: 10c0/7e2a8dad5480df7f872569b9dccff2f3da7e65f5353686b1d6032ab9f4ddf6e3a2cb83a9b52cf50b1497fd522154dda92f0abf7153290cc79cd14721ff121e52
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.2.4":
+  version: 8.12.0
+  resolution: "acorn@npm:8.12.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/a19f9dead009d3b430fa3c253710b47778cdaace15b316de6de93a68c355507bc1072a9956372b6c990cbeeb167d4a929249d0faeb8ae4bb6911d68d53299549
   languageName: node
   linkType: hard
 
@@ -148,6 +1554,92 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agoric@npm:0.21.2-dev-5676146.0":
+  version: 0.21.2-dev-5676146.0
+  resolution: "agoric@npm:0.21.2-dev-5676146.0"
+  dependencies:
+    "@agoric/access-token": "npm:0.4.22-dev-5676146.0+5676146"
+    "@agoric/assert": "npm:0.6.1-dev-5676146.0+5676146"
+    "@agoric/cache": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/casting": "npm:0.4.3-dev-5676146.0+5676146"
+    "@agoric/cosmic-proto": "npm:0.4.1-dev-5676146.0+5676146"
+    "@agoric/ertp": "npm:0.16.3-dev-5676146.0+5676146"
+    "@agoric/governance": "npm:0.10.4-dev-5676146.0+5676146"
+    "@agoric/inter-protocol": "npm:0.16.2-dev-5676146.0+5676146"
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0+5676146"
+    "@agoric/network": "npm:0.1.1-dev-5676146.0+5676146"
+    "@agoric/smart-wallet": "npm:0.5.4-dev-5676146.0+5676146"
+    "@agoric/store": "npm:0.9.3-dev-5676146.0+5676146"
+    "@agoric/swingset-vat": "npm:0.32.3-dev-5676146.0+5676146"
+    "@agoric/vats": "npm:0.15.2-dev-5676146.0+5676146"
+    "@agoric/zoe": "npm:0.26.3-dev-5676146.0+5676146"
+    "@agoric/zone": "npm:0.2.3-dev-5676146.0+5676146"
+    "@confio/relayer": "npm:^0.11.3"
+    "@cosmjs/crypto": "npm:^0.32.3"
+    "@cosmjs/encoding": "npm:^0.32.3"
+    "@cosmjs/math": "npm:^0.32.3"
+    "@cosmjs/proto-signing": "npm:^0.32.3"
+    "@cosmjs/stargate": "npm:^0.32.3"
+    "@endo/bundle-source": "npm:^3.1.0"
+    "@endo/captp": "npm:^4.0.4"
+    "@endo/compartment-mapper": "npm:^1.1.2"
+    "@endo/env-options": "npm:^1.1.1"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/init": "npm:^1.0.4"
+    "@endo/marshal": "npm:^1.3.0"
+    "@endo/nat": "npm:^5.0.4"
+    "@endo/patterns": "npm:^1.2.0"
+    "@endo/promise-kit": "npm:^1.0.4"
+    "@iarna/toml": "npm:^2.2.3"
+    anylogger: "npm:^0.21.0"
+    chalk: "npm:^5.2.0"
+    commander: "npm:^11.1.0"
+    deterministic-json: "npm:^1.0.5"
+    esm: "github:agoric-labs/esm#Agoric-built"
+    inquirer: "npm:^8.2.2"
+    opener: "npm:^1.5.2"
+    tmp: "npm:^0.2.1"
+    ws: "npm:^7.2.0"
+  bin:
+    agops: src/bin-agops.js
+    agoric: src/entrypoint.js
+  checksum: 10c0/abcea0bfd4594c2841d3e69ed6c78bedd5a4c573efa9ebcb34730e87ea445ab283e06a7dff2a0f44834faae3bb4dfc0153a2bd34cfd859064208cd7bfb92a19b
+  languageName: node
+  linkType: hard
+
+"ajv@npm:7.1.1":
+  version: 7.1.1
+  resolution: "ajv@npm:7.1.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+    uri-js: "npm:^4.2.2"
+  checksum: 10c0/328a86011a67dc10eff41e3e2ef412f88f5de546ad2288c8a3d2a563c203dd4dd479660c07f99fd9499e36c723afee212704b25f5599815991409528fd638329
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.1":
+  version: 8.16.0
+  resolution: "ajv@npm:8.16.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+    uri-js: "npm:^4.4.1"
+  checksum: 10c0/6fc38aa8fd4fbfaa7096ac049e48c0cb440db36b76fef2d7d5b7d92b102735670d055d412d19176c08c9d48eaa9d06661b67e59f04943dc71ab1551e0484f88c
+  languageName: node
+  linkType: hard
+
+"ansi-escapes@npm:^4.2.1":
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
+  dependencies:
+    type-fest: "npm:^0.21.3"
+  checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -162,7 +1654,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0":
+"ansi-styles@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "ansi-styles@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.0"
+  checksum: 10c0/ece5a8ef069fcc5298f67e3f4771a663129abd174ea2dfa87923a2be2abf6cd367ef72ac87942da00ce85bd1d651d4cd8595aebdb1b385889b89b205860e977b
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -175,6 +1676,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"anylogger@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "anylogger@npm:0.21.0"
+  checksum: 10c0/1ca7fcf5bc2b78d1e1d9b8c8cc7ce50b5c6cc67a8da5a28c9c975b7b46fff255a04abab02de38a5139190c9d8b34b3d6c59af6724521b077f7d7dfbad9b47a9c
   languageName: node
   linkType: hard
 
@@ -197,6 +1705,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
+  languageName: node
+  linkType: hard
+
 "array-find-index@npm:^1.0.1":
   version: 1.0.2
   resolution: "array-find-index@npm:1.0.2"
@@ -215,6 +1730,27 @@ __metadata:
   version: 3.0.0
   resolution: "arrify@npm:3.0.0"
   checksum: 10c0/2e26601b8486f29780f1f70f7ac05a226755814c2a3ab42e196748f650af1dc310cd575a11dd4b9841c70fd7460b2dd2b8fe6fb7a3375878e2660706efafa58e
+  languageName: node
+  linkType: hard
+
+"astral-regex@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "astral-regex@npm:2.0.0"
+  checksum: 10c0/f63d439cc383db1b9c5c6080d1e240bd14dae745f15d11ec5da863e182bbeca70df6c8191cffef5deba0b566ef98834610a68be79ac6379c95eeb26e1b310e25
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.1.0":
+  version: 3.2.5
+  resolution: "async@npm:3.2.5"
+  checksum: 10c0/1408287b26c6db67d45cb346e34892cee555b8b59e6c68e6f8c3e495cad5ca13b4f218180e871f3c2ca30df4ab52693b66f2f6ff43644760cab0b2198bda79c1
+  languageName: node
+  linkType: hard
+
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
   languageName: node
   linkType: hard
 
@@ -276,6 +1812,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.6.0, axios@npm:^1.6.7":
+  version: 1.7.2
+  resolution: "axios@npm:1.7.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/cbd47ce380fe045313364e740bb03b936420b8b5558c7ea36a4563db1258c658f05e40feb5ddd41f6633fdd96d37ac2a76f884dad599c5b0224b4c451b3fa7ae
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -283,10 +1830,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"bech32@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "bech32@npm:1.1.4"
+  checksum: 10c0/5f62ca47b8df99ace9c0e0d8deb36a919d91bf40066700aaa9920a45f86bb10eb56d537d559416fd8703aa0fb60dddb642e58f049701e7291df678b2033e5ee5
+  languageName: node
+  linkType: hard
+
+"better-sqlite3@npm:^9.1.1":
+  version: 9.6.0
+  resolution: "better-sqlite3@npm:9.6.0"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.1.1"
+  checksum: 10c0/8db9b38f414e26a56d4c40fc16e94a253118491dae0e2c054338a9e470f1a883c7eb4cb330f2f5737db30f704d4f2e697c59071ca04e03364ee9fe04375aa9c8
   languageName: node
   linkType: hard
 
@@ -317,7 +1882,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.3":
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 10c0/132944b20c93c1a8f97bf8aa25980a76c6eb4291b7f2df2dbcd01cb5b417c287d3ee0847c7260c9f05f3d5a4233aaa03dec95114e97f308abe9cc3f72bed4a44
+  languageName: node
+  linkType: hard
+
+"bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -332,6 +1904,30 @@ __metadata:
   version: 2.19.0
   resolution: "blueimp-md5@npm:2.19.0"
   checksum: 10c0/85d04343537dd99a288c62450341dcce7380d3454c81f8e5a971ddd80307d6f9ef51b5b92ad7d48aaaa92fd6d3a1f6b2f4fada068faae646887f7bfabc17a346
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^4.11.9":
+  version: 4.12.0
+  resolution: "bn.js@npm:4.12.0"
+  checksum: 10c0/9736aaa317421b6b3ed038ff3d4491935a01419ac2d83ddcfebc5717385295fcfcf0c57311d90fe49926d0abbd7a9dbefdd8861e6129939177f7e67ebc645b21
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.2.0":
+  version: 5.2.1
+  resolution: "bn.js@npm:5.2.1"
+  checksum: 10c0/bed3d8bd34ec89dbcf9f20f88bd7d4a49c160fda3b561c7bb227501f974d3e435a48fb9b61bc3de304acab9215a3bda0803f7017ffb4d0016a0c3a740a283caa
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^1.1.7":
+  version: 1.1.11
+  resolution: "brace-expansion@npm:1.1.11"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
   languageName: node
   linkType: hard
 
@@ -353,6 +1949,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brorand@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "brorand@npm:1.1.0"
+  checksum: 10c0/6f366d7c4990f82c366e3878492ba9a372a73163c09871e80d82fb4ae0d23f9f8924cb8a662330308206e6b3b76ba1d528b4601c9ef73c2166b440b2ea3b7571
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -360,6 +1963,13 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
+  languageName: node
+  linkType: hard
+
+"builtin-modules@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "builtin-modules@npm:3.3.0"
+  checksum: 10c0/2cb3448b4f7306dc853632a4fcddc95e8d4e4b9868c139400027b71938fc6806d4ff44007deffb362ac85724bd40c2c6452fb6a0aa4531650eeddb98d8e5ee8a
   languageName: node
   linkType: hard
 
@@ -383,6 +1993,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-bind@npm:^1.0.5":
+  version: 1.0.7
+  resolution: "call-bind@npm:1.0.7"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.1"
+  checksum: 10c0/a3ded2e423b8e2a265983dba81c27e125b48eefb2655e7dfab6be597088da3d47c47976c24bc51b8fd9af1061f8f87b4ab78a314f3c77784b2ae2ba535ad8b8d
+  languageName: node
+  linkType: hard
+
 "callsites@npm:^4.0.0":
   version: 4.1.0
   resolution: "callsites@npm:4.1.0"
@@ -399,10 +2022,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: "npm:^3.2.1"
+    escape-string-regexp: "npm:^1.0.5"
+    supports-color: "npm:^5.3.0"
+  checksum: 10c0/e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^5.2.0, chalk@npm:^5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 10c0/8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
   languageName: node
   linkType: hard
 
@@ -483,6 +2134,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-cursor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "cli-cursor@npm:3.1.0"
+  dependencies:
+    restore-cursor: "npm:^3.1.0"
+  checksum: 10c0/92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:^2.5.0":
+  version: 2.9.2
+  resolution: "cli-spinners@npm:2.9.2"
+  checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
+  languageName: node
+  linkType: hard
+
 "cli-truncate@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-truncate@npm:3.1.0"
@@ -490,6 +2157,13 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^5.0.0"
   checksum: 10c0/a19088878409ec0e5dc2659a5166929629d93cfba6d68afc9cde2282fd4c751af5b555bf197047e31c87c574396348d011b7aa806fec29c4139ea4f7f00b324c
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-width@npm:3.0.0"
+  checksum: 10c0/125a62810e59a2564268c80fdff56c23159a7690c003e34aeb2e68497dccff26911998ff49c33916fcfdf71e824322cc3953e3f7b48b27267c7a062c81348a9a
   languageName: node
   linkType: hard
 
@@ -504,12 +2178,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clone@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "clone@npm:1.0.4"
+  checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
+  languageName: node
+  linkType: hard
+
 "code-excerpt@npm:^4.0.0":
   version: 4.0.0
   resolution: "code-excerpt@npm:4.0.0"
   dependencies:
     convert-to-spaces: "npm:^2.0.1"
   checksum: 10c0/b6c5a06e039cecd2ab6a0e10ee0831de8362107d1f298ca3558b5f9004cb8e0260b02dd6c07f57b9a0e346c76864d2873311ee1989809fdeb05bd5fbbadde773
+  languageName: node
+  linkType: hard
+
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "color-convert@npm:1.9.3"
+  dependencies:
+    color-name: "npm:1.1.3"
+  checksum: 10c0/5ad3c534949a8c68fca8fbc6f09068f435f0ad290ab8b2f76841b9e6af7e0bb57b98cb05b0e19fe33f5d91e5a8611ad457e5f69e0a484caad1f7487fd0e8253c
   languageName: node
   linkType: hard
 
@@ -522,10 +2212,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:1.1.3":
+  version: 1.1.3
+  resolution: "color-name@npm:1.1.3"
+  checksum: 10c0/566a3d42cca25b9b3cd5528cd7754b8e89c0eb646b7f214e8e2eaddb69994ac5f0557d9c175eb5d8f0ad73531140d9c47525085ee752a91a2ab15ab459caf6d6
+  languageName: node
+  linkType: hard
+
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: "npm:^1.0.0"
+    simple-swizzle: "npm:^0.2.2"
+  checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.3"
+    color-string: "npm:^1.6.0"
+  checksum: 10c0/39345d55825884c32a88b95127d417a2c24681d8b57069413596d9fcbb721459ef9d9ec24ce3e65527b5373ce171b73e38dbcd9c830a52a6487e7f37bf00e83c
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: "npm:^3.1.3"
+    text-hex: "npm:1.0.x"
+  checksum: 10c0/af5f91ff7f8e146b96e439ac20ed79b197210193bde721b47380a75b21751d90fa56390c773bb67c0aedd34ff85091883a437ab56861c779bd507d639ba7e123
+  languageName: node
+  linkType: hard
+
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: "npm:~1.0.0"
+  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
+"commander@npm:7.1.0":
+  version: 7.1.0
+  resolution: "commander@npm:7.1.0"
+  checksum: 10c0/1c114cc2e0c7c980068d7f2472f3fc9129ea5d6f2f0a8699671afe5a44a51d5707a6c73daff1aaa919424284dea9fca4017307d30647935a1116518699d54c9d
+  languageName: node
+  linkType: hard
+
+"commander@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "commander@npm:11.1.0"
+  checksum: 10c0/13cc6ac875e48780250f723fb81c1c1178d35c5decb1abb1b628b3177af08a8554e76b2c0f29de72d69eef7c864d12613272a71fabef8047922bc622ab75a179
   languageName: node
   linkType: hard
 
@@ -533,6 +2283,20 @@ __metadata:
   version: 3.0.0
   resolution: "common-path-prefix@npm:3.0.0"
   checksum: 10c0/c4a74294e1b1570f4a8ab435285d185a03976c323caa16359053e749db4fde44e3e6586c29cd051100335e11895767cbbd27ea389108e327d62f38daf4548fdb
+  languageName: node
+  linkType: hard
+
+"commondir@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "commondir@npm:1.0.1"
+  checksum: 10c0/33a124960e471c25ee19280c9ce31ccc19574b566dc514fe4f4ca4c34fa8b0b57cf437671f5de380e11353ea9426213fca17687dd2ef03134fea2dbc53809fd6
+  languageName: node
+  linkType: hard
+
+"concat-map@npm:0.0.1":
+  version: 0.0.1
+  resolution: "concat-map@npm:0.0.1"
+  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
   languageName: node
   linkType: hard
 
@@ -559,6 +2323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmjs-types@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "cosmjs-types@npm:0.9.0"
+  checksum: 10c0/bc20f4293fb34629d7c5f96bafe533987f753df957ff68eb078d0128ae5a418320cb945024441769a07bb9bc5dde9d22b972fd40d485933e5706ea191c43727b
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -576,6 +2347,13 @@ __metadata:
   dependencies:
     array-find-index: "npm:^1.0.1"
   checksum: 10c0/32d197689ec32f035910202c1abb0dc6424dce01d7b51779c685119b380d98535c110ffff67a262fc7e367612a7dfd30d3d3055f9a6634b5a9dd1302de7ef11c
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "data-uri-to-buffer@npm:4.0.1"
+  checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
   languageName: node
   linkType: hard
 
@@ -600,6 +2378,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.1":
+  version: 4.3.5
+  resolution: "debug@npm:4.3.5"
+  dependencies:
+    ms: "npm:2.1.2"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/082c375a2bdc4f4469c99f325ff458adad62a3fc2c482d59923c260cb08152f34e2659f72b3767db8bb2f21ca81a60a42d1019605a412132d7b9f59363a005cc
+  languageName: node
+  linkType: hard
+
 "decompress-response@npm:^6.0.0":
   version: 6.0.0
   resolution: "decompress-response@npm:6.0.0"
@@ -616,10 +2406,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deepmerge@npm:^4.2.2":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
+"defaults@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "defaults@npm:1.0.4"
+  dependencies:
+    clone: "npm:^1.0.2"
+  checksum: 10c0/9cfbe498f5c8ed733775db62dfd585780387d93c17477949e1670bfcfb9346e0281ce8c4bf9f4ac1fc0f9b851113bd6dc9e41182ea1644ccd97de639fa13c35a
+  languageName: node
+  linkType: hard
+
+"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.0.1"
+  checksum: 10c0/dea0606d1483eb9db8d930d4eac62ca0fa16738b0b3e07046cddfacf7d8c868bbe13fa0cb263eb91c7d0d527960dc3f2f2471a69ed7816210307f6744fe62e37
+  languageName: node
+  linkType: hard
+
+"define-properties@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
+  dependencies:
+    define-data-property: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.0"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.0":
   version: 2.0.2
   resolution: "detect-libc@npm:2.0.2"
   checksum: 10c0/a9f4ffcd2701525c589617d98afe5a5d0676c8ea82bcc4ed6f3747241b79f781d36437c59a5e855254c864d36a3e9f8276568b6b531c28d6e53b093a15703f11
+  languageName: node
+  linkType: hard
+
+"deterministic-json@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "deterministic-json@npm:1.0.5"
+  dependencies:
+    json-stable-stringify: "npm:^1.0.1"
+  checksum: 10c0/e29679601cd3b05c73665529dcd0132b48797fd7dfbac6793238a479e82b5f3905114316fbb316332da58b4497e35df9aea77b41ff92fd74fe298a6f31b93d40
   languageName: node
   linkType: hard
 
@@ -636,6 +2480,21 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.4":
+  version: 6.5.5
+  resolution: "elliptic@npm:6.5.5"
+  dependencies:
+    bn.js: "npm:^4.11.9"
+    brorand: "npm:^1.1.0"
+    hash.js: "npm:^1.0.0"
+    hmac-drbg: "npm:^1.0.1"
+    inherits: "npm:^2.0.4"
+    minimalistic-assert: "npm:^1.0.1"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10c0/3e591e93783a1b66f234ebf5bd3a8a9a8e063a75073a35a671e03e3b25253b6e33ac121f7efe9b8808890fffb17b40596cc19d01e6e8d1fa13b9a56ff65597c8
   languageName: node
   linkType: hard
 
@@ -657,6 +2516,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 10c0/3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
   languageName: node
   linkType: hard
 
@@ -692,6 +2558,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-define-property@npm:1.0.0"
+  dependencies:
+    get-intrinsic: "npm:^1.2.4"
+  checksum: 10c0/6bf3191feb7ea2ebda48b577f69bdfac7a2b3c9bcf97307f55fd6ef1bbca0b49f0c219a935aca506c993d8c5d8bddd937766cb760cd5e5a1071351f2df9f9aa4
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -706,10 +2588,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "escape-string-regexp@npm:1.0.5"
+  checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^2.0.0":
   version: 2.0.0
   resolution: "escape-string-regexp@npm:2.0.0"
   checksum: 10c0/2530479fe8db57eace5e8646c9c2a9c80fa279614986d16dcc6bcaceb63ae77f05a851ba6c43756d816c61d7f4534baf56e3c705e3e0d884818a46808811c507
+  languageName: node
+  linkType: hard
+
+"esm@github:agoric-labs/esm#Agoric-built":
+  version: 3.2.25
+  resolution: "esm@https://github.com/agoric-labs/esm.git#commit=3603726ad4636b2f865f463188fcaade6375638e"
+  checksum: 10c0/fc1e112a3a681e7b4152d4f5c76dd5aa9e30496d2020490ffa0fb61aaf57d1e12dae0c1074fdd2e0f08949ab2df7e00e750262356781f072e4119955ee10b754
   languageName: node
   linkType: hard
 
@@ -720,6 +2616,20 @@ __metadata:
     esparse: ./bin/esparse.js
     esvalidate: ./bin/esvalidate.js
   checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "estree-walker@npm:1.0.1"
+  checksum: 10c0/fa9e5f8c1bbe8d01e314c0f03067b64a4f22d4c58410fc5237060d0c15b81e58c23921c41acc60abbdab490f1fdfcbd6408ede2d03ca704454272e0244d61a55
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 10c0/53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
   languageName: node
   linkType: hard
 
@@ -761,6 +2671,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"external-editor@npm:^3.0.3":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.0.0":
+  version: 3.19.0
+  resolution: "fast-check@npm:3.19.0"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10c0/5a15484d380fb5a3e94ec951c97e59b940ac4f2e1f3f7a05578d67851e5cb5283121bcf08c57e3238bc85899ce691b47ab477a6dd481a6f520e2e7ab4952d1ee
+  languageName: node
+  linkType: hard
+
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
 "fast-diff@npm:^1.2.0":
   version: 1.3.0
   resolution: "fast-diff@npm:1.3.0"
@@ -781,12 +2718,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-safe-stringify@npm:2.0.4":
+  version: 2.0.4
+  resolution: "fast-safe-stringify@npm:2.0.4"
+  checksum: 10c0/5e4fbafe8b8c4a1681c2ab259ed8ce6672fc209683a141876f020c36a2cbec73bfe25c417c269f439797020996d04ed2d7c4c6b2c5cf393d6febbf7f4d8a5f53
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.17.0
   resolution: "fastq@npm:1.17.0"
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/0a90ed46ccd6a858a32e297bd35f4249ba6544899b905d08f33a6ba36459041639161fa15bc85a38afa98dd44fb2fa2969419a879721a1395d3e24668a7732c7
+  languageName: node
+  linkType: hard
+
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
+  languageName: node
+  linkType: hard
+
+"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
+  version: 3.2.0
+  resolution: "fetch-blob@npm:3.2.0"
+  dependencies:
+    node-domexception: "npm:^1.0.0"
+    web-streams-polyfill: "npm:^3.0.3"
+  checksum: 10c0/60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
+  languageName: node
+  linkType: hard
+
+"figures@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "figures@npm:3.2.0"
+  dependencies:
+    escape-string-regexp: "npm:^1.0.5"
+  checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
   languageName: node
   linkType: hard
 
@@ -826,6 +2796,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 10c0/8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
+  languageName: node
+  linkType: hard
+
 "foreground-child@npm:^3.1.0":
   version: 3.1.1
   resolution: "foreground-child@npm:3.1.1"
@@ -833,6 +2820,26 @@ __metadata:
     cross-spawn: "npm:^7.0.0"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/9700a0285628abaeb37007c9a4d92bd49f67210f09067638774338e146c8e9c825c5c877f072b2f75f41dc6a2d0be8664f79ffc03f6576649f54a84fb9b47de0
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
+  languageName: node
+  linkType: hard
+
+"formdata-polyfill@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "formdata-polyfill@npm:4.0.10"
+  dependencies:
+    fetch-blob: "npm:^3.1.2"
+  checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
   languageName: node
   linkType: hard
 
@@ -861,6 +2868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs.realpath@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs.realpath@npm:1.0.0"
+  checksum: 10c0/444cf1291d997165dfd4c0d58b69f0e4782bfd9149fd72faa4fe299e68e0e93d6db941660b37dd29153bf7186672ececa3b50b7e7249477b03fdf850f287c948
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
@@ -880,10 +2894,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
+  languageName: node
+  linkType: hard
+
 "get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "get-intrinsic@npm:1.2.4"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    has-proto: "npm:^1.0.1"
+    has-symbols: "npm:^1.0.3"
+    hasown: "npm:^2.0.0"
+  checksum: 10c0/0a9b82c16696ed6da5e39b1267104475c47e3a9bdbe8b509dfe1710946e38a87be70d759f4bb3cda042d76a41ef47fe769660f3b7c0d1f68750299344ffb15b7
   languageName: node
   linkType: hard
 
@@ -925,6 +2959,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^7.1.6":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.1.1"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10c0/65676153e2b0c9095100fe7f25a778bf45608eeb32c6048cf307f579649bcc30353277b3b898a3792602c65764e5baa4f643714dfbdfd64ea271d210c7a425fe
+  languageName: node
+  linkType: hard
+
+"globals@npm:^11.1.0":
+  version: 11.12.0
+  resolution: "globals@npm:11.12.0"
+  checksum: 10c0/758f9f258e7b19226bd8d4af5d3b0dcf7038780fb23d82e6f98932c44e239f884847f1766e8fa9cc5635ccb3204f7fa7314d4408dd4002a5e8ea827b4018f0a1
+  languageName: node
+  linkType: hard
+
+"globalthis@npm:^1.0.1":
+  version: 1.0.4
+  resolution: "globalthis@npm:1.0.4"
+  dependencies:
+    define-properties: "npm:^1.2.1"
+    gopd: "npm:^1.0.1"
+  checksum: 10c0/9d156f313af79d80b1566b93e19285f481c591ad6d0d319b4be5e03750d004dde40a39a0f26f7e635f9007a3600802f53ecd85a759b86f109e80a5f705e01846
+  languageName: node
+  linkType: hard
+
 "globby@npm:^13.1.4":
   version: 13.2.2
   resolution: "globby@npm:13.2.2"
@@ -938,10 +3003,86 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.6":
+"gopd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "gopd@npm:1.0.1"
+  dependencies:
+    get-intrinsic: "npm:^1.1.3"
+  checksum: 10c0/505c05487f7944c552cee72087bf1567debb470d4355b1335f2c262d218ebbff805cd3715448fe29b4b380bae6912561d0467233e4165830efd28da241418c63
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 10c0/1c6c83b14b8b1b3c25b0727b8ba3e3b647f99e9e6e13eb7322107261de07a4c1be56fc0d45678fc376e09772a3a1642ccdaf8fc69bdf123b6c086598397ce473
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "has-flag@npm:4.0.0"
+  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+  checksum: 10c0/253c1f59e80bb476cf0dde8ff5284505d90c3bdb762983c3514d36414290475fe3fd6f574929d84de2a8eec00d35cf07cb6776205ff32efd7c50719125f00236
+  languageName: node
+  linkType: hard
+
+"has-proto@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "has-proto@npm:1.0.3"
+  checksum: 10c0/35a6989f81e9f8022c2f4027f8b48a552de714938765d019dbea6bb547bd49ce5010a3c7c32ec6ddac6e48fc546166a3583b128f5a7add8b058a6d8b4afec205
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-symbols@npm:1.0.3"
+  checksum: 10c0/e6922b4345a3f37069cdfe8600febbca791c94988c01af3394d86ca3360b4b93928bbf395859158f88099cb10b19d98e3bbab7c9ff2c1bd09cf665ee90afa2c3
+  languageName: node
+  linkType: hard
+
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+  version: 1.1.7
+  resolution: "hash.js@npm:1.1.7"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    minimalistic-assert: "npm:^1.0.1"
+  checksum: 10c0/41ada59494eac5332cfc1ce6b7ebdd7b88a3864a6d6b08a3ea8ef261332ed60f37f10877e0c825aaa4bddebf164fbffa618286aeeec5296675e2671cbfa746c4
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hmac-drbg@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "hmac-drbg@npm:1.0.1"
+  dependencies:
+    hash.js: "npm:^1.0.3"
+    minimalistic-assert: "npm:^1.0.0"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10c0/f3d9ba31b40257a573f162176ac5930109816036c59a09f901eb2ffd7e5e705c6832bedfff507957125f2086a0ab8f853c0df225642a88bf1fcaea945f20600d
   languageName: node
   linkType: hard
 
@@ -979,6 +3120,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -1009,6 +3159,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-meta-resolve@npm:^2.2.1":
+  version: 2.2.2
+  resolution: "import-meta-resolve@npm:2.2.2"
+  checksum: 10c0/80873aebf0d2a66e824e278fb6cbb16a6660f86df49b367404e5de80928720ecb44f643243b46dc5c5fae506abb666ef54d6f281b45ee0f1034951acb2261eb5
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -1030,7 +3187,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:^2.0.3, inherits@npm:^2.0.4":
+"inflight@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "inflight@npm:1.0.6"
+  dependencies:
+    once: "npm:^1.3.0"
+    wrappy: "npm:1"
+  checksum: 10c0/7faca22584600a9dc5b9fca2cd5feb7135ac8c935449837b315676b4c90aa4f391ec4f42240178244b5a34e8bede1948627fda392ca3191522fc46b34e985ab2
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -1041,6 +3208,29 @@ __metadata:
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:^8.2.2":
+  version: 8.2.6
+  resolution: "inquirer@npm:8.2.6"
+  dependencies:
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.1"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^3.0.0"
+    external-editor: "npm:^3.0.3"
+    figures: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mute-stream: "npm:0.0.8"
+    ora: "npm:^5.4.1"
+    run-async: "npm:^2.4.0"
+    rxjs: "npm:^7.5.5"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    through: "npm:^2.3.6"
+    wrap-ansi: "npm:^6.0.1"
+  checksum: 10c0/eb5724de1778265323f3a68c80acfa899378cb43c24cdcb58661386500e5696b6b0b6c700e046b7aa767fe7b4823c6f04e6ddc268173e3f84116112529016296
   languageName: node
   linkType: hard
 
@@ -1058,12 +3248,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 10c0/f59b43dc1d129edb6f0e282595e56477f98c40278a2acdc8b0a5c57097c9eff8fe55470493df5775478cf32a4dc8eaf6d3a749f07ceee5bc263a78b2434f6a54
+  languageName: node
+  linkType: hard
+
 "is-binary-path@npm:~2.1.0":
   version: 2.1.0
   resolution: "is-binary-path@npm:2.1.0"
   dependencies:
     binary-extensions: "npm:^2.0.0"
   checksum: 10c0/a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
+  languageName: node
+  linkType: hard
+
+"is-builtin-module@npm:^3.1.0":
+  version: 3.2.1
+  resolution: "is-builtin-module@npm:3.2.1"
+  dependencies:
+    builtin-modules: "npm:^3.3.0"
+  checksum: 10c0/5a66937a03f3b18803381518f0ef679752ac18cdb7dd53b5e23ee8df8d440558737bd8dcc04d2aae555909d2ecb4a81b5c0d334d119402584b61e6a003e31af1
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.13.0":
+  version: 2.14.0
+  resolution: "is-core-module@npm:2.14.0"
+  dependencies:
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ae8dbc82bd20426558bc8d20ce290ce301c1cfd6ae4446266d10cacff4c63c67ab16440ade1d72ced9ec41c569fbacbcee01e293782ce568527c4cdf35936e4c
   languageName: node
   linkType: hard
 
@@ -1104,10 +3319,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-interactive@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-interactive@npm:1.0.0"
+  checksum: 10c0/dd47904dbf286cd20aa58c5192161be1a67138485b9836d5a70433b21a45442e9611b8498b8ab1f839fc962c7620667a50535fdfb4a6bc7989b8858645c06b4d
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 10c0/85fee098ae62ba6f1e24cf22678805473c7afd0fb3978a3aa260e354cb7bcb3a5806cf0a98403188465efedec41ab4348e8e4e79305d409601323855b3839d4d
+  languageName: node
+  linkType: hard
+
+"is-module@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-module@npm:1.0.0"
+  checksum: 10c0/795a3914bcae7c26a1c23a1e5574c42eac13429625045737bf3e324ce865c0601d61aee7a5afbca1bee8cb300c7d9647e7dc98860c9bdbc3b7fdc51d8ac0bffc
   languageName: node
   linkType: hard
 
@@ -1132,6 +3361,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-reference@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "is-reference@npm:1.2.1"
+  dependencies:
+    "@types/estree": "npm:*"
+  checksum: 10c0/7dc819fc8de7790264a0a5d531164f9f5b9ef5aa1cd05f35322d14db39c8a2ec78fd5d4bf57f9789f3ddd2b3abeea7728432b759636157a42db12a9e8c3b549b
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
+  languageName: node
+  linkType: hard
+
 "is-stream@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-stream@npm:3.0.0"
@@ -1139,10 +3384,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: 10c0/00cbe3455c3756be68d2542c416cab888aebd5012781d6819749fefb15162ff23e38501fe681b3d751c73e8ff561ac09a5293eba6f58fdf0178462ce6dcb3453
+  languageName: node
+  linkType: hard
+
 "is-unicode-supported@npm:^1.2.0":
   version: 1.3.0
   resolution: "is-unicode-supported@npm:1.3.0"
   checksum: 10c0/b8674ea95d869f6faabddc6a484767207058b91aea0250803cbf1221345cb0c56f466d4ecea375dc77f6633d248d33c47bd296fb8f4cdba0b4edba8917e83d8a
+  languageName: node
+  linkType: hard
+
+"isarray@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "isarray@npm:2.0.5"
+  checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
   languageName: node
   linkType: hard
 
@@ -1160,6 +3419,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-ws@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "isomorphic-ws@npm:4.0.1"
+  peerDependencies:
+    ws: "*"
+  checksum: 10c0/7cb90dc2f0eb409825558982fb15d7c1d757a88595efbab879592f9d2b63820d6bbfb5571ab8abe36c715946e165a413a99f6aafd9f40ab1f514d73487bc9996
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^2.3.5":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
@@ -1173,10 +3441,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jessie.js@npm:^0.3.2":
+  version: 0.3.4
+  resolution: "jessie.js@npm:0.3.4"
+  dependencies:
+    "@endo/far": "npm:^1.0.0"
+  checksum: 10c0/853ab3f8a0e30df11742882f5e11479d1303033a5a203a247d8ffbf4c6f3f3d4bcbefa53084ae4632e6ab106e348f23dc988280486cbeaaf5d16487fa3d40e96
+  languageName: node
+  linkType: hard
+
 "js-string-escape@npm:^1.0.1":
   version: 1.0.1
   resolution: "js-string-escape@npm:1.0.1"
   checksum: 10c0/2c33b9ff1ba6b84681c51ca0997e7d5a1639813c95d5b61cb7ad47e55cc28fa4a0b1935c3d218710d8e6bcee5d0cd8c44755231e3a4e45fc604534d9595a3628
+  languageName: node
+  linkType: hard
+
+"js-tokens@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "js-tokens@npm:4.0.0"
+  checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:4.0.0":
+  version: 4.0.0
+  resolution: "js-yaml@npm:4.0.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/ef8489b87d9796b45df9f0bf3eefbb343b5063e39a9911d7b8ddbd4518cafaf73b49150d1f5865f54ee68719642ff0ab86110b9a332ff88bb05cd3bcf3039de1
   languageName: node
   linkType: hard
 
@@ -1189,6 +3484,64 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
+  languageName: node
+  linkType: hard
+
+"jsesc@npm:^2.5.1":
+  version: 2.5.2
+  resolution: "jsesc@npm:2.5.2"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 10c0/dbf59312e0ebf2b4405ef413ec2b25abb5f8f4d9bc5fb8d9f90381622ebca5f2af6a6aa9a8578f65903f9e33990a6dc798edd0ce5586894bf0e9e31803a1de88
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-stable-stringify@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "json-stable-stringify@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    isarray: "npm:^2.0.5"
+    jsonify: "npm:^0.0.1"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/3801e3eeccbd030afb970f54bea690a079cfea7d9ed206a1b17ca9367f4b7772c764bf77a48f03e56b50e5f7ee7d11c52339fe20d8d7ccead003e4ca69e4cfde
+  languageName: node
+  linkType: hard
+
+"jsonify@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "jsonify@npm:0.0.1"
+  checksum: 10c0/7f5499cdd59a0967ed35bda48b7cec43d850bbc8fb955cdd3a1717bb0efadbe300724d5646de765bb7a99fc1c3ab06eb80d93503c6faaf99b4ff50a3326692f6
+  languageName: node
+  linkType: hard
+
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 10c0/0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
+"libsodium-sumo@npm:^0.7.13":
+  version: 0.7.13
+  resolution: "libsodium-sumo@npm:0.7.13"
+  checksum: 10c0/8159205cc36cc4bdf46ee097e5f998d5cac7d11612be7406a8396ca3ee31560871ac17daa69e47ff0e8407eeae9f49313912ea95dbc8715875301b004c28ef5b
+  languageName: node
+  linkType: hard
+
+"libsodium-wrappers-sumo@npm:^0.7.11":
+  version: 0.7.13
+  resolution: "libsodium-wrappers-sumo@npm:0.7.13"
+  dependencies:
+    libsodium-sumo: "npm:^0.7.13"
+  checksum: 10c0/51a151d0f73418632dcf9cf0184b14d8eb6e16b9a3f01a652c7401c6d1bf8ead4f5ce40a4f00bd4754c5719a7a5fb71d6125691896aeb7a9c1abcfe4b73afc02
   languageName: node
   linkType: hard
 
@@ -1208,10 +3561,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15":
+"lodash.truncate@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.truncate@npm:4.4.2"
+  checksum: 10c0/4e870d54e8a6c86c8687e057cec4069d2e941446ccab7f40b4d9555fa5872d917d0b6aa73bece7765500a3123f1723bcdba9ae881b679ef120bba9e1a0b0ed70
+  languageName: node
+  linkType: hard
+
+"lodash@npm:4.17.21, lodash@npm:^4.17.15, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
+"log-symbols@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: "npm:^4.1.0"
+    is-unicode-supported: "npm:^0.1.0"
+  checksum: 10c0/67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.2.0, logform@npm:^2.3.2":
+  version: 2.6.0
+  resolution: "logform@npm:2.6.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/6e02f8617a03155b2fce451bacf777a2c01da16d32c4c745b3ec85be6c3f2602f2a4953a8bd096441cb4c42c447b52318541d6b6bc335dce903cb9ad77a1749f
+  languageName: node
+  linkType: hard
+
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 10c0/50a6417d15b06104dbe4e3d4a667c39b137f130a9108ea8752b352a4cfae047531a3ac351c181792f3f8768fe17cca6b0f406674a541a86fb638aaac560d83ed
   languageName: node
   linkType: hard
 
@@ -1228,6 +3619,15 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.25.7":
+  version: 0.25.9
+  resolution: "magic-string@npm:0.25.9"
+  dependencies:
+    sourcemap-codec: "npm:^1.4.8"
+  checksum: 10c0/37f5e01a7e8b19a072091f0b45ff127cda676232d373ce2c551a162dd4053c575ec048b9cbb4587a1f03adb6c5d0fd0dd49e8ab070cd2c83a4992b2182d9cb56
   languageName: node
   linkType: hard
 
@@ -1311,6 +3711,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"microtime@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "microtime@npm:3.1.1"
+  dependencies:
+    node-addon-api: "npm:^5.0.0"
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.4.0"
+  checksum: 10c0/02512993de914c6f71424d3b8b28ce53de44ba5895b904a213420fd4fc86a084c1d08ec0876ac60cdae6427022766e1b9b86d9b3442bf408701120bd61455e26
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.12":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "mimic-fn@npm:2.1.0"
+  checksum: 10c0/b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
+  languageName: node
+  linkType: hard
+
 "mimic-fn@npm:^4.0.0":
   version: 4.0.0
   resolution: "mimic-fn@npm:4.0.0"
@@ -1322,6 +3756,29 @@ __metadata:
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
+"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-assert@npm:1.0.1"
+  checksum: 10c0/96730e5601cd31457f81a296f521eb56036e6f69133c0b18c13fe941109d53ad23a4204d946a0d638d7f3099482a0cec8c9bb6d642604612ce43ee536be3dddd
+  languageName: node
+  linkType: hard
+
+"minimalistic-crypto-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-crypto-utils@npm:1.0.1"
+  checksum: 10c0/790ecec8c5c73973a4fbf2c663d911033e8494d5fb0960a4500634766ab05d6107d20af896ca2132e7031741f19888154d44b2408ada0852446705441383e9f8
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "minimatch@npm:3.1.2"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
   languageName: node
   linkType: hard
 
@@ -1448,10 +3905,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.3":
+"ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:0.0.8":
+  version: 0.0.8
+  resolution: "mute-stream@npm:0.0.8"
+  checksum: 10c0/18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
+  languageName: node
+  linkType: hard
+
+"n-readlines@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "n-readlines@npm:1.0.3"
+  checksum: 10c0/436c27ac071409314093da35dc3a4c5198c94fb10ad12b1c4d2b3e44bdb634da0a7a8ab0c107c1f4815788cbf5e0c7c180e3037ba3d974f34637cab363a95a74
   languageName: node
   linkType: hard
 
@@ -1475,6 +3946,58 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/9ebbb21e6951aa51e831549ed62b68dc56bcc10f6b21ffd04195a16a6abf5ddfc48b6ae5e3334720fe4459cafde5ec8103025902efff5599d0539f8656fc694e
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "node-addon-api@npm:5.1.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/0eb269786124ba6fad9df8007a149e03c199b3e5a3038125dfb3e747c2d5113d406a4e33f4de1ea600aa2339be1f137d55eba1a73ee34e5fff06c52a5c296d1d
+  languageName: node
+  linkType: hard
+
+"node-domexception@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.0":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: "npm:^4.0.0"
+    fetch-blob: "npm:^3.1.4"
+    formdata-polyfill: "npm:^4.0.10"
+  checksum: 10c0/f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
+  languageName: node
+  linkType: hard
+
+"node-gyp-build@npm:^4.4.0":
+  version: 4.8.1
+  resolution: "node-gyp-build@npm:4.8.1"
+  bin:
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
+  checksum: 10c0/e36ca3d2adf2b9cca316695d7687207c19ac6ed326d6d7c68d7112cebe0de4f82d6733dff139132539fcc01cf5761f6c9082a21864ab9172edf84282bc849ce7
   languageName: node
   linkType: hard
 
@@ -1532,12 +4055,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.1, once@npm:^1.4.0":
+"object-keys@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "object-keys@npm:1.1.1"
+  checksum: 10c0/b11f7ccdbc6d406d1f186cdadb9d54738e347b2692a14439ca5ac70c225fa6db46db809711b78589866d47b25fc3e8dee0b4c722ac751e11180f9380e3d8601d
+  languageName: node
+  linkType: hard
+
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
     wrappy: "npm:1"
   checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 10c0/6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^5.1.0":
+  version: 5.1.2
+  resolution: "onetime@npm:5.1.2"
+  dependencies:
+    mimic-fn: "npm:^2.1.0"
+  checksum: 10c0/ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
   languageName: node
   linkType: hard
 
@@ -1547,6 +4095,39 @@ __metadata:
   dependencies:
     mimic-fn: "npm:^4.0.0"
   checksum: 10c0/4eef7c6abfef697dd4479345a4100c382d73c149d2d56170a54a07418c50816937ad09500e1ed1e79d235989d073a9bade8557122aee24f0576ecde0f392bb6c
+  languageName: node
+  linkType: hard
+
+"opener@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 10c0/dd56256ab0cf796585617bc28e06e058adf09211781e70b264c76a1dbe16e90f868c974e5bf5309c93469157c7d14b89c35dc53fe7293b0e40b4d2f92073bc79
+  languageName: node
+  linkType: hard
+
+"ora@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "ora@npm:5.4.1"
+  dependencies:
+    bl: "npm:^4.1.0"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-spinners: "npm:^2.5.0"
+    is-interactive: "npm:^1.0.0"
+    is-unicode-supported: "npm:^0.1.0"
+    log-symbols: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    wcwidth: "npm:^1.0.1"
+  checksum: 10c0/10ff14aace236d0e2f044193362b22edce4784add08b779eccc8f8ef97195cae1248db8ec1ec5f5ff076f91acbe573f5f42a98c19b78dba8c54eefff983cae85
+  languageName: node
+  linkType: hard
+
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -1609,6 +4190,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^2.0.2":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 10c0/8e8646581410654b50eb22a5dfd71159cae98145bd5086c9a7a816ec0370b5f72b4648d08674624b3870a521e6a3daffd6c2f7bc00fdefc7063c9d8232ff5116
+  languageName: node
+  linkType: hard
+
 "parse-ms@npm:^3.0.0":
   version: 3.0.0
   resolution: "parse-ms@npm:3.0.0"
@@ -1623,6 +4211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-is-absolute@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "path-is-absolute@npm:1.0.1"
+  checksum: 10c0/127da03c82172a2a50099cddbf02510c1791fc2cc5f7713ddb613a56838db1e8168b121a920079d052e0936c23005562059756d653b7c544c53185efe53be078
+  languageName: node
+  linkType: hard
+
 "path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -1634,6 +4229,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-key@npm:4.0.0"
   checksum: 10c0/794efeef32863a65ac312f3c0b0a99f921f3e827ff63afa5cb09a377e202c262b671f7b3832a4e64731003fa94af0263713962d317b9887bd1e0c48a342efba3
+  languageName: node
+  linkType: hard
+
+"path-parse@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "path-parse@npm:1.0.7"
+  checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
   languageName: node
   linkType: hard
 
@@ -1654,7 +4256,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
+"picocolors@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "picocolors@npm:1.0.1"
+  checksum: 10c0/c63cdad2bf812ef0d66c8db29583802355d4ca67b9285d846f390cc15c2f6ccb94e8cb7eb6a6e97fc5990a6d3ad4ae42d86c84d3146e667c739a4234ed50d400
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
@@ -1718,6 +4327,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:13.1.0":
+  version: 13.1.0
+  resolution: "prom-client@npm:13.1.0"
+  dependencies:
+    tdigest: "npm:^0.1.1"
+  checksum: 10c0/0f117e044bdbc7e8fb3a926e16e0e76ff3fb308dbc98fdb084dfa16ad52a0b68cf6a79a31e907b1c4ac9009b1d50848e3e72fb36ed43893291148e1505844fc2
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -1728,6 +4346,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    retry: "npm:^0.12.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/2f265dbad15897a43110a02dae55105c04d356ec4ed560723dcb9f0d34bc4fb2f13f79bb930e7561be10278e2314db5aca2527d5d3dcbbdee5e6b331d1571f6d
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^6.8.8":
+  version: 6.11.4
+  resolution: "protobufjs@npm:6.11.4"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/long": "npm:^4.0.1"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^4.0.0"
+  bin:
+    pbjs: bin/pbjs
+    pbts: bin/pbts
+  checksum: 10c0/c244d7b9b6d3258193da5c0d1e558dfb47f208ae345e209f90ec45c9dca911b90fa17e937892a9a39a4136ab9886981aae9efdf6039f7baff4f7225f5eeb9812
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
 "pump@npm:^3.0.0":
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
@@ -1735,6 +4395,20 @@ __metadata:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
   checksum: 10c0/bbdeda4f747cdf47db97428f3a135728669e56a0ae5f354a9ac5b74556556f5446a46f720a8f14ca2ece5be9b4d5d23c346db02b555f46739934cc6c093a5478
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
   languageName: node
   linkType: hard
 
@@ -1759,7 +4433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -1779,10 +4453,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readonly-date@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "readonly-date@npm:1.0.0"
+  checksum: 10c0/7ab32bf19f6bfec102584a524fa79a289e6ede0bf20c80fd90ab309962e45b71d19dd0e3915dff6e81edf226f08fda65e890539b4aca74668921790b10471356
+  languageName: node
+  linkType: hard
+
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
   languageName: node
   linkType: hard
 
@@ -1802,6 +4490,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.17.0, resolve@npm:^1.19.0":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/07e179f4375e1fd072cfb72ad66d78547f86e6196c4014b31cb0b8bb1db5f7ca871f922d08da0fbc05b94e9fd42206f819648fa3b5b873ebbc8e1dc68fec433a
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>":
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
+  languageName: node
+  linkType: hard
+
+"restore-cursor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "restore-cursor@npm:3.1.0"
+  dependencies:
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -1816,14 +4540,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^2.79.1":
+  version: 2.79.1
+  resolution: "rollup@npm:2.79.1"
+  dependencies:
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/421418687f5dcd7324f4387f203c6bfc7118b7ace789e30f5da022471c43e037a76f5fd93837052754eeeae798a4fb266ac05ccee1e594406d912a59af98dde9
+  languageName: node
+  linkType: hard
+
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@agoric/internal": "npm:0.3.3-dev-5676146.0"
     "@agoric/synthetic-chain": "npm:^0.1.0"
+    "@cosmjs/stargate": "npm:^0.32.3"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.3"
+    "@endo/errors": "npm:^1.2.2"
+    "@endo/far": "npm:^1.0.4"
+    "@endo/init": "npm:^1.0.4"
+    agoric: "npm:0.21.2-dev-5676146.0"
     ava: "npm:^5.3.1"
+    execa: "npm:^8.0.1"
+    node-fetch: "npm:^3.3.2"
   languageName: unknown
   linkType: soft
+
+"run-async@npm:^2.4.0":
+  version: 2.4.1
+  resolution: "run-async@npm:2.4.1"
+  checksum: 10c0/35a68c8f1d9664f6c7c2e153877ca1d6e4f886e5ca067c25cdd895a6891ff3a1466ee07c63d6a9be306e9619ff7d509494e6d9c129516a36b9fd82263d579ee1
+  languageName: node
+  linkType: hard
 
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
@@ -1834,6 +4588,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.5.5":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/3c49c1ecd66170b175c9cacf5cef67f8914dcbc7cd0162855538d365c83fea631167cacb644b3ce533b2ea0e9a4d0b12175186985f89d75abe73dbd8f7f06f68
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -1841,10 +4604,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.4.3
+  resolution: "safe-stable-stringify@npm:2.4.3"
+  checksum: 10c0/81dede06b8f2ae794efd868b1e281e3c9000e57b39801c6c162267eb9efda17bd7a9eafa7379e1f1cacd528d4ced7c80d7460ad26f62ada7c9e01dec61b2e768
+  languageName: node
+  linkType: hard
+
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.3.0":
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
   languageName: node
   linkType: hard
 
@@ -1868,6 +4647,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ses@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "ses@npm:1.5.0"
+  dependencies:
+    "@endo/env-options": "npm:^1.1.4"
+  checksum: 10c0/bd5e230ff07abe84632ff212a5dce5163d979ab0ae657c4ac0ee2748aea9f587d83c75639d0058def62eae6dde55c0ae9652f33aecc5e0fe538c89ce54bffcdc
+  languageName: node
+  linkType: hard
+
+"set-function-length@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10c0/82850e62f412a258b71e123d4ed3873fa9377c216809551192bb6769329340176f109c2eeae8c22a8d386c76739855f78e8716515c818bcaef384b51110f0f3c
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -1881,6 +4683,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "signal-exit@npm:3.0.7"
+  checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
   languageName: node
   linkType: hard
 
@@ -1909,10 +4718,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: "npm:^0.3.1"
+  checksum: 10c0/df5e4662a8c750bdba69af4e8263c5d96fe4cd0f9fe4bdfa3cbdeb45d2e869dff640beaaeb1ef0e99db4d8d2ec92f85508c269f50c972174851bc1ae5bd64308
+  languageName: node
+  linkType: hard
+
 "slash@npm:^4.0.0":
   version: 4.0.0
   resolution: "slash@npm:4.0.0"
   checksum: 10c0/b522ca75d80d107fd30d29df0549a7b2537c83c4c4ecd12cd7d4ea6c8aaca2ab17ada002e7a1d78a9d736a0261509f26ea5b489082ee443a3a810586ef8eff18
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "slice-ansi@npm:4.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    astral-regex: "npm:^2.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+  checksum: 10c0/6c25678db1270d4793e0327620f1e0f9f5bea4630123f51e9e399191bc52c87d6e6de53ed33538609e5eacbd1fab769fae00f3705d08d029f02102a540648918
   languageName: node
   linkType: hard
 
@@ -1954,6 +4783,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.7.4":
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: 10c0/dc0cf3768fe23c345ea8760487f8c97ef6fca8a73c83cd7c9bf2fde8bc2c34adb9c0824d6feb14bc4f9e37fb522e18af621543f1289038a66ac7586da29aa7dc
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.5.0":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: 10c0/904e767bb9c494929be013017380cbba013637da1b28e5943b566031e29df04fba57edf3f093e0914be094648b577372bd8ad247fa98cfba9c600794cd16b599
+  languageName: node
+  linkType: hard
+
+"sourcemap-codec@npm:^1.4.8":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: 10c0/f099279fdaae070ff156df7414bbe39aad69cdd615454947ed3e19136bfdfcb4544952685ee73f56e17038f4578091e12b17b283ed8ac013882916594d95b9e6
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -1967,6 +4817,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/b091f2ae92474183c7ac5ed3f9811457e1df23df7a7e70c9476eaa9a0c4a0c8fc190fb45acefbf023ca9ee864dd6754237a697dc52a0fb182afe65d8e77443d8
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
   languageName: node
   linkType: hard
 
@@ -2054,6 +4911,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
+  dependencies:
+    has-flag: "npm:^3.0.0"
+  checksum: 10c0/6ae5ff319bfbb021f8a86da8ea1f8db52fac8bd4d499492e30ec17095b58af11f0c55f8577390a749b1c4dde691b6a0315dab78f5f54c9b3d83f8fb5905c1c05
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
+  languageName: node
+  linkType: hard
+
+"supports-preserve-symlinks-flag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
+  checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
+  languageName: node
+  linkType: hard
+
+"symbol-observable@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "symbol-observable@npm:2.0.3"
+  checksum: 10c0/03fb8766b75bfa65a3c7d68ae1e51a13a5ff71b40d6d53b17a0c9c77b1685c20a3bfbf45547ab36214a079665c3f551e250798f6b2f83a2a40762d864ed87f78
+  languageName: node
+  linkType: hard
+
+"table@npm:^6.7.1":
+  version: 6.8.2
+  resolution: "table@npm:6.8.2"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/f8b348af38ee34e419d8ce7306ba00671ce6f20e861ccff22555f491ba264e8416086063ce278a8d81abfa8d23b736ec2cca7ac4029b5472f63daa4b4688b803
+  languageName: node
+  linkType: hard
+
 "tar-fs@npm:^2.0.0":
   version: 2.1.1
   resolution: "tar-fs@npm:2.1.1"
@@ -2093,10 +4995,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tdigest@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "tdigest@npm:0.1.2"
+  dependencies:
+    bintrees: "npm:1.0.2"
+  checksum: 10c0/10187b8144b112fcdfd3a5e4e9068efa42c990b1e30cd0d4f35ee8f58f16d1b41bc587e668fa7a6f6ca31308961cbd06cd5d4a4ae1dc388335902ae04f7d57df
+  languageName: node
+  linkType: hard
+
 "temp-dir@npm:^3.0.0":
   version: 3.0.0
   resolution: "temp-dir@npm:3.0.0"
   checksum: 10c0/a86978a400984cd5f315b77ebf3fe53bb58c61f192278cafcb1f3fb32d584a21dc8e08b93171d7874b7cc972234d3455c467306cc1bfc4524b622e5ad3bfd671
+  languageName: node
+  linkType: hard
+
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
+"through@npm:^2.3.6":
+  version: 2.3.8
+  resolution: "through@npm:2.3.8"
+  checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
   languageName: node
   linkType: hard
 
@@ -2107,12 +5032,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.1":
+  version: 0.2.3
+  resolution: "tmp@npm:0.2.3"
+  checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
+  languageName: node
+  linkType: hard
+
+"to-fast-properties@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "to-fast-properties@npm:2.0.0"
+  checksum: 10c0/b214d21dbfb4bce3452b6244b336806ffea9c05297148d32ebb428d5c43ce7545bdfc65a1ceb58c9ef4376a65c0cb2854d645f33961658b3e3b4f84910ddcdd7
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:1.3.0":
+  version: 1.3.0
+  resolution: "triple-beam@npm:1.3.0"
+  checksum: 10c0/a6da96495f25b6c04b3629df5161c7eb84760927943f16665fd8dcd3a643daadf73d69eee78306b4b68d606937f22f8703afe763bc8d3723632ffb1f3a798493
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 10c0/4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0":
+  version: 2.6.3
+  resolution: "tslib@npm:2.6.3"
+  checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
   languageName: node
   linkType: hard
 
@@ -2129,6 +5105,20 @@ __metadata:
   version: 0.13.1
   resolution: "type-fest@npm:0.13.1"
   checksum: 10c0/0c0fa07ae53d4e776cf4dac30d25ad799443e9eef9226f9fddbb69242db86b08584084a99885cfa5a9dfe4c063ebdc9aa7b69da348e735baede8d43f1aeae93b
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 
@@ -2150,6 +5140,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uri-js@npm:^4.2.2, uri-js@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -2157,10 +5156,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wcwidth@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wcwidth@npm:1.0.1"
+  dependencies:
+    defaults: "npm:^1.0.3"
+  checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
 "well-known-symbols@npm:^2.0.0":
   version: 2.0.0
   resolution: "well-known-symbols@npm:2.0.0"
   checksum: 10c0/cb6c12e98877e8952ec28d13ae6f4fdb54ae1cb49b16a728720276dadd76c930e6cb0e174af3a4620054dd2752546f842540122920c6e31410208abd4958ee6b
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 
@@ -2186,6 +5218,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"winston-transport@npm:^4.4.0":
+  version: 4.7.0
+  resolution: "winston-transport@npm:4.7.0"
+  dependencies:
+    logform: "npm:^2.3.2"
+    readable-stream: "npm:^3.6.0"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/cd16f3d0ab56697f93c4899e0eb5f89690f291bb6cf309194819789326a7c7ed943ef00f0b2fab513b114d371314368bde1a7ae6252ad1516181a79f90199cd2
+  languageName: node
+  linkType: hard
+
+"winston@npm:3.3.3":
+  version: 3.3.3
+  resolution: "winston@npm:3.3.3"
+  dependencies:
+    "@dabh/diagnostics": "npm:^2.0.2"
+    async: "npm:^3.1.0"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.2.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.4.0"
+  checksum: 10c0/18205fa1e3ebb88dc910fbe5337e3c9d2dbd94310978adca5ab77444b854d5679dec0a70fed425e77cf93e237390c7670bb937f14c492b8415e594ab21540d3d
+  languageName: node
+  linkType: hard
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -2194,6 +5254,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^6.0.1":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
   languageName: node
   linkType: hard
 
@@ -2222,6 +5293,31 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/e8c850a8e3e74eeadadb8ad23c9d9d63e4e792bd10f4836ed74189ef6e996763959f1249c5650e232f3c77c11169d239cbfc8342fc70f3fe401407d23810505d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7, ws@npm:^7.2.0":
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  languageName: node
+  linkType: hard
+
+"xstream@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "xstream@npm:11.14.0"
+  dependencies:
+    globalthis: "npm:^1.0.1"
+    symbol-observable: "npm:^2.0.3"
+  checksum: 10c0/7a28baedc64385dc17597d04c7130ec3135db298e66d6dcf33821eb1953d5ad1b83c5fa08f1ce4d36e75fd219f2e9ef81ee0721aa8d4ccf619acc1760ba37f71
   languageName: node
   linkType: hard
 

--- a/a3p-integration/proposals/z:acceptance/README.md
+++ b/a3p-integration/proposals/z:acceptance/README.md
@@ -3,3 +3,9 @@
 Its `type` is `/cosmos.params.v1beta1.ParameterChangeProposal` because that is
 the lightest form of actual proposal to execute. It runs the [eval.sh](./eval.sh)
 script, which does nothing.
+
+## To consider testing here
+
+### Offer result vows
+
+#9308 updated the smart-wallet to support offer results that are vows and resolve them after the source vat restarts. The staker proposal had a test that it worked but we may want to have an acceptance test to ensure it always does. E.g. by producing a vow in an earlier layer, restarting the vat in this layer, then in a test triggering its resolution and confirming the result.

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -1,7 +1,4 @@
 /** @file upgrade network / IBC vat at many points in state machine */
-import { BridgeId } from '@agoric/internal';
-import type { BridgeHandler } from '@agoric/vats';
-import { makeFakeIbcBridge } from '@agoric/vats/tools/fake-bridge.js';
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 import type { TestFn } from 'ava';

--- a/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
+++ b/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
@@ -1,0 +1,106 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import type { TestFn } from 'ava';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import {
+  makeWalletFactoryContext,
+  type WalletFactoryTestContext,
+} from './walletFactory.ts';
+
+const test: TestFn<WalletFactoryTestContext> = anyTest;
+
+test.before(async t => {
+  t.context = await makeWalletFactoryContext(
+    t,
+    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+  );
+});
+test.after.always(t => t.context.shutdown?.());
+
+test('resolves', async t => {
+  const { walletFactoryDriver, buildProposal, evalProposal } = t.context;
+
+  t.log('start valueVow');
+  await evalProposal(
+    buildProposal('@agoric/builders/scripts/testing/start-valueVow.js'),
+  );
+
+  t.log('use wallet to get a vow');
+  const getter = await walletFactoryDriver.provideSmartWallet('agoric1getter');
+  console.log('executing offer');
+  // *send* b/c execution doesn't resolve until even the vow resolves and that won't happen until the set-value
+  await getter.sendOffer({
+    id: 'get-value',
+    invitationSpec: {
+      source: 'agoricContract',
+      instancePath: ['valueVow'],
+      callPipe: [['makeGetterInvitation']],
+    },
+    proposal: {},
+  });
+  // Ensure the offer has executed. Without this there's work in the
+  // crank when the contract is restarted below.
+  await new Promise(resolve => {
+    setTimeout(resolve, 1000);
+  });
+
+  t.log('confirm the value is not in offer results');
+  {
+    const statusRecord = getter.getLatestUpdateRecord();
+    t.like(statusRecord, {
+      status: {
+        id: 'get-value',
+        numWantsSatisfied: 1,
+      },
+      updated: 'offerStatus',
+    });
+    // narrow the type
+    assert(statusRecord.updated === 'offerStatus');
+    t.false('result' in statusRecord.status, 'no result yet');
+  }
+
+  t.log('restart valueVow');
+  await evalProposal(
+    buildProposal('@agoric/builders/scripts/testing/restart-valueVow.js'),
+  );
+
+  t.log('use wallet to set value');
+  const offerArgs = { value: 'Ciao, mondo!' };
+  const setter = await walletFactoryDriver.provideSmartWallet('agoric1setter');
+  await setter.executeOffer({
+    id: 'set-value',
+    invitationSpec: {
+      source: 'agoricContract',
+      instancePath: ['valueVow'],
+      callPipe: [['makeSetterInvitation']],
+    },
+    offerArgs,
+    proposal: {},
+  });
+  t.like(setter.getLatestUpdateRecord(), {
+    updated: 'offerStatus',
+    status: {
+      id: 'set-value',
+      numWantsSatisfied: 1,
+    },
+  });
+
+  t.log('confirm the value is now in offer results');
+  // Ensure the getter vow has had time to resolved.
+  await new Promise(resolve => {
+    setTimeout(resolve, 1000);
+  });
+  {
+    const statusRecord = getter.getLatestUpdateRecord();
+    // narrow the type
+    assert(statusRecord.updated === 'offerStatus');
+    t.true('result' in statusRecord.status, 'got result');
+    t.like(statusRecord, {
+      status: {
+        id: 'get-value',
+        result: offerArgs.value,
+      },
+      updated: 'offerStatus',
+    });
+  }
+});

--- a/packages/builders/scripts/testing/restart-valueVow.js
+++ b/packages/builders/scripts/testing/restart-valueVow.js
@@ -1,0 +1,81 @@
+/**
+ * @file This is for use in tests in a3p-integration
+ * Unlike most builder scripts, this one includes the proposal exports as well.
+ */
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+
+/// <reference types="@agoric/vats/src/core/types-ambient"/>
+/**
+ * @import {Instance} from '@agoric/zoe/src/zoeService/utils.js';
+ */
+
+const trace = makeTracer('RestartValueVow', true);
+
+/**
+ * @param {BootstrapPowers & {
+ *   instance: {
+ *     consume: {
+ *       valueVow: Instance<
+ *         import('@agoric/zoe/src/contracts/valueVow.contract.js').start
+ *       >;
+ *     };
+ *   };
+ * }} powers
+ */
+export const restartValueVow = async ({
+  consume: { contractKits },
+  instance: instances,
+}) => {
+  trace(restartValueVow.name);
+
+  const vvInstance = await instances.consume.valueVow;
+  trace('vvInstance', vvInstance);
+  const vvKit = await E(contractKits).get(vvInstance);
+
+  await E(vvKit.adminFacet).restartContract({});
+  trace('done');
+};
+harden(restartValueVow);
+
+export const getManifestForValueVow = ({ restoreRef }, { valueVowRef }) => {
+  console.log('valueVowRef', valueVowRef);
+  return {
+    manifest: {
+      [restartValueVow.name]: {
+        consume: {
+          contractKits: true,
+        },
+        instance: {
+          consume: { valueVow: true },
+        },
+      },
+    },
+    installations: {
+      valueVow: restoreRef(valueVowRef),
+    },
+  };
+};
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    // Somewhat unorthodox, source the exports from this builder module
+    sourceSpec: '@agoric/builders/scripts/testing/restart-valueVow.js',
+    getManifestCall: [
+      'getManifestForValueVow',
+      {
+        valueVowRef: publishRef(
+          install('@agoric/zoe/src/contracts/valueVow.contract.js'),
+        ),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  // import dynamically so the module can work in CoreEval environment
+  const dspModule = await import('@agoric/deploy-script-support');
+  const { makeHelpers } = dspModule;
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval(restartValueVow.name, defaultProposalBuilder);
+};

--- a/packages/builders/scripts/testing/start-valueVow.js
+++ b/packages/builders/scripts/testing/start-valueVow.js
@@ -1,0 +1,92 @@
+/**
+ * @file This is for use in tests in a3p-integration
+ * Unlike most builder scripts, this one includes the proposal exports as well.
+ */
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+
+/// <reference types="@agoric/vats/src/core/types-ambient"/>
+/**
+ * @import {Installation} from '@agoric/zoe/src/zoeService/utils.js';
+ */
+
+const trace = makeTracer('StartValueVow', true);
+
+/**
+ * @param {BootstrapPowers & {
+ *   installation: {
+ *     consume: {
+ *       valueVow: Installation<
+ *         import('@agoric/zoe/src/contracts/valueVow.contract.js').start
+ *       >;
+ *     };
+ *   };
+ * }} powers
+ */
+export const startValueVow = async ({
+  consume: { startUpgradable },
+  installation: {
+    consume: { valueVow },
+  },
+  instance: {
+    // @ts-expect-error unknown instance
+    produce: { valueVow: produceInstance },
+  },
+}) => {
+  trace(startValueVow.name);
+
+  const startOpts = {
+    label: 'valueVow',
+    installation: valueVow,
+  };
+
+  const { instance } = await E(startUpgradable)(startOpts);
+  produceInstance.resolve(instance);
+  trace('done');
+};
+harden(startValueVow);
+
+export const getManifestForValueVow = ({ restoreRef }, { valueVowRef }) => {
+  console.log('valueVowRef', valueVowRef);
+  return {
+    manifest: {
+      [startValueVow.name]: {
+        consume: {
+          startUpgradable: true,
+        },
+        installation: {
+          consume: { valueVow: true },
+        },
+        instance: {
+          produce: { valueVow: true },
+        },
+      },
+    },
+    installations: {
+      valueVow: restoreRef(valueVowRef),
+    },
+  };
+};
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    // Somewhat unorthodox, source the exports from this builder module
+    sourceSpec: '@agoric/builders/scripts/testing/start-valueVow.js',
+    getManifestCall: [
+      'getManifestForValueVow',
+      {
+        valueVowRef: publishRef(
+          install('@agoric/zoe/src/contracts/valueVow.contract.js'),
+        ),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  // import dynamically so the module can work in CoreEval environment
+  const dspModule = await import('@agoric/deploy-script-support');
+  const { makeHelpers } = dspModule;
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('start-valueVow', defaultProposalBuilder);
+};

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.4.0",
     "@agoric/swingset-vat": "^0.32.2",
-    "@agoric/zone": "^0.2.2",
     "@endo/bundle-source": "^3.2.3",
     "@endo/captp": "^4.2.0",
     "@endo/init": "^1.1.2",
@@ -36,6 +35,7 @@
     "@agoric/vats": "^0.15.1",
     "@agoric/vow": "^0.1.0",
     "@agoric/zoe": "^0.26.2",
+    "@agoric/zone": "^0.2.2",
     "@endo/eventual-send": "^1.2.2",
     "@endo/far": "^1.1.2",
     "@endo/marshal": "^1.5.0",

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -13,7 +13,7 @@ import { heapVowTools } from '@agoric/vow/vat.js';
 
 import { UNPUBLISHED_RESULT } from './offers.js';
 
-const { when, allVows } = heapVowTools;
+const { allVows, asPromise } = heapVowTools;
 
 /**
  * @import {OfferSpec} from "./offers.js";
@@ -38,10 +38,12 @@ const { when, allVows } = heapVowTools;
 /**
  * @param {OutcomeWatchers} watchers
  * @param {UserSeat} seat
+ * @returns {Promise<unknown>} promise for the value of the offer result, or its
+ *   rejection
  */
 const watchForOfferResult = ({ resultWatcher }, seat) => {
   // NOTE: this enables upgrade of the contract, NOT upgrade of the smart-wallet. See #9308
-  const p = when(E(seat).getOfferResult());
+  const p = asPromise(E(seat).getOfferResult());
   watchPromise(p, resultWatcher, seat);
   return p;
 };
@@ -72,7 +74,7 @@ const watchForPayout = ({ paymentWatcher }, seat) => {
  */
 export const watchOfferOutcomes = (watchers, seat) => {
   // NOTE: this enables upgrade of the contract, NOT upgrade of the smart-wallet. See #9308
-  return when(
+  return asPromise(
     allVows([
       watchForOfferResult(watchers, seat),
       watchForNumWants(watchers, seat),

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -9,17 +9,16 @@ import {
 } from '@agoric/zoe/src/typeGuards.js';
 import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
 import { deeplyFulfilledObject, objectMap } from '@agoric/internal';
-import { heapVowTools } from '@agoric/vow/vat.js';
 
 import { UNPUBLISHED_RESULT } from './offers.js';
 
-const { allVows, asPromise } = heapVowTools;
-
 /**
- * @import {OfferSpec} from "./offers.js";
- * @import {ContinuingOfferResult} from "./types.js";
+ * @import {OfferSpec} from './offers.js';
+ * @import {ContinuingOfferResult} from './types.js';
  * @import {Passable} from '@endo/pass-style';
  * @import {PromiseWatcher} from '@agoric/swingset-liveslots';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {Vow, VowTools} from '@agoric/vow';
  */
 
 /**
@@ -35,17 +34,19 @@ const { allVows, asPromise } = heapVowTools;
  * }} OutcomeWatchers
  */
 
-/**
- * @param {OutcomeWatchers} watchers
- * @param {UserSeat} seat
- * @returns {Promise<unknown>} promise for the value of the offer result, or its
- *   rejection
- */
-const watchForOfferResult = ({ resultWatcher }, seat) => {
-  // NOTE: this enables upgrade of the contract, NOT upgrade of the smart-wallet. See #9308
-  const p = asPromise(E(seat).getOfferResult());
-  watchPromise(p, resultWatcher, seat);
-  return p;
+/** @param {VowTools} vowTools */
+const makeWatchForOfferResult = ({ watch }) => {
+  /**
+   * @param {OutcomeWatchers} watchers
+   * @param {UserSeat} seat
+   * @returns {Vow<void>} Vow that resolves when offer result has been processed
+   *   by the resultWatcher
+   */
+  const watchForOfferResult = ({ resultWatcher }, seat) => {
+    // Offer result may be anything, including a Vow, so watch it durably.
+    return watch(E(seat).getOfferResult(), resultWatcher, seat);
+  };
+  return watchForOfferResult;
 };
 
 /**
@@ -68,19 +69,24 @@ const watchForPayout = ({ paymentWatcher }, seat) => {
   return p;
 };
 
-/**
- * @param {OutcomeWatchers} watchers
- * @param {UserSeat} seat
- */
-export const watchOfferOutcomes = (watchers, seat) => {
-  // NOTE: this enables upgrade of the contract, NOT upgrade of the smart-wallet. See #9308
-  return asPromise(
-    allVows([
-      watchForOfferResult(watchers, seat),
-      watchForNumWants(watchers, seat),
-      watchForPayout(watchers, seat),
-    ]),
-  );
+/** @param {VowTools} vowTools */
+export const makeWatchOfferOutcomes = vowTools => {
+  const watchForOfferResult = makeWatchForOfferResult(vowTools);
+  const { asPromise, allVows } = vowTools;
+  /**
+   * @param {OutcomeWatchers} watchers
+   * @param {UserSeat} seat
+   */
+  const watchOfferOutcomes = (watchers, seat) => {
+    return asPromise(
+      allVows([
+        watchForOfferResult(watchers, seat),
+        watchForNumWants(watchers, seat),
+        watchForPayout(watchers, seat),
+      ]),
+    );
+  };
+  return watchOfferOutcomes;
 };
 
 const offerWatcherGuard = harden({
@@ -113,9 +119,11 @@ const offerWatcherGuard = harden({
 });
 
 /**
- * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {Baggage} baggage
+ * @param {VowTools} vowTools
  */
-export const prepareOfferWatcher = baggage => {
+export const prepareOfferWatcher = (baggage, vowTools) => {
+  const watchForOfferResult = makeWatchForOfferResult(vowTools);
   return prepareExoClassKit(
     baggage,
     'OfferWatcher',
@@ -276,6 +284,8 @@ export const prepareOfferWatcher = baggage => {
           } else {
             facets.helper.handleError(reason);
           }
+          // throw so the vow watcher propagates the rejection
+          throw reason;
         },
       },
 

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -37,11 +37,13 @@ import {
   AmountKeywordRecordShape,
   PaymentPKeywordRecordShape,
 } from '@agoric/zoe/src/typeGuards.js';
+import { prepareVowTools } from '@agoric/vow';
+import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import { makeInvitationsHelper } from './invitations.js';
 import { shape } from './typeGuards.js';
 import { objectMapStoragePath } from './utils.js';
-import { prepareOfferWatcher, watchOfferOutcomes } from './offerWatcher.js';
+import { prepareOfferWatcher, makeWatchOfferOutcomes } from './offerWatcher.js';
 
 /** @import {OfferId, OfferStatus} from './offers.js'; */
 
@@ -285,7 +287,7 @@ export const prepareSmartWallet = (baggage, shared) => {
       secretWalletFactoryKey: M.any(),
     }),
   );
-
+  const zone = makeDurableZone(baggage);
   const makeRecorderKit = prepareRecorderKit(baggage, shared.publicMarshaller);
 
   const walletPurses = provide(baggage, BRAND_TO_PURSES_KEY, () => {
@@ -297,7 +299,10 @@ export const prepareSmartWallet = (baggage, shared) => {
     return store;
   });
 
-  const makeOfferWatcher = prepareOfferWatcher(baggage);
+  const vowTools = prepareVowTools(zone.subZone('vow'));
+
+  const makeOfferWatcher = prepareOfferWatcher(baggage, vowTools);
+  const watchOfferOutcomes = makeWatchOfferOutcomes(vowTools);
 
   const updateShape = {
     value: AmountShape,

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -23,7 +23,6 @@
     "@agoric/base-zone": "^0.1.0",
     "@agoric/store": "^0.9.2",
     "@agoric/swingset-liveslots": "^0.10.2",
-    "@agoric/vow": "^0.1.0",
     "@endo/exo": "^1.5.0",
     "@endo/patterns": "^1.4.0"
   },

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -11,6 +11,9 @@ import { makeAsVow } from './vow-utils.js';
  */
 
 /**
+ * NB: Not to be used in a Vat. It doesn't know what an upgrade is. For that you
+ * need `prepareVowTools` from `vat.js`.
+ *
  * @param {Zone} zone
  * @param {object} [powers]
  * @param {IsRetryableReason} [powers.isRetryableReason]

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -12,6 +12,10 @@ export const makeWhen = (
   /**
    * Shorten `specimenP` until we achieve a final result.
    *
+   * Does not survive upgrade (even if specimenP is a durable Vow).
+   *
+   * @see {@link ../../README.md}
+   *
    * @template T
    * @template [TResult1=EUnwrap<T>]
    * @template [TResult2=never]

--- a/packages/vow/vat.js
+++ b/packages/vow/vat.js
@@ -30,14 +30,17 @@ export const defaultPowers = harden({
  *
  * @type {typeof rawPrepareVowTools}
  */
-export const prepareVowTools = (zone, powers = {}) =>
+export const prepareSwingsetVowTools = (zone, powers = {}) =>
   rawPrepareVowTools(zone, { ...defaultPowers, ...powers });
+
+/** @deprecated */
+export const prepareVowTools = prepareSwingsetVowTools;
 
 /**
  * `vowTools` that are not durable, but are useful in non-durable clients that
  * need to consume vows from other SwingSet vats.
  */
-export const heapVowTools = prepareVowTools(makeHeapZone());
+export const heapVowTools = prepareSwingsetVowTools(makeHeapZone());
 
 /**
  * A vow-shortening E, for use in vats that are not durable but receive vows.

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -53,6 +53,7 @@
     "@agoric/swingset-vat": "^0.32.2",
     "@agoric/time": "^0.3.2",
     "@agoric/vat-data": "^0.5.2",
+    "@agoric/vow": "^0.1.0",
     "@agoric/zone": "^0.2.2",
     "@endo/bundle-source": "^3.2.3",
     "@endo/common": "^1.2.2",

--- a/packages/zoe/src/contracts/valueVow.contract.js
+++ b/packages/zoe/src/contracts/valueVow.contract.js
@@ -1,0 +1,59 @@
+import { prepareVowTools } from '@agoric/vow';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+
+/**
+ * @import { Baggage } from '@agoric/vat-data';
+ */
+
+/** @type {ContractMeta<typeof start>} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
+/**
+ * This is a simple contract to demonstrate durable vows.
+ *
+ * It provides an invitation to get a vow for a value and another invitation to set the value.
+ *
+ * @param {ZCF<{}>} zcf
+ * @param {undefined} _privateArgs
+ * @param {Baggage} baggage
+ */
+export const start = (zcf, _privateArgs, baggage) => {
+  const zone = makeDurableZone(baggage);
+
+  const vowTools = prepareVowTools(zone);
+
+  const { vow, resolver } = zone.makeOnce('vowResolver', () =>
+    vowTools.makeVowKit(),
+  );
+
+  const publicFacet = zone.exo('publicFacet', undefined, {
+    getValue() {
+      return vow;
+    },
+    setValue(value) {
+      resolver.resolve(value);
+    },
+    makeGetterInvitation() {
+      return zcf.makeInvitation(seat => {
+        seat.exit();
+        return vow;
+      }, 'get value');
+    },
+    makeSetterInvitation() {
+      return zcf.makeInvitation(
+        /** @type {HandleOffer<void, { value: unknown }>}} */
+        (seat, offerArgs) => {
+          seat.exit();
+          resolver.resolve(offerArgs.value);
+        },
+        'set value',
+      );
+    },
+  });
+
+  return harden({ publicFacet });
+};
+harden(start);

--- a/packages/zoe/test/unitTests/contracts/valueVow.test.js
+++ b/packages/zoe/test/unitTests/contracts/valueVow.test.js
@@ -1,0 +1,60 @@
+import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import path from 'path';
+
+import { heapVowTools } from '@agoric/vow/vat.js';
+
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { E } from '@endo/eventual-send';
+import { makeZoeForTest } from '../../../tools/setup-zoe.js';
+
+/**
+ * @import {start as startValueVow} from '../../../src/contracts/valueVow.contract.js';
+ * @import {Installation} from '../../../src/zoeService/utils.js';
+ */
+
+const dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const contractRoot = `${dirname}/../../../src/contracts/valueVow.contract.js`;
+
+/** @type {import('ava').TestFn<{ installation: Installation<typeof startValueVow>, zoe: ReturnType<typeof makeZoeForTest> }>} */
+const test = anyTest;
+
+test.before(async t => {
+  const bundleCache = await unsafeMakeBundleCache('bundles');
+  const zoe = makeZoeForTest();
+  const installation = await E(zoe).install(
+    await bundleCache.load(contractRoot),
+  );
+
+  t.context = {
+    installation,
+    zoe,
+  };
+});
+
+test('resolves', async t => {
+  const { installation, zoe } = t.context;
+  const { publicFacet } = await E(zoe).startInstance(installation);
+
+  const vow = publicFacet.getValue();
+  publicFacet.setValue('some value');
+  t.is(await heapVowTools.asPromise(vow), 'some value');
+});
+
+test('invitations', async t => {
+  const { installation, zoe } = t.context;
+  const { publicFacet } = await E(zoe).startInstance(installation);
+  const vow = await (
+    await E(zoe).offer(publicFacet.makeGetterInvitation())
+  ).getOfferResult();
+
+  await E(zoe).offer(
+    publicFacet.makeSetterInvitation(),
+    {},
+    {},
+    { value: 'hello' },
+  );
+
+  t.is(await heapVowTools.asPromise(vow), 'hello');
+});


### PR DESCRIPTION
closes: #9308

## Description
Makes the offer result watcher able to handle offer results that are vows or promises for vows.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
adds a test for a vow resolving after its source vat restarts

### Upgrade Considerations
This requires an upgrade of the smart-wallet contract, which will have to be deployed in a core-eval.

adds a smart wallet contract upgrade test
