### PR TITLE
chore: adding @returns for provideOrchestration

### DIFF
--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -43,6 +43,8 @@ import { makeZoeTools } from './zoe-tools.js';
  * @param {Baggage} baggage
  * @param {OrchestrationPowers} remotePowers
  * @param {Marshaller} marshaller
+ * @returns {(facade: OrchestrationFacade, chainHub: ChainHub, vowTools: VowTools, zoeTools: ZoeTools, zone: Zone} ochestration 
+ * tools including facade, chainHub, vowTools, zoeTools, and contract subzone.
  */
 export const provideOrchestration = (
   zcf,


### PR DESCRIPTION
Adding a @returns tag for `provideOrchestration` API

refs: 
[#9801](https://github.com/Agoric/agoric-sdk/issues/9801)
[#9757](https://github.com/Agoric/agoric-sdk/issues/9757)

## Description
@dckc
I am adding a @returns tag for `provideOrchestration` API based on what I see in code - if something is wrong, please make suggestions.

### Security/Scaling/Documentation Considerations
None

### Testing Considerations
Manual

### Upgrade Considerations
May need to be updated if `provideOrchestration` changes.
