### PR TITLE
fix vow failure handling

### DIFF
--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -91,20 +91,22 @@ const prepareRemoteChainFacadeKit = (
 
         /** @type {HostOf<Chain['makeAccount']>} */
         makeAccount() {
-          const { remoteChainInfo, connectionInfo } = this.state;
-          const stakingDenom = remoteChainInfo.stakingTokens?.[0]?.denom;
-          if (!stakingDenom) {
-            return asVow(Fail`chain info lacks staking denom`);
-          }
+          return asVow(() => {
+            const { remoteChainInfo, connectionInfo } = this.state;
+            const stakingDenom = remoteChainInfo.stakingTokens?.[0]?.denom;
+            if (!stakingDenom) {
+              throw Fail`chain info lacks staking denom`;
+            }
 
-          return watch(
-            E(orchestration).makeAccount(
-              remoteChainInfo.chainId,
-              connectionInfo.id,
-              connectionInfo.counterparty.connection_id,
-            ),
-            this.facets.makeAccountWatcher,
-          );
+            return watch(
+              E(orchestration).makeAccount(
+                remoteChainInfo.chainId,
+                connectionInfo.id,
+                connectionInfo.counterparty.connection_id,
+              ),
+              this.facets.makeAccountWatcher,
+            );
+          });
         },
       },
       makeAccountWatcher: {

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -2,6 +2,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
+import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
 import type { CosmosChainInfo, IBCConnectionInfo } from '../src/cosmos-api.js';
 import type { Chain } from '../src/orchestration-api.js';
 import { provideOrchestration } from '../src/utils/start-helper.js';
@@ -39,7 +40,7 @@ export const mockChainConnection: IBCConnectionInfo = {
   },
 };
 
-test('chain info', async t => {
+test.serial('chain info', async t => {
   const { bootstrap, facadeServices, commonPrivateArgs } = await commonSetup(t);
 
   const { zcf } = await setupZCFTest();
@@ -77,6 +78,53 @@ test('chain info', async t => {
 
   const result = (await handle()) as Chain<any>;
   t.deepEqual(await vt.when(result.getChainInfo()), mockChainInfo);
+});
+
+test.serial('faulty chain info', async t => {
+  const { facadeServices, commonPrivateArgs } = await commonSetup(t);
+
+  // XXX relax again so setupZCFTest can run. This is also why the tests are serial.
+  reincarnate({ relaxDurabilityRules: true });
+  const { zcf } = await setupZCFTest();
+
+  // After setupZCFTest because this disables relaxDurabilityRules
+  // which breaks Zoe test setup's fakeVatAdmin
+  const zone = provideDurableZone('test');
+  const vt = prepareSwingsetVowTools(zone);
+
+  const orchKit = provideOrchestration(
+    zcf,
+    zone.mapStore('test'),
+    {
+      agoricNames: facadeServices.agoricNames,
+      timerService: facadeServices.timerService,
+      storageNode: commonPrivateArgs.storageNode,
+      orchestrationService: facadeServices.orchestrationService,
+      localchain: facadeServices.localchain,
+    },
+    commonPrivateArgs.marshaller,
+  );
+
+  const { chainHub, orchestrate } = orchKit;
+
+  const { stakingTokens, ...sansStakingTokens } = mockChainInfo;
+
+  chainHub.registerChain('mock', sansStakingTokens);
+  chainHub.registerConnection(
+    'agoric-3',
+    mockChainInfo.chainId,
+    mockChainConnection,
+  );
+
+  const handle = orchestrate('mock', {}, async orc => {
+    const chain = await orc.getChain('mock');
+    const account = await chain.makeAccount();
+    return account;
+  });
+
+  await t.throwsAsync(handle(), {
+    message: 'chain info lacks staking denom',
+  });
 });
 
 test.todo('contract upgrade');


### PR DESCRIPTION
follow up on #9449 

## Description
https://github.com/Agoric/agoric-sdk/pull/9685 unwrapped an `asVow()` to get the promise failure to propagate. This reverts that now that https://github.com/Agoric/agoric-sdk/pull/9704 removed the need for it.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
not yet deployed