### PR TITLE
watchPromise fixes

### DIFF
--- a/packages/swingset-liveslots/src/watchedPromises.js
+++ b/packages/swingset-liveslots/src/watchedPromises.js
@@ -139,6 +139,12 @@ export function makeWatchedPromiseManager({
    */
   function loadWatchedPromiseTable(revivePromise) {
     for (const vpid of watchedPromiseTable.keys()) {
+      if (promiseRegistrations.has(vpid)) {
+        // We're only interested in reconnecting the promises from the previous
+        // incarnation. Any promise watched during buildRootObject would have
+        // already created a registration.
+        continue;
+      }
       const p = revivePromise(vpid);
       promiseRegistrations.init(vpid, p);
       pseudoThen(p, vpid);

--- a/packages/swingset-liveslots/test/liveslots-helpers.js
+++ b/packages/swingset-liveslots/test/liveslots-helpers.js
@@ -131,6 +131,7 @@ export async function makeDispatch(
   build,
   vatID = 'vatA',
   liveSlotsOptions = {},
+  vatParameters = undefined,
 ) {
   const gcTools = harden({
     WeakRef,
@@ -150,7 +151,7 @@ export async function makeDispatch(
       return { buildRootObject: build };
     },
   );
-  await dispatch(['startVat', kser()]);
+  await dispatch(['startVat', kser(vatParameters)]);
   return { dispatch, testHooks };
 }
 
@@ -171,6 +172,7 @@ function makeRPMaker(nextNumber = 1) {
  * @param {Map<string, string>} [options.kvStore]
  * @param {number} [options.nextPromiseImportNumber]
  * @param {boolean} [options.skipLogging]
+ * @param {any} [options.vatParameters]
  */
 export async function setupTestLiveslots(
   t,
@@ -183,6 +185,7 @@ export async function setupTestLiveslots(
     kvStore = new Map(),
     nextPromiseImportNumber,
     skipLogging = false,
+    vatParameters,
   } = options;
   const { log, syscall, fakestore } = buildSyscall({ skipLogging, kvStore });
   const nextRP = makeRPMaker(nextPromiseImportNumber);
@@ -190,6 +193,8 @@ export async function setupTestLiveslots(
     syscall,
     buildRootObject,
     vatName,
+    {},
+    vatParameters,
   );
 
   async function dispatchMessage(message, ...args) {


### PR DESCRIPTION
closes: #9728
closes: #9732
closes: #9747

## Description
This PR fixes a couple issues in `watchPromise` to support promises watched during buildRootObject or re-imported in vatParameters. 
It also refactors and update the tests for watchPromise to exercise these cases and others that were previously not sufficiently tested, including explicitly observing the watcher as invoked across upgrades.

While testing for #9728, I discovered that promises "allocated by vat" are rejected if not recognized, which can happen across upgrades. As described in #9747, we don't usually check which vat allocated a promise. Since that check is misguided, this PR removes it for promises.

Drive by fix a an unhandled rejection on failed start vat.

### Security Considerations
None. This effectively changes into early returns some assertions which were too strong.

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Updated unit tests

### Upgrade Considerations
Requires upgrading liveslots as part of a chain software upgrade before any vat using `watchPromise` during start/upgrade is upgraded, or before a previously exported promise can be reimported.
