### PR TITLE
ci(getting-started): mitigate `registry/yarn` flake

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -99,7 +99,7 @@ jobs:
           # won't increase the time for this workflow to complete.
           timeout_minutes: 20
           command: scripts/registry.sh test ${{ matrix.cli }} ${{steps.get-branch.outputs.result}}
-          on_retry_command: rm $HOME/bin/agoric
+          on_retry_command: rm -f $HOME/bin/agoric
 
       - name: notify on failure
         if: >

--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -45,6 +45,7 @@ export const makePspawn = ({
    * @param {string | [string, string, string]} [param2.stdio] standard IO
    * specification
    * @param {Record<string, string | undefined>} [param2.env] environment
+   * @param {boolean} [param2.detached] whether the child process should be detached
    * @returns {Promise<number> & { childProcess: ChildProcess }}} promise for
    * exit status. The return result has a `childProcess` property to obtain
    * control over the running process

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process setTimeout setInterval clearInterval Buffer */
 
 import fs from 'fs';
@@ -63,11 +64,15 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
   // Kill an entire process group.
   const pkill = (cp, signal = 'SIGINT') => process.kill(-cp.pid, signal);
 
+  /** @param {Parameters<typeof pspawn>} args */
   function pspawnStdout(...args) {
     const ps = pspawn(...args);
-    ps.childProcess.stdout.on('data', chunk => {
-      process.stdout.write(chunk);
-    });
+    const { stdout } = ps.childProcess;
+    if (stdout) {
+      stdout.on('data', chunk => {
+        process.stdout.write(chunk);
+      });
+    }
     // ps.childProcess.unref();
     return ps;
   }
@@ -202,7 +207,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
         });
         req.setTimeout(SOCKET_TIMEOUT_SECONDS * 1_000);
         req.on('error', err => {
-          if (err.code !== 'ECONNREFUSED') {
+          if (!('code' in err) || err.code !== 'ECONNREFUSED') {
             resolve(`Cannot connect to UI server: ${err}`);
           }
         });

--- a/scripts/get-versions.sh
+++ b/scripts/get-versions.sh
@@ -7,5 +7,5 @@ WORKDIR=${1:-.}
 cd -- "$WORKDIR"
 npm query .workspace \
   | jq -r '.[].location | "\(.)/package.json"' \
-  | xargs jq '{key: .name, value: "^\(.version)"}' \
+  | xargs jq 'select(.private | not) | {key: .name, value: "^\(.version)"}' \
   | jq --slurp from_entries

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -119,7 +119,7 @@ integrationTest() {
       ;;
     *)
       yarn global add "agoric@$DISTTAG"
-      persistVar AGORIC_CMD '["agoric"]'
+      persistVar AGORIC_CMD "[\"$(yarn global bin)/agoric\"]"
       ;;
   esac
 

--- a/scripts/resolve-versions.sh
+++ b/scripts/resolve-versions.sh
@@ -8,7 +8,7 @@ set -ueo pipefail
 
 DIR=$(dirname -- "${BASH_SOURCE[0]}")
 
-cd -- "$DIR/.."
+cd -- "${1-$DIR/..}"
 
 override=$(jq 'to_entries | map({ key: ("**/" + .key), value: .value }) | from_entries')
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #9325, closes: #9710

## Description
This is a minor fix to make sure the `registry/yarn` getting-started CI test doesn't fail.  It embraces the current situation that `agoric install $DISTTAG` is not currently usable within the default [Agoric/dapp-offer-up](https://github.com/Agoric/dapp-offer-up) because of the long list of `packageJson.resolutions`  `dapp-offer-up` uses.

Thus, `getting-started.js` has `AGORIC_INSTALL_DISTTAG` set to `false`.  This ensures that `agoric install $DISTTAG` does not execute.  It is replaced by simply `yarn install`.
