### PR TITLE
feat: add UpdateValidator and CancelAutoStake invitations to auto-stake-it

### DIFF
--- a/packages/orchestration/src/examples/auto-stake-it-tap-kit.js
+++ b/packages/orchestration/src/examples/auto-stake-it-tap-kit.js
@@ -56,6 +56,9 @@ const prepareStakingTapKit = (zone, { watch }) => {
           M.or(VowShape, M.undefined()),
         ),
       }),
+      holder: M.interface('Holder', {
+        updateValidator: M.call(ChainAddressShape).returns(),
+      }),
       transferWatcher: M.interface('TransferWatcher', {
         onFulfilled: M.call(M.undefined())
           .optional(M.bigint())
@@ -113,6 +116,15 @@ const prepareStakingTapKit = (zone, { watch }) => {
           );
         },
       },
+      holder: {
+        /**
+         * @param {CosmosValidatorAddress} validator
+         */
+        updateValidator(validator) {
+          mustMatch(validator, ChainAddressShape);
+          this.state.validator = validator;
+        },
+      },
       transferWatcher: {
         /**
          * @param {void} _result
@@ -146,11 +158,17 @@ const prepareStakingTapKit = (zone, { watch }) => {
  * @param {VowTools} vowTools
  * @returns {(
  *   ...args: Parameters<ReturnType<typeof prepareStakingTapKit>>
- * ) => ReturnType<ReturnType<typeof prepareStakingTapKit>>['tap']}
+ * ) => {
+ *   holder: ReturnType<ReturnType<typeof prepareStakingTapKit>>['holder'];
+ *   tap: ReturnType<ReturnType<typeof prepareStakingTapKit>>['tap'];
+ * }}
  */
 export const prepareStakingTap = (zone, vowTools) => {
   const makeKit = prepareStakingTapKit(zone, vowTools);
-  return (...args) => makeKit(...args).tap;
+  return (...args) => {
+    const { tap, holder } = makeKit(...args);
+    return harden({ tap, holder });
+  };
 };
 
 /** @typedef {ReturnType<typeof prepareStakingTap>} MakeStakingTap */

--- a/packages/orchestration/src/examples/auto-stake-it.flows.js
+++ b/packages/orchestration/src/examples/auto-stake-it.flows.js
@@ -66,7 +66,7 @@ export const makeAccounts = async (
   assert(transferChannel.counterPartyChannelId, 'unable to find sourceChannel');
 
   // Every time the `localAccount` receives `remoteDenom` over IBC, delegate it.
-  const tap = makeStakingTap({
+  const { tap } = makeStakingTap({
     localAccount,
     stakingAccount,
     validator,

--- a/packages/orchestration/src/examples/auto-stake-it.flows.js
+++ b/packages/orchestration/src/examples/auto-stake-it.flows.js
@@ -66,7 +66,7 @@ export const makeAccounts = async (
   assert(transferChannel.counterPartyChannelId, 'unable to find sourceChannel');
 
   // Every time the `localAccount` receives `remoteDenom` over IBC, delegate it.
-  const { tap } = makeStakingTap({
+  const { tap, holder: tapHolder } = makeStakingTap({
     localAccount,
     stakingAccount,
     validator,
@@ -76,9 +76,8 @@ export const makeAccounts = async (
     remoteDenom,
     localDenom,
   });
-  // XXX consider storing appRegistration, so we can .revoke() or .updateTargetApp()
   // @ts-expect-error tap.receiveUpcall: 'Vow<void> | undefined' not assignable to 'Promise<any>'
-  await localAccount.monitorTransfers(tap);
+  const appRegistration = await localAccount.monitorTransfers(tap);
 
   const accountEntries = harden(
     /** @type {[string, OrchestrationAccount<any>][]} */ ([
@@ -99,6 +98,7 @@ export const makeAccounts = async (
   const portfolioHolder = makePortfolioHolder(
     accountEntries,
     publicTopicEntries,
+    harden({ appRegistration, tapHolder }),
   );
   return portfolioHolder.asContinuingOffer();
 };

--- a/packages/orchestration/tools/ibc-mocks.ts
+++ b/packages/orchestration/tools/ibc-mocks.ts
@@ -4,11 +4,12 @@ import {
   RequestQuery,
   ResponseQuery,
 } from '@agoric/cosmic-proto/tendermint/abci/types.js';
-import { encodeBase64, btoa } from '@endo/base64';
+import { encodeBase64, btoa, atob, decodeBase64 } from '@endo/base64';
 import { toRequestQueryJson } from '@agoric/cosmic-proto';
 import { IBCChannelID, VTransferIBCEvent } from '@agoric/vats';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import { FungibleTokenPacketData } from '@agoric/cosmic-proto/ibc/applications/transfer/v2/packet.js';
+import { TxBody } from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
 import { makeQueryPacket, makeTxPacket } from '../src/utils/packet.js';
 import { ChainAddress } from '../src/orchestration-api.js';
 
@@ -116,6 +117,16 @@ export function buildTxPacketString(
 ): string {
   return btoa(makeTxPacket(msgs.map(Any.toJSON)));
 }
+
+/**
+ * Parse an outgoing ica tx packet. Useful for testing when inspecting
+ * outgoing dibc bridge messages.
+ *
+ * @param b64 base64 encoded string
+ */
+export const parseOutgoingTxPacket = (b64: string) => {
+  return TxBody.decode(decodeBase64(JSON.parse(atob(b64)).data));
+};
 
 /**
  * Build a query packet string for the mocked dibc bridge handler


### PR DESCRIPTION
closes: #XXXX
refs: #9042

## Description
While the title includes the primary changes, this was also a side-quest to explore patterns for object composition with exos. Here, an opts bag is added to `preparePortfolioHolder` that allows the caller to supply extra invitation methods. This pattern seems useful as it allows developers to easily add new functionality to an existing kit while ensuring safety-critical invitations (i.e. Transfer or Withdraw funds) are still available to the end wallet user.

## To Do
- [ ] type support for dynamic guards + methods in an exo class kit 
- [ ] bootstrap test needed?

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
