### PR TITLE
feat(patches): patch in endo #2377

### DIFF
--- a/patches/@endo+import-bundle+1.1.2.patch
+++ b/patches/@endo+import-bundle+1.1.2.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@endo/import-bundle/src/compartment-wrapper.js b/node_modules/@endo/import-bundle/src/compartment-wrapper.js
-index b5bc57d..3898a20 100644
+index b5bc57d..bd42014 100644
 --- a/node_modules/@endo/import-bundle/src/compartment-wrapper.js
 +++ b/node_modules/@endo/import-bundle/src/compartment-wrapper.js
-@@ -42,11 +42,14 @@ export function wrapInescapableCompartment(
+@@ -42,10 +42,32 @@ export function wrapInescapableCompartment(
      // there are details to work out.
      c.globalThis.Compartment = NewCompartment;
  
@@ -10,12 +10,29 @@ index b5bc57d..3898a20 100644
 +    // Use Reflect.ownKeys, not Object.keys, because we want both
 +    // string-named and symbol-named properties. Note that
 +    // Reflect.ownKeys also includes non-enumerable keys.
++    // This differs from the longer term agreement discussed at
++    // https://www.youtube.com/watch?v=xlR21uDigGE in these ways:
++    // - The option in question should be named `inescapableGlobals` since
++    //   we want to reserve `*Properties` for descriptor copying rather
++    //   than value copying.
++    // - We don't plan to support such `*Properties` options at this time.
++    //   Rather, we should deprecate (and eventually remove) this one
++    //   once we introduce`inescapableGlobals`.
++    // - We plan to move these options to the `Compartment` constructor itself,
++    //   in which case their support in import-bundle will just forward
++    //   to `Compartment`.
++    // - Following the `assign`-like semantics agree on in that meeting,
++    //   this should only copy enumerable own properties, whereas the loop
++    //   below copies all own properties.
++    // The loop here does follow this agreement by differing from `assign` in
++    // making all the target properties non-enumerable. The agreement would
++    // further align the normal `Compartment` endowments argument to also
++    // make the target properties non-enumerable.
 +    for (const prop of Reflect.ownKeys(inescapableGlobalProperties)) {
        Object.defineProperty(c.globalThis, prop, {
          value: inescapableGlobalProperties[prop],
          writable: true,
--        enumerable: false,
-+        enumerable: false, // TODO: really? why?
++        // properties of globalThis are generally non-enumerable
+         enumerable: false,
          configurable: true,
        });
-     }

--- a/patches/@endo+import-bundle+1.1.2.patch
+++ b/patches/@endo+import-bundle+1.1.2.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/@endo/import-bundle/src/compartment-wrapper.js b/node_modules/@endo/import-bundle/src/compartment-wrapper.js
+index b5bc57d..3898a20 100644
+--- a/node_modules/@endo/import-bundle/src/compartment-wrapper.js
++++ b/node_modules/@endo/import-bundle/src/compartment-wrapper.js
+@@ -42,11 +42,14 @@ export function wrapInescapableCompartment(
+     // there are details to work out.
+     c.globalThis.Compartment = NewCompartment;
+ 
+-    for (const prop of Object.keys(inescapableGlobalProperties)) {
++    // Use Reflect.ownKeys, not Object.keys, because we want both
++    // string-named and symbol-named properties. Note that
++    // Reflect.ownKeys also includes non-enumerable keys.
++    for (const prop of Reflect.ownKeys(inescapableGlobalProperties)) {
+       Object.defineProperty(c.globalThis, prop, {
+         value: inescapableGlobalProperties[prop],
+         writable: true,
+-        enumerable: false,
++        enumerable: false, // TODO: really? why?
+         configurable: true,
+       });
+     }


### PR DESCRIPTION
Patches in https://github.com/endojs/endo/pull/2377 "feat(import-bundle): accept symbol-named properties on inescapableGlobalProperties"

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2377 https://github.com/Agoric/agoric-sdk/pull/9431 https://github.com/Agoric/agoric-sdk/pull/8051 https://github.com/endojs/endo/pull/1676 https://github.com/Agoric/agoric-sdk/pull/9431

## Description

Before this and related PRs, the `passStyleOf` created by the `@endo/pass-style` package as bundled in contracts was using the `globalThis.WeakMap` it found on its global to build its memo table. Under liveslots, this was the Virtual Object Aware WeakMap, which caused a cumulative leak. 

To fix this, https://github.com/endojs/endo/pull/1676 changed `@endo/pass-style` to look for a symbol-named property to serve as the endowed `passStyleOf`. #9431 on #8051 change liveslots to provide that endowment -- its own `passStyleOf` made with the primordial non-leaky `WeakMap`. The remaining piece is https://github.com/endojs/endo/pull/2377 , which modifies `@endo/import-bundle` to pass through such symbol-named endowment properties. To get ahead of the next endo-release-agoric-sdk-sync cycle, this PR temporarily patches https://github.com/endojs/endo/pull/2377 until then, so we can test and use the performance difference immediately.

### Security Considerations
none

### Scaling Considerations
The point. By itself none, but enables #9431 , which should cure that memory leak.

### Documentation Considerations
For this temporary patch PR, none

### Testing Considerations
Enables us to test the performance difference #9431 would make.

### Upgrade Considerations
See https://github.com/endojs/endo/pull/2377