### PR TITLE
export withOrchestration

### DIFF
--- a/packages/orchestration/index.js
+++ b/packages/orchestration/index.js
@@ -5,3 +5,4 @@
 export * from './src/types.js';
 export * from './src/exos/cosmos-interchain-service.js';
 export * from './src/typeGuards.js';
+export * from './src/utils/start-helper.js';

--- a/packages/orchestration/src/examples/auto-stake-it.contract.js
+++ b/packages/orchestration/src/examples/auto-stake-it.contract.js
@@ -15,8 +15,7 @@ import * as flows from './auto-stake-it.flows.js';
  * @import {NameHub} from '@agoric/vats';
  * @import {Remote} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
- * @import {CosmosInterchainService} from '@agoric/orchestration';
- * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
+ * @import {OrchestrationPowers, OrchestrationTools} from '@agoric/orchestration';
  */
 
 /**

--- a/packages/orchestration/src/examples/auto-stake-it.contract.js
+++ b/packages/orchestration/src/examples/auto-stake-it.contract.js
@@ -16,17 +16,7 @@ import * as flows from './auto-stake-it.flows.js';
  * @import {Remote} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
  * @import {CosmosInterchainService} from '@agoric/orchestration';
- * @import {OrchestrationTools} from '../utils/start-helper.js';
- */
-
-/**
- * @typedef {{
- *   localchain: Remote<LocalChain>;
- *   orchestrationService: Remote<CosmosInterchainService>;
- *   storageNode: Remote<StorageNode>;
- *   timerService: Remote<TimerService>;
- *   agoricNames: Remote<NameHub>;
- * }} OrchestrationPowers
+ * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
  */
 
 /**

--- a/packages/orchestration/src/examples/basic-flows.contract.js
+++ b/packages/orchestration/src/examples/basic-flows.contract.js
@@ -10,8 +10,7 @@ import * as flows from './basic-flows.flows.js';
 
 /**
  * @import {Zone} from '@agoric/zone';
- * @import {OrchestrationPowers} from '../utils/start-helper.js';
- * @import {OrchestrationTools} from '../utils/start-helper.js';
+ * @import {OrchestrationPowers, OrchestrationTools} from '@agoric/orchestration';
  */
 
 /**

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -5,12 +5,9 @@
 import { M, mustMatch } from '@endo/patterns';
 
 /**
- * @import {Zone} from '@agoric/zone';
  * @import {OrchestrationAccount, OrchestrationFlow, Orchestrator} from '@agoric/orchestration';
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
- * @import {OrchestrationPowers} from '../utils/start-helper.js';
  * @import {MakePortfolioHolder} from '../exos/portfolio-holder-kit.js';
- * @import {OrchestrationTools} from '../utils/start-helper.js';
  */
 
 /**

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -15,8 +15,7 @@ import { prepareChainHubAdmin } from '../exos/chain-hub-admin.js';
  * @import {Remote, Vow} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
  * @import {VBankAssetDetail} from '@agoric/vats/tools/board-utils.js';
- * @import {CosmosInterchainService} from '../types.js';
- * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
+ * @import {OrchestrationPowers, OrchestrationTools} from '@agoric/orchestration';
  */
 
 export const SingleAmountRecord = M.and(

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -15,7 +15,7 @@ import { prepareChainHubAdmin } from '../exos/chain-hub-admin.js';
  * @import {Remote, Vow} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
  * @import {VBankAssetDetail} from '@agoric/vats/tools/board-utils.js';
- * @import {CosmosInterchainService} from '../exos/cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  * @import {OrchestrationTools} from '../utils/start-helper.js';
  */
 

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -16,17 +16,7 @@ import { prepareChainHubAdmin } from '../exos/chain-hub-admin.js';
  * @import {Zone} from '@agoric/zone';
  * @import {VBankAssetDetail} from '@agoric/vats/tools/board-utils.js';
  * @import {CosmosInterchainService} from '../types.js';
- * @import {OrchestrationTools} from '../utils/start-helper.js';
- */
-
-/**
- * @typedef {{
- *   localchain: Remote<LocalChain>;
- *   orchestrationService: Remote<CosmosInterchainService>;
- *   storageNode: Remote<StorageNode>;
- *   timerService: Remote<TimerService>;
- *   agoricNames: Remote<NameHub>;
- * }} OrchestrationPowers
+ * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
  */
 
 export const SingleAmountRecord = M.and(

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -10,7 +10,7 @@ import { withOrchestration } from '../utils/start-helper.js';
  * @import {TimerService} from '@agoric/time';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
  * @import {Remote} from '@agoric/internal';
- * @import {CosmosInterchainService} from '../exos/cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  * @import {NameHub} from '@agoric/vats';
  * @import {Zone} from '@agoric/zone';
  * @import {OrchestrationTools} from '../utils/start-helper.js';

--- a/packages/orchestration/src/examples/swapExample.contract.js
+++ b/packages/orchestration/src/examples/swapExample.contract.js
@@ -13,7 +13,7 @@ import { withOrchestration } from '../utils/start-helper.js';
  * @import {CosmosInterchainService} from '../types.js';
  * @import {NameHub} from '@agoric/vats';
  * @import {Zone} from '@agoric/zone';
- * @import {OrchestrationTools} from '../utils/start-helper.js';
+ * @import {OrchestrationPowers, OrchestrationTools} from '@agoric/orchestration';
  */
 
 /**

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -8,7 +8,7 @@ import { withOrchestration } from '../utils/start-helper.js';
  * @import {NameHub} from '@agoric/vats';
  * @import {Remote} from '@agoric/internal';
  * @import {Zone} from '@agoric/zone';
- * @import {CosmosInterchainService} from '../exos/cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  * @import {OrchestrationTools} from '../utils/start-helper.js';
  */
 

--- a/packages/orchestration/src/examples/unbondExample.contract.js
+++ b/packages/orchestration/src/examples/unbondExample.contract.js
@@ -2,6 +2,7 @@ import { M } from '@endo/patterns';
 import { withOrchestration } from '../utils/start-helper.js';
 
 /**
+ * @import {OrchestrationPowers, OrchestrationTools} from '@agoric/orchestration';
  * @import {Orchestrator, OrchestrationFlow} from '../types.js'
  * @import {TimerService} from '@agoric/time';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
@@ -9,7 +10,6 @@ import { withOrchestration } from '../utils/start-helper.js';
  * @import {Remote} from '@agoric/internal';
  * @import {Zone} from '@agoric/zone';
  * @import {CosmosInterchainService} from '../types.js';
- * @import {OrchestrationTools} from '../utils/start-helper.js';
  */
 
 /**

--- a/packages/orchestration/src/exos/cosmos-interchain-service.js
+++ b/packages/orchestration/src/exos/cosmos-interchain-service.js
@@ -259,4 +259,3 @@ export const prepareCosmosInterchainService = (zone, vowTools) => {
 harden(prepareCosmosInterchainService);
 
 /** @typedef {ReturnType<typeof prepareCosmosInterchainService>} MakeCosmosInterchainService */
-/** @typedef {ReturnType<MakeCosmosInterchainService>} CosmosInterchainService */

--- a/packages/orchestration/src/exos/cosmos-interchain-service.js
+++ b/packages/orchestration/src/exos/cosmos-interchain-service.js
@@ -23,7 +23,7 @@ import {
 
 const { Vow$ } = NetworkShape; // TODO #9611
 /**
- * @typedef {object} OrchestrationPowers
+ * @typedef {object} CosmosInterchainPowers
  * @property {Remote<PortAllocator>} portAllocator
  */
 
@@ -33,8 +33,8 @@ const { Vow$ } = NetworkShape; // TODO #9611
  * state migrations.
  *
  * @typedef {MapStore<
- *   keyof OrchestrationPowers,
- *   OrchestrationPowers[keyof OrchestrationPowers]
+ *   keyof CosmosInterchainPowers,
+ *   CosmosInterchainPowers[keyof CosmosInterchainPowers]
  * >} PowerStore
  */
 
@@ -43,13 +43,13 @@ const { Vow$ } = NetworkShape; // TODO #9611
 /** @typedef {ChainAccountKit | ICQConnectionKit} ConnectionKit */
 
 /**
- * @template {keyof OrchestrationPowers} K
+ * @template {keyof CosmosInterchainPowers} K
  * @param {PowerStore} powers
  * @param {K} name
  */
 const getPower = (powers, name) => {
   powers.has(name) || Fail`need powers.${b(name)} for this method`;
-  return /** @type {OrchestrationPowers[K]} */ (powers.get(name));
+  return /** @type {CosmosInterchainPowers[K]} */ (powers.get(name));
 };
 
 /** @typedef {{ powers: PowerStore; icqConnections: ICQConnectionStore }} OrchestrationState */
@@ -101,13 +101,16 @@ const prepareCosmosOrchestrationServiceKit = (
         ),
       }),
     },
-    /** @param {Partial<OrchestrationPowers>} [initialPowers] */
+    /** @param {Partial<CosmosInterchainPowers>} [initialPowers] */
     initialPowers => {
       /** @type {PowerStore} */
       const powers = zone.detached().mapStore('PowerStore');
       if (initialPowers) {
         for (const [name, power] of Object.entries(initialPowers)) {
-          powers.init(/** @type {keyof OrchestrationPowers} */ (name), power);
+          powers.init(
+            /** @type {keyof CosmosInterchainPowers} */ (name),
+            power,
+          );
         }
       }
       const icqConnections = zone.detached().mapStore('ICQConnections');

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -14,7 +14,7 @@ import { ChainFacadeI } from '../typeGuards.js';
  * @import {Remote} from '@agoric/internal';
  * @import {LocalChain, LocalChainAccount} from '@agoric/vats/src/localchain.js';
  * @import {Vow, VowTools} from '@agoric/vow';
- * @import {CosmosInterchainService} from './cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  * @import {LocalOrchestrationAccountKit, MakeLocalOrchestrationAccountKit} from './local-orchestration-account.js';
  * @import {ChainAddress, ChainInfo, CosmosChainInfo, IBCConnectionInfo, OrchestrationAccount} from '../types.js';
  */

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -23,7 +23,7 @@ import {
  * @import {RecorderKit, MakeRecorderKit} from '@agoric/zoe/src/contractSupport/recorder.js'.
  * @import {Remote} from '@agoric/internal';
  * @import {PickFacet} from '@agoric/swingset-liveslots';
- * @import {CosmosInterchainService} from './cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  * @import {MakeLocalOrchestrationAccountKit} from './local-orchestration-account.js';
  * @import {MakeLocalChainFacade} from './local-chain-facade.js';
  * @import {MakeRemoteChainFacade} from './remote-chain-facade.js';

--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -12,7 +12,7 @@ import { ChainAddressShape, ChainFacadeI } from '../typeGuards.js';
  * @import {TimerService} from '@agoric/time';
  * @import {Remote} from '@agoric/internal';
  * @import {Vow, VowTools} from '@agoric/vow';
- * @import {CosmosInterchainService} from './cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  * @import {prepareCosmosOrchestrationAccount} from './cosmos-orchestration-account.js';
  * @import {ChainInfo, CosmosChainInfo, IBCConnectionInfo, OrchestrationAccount, ChainAddress, IcaAccount, Denom, Chain} from '../types.js';
  */

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -10,7 +10,7 @@ import { assertAllDefined } from '@agoric/internal';
  * @import {RecorderKit, MakeRecorderKit} from '@agoric/zoe/src/contractSupport/recorder.js'.
  * @import {HostOrchestrator} from './exos/orchestrator.js';
  * @import {Remote} from '@agoric/internal';
- * @import {CosmosInterchainService} from './exos/cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from './types.js';
  * @import {Chain, ChainInfo, CosmosChainInfo, IBCConnectionInfo, OrchestrationAccount, OrchestrationFlow, Orchestrator} from './types.js';
  */
 

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -9,7 +9,6 @@ const trace = makeTracer('CoreEvalOrchestration', true);
 
 /**
  * @import {PortAllocator} from '@agoric/network';
- * @import {CosmosInterchainService} from '../exos/cosmos-interchain-service.js'
  */
 
 /**

--- a/packages/orchestration/src/types.ts
+++ b/packages/orchestration/src/types.ts
@@ -1,5 +1,7 @@
 /** @file Rollup of all type definitions in the package, for local import and external export */
 
+import type { MakeCosmosInterchainService } from './exos/cosmos-interchain-service.js';
+
 export type * from './chain-info.js';
 export type * from './cosmos-api.js';
 export type * from './ethereum-api.js';
@@ -9,3 +11,6 @@ export type * from './orchestration-api.js';
 export type * from './exos/cosmos-interchain-service.js';
 export type * from './exos/chain-hub.js';
 export type * from './vat-orchestration.js';
+
+/** @interface */
+export type CosmosInterchainService = ReturnType<MakeCosmosInterchainService>;

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -20,7 +20,7 @@ import { makeZoeTools } from './zoe-tools.js';
  * @import {NameHub} from '@agoric/vats';
  * @import {Remote} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
- * @import {CosmosInterchainService} from '../exos/cosmos-interchain-service.js';
+ * @import {CosmosInterchainService} from '../types.js';
  */
 
 /**

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -43,6 +43,7 @@ import { makeZoeTools } from './zoe-tools.js';
  * @param {Baggage} baggage
  * @param {OrchestrationPowers} remotePowers
  * @param {Marshaller} marshaller
+ * @internal
  */
 export const provideOrchestration = (
   zcf,

--- a/packages/orchestration/src/vat-orchestration.js
+++ b/packages/orchestration/src/vat-orchestration.js
@@ -3,7 +3,7 @@ import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareCosmosInterchainService } from './exos/cosmos-interchain-service.js';
 
-/** @import {OrchestrationPowers} from './exos/cosmos-interchain-service.js' */
+/** @import {CosmosInterchainPowers} from './exos/cosmos-interchain-service.js' */
 
 export const buildRootObject = (_vatPowers, _args, baggage) => {
   const zone = makeDurableZone(baggage);
@@ -14,7 +14,7 @@ export const buildRootObject = (_vatPowers, _args, baggage) => {
   );
 
   return Far('OrchestrationVat', {
-    /** @param {Partial<OrchestrationPowers>} [initialPowers] */
+    /** @param {Partial<CosmosInterchainPowers>} [initialPowers] */
     makeCosmosInterchainService(initialPowers = {}) {
       return makeCosmosInterchainService(initialPowers);
     },


### PR DESCRIPTION
refs: #9757 
refs: https://github.com/Agoric/agoric-sdk/issues/9765

## Description

I noticed that `withOrchestration` isn't exported from the package. This exports it. It also exports the `OrchestrationTools` that the docs for that type require. I tried to not export `provideOrchestration` because it's more of an implementation detail, but JSDoc type expressions make it hard to export `OrchestrationTools` without also exporting `provideOrchestration`. I also considered getting rid of it but tests need to be able to set up OrchestrationTools without spinning up a contract. So I marked `provideOrchestration` as `@internal` so it doesn't show up in docs.

This also proposes a solution to,
- https://github.com/Agoric/agoric-sdk/issues/9765
using the [@interface](https://typedoc.org/tags/interface/#%40interface) tag to get the dynamic aspects to expand.

**Before**
```
CosmosInterchainService: ReturnType<[MakeCosmosInterchainService
```

**After**

```
interface CosmosInterchainService {
    [PASS_STYLE]: "remotable";
    [toStringTag]: string;
    __getInterfaceGuard__?: (() => undefined | InterfaceGuard<{
        makeAccount: any;
        provideICQConnection: any;
    }>);
    makeAccount(chainId, hostConnectionId, controllerConnectionId): Vow<IcaAccount>;
    provideICQConnection(controllerConnectionId): Guarded<{
        getLocalAddress(): `/ibc-port/${string}`;
        getRemoteAddress(): `/${string}ibc-port/${string}/ordered/${string}` | `/${string}ibc-port/${string}/unordered/${string}`;
        query(msgs): Promise<JsonSafe<ResponseQuery>[]>;
    }> | Vow<Guarded<{
        getLocalAddress(): `/ibc-port/${string}`;
        getRemoteAddress(): `/${string}ibc-port/${string}/ordered/${string}` | `/${string}ibc-port/${string}/unordered/${string}`;
        query(msgs): Promise<JsonSafe<ResponseQuery>[]>;
    }>>;
}
```

If that is agreeable I can convert the others in this PR or follow up.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
- `provideOrchestration` not in Markdown docs build for docs site
- `withOrchestration` signature is clear and concise

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
