### PR TITLE
fix(agoric-sdk): Include version twins in valid bundle compartment names

### DIFF
--- a/packages/agoric-cli/src/lib/bundles.js
+++ b/packages/agoric-cli/src/lib/bundles.js
@@ -11,7 +11,7 @@ import { ZipReader } from '@endo/zip';
 /** @import {Bundle} from '@agoric/swingset-vat'; */
 /** @import {CoreEvalPlan} from '@agoric/deploy-script-support/src/writeCoreEvalParts.js' */
 
-const PACKAGE_NAME_RE = /(?<packageName>.*-v[\d.]+)\//;
+const PACKAGE_NAME_RE = /(?<packageName>.*-v[\d.]+(?:-n\d+)?)\//;
 
 /**
  * @typedef {{ name: string, label: string, location: string, modules: Record<string, {compartment: string, module: string}>}} Compartment


### PR DESCRIPTION

## Description
The Agoric CLI now does some validation of bundles. This includes a regular expression for valid compartment names, but doesn’t account for duplicate compartments from the same alleged version of a package.

### Security Considerations
None.

### Scaling Considerations
As written, we replace a cryptic failure mode (valid bundle) with a different cryptic failure mode (bundle is oversized due to duplicates of the same package).

### Documentation Considerations
None.

### Testing Considerations
To test would require an overconstrained scenario that would fail in the face of valid changes. It might be better to further relax these constraints to warnings.

### Upgrade Considerations
None.