### PR TITLE
feat(scripts): Add npm-dist-tag.sh --otp-stream for a better CLI experience

### DIFF
--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -77,10 +77,13 @@ case ${3-} in
     # "add <tag> -<pre-release>" scans published versions for an exact match of
     # the specified pre-release suffix and applies the new dist-tag to that
     # version rather than to the version read from package.json.
+
+    # cf. https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
+    semver_prefix="^((^|[.])(0|[1-9][0-9]*)){3}"
+
     version=$(npm view "$pkg" versions --json \
-      |
-      # cf. https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
-      jq --arg s "$3" -r '.[] | select(sub("^((^|[.])(0|[1-9][0-9]*)){3}"; "") == $s)' || true)
+      | jq --arg p "$semver_prefix" --arg suffix "$3" -r '.[] | select(sub($p; "") == $suffix)' \
+      | tail -n 1)
     ;;
   *)
     test "$#" -le 2 || fail "Invalid pre-release suffix!"

--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 usage() {
   cat << END_USAGE
-Usage: $0 [--dry-run] [lerna] <command> [<argument>]...
+Usage: $0 [--dry-run|--otp-stream=<fifo>] [lerna] <command> [<argument>]...
 
 Commands:
 add <tag> [-<pre-release>]
@@ -14,6 +14,12 @@ add <tag> [-<pre-release>]
   (optionally limited to the dist-tag named <tag>).
 
 With "--dry-run", npm commands are printed to standard error rather than executed.
+
+With "--otp-stream=<fifo>", for each npm command the value  of an "--otp" option
+is read from the specified file (generally expected to be a named pipe created
+by \`mkfifo\`) and failing commands are retried until the read value is empty.
+Alternatively, environment variable configuration \`npm_config_auth_type=legacy\`
+causes npm itself to prompt for and read OTP values from standard input.
 
 If the first operand is "lerna", the operation is extended to all packages.
 END_USAGE
@@ -29,15 +35,34 @@ fail() {
 # Exit on any errors.
 set -ueo pipefail
 
-# Check for `--dry-run`.
+# Check for `--dry-run` and `--otp-stream`.
 npm=npm
-dryrun=
-if test "${1:-}" = "--dry-run"; then
-  dryrun=$1
-  npm="echo-to-stderr npm"
-  shift
-fi
+style=
+otpfile=
+case "${1:-}" in
+  --dry-run)
+    style="$1"
+    npm="echo-to-stderr npm"
+    shift
+    ;;
+  --otp-stream=*)
+    style="$1"
+    otpfile="${1##--otp-stream=}"
+    npm="npm-otp"
+    shift
+    ;;
+esac
 echo-to-stderr() { echo "$@"; } 1>&2
+npm-otp() {
+  printf 1>&2 "Reading OTP from %s ... " "$otpfile"
+  otp=$(head -n 1 "$otpfile")
+  if test -z "$otp"; then
+    echo 1>&2 "No OTP"
+    return 66
+  fi
+  echo 1>&2 OK
+  npm --otp="$otp" "$@"
+}
 
 # Check for `lerna`.
 case "${1-}" in
@@ -52,7 +77,7 @@ case "${1-}" in
 
     # Strip the first argument (`lerna`), so that `$@` gives us remaining args.
     shift
-    exec npm run -- lerna exec --concurrency=1 --no-bail -- "$thisdir/$thisprog" "$dryrun" "$@"
+    exec npm run -- lerna exec --concurrency=1 --no-bail -- "$thisdir/$thisprog" "$style" "$@"
     ;;
 esac
 CMD="${1-"--help"}"
@@ -98,19 +123,31 @@ case "$CMD" in
     # Add $TAG to dist-tags.
     test -n "$TAG" || fail "Missing tag!"
     test "$#" -le 3 || fail "Too many arguments!"
-    $npm dist-tag add "$pkg@$version" "$TAG"
+    while true; do
+      $npm dist-tag add "$pkg@$version" "$TAG" && break || ret=$?
+      [[ "$style" =~ --otp-stream ]] || exit $ret
+      [ $ret -ne 66 ] && continue
+      echo Aborting
+      exit 1
+    done
     ;;
   remove | rm)
     # Remove $TAG from dist-tags.
     test -n "$TAG" || fail "Missing tag!"
     test "$#" -le 2 || fail "Too many arguments!"
-    $npm dist-tag rm "$pkg" "$TAG"
+    while true; do
+      $npm dist-tag rm "$pkg" "$TAG" && break || ret=$?
+      [[ "$style" =~ --otp-stream ]] || exit $ret
+      [ $ret -ne 66 ] && continue
+      echo Aborting
+      exit 1
+    done
     ;;
   list | ls)
     # List either all dist-tags or just the specific $TAG.
     test "$#" -le 2 || fail "Too many arguments!"
     if test -n "$TAG"; then
-      if test -n "$dryrun"; then
+      if test "$style" = "--dry-run"; then
         # Print the entire pipeline.
         $npm dist-tag ls "$pkg" \| awk -vP="$TAG" -F: '$1==P'
       else

--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -48,10 +48,11 @@ case "${1-}" in
     # Find the absolute path to this script.
     thisdir=$(cd "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)
     thisprog=$(basename -- "${BASH_SOURCE[0]}")
+    cd "$thisdir"
 
     # Strip the first argument (`lerna`), so that `$@` gives us remaining args.
     shift
-    exec npm run -- lerna exec --concurrency=1 --no-bail "$thisdir/$thisprog" -- $dryrun ${1+"$@"}
+    exec npm run -- lerna exec --concurrency=1 --no-bail -- "$thisdir/$thisprog" "$dryrun" "$@"
     ;;
 esac
 CMD="${1-"--help"}"

--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -112,9 +112,9 @@ case "$CMD" in
     if test -n "$TAG"; then
       if test -n "$dryrun"; then
         # Print the entire pipeline.
-        $npm dist-tag ls "$pkg" \| sed -ne "s/^$TAG: //p"
+        $npm dist-tag ls "$pkg" \| awk -vP="$TAG" -F: '$1==P'
       else
-        $npm dist-tag ls "$pkg" | sed -ne "s/^$TAG: //p"
+        $npm dist-tag ls "$pkg" | awk -vP="$TAG" -F: '$1==P'
       fi
     else
       $npm dist-tag ls "$pkg"

--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -54,6 +54,7 @@ case "${1-}" in
     exec npm run -- lerna exec --concurrency=1 --no-bail "$thisdir/$thisprog" -- $dryrun ${1+"$@"}
     ;;
 esac
+CMD="${1-"--help"}"
 
 # Read current-directory package.json data into shell variables: pkg, version, priv.
 eval "$(jq < package.json -r --arg Q "'" '
@@ -66,13 +67,12 @@ eval "$(jq < package.json -r --arg Q "'" '
 ')"
 
 # dist-tags are only applicable to published packages.
-if test "$priv" = true; then
+if test "$priv" = true -a "$CMD" != "--help"; then
   echo 1>&2 "Skipping private package $pkg"
   exit 0
 fi
 
-# Process remaining arguments: <command> [<tag> [-<pre-release>]].
-CMD="${1-}"
+# Process command arguments: [<tag> [-<pre-release>]].
 TAG="${2-}"
 case ${3-} in
   -*)


### PR DESCRIPTION
Ref #9079

## Description
Refactor npm-dist-tag.sh to improve readability, efficiency, correctness, and most importantly user experience (in particular by avoiding breakouts to browser tabs for entering OTP values with default npm configuration).

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
Usage output and internal comments better explain how to use the script and what it does.

### Testing Considerations
Tested manually.

### Upgrade Considerations
n/a