### PR TITLE
chore: revert codecov comment and required check

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,9 +1,6 @@
 codecov:
   require_ci_to_pass: true
-comment:
-  layout: "flags, components, files"
-  behavior: default
-  hide_project_coverage: false
+comment: false
 coverage:
   status:
     patch:
@@ -19,37 +16,3 @@ parsers:
     enable_partials: yes
 ignore:
   - '**/*.json'
-component_management:
-  individual_components:
-    - component_id: module_swingset_kernel  
-      name: SwingSet/kernel
-      paths:
-        - packages/SwingSet/src/kernel/**
-      statuses:
-        - type: project
-          target: auto
-          threshold: 0.05%
-    - component_id: module_ertp
-      name: ERTP
-      paths:
-        - packages/ERTP/**
-      statuses:
-        - type: project
-          target: auto
-          threshold: 0.05%
-    - component_id: module_orchestration
-      name: Orchestration
-      paths:
-        - packages/orchestration/**
-      statuses:
-        - type: project
-          target: auto
-          threshold: 0.05%
-    - component_id: module_swing_store
-      name: swing-store
-      paths:
-        - packages/swing-store/**
-      statuses:
-        - type: project
-          target: auto
-          threshold: 0.05%


### PR DESCRIPTION
This reverts #9687 and #9758

We discussed offline in slack that codecov is not helping at the moment and counter productive.

refs: #9778

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
