### PR TITLE
config lint to harden exports

### DIFF
--- a/packages/boot/test/bootstrapTests/zcf-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/zcf-upgrade.test.ts
@@ -11,7 +11,7 @@ import { makeZoeDriver } from '../../tools/drivers.ts';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
-const ZCF_PROBE_SRC = './zcfProbe.js';
+const ZCF_PROBE_SRC = './zcfProbe.contract.js';
 
 /**
  * @file Bootstrap test of upgrading ZCF to support atomicRearrange internally.
@@ -85,7 +85,7 @@ test('run restart-vats proposal', async t => {
   await controller.validateAndInstallBundle(zcfProbeBundle);
   // This test self-sufficiently builds all the artifacts it needs. The test in
   // .../packages/deployment/upgradeTest/upgrade-test-scripts/unreleased-upgrade/zoe-upgrade/
-  // needs a bundled copy of ./zcfProbe.js as of the final commit that will be
+  // needs a bundled copy of ./zcfProbe.contract.js as of the final commit that will be
   // installed on-chain. Uncomment the following line and add
   // `import fs from "fs";` to generate a bundle of the contract.
   // fs.writeFileSync('bundles/prober-contract-bundle.json', JSON.stringify(zcfProbeBundle));

--- a/packages/boot/test/bootstrapTests/zcfProbe.contract.js
+++ b/packages/boot/test/bootstrapTests/zcfProbe.contract.js
@@ -151,3 +151,4 @@ export const start = async (zcf, privateArgs, baggage) => {
     creatorFacet: probe,
   });
 };
+harden(start);

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -112,6 +112,7 @@ module.exports = {
       files: ['**/*.flows.js'],
       rules: {
         'no-restricted-syntax': ['error', ...orchestrationFlowRestrictions],
+        '@endo/harden-exports': 'error',
       },
     },
   ],

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -108,6 +108,13 @@ module.exports = {
       },
     },
     {
+      // Zoe contract module
+      files: ['**/*.contract.js'],
+      rules: {
+        '@endo/harden-exports': 'error',
+      },
+    },
+    {
       // Orchestration flows
       files: ['**/*.flows.js'],
       rules: {

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -108,7 +108,7 @@ export const makeAllManagersDo = (collateralManagers, vaultManagers) => {
  * @param {ERef<Marshaller>} marshaller
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeERecorderKit} makeERecorderKit
- * @param managerParams
+ * @param {Record<string, import('./params.js').VaultManagerParamOverrides>} managerParams
  */
 const prepareVaultDirector = (
   baggage,

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -59,11 +59,8 @@ harden(setUpZoeForTest);
  */
 export const setupBootstrap = async (t, optTimer) => {
   const trace = makeTracer('PromiseSpace', false);
-  const space = /** @type {any} */ (makePromiseSpace(trace));
-  const { produce, consume } = /**
-   * @type {import('../src/proposals/econ-behaviors.js').EconomyBootstrapPowers &
-   *     BootstrapPowers}
-   */ (space);
+  const space = /** @type {Space} */ (makePromiseSpace(trace));
+  const { produce, consume } = space;
 
   await produceDiagnostics(space);
 

--- a/packages/orchestration/src/examples/auto-stake-it.contract.js
+++ b/packages/orchestration/src/examples/auto-stake-it.contract.js
@@ -86,5 +86,6 @@ const contract = async (
 };
 
 export const start = withOrchestration(contract);
+harden(start);
 
 /** @typedef {typeof start} AutoStakeItSF */

--- a/packages/orchestration/src/examples/auto-stake-it.flows.js
+++ b/packages/orchestration/src/examples/auto-stake-it.flows.js
@@ -102,3 +102,4 @@ export const makeAccounts = async (
   );
   return portfolioHolder.asContinuingOffer();
 };
+harden(makeAccounts);

--- a/packages/orchestration/src/examples/basic-flows.contract.js
+++ b/packages/orchestration/src/examples/basic-flows.contract.js
@@ -61,5 +61,6 @@ const contract = async (
 };
 
 export const start = withOrchestration(contract);
+harden(start);
 
 /** @typedef {typeof start} BasicFlowsSF */

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -30,6 +30,7 @@ export const makeOrchAccount = async (orch, _ctx, seat, { chainName }) => {
   const orchAccount = await remoteChain.makeAccount();
   return orchAccount.asContinuingOffer();
 };
+harden(makeOrchAccount);
 
 /**
  * Create accounts on multiple chains and return them in a single continuing
@@ -77,3 +78,4 @@ export const makePortfolioAccount = async (
 
   return portfolioHolder.asContinuingOffer();
 };
+harden(makePortfolioAccount);

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -33,6 +33,7 @@ export const SingleAmountRecord = M.and(
   }),
   M.not(harden({})),
 );
+harden(SingleAmountRecord);
 
 /**
  * Orchestration contract to be wrapped by withOrchestration for Zoe
@@ -86,3 +87,4 @@ const contract = async (
 };
 
 export const start = withOrchestration(contract);
+harden(start);

--- a/packages/orchestration/src/examples/sendAnywhere.flows.js
+++ b/packages/orchestration/src/examples/sendAnywhere.flows.js
@@ -21,12 +21,12 @@ const { entries } = Object;
  * @param {ZCFSeat} seat
  * @param {{ chainName: string; destAddr: string }} offerArgs
  */
-export async function sendIt(
+export const sendIt = async (
   orch,
   { contractState, localTransfer },
   seat,
   offerArgs,
-) {
+) => {
   mustMatch(offerArgs, harden({ chainName: M.scalar(), destAddr: M.string() }));
   const { chainName, destAddr } = offerArgs;
   // NOTE the proposal shape ensures that the `give` is a single asset
@@ -59,5 +59,5 @@ export async function sendIt(
       chainId,
     },
   );
-}
+};
 harden(sendIt);

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -123,3 +123,4 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   return { publicFacet };
 };
+harden(start);

--- a/packages/orchestration/src/examples/stakeIca.contract.js
+++ b/packages/orchestration/src/examples/stakeIca.contract.js
@@ -37,7 +37,9 @@ export const meta = harden({
     timer: TimerServiceShape,
   },
 });
+harden(meta);
 export const privateArgsShape = meta.privateArgsShape;
+harden(privateArgsShape);
 
 /**
  * @typedef {{
@@ -150,5 +152,6 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   return { publicFacet };
 };
+harden(start);
 
 /** @typedef {typeof start} StakeIcaSF */

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -82,6 +82,7 @@ harden(meta);
  */
 export const makeNatAmountShape = (brand, min) =>
   harden({ brand, value: min ? M.gte(min) : M.nat() });
+harden(makeNatAmountShape);
 
 /**
  * Orchestration contract to be wrapped by withOrchestration for Zoe
@@ -127,3 +128,4 @@ const contract = async (zcf, privateArgs, zone, { orchestrate, zoeTools }) => {
 };
 
 export const start = withOrchestration(contract);
+harden(start);

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -85,3 +85,4 @@ const contract = async (zcf, privateArgs, zone, { orchestrate }) => {
 };
 
 export const start = withOrchestration(contract);
+harden(start);

--- a/packages/orchestration/test/examples/bad.flows.js
+++ b/packages/orchestration/test/examples/bad.flows.js
@@ -5,21 +5,29 @@
  */
 
 // TODO error on exports that:
-// - aren't hardened (probably a new rule in @endo/eslint-plugin )
 // - don't satisfy orchestration flow type
 
 // eslint-disable-next-line no-restricted-syntax -- intentional for test
 import { E } from '@endo/far';
 
-export function notFlow() {
-  console.log('This function is not a flow');
+// eslint-disable-next-line @endo/harden-exports -- intentional for test
+export function unhardenable() {
+  console.log('hardening on function keyword is not safe due to hoisting');
 }
+harden(unhardenable);
 
+export const notFlow = () => {
+  console.log('This function is not a flow');
+};
+harden(notFlow);
+
+// eslint-disable-next-line @endo/harden-exports -- intentional for test
 export async function notHardened() {
   console.log('This function is the most minimal flow, but it’s not hardened');
 }
 
-export async function usesE(orch, { someEref }) {
+export const usesE = async (orch, { someEref }) => {
   // eslint-disable-next-line no-restricted-syntax -- intentional for test
   await E(someEref).foo();
-}
+};
+harden(usesE);


### PR DESCRIPTION
closes: #9693 

## Description

more linting for #9693, using https://github.com/endojs/endo/pull/2369

Also adopts `harden-exports` for `.contract.js` modules,
- https://github.com/Agoric/agoric-sdk/issues/4770

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI with expected errors

### Upgrade Considerations
n/a
