### PR TITLE
ci: force rebase and autosquash before merging

### DIFF
--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -77,14 +77,43 @@ jobs:
 
           fixup_commits=
           for commit in $(git rev-list $BASE_SHA..$HEAD_SHA); do
-            case $(git show --pretty=format:%s -s $commit) in fixup\!*|squash\!*)
+            case $(git show --pretty=format:%s -s $commit) in fixup\!*|squash\!*|amend\!*)
               fixup_commits="$fixup_commits\n$commit"
               ;;
             esac
           done
 
           if [ -n "$fixup_commits" ]; then
-            echo "Error: fixup/squash commits found in $BASE_LABEL..$HEAD_LABEL"
+            echo "Error: fixup/squash/amend commits found in $BASE_LABEL..$HEAD_LABEL"
             echo -e "$fixup_commits"
+            exit 1
+          fi
+
+  no-fixup-commits:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.ref == 'master' && 
+      contains(github.event.pull_request.labels.*.name, 'automerge:rebase') &&
+      !contains(github.event.pull_request.labels.*.name, 'bypass:linear-history')
+
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for fixup commits
+        id: fixup-commits
+        run: |
+          if [[ $(git rev-list "$BASE_SHA".."$HEAD_SHA" --grep="^\(fixup\|amend\|squash\)! " | wc -l) -eq 0 ]]; then
+            echo "No fixup/amend/squash commits found in commit history"
+          else
+            echo "fixup/amend/squash commits found in commit history"
             exit 1
           fi

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -65,6 +65,9 @@ pull_request_rules:
     conditions:
       - base=master
       - label=automerge:rebase
+      - or:
+          - '#commits-behind>0'
+          - linear-history
     actions:
       queue:
         merge_method: merge
@@ -76,3 +79,15 @@ pull_request_rules:
     actions:
       queue:
         merge_method: squash
+  - name: rebase and autosquash
+    conditions:
+      - base=master
+      - label=automerge:rebase
+      - '#commits-behind=0'
+      - or:
+        - -linear-history
+        - check-failure=no-fixup-commits
+      - -draft
+    actions:
+      rebase:
+        autosquash: true

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,12 @@ queue_rules:
               - label=proto:expect-breakage
     merge_conditions:
       - base=master
+      # Rebase PRs with fixup commits are allowed to enter the merge queue but 
+      # should not be allowed to merge if there are leftover fixup commits after rebase
+      - or:
+          - label=bypass:linear-history
+          - check-success=no-fixup-commits
+          - check-skipped=no-fixup-commits
       # Require integration tests before merging only
       - or:
           - label=bypass:integration
@@ -45,6 +51,12 @@ queue_rules:
               - label=proto:expect-breakage
     merge_conditions:
       - base=master
+      # Rebase PRs with fixup commits are allowed to enter the merge queue but 
+      # should not be allowed to merge if there are leftover fixup commits after rebase
+      - or:
+          - label=bypass:linear-history
+          - check-success=no-fixup-commits
+          - check-skipped=no-fixup-commits
       # Require integration tests before merging only
       - or:
           - label=bypass:integration


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #8500

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR does the following:
- adds a new rule to mergify which forces it to rebase and autosquash the branch. 
- adds a condition of `linear-history` to the queuing rule for rebasing, so that only rebased PRs can be queued. 
- adds a new fixup commit ci check which is a required condition for merging

**Note**: autosquash here refers to `--autosquash` flag used by the `git rebase` command. it is used to squash and combine `fixup!` commits. it does not squash all commits into a single commit before merging

It fixes the following problems in #8500 
- rebases the PR to remove all merge commits and `fixup!` commits
- forces rebase on all PRs even if they are up to date with the master branch
- enforce `linear-history` check on `automerge:rebase` enqueue to always enforce a linear-history before merging
- the `rebase and autosquash` rule in mergify also fails if the PR cannot be rebased without conflicts. The failure indicates to the user that the PR must be rebased manually

### Examples of use:
Testing rebase on PR that was up to date: https://github.com/frazarshad/mergify-experiements/pull/2
Testing if a fixup with incorrect title stops the PR from merging: https://github.com/frazarshad/agoric-sdk/pull/6

### Fallback:
In case the new action does not work as expected and does not auto-rebase, the user can still manually rebase in order to use the `automerge:rebase` action. All other `automerge` actions work as originally intended.

In order to bypass the `no-fixup-commit` check, simply add a `bypass:linear-history` label to the PR

### Comparison report:
This is a comparison made of the previous method for merging and the new method: https://drive.google.com/file/d/1kfIW-pVOORuYwBOQlxt-2cus0k9ynAfb/view?usp=drive_link

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
