### PR TITLE
9449 chainHub durability

### DIFF
--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -53,6 +53,7 @@
     "@endo/patterns": "^1.4.0"
   },
   "devDependencies": {
+    "@agoric/swingset-liveslots": "^0.10.2",
     "@chain-registry/client": "^1.47.4",
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -47,7 +47,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     zcf,
     privateArgs.timerService,
     vowTools,
-    makeChainHub(privateArgs.agoricNames),
+    makeChainHub(privateArgs.agoricNames, vowTools),
   );
 
   // ----------------

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -1,6 +1,8 @@
 import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { heapVowE as E } from '@agoric/vow/vat.js';
+import { prepareVowTools } from '@agoric/vow';
+import { makeHeapZone } from '@agoric/zone';
+import { E } from '@endo/far';
 import { makeChainHub } from '../exos/chain-hub.js';
 
 /**
@@ -44,9 +46,10 @@ export const startStakeAtom = async ({
   const storageNode = await makeStorageNodeChild(chainStorage, VSTORAGE_PATH);
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const chainHub = makeChainHub(await agoricNames);
+  const vt = prepareVowTools(makeHeapZone());
+  const chainHub = makeChainHub(await agoricNames, vt);
 
-  const [_, cosmoshub, connectionInfo] = await E.when(
+  const [_, cosmoshub, connectionInfo] = await vt.when(
     chainHub.getChainsAndConnection('agoric', 'cosmoshub'),
   );
 

--- a/packages/orchestration/src/proposals/start-stakeOsmo.js
+++ b/packages/orchestration/src/proposals/start-stakeOsmo.js
@@ -1,6 +1,8 @@
 import { makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { heapVowE as E } from '@agoric/vow/vat.js';
+import { prepareVowTools } from '@agoric/vow';
+import { makeHeapZone } from '@agoric/zone';
+import { E } from '@endo/far';
 import { makeChainHub } from '../exos/chain-hub.js';
 
 /**
@@ -45,9 +47,10 @@ export const startStakeOsmo = async ({
   const storageNode = await makeStorageNodeChild(chainStorage, VSTORAGE_PATH);
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const chainHub = makeChainHub(await agoricNames);
+  const vt = prepareVowTools(makeHeapZone());
+  const chainHub = makeChainHub(await agoricNames, vt);
 
-  const [_, osmosis, connectionInfo] = await E.when(
+  const [_, osmosis, connectionInfo] = await vt.when(
     chainHub.getChainsAndConnection('agoric', 'osmosis'),
   );
 

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -51,9 +51,9 @@ export const provideOrchestration = (
   const zone = makeDurableZone(baggage);
   const { agoricNames, timerService } = remotePowers;
 
-  const chainHub = makeChainHub(agoricNames);
-
   const vowTools = prepareVowTools(zone.subZone('vows'));
+
+  const chainHub = makeChainHub(agoricNames, vowTools);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @jessie.js/safe-await-separator -- XXX irrelevant for tests */
+import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { makeNameHubKit } from '@agoric/vats';
-import { heapVowE as E } from '@agoric/vow/vat.js';
+import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { makeChainHub } from '../../src/exos/chain-hub.js';
+import { provideDurableZone } from '../supports.js';
 
 const connection = {
   id: 'connection-1',
@@ -28,8 +30,10 @@ const connection = {
 } as const;
 
 test('getConnectionInfo', async t => {
+  const zone = provideDurableZone('root');
+  const vt = prepareSwingsetVowTools(zone);
   const { nameHub } = makeNameHubKit();
-  const chainHub = makeChainHub(nameHub);
+  const chainHub = makeChainHub(nameHub, zone);
 
   const aChain = { chainId: 'a-1' };
   const bChain = { chainId: 'b-2' };
@@ -38,11 +42,11 @@ test('getConnectionInfo', async t => {
 
   // Look up by string or info object
   t.deepEqual(
-    await E.when(chainHub.getConnectionInfo(aChain.chainId, bChain.chainId)),
+    await vt.when(chainHub.getConnectionInfo(aChain.chainId, bChain.chainId)),
     connection,
   );
   t.deepEqual(
-    await E.when(chainHub.getConnectionInfo(aChain, bChain)),
+    await vt.when(chainHub.getConnectionInfo(aChain, bChain)),
     connection,
   );
 });

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -36,7 +36,7 @@ test('deposit, withdraw', async t => {
     Far('MockZCF', {}),
     timer,
     vowTools,
-    makeChainHub(bootstrap.agoricNames),
+    makeChainHub(bootstrap.agoricNames, vowTools),
   );
 
   t.log('request account from vat-localchain');
@@ -107,7 +107,7 @@ test('delegate, undelegate', async t => {
     Far('MockZCF', {}),
     timer,
     vowTools,
-    makeChainHub(bootstrap.agoricNames),
+    makeChainHub(bootstrap.agoricNames, vowTools),
   );
 
   t.log('request account from vat-localchain');
@@ -170,7 +170,7 @@ test('transfer', async t => {
     Far('MockZCF', {}),
     timer,
     vowTools,
-    makeChainHub(bootstrap.agoricNames),
+    makeChainHub(bootstrap.agoricNames, vowTools),
   );
 
   t.log('request account from vat-localchain');

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -5,7 +5,7 @@ import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import type { CosmosChainInfo, IBCConnectionInfo } from '../src/cosmos-api.js';
 import type { Chain } from '../src/orchestration-api.js';
 import { provideOrchestration } from '../src/utils/start-helper.js';
-import { commonSetup } from './supports.js';
+import { commonSetup, provideDurableZone } from './supports.js';
 
 const test = anyTest;
 
@@ -44,8 +44,11 @@ const makeLocalOrchestrationAccountKit = () => assert.fail(`not used`);
 test('chain info', async t => {
   const { bootstrap, facadeServices, commonPrivateArgs } = await commonSetup(t);
 
-  const zone = bootstrap.rootZone;
   const { zcf } = await setupZCFTest();
+
+  // After setupZCFTest because this disables relaxDurabilityRules
+  // which breaks Zoe test setup's fakeVatAdmin
+  const zone = provideDurableZone('test');
 
   const orchKit = provideOrchestration(
     zcf,

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -1,6 +1,6 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { heapVowE as E } from '@agoric/vow/vat.js';
+import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import type { CosmosChainInfo, IBCConnectionInfo } from '../src/cosmos-api.js';
 import type { Chain } from '../src/orchestration-api.js';
@@ -39,8 +39,6 @@ export const mockChainConnection: IBCConnectionInfo = {
   },
 };
 
-const makeLocalOrchestrationAccountKit = () => assert.fail(`not used`);
-
 test('chain info', async t => {
   const { bootstrap, facadeServices, commonPrivateArgs } = await commonSetup(t);
 
@@ -49,6 +47,7 @@ test('chain info', async t => {
   // After setupZCFTest because this disables relaxDurabilityRules
   // which breaks Zoe test setup's fakeVatAdmin
   const zone = provideDurableZone('test');
+  const vt = prepareSwingsetVowTools(zone);
 
   const orchKit = provideOrchestration(
     zcf,
@@ -77,7 +76,7 @@ test('chain info', async t => {
   });
 
   const result = (await handle()) as Chain<any>;
-  t.deepEqual(await E.when(result.getChainInfo()), mockChainInfo);
+  t.deepEqual(await vt.when(result.getChainInfo()), mockChainInfo);
 });
 
 test.todo('contract upgrade');

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -1,8 +1,11 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { prepareLocalChainTools } from '@agoric/vats/src/localchain.js';
+import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
+import { makeNameHubKit } from '@agoric/vats';
 import { prepareBridgeTargetModule } from '@agoric/vats/src/bridge-target.js';
+import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
+import { prepareLocalChainTools } from '@agoric/vats/src/localchain.js';
 import { prepareTransferTools } from '@agoric/vats/src/transfer.js';
 import { makeFakeBankManagerKit } from '@agoric/vats/tools/bank-utils.js';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
@@ -14,20 +17,20 @@ import { prepareVowTools } from '@agoric/vow';
 import type { Installation } from '@agoric/zoe/src/zoeService/utils.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
-import { makeHeapZone } from '@agoric/zone';
+import { makeHeapZone, type Zone } from '@agoric/zone';
+import { makeDurableZone } from '@agoric/zone/durable.js';
 import { E } from '@endo/far';
-import { makeNameHubKit } from '@agoric/vats';
-import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
-import { setupFakeNetwork } from './network-fakes.js';
-import { prepareOrchestrationTools } from '../src/service.js';
+import type { ExecutionContext } from 'ava';
 import { registerChainNamespace } from '../src/chain-info.js';
+import { prepareOrchestrationTools } from '../src/service.js';
+import { setupFakeNetwork } from './network-fakes.js';
 
 export {
   makeFakeLocalchainBridge,
   makeFakeTransferBridge,
 } from '@agoric/vats/tools/fake-bridge.js';
 
-export const commonSetup = async t => {
+export const commonSetup = async (t: ExecutionContext<any>) => {
   t.log('bootstrap vat dependencies');
   // The common setup cannot support a durable zone because many of the fakes are not durable.
   // They were made before we had durable kinds (and thus don't take a zone or baggage).
@@ -159,3 +162,14 @@ export const commonSetup = async t => {
 };
 
 export const makeDefaultContext = <SF>(contract: Installation<SF>) => {};
+
+/**
+ * Reincarnate without relaxDurabilityRules and provide a durable zone in the incarnation.
+ * @param key
+ */
+export const provideDurableZone = (key: string): Zone => {
+  const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });
+  const root = fakeVomKit.cm.provideBaggage();
+  const zone = makeDurableZone(root);
+  return zone.subZone(key);
+};

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -5,12 +5,15 @@ import { E } from '@endo/far';
 
 import { byteSourceToBase64, base64ToBytes } from '@agoric/network';
 
+import { makeTracer } from '@agoric/internal';
 import {
   localAddrToPortID,
   decodeRemoteIbcAddress,
   encodeLocalIbcAddress,
   encodeRemoteIbcAddress,
 } from '../tools/ibc-utils.js';
+
+const trace = makeTracer('IBC', false);
 
 /**
  * @import {LocalIbcAddress, RemoteIbcAddress} from '../tools/ibc-utils.js';
@@ -105,7 +108,7 @@ export const prepareIBCConnectionHandler = zone => {
       async onOpen(conn, localAddr, remoteAddr, _handler) {
         const { channelID, portID, channelKeyToConnP } = this.state;
 
-        console.debug(
+        trace(
           'onOpen Remote IBC Connection',
           channelID,
           portID,
@@ -236,7 +239,7 @@ export const prepareIBCProtocol = (zone, powers) => {
       protocolHandler: {
         /** @type {Required<ProtocolHandler>['onCreate']} */
         async onCreate(impl) {
-          console.debug('IBC onCreate');
+          trace('onCreate');
           this.state.protocolImpl = impl;
         },
         /** @type {Required<ProtocolHandler>['onInstantiate']} */
@@ -267,7 +270,7 @@ export const prepareIBCProtocol = (zone, powers) => {
           const { util } = this.facets;
           const { portToPendingConns, srcPortToOutbounds } = this.state;
 
-          console.debug('IBC onConnect', localAddr, remoteAddr);
+          trace('onConnect', localAddr, remoteAddr);
           // @ts-expect-error may not be LocalIbcAddress
           const portID = localAddrToPortID(localAddr);
           const pendingConns = portToPendingConns.get(portID);
@@ -313,16 +316,16 @@ export const prepareIBCProtocol = (zone, powers) => {
         },
         /** @type {Required<ProtocolHandler>['onListen']} */
         async onListen(_port, localAddr) {
-          console.debug('IBC onListen', localAddr);
+          trace('onListen', localAddr);
         },
         /** @type {Required<ProtocolHandler>['onListenRemove']} */
         async onListenRemove(_port, localAddr) {
-          console.debug('IBC onListenRemove', localAddr);
+          trace('onListenRemove', localAddr);
         },
         /** @type {Required<ProtocolHandler>['onRevoke']} */
         async onRevoke(_port, localAddr) {
           const { portToPendingConns } = this.state;
-          console.debug('IBC onRevoke', localAddr);
+          trace('onRevoke', localAddr);
           // @ts-expect-error may not be LocalIbcAddress
           const portID = localAddrToPortID(localAddr);
 

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -1,9 +1,9 @@
 // @ts-check
-import { makeWhen } from './when.js';
-import { prepareVowKit } from './vow.js';
-import { prepareWatch } from './watch.js';
-import { prepareWatchUtils } from './watch-utils.js';
 import { makeAsVow } from './vow-utils.js';
+import { prepareVowKit } from './vow.js';
+import { prepareWatchUtils } from './watch-utils.js';
+import { prepareWatch } from './watch.js';
+import { makeWhen } from './when.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
@@ -34,6 +34,23 @@ export const prepareVowTools = (zone, powers = {}) => {
   const asVow = makeAsVow(makeVowKit);
 
   /**
+   * TODO FIXME make this real
+   * Create a function that retries the given function if the underlying
+   * functions rejects due to upgrade disconnection.
+   *
+   * The internal functions
+   *
+   * @param {Zone} fnZone - the zone for the named function
+   * @param {string} name
+   * @param {(...args: unknown[]) => unknown} fn
+   */
+  const retriable =
+    (fnZone, name, fn) =>
+    (...args) => {
+      return watch(fn(...args));
+    };
+
+  /**
    * Vow-tolerant implementation of Promise.all.
    *
    * @param {EVow<unknown>[]} maybeVows
@@ -44,7 +61,15 @@ export const prepareVowTools = (zone, powers = {}) => {
   const asPromise = (specimenP, ...watcherArgs) =>
     watchUtils.asPromise(specimenP, ...watcherArgs);
 
-  return harden({ when, watch, makeVowKit, allVows, asVow, asPromise });
+  return harden({
+    when,
+    watch,
+    makeVowKit,
+    allVows,
+    asVow,
+    asPromise,
+    retriable,
+  });
 };
 harden(prepareVowTools);
 

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -7,7 +7,7 @@ import { makeWhen } from './when.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
- * @import {IsRetryableReason, AsPromiseFunction, EVow} from './types.js';
+ * @import {IsRetryableReason, AsPromiseFunction, EVow, Vow, ERef} from './types.js';
  */
 
 /**
@@ -40,9 +40,11 @@ export const prepareVowTools = (zone, powers = {}) => {
    *
    * The internal functions
    *
+   * @template T
    * @param {Zone} fnZone - the zone for the named function
    * @param {string} name
-   * @param {(...args: unknown[]) => unknown} fn
+   * @param {(...args: unknown[]) => ERef<T>} fn
+   * @returns {(...args: unknown[]) => Vow<T>}
    */
   const retriable =
     (fnZone, name, fn) =>


### PR DESCRIPTION
refs: #9449

## Description

This makes ChainHub return durable vows. The underlying lookup functions are not durable but they made so by the `retriable` helper.

So this also introduces a stub version of https://github.com/Agoric/agoric-sdk/issues/9541 pulled from @dtribble 's https://github.com/Agoric/agoric-sdk/pull/9657

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
not yet upgradable. Communicated by https://github.com/Agoric/agoric-sdk/blob/a267ba20db0eeb2082c287ca7b69e37d6f272eb9/packages/vow/src/tools.js#L37-L38