### PR TITLE
refactor: Remove extraneous CapTP types imports

### DIFF
--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
 import { makePspawn } from './helpers.js';
 
-/// <reference types="@endo/captp/src/types.js" />
-
 // Use either an absolute template URL, or find it relative to DAPP_URL_BASE.
 const gitURL = (relativeOrAbsoluteURL, base) => {
   const url = new URL(relativeOrAbsoluteURL, base);


### PR DESCRIPTION
## Description

In anticipation of typescript joining Node.js in taking package.json exports into account to determine the public types of a package, this change removes an extraneous ambient types import that will no longer work in the new type discipline.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

Type checks pass before and after this change.

### Upgrade Considerations

None.