### PR TITLE
feat(undelegate): use Timestamp instead of Date

### DIFF
--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -191,6 +191,11 @@ test.serial('stakeAtom - smart wallet', async t => {
   );
 });
 
+test.todo('undelegate wallet offer');
+test.todo('undelegate with multiple undelegations wallet offer');
+test.todo('redelegate wallet offer');
+test.todo('withdraw reward wallet offer');
+
 // XXX rely on .serial to be in sequence, and keep this one last
 test.serial('revise chain info', async t => {
   const {

--- a/packages/cosmic-proto/scripts/codegen.cjs
+++ b/packages/cosmic-proto/scripts/codegen.cjs
@@ -73,6 +73,7 @@ telescope({
       },
       typingsFormat: {
         useDeepPartial: false,
+        timestamp: 'timestamp',
 
         // [Defaults]
         // timestamp: 'date',

--- a/packages/cosmic-proto/src/codegen/cosmos/authz/v1beta1/authz.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/authz/v1beta1/authz.ts
@@ -1,6 +1,9 @@
 //@ts-nocheck
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
 import {
   SendAuthorization,
   SendAuthorizationSDKType,
@@ -14,12 +17,7 @@ import {
   TransferAuthorizationSDKType,
 } from '../../../ibc/applications/transfer/v1/authz.js';
 import { BinaryReader, BinaryWriter } from '../../../binary.js';
-import {
-  isSet,
-  toTimestamp,
-  fromTimestamp,
-  fromJsonTimestamp,
-} from '../../../helpers.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../../helpers.js';
 import { JsonSafe } from '../../../json-safe.js';
 /**
  * GenericAuthorization gives the grantee unrestricted permissions to execute
@@ -59,7 +57,7 @@ export interface Grant {
    * doesn't have a time expiration (other conditions  in `authorization`
    * may apply to invalidate the grant)
    */
-  expiration?: Date;
+  expiration?: Timestamp;
 }
 export interface GrantProtoMsg {
   typeUrl: '/cosmos.authz.v1beta1.Grant';
@@ -77,7 +75,7 @@ export interface GrantSDKType {
     | TransferAuthorizationSDKType
     | AnySDKType
     | undefined;
-  expiration?: Date;
+  expiration?: TimestampSDKType;
 }
 /**
  * GrantAuthorization extends a grant with both the addresses of the grantee and granter.
@@ -93,7 +91,7 @@ export interface GrantAuthorization {
         TransferAuthorization &
         Any)
     | undefined;
-  expiration?: Date;
+  expiration?: Timestamp;
 }
 export interface GrantAuthorizationProtoMsg {
   typeUrl: '/cosmos.authz.v1beta1.GrantAuthorization';
@@ -113,7 +111,7 @@ export interface GrantAuthorizationSDKType {
     | TransferAuthorizationSDKType
     | AnySDKType
     | undefined;
-  expiration?: Date;
+  expiration?: TimestampSDKType;
 }
 /** GrantQueueItem contains the list of TypeURL of a sdk.Msg. */
 export interface GrantQueueItem {
@@ -213,10 +211,7 @@ export const Grant = {
       ).ldelim();
     }
     if (message.expiration !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.expiration),
-        writer.uint32(18).fork(),
-      ).ldelim();
+      Timestamp.encode(message.expiration, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -232,9 +227,7 @@ export const Grant = {
           message.authorization = Authorization_InterfaceDecoder(reader) as Any;
           break;
         case 2:
-          message.expiration = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.expiration = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -260,7 +253,7 @@ export const Grant = {
         ? Any.toJSON(message.authorization)
         : undefined);
     message.expiration !== undefined &&
-      (obj.expiration = message.expiration.toISOString());
+      (obj.expiration = fromTimestamp(message.expiration).toISOString());
     return obj;
   },
   fromPartial(object: Partial<Grant>): Grant {
@@ -269,7 +262,10 @@ export const Grant = {
       object.authorization !== undefined && object.authorization !== null
         ? Any.fromPartial(object.authorization)
         : undefined;
-    message.expiration = object.expiration ?? undefined;
+    message.expiration =
+      object.expiration !== undefined && object.expiration !== null
+        ? Timestamp.fromPartial(object.expiration)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: GrantProtoMsg): Grant {
@@ -312,10 +308,7 @@ export const GrantAuthorization = {
       ).ldelim();
     }
     if (message.expiration !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.expiration),
-        writer.uint32(34).fork(),
-      ).ldelim();
+      Timestamp.encode(message.expiration, writer.uint32(34).fork()).ldelim();
     }
     return writer;
   },
@@ -340,9 +333,7 @@ export const GrantAuthorization = {
           message.authorization = Authorization_InterfaceDecoder(reader) as Any;
           break;
         case 4:
-          message.expiration = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.expiration = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -372,7 +363,7 @@ export const GrantAuthorization = {
         ? Any.toJSON(message.authorization)
         : undefined);
     message.expiration !== undefined &&
-      (obj.expiration = message.expiration.toISOString());
+      (obj.expiration = fromTimestamp(message.expiration).toISOString());
     return obj;
   },
   fromPartial(object: Partial<GrantAuthorization>): GrantAuthorization {
@@ -383,7 +374,10 @@ export const GrantAuthorization = {
       object.authorization !== undefined && object.authorization !== null
         ? Any.fromPartial(object.authorization)
         : undefined;
-    message.expiration = object.expiration ?? undefined;
+    message.expiration =
+      object.expiration !== undefined && object.expiration !== null
+        ? Timestamp.fromPartial(object.expiration)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: GrantAuthorizationProtoMsg): GrantAuthorization {

--- a/packages/cosmic-proto/src/codegen/cosmos/feegrant/v1beta1/feegrant.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/feegrant/v1beta1/feegrant.ts
@@ -1,18 +1,16 @@
 //@ts-nocheck
 import { Coin, CoinSDKType } from '../../base/v1beta1/coin.js';
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
 import {
   Duration,
   DurationSDKType,
 } from '../../../google/protobuf/duration.js';
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
 import { BinaryReader, BinaryWriter } from '../../../binary.js';
-import {
-  toTimestamp,
-  fromTimestamp,
-  isSet,
-  fromJsonTimestamp,
-} from '../../../helpers.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../../helpers.js';
 import { JsonSafe } from '../../../json-safe.js';
 /**
  * BasicAllowance implements Allowance with a one-time grant of coins
@@ -27,7 +25,7 @@ export interface BasicAllowance {
    */
   spendLimit: Coin[];
   /** expiration specifies an optional time when this allowance expires */
-  expiration?: Date;
+  expiration?: Timestamp;
 }
 export interface BasicAllowanceProtoMsg {
   typeUrl: '/cosmos.feegrant.v1beta1.BasicAllowance';
@@ -40,7 +38,7 @@ export interface BasicAllowanceProtoMsg {
 export interface BasicAllowanceSDKType {
   $typeUrl?: '/cosmos.feegrant.v1beta1.BasicAllowance';
   spend_limit: CoinSDKType[];
-  expiration?: Date;
+  expiration?: TimestampSDKType;
 }
 /**
  * PeriodicAllowance extends Allowance to allow for both a maximum cap,
@@ -67,7 +65,7 @@ export interface PeriodicAllowance {
    * it is calculated from the start time of the first transaction after the
    * last period ended
    */
-  periodReset: Date;
+  periodReset: Timestamp;
 }
 export interface PeriodicAllowanceProtoMsg {
   typeUrl: '/cosmos.feegrant.v1beta1.PeriodicAllowance';
@@ -83,7 +81,7 @@ export interface PeriodicAllowanceSDKType {
   period: DurationSDKType;
   period_spend_limit: CoinSDKType[];
   period_can_spend: CoinSDKType[];
-  period_reset: Date;
+  period_reset: TimestampSDKType;
 }
 /** AllowedMsgAllowance creates allowance only for specified message types. */
 export interface AllowedMsgAllowance {
@@ -153,10 +151,7 @@ export const BasicAllowance = {
       Coin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
     if (message.expiration !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.expiration),
-        writer.uint32(18).fork(),
-      ).ldelim();
+      Timestamp.encode(message.expiration, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -172,9 +167,7 @@ export const BasicAllowance = {
           message.spendLimit.push(Coin.decode(reader, reader.uint32()));
           break;
         case 2:
-          message.expiration = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.expiration = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -203,13 +196,16 @@ export const BasicAllowance = {
       obj.spendLimit = [];
     }
     message.expiration !== undefined &&
-      (obj.expiration = message.expiration.toISOString());
+      (obj.expiration = fromTimestamp(message.expiration).toISOString());
     return obj;
   },
   fromPartial(object: Partial<BasicAllowance>): BasicAllowance {
     const message = createBaseBasicAllowance();
     message.spendLimit = object.spendLimit?.map(e => Coin.fromPartial(e)) || [];
-    message.expiration = object.expiration ?? undefined;
+    message.expiration =
+      object.expiration !== undefined && object.expiration !== null
+        ? Timestamp.fromPartial(object.expiration)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: BasicAllowanceProtoMsg): BasicAllowance {
@@ -232,7 +228,7 @@ function createBasePeriodicAllowance(): PeriodicAllowance {
     period: Duration.fromPartial({}),
     periodSpendLimit: [],
     periodCanSpend: [],
-    periodReset: new Date(),
+    periodReset: Timestamp.fromPartial({}),
   };
 }
 export const PeriodicAllowance = {
@@ -254,10 +250,7 @@ export const PeriodicAllowance = {
       Coin.encode(v!, writer.uint32(34).fork()).ldelim();
     }
     if (message.periodReset !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.periodReset),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.periodReset, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -282,9 +275,7 @@ export const PeriodicAllowance = {
           message.periodCanSpend.push(Coin.decode(reader, reader.uint32()));
           break;
         case 5:
-          message.periodReset = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.periodReset = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -337,7 +328,7 @@ export const PeriodicAllowance = {
       obj.periodCanSpend = [];
     }
     message.periodReset !== undefined &&
-      (obj.periodReset = message.periodReset.toISOString());
+      (obj.periodReset = fromTimestamp(message.periodReset).toISOString());
     return obj;
   },
   fromPartial(object: Partial<PeriodicAllowance>): PeriodicAllowance {
@@ -354,7 +345,10 @@ export const PeriodicAllowance = {
       object.periodSpendLimit?.map(e => Coin.fromPartial(e)) || [];
     message.periodCanSpend =
       object.periodCanSpend?.map(e => Coin.fromPartial(e)) || [];
-    message.periodReset = object.periodReset ?? undefined;
+    message.periodReset =
+      object.periodReset !== undefined && object.periodReset !== null
+        ? Timestamp.fromPartial(object.periodReset)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: PeriodicAllowanceProtoMsg): PeriodicAllowance {

--- a/packages/cosmic-proto/src/codegen/cosmos/gov/v1/gov.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/gov/v1/gov.ts
@@ -1,18 +1,16 @@
 //@ts-nocheck
 import { Coin, CoinSDKType } from '../../base/v1beta1/coin.js';
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
 import {
   Duration,
   DurationSDKType,
 } from '../../../google/protobuf/duration.js';
 import { BinaryReader, BinaryWriter } from '../../../binary.js';
-import {
-  isSet,
-  toTimestamp,
-  fromTimestamp,
-  fromJsonTimestamp,
-} from '../../../helpers.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../../helpers.js';
 import { JsonSafe } from '../../../json-safe.js';
 /** VoteOption enumerates the valid vote options for a given governance proposal. */
 export enum VoteOption {
@@ -193,11 +191,11 @@ export interface Proposal {
    * proposal's voting period has ended.
    */
   finalTallyResult?: TallyResult;
-  submitTime?: Date;
-  depositEndTime?: Date;
+  submitTime?: Timestamp;
+  depositEndTime?: Timestamp;
   totalDeposit: Coin[];
-  votingStartTime?: Date;
-  votingEndTime?: Date;
+  votingStartTime?: Timestamp;
+  votingEndTime?: Timestamp;
   /** metadata is any arbitrary metadata attached to the proposal. */
   metadata: string;
 }
@@ -211,11 +209,11 @@ export interface ProposalSDKType {
   messages: AnySDKType[];
   status: ProposalStatus;
   final_tally_result?: TallyResultSDKType;
-  submit_time?: Date;
-  deposit_end_time?: Date;
+  submit_time?: TimestampSDKType;
+  deposit_end_time?: TimestampSDKType;
   total_deposit: CoinSDKType[];
-  voting_start_time?: Date;
-  voting_end_time?: Date;
+  voting_start_time?: TimestampSDKType;
+  voting_end_time?: TimestampSDKType;
   metadata: string;
 }
 /** TallyResult defines a standard tally for a governance proposal. */
@@ -524,14 +522,11 @@ export const Proposal = {
       ).ldelim();
     }
     if (message.submitTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.submitTime),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.submitTime, writer.uint32(42).fork()).ldelim();
     }
     if (message.depositEndTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.depositEndTime),
+        message.depositEndTime,
         writer.uint32(50).fork(),
       ).ldelim();
     }
@@ -540,13 +535,13 @@ export const Proposal = {
     }
     if (message.votingStartTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.votingStartTime),
+        message.votingStartTime,
         writer.uint32(66).fork(),
       ).ldelim();
     }
     if (message.votingEndTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.votingEndTime),
+        message.votingEndTime,
         writer.uint32(74).fork(),
       ).ldelim();
     }
@@ -579,27 +574,19 @@ export const Proposal = {
           );
           break;
         case 5:
-          message.submitTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.submitTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 6:
-          message.depositEndTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.depositEndTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 7:
           message.totalDeposit.push(Coin.decode(reader, reader.uint32()));
           break;
         case 8:
-          message.votingStartTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.votingStartTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 9:
-          message.votingEndTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.votingEndTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 10:
           message.metadata = reader.string();
@@ -654,9 +641,11 @@ export const Proposal = {
         ? TallyResult.toJSON(message.finalTallyResult)
         : undefined);
     message.submitTime !== undefined &&
-      (obj.submitTime = message.submitTime.toISOString());
+      (obj.submitTime = fromTimestamp(message.submitTime).toISOString());
     message.depositEndTime !== undefined &&
-      (obj.depositEndTime = message.depositEndTime.toISOString());
+      (obj.depositEndTime = fromTimestamp(
+        message.depositEndTime,
+      ).toISOString());
     if (message.totalDeposit) {
       obj.totalDeposit = message.totalDeposit.map(e =>
         e ? Coin.toJSON(e) : undefined,
@@ -665,9 +654,11 @@ export const Proposal = {
       obj.totalDeposit = [];
     }
     message.votingStartTime !== undefined &&
-      (obj.votingStartTime = message.votingStartTime.toISOString());
+      (obj.votingStartTime = fromTimestamp(
+        message.votingStartTime,
+      ).toISOString());
     message.votingEndTime !== undefined &&
-      (obj.votingEndTime = message.votingEndTime.toISOString());
+      (obj.votingEndTime = fromTimestamp(message.votingEndTime).toISOString());
     message.metadata !== undefined && (obj.metadata = message.metadata);
     return obj;
   },
@@ -683,12 +674,24 @@ export const Proposal = {
       object.finalTallyResult !== undefined && object.finalTallyResult !== null
         ? TallyResult.fromPartial(object.finalTallyResult)
         : undefined;
-    message.submitTime = object.submitTime ?? undefined;
-    message.depositEndTime = object.depositEndTime ?? undefined;
+    message.submitTime =
+      object.submitTime !== undefined && object.submitTime !== null
+        ? Timestamp.fromPartial(object.submitTime)
+        : undefined;
+    message.depositEndTime =
+      object.depositEndTime !== undefined && object.depositEndTime !== null
+        ? Timestamp.fromPartial(object.depositEndTime)
+        : undefined;
     message.totalDeposit =
       object.totalDeposit?.map(e => Coin.fromPartial(e)) || [];
-    message.votingStartTime = object.votingStartTime ?? undefined;
-    message.votingEndTime = object.votingEndTime ?? undefined;
+    message.votingStartTime =
+      object.votingStartTime !== undefined && object.votingStartTime !== null
+        ? Timestamp.fromPartial(object.votingStartTime)
+        : undefined;
+    message.votingEndTime =
+      object.votingEndTime !== undefined && object.votingEndTime !== null
+        ? Timestamp.fromPartial(object.votingEndTime)
+        : undefined;
     message.metadata = object.metadata ?? '';
     return message;
   },

--- a/packages/cosmic-proto/src/codegen/cosmos/gov/v1beta1/gov.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/gov/v1beta1/gov.ts
@@ -1,7 +1,10 @@
 //@ts-nocheck
 import { Coin, CoinSDKType } from '../../base/v1beta1/coin.js';
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
 import {
   Duration,
   DurationSDKType,
@@ -10,9 +13,8 @@ import { BinaryReader, BinaryWriter } from '../../../binary.js';
 import { Decimal } from '@cosmjs/math';
 import {
   isSet,
-  toTimestamp,
-  fromTimestamp,
   fromJsonTimestamp,
+  fromTimestamp,
   bytesFromBase64,
   base64FromBytes,
 } from '../../../helpers.js';
@@ -226,11 +228,11 @@ export interface Proposal {
    * proposal's voting period has ended.
    */
   finalTallyResult: TallyResult;
-  submitTime: Date;
-  depositEndTime: Date;
+  submitTime: Timestamp;
+  depositEndTime: Timestamp;
   totalDeposit: Coin[];
-  votingStartTime: Date;
-  votingEndTime: Date;
+  votingStartTime: Timestamp;
+  votingEndTime: Timestamp;
 }
 export interface ProposalProtoMsg {
   typeUrl: '/cosmos.gov.v1beta1.Proposal';
@@ -242,11 +244,11 @@ export interface ProposalSDKType {
   content?: TextProposalSDKType | AnySDKType | undefined;
   status: ProposalStatus;
   final_tally_result: TallyResultSDKType;
-  submit_time: Date;
-  deposit_end_time: Date;
+  submit_time: TimestampSDKType;
+  deposit_end_time: TimestampSDKType;
   total_deposit: CoinSDKType[];
-  voting_start_time: Date;
-  voting_end_time: Date;
+  voting_start_time: TimestampSDKType;
+  voting_end_time: TimestampSDKType;
 }
 /** TallyResult defines a standard tally for a governance proposal. */
 export interface TallyResult {
@@ -607,11 +609,11 @@ function createBaseProposal(): Proposal {
     content: undefined,
     status: 0,
     finalTallyResult: TallyResult.fromPartial({}),
-    submitTime: new Date(),
-    depositEndTime: new Date(),
+    submitTime: Timestamp.fromPartial({}),
+    depositEndTime: Timestamp.fromPartial({}),
     totalDeposit: [],
-    votingStartTime: new Date(),
-    votingEndTime: new Date(),
+    votingStartTime: Timestamp.fromPartial({}),
+    votingEndTime: Timestamp.fromPartial({}),
   };
 }
 export const Proposal = {
@@ -636,14 +638,11 @@ export const Proposal = {
       ).ldelim();
     }
     if (message.submitTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.submitTime),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.submitTime, writer.uint32(42).fork()).ldelim();
     }
     if (message.depositEndTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.depositEndTime),
+        message.depositEndTime,
         writer.uint32(50).fork(),
       ).ldelim();
     }
@@ -652,13 +651,13 @@ export const Proposal = {
     }
     if (message.votingStartTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.votingStartTime),
+        message.votingStartTime,
         writer.uint32(66).fork(),
       ).ldelim();
     }
     if (message.votingEndTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.votingEndTime),
+        message.votingEndTime,
         writer.uint32(74).fork(),
       ).ldelim();
     }
@@ -688,27 +687,19 @@ export const Proposal = {
           );
           break;
         case 5:
-          message.submitTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.submitTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 6:
-          message.depositEndTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.depositEndTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 7:
           message.totalDeposit.push(Coin.decode(reader, reader.uint32()));
           break;
         case 8:
-          message.votingStartTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.votingStartTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 9:
-          message.votingEndTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.votingEndTime = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -757,9 +748,11 @@ export const Proposal = {
         ? TallyResult.toJSON(message.finalTallyResult)
         : undefined);
     message.submitTime !== undefined &&
-      (obj.submitTime = message.submitTime.toISOString());
+      (obj.submitTime = fromTimestamp(message.submitTime).toISOString());
     message.depositEndTime !== undefined &&
-      (obj.depositEndTime = message.depositEndTime.toISOString());
+      (obj.depositEndTime = fromTimestamp(
+        message.depositEndTime,
+      ).toISOString());
     if (message.totalDeposit) {
       obj.totalDeposit = message.totalDeposit.map(e =>
         e ? Coin.toJSON(e) : undefined,
@@ -768,9 +761,11 @@ export const Proposal = {
       obj.totalDeposit = [];
     }
     message.votingStartTime !== undefined &&
-      (obj.votingStartTime = message.votingStartTime.toISOString());
+      (obj.votingStartTime = fromTimestamp(
+        message.votingStartTime,
+      ).toISOString());
     message.votingEndTime !== undefined &&
-      (obj.votingEndTime = message.votingEndTime.toISOString());
+      (obj.votingEndTime = fromTimestamp(message.votingEndTime).toISOString());
     return obj;
   },
   fromPartial(object: Partial<Proposal>): Proposal {
@@ -788,12 +783,24 @@ export const Proposal = {
       object.finalTallyResult !== undefined && object.finalTallyResult !== null
         ? TallyResult.fromPartial(object.finalTallyResult)
         : undefined;
-    message.submitTime = object.submitTime ?? undefined;
-    message.depositEndTime = object.depositEndTime ?? undefined;
+    message.submitTime =
+      object.submitTime !== undefined && object.submitTime !== null
+        ? Timestamp.fromPartial(object.submitTime)
+        : undefined;
+    message.depositEndTime =
+      object.depositEndTime !== undefined && object.depositEndTime !== null
+        ? Timestamp.fromPartial(object.depositEndTime)
+        : undefined;
     message.totalDeposit =
       object.totalDeposit?.map(e => Coin.fromPartial(e)) || [];
-    message.votingStartTime = object.votingStartTime ?? undefined;
-    message.votingEndTime = object.votingEndTime ?? undefined;
+    message.votingStartTime =
+      object.votingStartTime !== undefined && object.votingStartTime !== null
+        ? Timestamp.fromPartial(object.votingStartTime)
+        : undefined;
+    message.votingEndTime =
+      object.votingEndTime !== undefined && object.votingEndTime !== null
+        ? Timestamp.fromPartial(object.votingEndTime)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: ProposalProtoMsg): Proposal {

--- a/packages/cosmic-proto/src/codegen/cosmos/group/v1/types.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/group/v1/types.ts
@@ -1,17 +1,15 @@
 //@ts-nocheck
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
 import {
   Duration,
   DurationSDKType,
 } from '../../../google/protobuf/duration.js';
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
 import { BinaryReader, BinaryWriter } from '../../../binary.js';
-import {
-  toTimestamp,
-  fromTimestamp,
-  isSet,
-  fromJsonTimestamp,
-} from '../../../helpers.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../../helpers.js';
 import { JsonSafe } from '../../../json-safe.js';
 /** VoteOption enumerates the valid vote options for a given proposal. */
 export enum VoteOption {
@@ -209,7 +207,7 @@ export interface Member {
   /** metadata is any arbitrary metadata attached to the member. */
   metadata: string;
   /** added_at is a timestamp specifying when a member was added. */
-  addedAt: Date;
+  addedAt: Timestamp;
 }
 export interface MemberProtoMsg {
   typeUrl: '/cosmos.group.v1.Member';
@@ -223,7 +221,7 @@ export interface MemberSDKType {
   address: string;
   weight: string;
   metadata: string;
-  added_at: Date;
+  added_at: TimestampSDKType;
 }
 /**
  * MemberRequest represents a group member to be used in Msg server requests.
@@ -371,7 +369,7 @@ export interface GroupInfo {
   /** total_weight is the sum of the group members' weights. */
   totalWeight: string;
   /** created_at is a timestamp specifying when a group was created. */
-  createdAt: Date;
+  createdAt: Timestamp;
 }
 export interface GroupInfoProtoMsg {
   typeUrl: '/cosmos.group.v1.GroupInfo';
@@ -384,7 +382,7 @@ export interface GroupInfoSDKType {
   metadata: string;
   version: bigint;
   total_weight: string;
-  created_at: Date;
+  created_at: TimestampSDKType;
 }
 /** GroupMember represents the relationship between a group and a member. */
 export interface GroupMember {
@@ -420,7 +418,7 @@ export interface GroupPolicyInfo {
   /** decision_policy specifies the group policy's decision policy. */
   decisionPolicy?: Any | undefined;
   /** created_at is a timestamp specifying when a group policy was created. */
-  createdAt: Date;
+  createdAt: Timestamp;
 }
 export interface GroupPolicyInfoProtoMsg {
   typeUrl: '/cosmos.group.v1.GroupPolicyInfo';
@@ -434,7 +432,7 @@ export interface GroupPolicyInfoSDKType {
   metadata: string;
   version: bigint;
   decision_policy?: AnySDKType | undefined;
-  created_at: Date;
+  created_at: TimestampSDKType;
 }
 /**
  * Proposal defines a group proposal. Any member of a group can submit a proposal
@@ -452,7 +450,7 @@ export interface Proposal {
   /** proposers are the account addresses of the proposers. */
   proposers: string[];
   /** submit_time is a timestamp specifying when a proposal was submitted. */
-  submitTime: Date;
+  submitTime: Timestamp;
   /**
    * group_version tracks the version of the group at proposal submission.
    * This field is here for informational purposes only.
@@ -481,7 +479,7 @@ export interface Proposal {
    * at this point, and the `final_tally_result`and `status` fields will be
    * accordingly updated.
    */
-  votingPeriodEnd: Date;
+  votingPeriodEnd: Timestamp;
   /** executor_result is the final result of the proposal execution. Initial value is NotRun. */
   executorResult: ProposalExecutorResult;
   /** messages is a list of `sdk.Msg`s that will be executed if the proposal passes. */
@@ -502,12 +500,12 @@ export interface ProposalSDKType {
   group_policy_address: string;
   metadata: string;
   proposers: string[];
-  submit_time: Date;
+  submit_time: TimestampSDKType;
   group_version: bigint;
   group_policy_version: bigint;
   status: ProposalStatus;
   final_tally_result: TallyResultSDKType;
-  voting_period_end: Date;
+  voting_period_end: TimestampSDKType;
   executor_result: ProposalExecutorResult;
   messages: AnySDKType[];
 }
@@ -544,7 +542,7 @@ export interface Vote {
   /** metadata is any arbitrary metadata to attached to the vote. */
   metadata: string;
   /** submit_time is the timestamp when the vote was submitted. */
-  submitTime: Date;
+  submitTime: Timestamp;
 }
 export interface VoteProtoMsg {
   typeUrl: '/cosmos.group.v1.Vote';
@@ -556,14 +554,14 @@ export interface VoteSDKType {
   voter: string;
   option: VoteOption;
   metadata: string;
-  submit_time: Date;
+  submit_time: TimestampSDKType;
 }
 function createBaseMember(): Member {
   return {
     address: '',
     weight: '',
     metadata: '',
-    addedAt: new Date(),
+    addedAt: Timestamp.fromPartial({}),
   };
 }
 export const Member = {
@@ -582,10 +580,7 @@ export const Member = {
       writer.uint32(26).string(message.metadata);
     }
     if (message.addedAt !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.addedAt),
-        writer.uint32(34).fork(),
-      ).ldelim();
+      Timestamp.encode(message.addedAt, writer.uint32(34).fork()).ldelim();
     }
     return writer;
   },
@@ -607,9 +602,7 @@ export const Member = {
           message.metadata = reader.string();
           break;
         case 4:
-          message.addedAt = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.addedAt = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -634,7 +627,7 @@ export const Member = {
     message.weight !== undefined && (obj.weight = message.weight);
     message.metadata !== undefined && (obj.metadata = message.metadata);
     message.addedAt !== undefined &&
-      (obj.addedAt = message.addedAt.toISOString());
+      (obj.addedAt = fromTimestamp(message.addedAt).toISOString());
     return obj;
   },
   fromPartial(object: Partial<Member>): Member {
@@ -642,7 +635,10 @@ export const Member = {
     message.address = object.address ?? '';
     message.weight = object.weight ?? '';
     message.metadata = object.metadata ?? '';
-    message.addedAt = object.addedAt ?? undefined;
+    message.addedAt =
+      object.addedAt !== undefined && object.addedAt !== null
+        ? Timestamp.fromPartial(object.addedAt)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: MemberProtoMsg): Member {
@@ -1036,7 +1032,7 @@ function createBaseGroupInfo(): GroupInfo {
     metadata: '',
     version: BigInt(0),
     totalWeight: '',
-    createdAt: new Date(),
+    createdAt: Timestamp.fromPartial({}),
   };
 }
 export const GroupInfo = {
@@ -1061,10 +1057,7 @@ export const GroupInfo = {
       writer.uint32(42).string(message.totalWeight);
     }
     if (message.createdAt !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.createdAt),
-        writer.uint32(50).fork(),
-      ).ldelim();
+      Timestamp.encode(message.createdAt, writer.uint32(50).fork()).ldelim();
     }
     return writer;
   },
@@ -1092,9 +1085,7 @@ export const GroupInfo = {
           message.totalWeight = reader.string();
           break;
         case 6:
-          message.createdAt = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.createdAt = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -1127,7 +1118,7 @@ export const GroupInfo = {
     message.totalWeight !== undefined &&
       (obj.totalWeight = message.totalWeight);
     message.createdAt !== undefined &&
-      (obj.createdAt = message.createdAt.toISOString());
+      (obj.createdAt = fromTimestamp(message.createdAt).toISOString());
     return obj;
   },
   fromPartial(object: Partial<GroupInfo>): GroupInfo {
@@ -1143,7 +1134,10 @@ export const GroupInfo = {
         ? BigInt(object.version.toString())
         : BigInt(0);
     message.totalWeight = object.totalWeight ?? '';
-    message.createdAt = object.createdAt ?? undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Timestamp.fromPartial(object.createdAt)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: GroupInfoProtoMsg): GroupInfo {
@@ -1249,7 +1243,7 @@ function createBaseGroupPolicyInfo(): GroupPolicyInfo {
     metadata: '',
     version: BigInt(0),
     decisionPolicy: undefined,
-    createdAt: new Date(),
+    createdAt: Timestamp.fromPartial({}),
   };
 }
 export const GroupPolicyInfo = {
@@ -1280,10 +1274,7 @@ export const GroupPolicyInfo = {
       ).ldelim();
     }
     if (message.createdAt !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.createdAt),
-        writer.uint32(58).fork(),
-      ).ldelim();
+      Timestamp.encode(message.createdAt, writer.uint32(58).fork()).ldelim();
     }
     return writer;
   },
@@ -1315,9 +1306,7 @@ export const GroupPolicyInfo = {
             Cosmos_groupv1DecisionPolicy_InterfaceDecoder(reader) as Any;
           break;
         case 7:
-          message.createdAt = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.createdAt = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -1359,7 +1348,7 @@ export const GroupPolicyInfo = {
         ? Any.toJSON(message.decisionPolicy)
         : undefined);
     message.createdAt !== undefined &&
-      (obj.createdAt = message.createdAt.toISOString());
+      (obj.createdAt = fromTimestamp(message.createdAt).toISOString());
     return obj;
   },
   fromPartial(object: Partial<GroupPolicyInfo>): GroupPolicyInfo {
@@ -1379,7 +1368,10 @@ export const GroupPolicyInfo = {
       object.decisionPolicy !== undefined && object.decisionPolicy !== null
         ? Any.fromPartial(object.decisionPolicy)
         : undefined;
-    message.createdAt = object.createdAt ?? undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Timestamp.fromPartial(object.createdAt)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: GroupPolicyInfoProtoMsg): GroupPolicyInfo {
@@ -1401,12 +1393,12 @@ function createBaseProposal(): Proposal {
     groupPolicyAddress: '',
     metadata: '',
     proposers: [],
-    submitTime: new Date(),
+    submitTime: Timestamp.fromPartial({}),
     groupVersion: BigInt(0),
     groupPolicyVersion: BigInt(0),
     status: 0,
     finalTallyResult: TallyResult.fromPartial({}),
-    votingPeriodEnd: new Date(),
+    votingPeriodEnd: Timestamp.fromPartial({}),
     executorResult: 0,
     messages: [],
   };
@@ -1430,10 +1422,7 @@ export const Proposal = {
       writer.uint32(34).string(v!);
     }
     if (message.submitTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.submitTime),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.submitTime, writer.uint32(42).fork()).ldelim();
     }
     if (message.groupVersion !== BigInt(0)) {
       writer.uint32(48).uint64(message.groupVersion);
@@ -1452,7 +1441,7 @@ export const Proposal = {
     }
     if (message.votingPeriodEnd !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.votingPeriodEnd),
+        message.votingPeriodEnd,
         writer.uint32(82).fork(),
       ).ldelim();
     }
@@ -1485,9 +1474,7 @@ export const Proposal = {
           message.proposers.push(reader.string());
           break;
         case 5:
-          message.submitTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.submitTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 6:
           message.groupVersion = reader.uint64();
@@ -1505,9 +1492,7 @@ export const Proposal = {
           );
           break;
         case 10:
-          message.votingPeriodEnd = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.votingPeriodEnd = Timestamp.decode(reader, reader.uint32());
           break;
         case 11:
           message.executorResult = reader.int32() as any;
@@ -1568,7 +1553,7 @@ export const Proposal = {
       obj.proposers = [];
     }
     message.submitTime !== undefined &&
-      (obj.submitTime = message.submitTime.toISOString());
+      (obj.submitTime = fromTimestamp(message.submitTime).toISOString());
     message.groupVersion !== undefined &&
       (obj.groupVersion = (message.groupVersion || BigInt(0)).toString());
     message.groupPolicyVersion !== undefined &&
@@ -1582,7 +1567,9 @@ export const Proposal = {
         ? TallyResult.toJSON(message.finalTallyResult)
         : undefined);
     message.votingPeriodEnd !== undefined &&
-      (obj.votingPeriodEnd = message.votingPeriodEnd.toISOString());
+      (obj.votingPeriodEnd = fromTimestamp(
+        message.votingPeriodEnd,
+      ).toISOString());
     message.executorResult !== undefined &&
       (obj.executorResult = proposalExecutorResultToJSON(
         message.executorResult,
@@ -1603,7 +1590,10 @@ export const Proposal = {
     message.groupPolicyAddress = object.groupPolicyAddress ?? '';
     message.metadata = object.metadata ?? '';
     message.proposers = object.proposers?.map(e => e) || [];
-    message.submitTime = object.submitTime ?? undefined;
+    message.submitTime =
+      object.submitTime !== undefined && object.submitTime !== null
+        ? Timestamp.fromPartial(object.submitTime)
+        : undefined;
     message.groupVersion =
       object.groupVersion !== undefined && object.groupVersion !== null
         ? BigInt(object.groupVersion.toString())
@@ -1618,7 +1608,10 @@ export const Proposal = {
       object.finalTallyResult !== undefined && object.finalTallyResult !== null
         ? TallyResult.fromPartial(object.finalTallyResult)
         : undefined;
-    message.votingPeriodEnd = object.votingPeriodEnd ?? undefined;
+    message.votingPeriodEnd =
+      object.votingPeriodEnd !== undefined && object.votingPeriodEnd !== null
+        ? Timestamp.fromPartial(object.votingPeriodEnd)
+        : undefined;
     message.executorResult = object.executorResult ?? 0;
     message.messages = object.messages?.map(e => Any.fromPartial(e)) || [];
     return message;
@@ -1740,7 +1733,7 @@ function createBaseVote(): Vote {
     voter: '',
     option: 0,
     metadata: '',
-    submitTime: new Date(),
+    submitTime: Timestamp.fromPartial({}),
   };
 }
 export const Vote = {
@@ -1762,10 +1755,7 @@ export const Vote = {
       writer.uint32(34).string(message.metadata);
     }
     if (message.submitTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.submitTime),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.submitTime, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -1790,9 +1780,7 @@ export const Vote = {
           message.metadata = reader.string();
           break;
         case 5:
-          message.submitTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.submitTime = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -1823,7 +1811,7 @@ export const Vote = {
       (obj.option = voteOptionToJSON(message.option));
     message.metadata !== undefined && (obj.metadata = message.metadata);
     message.submitTime !== undefined &&
-      (obj.submitTime = message.submitTime.toISOString());
+      (obj.submitTime = fromTimestamp(message.submitTime).toISOString());
     return obj;
   },
   fromPartial(object: Partial<Vote>): Vote {
@@ -1835,7 +1823,10 @@ export const Vote = {
     message.voter = object.voter ?? '';
     message.option = object.option ?? 0;
     message.metadata = object.metadata ?? '';
-    message.submitTime = object.submitTime ?? undefined;
+    message.submitTime =
+      object.submitTime !== undefined && object.submitTime !== null
+        ? Timestamp.fromPartial(object.submitTime)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: VoteProtoMsg): Vote {

--- a/packages/cosmic-proto/src/codegen/cosmos/staking/v1beta1/staking.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/staking/v1beta1/staking.ts
@@ -1,6 +1,9 @@
 //@ts-nocheck
 import { Header, HeaderSDKType } from '../../../tendermint/types/types.js';
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
 import {
   Duration,
@@ -8,12 +11,7 @@ import {
 } from '../../../google/protobuf/duration.js';
 import { Coin, CoinSDKType } from '../../base/v1beta1/coin.js';
 import { BinaryReader, BinaryWriter } from '../../../binary.js';
-import {
-  isSet,
-  toTimestamp,
-  fromTimestamp,
-  fromJsonTimestamp,
-} from '../../../helpers.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../../helpers.js';
 import { JsonSafe } from '../../../json-safe.js';
 import { Decimal } from '@cosmjs/math';
 /** BondStatus is the status of a validator. */
@@ -118,7 +116,7 @@ export interface Commission {
   /** commission_rates defines the initial commission rates to be used for creating a validator. */
   commissionRates: CommissionRates;
   /** update_time is the last time the commission rate was changed. */
-  updateTime: Date;
+  updateTime: Timestamp;
 }
 export interface CommissionProtoMsg {
   typeUrl: '/cosmos.staking.v1beta1.Commission';
@@ -127,7 +125,7 @@ export interface CommissionProtoMsg {
 /** Commission defines commission parameters for a given validator. */
 export interface CommissionSDKType {
   commission_rates: CommissionRatesSDKType;
-  update_time: Date;
+  update_time: TimestampSDKType;
 }
 /** Description defines a validator description. */
 export interface Description {
@@ -182,7 +180,7 @@ export interface Validator {
   /** unbonding_height defines, if unbonding, the height at which this validator has begun unbonding. */
   unbondingHeight: bigint;
   /** unbonding_time defines, if unbonding, the min time for the validator to complete unbonding. */
-  unbondingTime: Date;
+  unbondingTime: Timestamp;
   /** commission defines the commission parameters. */
   commission: Commission;
   /**
@@ -215,7 +213,7 @@ export interface ValidatorSDKType {
   delegator_shares: string;
   description: DescriptionSDKType;
   unbonding_height: bigint;
-  unbonding_time: Date;
+  unbonding_time: TimestampSDKType;
   commission: CommissionSDKType;
   min_self_delegation: string;
 }
@@ -360,7 +358,7 @@ export interface UnbondingDelegationEntry {
   /** creation_height is the height which the unbonding took place. */
   creationHeight: bigint;
   /** completion_time is the unix time for unbonding completion. */
-  completionTime: Date;
+  completionTime: Timestamp;
   /** initial_balance defines the tokens initially scheduled to receive at completion. */
   initialBalance: string;
   /** balance defines the tokens to receive at completion. */
@@ -373,7 +371,7 @@ export interface UnbondingDelegationEntryProtoMsg {
 /** UnbondingDelegationEntry defines an unbonding object with relevant metadata. */
 export interface UnbondingDelegationEntrySDKType {
   creation_height: bigint;
-  completion_time: Date;
+  completion_time: TimestampSDKType;
   initial_balance: string;
   balance: string;
 }
@@ -382,7 +380,7 @@ export interface RedelegationEntry {
   /** creation_height  defines the height which the redelegation took place. */
   creationHeight: bigint;
   /** completion_time defines the unix time for redelegation completion. */
-  completionTime: Date;
+  completionTime: Timestamp;
   /** initial_balance defines the initial balance when redelegation started. */
   initialBalance: string;
   /** shares_dst is the amount of destination-validator shares created by redelegation. */
@@ -395,7 +393,7 @@ export interface RedelegationEntryProtoMsg {
 /** RedelegationEntry defines a redelegation object with relevant metadata. */
 export interface RedelegationEntrySDKType {
   creation_height: bigint;
-  completion_time: Date;
+  completion_time: TimestampSDKType;
   initial_balance: string;
   shares_dst: string;
 }
@@ -718,7 +716,7 @@ export const CommissionRates = {
 function createBaseCommission(): Commission {
   return {
     commissionRates: CommissionRates.fromPartial({}),
-    updateTime: new Date(),
+    updateTime: Timestamp.fromPartial({}),
   };
 }
 export const Commission = {
@@ -734,10 +732,7 @@ export const Commission = {
       ).ldelim();
     }
     if (message.updateTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.updateTime),
-        writer.uint32(18).fork(),
-      ).ldelim();
+      Timestamp.encode(message.updateTime, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -756,9 +751,7 @@ export const Commission = {
           );
           break;
         case 2:
-          message.updateTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.updateTime = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -784,7 +777,7 @@ export const Commission = {
         ? CommissionRates.toJSON(message.commissionRates)
         : undefined);
     message.updateTime !== undefined &&
-      (obj.updateTime = message.updateTime.toISOString());
+      (obj.updateTime = fromTimestamp(message.updateTime).toISOString());
     return obj;
   },
   fromPartial(object: Partial<Commission>): Commission {
@@ -793,7 +786,10 @@ export const Commission = {
       object.commissionRates !== undefined && object.commissionRates !== null
         ? CommissionRates.fromPartial(object.commissionRates)
         : undefined;
-    message.updateTime = object.updateTime ?? undefined;
+    message.updateTime =
+      object.updateTime !== undefined && object.updateTime !== null
+        ? Timestamp.fromPartial(object.updateTime)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: CommissionProtoMsg): Commission {
@@ -924,7 +920,7 @@ function createBaseValidator(): Validator {
     delegatorShares: '',
     description: Description.fromPartial({}),
     unbondingHeight: BigInt(0),
-    unbondingTime: new Date(),
+    unbondingTime: Timestamp.fromPartial({}),
     commission: Commission.fromPartial({}),
     minSelfDelegation: '',
   };
@@ -969,7 +965,7 @@ export const Validator = {
     }
     if (message.unbondingTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.unbondingTime),
+        message.unbondingTime,
         writer.uint32(74).fork(),
       ).ldelim();
     }
@@ -1019,9 +1015,7 @@ export const Validator = {
           message.unbondingHeight = reader.int64();
           break;
         case 9:
-          message.unbondingTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.unbondingTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 10:
           message.commission = Commission.decode(reader, reader.uint32());
@@ -1088,7 +1082,7 @@ export const Validator = {
     message.unbondingHeight !== undefined &&
       (obj.unbondingHeight = (message.unbondingHeight || BigInt(0)).toString());
     message.unbondingTime !== undefined &&
-      (obj.unbondingTime = message.unbondingTime.toISOString());
+      (obj.unbondingTime = fromTimestamp(message.unbondingTime).toISOString());
     message.commission !== undefined &&
       (obj.commission = message.commission
         ? Commission.toJSON(message.commission)
@@ -1116,7 +1110,10 @@ export const Validator = {
       object.unbondingHeight !== undefined && object.unbondingHeight !== null
         ? BigInt(object.unbondingHeight.toString())
         : BigInt(0);
-    message.unbondingTime = object.unbondingTime ?? undefined;
+    message.unbondingTime =
+      object.unbondingTime !== undefined && object.unbondingTime !== null
+        ? Timestamp.fromPartial(object.unbondingTime)
+        : undefined;
     message.commission =
       object.commission !== undefined && object.commission !== null
         ? Commission.fromPartial(object.commission)
@@ -1708,7 +1705,7 @@ export const UnbondingDelegation = {
 function createBaseUnbondingDelegationEntry(): UnbondingDelegationEntry {
   return {
     creationHeight: BigInt(0),
-    completionTime: new Date(),
+    completionTime: Timestamp.fromPartial({}),
     initialBalance: '',
     balance: '',
   };
@@ -1724,7 +1721,7 @@ export const UnbondingDelegationEntry = {
     }
     if (message.completionTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.completionTime),
+        message.completionTime,
         writer.uint32(18).fork(),
       ).ldelim();
     }
@@ -1751,9 +1748,7 @@ export const UnbondingDelegationEntry = {
           message.creationHeight = reader.int64();
           break;
         case 2:
-          message.completionTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.completionTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 3:
           message.initialBalance = reader.string();
@@ -1789,7 +1784,9 @@ export const UnbondingDelegationEntry = {
     message.creationHeight !== undefined &&
       (obj.creationHeight = (message.creationHeight || BigInt(0)).toString());
     message.completionTime !== undefined &&
-      (obj.completionTime = message.completionTime.toISOString());
+      (obj.completionTime = fromTimestamp(
+        message.completionTime,
+      ).toISOString());
     message.initialBalance !== undefined &&
       (obj.initialBalance = message.initialBalance);
     message.balance !== undefined && (obj.balance = message.balance);
@@ -1803,7 +1800,10 @@ export const UnbondingDelegationEntry = {
       object.creationHeight !== undefined && object.creationHeight !== null
         ? BigInt(object.creationHeight.toString())
         : BigInt(0);
-    message.completionTime = object.completionTime ?? undefined;
+    message.completionTime =
+      object.completionTime !== undefined && object.completionTime !== null
+        ? Timestamp.fromPartial(object.completionTime)
+        : undefined;
     message.initialBalance = object.initialBalance ?? '';
     message.balance = object.balance ?? '';
     return message;
@@ -1828,7 +1828,7 @@ export const UnbondingDelegationEntry = {
 function createBaseRedelegationEntry(): RedelegationEntry {
   return {
     creationHeight: BigInt(0),
-    completionTime: new Date(),
+    completionTime: Timestamp.fromPartial({}),
     initialBalance: '',
     sharesDst: '',
   };
@@ -1844,7 +1844,7 @@ export const RedelegationEntry = {
     }
     if (message.completionTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.completionTime),
+        message.completionTime,
         writer.uint32(18).fork(),
       ).ldelim();
     }
@@ -1870,9 +1870,7 @@ export const RedelegationEntry = {
           message.creationHeight = reader.int64();
           break;
         case 2:
-          message.completionTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.completionTime = Timestamp.decode(reader, reader.uint32());
           break;
         case 3:
           message.initialBalance = reader.string();
@@ -1909,7 +1907,9 @@ export const RedelegationEntry = {
     message.creationHeight !== undefined &&
       (obj.creationHeight = (message.creationHeight || BigInt(0)).toString());
     message.completionTime !== undefined &&
-      (obj.completionTime = message.completionTime.toISOString());
+      (obj.completionTime = fromTimestamp(
+        message.completionTime,
+      ).toISOString());
     message.initialBalance !== undefined &&
       (obj.initialBalance = message.initialBalance);
     message.sharesDst !== undefined && (obj.sharesDst = message.sharesDst);
@@ -1921,7 +1921,10 @@ export const RedelegationEntry = {
       object.creationHeight !== undefined && object.creationHeight !== null
         ? BigInt(object.creationHeight.toString())
         : BigInt(0);
-    message.completionTime = object.completionTime ?? undefined;
+    message.completionTime =
+      object.completionTime !== undefined && object.completionTime !== null
+        ? Timestamp.fromPartial(object.completionTime)
+        : undefined;
     message.initialBalance = object.initialBalance ?? '';
     message.sharesDst = object.sharesDst ?? '';
     return message;

--- a/packages/cosmic-proto/src/codegen/cosmos/staking/v1beta1/tx.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/staking/v1beta1/tx.ts
@@ -7,14 +7,12 @@ import {
 } from './staking.js';
 import { Any, AnySDKType } from '../../../google/protobuf/any.js';
 import { Coin, CoinSDKType } from '../../base/v1beta1/coin.js';
-import { Timestamp } from '../../../google/protobuf/timestamp.js';
-import { BinaryReader, BinaryWriter } from '../../../binary.js';
 import {
-  isSet,
-  toTimestamp,
-  fromTimestamp,
-  fromJsonTimestamp,
-} from '../../../helpers.js';
+  Timestamp,
+  TimestampSDKType,
+} from '../../../google/protobuf/timestamp.js';
+import { BinaryReader, BinaryWriter } from '../../../binary.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../../helpers.js';
 import { JsonSafe } from '../../../json-safe.js';
 import { Decimal } from '@cosmjs/math';
 /** MsgCreateValidator defines a SDK message for creating a new validator. */
@@ -137,7 +135,7 @@ export interface MsgBeginRedelegateSDKType {
 }
 /** MsgBeginRedelegateResponse defines the Msg/BeginRedelegate response type. */
 export interface MsgBeginRedelegateResponse {
-  completionTime: Date;
+  completionTime: Timestamp;
 }
 export interface MsgBeginRedelegateResponseProtoMsg {
   typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegateResponse';
@@ -145,7 +143,7 @@ export interface MsgBeginRedelegateResponseProtoMsg {
 }
 /** MsgBeginRedelegateResponse defines the Msg/BeginRedelegate response type. */
 export interface MsgBeginRedelegateResponseSDKType {
-  completion_time: Date;
+  completion_time: TimestampSDKType;
 }
 /**
  * MsgUndelegate defines a SDK message for performing an undelegation from a
@@ -171,7 +169,7 @@ export interface MsgUndelegateSDKType {
 }
 /** MsgUndelegateResponse defines the Msg/Undelegate response type. */
 export interface MsgUndelegateResponse {
-  completionTime: Date;
+  completionTime: Timestamp;
 }
 export interface MsgUndelegateResponseProtoMsg {
   typeUrl: '/cosmos.staking.v1beta1.MsgUndelegateResponse';
@@ -179,7 +177,7 @@ export interface MsgUndelegateResponseProtoMsg {
 }
 /** MsgUndelegateResponse defines the Msg/Undelegate response type. */
 export interface MsgUndelegateResponseSDKType {
-  completion_time: Date;
+  completion_time: TimestampSDKType;
 }
 /**
  * MsgCancelUnbondingDelegation defines the SDK message for performing a cancel unbonding delegation for delegator
@@ -877,7 +875,7 @@ export const MsgBeginRedelegate = {
 };
 function createBaseMsgBeginRedelegateResponse(): MsgBeginRedelegateResponse {
   return {
-    completionTime: new Date(),
+    completionTime: Timestamp.fromPartial({}),
   };
 }
 export const MsgBeginRedelegateResponse = {
@@ -888,7 +886,7 @@ export const MsgBeginRedelegateResponse = {
   ): BinaryWriter {
     if (message.completionTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.completionTime),
+        message.completionTime,
         writer.uint32(10).fork(),
       ).ldelim();
     }
@@ -906,9 +904,7 @@ export const MsgBeginRedelegateResponse = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.completionTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.completionTime = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -929,14 +925,19 @@ export const MsgBeginRedelegateResponse = {
   ): JsonSafe<MsgBeginRedelegateResponse> {
     const obj: any = {};
     message.completionTime !== undefined &&
-      (obj.completionTime = message.completionTime.toISOString());
+      (obj.completionTime = fromTimestamp(
+        message.completionTime,
+      ).toISOString());
     return obj;
   },
   fromPartial(
     object: Partial<MsgBeginRedelegateResponse>,
   ): MsgBeginRedelegateResponse {
     const message = createBaseMsgBeginRedelegateResponse();
-    message.completionTime = object.completionTime ?? undefined;
+    message.completionTime =
+      object.completionTime !== undefined && object.completionTime !== null
+        ? Timestamp.fromPartial(object.completionTime)
+        : undefined;
     return message;
   },
   fromProtoMsg(
@@ -1050,7 +1051,7 @@ export const MsgUndelegate = {
 };
 function createBaseMsgUndelegateResponse(): MsgUndelegateResponse {
   return {
-    completionTime: new Date(),
+    completionTime: Timestamp.fromPartial({}),
   };
 }
 export const MsgUndelegateResponse = {
@@ -1061,7 +1062,7 @@ export const MsgUndelegateResponse = {
   ): BinaryWriter {
     if (message.completionTime !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.completionTime),
+        message.completionTime,
         writer.uint32(10).fork(),
       ).ldelim();
     }
@@ -1079,9 +1080,7 @@ export const MsgUndelegateResponse = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.completionTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.completionTime = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -1100,12 +1099,17 @@ export const MsgUndelegateResponse = {
   toJSON(message: MsgUndelegateResponse): JsonSafe<MsgUndelegateResponse> {
     const obj: any = {};
     message.completionTime !== undefined &&
-      (obj.completionTime = message.completionTime.toISOString());
+      (obj.completionTime = fromTimestamp(
+        message.completionTime,
+      ).toISOString());
     return obj;
   },
   fromPartial(object: Partial<MsgUndelegateResponse>): MsgUndelegateResponse {
     const message = createBaseMsgUndelegateResponse();
-    message.completionTime = object.completionTime ?? undefined;
+    message.completionTime =
+      object.completionTime !== undefined && object.completionTime !== null
+        ? Timestamp.fromPartial(object.completionTime)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: MsgUndelegateResponseProtoMsg): MsgUndelegateResponse {

--- a/packages/cosmic-proto/src/codegen/ibc/lightclients/tendermint/v1/tendermint.ts
+++ b/packages/cosmic-proto/src/codegen/ibc/lightclients/tendermint/v1/tendermint.ts
@@ -5,7 +5,10 @@ import {
 } from '../../../../google/protobuf/duration.js';
 import { Height, HeightSDKType } from '../../../core/client/v1/client.js';
 import { ProofSpec, ProofSpecSDKType } from '../../../../proofs.js';
-import { Timestamp } from '../../../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../../../google/protobuf/timestamp.js';
 import {
   MerkleRoot,
   MerkleRootSDKType,
@@ -21,10 +24,9 @@ import {
 import { BinaryReader, BinaryWriter } from '../../../../binary.js';
 import {
   isSet,
-  toTimestamp,
-  fromTimestamp,
   fromJsonTimestamp,
   bytesFromBase64,
+  fromTimestamp,
   base64FromBytes,
 } from '../../../../helpers.js';
 import { JsonSafe } from '../../../../json-safe.js';
@@ -96,7 +98,7 @@ export interface ConsensusState {
    * timestamp that corresponds to the block height in which the ConsensusState
    * was stored.
    */
-  timestamp: Date;
+  timestamp: Timestamp;
   /** commitment root (i.e app hash) */
   root: MerkleRoot;
   nextValidatorsHash: Uint8Array;
@@ -107,7 +109,7 @@ export interface ConsensusStateProtoMsg {
 }
 /** ConsensusState defines the consensus state from Tendermint. */
 export interface ConsensusStateSDKType {
-  timestamp: Date;
+  timestamp: TimestampSDKType;
   root: MerkleRootSDKType;
   next_validators_hash: Uint8Array;
 }
@@ -437,7 +439,7 @@ export const ClientState = {
 };
 function createBaseConsensusState(): ConsensusState {
   return {
-    timestamp: new Date(),
+    timestamp: Timestamp.fromPartial({}),
     root: MerkleRoot.fromPartial({}),
     nextValidatorsHash: new Uint8Array(),
   };
@@ -449,10 +451,7 @@ export const ConsensusState = {
     writer: BinaryWriter = BinaryWriter.create(),
   ): BinaryWriter {
     if (message.timestamp !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.timestamp),
-        writer.uint32(10).fork(),
-      ).ldelim();
+      Timestamp.encode(message.timestamp, writer.uint32(10).fork()).ldelim();
     }
     if (message.root !== undefined) {
       MerkleRoot.encode(message.root, writer.uint32(18).fork()).ldelim();
@@ -471,9 +470,7 @@ export const ConsensusState = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.timestamp = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.timestamp = Timestamp.decode(reader, reader.uint32());
           break;
         case 2:
           message.root = MerkleRoot.decode(reader, reader.uint32());
@@ -502,7 +499,7 @@ export const ConsensusState = {
   toJSON(message: ConsensusState): JsonSafe<ConsensusState> {
     const obj: any = {};
     message.timestamp !== undefined &&
-      (obj.timestamp = message.timestamp.toISOString());
+      (obj.timestamp = fromTimestamp(message.timestamp).toISOString());
     message.root !== undefined &&
       (obj.root = message.root ? MerkleRoot.toJSON(message.root) : undefined);
     message.nextValidatorsHash !== undefined &&
@@ -515,7 +512,10 @@ export const ConsensusState = {
   },
   fromPartial(object: Partial<ConsensusState>): ConsensusState {
     const message = createBaseConsensusState();
-    message.timestamp = object.timestamp ?? undefined;
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null
+        ? Timestamp.fromPartial(object.timestamp)
+        : undefined;
     message.root =
       object.root !== undefined && object.root !== null
         ? MerkleRoot.fromPartial(object.root)

--- a/packages/cosmic-proto/src/codegen/tendermint/abci/types.ts
+++ b/packages/cosmic-proto/src/codegen/tendermint/abci/types.ts
@@ -1,5 +1,8 @@
 //@ts-nocheck
-import { Timestamp } from '../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../google/protobuf/timestamp.js';
 import { Header, HeaderSDKType } from '../types/types.js';
 import { ProofOps, ProofOpsSDKType } from '../crypto/proof.js';
 import {
@@ -14,10 +17,9 @@ import { PublicKey, PublicKeySDKType } from '../crypto/keys.js';
 import { BinaryReader, BinaryWriter } from '../../binary.js';
 import {
   isSet,
-  toTimestamp,
-  fromTimestamp,
   fromJsonTimestamp,
   bytesFromBase64,
+  fromTimestamp,
   base64FromBytes,
 } from '../../helpers.js';
 import { JsonSafe } from '../../json-safe.js';
@@ -303,7 +305,7 @@ export interface RequestSetOptionSDKType {
   value: string;
 }
 export interface RequestInitChain {
-  time: Date;
+  time: Timestamp;
   chainId: string;
   consensusParams?: ConsensusParams;
   validators: ValidatorUpdate[];
@@ -315,7 +317,7 @@ export interface RequestInitChainProtoMsg {
   value: Uint8Array;
 }
 export interface RequestInitChainSDKType {
-  time: Date;
+  time: TimestampSDKType;
   chain_id: string;
   consensus_params?: ConsensusParamsSDKType;
   validators: ValidatorUpdateSDKType[];
@@ -899,7 +901,7 @@ export interface Evidence {
   /** The height when the offense occurred */
   height: bigint;
   /** The corresponding time where the offense occurred */
-  time: Date;
+  time: Timestamp;
   /**
    * Total voting power of the validator set in case the ABCI application does
    * not store historical validators.
@@ -915,7 +917,7 @@ export interface EvidenceSDKType {
   type: EvidenceType;
   validator: ValidatorSDKType;
   height: bigint;
-  time: Date;
+  time: TimestampSDKType;
   total_voting_power: bigint;
 }
 export interface Snapshot {
@@ -1579,7 +1581,7 @@ export const RequestSetOption = {
 };
 function createBaseRequestInitChain(): RequestInitChain {
   return {
-    time: new Date(),
+    time: Timestamp.fromPartial({}),
     chainId: '',
     consensusParams: undefined,
     validators: [],
@@ -1594,10 +1596,7 @@ export const RequestInitChain = {
     writer: BinaryWriter = BinaryWriter.create(),
   ): BinaryWriter {
     if (message.time !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.time),
-        writer.uint32(10).fork(),
-      ).ldelim();
+      Timestamp.encode(message.time, writer.uint32(10).fork()).ldelim();
     }
     if (message.chainId !== '') {
       writer.uint32(18).string(message.chainId);
@@ -1628,9 +1627,7 @@ export const RequestInitChain = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.time = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.time = Timestamp.decode(reader, reader.uint32());
           break;
         case 2:
           message.chainId = reader.string();
@@ -1679,7 +1676,8 @@ export const RequestInitChain = {
   },
   toJSON(message: RequestInitChain): JsonSafe<RequestInitChain> {
     const obj: any = {};
-    message.time !== undefined && (obj.time = message.time.toISOString());
+    message.time !== undefined &&
+      (obj.time = fromTimestamp(message.time).toISOString());
     message.chainId !== undefined && (obj.chainId = message.chainId);
     message.consensusParams !== undefined &&
       (obj.consensusParams = message.consensusParams
@@ -1704,7 +1702,10 @@ export const RequestInitChain = {
   },
   fromPartial(object: Partial<RequestInitChain>): RequestInitChain {
     const message = createBaseRequestInitChain();
-    message.time = object.time ?? undefined;
+    message.time =
+      object.time !== undefined && object.time !== null
+        ? Timestamp.fromPartial(object.time)
+        : undefined;
     message.chainId = object.chainId ?? '';
     message.consensusParams =
       object.consensusParams !== undefined && object.consensusParams !== null
@@ -5341,7 +5342,7 @@ function createBaseEvidence(): Evidence {
     type: 0,
     validator: Validator.fromPartial({}),
     height: BigInt(0),
-    time: new Date(),
+    time: Timestamp.fromPartial({}),
     totalVotingPower: BigInt(0),
   };
 }
@@ -5361,10 +5362,7 @@ export const Evidence = {
       writer.uint32(24).int64(message.height);
     }
     if (message.time !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.time),
-        writer.uint32(34).fork(),
-      ).ldelim();
+      Timestamp.encode(message.time, writer.uint32(34).fork()).ldelim();
     }
     if (message.totalVotingPower !== BigInt(0)) {
       writer.uint32(40).int64(message.totalVotingPower);
@@ -5389,9 +5387,7 @@ export const Evidence = {
           message.height = reader.int64();
           break;
         case 4:
-          message.time = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.time = Timestamp.decode(reader, reader.uint32());
           break;
         case 5:
           message.totalVotingPower = reader.int64();
@@ -5427,7 +5423,8 @@ export const Evidence = {
         : undefined);
     message.height !== undefined &&
       (obj.height = (message.height || BigInt(0)).toString());
-    message.time !== undefined && (obj.time = message.time.toISOString());
+    message.time !== undefined &&
+      (obj.time = fromTimestamp(message.time).toISOString());
     message.totalVotingPower !== undefined &&
       (obj.totalVotingPower = (
         message.totalVotingPower || BigInt(0)
@@ -5445,7 +5442,10 @@ export const Evidence = {
       object.height !== undefined && object.height !== null
         ? BigInt(object.height.toString())
         : BigInt(0);
-    message.time = object.time ?? undefined;
+    message.time =
+      object.time !== undefined && object.time !== null
+        ? Timestamp.fromPartial(object.time)
+        : undefined;
     message.totalVotingPower =
       object.totalVotingPower !== undefined && object.totalVotingPower !== null
         ? BigInt(object.totalVotingPower.toString())

--- a/packages/cosmic-proto/src/codegen/tendermint/p2p/types.ts
+++ b/packages/cosmic-proto/src/codegen/tendermint/p2p/types.ts
@@ -1,13 +1,15 @@
 //@ts-nocheck
-import { Timestamp } from '../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../google/protobuf/timestamp.js';
 import { BinaryReader, BinaryWriter } from '../../binary.js';
 import {
   isSet,
   bytesFromBase64,
   base64FromBytes,
-  toTimestamp,
-  fromTimestamp,
   fromJsonTimestamp,
+  fromTimestamp,
 } from '../../helpers.js';
 import { JsonSafe } from '../../json-safe.js';
 export interface ProtocolVersion {
@@ -63,7 +65,7 @@ export interface NodeInfoOtherSDKType {
 export interface PeerInfo {
   id: string;
   addressInfo: PeerAddressInfo[];
-  lastConnected?: Date;
+  lastConnected?: Timestamp;
 }
 export interface PeerInfoProtoMsg {
   typeUrl: '/tendermint.p2p.PeerInfo';
@@ -72,12 +74,12 @@ export interface PeerInfoProtoMsg {
 export interface PeerInfoSDKType {
   id: string;
   address_info: PeerAddressInfoSDKType[];
-  last_connected?: Date;
+  last_connected?: TimestampSDKType;
 }
 export interface PeerAddressInfo {
   address: string;
-  lastDialSuccess?: Date;
-  lastDialFailure?: Date;
+  lastDialSuccess?: Timestamp;
+  lastDialFailure?: Timestamp;
   dialFailures: number;
 }
 export interface PeerAddressInfoProtoMsg {
@@ -86,8 +88,8 @@ export interface PeerAddressInfoProtoMsg {
 }
 export interface PeerAddressInfoSDKType {
   address: string;
-  last_dial_success?: Date;
-  last_dial_failure?: Date;
+  last_dial_success?: TimestampSDKType;
+  last_dial_failure?: TimestampSDKType;
   dial_failures: number;
 }
 function createBaseProtocolVersion(): ProtocolVersion {
@@ -436,7 +438,7 @@ export const PeerInfo = {
     }
     if (message.lastConnected !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.lastConnected),
+        message.lastConnected,
         writer.uint32(26).fork(),
       ).ldelim();
     }
@@ -459,9 +461,7 @@ export const PeerInfo = {
           );
           break;
         case 3:
-          message.lastConnected = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.lastConnected = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -492,7 +492,7 @@ export const PeerInfo = {
       obj.addressInfo = [];
     }
     message.lastConnected !== undefined &&
-      (obj.lastConnected = message.lastConnected.toISOString());
+      (obj.lastConnected = fromTimestamp(message.lastConnected).toISOString());
     return obj;
   },
   fromPartial(object: Partial<PeerInfo>): PeerInfo {
@@ -500,7 +500,10 @@ export const PeerInfo = {
     message.id = object.id ?? '';
     message.addressInfo =
       object.addressInfo?.map(e => PeerAddressInfo.fromPartial(e)) || [];
-    message.lastConnected = object.lastConnected ?? undefined;
+    message.lastConnected =
+      object.lastConnected !== undefined && object.lastConnected !== null
+        ? Timestamp.fromPartial(object.lastConnected)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: PeerInfoProtoMsg): PeerInfo {
@@ -535,13 +538,13 @@ export const PeerAddressInfo = {
     }
     if (message.lastDialSuccess !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.lastDialSuccess),
+        message.lastDialSuccess,
         writer.uint32(18).fork(),
       ).ldelim();
     }
     if (message.lastDialFailure !== undefined) {
       Timestamp.encode(
-        toTimestamp(message.lastDialFailure),
+        message.lastDialFailure,
         writer.uint32(26).fork(),
       ).ldelim();
     }
@@ -562,14 +565,10 @@ export const PeerAddressInfo = {
           message.address = reader.string();
           break;
         case 2:
-          message.lastDialSuccess = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.lastDialSuccess = Timestamp.decode(reader, reader.uint32());
           break;
         case 3:
-          message.lastDialFailure = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.lastDialFailure = Timestamp.decode(reader, reader.uint32());
           break;
         case 4:
           message.dialFailures = reader.uint32();
@@ -599,9 +598,13 @@ export const PeerAddressInfo = {
     const obj: any = {};
     message.address !== undefined && (obj.address = message.address);
     message.lastDialSuccess !== undefined &&
-      (obj.lastDialSuccess = message.lastDialSuccess.toISOString());
+      (obj.lastDialSuccess = fromTimestamp(
+        message.lastDialSuccess,
+      ).toISOString());
     message.lastDialFailure !== undefined &&
-      (obj.lastDialFailure = message.lastDialFailure.toISOString());
+      (obj.lastDialFailure = fromTimestamp(
+        message.lastDialFailure,
+      ).toISOString());
     message.dialFailures !== undefined &&
       (obj.dialFailures = Math.round(message.dialFailures));
     return obj;
@@ -609,8 +612,14 @@ export const PeerAddressInfo = {
   fromPartial(object: Partial<PeerAddressInfo>): PeerAddressInfo {
     const message = createBasePeerAddressInfo();
     message.address = object.address ?? '';
-    message.lastDialSuccess = object.lastDialSuccess ?? undefined;
-    message.lastDialFailure = object.lastDialFailure ?? undefined;
+    message.lastDialSuccess =
+      object.lastDialSuccess !== undefined && object.lastDialSuccess !== null
+        ? Timestamp.fromPartial(object.lastDialSuccess)
+        : undefined;
+    message.lastDialFailure =
+      object.lastDialFailure !== undefined && object.lastDialFailure !== null
+        ? Timestamp.fromPartial(object.lastDialFailure)
+        : undefined;
     message.dialFailures = object.dialFailures ?? 0;
     return message;
   },

--- a/packages/cosmic-proto/src/codegen/tendermint/types/evidence.ts
+++ b/packages/cosmic-proto/src/codegen/tendermint/types/evidence.ts
@@ -1,14 +1,12 @@
 //@ts-nocheck
 import { Vote, VoteSDKType, LightBlock, LightBlockSDKType } from './types.js';
-import { Timestamp } from '../../google/protobuf/timestamp.js';
+import {
+  Timestamp,
+  TimestampSDKType,
+} from '../../google/protobuf/timestamp.js';
 import { Validator, ValidatorSDKType } from './validator.js';
 import { BinaryReader, BinaryWriter } from '../../binary.js';
-import {
-  isSet,
-  toTimestamp,
-  fromTimestamp,
-  fromJsonTimestamp,
-} from '../../helpers.js';
+import { isSet, fromJsonTimestamp, fromTimestamp } from '../../helpers.js';
 import { JsonSafe } from '../../json-safe.js';
 export interface Evidence {
   duplicateVoteEvidence?: DuplicateVoteEvidence;
@@ -28,7 +26,7 @@ export interface DuplicateVoteEvidence {
   voteB?: Vote;
   totalVotingPower: bigint;
   validatorPower: bigint;
-  timestamp: Date;
+  timestamp: Timestamp;
 }
 export interface DuplicateVoteEvidenceProtoMsg {
   typeUrl: '/tendermint.types.DuplicateVoteEvidence';
@@ -40,7 +38,7 @@ export interface DuplicateVoteEvidenceSDKType {
   vote_b?: VoteSDKType;
   total_voting_power: bigint;
   validator_power: bigint;
-  timestamp: Date;
+  timestamp: TimestampSDKType;
 }
 /** LightClientAttackEvidence contains evidence of a set of validators attempting to mislead a light client. */
 export interface LightClientAttackEvidence {
@@ -48,7 +46,7 @@ export interface LightClientAttackEvidence {
   commonHeight: bigint;
   byzantineValidators: Validator[];
   totalVotingPower: bigint;
-  timestamp: Date;
+  timestamp: Timestamp;
 }
 export interface LightClientAttackEvidenceProtoMsg {
   typeUrl: '/tendermint.types.LightClientAttackEvidence';
@@ -60,7 +58,7 @@ export interface LightClientAttackEvidenceSDKType {
   common_height: bigint;
   byzantine_validators: ValidatorSDKType[];
   total_voting_power: bigint;
-  timestamp: Date;
+  timestamp: TimestampSDKType;
 }
 export interface EvidenceList {
   evidence: Evidence[];
@@ -182,7 +180,7 @@ function createBaseDuplicateVoteEvidence(): DuplicateVoteEvidence {
     voteB: undefined,
     totalVotingPower: BigInt(0),
     validatorPower: BigInt(0),
-    timestamp: new Date(),
+    timestamp: Timestamp.fromPartial({}),
   };
 }
 export const DuplicateVoteEvidence = {
@@ -204,10 +202,7 @@ export const DuplicateVoteEvidence = {
       writer.uint32(32).int64(message.validatorPower);
     }
     if (message.timestamp !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.timestamp),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.timestamp, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -235,9 +230,7 @@ export const DuplicateVoteEvidence = {
           message.validatorPower = reader.int64();
           break;
         case 5:
-          message.timestamp = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.timestamp = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -274,7 +267,7 @@ export const DuplicateVoteEvidence = {
     message.validatorPower !== undefined &&
       (obj.validatorPower = (message.validatorPower || BigInt(0)).toString());
     message.timestamp !== undefined &&
-      (obj.timestamp = message.timestamp.toISOString());
+      (obj.timestamp = fromTimestamp(message.timestamp).toISOString());
     return obj;
   },
   fromPartial(object: Partial<DuplicateVoteEvidence>): DuplicateVoteEvidence {
@@ -295,7 +288,10 @@ export const DuplicateVoteEvidence = {
       object.validatorPower !== undefined && object.validatorPower !== null
         ? BigInt(object.validatorPower.toString())
         : BigInt(0);
-    message.timestamp = object.timestamp ?? undefined;
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null
+        ? Timestamp.fromPartial(object.timestamp)
+        : undefined;
     return message;
   },
   fromProtoMsg(message: DuplicateVoteEvidenceProtoMsg): DuplicateVoteEvidence {
@@ -317,7 +313,7 @@ function createBaseLightClientAttackEvidence(): LightClientAttackEvidence {
     commonHeight: BigInt(0),
     byzantineValidators: [],
     totalVotingPower: BigInt(0),
-    timestamp: new Date(),
+    timestamp: Timestamp.fromPartial({}),
   };
 }
 export const LightClientAttackEvidence = {
@@ -342,10 +338,7 @@ export const LightClientAttackEvidence = {
       writer.uint32(32).int64(message.totalVotingPower);
     }
     if (message.timestamp !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.timestamp),
-        writer.uint32(42).fork(),
-      ).ldelim();
+      Timestamp.encode(message.timestamp, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -375,9 +368,7 @@ export const LightClientAttackEvidence = {
           message.totalVotingPower = reader.int64();
           break;
         case 5:
-          message.timestamp = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32()),
-          );
+          message.timestamp = Timestamp.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -427,7 +418,7 @@ export const LightClientAttackEvidence = {
         message.totalVotingPower || BigInt(0)
       ).toString());
     message.timestamp !== undefined &&
-      (obj.timestamp = message.timestamp.toISOString());
+      (obj.timestamp = fromTimestamp(message.timestamp).toISOString());
     return obj;
   },
   fromPartial(
@@ -448,7 +439,10 @@ export const LightClientAttackEvidence = {
       object.totalVotingPower !== undefined && object.totalVotingPower !== null
         ? BigInt(object.totalVotingPower.toString())
         : BigInt(0);
-    message.timestamp = object.timestamp ?? undefined;
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null
+        ? Timestamp.fromPartial(object.timestamp)
+        : undefined;
     return message;
   },
   fromProtoMsg(

--- a/packages/cosmic-proto/test/helpers.test-d.ts
+++ b/packages/cosmic-proto/test/helpers.test-d.ts
@@ -2,6 +2,7 @@ import { expectType } from 'tsd';
 import { typedJson } from '../src/helpers.js';
 import type { ResponseTo, TypedJson } from '../src/helpers.ts';
 import type { JsonSafe } from '../src/codegen/json-safe.js';
+import type { Timestamp } from '../src/codegen/google/protobuf/timestamp.js';
 
 // MsgSend
 {
@@ -66,7 +67,8 @@ import type { JsonSafe } from '../src/codegen/json-safe.js';
 {
   const response: TypedJson<'/cosmos.staking.v1beta1.MsgUndelegateResponse'> =
     null as any;
-  expectType<Date>(response.completionTime);
+  expectType<Timestamp>(response.completionTime);
   const responseJson: JsonSafe<typeof response> = null as any;
-  expectType<string>(responseJson.completionTime);
+  // FIXME: should be a string. UNTIL: github.com/cosmology-tech/telescope/pull/632
+  expectType<bigint>(responseJson.completionTime.seconds);
 }

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -212,6 +212,13 @@ export type LiquidStakingMethods = {
   liquidStake: (amount: AmountArg) => Promise<void>;
 };
 
+export type LocalAccountMethods = {
+  /** deposit payment (from zoe, for example) to the account */
+  deposit: (payment: Payment<'nat'>) => Promise<void>;
+  /** withdraw a Payment from the account */
+  withdraw: (amount: Amount<'nat'>) => Promise<Payment<'nat'>>;
+};
+
 export type IBCMsgTransferOptions = {
   timeoutHeight?: MsgTransfer['timeoutHeight'];
   timeoutTimestamp?: MsgTransfer['timeoutTimestamp'];

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -11,7 +11,7 @@ import type {
   Order,
 } from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
 import type { State as IBCConnectionState } from '@agoric/cosmic-proto/ibc/core/connection/v1/connection.js';
-import type { Brand, Purse } from '@agoric/ertp/src/types.js';
+import type { Brand, Purse, Payment, Amount } from '@agoric/ertp/src/types.js';
 import type { Port } from '@agoric/network';
 import { IBCChannelID, type IBCConnectionID } from '@agoric/vats';
 import type {

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -68,6 +68,8 @@ const sendItFn = async (
   const { chainId } = info;
   assert(typeof chainId === 'string', 'bad chainId');
   const { [kw]: pmtP } = await withdrawFromSeat(zcf, seat, give);
+  // #9212 types for chain account helpers
+  // @ts-expect-error LCA should have .deposit() method
   await E.when(pmtP, pmt => contractState.account?.deposit(pmt));
   await contractState.account?.transfer(
     { denom, value: amt.value },

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -32,7 +32,6 @@ import {
 } from '../typeGuards.js';
 import { maxClockSkew, tryDecodeResponse } from '../utils/cosmos.js';
 import { orchestrationAccountMethods } from '../utils/orchestrationAccount.js';
-import { dateInSeconds } from '../utils/time.js';
 
 /**
  * @import {AmountArg, IcaAccount, ChainAddress, CosmosValidatorAddress, ICQConnection, StakingAccountActions, DenomAmount, OrchestrationAccountI, DenomArg} from '../types.js';
@@ -230,9 +229,8 @@ export const prepareCosmosOrchestrationAccountKit = (
           const { completionTime } = response;
           completionTime || Fail`No completion time result ${result}`;
           return watch(
-            E(this.state.timer).wakeAt(
-              dateInSeconds(completionTime) + maxClockSkew,
-            ),
+            // ignore nanoseconds and just use seconds from Timestamp
+            E(this.state.timer).wakeAt(completionTime.seconds + maxClockSkew),
           );
         },
       },

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -367,12 +367,6 @@ export const prepareCosmosOrchestrationAccountKit = (
             return watch(results, this.facets.returnVoidWatcher);
           });
         },
-        deposit(payment) {
-          trace('deposit', payment);
-          console.error(
-            'FIXME deposit noop until https://github.com/Agoric/agoric-sdk/issues/9193',
-          );
-        },
         getBalances() {
           // TODO https://github.com/Agoric/agoric-sdk/issues/9610
           return asVow(() => Fail`not yet implemented`);

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -13,10 +13,11 @@ import {
   DenomAmountShape,
   DenomShape,
   IBCTransferOptionsShape,
+  TimestampProtoShape,
 } from '../typeGuards.js';
 import { maxClockSkew } from '../utils/cosmos.js';
 import { orchestrationAccountMethods } from '../utils/orchestrationAccount.js';
-import { dateInSeconds, makeTimestampHelper } from '../utils/time.js';
+import { makeTimestampHelper } from '../utils/time.js';
 
 /**
  * @import {LocalChainAccount} from '@agoric/vats/src/localchain.js';
@@ -87,7 +88,9 @@ export const prepareLocalOrchestrationAccountKit = (
     {
       holder: HolderI,
       undelegateWatcher: M.interface('undelegateWatcher', {
-        onFulfilled: M.call([M.splitRecord({ completionTime: M.string() })])
+        onFulfilled: M.call([
+          M.splitRecord({ completionTime: TimestampProtoShape }),
+        ])
           .optional(M.arrayOf(M.undefined())) // empty context
           .returns(VowShape),
       }),
@@ -186,9 +189,10 @@ export const prepareLocalOrchestrationAccountKit = (
           const { completionTime } = response[0];
           return watch(
             E(timerService).wakeAt(
-              // TODO clean up date handling once we have real data
-              dateInSeconds(new Date(completionTime)) + maxClockSkew,
+              // ignore nanoseconds and just use seconds from Timestamp
+              BigInt(completionTime.seconds) + maxClockSkew,
             ),
+            this.facets.returnVoidWatcher,
           );
         },
       },

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -53,6 +53,7 @@ const HolderI = M.interface('holder', {
   getPublicTopics: M.call().returns(TopicsRecordShape),
   delegate: M.call(M.string(), AmountShape).returns(VowShape),
   undelegate: M.call(M.string(), AmountShape).returns(VowShape),
+  deposit: M.call(PaymentShape).returns(VowShape),
   withdraw: M.call(AmountShape).returns(Vow$(PaymentShape)),
   executeTx: M.call(M.arrayOf(M.record())).returns(Vow$(M.record())),
 });
@@ -367,7 +368,7 @@ export const prepareLocalOrchestrationAccountKit = (
          * updater will get a special notification that the account is being
          * transferred.
          */
-        /** @type {PromiseToVow<OrchestrationAccount<any>['deposit']>} */
+        /** @type {PromiseToVow<LocalChainAccount['deposit']>} */
         deposit(payment) {
           return watch(
             E(this.state.account).deposit(payment),

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -172,11 +172,6 @@ export interface OrchestrationAccountI {
    * @returns void
    */
   transferSteps: (amount: AmountArg, msg: TransferMsg) => Promise<void>;
-  /**
-   * deposit payment from zoe to the account. For remote accounts,
-   * an IBC Transfer will be executed to transfer funds there.
-   */
-  deposit: (payment: Payment<'nat'>) => Promise<void>;
 }
 
 /**

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -102,3 +102,9 @@ export const ChainFacadeI = M.interface('ChainFacade', {
   getChainInfo: M.call().returns(VowShape),
   makeAccount: M.call().returns(VowShape),
 });
+
+/**
+ * for google/protobuf/timestamp.proto, not to be confused with TimestampShape
+ * from `@agoric/time`
+ */
+export const TimestampProtoShape = { seconds: M.nat(), nanos: M.number() };

--- a/packages/orchestration/src/utils/orchestrationAccount.js
+++ b/packages/orchestration/src/utils/orchestrationAccount.js
@@ -1,5 +1,4 @@
 import { M } from '@endo/patterns';
-import { PaymentShape } from '@agoric/ertp';
 import { Shape as NetworkShape } from '@agoric/network';
 import { VowShape } from '@agoric/vow';
 import { AmountArgShape, ChainAddressShape, CoinShape } from '../typeGuards.js';
@@ -18,5 +17,4 @@ export const orchestrationAccountMethods = {
     .optional(M.record())
     .returns(VowShape),
   transferSteps: M.call(AmountArgShape, M.any()).returns(VowShape),
-  deposit: M.call(PaymentShape).returns(VowShape),
 };

--- a/packages/orchestration/src/utils/time.js
+++ b/packages/orchestration/src/utils/time.js
@@ -7,6 +7,7 @@ import { TimeMath } from '@agoric/time';
  */
 
 export const SECONDS_PER_MINUTE = 60n;
+export const MILLISECONDS_PER_SECOND = 1000n;
 export const NANOSECONDS_PER_SECOND = 1_000_000_000n;
 
 /**

--- a/packages/orchestration/src/utils/time.js
+++ b/packages/orchestration/src/utils/time.js
@@ -53,12 +53,3 @@ export function makeTimestampHelper(timer) {
 }
 
 /** @typedef {Awaited<ReturnType<typeof makeTimestampHelper>>} TimestampHelper */
-
-/**
- * Convert a Date from a Cosmos message, which has millisecond precision, to a
- * BigInt for number of seconds since epoch, for use in a timer.
- *
- * @param {Date} date
- * @returns {bigint}
- */
-export const dateInSeconds = date => BigInt(Math.floor(date.getTime() / 1000));

--- a/packages/orchestration/test/ibc-mocks.ts
+++ b/packages/orchestration/test/ibc-mocks.ts
@@ -3,9 +3,17 @@ import {
   QueryBalanceResponse,
 } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
 import {
+  MsgBeginRedelegate,
+  MsgBeginRedelegateResponse,
   MsgDelegate,
   MsgDelegateResponse,
+  MsgUndelegate,
+  MsgUndelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
+import {
+  MsgWithdrawDelegatorReward,
+  MsgWithdrawDelegatorRewardResponse,
+} from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/tx.js';
 import {
   buildMsgResponseString,
   buildQueryResponseString,
@@ -13,48 +21,89 @@ import {
   buildTxPacketString,
   buildQueryPacketString,
 } from '../tools/ibc-mocks.js';
+import { MILLISECONDS_PER_SECOND } from '../src/utils/time.js';
 
-const responses = {
-  delegate: buildMsgResponseString(MsgDelegateResponse, {}),
-  queryBalance: buildQueryResponseString(QueryBalanceResponse, {
-    balance: { amount: '0', denom: 'uatom' },
-  }),
+/**
+ * TODO: provide mappings to cosmos error codes (and module specific error codes)
+ * see https://github.com/Agoric/agoric-sdk/issues/9629 for more details about
+ * error messages over ibc
+ */
+export const errorAcknowledgments = {
   error5: buildMsgErrorString(
     'ABCI code: 5: error handling packet: see events for details',
   ),
 };
 
+const delegation = {
+  amount: {
+    denom: 'uatom',
+    amount: '10',
+  },
+  delegatorAddress: 'cosmos1test',
+  validatorAddress: 'cosmosvaloper1test',
+};
+const redelegation = {
+  delegatorAddress: 'cosmos1test',
+  validatorSrcAddress: 'cosmosvaloper1test',
+  validatorDstAddress: 'cosmosvaloper2test',
+  amount: {
+    denom: 'uatom',
+    amount: '10',
+  },
+};
+
+export const UNBOND_PERIOD_SECONDS = 5n;
+
+const getCompletionTime = () => {
+  // 5 seconds fron unix epoch
+  return new Date(0 + Number(UNBOND_PERIOD_SECONDS * MILLISECONDS_PER_SECOND));
+};
+
 export const protoMsgMocks = {
   delegate: {
-    // delegate 10 uatom from cosmos1test to cosmosvaloper1test
+    msg: buildTxPacketString([MsgDelegate.toProtoMsg(delegation)]),
+    ack: buildMsgResponseString(MsgDelegateResponse, {}),
+  },
+  undelegate: {
+    msg: buildTxPacketString([MsgUndelegate.toProtoMsg(delegation)]),
+    ack: buildMsgResponseString(MsgUndelegateResponse, {
+      completionTime: getCompletionTime(),
+    }),
+  },
+  redelegate: {
+    msg: buildTxPacketString([MsgBeginRedelegate.toProtoMsg(redelegation)]),
+    ack: buildMsgResponseString(MsgBeginRedelegateResponse, {
+      completionTime: getCompletionTime(),
+    }),
+  },
+  withdrawReward: {
     msg: buildTxPacketString([
-      MsgDelegate.toProtoMsg({
-        amount: {
-          denom: 'uatom',
-          amount: '10',
-        },
-        delegatorAddress: 'cosmos1test',
-        validatorAddress: 'cosmosvaloper1test',
-      }),
+      MsgWithdrawDelegatorReward.toProtoMsg(delegation),
     ]),
-    ack: responses.delegate,
+    ack: buildMsgResponseString(MsgWithdrawDelegatorRewardResponse, {
+      amount: [{ amount: '1', denom: 'uatom' }],
+    }),
   },
   queryBalance: {
-    // query balance of uatom for cosmos1test
     msg: buildQueryPacketString([
       QueryBalanceRequest.toProtoMsg({
         address: 'cosmos1test',
         denom: 'uatom',
       }),
     ]),
-    ack: responses.queryBalance,
-  },
-  error: {
-    ack: responses.error5,
+    ack: buildQueryResponseString(QueryBalanceResponse, {
+      balance: { amount: '0', denom: 'uatom' },
+    }),
   },
 };
 
-export const defaultMockAckMap: Record<string, string> = {
-  [protoMsgMocks.delegate.msg]: protoMsgMocks.delegate.ack,
-  [protoMsgMocks.queryBalance.msg]: protoMsgMocks.queryBalance.ack,
-};
+export function createMockAckMap(mockMap: typeof protoMsgMocks) {
+  const res = Object.values(mockMap).reduce((acc, { msg, ack }) => {
+    acc[msg] = ack;
+    return acc;
+  }, {});
+  return res;
+}
+
+export const defaultMockAckMap: Record<string, string> =
+  createMockAckMap(protoMsgMocks);

--- a/packages/orchestration/test/ibc-mocks.ts
+++ b/packages/orchestration/test/ibc-mocks.ts
@@ -14,6 +14,7 @@ import {
   MsgWithdrawDelegatorReward,
   MsgWithdrawDelegatorRewardResponse,
 } from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/tx.js';
+import type { Timestamp } from '@agoric/cosmic-proto/google/protobuf/timestamp.js';
 import {
   buildMsgResponseString,
   buildQueryResponseString,
@@ -21,7 +22,6 @@ import {
   buildTxPacketString,
   buildQueryPacketString,
 } from '../tools/ibc-mocks.js';
-import { MILLISECONDS_PER_SECOND } from '../src/utils/time.js';
 
 /**
  * TODO: provide mappings to cosmos error codes (and module specific error codes)
@@ -54,10 +54,10 @@ const redelegation = {
 
 export const UNBOND_PERIOD_SECONDS = 5n;
 
-const getCompletionTime = () => {
-  // 5 seconds fron unix epoch
-  return new Date(0 + Number(UNBOND_PERIOD_SECONDS * MILLISECONDS_PER_SECOND));
-};
+const getUnbondingTime = (): Timestamp => ({
+  seconds: UNBOND_PERIOD_SECONDS,
+  nanos: 0,
+});
 
 export const protoMsgMocks = {
   delegate: {
@@ -67,13 +67,13 @@ export const protoMsgMocks = {
   undelegate: {
     msg: buildTxPacketString([MsgUndelegate.toProtoMsg(delegation)]),
     ack: buildMsgResponseString(MsgUndelegateResponse, {
-      completionTime: getCompletionTime(),
+      completionTime: getUnbondingTime(),
     }),
   },
   redelegate: {
     msg: buildTxPacketString([MsgBeginRedelegate.toProtoMsg(redelegation)]),
     ack: buildMsgResponseString(MsgBeginRedelegateResponse, {
-      completionTime: getCompletionTime(),
+      completionTime: getUnbondingTime(),
     }),
   },
   withdrawReward: {

--- a/packages/orchestration/test/network-fakes.ts
+++ b/packages/orchestration/test/network-fakes.ts
@@ -19,7 +19,7 @@ import {
 import { BridgeId } from '@agoric/internal';
 import { E, Far } from '@endo/far';
 import type { Guarded } from '@endo/exo';
-import { defaultMockAckMap, protoMsgMocks } from './ibc-mocks.js';
+import { defaultMockAckMap, errorAcknowledgments } from './ibc-mocks.js';
 
 /**
  * Mimic IBC Channel version negotation
@@ -174,7 +174,7 @@ export const makeFakeIBCBridge = (
             const ackEvent = ibcBridgeMocks.acknowledgementPacket(obj, {
               sequence: ibcSequenceNonce,
               acknowledgement:
-                mockAckMap?.[obj.packet.data] || protoMsgMocks.error.ack,
+                mockAckMap?.[obj.packet.data] || errorAcknowledgments.error5,
             });
             ibcSequenceNonce += 1;
             bridgeHandler?.fromBridge(ackEvent);

--- a/packages/orchestration/test/utils/time.test.ts
+++ b/packages/orchestration/test/utils/time.test.ts
@@ -2,7 +2,6 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { TimeMath } from '@agoric/time';
 import {
-  dateInSeconds,
   makeTimestampHelper,
   NANOSECONDS_PER_SECOND,
   SECONDS_PER_MINUTE,
@@ -38,12 +37,4 @@ test('makeTimestampHelper - getCurrentTimestamp', async t => {
     (1n + 3n) * NANOSECONDS_PER_SECOND,
     'timestamp is 4 seconds since unix epoch, in nanoseconds',
   );
-});
-
-test('dateInSeconds', t => {
-  t.is(dateInSeconds(new Date(1)), 0n);
-  t.is(dateInSeconds(new Date(999)), 0n);
-  t.is(dateInSeconds(new Date(1000)), 1n);
-
-  t.is(dateInSeconds(new Date('2025-12-17T12:23:45Z')), 1765974225n);
 });

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -200,7 +200,8 @@ export const makeFakeLocalchainBridge = (zone, onToBridge = () => {}) => {
               }
               case '/cosmos.staking.v1beta1.MsgUndelegate': {
                 return /** @type {JsonSafe<MsgUndelegateResponse>} */ ({
-                  completionTime: new Date().toJSON(),
+                  // 5 seconds from unix epoch
+                  completionTime: { seconds: 5n, nanos: 0 },
                 });
               }
               // returns one empty object per message unless specified


### PR DESCRIPTION
refs: #9042

## Description

This PR primarily improves unit testing around the `.undelegate()` flow and was motivated by a failure (inability to decode `completionTime`) discovered in E2E testing. 

- Add tests for cosmos-orchestration-account staking flows using mocked IBC messages
- Use `Timestamp` (from [google/protobuf/timestamp.proto](https://buf.build/protocolbuffers/wellknowntypes/docs/657250e6a39648cbb169d079a60bd9ba:google.protobuf#google.protobuf.Timestamp)) instead of `Date` for `@agoric/cosmic-proto` codegen for better endo compatibility
- Update `undelegate()` to use Timestamp for `wakeAt()` calculation

### Testing Considerations
This PR includes additional tests for cosmos-orchestration-account flows.

### Upgrade Considerations
This is a breaking change for `@agoric/cosmic-proto`, but not for the `agoric` namespace.