### PR TITLE
chore: cosmos interchain service cleanup

### DIFF
--- a/packages/orchestration/src/exos/cosmos-interchain-service.js
+++ b/packages/orchestration/src/exos/cosmos-interchain-service.js
@@ -60,7 +60,7 @@ const getICQConnectionKey = (controllerConnectionId, version) => {
  */
 const prepareCosmosOrchestrationServiceKit = (
   zone,
-  { watch },
+  { watch, asVow },
   makeChainAccountKit,
   makeICQConnectionKit,
 ) =>
@@ -218,8 +218,9 @@ const prepareCosmosOrchestrationServiceKit = (
             version,
           );
           if (this.state.icqConnections.has(icqLookupKey)) {
-            // TODO #9281 do not return synchronously. see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
-            return this.state.icqConnections.get(icqLookupKey).connection;
+            return asVow(
+              () => this.state.icqConnections.get(icqLookupKey).connection,
+            );
           }
           const remoteConnAddr = makeICQChannelAddress(
             controllerConnectionId,

--- a/packages/orchestration/src/exos/cosmos-interchain-service.js
+++ b/packages/orchestration/src/exos/cosmos-interchain-service.js
@@ -19,6 +19,7 @@ import {
  * @import {RemoteIbcAddress} from '@agoric/vats/tools/ibc-utils.js';
  * @import {Vow, VowTools} from '@agoric/vow';
  * @import {ICQConnection, IcaAccount, ICQConnectionKit, ChainAccountKit} from '../types.js';
+ * @import {ICAChannelAddressOpts} from '../utils/address.js';
  */
 
 const { Vow$ } = NetworkShape; // TODO #9611
@@ -93,9 +94,9 @@ const prepareCosmosOrchestrationServiceKit = (
           .returns(M.remotable('ConnectionKit Holder facet')),
       }),
       public: M.interface('CosmosInterchainService', {
-        makeAccount: M.call(M.string(), M.string(), M.string()).returns(
-          Vow$(M.remotable('ChainAccountKit')),
-        ),
+        makeAccount: M.call(M.string(), M.string(), M.string())
+          .optional(M.record())
+          .returns(Vow$(M.remotable('ChainAccountKit'))),
         provideICQConnection: M.call(M.string()).returns(
           Vow$(M.remotable('ICQConnection')),
         ),
@@ -192,12 +193,15 @@ const prepareCosmosOrchestrationServiceKit = (
          * @param {IBCConnectionID} hostConnectionId the counterparty
          *   connection_id
          * @param {IBCConnectionID} controllerConnectionId self connection_id
+         * @param {ICAChannelAddressOpts} [opts] optional to configure the
+         *   channel address, such as version and ordering
          * @returns {Vow<IcaAccount>}
          */
-        makeAccount(chainId, hostConnectionId, controllerConnectionId) {
+        makeAccount(chainId, hostConnectionId, controllerConnectionId, opts) {
           const remoteConnAddr = makeICAChannelAddress(
             hostConnectionId,
             controllerConnectionId,
+            opts,
           );
           const portAllocator = getPower(this.state.powers, 'portAllocator');
           return watch(

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -9,7 +9,6 @@ const trace = makeTracer('CoreEvalOrchestration', true);
 
 /**
  * @import {PortAllocator} from '@agoric/network';
- * @import {CosmosInterchainService} from '../exos/cosmos-interchain-service.js'
  */
 
 /**

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -7,15 +7,19 @@ import { Fail } from '@endo/errors';
  */
 
 /**
+ * @typedef {object} ICAChannelAddressOpts
+ * @property {string} [encoding='proto3'] message encoding format for the
+ *   channel
+ * @property {'ordered' | 'unordered'} [ordering='ordered'] channel ordering.
+ *   currently only `ordered` is supported for ics27-1
+ * @property {string} [txType='sdk_multi_msg'] default is `sdk_multi_msg`
+ * @property {string} [version='ics27-1'] default is `ics27-1`
+ */
+
+/**
  * @param {IBCConnectionID} hostConnectionId Counterparty Connection ID
  * @param {IBCConnectionID} controllerConnectionId Self Connection ID
- * @param {object} [opts]
- * @param {string} [opts.encoding] - message encoding format for the channel.
- *   default is `proto3`
- * @param {'ordered' | 'unordered'} [opts.ordering] - channel ordering.
- *   currently only `ordered` is supported for ics27-1
- * @param {string} [opts.txType] - default is `sdk_multi_msg`
- * @param {string} [opts.version] - default is `ics27-1`
+ * @param {ICAChannelAddressOpts} [opts]
  * @returns {RemoteIbcAddress}
  */
 export const makeICAChannelAddress = (

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -46,14 +46,16 @@ export const makeICAChannelAddress = (
 };
 harden(makeICAChannelAddress);
 
+export const DEFAULT_ICQ_VERSION = 'icq-1';
+
 /**
  * @param {IBCConnectionID} controllerConnectionId
- * @param {{ version?: string }} [opts]
+ * @param {string} version defaults to icq-1
  * @returns {RemoteIbcAddress}
  */
 export const makeICQChannelAddress = (
   controllerConnectionId,
-  { version = 'icq-1' } = {},
+  version = DEFAULT_ICQ_VERSION,
 ) => {
   controllerConnectionId || Fail`controllerConnectionId is required`;
   return `/ibc-hop/${controllerConnectionId}/ibc-port/icqhost/unordered/${version}`;

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -16,12 +16,14 @@ import { commonSetup } from './supports.js';
 import { ChainAddressShape } from '../src/typeGuards.js';
 import { tryDecodeResponse } from '../src/utils/cosmos.js';
 
+const CHAIN_ID = 'cosmoshub-99';
+const HOST_CONNECTION_ID = 'connection-0';
+const CONTROLLER_CONNECTION_ID = 'connection-1';
+
 test('makeICQConnection returns an ICQConnection', async t => {
   const {
     bootstrap: { cosmosInterchainService },
   } = await commonSetup(t);
-
-  const CONTROLLER_CONNECTION_ID = 'connection-0';
 
   const icqConnection = await E(cosmosInterchainService).provideICQConnection(
     CONTROLLER_CONNECTION_ID,
@@ -64,11 +66,25 @@ test('makeICQConnection returns an ICQConnection', async t => {
   t.like(QueryBalanceResponse.decode(decodeBase64(result.key)), {
     balance: { amount: '0', denom: 'uatom' },
   });
-});
 
-const CHAIN_ID = 'cosmoshub-99';
-const HOST_CONNECTION_ID = 'connection-0';
-const CONTROLLER_CONNECTION_ID = 'connection-1';
+  const icqConnection3 = await E(cosmosInterchainService).provideICQConnection(
+    CONTROLLER_CONNECTION_ID,
+    'icq-2',
+  );
+  const localAddr3 = await E(icqConnection3).getLocalAddress();
+  t.not(
+    localAddr3,
+    localAddr2,
+    'non default version results in a new connection',
+  );
+
+  const icqConnection4 = await E(cosmosInterchainService).provideICQConnection(
+    CONTROLLER_CONNECTION_ID,
+    'icq-2',
+  );
+  const localAddr4 = await E(icqConnection4).getLocalAddress();
+  t.is(localAddr3, localAddr4, 'custom version is idempotent');
+});
 
 test('makeAccount returns a ChainAccount', async t => {
   const {

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -12,6 +12,7 @@ import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { matches } from '@endo/patterns';
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { decodeBase64 } from '@endo/base64';
+import type { LocalIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
 import { commonSetup } from './supports.js';
 import { ChainAddressShape } from '../src/typeGuards.js';
 import { tryDecodeResponse } from '../src/utils/cosmos.js';
@@ -84,6 +85,18 @@ test('makeICQConnection returns an ICQConnection', async t => {
   );
   const localAddr4 = await E(icqConnection4).getLocalAddress();
   t.is(localAddr3, localAddr4, 'custom version is idempotent');
+
+  const icqConnection5 = await E(cosmosInterchainService).provideICQConnection(
+    'connection-99',
+  );
+  const localAddr5 = await E(icqConnection5).getLocalAddress();
+
+  const getPortId = (lAddr: LocalIbcAddress) => lAddr.split('/')[2];
+  const uniquePortIds = new Set(
+    [localAddr, localAddr2, localAddr3, localAddr4, localAddr5].map(getPortId),
+  );
+  t.regex([...uniquePortIds][0], /icqcontroller-\d+/);
+  t.is(uniquePortIds.size, 1, 'all connections share same port');
 });
 
 test('makeAccount returns a ChainAccount', async t => {

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -84,18 +84,14 @@ test('makeICQChannelAddress', t => {
     'returns connection string when controllerConnectionId is provided',
   );
   t.is(
-    makeICQChannelAddress('connection-0', {
-      version: 'icq-2',
-    }),
+    makeICQChannelAddress('connection-0', 'icq-2'),
     '/ibc-hop/connection-0/ibc-port/icqhost/unordered/icq-2',
     'accepts custom version',
   );
   t.throws(
     () =>
       validateRemoteIbcAddress(
-        makeICQChannelAddress('connection-0', {
-          version: 'ic/q-/2',
-        }),
+        makeICQChannelAddress('connection-0', 'ic/q-/2'),
       ),
     {
       message:


### PR DESCRIPTION
refs: #9114
closes: #9317 

## Description
- Miscellaneous cleanup related to `CosmosInterchainService` (part of `vat-orchestration`), closing out todos for 1) unnecessary PowerStore abstraction and 2) vow compat for early synchronous returns
- Optimizes ICQ Port Allocation by reusing a single port for all ICQ connections

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
js doc added where necessary

### Testing Considerations
included tests for new behavior

### Upgrade Considerations
these changes are intended to better prepare us for future upgrades
