### PR TITLE
fix: Improve agd build prerequisite checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ to use.
 
 ## Prerequisites
 
+Prerequisites are enforced in various places that should be kept synchronized with this section (e.g., [repoconfig.sh](./repoconfig.sh) defines `golang_version_check` and `nodejs_version_check` shell functions).
+
 * Git
 * Go ^1.20.2
 * Node.js ^18.12 or ^20.9

--- a/docs/node-version.md
+++ b/docs/node-version.md
@@ -15,3 +15,4 @@ When a new version becomes Active LTS:
 - [ ] update Node.js test ranges to remove the EOLed version and add the new LTS
 - [ ] update package.json engines to allow the two LTS versions
 - [ ] update README.md to document the new supported versions
+- [ ] update repoconfig.sh to verify against the new supported versions

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -5,25 +5,24 @@ GOLANG_VERSION=1.20.3
 GOLANG_DIR=golang/cosmos
 GOLANG_DAEMON=$GOLANG_DIR/build/agd
 
-# Args are major, minor and patch version numbers
+# golang_version_check $major $minor $patch $version
 golang_version_check() {
   # Keep synchronized with README.md section "Prerequisites".
   {
     [ "$1" -eq 1 ] && [ "$2" -eq 20 ] && [ "$3" -ge 2 ] && return 0
     [ "$1" -eq 1 ] && [ "$2" -ge 21 ] && return 0
-    [ "$1" -ge 2 ] && return 0
   } 2> /dev/null
-  echo 1>&2 "need go version 1.20.2+, 1.21+, or 2+"
+  echo 1>&2 "need Go version 1.20.2+ or 1.21+, found $4"
   return 1
 }
 
-# Args are major, minor and patch version numbers
+# nodejs_version_check $major $minor $patch $version
 nodejs_version_check() {
   # Keep synchronized with README.md section "Prerequisites".
   {
     [ "$1" -eq 18 ] && [ "$2" -ge 12 ] && return 0
     [ "$1" -eq 20 ] && [ "$2" -ge 9 ] && return 0
   } 2> /dev/null
-  echo 1>&2 "need Node.js LTS version ^18.12 or ^20.9, found $1.$2.$3"
+  echo 1>&2 "need Node.js LTS version ^18.12 or ^20.9, found $4"
   return 1
 }

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -7,6 +7,7 @@ GOLANG_DAEMON=$GOLANG_DIR/build/agd
 
 # Args are major, minor and patch version numbers
 golang_version_check() {
+  # Keep synchronized with README.md section "Prerequisites".
   {
     [ "$1" -eq 1 ] && [ "$2" -eq 20 ] && [ "$3" -ge 2 ] && return 0
     [ "$1" -eq 1 ] && [ "$2" -ge 21 ] && return 0
@@ -18,6 +19,7 @@ golang_version_check() {
 
 # Args are major, minor and patch version numbers
 nodejs_version_check() {
+  # Keep synchronized with README.md section "Prerequisites".
   {
     [ "$1" -eq 18 ] && [ "$2" -ge 12 ] && return 0
     [ "$1" -eq 20 ] && [ "$2" -ge 9 ] && return 0

--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -107,11 +107,10 @@ if $need_nodejs; then
       ;;
   esac
 
-  if nodeversion=$(node --version 2> /dev/null); then
-    noderegexp='v([0-9]+)\.([0-9]+)\.([0-9]+)'
-    [[ "$nodeversion" =~ $noderegexp ]] || fatal "illegible Node.js version '$nodeversion'"
-    nodejs_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "$nodeversion"
-  fi
+  nodeversion=$(node --version 2> /dev/null || fatal 'command failed: node --version')
+  noderegexp='v([0-9]+)\.([0-9]+)\.([0-9]+)'
+  [[ "$nodeversion" =~ $noderegexp ]] || fatal "illegible Node.js version '$nodeversion'"
+  nodejs_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "$nodeversion"
 fi
 
 $do_not_build || (
@@ -159,12 +158,11 @@ $do_not_build || (
     esac
     # Ensure minimum patch versions of Go environment
     cd "$GOLANG_DIR"
-    if goversion=$(go version 2> /dev/null); then
-      goregexp='go version go([0-9]+)(.([0-9]+)(.([0-9]+))?)?( |$)'
-      [[ "$goversion" =~ $goregexp ]] || fatal "illegible Go version '$goversion'"
-      golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[5]}" "$goversion"
-      make compile-go
-    fi
+    goversion=$(go version 2> /dev/null || fatal 'command failed: go version')
+    goregexp='go version go([0-9]+)(.([0-9]+)(.([0-9]+))?)?( |$)'
+    [[ "$goversion" =~ $goregexp ]] || fatal "illegible Go version '$goversion'"
+    golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[5]}" "$goversion"
+    make compile-go
   )
 
   if $need_nodejs; then

--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -109,8 +109,8 @@ if $need_nodejs; then
 
   if nodeversion=$(node --version 2> /dev/null); then
     noderegexp='v([0-9]+)\.([0-9]+)\.([0-9]+)'
-    [[ "$nodeversion" =~ $noderegexp ]] || fatal "illegible node version '$nodeversion'"
-    nodejs_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" || exit 1
+    [[ "$nodeversion" =~ $noderegexp ]] || fatal "illegible Node.js version '$nodeversion'"
+    nodejs_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "$nodeversion"
   fi
 fi
 
@@ -160,9 +160,9 @@ $do_not_build || (
     # Ensure minimum patch versions of Go environment
     cd "$GOLANG_DIR"
     if goversion=$(go version 2> /dev/null); then
-      goregexp='go version go([0-9]+)(.([0-9]+)(.([0-9]+))?)? '
-      [[ "$goversion" =~ $goregexp ]] || fatal "illegible go version '$goversion'"
-      golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[5]}"
+      goregexp='go version go([0-9]+)(.([0-9]+)(.([0-9]+))?)?( |$)'
+      [[ "$goversion" =~ $goregexp ]] || fatal "illegible Go version '$goversion'"
+      golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[5]}" "$goversion"
       make compile-go
     fi
   )


### PR DESCRIPTION
Fixes #9636
Fixes #9637
Fixes #9638

## Description
* Adds cross references between README.md and repoconfig.sh to better support their synchronization.
* Removes claimed support for Go version 2+, aligning repoconfig.sh with README.md.
* Generates clear and readable error messages when `node` and/or `go` are needed but missing.

### Security Considerations
None; behavior is largely the same except for failing sooner when prerequisites are not met.

### Scaling Considerations
n/a

### Documentation Considerations
Includes instructions to keep support ranges synchronized between documentation and code.

### Testing Considerations
CI already exercises scripts/agd-builder.sh.

### Upgrade Considerations
When updating version ranges, each relevant file identifies its analog.