### PR TITLE
fix(deps): stop taming stack trace with 'unsafe'

### DIFF
--- a/patches/ses+1.5.0.patch
+++ b/patches/ses+1.5.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/ses/src/error/tame-error-constructor.js b/node_modules/ses/src/error/tame-error-constructor.js
+index 2788c42..c7f0518 100644
+--- a/node_modules/ses/src/error/tame-error-constructor.js
++++ b/node_modules/ses/src/error/tame-error-constructor.js
+@@ -173,12 +173,14 @@ export default function tameErrorConstructor(
+ 
+   let initialGetStackString = tamedMethods.getStackString;
+   if (platform === 'v8') {
+-    initialGetStackString = tameV8ErrorConstructor(
+-      FERAL_ERROR,
+-      InitialError,
+-      errorTaming,
+-      stackFiltering,
+-    );
++    if (errorTaming === 'safe') {
++      initialGetStackString = tameV8ErrorConstructor(
++        FERAL_ERROR,
++        InitialError,
++        errorTaming,
++        stackFiltering,
++      ); 
++    }
+   } else if (errorTaming === 'unsafe') {
+     // v8 has too much magic around their 'stack' own property for it to
+     // coexist cleanly with this accessor. So only install it on non-v8


### PR DESCRIPTION
closes:  #8662

## Description

If there's an error in a `.ts` test, the stack trace is without a useful line number:
```
  Rejected promise returned by test. Reason:

  Error {
    message: 'foo',
  }

  › file://test/facade.test.ts:1:1043
```

This patches `ses` so leave the stack trace alone in v8 if `errorTaming: 'unsafe'`.

```
  Rejected promise returned by test. Reason:

  Error {
    message: 'foo',
  }

  › <anonymous> (test/facade.test.ts:52:9)
```

### Security Considerations

More aggressively unsafe error taming, but only in V8 which does not run on chain.

### Scaling Considerations
none

### Documentation Considerations

This would differ from Endo. I don't know whether Endo should have this exact change or not. I'm just trying to get my tests in agoric-sdk working properly.

### Testing Considerations
Tested locally by forcing an error and seeing the change above.

### Upgrade Considerations
n/a