### PR TITLE
ci: removed deprecated fields in mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,25 +1,26 @@
 # Linear queue for the main branch.
-queue_rules:
-  - name: high_priority_main
-    commit_message_template: |-
+shared:
+    commit_message_template: &commit-message-template |-
       {{ title }} (#{{ number }})
 
       {{ body | trim }}
-    queue_conditions:
+    queue_conditions: &queue-conditions
       - base=master
+      - or:
+          - check-pending=integration-test-result
+          - check-success=integration-test-result
+          - label=bypass:integration
+      - or:
+          - and: # breakage succeeds like we thought
+              - check-success=breakage
+              - -label=proto:expect-breakage
+          - and: # breakage fails like we thought
+              - check-failure=breakage
+              - label=proto:expect-breakage
+    high_priority_queue_conditions: &high-priority-queue-conditions
+      - and: *queue-conditions
       - label=priority:high
-      - or:
-          - check-pending=integration-test-result
-          - check-success=integration-test-result
-          - label=bypass:integration
-      - or:
-          - and: # breakage succeeds like we thought
-              - check-success=breakage
-              - -label=proto:expect-breakage
-          - and: # breakage fails like we thought
-              - check-failure=breakage
-              - label=proto:expect-breakage
-    merge_conditions:
+    merge_conditions: &merge-conditions
       - base=master
       # Rebase PRs with fixup commits are allowed to enter the merge queue but 
       # should not be allowed to merge if there are leftover fixup commits after rebase
@@ -31,66 +32,108 @@ queue_rules:
       - or:
           - label=bypass:integration
           - check-success=integration-test-result
-  - name: main
-    commit_message_template: |-
-      {{ title }} (#{{ number }})
-
-      {{ body | trim }}
-    queue_conditions:
-      - base=master
-      - or:
-          - check-pending=integration-test-result
-          - check-success=integration-test-result
-          - label=bypass:integration
-      - or:
-          - and: # breakage succeeds like we thought
-              - check-success=breakage
-              - -label=proto:expect-breakage
-          - and: # breakage fails like we thought
-              - check-failure=breakage
-              - label=proto:expect-breakage
-    merge_conditions:
-      - base=master
-      # Rebase PRs with fixup commits are allowed to enter the merge queue but 
-      # should not be allowed to merge if there are leftover fixup commits after rebase
-      - or:
-          - label=bypass:linear-history
-          - check-success=no-fixup-commits
-          - check-skipped=no-fixup-commits
-      # Require integration tests before merging only
-      - or:
-          - label=bypass:integration
-          - check-success=integration-test-result
-
-pull_request_rules:
-  - name: merge to master
-    conditions:
+    pr_queue_merge_conditions: &pr-queue-merge-conditions
       - base=master
       - label=automerge:no-update
       - or:
           - '#commits-behind=0'
           - label=bypass:linear-history
-    actions:
-      queue:
-        merge_method: merge
-  - name: rebase updates then merge to master
-    conditions:
+    pr_queue_rebase_conditions: &pr-queue-rebase-conditions
       - base=master
       - label=automerge:rebase
       - or:
           - '#commits-behind>0'
           - linear-history
-    actions:
-      queue:
-        merge_method: merge
-        update_method: rebase
-  - name: squash to master
-    conditions:
+    pr_queue_squash_conditions: &pr-queue-squash-conditions
       - base=master
       - label=automerge:squash
+
+queue_rules:
+  - name: high_priority_rebase
+    commit_message_template: *commit-message-template
+    queue_conditions: *high-priority-queue-conditions
+    merge_conditions: *merge-conditions
+    merge_method: merge
+    update_method: rebase
+
+  - name: high_priority_merge
+    commit_message_template: *commit-message-template
+    queue_conditions: *high-priority-queue-conditions
+    merge_conditions: *merge-conditions
+    disallow_checks_interruption_from_queues:
+      - high_priority_rebase
+    merge_method: merge
+
+  - name: high_priority_squash
+    commit_message_template: *commit-message-template
+    queue_conditions: *high-priority-queue-conditions
+    merge_conditions: *merge-conditions
+    disallow_checks_interruption_from_queues:
+      - high_priority_rebase
+      - high_priority_merge
+    merge_method: squash
+
+  - name: rebase
+    commit_message_template: *commit-message-template
+    queue_conditions: *queue-conditions
+    merge_conditions: *merge-conditions
+    merge_method: merge
+    update_method: rebase
+
+  - name: merge
+    commit_message_template: *commit-message-template
+    queue_conditions: *queue-conditions
+    merge_conditions: *merge-conditions
+    disallow_checks_interruption_from_queues:
+      - rebase
+    merge_method: merge
+
+  - name: squash
+    commit_message_template: *commit-message-template
+    queue_conditions: *queue-conditions
+    merge_conditions: *merge-conditions
+    disallow_checks_interruption_from_queues:
+      - rebase
+      - merge
+    merge_method: squash
+
+pull_request_rules:
+  - name:  high priority - merge to master
+    conditions:
+      - and: *pr-queue-merge-conditions
+      - label=priority:high
     actions:
       queue:
-        merge_method: squash
+        name: high_priority_merge
+  - name: high priority - rebase updates then merge to master
+    conditions:
+      - and: *pr-queue-rebase-conditions
+      - label=priority:high
+    actions:
+      queue:
+        name: high_priority_rebase
+  - name: high priority - squash to master
+    conditions:
+      - and: *pr-queue-squash-conditions
+      - label=priority:high
+    actions:
+      queue:
+        name: high_priority_squash
+  - name: merge to master
+    conditions: *pr-queue-merge-conditions
+    actions:
+      queue:
+        name: merge
+  - name: rebase updates then merge to master
+    conditions: *pr-queue-rebase-conditions
+    actions:
+      queue:
+        name: rebase
+  - name: squash to master
+    conditions: *pr-queue-squash-conditions
+    actions:
+      queue:
+        name: squash
   - name: rebase and autosquash
     conditions:
       - base=master


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #9836

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR removes the following deprecated fields in the queue action in mergify:
- `merge_method`
- `update_method`

Mergify recommends using these fields in the `queue_rules` section instead. each queue can only have a single update/merge method, so In order to have different update/merge methods for different pull_requests we must create multiple queues 

This creates two issues in priority:
- Each queue has its own priority level i.e. queues defined first are executed first. This creates a difference in priority that we do no intend. 
- since we have to create multiple queues our previous method of creating a high priority queue will not work, instead we'll have to duplicate the queues again, creating one queue for high_priority and one for normal priority. 

As of now there exists no way around these problems. After some discussion with the Mergify team this is what they recommend: 
>  We’re WIP in removing the priorities between queues, but in the meantime you can mitigate this with `allow_checks_interruption`  set to false and `disallow_checks_interruption_from_queues` 

### Testing of PR:
I tested this PR to verify that all queues work as expected. these 3 PRs were created for this purpose:
https://github.com/frazarshad/mergify-experiements/pull/20
https://github.com/frazarshad/mergify-experiements/pull/21
https://github.com/frazarshad/mergify-experiements/pull/22
![image](https://github.com/user-attachments/assets/145c2e6b-a97b-4c0a-bcfb-912eb9916482)

The new priority_rules were also checked and work as expected:
![Screenshot 2024-08-05 at 4 33 22 PM](https://github.com/user-attachments/assets/f49bcdce-5fcf-44cd-b117-074952fdc38a)


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
