### PR TITLE
style(swing-store): Use the "generator" convention in function names

### DIFF
--- a/packages/swing-store/src/exporter.js
+++ b/packages/swing-store/src/exporter.js
@@ -163,23 +163,23 @@ export function makeSwingStoreExporter(dirPath, options = {}) {
   harden(getExportData);
 
   /** @yields {string} */
-  async function* artifactNames() {
+  async function* generateArtifactNames() {
     yield* snapStore.getArtifactNames(artifactMode);
     yield* transcriptStore.getArtifactNames(artifactMode);
     yield* bundleStore.getArtifactNames();
   }
-  harden(artifactNames);
+  harden(generateArtifactNames);
 
   /**
    * @returns {AsyncIterableIterator<string>}
    */
   function getArtifactNames() {
     if (artifactMode !== 'debug') {
-      // throw if this DB will not be able to yield all the desired artifacts
+      // synchronously throw if this DB will not be able to yield all the desired artifacts
       const internal = { snapStore, bundleStore, transcriptStore };
       assertComplete(internal, artifactMode);
     }
-    return artifactNames();
+    return generateArtifactNames();
   }
 
   /**


### PR DESCRIPTION
Ref #9423

## Description
This maintains `getArtifactNames` as a SwingStoreExporter method that synchronously either throws an error or returns an async iterator, but renames the internal helper function responsible for constructing that iterator from the overly-similar `artifactNames` to the more conventional `generateArtifactNames`. I initially wanted to reconsolidate both behaviors into `getArtifactNames`, but ultimately decided that separation better highlights the potential for a synchronous exception.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
n/a