### PR TITLE
fix(vow): fix vow bug instead

### DIFF
--- a/packages/async-flow/src/replay-membrane.js
+++ b/packages/async-flow/src/replay-membrane.js
@@ -571,7 +571,7 @@ export const makeReplayMembrane = ({
           }
         }
       },
-    ).catch(reject);
+    );
     return promise;
   };
   harden(makeGuestForHostVow);

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -28,47 +28,54 @@ export const makeWhen = (
     // Ensure we don't run until a subsequent turn.
     await null;
 
-    // Ensure we have a presence that won't be disconnected later.
-    let result = await specimenP;
-    let payload = getVowPayload(result);
-    let priorRetryValue;
-    const seenPayloads = new WeakSet();
-    while (payload) {
-      // TODO: rely on endowed helpers for getting storable cap and performing
-      // shorten "next step"
-      const { vowV0 } = payload;
-      if (seenPayloads.has(vowV0)) {
-        throw Error('Vow resolution cycle detected');
+    try {
+      // Ensure we have a presence that won't be disconnected later.
+      let result = await specimenP;
+      let payload = getVowPayload(result);
+      let priorRetryValue;
+      const seenPayloads = new WeakSet();
+      while (payload) {
+        // TODO: rely on endowed helpers for getting storable cap and performing
+        // shorten "next step"
+        const { vowV0 } = payload;
+        if (seenPayloads.has(vowV0)) {
+          throw Error('Vow resolution cycle detected');
+        }
+        result = await basicE(vowV0)
+          .shorten()
+          .then(
+            res => {
+              seenPayloads.add(vowV0);
+              priorRetryValue = undefined;
+              return res;
+            },
+            e => {
+              const nextValue = isRetryableReason(e, priorRetryValue);
+              if (nextValue) {
+                // Shorten the same specimen to try again.
+                priorRetryValue = nextValue;
+                return result;
+              }
+              throw e;
+            },
+          );
+        // Advance to the next vow.
+        payload = getVowPayload(result);
       }
-      result = await basicE(vowV0)
-        .shorten()
-        .then(
-          res => {
-            seenPayloads.add(vowV0);
-            priorRetryValue = undefined;
-            return res;
-          },
-          e => {
-            const nextValue = isRetryableReason(e, priorRetryValue);
-            if (nextValue) {
-              // Shorten the same specimen to try again.
-              priorRetryValue = nextValue;
-              return result;
-            }
-            throw e;
-          },
-        );
-      // Advance to the next vow.
-      payload = getVowPayload(result);
-    }
 
-    const unwrapped = /** @type {EUnwrap<T>} */ (result);
+      const unwrapped = /** @type {EUnwrap<T>} */ (result);
 
-    // We've extracted the final result.
-    if (onFulfilled == null && onRejected == null) {
-      return /** @type {TResult1} */ (unwrapped);
+      // We've extracted the final result.
+      if (onFulfilled == null && onRejected == null) {
+        return /** @type {TResult1} */ (unwrapped);
+      }
+      return basicE.resolve(unwrapped).then(onFulfilled, onRejected);
+    } catch (thrownReason) {
+      if (onRejected == null) {
+        throw thrownReason;
+      }
+      return onRejected(thrownReason);
     }
-    return basicE.resolve(unwrapped).then(onFulfilled, onRejected);
   };
   harden(when);
 


### PR DESCRIPTION
Staged on #9696 

closes: #XXXX
refs: #XXXX

## Description

@mhofman 's comment at https://github.com/Agoric/agoric-sdk/pull/9696#discussion_r1676410729 indicated a puzzling rejection in a place that should not happen. If the code were correct, this extra `.catch(reject)` should not have been necessary, and should never do anything. The flaw in when.js is caused by the `await` at the top of

```js
        result = await basicE(vowV0)
          .shorten()
          .then(
            res => {...},
            e => {
              ...
              throw e;
            },
          );
```

The problem is that if that onRejected clause happens, it throws `e`. That should be fine, because it is in a `then` which will turn that throw into a rejected promise. However the `await` at the top of the above snippet turns it back into a thrown error.

This PR does not remove that `await`. That turned out to be trickier than I expected. Rather, it surrounds most of the `when` code with a `try/catch`, turning any error thrown in the body into a call to the `onRejected` callback if present.

Reviewers, please review with whitespace differences turned off. Or, @turadg , feel free to simply merge this PR into your #9696.

### Security Considerations
none beyond the usual: Correct code is better for security than incorrect code.
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
Would be good for this to be caught by a vow test. Attn @michaelfig 
### Upgrade Considerations
none