### PR TITLE
chore: chain account kit cleanup

### DIFF
--- a/packages/orchestration/src/examples/stakeIca.contract.js
+++ b/packages/orchestration/src/examples/stakeIca.contract.js
@@ -119,7 +119,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const publicFacet = zone.exo(
     'StakeAtom',
     M.interface('StakeAtomI', {
-      makeAccount: M.callWhen().returns(M.remotable('ChainAccount')),
+      makeAccount: M.callWhen().returns(M.remotable('OrchestrationAccountKit')),
       makeAccountInvitationMaker: M.callWhen().returns(InvitationShape),
     }),
     {

--- a/packages/orchestration/src/exos/README.md
+++ b/packages/orchestration/src/exos/README.md
@@ -9,11 +9,11 @@ classDiagram
     LCAKit --* LocalchainAccount
     ICQConnectionKit --* Port
     ICQConnectionKit --* Connection
-    ChainAccountKit --* Port
-    ChainAccountKit --* Connection
+    IcaAccountKit --* Port
+    IcaAccountKit --* Connection
     StakingAccountKit --* IcaAccount
 
-    class ChainAccountKit {
+    class IcaAccountKit {
       port: Port
       connection: Connection
       localAddress: LocalIbcAddress

--- a/packages/orchestration/src/exos/chain-account-kit.js
+++ b/packages/orchestration/src/exos/chain-account-kit.js
@@ -163,10 +163,12 @@ export const prepareChainAccountKit = (zone, { watch, asVow }) =>
           this.state.connection = connection;
           this.state.remoteAddress = remoteAddr;
           this.state.localAddress = localAddr;
+          const address = findAddressField(remoteAddr);
+          if (!address) {
+            console.error('⚠️ failed to parse chain address', remoteAddr);
+          }
           this.state.chainAddress = harden({
-            // FIXME need a fallback value like icacontroller-1-connection-1 if this fails
-            // https://github.com/Agoric/agoric-sdk/issues/9066
-            value: findAddressField(remoteAddr) || UNPARSABLE_CHAIN_ADDRESS,
+            value: address || UNPARSABLE_CHAIN_ADDRESS,
             chainId: this.state.chainId,
             encoding: 'bech32',
           });

--- a/packages/orchestration/src/exos/chain-account-kit.js
+++ b/packages/orchestration/src/exos/chain-account-kit.js
@@ -29,8 +29,6 @@ const UNPARSABLE_CHAIN_ADDRESS = 'UNPARSABLE_CHAIN_ADDRESS';
 
 export const ChainAccountI = M.interface('ChainAccount', {
   getAddress: M.call().returns(ChainAddressShape),
-  getBalance: M.call(M.string()).returns(VowShape),
-  getBalances: M.call().returns(VowShape),
   getLocalAddress: M.call().returns(M.string()),
   getRemoteAddress: M.call().returns(M.string()),
   getPort: M.call().returns(M.remotable('Port')),
@@ -39,7 +37,6 @@ export const ChainAccountI = M.interface('ChainAccount', {
     .optional(M.record())
     .returns(VowShape),
   close: M.call().returns(VowShape),
-  getPurse: M.call().returns(VowShape),
 });
 
 /**
@@ -100,16 +97,6 @@ export const prepareChainAccountKit = (zone, { watch, asVow }) =>
             'ICA channel creation acknowledgement not yet received.',
           );
         },
-        getBalance(_denom) {
-          // TODO https://github.com/Agoric/agoric-sdk/issues/9610
-          // UNTIL https://github.com/Agoric/agoric-sdk/issues/9326
-          return asVow(() => Fail`not yet implemented`);
-        },
-        getBalances() {
-          // TODO https://github.com/Agoric/agoric-sdk/issues/9610
-          // UNTIL https://github.com/Agoric/agoric-sdk/issues/9326
-          return asVow(() => Fail`not yet implemented`);
-        },
         getLocalAddress() {
           return NonNullish(
             this.state.localAddress,
@@ -163,15 +150,6 @@ export const prepareChainAccountKit = (zone, { watch, asVow }) =>
             if (!connection) throw Fail`connection not available`;
             return E(connection).close();
           });
-        },
-        /**
-         * get Purse for a brand to .withdraw() a Payment from the account
-         *
-         * @param {Brand} brand
-         */
-        getPurse(brand) {
-          console.log('getPurse got', brand);
-          return asVow(() => Fail`not yet implemented`);
         },
       },
       connectionHandler: {

--- a/packages/orchestration/src/exos/ica-account-kit.js
+++ b/packages/orchestration/src/exos/ica-account-kit.js
@@ -1,4 +1,4 @@
-/** @file ChainAccount exo */
+/** @file IcaAccount exo */
 import { Fail } from '@endo/errors';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
@@ -22,12 +22,12 @@ import { makeTxPacket, parseTxPacket } from '../utils/packet.js';
  * @import {ChainAddress} from '../types.js';
  */
 
-const trace = makeTracer('ChainAccountKit');
+const trace = makeTracer('IcaAccountKit');
 
 /** @typedef {'UNPARSABLE_CHAIN_ADDRESS'} UnparsableChainAddress */
 const UNPARSABLE_CHAIN_ADDRESS = 'UNPARSABLE_CHAIN_ADDRESS';
 
-export const ChainAccountI = M.interface('ChainAccount', {
+export const IcaAccountI = M.interface('IcaAccount', {
   getAddress: M.call().returns(ChainAddressShape),
   getLocalAddress: M.call().returns(M.string()),
   getRemoteAddress: M.call().returns(M.string()),
@@ -55,11 +55,11 @@ export const ChainAccountI = M.interface('ChainAccount', {
  * @param {Zone} zone
  * @param {VowTools} vowTools
  */
-export const prepareChainAccountKit = (zone, { watch, asVow }) =>
+export const prepareIcaAccountKit = (zone, { watch, asVow }) =>
   zone.exoClassKit(
-    'ChainAccountKit',
+    'IcaAccountKit',
     {
-      account: ChainAccountI,
+      account: IcaAccountI,
       connectionHandler: OutboundConnectionHandlerI,
       parseTxPacketWatcher: M.interface('ParseTxPacketWatcher', {
         onFulfilled: M.call(M.string())
@@ -186,4 +186,4 @@ export const prepareChainAccountKit = (zone, { watch, asVow }) =>
     },
   );
 
-/** @typedef {ReturnType<ReturnType<typeof prepareChainAccountKit>>} ChainAccountKit */
+/** @typedef {ReturnType<ReturnType<typeof prepareIcaAccountKit>>} IcaAccountKit */

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -1,4 +1,4 @@
-/** @file ChainAccount exo */
+/** @file Localchain Facade exo */
 import { E } from '@endo/far';
 // eslint-disable-next-line no-restricted-syntax -- just the import
 import { heapVowE } from '@agoric/vow/vat.js';

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -1,4 +1,4 @@
-/** @file ChainAccount exo */
+/** @file Orchestrator exo */
 import { AmountShape } from '@agoric/ertp';
 import { pickFacet } from '@agoric/vat-data';
 import { makeTracer } from '@agoric/internal';

--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -1,4 +1,4 @@
-/** @file ChainAccount exo */
+/** @file Remote Chain Facade exo */
 import { makeTracer } from '@agoric/internal';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';

--- a/packages/orchestration/src/types.ts
+++ b/packages/orchestration/src/types.ts
@@ -3,7 +3,7 @@
 export type * from './chain-info.js';
 export type * from './cosmos-api.js';
 export type * from './ethereum-api.js';
-export type * from './exos/chain-account-kit.js';
+export type * from './exos/ica-account-kit.js';
 export type * from './exos/icq-connection-kit.js';
 export type * from './orchestration-api.js';
 export type * from './exos/cosmos-interchain-service.js';

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -77,7 +77,8 @@ export const findAddressField = remoteAddressString => {
     // Extract JSON version string assuming it's always surrounded by {}
     const jsonStr = remoteAddressString?.match(/{.*?}/)?.[0];
     const jsonObj = jsonStr ? JSON.parse(jsonStr) : undefined;
-    return jsonObj?.address ?? undefined;
+    if (!jsonObj?.address?.length) return undefined;
+    return jsonObj.address;
   } catch (error) {
     return undefined;
   }

--- a/packages/orchestration/test/service.test.ts
+++ b/packages/orchestration/test/service.test.ts
@@ -99,7 +99,7 @@ test('makeICQConnection returns an ICQConnection', async t => {
   t.is(uniquePortIds.size, 1, 'all connections share same port');
 });
 
-test('makeAccount returns a ChainAccount', async t => {
+test('makeAccount returns an IcaAccountKit', async t => {
   const {
     bootstrap: { cosmosInterchainService },
   } = await commonSetup(t);

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -54,8 +54,8 @@ test('findAddressField', t => {
     findAddressField(
       '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
     ),
-    '',
-    'returns empty string if address is an empty string',
+    undefined,
+    'returns undefined if address is an empty string',
   );
   t.is(
     findAddressField(
@@ -70,6 +70,13 @@ test('findAddressField', t => {
     ),
     'osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq',
     'returns address when localAddrr is appended to version string',
+  );
+  t.is(
+    findAddressField(
+      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{not valid JSON}',
+    ),
+    undefined,
+    'returns undefined when JSON is malformed',
   );
 });
 


### PR DESCRIPTION
refs: #9064

## Description
- remove getBalance, getBalances, getPurse from IcaAccountKit
- cleanup TODO surrounding `UNPARSABLE_CHAIN_ADDRESS`
- rename `ChainAccountKit` -> `IcaAccountKit`
- `findAddressField` should treat an empty string as an `UNPARSABLE_ADDRESS`
- improve testing coverage for `IcaAccount.getPort()`
- docs: update exo classDiagram

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
n/a
