### PR TITLE
feat: add the ability to override param values

### DIFF
--- a/packages/governance/test/unitTests/typedParamManager.test.js
+++ b/packages/governance/test/unitTests/typedParamManager.test.js
@@ -361,3 +361,27 @@ test('Unknown', async t => {
   await paramManager.updateParams({ Surprise: ['gift', 'party'] });
   t.deepEqual(paramManager.getSurprise(), ['gift', 'party']);
 });
+
+test('makeParamManagerFromTerms overrides', async t => {
+  const terms = harden({
+    governedParams: {
+      Mmr: { type: 'nat', value: makeRatio(150n, drachmaKit.brand) },
+    },
+  });
+  const issuerKeywordRecord = harden({
+    Ignore: drachmaKit.issuer,
+  });
+  const { zcf } = await setupZCFTest(issuerKeywordRecord, terms);
+
+  const paramManager = await makeParamManagerFromTerms(
+    makeStoredPublisherKit(),
+    // @ts-expect-error missing governance terms
+    zcf,
+    { Electorate: zcf.makeInvitation(() => null, 'mock poser invitation') },
+    {
+      Mmr: 'ratio',
+    },
+    { Mmr: makeRatio(100n, drachmaKit.brand) },
+  );
+  t.deepEqual(paramManager.getMmr().numerator.value, 100n);
+});

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -74,6 +74,7 @@ harden(meta);
  *     string,
  *     import('./params.js').VaultManagerParamOverrides
  *   >;
+ *   directorParamOverrides: [object];
  * }} privateArgs
  * @param {import('@agoric/swingset-liveslots').Baggage} baggage
  */
@@ -86,6 +87,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     storageNode,
     auctioneerInstance,
     managerParams,
+    directorParamOverrides,
   } = privateArgs;
 
   trace('awaiting debtMint');
@@ -117,7 +119,6 @@ export const start = async (zcf, privateArgs, baggage) => {
     marshaller,
   );
   /** a powerful object; can modify the invitation */
-  trace('awaiting makeParamManagerFromTerms');
   const vaultDirectorParamManager = await makeParamManagerFromTerms(
     {
       publisher: governanceSubscriptionKit.publication,
@@ -129,6 +130,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       [SHORTFALL_INVITATION_KEY]: initialShortfallInvitation,
     },
     vaultDirectorParamTypes,
+    directorParamOverrides,
   );
 
   const director = provideDirector(


### PR DESCRIPTION
closes: #9596
refs: #9748

## Description

When upgrading VaultFactory, restore the VaultDirector's parameters to the values that exist on chain.

### Security Considerations

No particular security implications.

### Scaling Considerations

Run only on upgrade. No impact.

### Documentation Considerations

No user visible impact.

### Testing Considerations

being tested manually thoroughly. The change to `typeParamManager.js` has a unit test.

### Upgrade Considerations

Make it possible to preserve values that have been updated on chain. It would have been bad to lose the updated value of `ReferencedUI`.