### PR TITLE
fix(cosmos): don't rerun store migrations on upgrade

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -862,18 +862,23 @@ func NewAgoricApp(
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
 
-	for name := range upgradeNamesOfThisVersion {
+	for _, name := range upgradeNamesOfThisVersion {
 		app.UpgradeKeeper.SetUpgradeHandler(
 			name,
 			upgrade16Handler(app, name),
 		)
 	}
 
+	// At this point we don't have a way to read from the store, so we have to
+	// rely on data saved by the x/upgrade module in the previous software.
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(err)
 	}
-	if upgradeNamesOfThisVersion[upgradeInfo.Name] && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	// Store migrations can only run once, so we use a notion of "primary upgrade
+	// name" to trigger them. Testnets may end up upgrading from one rc to
+	// another, which shouldn't re-run store upgrades.
+	if isPrimaryUpgradeName(upgradeInfo.Name) && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{
 				packetforwardtypes.ModuleName, // Added PFM


### PR DESCRIPTION
closes: #9682 

## Description
Add logic to check if the upgrade plan name is a "primary name", and only run store migrations for those.
Check in the upgrade handler that the first upgrade is using a primary name to ensure store migrations were run.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
a3p test for primary upgrade will run on this PR
[mhofman/9682-test-double-upgrade](https://github.com/Agoric/agoric-sdk/tree/mhofman/9682-test-double-upgrade) tests applying primary followed by secondary upgrade

### Upgrade Considerations
Fixes cosmos store upgrade logic during chain software upgrades
