### PR TITLE
chore: Resolve Array.forEach lint warnings

### DIFF
--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -316,13 +316,13 @@ export function exportKernelStats({
     }
     kernelStatsLast = now;
     kernelStatsCache = controller.getStats();
-    Object.keys(kernelStatsCache).forEach(key => {
+    for (const key of Object.keys(kernelStatsCache)) {
       warnUnexpectedKernelStat(key);
-    });
+    }
     return kernelStatsCache;
   };
 
-  KERNEL_STATS_SUM_METRICS.forEach(({ key, name, sub, ...options }) => {
+  for (const { key, name, sub, ...options } of KERNEL_STATS_SUM_METRICS) {
     expectedKernelStats.add(key);
     let counter = kernelStatsCounters.get(name);
     if (!counter) {
@@ -337,9 +337,9 @@ export function exportKernelStats({
       observableResult.observe(getKernelStats()[key], reportedAttributes);
     });
     kernelStatsMetrics.add(key);
-  });
+  }
 
-  KERNEL_STATS_UPDOWN_METRICS.forEach(({ key, name, sub, ...options }) => {
+  for (const { key, name, sub, ...options } of KERNEL_STATS_UPDOWN_METRICS) {
     expectedKernelStats.add(key);
     expectedKernelStats.add(`${key}Up`);
     expectedKernelStats.add(`${key}Down`);
@@ -357,7 +357,7 @@ export function exportKernelStats({
       observableResult.observe(getKernelStats()[key], reportedAttributes);
     });
     kernelStatsMetrics.add(key);
-  });
+  }
 
   if (inboundQueueMetrics) {
     // These are not kernelStatsMetrics, they're outside the kernel.
@@ -425,13 +425,13 @@ export function exportKernelStats({
 
   function checkKernelStats(stats) {
     const notYetFoundKernelStats = new Set(kernelStatsMetrics.keys());
-    Object.keys(stats).forEach(key => {
+    for (const key of Object.keys(stats)) {
       notYetFoundKernelStats.delete(key);
       warnUnexpectedKernelStat(key);
-    });
-    notYetFoundKernelStats.forEach(key => {
+    }
+    for (const key of notYetFoundKernelStats) {
       log.warn(`Expected SwingSet kernel statistic`, key, `not found`);
-    });
+    }
   }
 
   // We check everything on initialization.  Other checks happen when scraping.

--- a/packages/cosmic-swingset/test/export-storage.test.js
+++ b/packages/cosmic-swingset/test/export-storage.test.js
@@ -47,13 +47,12 @@ const makeBatchChainStorage = published => {
         const [path] = args;
         return entries(path).map(([key]) => key);
       }
-      case 'setWithoutNotify':
-        {
-          for (const [path] of args) {
-            deleted.push(path);
-          }
+      case 'setWithoutNotify': {
+        for (const [path] of args) {
+          deleted.push(path);
         }
         return;
+      }
       default:
         throw Error(`not impl: ${method}`);
     }

--- a/packages/cosmic-swingset/test/export-storage.test.js
+++ b/packages/cosmic-swingset/test/export-storage.test.js
@@ -48,7 +48,11 @@ const makeBatchChainStorage = published => {
         return entries(path).map(([key]) => key);
       }
       case 'setWithoutNotify':
-        args.forEach(([path]) => deleted.push(path));
+        {
+          for (const [path] of args) {
+            deleted.push(path);
+          }
+        }
         return;
       default:
         throw Error(`not impl: ${method}`);

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -227,7 +227,9 @@ export const synchronizedTee = (sourceStream, readerCount) => {
         doneResult = { done: true, value: undefined };
       },
     );
-    resolvers.forEach(resolve => resolve(result));
+    for (const resolve of resolvers) {
+      resolve(result);
+    }
     return pullNext();
   };
 

--- a/packages/notifier/test/publish-kit.test.js
+++ b/packages/notifier/test/publish-kit.test.js
@@ -82,6 +82,8 @@ const assertCells = (t, label, cells, publishCount, expected, options = {}) => {
     }
   } else {
     const { tail: _tail, ...props } = firstCell;
+    // We need an element and an index here, which for..of does not give us in one go
+    // eslint-disable-next-line github/array-foreach
     cells.slice(1).forEach((cell, i) => {
       t.like(cell, props, `${label} cell ${i + 1} must match cell 0`);
     });

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -442,6 +442,7 @@ export async function connectToChain(
 
           // Find only the latest value in the events.
           let storageValue;
+          // eslint-disable-next-line github/array-foreach
           paths.forEach((key, i) => {
             if (key === storagePath) {
               storageValue = values[i];

--- a/packages/solo/src/outbound.js
+++ b/packages/solo/src/outbound.js
@@ -33,7 +33,7 @@ export function deliver(mbs) {
     }
     const t = knownTargets.get(target);
     const newMessages = [];
-    data[target].outbox.forEach(m => {
+    for (const m of data[target].outbox) {
       const [msgnum, body] = m;
       if (msgnum > t.highestSent) {
         log.debug(
@@ -44,7 +44,7 @@ export function deliver(mbs) {
         );
         newMessages.push(m);
       }
-    });
+    }
     newMessages.sort((a, b) => a[0] - b[0]);
     // console.debug(` ${newMessages.length} new messages`);
     const acknum = data[target].inboundAck;

--- a/packages/solo/src/set-fake-chain.js
+++ b/packages/solo/src/set-fake-chain.js
@@ -39,7 +39,7 @@ export default function setFakeChain(basedir, GCI, fakeDelay) {
   };
   add(newconn);
   const connections = [];
-  for (const [_type, conns] of Object.entries(connsByType)) {
+  for (const conns of Object.values(connsByType)) {
     connections.push(...conns);
   }
   fs.writeFileSync(fn, `${JSON.stringify(connections, undefined, 2)}\n`);

--- a/packages/solo/src/set-fake-chain.js
+++ b/packages/solo/src/set-fake-chain.js
@@ -29,7 +29,9 @@ export default function setFakeChain(basedir, GCI, fakeDelay) {
     }
   };
 
-  JSON.parse(fs.readFileSync(fn)).forEach(add);
+  for (const conn of JSON.parse(fs.readFileSync(fn))) {
+    add(conn);
+  }
   const newconn = {
     type: 'fake-chain',
     GCI,
@@ -37,8 +39,8 @@ export default function setFakeChain(basedir, GCI, fakeDelay) {
   };
   add(newconn);
   const connections = [];
-  Object.entries(connsByType).forEach(([_type, conns]) =>
-    connections.push(...conns),
-  );
+  for (const [_type, conns] of Object.entries(connsByType)) {
+    connections.push(...conns);
+  }
   fs.writeFileSync(fn, `${JSON.stringify(connections, undefined, 2)}\n`);
 }

--- a/packages/solo/src/set-gci-ingress.js
+++ b/packages/solo/src/set-gci-ingress.js
@@ -58,7 +58,9 @@ export default function setGCIIngress(basedir, GCI, rpcAddresses, chainID) {
     }
   };
 
-  JSON.parse(fs.readFileSync(fn)).forEach(add);
+  for (const conn of JSON.parse(fs.readFileSync(fn))) {
+    add(conn);
+  }
   const newconn = {
     type: 'chain-cosmos-sdk',
     chainID,
@@ -68,9 +70,9 @@ export default function setGCIIngress(basedir, GCI, rpcAddresses, chainID) {
   };
   add(newconn);
   const connections = [];
-  // eslint-disable-next-line no-unused-vars
-  Object.entries(connsByType).forEach(([type, conns]) =>
-    connections.push(...conns),
-  );
+
+  for (const conns of Object.values(connsByType)) {
+    connections.push(...conns);
+  }
   fs.writeFileSync(fn, `${JSON.stringify(connections, undefined, 2)}\n`);
 }

--- a/packages/solo/src/set-gci-ingress.js
+++ b/packages/solo/src/set-gci-ingress.js
@@ -70,7 +70,6 @@ export default function setGCIIngress(basedir, GCI, rpcAddresses, chainID) {
   };
   add(newconn);
   const connections = [];
-
   for (const conns of Object.values(connsByType)) {
     connections.push(...conns);
   }

--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -306,14 +306,14 @@ export async function makeHTTPListener(
   server.listen(port, host, () => log.info('Listening on', `${host}:${port}`));
 
   const pingInterval = setInterval(function ping() {
-    wss.clients.forEach(ws => {
+    for (const ws of wss.clients) {
       if (!ws.isAlive) {
         ws.terminate();
         return;
       }
       ws.isAlive = false;
       ws.ping(() => {});
-    });
+    }
   }, 30000);
 
   wss.on('close', () => clearInterval(pingInterval));

--- a/packages/vats/test/demoAMM.test.js
+++ b/packages/vats/test/demoAMM.test.js
@@ -82,7 +82,7 @@ test('poolRates: spot check WETH', t => {
     interestRate: '0.025',
     mintFee: '0.0001',
   };
-  Object.entries(expected).forEach(([prop, val]) =>
-    t.is(showRatio(rates[prop]), val),
-  );
+  for (const [prop, val] of Object.entries(expected)) {
+    t.is(showRatio(rates[prop]), val);
+  }
 });

--- a/packages/wallet/api/src/pubsub.js
+++ b/packages/wallet/api/src/pubsub.js
@@ -11,9 +11,9 @@ export default function makePubsub(E) {
     },
     publish(m) {
       lastPublished = m;
-      subscribers.forEach(s => {
+      for (const s of subscribers) {
         E(s).notify(m);
-      });
+      }
     },
   });
 }

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -58,7 +58,7 @@ export function buildRootObject(vatPowers) {
 
   const pushOfferSubscriptions = (channelHandle, offers) => {
     const subs = offerSubscriptions.get(channelHandle);
-    (subs || []).forEach(({ origin, status }) => {
+    for (const { origin, status } of subs || []) {
       // Filter by optional status and origin.
       const result = harden(
         offers.filter(
@@ -75,7 +75,7 @@ export function buildRootObject(vatPowers) {
         },
         [channelHandle],
       );
-    });
+    }
   };
 
   const subscribeToOffers = (channelHandle, { origin, status = null }) => {

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -384,7 +384,9 @@ export async function main(
 
     stats.total += results.total;
     stats.pass += results.pass;
-    results.fail.forEach(info => stats.fail.push(info));
+    for (const info of results.fail) {
+      stats.fail.push(info);
+    }
   }
 
   console.log(stats.pass, 'tests passed');

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -47,7 +47,9 @@ export const cleanKeywords = uncleanKeywordRecord => {
 
   // Assert all names are ascii identifiers starting with
   // an upper case letter.
-  keywords.forEach(assertKeywordName);
+  for (const keyword of keywords) {
+    assertKeywordName(keyword);
+  }
 
   return /** @type {string[]} */ (keywords);
 };

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -18,7 +18,7 @@ import '../internal-types.js';
 const sumByBrand = amounts => {
   /** @type {MapStore<Brand, Amount>} */
   const sumsByBrand = makeScalarMapStore('brand');
-  amounts.forEach(amount => {
+  for (const amount of amounts) {
     const { brand } = amount;
     if (!sumsByBrand.has(brand)) {
       sumsByBrand.init(brand, amount);
@@ -26,7 +26,7 @@ const sumByBrand = amounts => {
       const sumSoFar = sumsByBrand.get(brand);
       sumsByBrand.set(brand, AmountMath.add(sumSoFar, amount));
     }
-  });
+  }
   return sumsByBrand;
 };
 
@@ -76,11 +76,11 @@ const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
     ...rightSumsByBrand.keys(),
   ]);
 
-  allBrands.forEach(brand => {
+  for (const brand of allBrands) {
     const { leftSum, rightSum } = getSums(brand);
     AmountMath.isEqual(leftSum, rightSum) ||
       Fail`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`;
-  });
+  }
 };
 
 /**

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -414,8 +414,6 @@ export const createSeatManager = (
         reallocate(/** @type {ZCFSeat[]} */ ...seats) {
           for (const seat of seats) {
             assertActive(seat);
-          }
-          for (const seat of seats) {
             assertStagedAllocation(seat);
           }
 

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -412,8 +412,12 @@ export const createSeatManager = (
           }
         },
         reallocate(/** @type {ZCFSeat[]} */ ...seats) {
-          seats.forEach(assertActive);
-          seats.forEach(assertStagedAllocation);
+          for (const seat of seats) {
+            assertActive(seat);
+          }
+          for (const seat of seats) {
+            assertStagedAllocation(seat);
+          }
 
           // Ensure that rights are conserved overall.
           const flattenAllocations = allocations =>
@@ -458,8 +462,9 @@ export const createSeatManager = (
             // for each of the seats) and inform Zoe of the
             // newAllocation.
 
-            seats.forEach(commitStagedAllocation);
-
+            for (const seat of seats) {
+              commitStagedAllocation(seat);
+            }
             const seatHandleAllocations = seats.map(seat => {
               const seatHandle = zcfSeatToSeatHandle.get(seat);
               return { seatHandle, allocation: seat.getCurrentAllocation() };

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -136,11 +136,10 @@ export const assertProposalShape = (seat, expected) => {
   !Array.isArray(expected) || Fail`Expected must be an non-array object`;
   const assertValuesNull = e => {
     if (e !== undefined) {
-      Object.values(e).forEach(
-        value =>
-          value === null ||
-          Fail`The value of the expected record must be null but was ${value}`,
-      );
+      for (const value of Object.values(e)) {
+        value === null ||
+          Fail`The value of the expected record must be null but was ${value}`;
+      }
     }
   };
 

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -20,7 +20,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   let highestBidSeat = bidSeats[0];
   let activeBidsCount = 0n;
 
-  bidSeats.forEach(bidSeat => {
+  for (const bidSeat of bidSeats) {
     if (!bidSeat.hasExited()) {
       activeBidsCount += 1n;
       const bid = bidSeat.getAmountAllocated('Bid', bidBrand);
@@ -35,7 +35,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
         secondHighestBid = bid;
       }
     }
-  });
+  }
 
   if (activeBidsCount === 0n) {
     throw sellSeat.fail(Error(`Could not close auction. No bids were active`));
@@ -59,10 +59,10 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   );
 
   sellSeat.exit();
-  bidSeats.forEach(bidSeat => {
+  for (const bidSeat of bidSeats) {
     if (!bidSeat.hasExited()) {
       bidSeat.exit();
     }
-  });
+  }
   zcf.shutdown('Auction closed.');
 };

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -64,7 +64,9 @@ const start = async zcf => {
   // In order to get all the brands, we must call zcf.getTerms() after
   // we create the liquidityIssuer
   const { brands } = zcf.getTerms();
-  Object.values(brands).forEach(brand => assertNatAssetKind(zcf, brand));
+  for (const brand of Object.values(brands)) {
+    assertNatAssetKind(zcf, brand);
+  }
   /** @type {Map<Brand,Keyword>} */
   const brandToKeyword = new Map(
     Object.entries(brands).map(([keyword, brand]) => [brand, keyword]),

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -146,11 +146,11 @@ const start = async (zcf, privateArgs) => {
     async wake(timestamp) {
       // Run all the queriers.
       const querierPs = [];
-      oracleRecords.forEach(({ querier }) => {
+      for (const { querier } of oracleRecords) {
         if (querier) {
           querierPs.push(querier(timestamp));
         }
-      });
+      }
       if (!querierPs.length) {
         // Only have push results, so publish them.
         // eslint-disable-next-line no-use-before-define

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -182,7 +182,9 @@ export const provideIssuerStorage = zcfBaggage => {
     if (!zcfBaggage.has(STORAGE_INSTANTIATED_KEY)) {
       zcfBaggage.init(STORAGE_INSTANTIATED_KEY, true);
       instantiated = true;
-      issuerRecords.forEach(storeIssuerRecord);
+      for (const record of issuerRecords) {
+        storeIssuerRecord(record);
+      }
     }
   };
 

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -80,14 +80,14 @@ export const provideEscrowStorage = baggage => {
     // Assert that all of the payment keywords are present in the give
     // keywords. Proposal.give keywords that do not have matching payments will
     // be caught in the deposit step.
-    paymentKeywords.forEach(keyword => {
+    for (const keyword of paymentKeywords) {
       giveKeywords.includes(keyword) ||
         Fail`The ${q(
           keyword,
         )} keyword in the paymentKeywordRecord was not a keyword in proposal.give, which had keywords: ${q(
           giveKeywords,
         )}`;
-    });
+    }
 
     // If any of these deposits hang or fail, then this `await` also
     // hangs or fails, the offer does not succeed, and any funds that

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -138,15 +138,15 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
     },
     exitAllSeats: ({ state }, completion) => {
       state.acceptingOffers = false;
-      Array.from(state.zoeSeatAdmins.keys()).forEach(zoeSeatAdmin =>
-        zoeSeatAdmin.exit(completion),
-      );
+      for (const zoeSeatAdmin of state.zoeSeatAdmins.keys()) {
+        zoeSeatAdmin.exit(completion);
+      }
     },
     failAllSeats: ({ state }, reason) => {
       state.acceptingOffers = false;
-      Array.from(state.zoeSeatAdmins.keys()).forEach(zoeSeatAdmin =>
-        zoeSeatAdmin.fail(reason),
-      );
+      for (const zoeSeatAdmin of state.zoeSeatAdmins.keys()) {
+        zoeSeatAdmin.fail(reason);
+      }
     },
     stopAcceptingOffers: ({ state }) => {
       state.acceptingOffers = false;

--- a/packages/zoe/test/unitTests/contracts/loan/updateDebt.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/updateDebt.test.js
@@ -19,6 +19,7 @@ test('test calculateInterest', async t => {
     t.is(interest.brand, brand);
   };
 
+  /** @type {Array<[oldDebt: bigint, interestRate: bigint, expected: bigint]>} */
   const expectations = [
     [40000n, 5n, 20n],
     [0n, 5n, 0n], // debt of 0 is 0 interest
@@ -27,5 +28,7 @@ test('test calculateInterest', async t => {
     [20392n, 1n, 3n],
   ];
 
-  expectations.forEach(testCalculateInterest);
+  for (const expectation of expectations) {
+    testCalculateInterest(expectation);
+  }
 });


### PR DESCRIPTION
Ref #9632

## Description
Replaced `Array.forEach();` calls with `for ( x of y ) { };` loops.

### Security Considerations
Assume that Array.forEach() calls are equivalent to `for ( x of y ) { };` in all cases.

### Scaling Considerations
No significant difference expected.

### Documentation Considerations
N/A

### Testing Considerations
No new tests required. Local tests passed, including lint (specific to this PR).

### Upgrade Considerations
The change preserves the behavior, thus there are no upgrade concerns.