### PR TITLE
ci: fix flakiness in `update-check` in Manage integration check workflow

### DIFF
--- a/.github/workflows/manage-integration-check.yml
+++ b/.github/workflows/manage-integration-check.yml
@@ -16,7 +16,7 @@ jobs:
         if: ${{ github.event.action == 'requested' || github.event.action == 'in_progress' }}
         with:
           script: |
-            const external_id = context.payload.workflow_run.html_url;
+            const external_id = context.payload.workflow_run.html_url + "-" + context.payload.workflow_run.run_attempt;
             const head_sha = context.payload.workflow_run.head_sha;
             const runs = await github.paginate(github.rest.checks.listForRef, {
               ...context.repo,
@@ -25,7 +25,7 @@ jobs:
               external_id,
             })
             core.debug(`integration-test-result check runs: ${JSON.stringify(runs, null, 2)}`);
-            const filtRuns = runs.filter(run => run.status !== 'completed');
+            const filtRuns = runs.filter(run => run.external_id === external_id);
             const descRuns = filtRuns.sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at));
             const run = descRuns[0];
 
@@ -42,7 +42,7 @@ jobs:
               external_id,
               output: {
                 title: "Integration Test Aggregate Result",
-                summary: `Synthetic check capturing the result of the <a href="${context.payload.workflow_run.html_url}">integration-test workflow run</a>`,
+                summary: `Synthetic check capturing the result of the <a href="${context.payload.workflow_run.html_url}">integration-test workflow run</a> (attempt ${context.payload.workflow_run.run_attempt})`,
               }
             });
             return check.data.id;
@@ -56,7 +56,7 @@ jobs:
           result-encoding: string
           script: |
             // Update the check run
-            const external_id = context.payload.workflow_run.html_url;
+            const external_id = context.payload.workflow_run.html_url + "-" + context.payload.workflow_run.run_attempt;
             const head_sha = context.payload.workflow_run.head_sha;
             const runs = await github.paginate(github.rest.checks.listForRef, {
               ...context.repo,
@@ -65,12 +65,23 @@ jobs:
               external_id,
             })
             core.debug(`integration-test-result check runs: ${JSON.stringify(runs, null, 2)}`);
-            const filtRuns = runs.filter(run => run.status !== 'completed');
+            const filtRuns = runs.filter(run => run.status !== 'completed' && run.external_id === external_id);
             const descRuns = filtRuns.sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at));
             const run = descRuns[0];
 
             if (!run) {
-              core.setFailed(`No integration-test-result check found for commit ${head_sha} ${external_id}`);
+              const check = await github.rest.checks.create({
+                ...context.repo,
+                head_sha,
+                name: "integration-test-result",
+                status: "completed",
+                conclusion: context.payload.workflow_run.conclusion,
+                external_id,
+                output: {
+                  title: "Integration Test Aggregate Result",
+                  summary: `Synthetic check capturing the result of the <a href="${context.payload.workflow_run.html_url}">integration-test workflow run</a> (attempt ${context.payload.workflow_run.run_attempt})`,
+                }
+              });
               return;
             }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #8937 

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Addresses the issue with flake in the `manage-integration-check.yml` workflow. This is due to a race condition where the workflow is executed 3 times in quick succession and is expected to run in order of execution. 

The "Integration tests" workflow triggers `manage-integration-check.yml`  3 times. once for `requested`, `in_progress`, and `completed` statuses of the calling workflow. 
In cases where the `completed` status might happen at the same time as the other two (such as when the "Integration tests" workflow is skipped), the 3 calls of the `manage-integration-check.yml` workflow might run simultaneously and cause a race condition.

the race condition occurs because the final call of `manage-integration-check.yml` (the one triggered by the `completed` status of "Integration tests") expects a github check run to already exist. since this might not be the case in a race condition, it fails

To fix this two things have been done:
- instead of crashing, the job now creates a new github check run with a `completed` status
- since the previous two jobs will run after the final job, they might accidentally overwrite the github check run with the `completed` status and accidentally create a check run with `in_progess` status.   their  filter check has been removed entirely so that they consider `completed` check runs as well.


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
