### PR TITLE
refactor: change `.then` and `.catch` to `await` in `try-catch`

### DIFF
--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -26,7 +26,7 @@ import { withOrchestration } from '../utils/start-helper.js';
  * @param {Amount<'nat'>} offerArgs.staked
  * @param {CosmosValidatorAddress} offerArgs.validator
  */
-const stackAndSwapFn = async (orch, { localTransfer }, seat, offerArgs) => {
+const stakeAndSwapFn = async (orch, { localTransfer }, seat, offerArgs) => {
   const { give } = seat.getProposal();
 
   const omni = await orch.getChain('omniflixhub');
@@ -52,12 +52,12 @@ const stackAndSwapFn = async (orch, { localTransfer }, seat, offerArgs) => {
     slippage: 0.03,
   });
 
-  await localAccount
-    .transferSteps(give.Stable, transferMsg)
-    .then(_txResult =>
-      omniAccount.delegate(offerArgs.validator, offerArgs.staked),
-    )
-    .catch(e => console.error(e));
+  try {
+    await localAccount.transferSteps(give.Stable, transferMsg);
+    await omniAccount.delegate(offerArgs.validator, offerArgs.staked);
+  } catch (e) {
+    console.error(e);
+  }
 };
 
 /** @type {ContractMeta<typeof start>} */
@@ -105,7 +105,7 @@ const contract = async (zcf, privateArgs, zone, { orchestrate, zoeTools }) => {
   const swapAndStakeHandler = orchestrate(
     'LSTTia',
     { zcf, localTransfer: zoeTools.localTransfer },
-    stackAndSwapFn,
+    stakeAndSwapFn,
   );
 
   const publicFacet = zone.exo('publicFacet', undefined, {

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -104,6 +104,8 @@ integrationTest() {
   # Install the Agoric CLI on this machine's $PATH.
   case $1 in
     link-cli | link-cli/*)
+      # Prevent retries from failing with "must not already exist"
+      rm -f "$HOME/bin/agoric"
       yarn link-cli "$HOME/bin/agoric"
       persistVar AGORIC_CMD "[\"$HOME/bin/agoric\"]"
       ;;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: Agoric/documentation#1158

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Refactor to clarify some code by using `try { await... } catch (e) {...}` rather than calling a promise's `.then` and `.catch` methods explicitly.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
Updated `swapExample.contract.js` in Agoric/documentation#1158 as well.
