### PR TITLE
ci: Update after-merge workflow to tolerate non-dirty git state

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -75,13 +75,13 @@ jobs:
               ;;
           esac
           # Prevent `lerna publish` from failing due to uncommitted changes.
-          git stash
+          git stash || true
           # without concurrency until https://github.com/Agoric/agoric-sdk/issues/8091
           yarn lerna publish --concurrency 1 --conventional-prerelease --canary --exact \
             --dist-tag=$TAG --preid=$TAG-$(git rev-parse --short=7 HEAD) \
             --no-push --no-verify-access --yes
-          # restore the stashed changes for caching
-          git stash apply
+          # restore any stashed changes for caching
+          git stash pop || true
       - name: notify on failure
         if: failure()
         uses: ./.github/actions/notify-status


### PR DESCRIPTION
Ref #9709
Ref #9708

## Description
As of #9709, git state might not include untracked files after our custom [restore-node GitHub action](https://github.com/Agoric/agoric-sdk/blob/7bde505dd23289218a19bc86f8e94bbff48b65e0/.github/actions/restore-node/action.yml), in which case the after-merge workflow job "dev-canary" will execute a [no-op `git stash` followed later by a no-op `git stash apply`](https://github.com/Agoric/agoric-sdk/blob/7bde505dd23289218a19bc86f8e94bbff48b65e0/.github/workflows/after-merge.yml#L78-L84), the latter of which exits with a non-zero status code that fails the step and thereby the containing job.

This PR fixes things to tolerate absence of any stashed changes.

### Security Considerations
No relevant change.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
It's difficult to test these kinds of changes, but the proof of the pudding is in the taste.

### Upgrade Considerations
n/a