### PR TITLE
docs: add badges for build status, license and auto-wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Agoric Platform SDK
 
+![unit tests status](https://github.com/Agoric/agoric-sdk/actions/workflows/test-all-packages.yml/badge.svg)
+![integration tests status](https://github.com/Agoric/agoric-sdk/actions/workflows/integration.yml/badge.svg)
+[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
+[![Mutable.ai Auto Wiki](https://img.shields.io/badge/Auto_Wiki-Mutable.ai-blue)](https://wiki.mutable.ai/Agoric/agoric-sdk)
+
 This repository contains most of the packages that make up the upper
 layers of the Agoric platform, with
 [the endo repository](https://github.com/endojs/endo)


### PR DESCRIPTION
_incidental_

## Description

The auto-wiki from Mutable.ai is quite useful. Provide a link: https://wiki.mutable.ai/Agoric/agoric-sdk

While adding that badge I noticed we lacked a couple other important ones so this adds those too.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
nothing more

### Testing Considerations
Reviewers, take a look at the rendered README

### Upgrade Considerations
none
