### PR TITLE
Upgrade-16 cherry-picks round 3

### DIFF
--- a/packages/base-zone/src/watch-promise.js
+++ b/packages/base-zone/src/watch-promise.js
@@ -9,7 +9,7 @@ const { apply } = Reflect;
 /**
  * A PromiseWatcher method guard callable with or more arguments, returning void.
  */
-export const PromiseWatcherHandler = M.call(M.any()).rest(M.any()).returns();
+export const PromiseWatcherHandler = M.call(M.raw()).rest(M.raw()).returns();
 
 /**
  * A PromiseWatcher interface that has both onFulfilled and onRejected handlers.

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -7,7 +7,7 @@ import { makeAsVow } from './vow-utils.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
- * @import {IsRetryableReason, AsPromiseFunction, Vow, EVow} from './types.js';
+ * @import {IsRetryableReason, AsPromiseFunction, EVow} from './types.js';
  */
 
 /**

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -5,8 +5,10 @@ import { prepareWatch } from './watch.js';
 import { prepareWatchUtils } from './watch-utils.js';
 import { makeAsVow } from './vow-utils.js';
 
-/** @import {Zone} from '@agoric/base-zone' */
-/** @import {IsRetryableReason, AsPromiseFunction} from './types.js' */
+/**
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {IsRetryableReason, AsPromiseFunction} from './types.js';
+ */
 
 /**
  * @param {Zone} zone

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -7,7 +7,7 @@ import { makeAsVow } from './vow-utils.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
- * @import {IsRetryableReason, AsPromiseFunction} from './types.js';
+ * @import {IsRetryableReason, AsPromiseFunction, Vow, EVow} from './types.js';
  */
 
 /**
@@ -33,9 +33,9 @@ export const prepareVowTools = (zone, powers = {}) => {
   /**
    * Vow-tolerant implementation of Promise.all.
    *
-   * @param {unknown[]} vows
+   * @param {EVow<unknown>[]} maybeVows
    */
-  const allVows = vows => watchUtils.all(vows);
+  const allVows = maybeVows => watchUtils.all(maybeVows);
 
   /** @type {AsPromiseFunction} */
   const asPromise = (specimenP, ...watcherArgs) =>

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -6,7 +6,7 @@ import { prepareWatchUtils } from './watch-utils.js';
 import { makeAsVow } from './vow-utils.js';
 
 /** @import {Zone} from '@agoric/base-zone' */
-/** @import {IsRetryableReason, Vow} from './types.js' */
+/** @import {IsRetryableReason} from './types.js' */
 
 /**
  * @param {Zone} zone

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -6,7 +6,7 @@ import { prepareWatchUtils } from './watch-utils.js';
 import { makeAsVow } from './vow-utils.js';
 
 /** @import {Zone} from '@agoric/base-zone' */
-/** @import {IsRetryableReason} from './types.js' */
+/** @import {IsRetryableReason, AsPromiseFunction} from './types.js' */
 
 /**
  * @param {Zone} zone
@@ -35,6 +35,10 @@ export const prepareVowTools = (zone, powers = {}) => {
    */
   const allVows = vows => watchUtils.all(vows);
 
-  return harden({ when, watch, makeVowKit, allVows, asVow });
+  /** @type {AsPromiseFunction} */
+  const asPromise = (specimenP, ...watcherArgs) =>
+    watchUtils.asPromise(specimenP, ...watcherArgs);
+
+  return harden({ when, watch, makeVowKit, allVows, asVow, asPromise });
 };
 harden(prepareVowTools);

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -3,9 +3,10 @@ import { makeWhen } from './when.js';
 import { prepareVowKit } from './vow.js';
 import { prepareWatch } from './watch.js';
 import { prepareWatchUtils } from './watch-utils.js';
+import { makeAsVow } from './vow-utils.js';
 
 /** @import {Zone} from '@agoric/base-zone' */
-/** @import {IsRetryableReason} from './types.js' */
+/** @import {IsRetryableReason, Vow} from './types.js' */
 
 /**
  * @param {Zone} zone
@@ -20,6 +21,7 @@ export const prepareVowTools = (zone, powers = {}) => {
   const watch = prepareWatch(zone, makeVowKit, isRetryableReason);
   const makeWatchUtils = prepareWatchUtils(zone, watch, makeVowKit);
   const watchUtils = makeWatchUtils();
+  const asVow = makeAsVow(makeVowKit);
 
   /**
    * Vow-tolerant implementation of Promise.all.
@@ -28,6 +30,6 @@ export const prepareVowTools = (zone, powers = {}) => {
    */
   const allVows = vows => watchUtils.all(vows);
 
-  return harden({ when, watch, makeVowKit, allVows });
+  return harden({ when, watch, makeVowKit, allVows, asVow });
 };
 harden(prepareVowTools);

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -19,7 +19,12 @@ export const prepareVowTools = (zone, powers = {}) => {
   const makeVowKit = prepareVowKit(zone);
   const when = makeWhen(isRetryableReason);
   const watch = prepareWatch(zone, makeVowKit, isRetryableReason);
-  const makeWatchUtils = prepareWatchUtils(zone, watch, makeVowKit);
+  const makeWatchUtils = prepareWatchUtils(zone, {
+    watch,
+    when,
+    makeVowKit,
+    isRetryableReason,
+  });
   const watchUtils = makeWatchUtils();
   const asVow = makeAsVow(makeVowKit);
 

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -30,6 +30,12 @@ export {};
  */
 
 /**
+ * Eventually a value T or Vow for it.
+ * @template T
+ * @typedef {ERef<T | Vow<T>>} EVow
+ */
+
+/**
  * Follow the chain of vow shortening to the end, returning the final value.
  * This is used within E, so we must narrow the type to its remote form.
  * @template T

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -87,4 +87,18 @@ export {};
  * @property {(reason: any, ...args: C) => Vow<TResult2> | PromiseVow<TResult2> | TResult2} [onRejected]
  */
 
+/**
+ * Converts a vow or promise to a promise, ensuring proper handling of ephemeral promises.
+ *
+ * @template [T=any]
+ * @template [TResult1=T]
+ * @template [TResult2=never]
+ * @template {any[]} [C=any[]]
+ * @callback AsPromiseFunction
+ * @param {ERef<T | Vow<T>>} specimenP
+ * @param {Watcher<T, TResult1, TResult2, C>} [watcher]
+ * @param {C} [watcherArgs]
+ * @returns {Promise<TResult1 | TResult2>}
+ */
+
 /** @typedef {ReturnType<typeof prepareVowTools>} VowTools */

--- a/packages/vow/src/vow-utils.js
+++ b/packages/vow/src/vow-utils.js
@@ -85,12 +85,17 @@ export const makeAsVow = makeVowKit => {
    * @returns {Vow<Awaited<T>>}
    */
   const asVow = fn => {
-    const kit = makeVowKit();
+    let result;
     try {
-      kit.resolver.resolve(fn());
+      result = fn();
     } catch (e) {
-      kit.resolver.reject(e);
+      result = Promise.reject(e);
     }
+    if (isVow(result)) {
+      return result;
+    }
+    const kit = makeVowKit();
+    kit.resolver.resolve(result);
     return kit.vow;
   };
   return harden(asVow);

--- a/packages/vow/src/vow-utils.js
+++ b/packages/vow/src/vow-utils.js
@@ -4,8 +4,9 @@ import { isPassable } from '@endo/pass-style';
 import { M, matches } from '@endo/patterns';
 
 /**
- * @import {PassableCap} from '@endo/pass-style'
- * @import {VowPayload, Vow} from './types.js'
+ * @import {PassableCap} from '@endo/pass-style';
+ * @import {VowPayload, Vow} from './types.js';
+ * @import {MakeVowKit} from './vow.js';
  */
 
 export { basicE };
@@ -73,3 +74,25 @@ export const toPassableCap = k => {
   return vowV0;
 };
 harden(toPassableCap);
+
+/** @param {MakeVowKit} makeVowKit */
+export const makeAsVow = makeVowKit => {
+  /**
+   * Helper function that coerces the result of a function to a Vow. Helpful
+   * for scenarios like a synchronously thrown error.
+   * @template {any} T
+   * @param {(...args: any[]) => Vow<Awaited<T>> | Awaited<T>} fn
+   * @returns {Vow<Awaited<T>>}
+   */
+  const asVow = fn => {
+    const kit = makeVowKit();
+    try {
+      kit.resolver.resolve(fn());
+    } catch (e) {
+      kit.resolver.reject(e);
+    }
+    return kit.vow;
+  };
+  return harden(asVow);
+};
+harden(makeAsVow);

--- a/packages/vow/src/vow.js
+++ b/packages/vow/src/vow.js
@@ -157,5 +157,6 @@ export const prepareVowKit = zone => {
 
   return makeVowKit;
 };
+/** @typedef {ReturnType<typeof prepareVowKit>} MakeVowKit */
 
 harden(prepareVowKit);

--- a/packages/vow/src/vow.js
+++ b/packages/vow/src/vow.js
@@ -9,6 +9,7 @@ const { details: X } = assert;
 /**
  * @import {PromiseKit} from '@endo/promise-kit';
  * @import {Zone} from '@agoric/base-zone';
+ * @import {MapStore} from '@agoric/store';
  * @import {VowResolver, VowKit} from './types.js';
  */
 
@@ -78,6 +79,12 @@ export const prepareVowKit = zone => {
         null
       ),
       isStoredValue: /** @type {boolean} */ (false),
+      /**
+       * Map for future properties that aren't in the schema.
+       * UNTIL https://github.com/Agoric/agoric-sdk/issues/7407
+       * @type {MapStore<any, any> | undefined}
+       */
+      extra: undefined,
     }),
     {
       vowV0: {

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -6,12 +6,11 @@ import { PromiseWatcherI } from '@agoric/base-zone';
 const { Fail, bare, details: X } = assert;
 
 /**
- * @import {MapStore} from '@agoric/store/src/types.js'
- * @import { Zone } from '@agoric/base-zone'
- * @import { Watch } from './watch.js'
- * @import { When } from './when.js'
- * @import {VowKit, AsPromiseFunction} from './types.js'
- * @import {IsRetryableReason} from './types.js'
+ * @import {MapStore} from '@agoric/store/src/types.js';
+ * @import {Zone} from '@agoric/base-zone';
+ * @import {Watch} from './watch.js';
+ * @import {When} from './when.js';
+ * @import {VowKit, AsPromiseFunction, IsRetryableReason, Vow, EVow} from './types.js';
  */
 
 const VowShape = M.tagged(
@@ -81,7 +80,7 @@ export const prepareWatchUtils = (
     {
       utils: {
         /**
-         * @param {unknown[]} vows
+         * @param {EVow<unknown>[]} vows
          */
         all(vows) {
           const { nextId: id, idToVowState } = this.state;

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -88,24 +88,22 @@ export const prepareWatchUtils = (
           const kit = makeVowKit();
 
           // Preserve the order of the vow results.
-          let index = 0;
-          for (const vow of vows) {
-            watch(vow, this.facets.watcher, {
+          for (let index = 0; index < vows.length; index += 1) {
+            watch(vows[index], this.facets.watcher, {
               id,
               index,
               numResults: vows.length,
             });
-            index += 1;
           }
 
-          if (index > 0) {
+          if (vows.length > 0) {
             // Save the state until rejection or all fulfilled.
             this.state.nextId += 1n;
             idToVowState.init(
               id,
               harden({
                 resolver: kit.resolver,
-                remaining: index,
+                remaining: vows.length,
                 resultsMap: detached.mapStore('resultsMap'),
               }),
             );

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -10,7 +10,7 @@ const { Fail, bare, details: X } = assert;
  * @import {Zone} from '@agoric/base-zone';
  * @import {Watch} from './watch.js';
  * @import {When} from './when.js';
- * @import {VowKit, AsPromiseFunction, IsRetryableReason, Vow, EVow} from './types.js';
+ * @import {VowKit, AsPromiseFunction, IsRetryableReason, EVow} from './types.js';
  */
 
 const VowShape = M.tagged(

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -10,7 +10,7 @@ const { Fail, bare } = assert;
  * @import { Zone } from '@agoric/base-zone'
  * @import { Watch } from './watch.js'
  * @import { When } from './when.js'
- * @import {VowKit} from './types.js'
+ * @import {VowKit, AsPromiseFunction} from './types.js'
  * @import {IsRetryableReason} from './types.js'
  */
 
@@ -96,6 +96,7 @@ export const prepareWatchUtils = (
           }
           return kit.vow;
         },
+        /** @type {AsPromiseFunction} */
         asPromise(specimenP, ...watcherArgs) {
           // Watch the specimen in case it is an ephemeral promise.
           const vow = watch(specimenP, ...watcherArgs);

--- a/packages/vow/src/watch.js
+++ b/packages/vow/src/watch.js
@@ -6,7 +6,7 @@ const { apply } = Reflect;
 
 /**
  * @import { PromiseWatcher, Zone } from '@agoric/base-zone';
- * @import { ERef, IsRetryableReason, Vow, VowKit, VowResolver, Watcher } from './types.js';
+ * @import { ERef, EVow, IsRetryableReason, Vow, VowKit, VowResolver, Watcher } from './types.js';
  */
 
 /**
@@ -170,7 +170,7 @@ export const prepareWatch = (
    * @template [TResult1=T]
    * @template [TResult2=never]
    * @template {any[]} [C=any[]] watcher args
-   * @param {ERef<T | Vow<T>>} specimenP
+   * @param {EVow<T>} specimenP
    * @param {Watcher<T, TResult1, TResult2, C>} [watcher]
    * @param {C} watcherArgs
    */

--- a/packages/vow/test/asVow.test.js
+++ b/packages/vow/test/asVow.test.js
@@ -1,14 +1,14 @@
 // @ts-check
 import test from 'ava';
 
+import { E } from '@endo/far';
 import { makeHeapZone } from '@agoric/base-zone/heap.js';
 
 import { prepareVowTools } from '../src/tools.js';
-import { isVow } from '../src/vow-utils.js';
+import { getVowPayload, isVow } from '../src/vow-utils.js';
 
 test('asVow takes a function that throws/returns synchronously and returns a vow', async t => {
-  const zone = makeHeapZone();
-  const { watch, when, asVow } = prepareVowTools(zone);
+  const { watch, when, asVow } = prepareVowTools(makeHeapZone());
 
   const fnThatThrows = () => {
     throw Error('fail');
@@ -16,11 +16,15 @@ test('asVow takes a function that throws/returns synchronously and returns a vow
 
   const vowWithRejection = asVow(fnThatThrows);
   t.true(isVow(vowWithRejection));
-  await t.throwsAsync(when(vowWithRejection), { message: 'fail' }, 'failure ');
+  await t.throwsAsync(
+    when(vowWithRejection),
+    { message: 'fail' },
+    'error should propogate as promise rejection',
+  );
 
   const isWatchAble = watch(asVow(fnThatThrows));
   t.true(isVow(vowWithRejection));
-  await t.throwsAsync(when(isWatchAble), { message: 'fail' }, 'failure ');
+  await t.throwsAsync(when(isWatchAble), { message: 'fail' });
 
   const fnThatReturns = () => {
     return 'early return';
@@ -29,4 +33,22 @@ test('asVow takes a function that throws/returns synchronously and returns a vow
   t.true(isVow(vowWithReturn));
   t.is(await when(vowWithReturn), 'early return');
   t.is(await when(watch(vowWithReturn)), 'early return');
+});
+
+test('asVow does not resolve a vow to a vow', async t => {
+  const { watch, when, asVow } = prepareVowTools(makeHeapZone());
+
+  const testVow = watch(Promise.resolve('payload'));
+  const testVowAsVow = asVow(() => testVow);
+
+  const vowPayload = getVowPayload(testVowAsVow);
+  assert(vowPayload?.vowV0, 'testVowAsVow is a vow');
+  const unwrappedOnce = await E(vowPayload.vowV0).shorten();
+  t.false(
+    isVow(unwrappedOnce),
+    'vows passed to asVow are not rewrapped as vows',
+  );
+  t.is(unwrappedOnce, 'payload');
+
+  t.is(await when(testVow), await when(testVowAsVow), 'result is preserved');
 });

--- a/packages/vow/test/asVow.test.js
+++ b/packages/vow/test/asVow.test.js
@@ -1,0 +1,32 @@
+// @ts-check
+import test from 'ava';
+
+import { makeHeapZone } from '@agoric/base-zone/heap.js';
+
+import { prepareVowTools } from '../src/tools.js';
+import { isVow } from '../src/vow-utils.js';
+
+test('asVow takes a function that throws/returns synchronously and returns a vow', async t => {
+  const zone = makeHeapZone();
+  const { watch, when, asVow } = prepareVowTools(zone);
+
+  const fnThatThrows = () => {
+    throw Error('fail');
+  };
+
+  const vowWithRejection = asVow(fnThatThrows);
+  t.true(isVow(vowWithRejection));
+  await t.throwsAsync(when(vowWithRejection), { message: 'fail' }, 'failure ');
+
+  const isWatchAble = watch(asVow(fnThatThrows));
+  t.true(isVow(vowWithRejection));
+  await t.throwsAsync(when(isWatchAble), { message: 'fail' }, 'failure ');
+
+  const fnThatReturns = () => {
+    return 'early return';
+  };
+  const vowWithReturn = asVow(fnThatReturns);
+  t.true(isVow(vowWithReturn));
+  t.is(await when(vowWithReturn), 'early return');
+  t.is(await when(watch(vowWithReturn)), 'early return');
+});

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -160,6 +160,7 @@ test('asPromise handles watcher arguments', async t => {
     },
   };
 
+  // XXX fix type: `watcherContext` doesn't need to be an array
   const result = await asPromise(vow, watcher, ['ctx']);
   t.is(result, 'watcher test');
   t.true(watcherCalled);

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -112,3 +112,55 @@ test('allVows - watch promises mixed with vows', async t => {
   t.is(result.length, 2);
   t.like(result, ['vow', 'promise']);
 });
+
+test('asPromise converts a vow to a promise', async t => {
+  const zone = makeHeapZone();
+  const { watch, asPromise } = prepareVowTools(zone);
+
+  const testPromiseP = Promise.resolve('test value');
+  const vow = watch(testPromiseP);
+
+  const result = await asPromise(vow);
+  t.is(result, 'test value');
+});
+
+test('asPromise handles vow rejection', async t => {
+  const zone = makeHeapZone();
+  const { watch, asPromise } = prepareVowTools(zone);
+
+  const testPromiseP = Promise.reject(new Error('test error'));
+  const vow = watch(testPromiseP);
+
+  await t.throwsAsync(asPromise(vow), { message: 'test error' });
+});
+
+test('asPromise accepts and resolves promises', async t => {
+  const zone = makeHeapZone();
+  const { asPromise } = prepareVowTools(zone);
+
+  const p = Promise.resolve('a promise');
+  const result = await asPromise(p);
+  t.is(result, 'a promise');
+});
+
+test('asPromise handles watcher arguments', async t => {
+  const zone = makeHeapZone();
+  const { watch, asPromise } = prepareVowTools(zone);
+
+  const testPromiseP = Promise.resolve('watcher test');
+  const vow = watch(testPromiseP);
+
+  let watcherCalled = false;
+  const watcher = {
+    onFulfilled(value, ctx) {
+      watcherCalled = true;
+      t.is(value, 'watcher test');
+      t.deepEqual(ctx, ['ctx']);
+      return value;
+    },
+  };
+
+  const result = await asPromise(vow, watcher, ['ctx']);
+  t.is(result, 'watcher test');
+  t.true(watcherCalled);
+});


### PR DESCRIPTION
git rebase-todo
```
# Branch pc/as-vow
label base-pc-as-vow
pick b6b5f5f7dd feat(vowTools): add asVow helper
pick 0cdcd5f32b feat(vowTools): asVow should not wrap a vow as a vow
label pc-as-vow
reset base-pc-as-vow
merge -C 0ad10c6e7b pc-as-vow # feat(vowTools): add asVow helper (#9577)

# Branch pc/watch-utils-as-promise
label base-pc-watch-utils-as-promise
pick bf430a12af feat(watchUtils): add asPromise helper
# To resolve conflicts in the following commit:
# * In packages/vow/src/types.js, keep inbound changes and (after that) the
#   definition of VowTools.
# * In packages/vow/test/watch-utils.test.js, keep only inbound changes and
#   limit them to start at "asPromise converts a vow to a promise" (i.e.,
#   just the additions of
#   https://github.com/Agoric/agoric-sdk/pull/9620/files#diff-fd7cabcc7d1097036e2981c3262aa20612bec349f6e418d53324fc33b1b26946 ).
pick c940d5ca73 feat(vowTools): asPromise helper for unwrapping vows
pick 8c27c6725b feat(watchUtils): handle non-storables
pick 3d5a3f3e44 feat(types): EVow
pick 1c0b96468c refactor: don't re-use index
pick 274df1833f fix(vow): clearer stored/non-stored values
pick ff92211d04 refactor: 'extra' field for future properties
label pc-watch-utils-as-promise
reset base-pc-watch-utils-as-promise
merge -C 8edf90288c pc-watch-utils-as-promise # feat(vows): improve handling of ephemeral values (#9620)
```

and as noted in Slack:
> if the #9620 derivative still modifies base-zone to relax <code>PromiseWatcherHandler</code> argument and return patterns from <code>M.any()</code> to <code>M.raw()</code> [_which is this PR, and it does_], those changes will make it harder to debug any vat code that relies upon e.g. <code>prepareVowKit</code>/<code>prepareVowTools</code>/<code>heapVowTools</code>/<code>heapVowE</code> and either receives or attempts to return a non-storable value, because those scenarios will fail even though the state of the repository makes it <i data-stringify-type="italic">look</i> like they should succeed (as they will once the relevant vat(s) are restarted). Looking at dev-upgrade-16, I think that's vat-{ibc,localchain,network,transfer}, so we'll need to keep the gap in mind if such a situation comes up