### PR TITLE
fix(vm-config): always use `init-localchain` and `init-transfer`

### DIFF
--- a/packages/cosmic-swingset/economy-template.json
+++ b/packages/cosmic-swingset/economy-template.json
@@ -5,9 +5,8 @@
     ],
     [
       "@agoric/builders/scripts/vats/init-network.js",
-      "@agoric/builders/scripts/pegasus/init-core.js",
       "@agoric/builders/scripts/vats/init-localchain.js",
-      "@agoric/builders/scripts/vats/init-transfer.js"
+      "@agoric/builders/scripts/vats/init-transfer.js"       
     ],
     [
       {

--- a/packages/cosmic-swingset/economy-template.json
+++ b/packages/cosmic-swingset/economy-template.json
@@ -6,6 +6,7 @@
     [
       "@agoric/builders/scripts/vats/init-network.js",
       "@agoric/builders/scripts/pegasus/init-core.js",
+      "@agoric/builders/scripts/vats/init-localchain.js",
       "@agoric/builders/scripts/vats/init-transfer.js"
     ],
     [

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -200,7 +200,7 @@ const prepareBankChannelHandler = zone =>
                   updater = addressToUpdater.get(address);
                 }
               } catch (e) {
-                console.error('Unregistered denom in', update, e);
+                console.debug('Unregistered denom in', update, e);
               }
               if (updater) {
                 try {

--- a/packages/vm-config/decentral-itest-vaults-config.json
+++ b/packages/vm-config/decentral-itest-vaults-config.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) is designed to bring up vaults test networks in an automated fashion. It includes coreProposals to start vaults. Testing facilities are limited to an initialPrice for ATOM and addresses with known keys.",
+  "$comment": "Not just vaults! This SwingSet config (see loadSwingsetConfigFile) started for integration testing of Vaults is designed to bring up vaults but became the defacto config for integration testing outside this repo (e.g. instagoric). It includes coreProposals to start Inter Protocol (including vaults) plus Orchestration. Testing facilities are limited to an initialPrice for ATOM and addresses with known keys.",
   "bootstrap": "bootstrap",
   "defaultReapInterval": 1000,
   "coreProposals": [

--- a/packages/vm-config/decentral-itest-vaults-config.json
+++ b/packages/vm-config/decentral-itest-vaults-config.json
@@ -5,6 +5,8 @@
   "coreProposals": [
     "@agoric/builders/scripts/vats/init-core.js",
     "@agoric/builders/scripts/vats/init-network.js",
+    "@agoric/builders/scripts/vats/init-localchain.js",
+    "@agoric/builders/scripts/vats/init-transfer.js",
     {
       "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
       "entrypoint": "defaultProposalBuilder",

--- a/packages/vm-config/demo-proposals.json
+++ b/packages/vm-config/demo-proposals.json
@@ -1,6 +1,5 @@
 [
   "@agoric/builders/scripts/inter-protocol/init-core.js",
-  "@agoric/builders/scripts/pegasus/init-core.js",
   "@agoric/builders/scripts/vats/init-network.js",
   "@agoric/builders/scripts/vats/init-localchain.js",
   "@agoric/builders/scripts/vats/init-transfer.js"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
While working on orchnet, I discovered that `decentral-itest-vaults-config.json` lacked references to the `init-localchain.js` and `init-transfer.js` core-evals.

This PR:
- enables them for future chains, since we intend to use them wherever `init-network.js` is present
- removes config references to Pegasus, since it is an obsolete demonstration of an IBC contract, and now we have newer and better examples,
- reduces loud warnings from `vat-bank.js` when unregistered asset balances were detected, since we expect this to be commonplace when dealing with IBC assets from many chains

### Security Considerations
n/a

### Scaling Considerations
Less logging from `vat-bank.js`, once it is upgraded (or started on a new chain).

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
The `vat-bank.js` changes do not modify functionality except logging, so I consider it safe to include for future chains without requiring mainnet's bank vat to be upgraded.
