### PR TITLE
VowTools when honors rejection handler

### DIFF
--- a/packages/async-flow/test/async-flow.test.js
+++ b/packages/async-flow/test/async-flow.test.js
@@ -242,7 +242,7 @@ const testGoodReplay = async (t, zone) => {
       // same question. different answer
       t.is(prod2, 42);
       t.log('about to await p3');
-      await p3;
+      t.is(await p3.catch(r => r), 'done');
       t.log('p3 settled');
     },
   };
@@ -294,7 +294,7 @@ const testGoodReplay = async (t, zone) => {
   ]);
 
   // @ts-expect-error TS doesn't know it is a resolver
-  r3.resolve('done');
+  r3.reject('done');
   await eventLoopIteration();
 
   t.is(await when(outcomeV), undefined);

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -17,14 +17,10 @@ export const makeWhen = (
    * @see {@link ../../README.md}
    *
    * @template T
-   * @template [TResult1=EUnwrap<T>]
-   * @template [TResult2=never]
    * @param {T} specimenP value to unwrap
-   * @param {(value: EUnwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
-   * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
-   * @returns {Promise<TResult1 | TResult2>}
+   * @returns {Promise<EUnwrap<T>>}
    */
-  const when = async (specimenP, onFulfilled, onRejected) => {
+  const unwrap = async specimenP => {
     // Ensure we don't run until a subsequent turn.
     await null;
 
@@ -63,10 +59,30 @@ export const makeWhen = (
     }
 
     const unwrapped = /** @type {EUnwrap<T>} */ (result);
+    return unwrapped;
+  };
+
+  /**
+   * Shorten `specimenP` until we achieve a final result.
+   *
+   * Does not survive upgrade (even if specimenP is a durable Vow).
+   *
+   * @see {@link ../../README.md}
+   *
+   * @template T
+   * @template [TResult1=EUnwrap<T>]
+   * @template [TResult2=never]
+   * @param {T} specimenP value to unwrap
+   * @param {(value: EUnwrap<T>) => TResult1 | PromiseLike<TResult1>} [onFulfilled]
+   * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
+   * @returns {Promise<TResult1 | TResult2>}
+   */
+  const when = (specimenP, onFulfilled, onRejected) => {
+    const unwrapped = unwrap(specimenP);
 
     // We've extracted the final result.
     if (onFulfilled == null && onRejected == null) {
-      return /** @type {TResult1} */ (unwrapped);
+      return /** @type {Promise<TResult1>} */ (unwrapped);
     }
     return basicE.resolve(unwrapped).then(onFulfilled, onRejected);
   };

--- a/packages/vow/test/disconnect.test.js
+++ b/packages/vow/test/disconnect.test.js
@@ -54,7 +54,12 @@ test('retry on disconnection', async t => {
     [2, 'disco', 'disco', 'sad'],
   ];
 
-  for await (const pattern of ['when', 'watch']) {
+  for await (const pattern of [
+    'when',
+    'when-with-handlers',
+    'watch',
+    'watch-with-handler',
+  ]) {
     t.log('testing', pattern);
     for await (const [final, ...plan] of PLANS) {
       t.log(`testing (plan=${plan}, ${pattern})`);
@@ -66,7 +71,7 @@ test('retry on disconnection', async t => {
 
       let resultP;
       switch (pattern) {
-        case 'watch': {
+        case 'watch-with-handler': {
           const resultW = watch(vow, {
             onFulfilled(value) {
               t.is(plan[final], 'happy');
@@ -83,8 +88,22 @@ test('retry on disconnection', async t => {
           resultP = when(resultW);
           break;
         }
+        case 'watch': {
+          const resultW = watch(vow);
+          t.is('then' in resultW, false, 'watch resultW.then is undefined');
+          resultP = when(resultW).catch(e => ['rejected', e]);
+          break;
+        }
         case 'when': {
           resultP = when(vow).catch(e => ['rejected', e]);
+          break;
+        }
+        case 'when-with-handlers': {
+          resultP = when(
+            vow,
+            v => v,
+            e => ['rejected', e],
+          );
           break;
         }
         default: {


### PR DESCRIPTION
closes: #9703

## Description
Split `when` into a base `unwrap` and a `when` helper which accepts fulfillment and rejection handlers

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Added coverage for both `when` and `watch` without handlers
Adds vow rejection test in async-flow

### Upgrade Considerations
None of the usages in upgrade-16 use a handler for `when`, but we should incorporate this change in the upgrade-16 branch regardless and publish new NPM packages for dapps.