### PR TITLE
require bridge in cosmic-swingset

### DIFF
--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -12,7 +12,6 @@ import addChain from './add-chain.js';
 import initBasedir from './init-basedir.js';
 import resetState from './reset-state.js';
 import setGCIIngress from './set-gci-ingress.js';
-import setFakeChain from './set-fake-chain.js';
 import start from './start.js';
 
 const log = anylogger('ag-solo');
@@ -118,13 +117,6 @@ start
       const chainID = subOpts.chainID || 'agoric';
       const rpcAddresses = subArgs.slice(1);
       setGCIIngress(basedir, GCI, rpcAddresses, chainID);
-      break;
-    }
-    case 'set-fake-chain': {
-      const basedir = insistIsBasedir();
-      const { _: subArgs, delay } = parseArgs(argv.slice(1), {});
-      const GCI = subArgs[0];
-      setFakeChain(basedir, GCI, delay);
       break;
     }
     case 'start': {

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -40,7 +40,7 @@ import {
 } from '@agoric/cosmic-swingset/src/kernel-stats.js';
 
 import { deliver, addDeliveryTarget } from './outbound.js';
-import { connectToPipe } from './pipe.js';
+// import { connectToPipe } from './pipe.js';
 import { makeHTTPListener } from './web.js';
 
 import { connectToChain } from './chain-cosmos-sdk.js';
@@ -518,16 +518,6 @@ const start = async (basedir, argv) => {
             addDeliveryTarget(c.GCI, deliverator);
           }
           break;
-        case 'fake-chain': {
-          log(`adding follower/sender for fake chain ${c.GCI}`);
-          const deliverator = await connectToPipe({
-            method: 'connectToFakeChain',
-            args: [basedir, c.GCI, c.fakeDelay],
-            deliverInboundToMbx,
-          });
-          addDeliveryTarget(c.GCI, deliverator);
-          break;
-        }
         case 'http': {
           log(`adding HTTP/WS listener on ${c.host}:${c.port}`);
           !broadcastJSON || Fail`duplicate type=http in connections.json`;

--- a/packages/solo/test/home.test.js
+++ b/packages/solo/test/home.test.js
@@ -48,7 +48,7 @@ test.before('setup', async t => {
 // Now come the tests that use `home`...
 // =========================================
 
-test.serial('home.board', async t => {
+test.skip('home.board', async t => {
   const { home } = t.context;
   const { board } = E.get(home);
   await t.throwsAsync(
@@ -73,7 +73,7 @@ test.serial('home.board', async t => {
   t.is(myId2, myId, `board gives the same id for the same value`);
 });
 
-test.serial('home.wallet - transfer funds to the feePurse', async t => {
+test.skip('home.wallet - transfer funds to the feePurse', async t => {
   const { home } = t.context;
   const { wallet, faucet } = E.get(home);
   const feePurse = E(faucet).getFeePurse();
@@ -86,7 +86,7 @@ test.serial('home.wallet - transfer funds to the feePurse', async t => {
   t.deepEqual(deposited, feeAmount, `all fees deposited to feePurse`);
 });
 
-test.serial('home.wallet - receive zoe invite', async t => {
+test.skip('home.wallet - receive zoe invite', async t => {
   const { home, loadBundle } = t.context;
   const { wallet, zoe, board } = E.get(home);
 
@@ -133,7 +133,7 @@ test.serial('home.wallet - receive zoe invite', async t => {
   );
 });
 
-test.serial('home.wallet - central issuer setup', async t => {
+test.skip('home.wallet - central issuer setup', async t => {
   const { home } = t.context;
   const { wallet } = E.get(home);
 

--- a/packages/solo/test/startsolo.sh
+++ b/packages/solo/test/startsolo.sh
@@ -5,7 +5,6 @@ AG_SOLO=$(cd .. && pwd)/bin/ag-solo
 
 TDIR="${TMPDIR-/tmp}/startsolo.$$"
 trap 'rm -rf "$TDIR"' EXIT
-"$AG_SOLO" init "$TDIR" --egresses=fake --webport=$PORT --defaultManagerType=local
+"$AG_SOLO" init "$TDIR" --webport=$PORT --defaultManagerType=local
 cd "$TDIR"
-"$AG_SOLO" set-fake-chain --delay=0 mySimGCI
 exec "$AG_SOLO" start

--- a/packages/vats/src/core/client-behaviors.js
+++ b/packages/vats/src/core/client-behaviors.js
@@ -1,4 +1,3 @@
-import { Fail } from '@endo/errors';
 import { E, Far } from '@endo/far';
 import { makePluginManager } from '@agoric/swingset-vat/src/vats/plugin-manager.js';
 import { observeNotifier } from '@agoric/notifier';
@@ -136,7 +135,13 @@ export const startClient = async ({
   }
 
   const addChainPresences = async () => {
-    FIXME_GCI || Fail`client must be given GCI`;
+    if (!FIXME_GCI) {
+      chainBundle = {
+        DISCONNECTED: `Chain is disconnected: no GCI provided`,
+      };
+      void updatePresences();
+      return;
+    }
     await addRemote(FIXME_GCI);
     // addEgress(..., index, ...) is called in vat-provisioning.
     const chainProvider = E(vats.comms).addIngress(

--- a/packages/wallet/api/deploy.js
+++ b/packages/wallet/api/deploy.js
@@ -16,6 +16,7 @@ export default async function deployWallet(
   // console.log('have home', home);
   const {
     agoric: {
+      DISCONNECTED,
       agoricNames,
       bank,
       namesByAddress,
@@ -26,6 +27,11 @@ export default async function deployWallet(
     },
     local: { http, localTimerService, spawner, wallet: oldWallet, scratch },
   } = home;
+
+  if (DISCONNECTED) {
+    console.warn(DISCONNECTED);
+    return;
+  }
 
   let walletVat = await E(scratch).get('wallet/api');
   if (!walletVat) {


### PR DESCRIPTION
refs: #9725

## Description
On the path to,
- #9725 

Remove concessions in SwingSet to `@agoric/cosmic-swingset/src/sim-chain.js` by requiring a bridgeDevice.

Since `sim-chain` is no longer supported, we remove the ability to use it from `@agoric/solo`.  This makes several of the tests in `@agoric/solo` fail, so we skip those that relied on `sim-chain`, while continuing to test the `ag-solo` basic functionality.   We don't remove `@agoric/solo` because it serves as an example of a non-chain SwingSet application, and @michaelfig would like to refactor it into a configuration of a general `agvm` program.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI suffices

### Upgrade Considerations

On-chain uses always provide a bridge device. This does affect line numbers. It will go out with the next kernel upgrade.