### PR TITLE
chore: build agoric-sdk from source in multichain ci

### DIFF
--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   multichain-e2e:
     runs-on: ubuntu-latest-16core
+    env:
+      AGORIC_IMAGE_TAG: ${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +42,7 @@ jobs:
         id: starship-infra
         uses: cosmology-tech/starship-action@0.3.0
         with:
-          # uses ghcr.io/agoric/agoric-sdk:dev image (latest master)
-          values: ./agoric-sdk/multichain-testing/config.yaml
+          values: ./agoric-sdk/multichain-testing/config.ci.yaml
           port-forward: true
           version: 0.2.10
           timeout: 30m

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -37,7 +37,8 @@ jobs:
         working-directory: ./agoric-sdk/multichain-testing
 
       - name: Update config.ci.yaml with commit SHA
-        run: sed -i 's|${AGORIC_IMAGE_TAG}|'"$(git rev-parse HEAD)"'|' ./agoric-sdk/multichain-testing/config.ci.yaml
+        run: sed -i 's|${AGORIC_IMAGE_TAG}|'"$(git rev-parse HEAD)"'|' ./multichain-testing/config.ci.yaml
+        working-directory: ./agoric-sdk
 
       - name: Setup Starship Infrastructure
         id: starship-infra

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   multichain-e2e:
     runs-on: ubuntu-latest-16core
-    env:
-      AGORIC_IMAGE_TAG: ${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +35,9 @@ jobs:
       - name: Lint @agoric/multichain-testing
         run: yarn lint
         working-directory: ./agoric-sdk/multichain-testing
+
+      - name: Update config.ci.yaml with commit SHA
+        run: sed -i 's|${AGORIC_IMAGE_TAG}|${{ github.sha }}|' ./agoric-sdk/multichain-testing/config.ci.yaml
 
       - name: Setup Starship Infrastructure
         id: starship-infra

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./agoric-sdk/multichain-testing
 
       - name: Update config.ci.yaml with commit SHA
-        run: sed -i 's|${AGORIC_IMAGE_TAG}|${{ github.sha }}|' ./agoric-sdk/multichain-testing/config.ci.yaml
+        run: sed -i 's|${AGORIC_IMAGE_TAG}|'"$(git rev-parse HEAD)"'|' ./agoric-sdk/multichain-testing/config.ci.yaml
 
       - name: Setup Starship Infrastructure
         id: starship-infra

--- a/multichain-testing/config ci.yaml
+++ b/multichain-testing/config ci.yaml
@@ -1,0 +1,110 @@
+chains:
+  - id: agoriclocal
+    name: agoric
+    image: ghcr.io/agoric/agoric-sdk:dev
+    numValidators: 1
+    env:
+      - name: DEBUG
+        value: SwingSet:vat,SwingSet:ls
+    genesis:
+      app_state:
+        staking:
+          params:
+            unbonding_time: '2m'
+        swingset:
+          params:
+            bootstrap_vat_config: '@agoric/vm-config/decentral-itest-orchestration-config.json'
+    scripts:
+      updateConfig:
+        file: scripts/update-config.sh
+    faucet:
+      enabled: false
+    ports:
+      rest: 1317
+      rpc: 26657
+      exposer: 38087
+      grpc: 9090
+    resources:
+      cpu: 1
+      memory: 4Gi
+  - id: osmosislocal
+    name: osmosis
+    numValidators: 1
+    genesis:
+      app_state:
+        staking:
+          params:
+            unbonding_time: '2m'
+        interchain_accounts:
+          host_genesis_state:
+            params:
+              host_enabled: true
+              allow_messages: ['*']
+        interchainquery:
+          host_port: 'icqhost'
+          params:
+            host_enabled: true
+            allow_queries: ['*']
+    faucet:
+      enabled: true
+      type: starship
+    ports:
+      rest: 1315
+      rpc: 26655
+      grpc: 9093
+      faucet: 8084
+    resources:
+      cpu: 1
+      memory: 1Gi
+  - id: gaialocal
+    name: cosmoshub
+    numValidators: 1
+    genesis:
+      app_state:
+        staking:
+          params:
+            unbonding_time: '2m'
+        interchain_accounts:
+          host_genesis_state:
+            params:
+              host_enabled: true
+              allow_messages: ['*']
+    faucet:
+      enabled: true
+      type: starship
+    ports:
+      rest: 1314
+      rpc: 26654
+      grpc: 9092
+      faucet: 8083
+    resources:
+      cpu: 1
+      memory: 1Gi
+
+relayers:
+  - name: osmosis-gaia
+    type: hermes
+    replicas: 1
+    chains:
+      - osmosislocal
+      - gaialocal
+  - name: agoric-osmosis
+    type: hermes
+    replicas: 1
+    chains:
+      - agoriclocal
+      - osmosislocal
+  - name: agoric-gaia
+    type: hermes
+    replicas: 1
+    chains:
+      - agoriclocal
+      - gaialocal
+
+explorer:
+  enabled: false
+
+registry:
+  enabled: true
+  ports:
+    rest: 8081

--- a/multichain-testing/config.ci.yaml
+++ b/multichain-testing/config.ci.yaml
@@ -110,5 +110,3 @@ registry:
   enabled: true
   ports:
     rest: 8081
-
-commit_sha: &commit_sha ${commit_sha}

--- a/multichain-testing/config.ci.yaml
+++ b/multichain-testing/config.ci.yaml
@@ -1,7 +1,9 @@
 chains:
   - id: agoriclocal
     name: agoric
-    image: ghcr.io/agoric/agoric-sdk:dev
+    build:
+      enabled: true
+      source: ${AGORIC_IMAGE_TAG}
     numValidators: 1
     env:
       - name: DEBUG
@@ -108,3 +110,5 @@ registry:
   enabled: true
   ports:
     rest: 8081
+
+commit_sha: &commit_sha ${commit_sha}


### PR DESCRIPTION
closes: #9805

## Description
Create a CI-only starship config that builds the agoric chain from the latest git commit hash.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This change helps improve the fidelity of our testing environment.

### Upgrade Considerations
n/a
