### PR TITLE
fix(agoric-cli): Fully generalize package name extractor from zip files

### DIFF
--- a/packages/agoric-cli/src/lib/bundles.js
+++ b/packages/agoric-cli/src/lib/bundles.js
@@ -11,7 +11,8 @@ import { ZipReader } from '@endo/zip';
 /** @import {Bundle} from '@agoric/swingset-vat'; */
 /** @import {CoreEvalPlan} from '@agoric/deploy-script-support/src/writeCoreEvalParts.js' */
 
-const PACKAGE_NAME_RE = /^(?:@[^\/]+\/)?[^\/]+/;
+// exported for testing
+export const PACKAGE_NAME_RE = /^(?:@[^/]+\/)?[^/]+/;
 
 /**
  * @typedef {{ name: string, label: string, location: string, modules: Record<string, {compartment: string, module: string}>}} Compartment

--- a/packages/agoric-cli/src/lib/bundles.js
+++ b/packages/agoric-cli/src/lib/bundles.js
@@ -11,7 +11,7 @@ import { ZipReader } from '@endo/zip';
 /** @import {Bundle} from '@agoric/swingset-vat'; */
 /** @import {CoreEvalPlan} from '@agoric/deploy-script-support/src/writeCoreEvalParts.js' */
 
-const PACKAGE_NAME_RE = /(?<packageName>.*-v[\d.]+(?:-n\d+)?)\//;
+const PACKAGE_NAME_RE = /^(?:@[^\/]+\/)?[^\/]+/;
 
 /**
  * @typedef {{ name: string, label: string, location: string, modules: Record<string, {compartment: string, module: string}>}} Compartment
@@ -70,7 +70,7 @@ export const statBundle = async bundleFilename => {
     if (filename === 'compartment-map.json') {
       continue;
     }
-    const { packageName } = filename.match(PACKAGE_NAME_RE)?.groups ?? {};
+    const packageName = filename.match(PACKAGE_NAME_RE)?.[0];
     assert(packageName, `invalid filename ${filename}`);
     byPackage[packageName] ||= 0;
     byPackage[packageName] += size;

--- a/packages/agoric-cli/test/bundles-regExp.test.js
+++ b/packages/agoric-cli/test/bundles-regExp.test.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import { PACKAGE_NAME_RE } from '../src/lib/bundles.js';
+
+const goodPatterns = [
+  ['@agoric/assert-v0.6.0'],
+  ['@agoric/base-zone-v0.1.0/', '@agoric/base-zone-v0.1.0'],
+  ['@endo/base64-v1.0.5-n1/index.js', '@endo/base64-v1.0.5-n1'],
+  ['@endo/base64-v1.0.5-n1/decode.js', '@endo/base64-v1.0.5-n1'],
+  [
+    '@agoric/store-v0.9.3-dev-37ec151.0+37ec151/src/legacy/legacyWeakMap.js',
+    '@agoric/store-v0.9.3-dev-37ec151.0+37ec151',
+  ],
+  [
+    'calypso-contract-v0.1.0/src/proposals/core-proposal.js',
+    'calypso-contract-v0.1.0',
+  ],
+  ['/index.js', undefined],
+  ['/src', undefined],
+];
+
+test('simple positive', t => {
+  for (const pattern of goodPatterns) {
+    const name = pattern[0];
+    const expected = pattern.length === 2 ? pattern[1] : pattern[0];
+
+    t.is(name.match(PACKAGE_NAME_RE)?.[0], expected);
+  }
+});
+
+const badPatterns = [
+  '/user/name/sdk/node_modules/@agoric/assert-v0.6.0',
+  '/random/@agoric/base-zone-v0.1.0/',
+];
+
+test('simple negative', t => {
+  for (const pattern of badPatterns) {
+    t.falsy(pattern.match(PACKAGE_NAME_RE)?.[0], `expected ${pattern} to fail`);
+  }
+});


### PR DESCRIPTION
## Description

Following https://github.com/Agoric/agoric-sdk/pull/9667 we learn that the bundle analyzer needs to understand exotic package names that include `-dev$hash` and such. To that end, this change fully generalizes the package name detector based on the `@` prefix distinguishing a package name with two path components.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

None.

### Upgrade Considerations

None.