### PR TITLE
feat: implement `OrchestrationAccountI` .send() and .sendAll() methods

### DIFF
--- a/packages/boot/test/bootstrapTests/lca.test.ts
+++ b/packages/boot/test/bootstrapTests/lca.test.ts
@@ -113,4 +113,72 @@ test.serial('stakeBld', async t => {
     // FIXME should receive "simulated packet timeout" error
     // { message: 'simulated packet timeout' },
   );
+
+  await wd.executeOffer({
+    id: 'bank-send',
+    invitationSpec: {
+      source: 'continuing',
+      previousOffer: 'request-stake',
+      invitationMakerName: 'Send',
+    },
+    proposal: {},
+    offerArgs: {
+      toAccount: {
+        value: 'agoric1EOAAccAddress',
+        chainId: 'agoriclocal',
+        encoding: 'bech32',
+      },
+      amount: { denom: 'ibc/1234', value: 10n },
+    },
+  });
+  t.like(wd.getLatestUpdateRecord(), {
+    status: { id: 'bank-send', numWantsSatisfied: 1 },
+  });
+
+  await wd.executeOffer({
+    id: 'bank-sendAll',
+    invitationSpec: {
+      source: 'continuing',
+      previousOffer: 'request-stake',
+      invitationMakerName: 'SendAll',
+    },
+    proposal: {},
+    offerArgs: {
+      toAccount: {
+        value: 'agoric1EOAAccAddress',
+        chainId: 'agoriclocal',
+        encoding: 'bech32',
+      },
+      amounts: [
+        { denom: 'uatom', value: 10n },
+        { denom: 'ibc/1234', value: 10n },
+      ],
+    },
+  });
+  t.like(wd.getLatestUpdateRecord(), {
+    status: { id: 'bank-sendAll', numWantsSatisfied: 1 },
+  });
+
+  await t.throwsAsync(
+    wd.executeOffer({
+      id: 'bank-send-fail',
+      invitationSpec: {
+        source: 'continuing',
+        previousOffer: 'request-stake',
+        invitationMakerName: 'Send',
+      },
+      proposal: {},
+      offerArgs: {
+        toAccount: {
+          value: 'agoric1EOAAccAddress',
+          chainId: 'agoriclocal',
+          encoding: 'bech32',
+        },
+        amount: {
+          denom: 'ibc/1234',
+          value: 400n,
+        },
+      },
+    }),
+  );
 });

--- a/packages/boot/test/bootstrapTests/lca.test.ts
+++ b/packages/boot/test/bootstrapTests/lca.test.ts
@@ -5,6 +5,7 @@ import type { TestFn } from 'ava';
 import { Fail } from '@endo/errors';
 import type { start as stakeBldStart } from '@agoric/orchestration/src/examples/stakeBld.contract.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
+import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
@@ -100,12 +101,15 @@ test.serial('stakeBld', async t => {
         source: 'continuing',
         previousOffer: 'request-stake',
         invitationMakerName: 'Delegate',
-        invitationArgs: ['agoric1validator1', { brand: BLD, value: 504n }],
+        invitationArgs: [
+          'agoric1validator1',
+          { brand: BLD, value: SIMULATED_ERRORS.TIMEOUT },
+        ],
       },
       proposal: {
         give: {
           // @ts-expect-error XXX BoardRemote
-          In: { brand: BLD, value: 504n },
+          In: { brand: BLD, value: SIMULATED_ERRORS.TIMEOUT },
         },
       },
     }),
@@ -176,7 +180,7 @@ test.serial('stakeBld', async t => {
         },
         amount: {
           denom: 'ibc/1234',
-          value: 400n,
+          value: SIMULATED_ERRORS.BAD_REQUEST,
         },
       },
     }),

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -19,6 +19,8 @@ const validatorAddress: CosmosValidatorAddress = {
   encoding: 'bech32',
 };
 
+const ATOM_DENOM = 'uatom';
+
 test.before(async t => {
   t.context = await makeWalletFactoryContext(
     t,
@@ -43,7 +45,7 @@ test.serial('config', async t => {
     const cosmosChainInfo = await EV(agoricNames).lookup('chain', 'cosmoshub');
     t.like(cosmosChainInfo, {
       chainId: 'cosmoshub-4',
-      stakingTokens: [{ denom: 'uatom' }],
+      stakingTokens: [{ denom: ATOM_DENOM }],
     });
     t.deepEqual(
       readLatest(`published.agoricNames.chain.cosmoshub`),
@@ -120,8 +122,8 @@ test.skip('stakeOsmo - queries', async t => {
   t.log('account', account);
   t.truthy(account, 'makeAccount returns an account on OSMO connection');
 
-  const queryRes = await EV(account).getBalance('uatom');
-  t.deepEqual(queryRes, { value: 0n, denom: 'uatom' });
+  const queryRes = await EV(account).getBalance(ATOM_DENOM);
+  t.deepEqual(queryRes, { value: 0n, denom: ATOM_DENOM });
 
   const queryUnknownDenom = await EV(account).getBalance('some-invalid-denom');
   t.deepEqual(
@@ -184,7 +186,7 @@ test.serial('stakeAtom - smart wallet', async t => {
       source: 'continuing',
       previousOffer: 'request-account',
       invitationMakerName: 'Delegate',
-      invitationArgs: [validatorAddress, { brand: ATOM, value: 10n }],
+      invitationArgs: [validatorAddress, { denom: ATOM_DENOM, value: 10n }],
     },
     proposal: {},
   });
@@ -206,7 +208,10 @@ test.serial('stakeAtom - smart wallet', async t => {
         source: 'continuing',
         previousOffer: 'request-account',
         invitationMakerName: 'Delegate',
-        invitationArgs: [validatorAddressFail, { brand: ATOM, value: 10n }],
+        invitationArgs: [
+          validatorAddressFail,
+          { denom: ATOM_DENOM, value: 10n },
+        ],
       },
       proposal: {},
     }),
@@ -214,6 +219,24 @@ test.serial('stakeAtom - smart wallet', async t => {
       message: 'ABCI code: 5: error handling packet: see events for details',
     },
     'delegate fails with invalid validator',
+  );
+
+  // This will trigger the immediate ack of the mock bridge
+  await t.throwsAsync(
+    wd.executeOffer({
+      id: 'request-delegate-brand',
+      invitationSpec: {
+        source: 'continuing',
+        previousOffer: 'request-account',
+        invitationMakerName: 'Delegate',
+        invitationArgs: [validatorAddress, { brand: ATOM, value: 10n }],
+      },
+      proposal: {},
+    }),
+    {
+      message: 'Brands not currently supported.',
+    },
+    'brands not currently supported',
   );
 });
 
@@ -393,8 +416,7 @@ test.serial('basic-flows - portfolio holder', async t => {
   // XXX this overrides a previous account, since mocks only provide one address
   t.is(readLatest('published.basicFlows.agoric1mockVlocalchainAddress'), '');
 
-  const { ATOM, BLD } = agoricNamesRemotes.brand;
-  ATOM || Fail`ATOM missing from agoricNames`;
+  const { BLD } = agoricNamesRemotes.brand;
   BLD || Fail`BLD missing from agoricNames`;
 
   await wd.sendOffer({
@@ -406,7 +428,7 @@ test.serial('basic-flows - portfolio holder', async t => {
       invitationArgs: [
         'cosmoshub',
         'Delegate',
-        [validatorAddress, { brand: ATOM, value: 10n }],
+        [validatorAddress, { denom: ATOM_DENOM, value: 10n }],
       ],
     },
     proposal: {},
@@ -444,7 +466,7 @@ test.serial('basic-flows - portfolio holder', async t => {
         invitationArgs: [
           'cosmoshub',
           'Delegate',
-          [validatorAddress, { brand: ATOM, value: 504n }],
+          [validatorAddress, { denom: ATOM_DENOM, value: 504n }],
         ],
       },
       proposal: {},

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -6,6 +6,7 @@ import type { CosmosValidatorAddress } from '@agoric/orchestration';
 import type { start as startStakeIca } from '@agoric/orchestration/src/examples/stakeIca.contract.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
 import type { TestFn } from 'ava';
+import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
@@ -466,7 +467,10 @@ test.serial('basic-flows - portfolio holder', async t => {
         invitationArgs: [
           'cosmoshub',
           'Delegate',
-          [validatorAddress, { denom: ATOM_DENOM, value: 504n }],
+          [
+            validatorAddress,
+            { denom: ATOM_DENOM, value: SIMULATED_ERRORS.TIMEOUT },
+          ],
         ],
       },
       proposal: {},
@@ -483,7 +487,10 @@ test.serial('basic-flows - portfolio holder', async t => {
         invitationArgs: [
           'agoric',
           'Delegate',
-          ['agoric1validator1', { brand: BLD, value: 504n }],
+          [
+            'agoric1validator1',
+            { brand: BLD, value: SIMULATED_ERRORS.TIMEOUT },
+          ],
         ],
       },
       proposal: {},

--- a/packages/boot/test/orchestration/restart-contracts.test.ts
+++ b/packages/boot/test/orchestration/restart-contracts.test.ts
@@ -101,6 +101,7 @@ const validatorAddress: CosmosValidatorAddress = {
   chainId: 'gaiatest',
   encoding: 'bech32',
 };
+const ATOM_DENOM = 'uatom';
 
 // check for key because the value will be 'undefined' when the result is provided
 // TODO should it be something truthy?
@@ -152,7 +153,7 @@ test.serial('stakeAtom', async t => {
       source: 'continuing',
       previousOffer: 'request-account',
       invitationMakerName: 'Delegate',
-      invitationArgs: [validatorAddress, { brand: ATOM, value: 10n }],
+      invitationArgs: [validatorAddress, { denom: ATOM_DENOM, value: 10n }],
     },
     proposal: {},
   });

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -32,6 +32,10 @@
       "types": "./dist/codegen/cosmos/bank/v1beta1/query.d.ts",
       "default": "./dist/codegen/cosmos/bank/v1beta1/query.js"
     },
+    "./cosmos/bank/v1beta1/tx.js": {
+      "types": "./dist/codegen/cosmos/bank/v1beta1/tx.d.ts",
+      "default": "./dist/codegen/cosmos/bank/v1beta1/tx.js"
+    },
     "./cosmos/distribution/v1beta1/tx.js": {
       "types": "./dist/codegen/cosmos/distribution/v1beta1/tx.d.ts",
       "default": "./dist/codegen/cosmos/distribution/v1beta1/tx.js"

--- a/packages/orchestration/src/exos/README.md
+++ b/packages/orchestration/src/exos/README.md
@@ -98,6 +98,7 @@ classDiagram
       getPublicTopics()
       monitorTransfers()
       send()
+      sendAll()
       transfer()
       undelegate()
       withdraw()
@@ -117,6 +118,8 @@ classDiagram
       getBalance()
       getPublicTopics()
       redelegate()
+      send()
+      sendAll()
       undelegate()
       withdrawReward()
     }

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -15,6 +15,7 @@ import {
   MsgUndelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
+import { MsgSend } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
 import { makeTracer } from '@agoric/internal';
 import { Shape as NetworkShape } from '@agoric/network';
 import { M } from '@agoric/vat-data';
@@ -145,6 +146,8 @@ export const prepareCosmosOrchestrationAccountKit = (
         Undelegate: M.call(M.arrayOf(DelegationShape)).returns(M.promise()),
         CloseAccount: M.call().returns(M.promise()),
         TransferAccount: M.call().returns(M.promise()),
+        Send: M.call().returns(M.promise()),
+        SendAll: M.call().returns(M.promise()),
       }),
     },
     /**
@@ -298,6 +301,32 @@ export const prepareCosmosOrchestrationAccountKit = (
         CloseAccount() {
           throw Error('not yet implemented');
         },
+        Send() {
+          /**
+           * @type {OfferHandler<
+           *   Vow<void>,
+           *   { toAccount: ChainAddress; amount: AmountArg }
+           * >}
+           */
+          const offerHandler = (seat, { toAccount, amount }) => {
+            seat.exit();
+            return watch(this.facets.holder.send(toAccount, amount));
+          };
+          return zcf.makeInvitation(offerHandler, 'Send');
+        },
+        SendAll() {
+          /**
+           * @type {OfferHandler<
+           *   Vow<void>,
+           *   { toAccount: ChainAddress; amounts: AmountArg[] }
+           * >}
+           */
+          const offerHandler = (seat, { toAccount, amounts }) => {
+            seat.exit();
+            return watch(this.facets.holder.sendAll(toAccount, amounts));
+          };
+          return zcf.makeInvitation(offerHandler, 'SendAll');
+        },
         /**
          * Starting a transfer revokes the account holder. The associated
          * updater will get a special notification that the account is being
@@ -443,8 +472,44 @@ export const prepareCosmosOrchestrationAccountKit = (
 
         /** @type {HostOf<OrchestrationAccountI['send']>} */
         send(toAccount, amount) {
-          console.log('send got', toAccount, amount);
-          return asVow(() => Fail`not yet implemented`);
+          return asVow(() => {
+            trace('send', toAccount, amount);
+            const { helper } = this.facets;
+            const { chainAddress } = this.state;
+            return watch(
+              E(helper.owned()).executeEncodedTx([
+                Any.toJSON(
+                  MsgSend.toProtoMsg({
+                    fromAddress: chainAddress.value,
+                    toAddress: toAccount.value,
+                    amount: [helper.amountToCoin(amount)],
+                  }),
+                ),
+              ]),
+              this.facets.returnVoidWatcher,
+            );
+          });
+        },
+
+        /** @type {HostOf<OrchestrationAccountI['sendAll']>} */
+        sendAll(toAccount, amounts) {
+          return asVow(() => {
+            trace('sendAll', toAccount, amounts);
+            const { helper } = this.facets;
+            const { chainAddress } = this.state;
+            return watch(
+              E(helper.owned()).executeEncodedTx([
+                Any.toJSON(
+                  MsgSend.toProtoMsg({
+                    fromAddress: chainAddress.value,
+                    toAddress: toAccount.value,
+                    amount: amounts.map(x => helper.amountToCoin(x)),
+                  }),
+                ),
+              ]),
+              this.facets.returnVoidWatcher,
+            );
+          });
         },
 
         /** @type {HostOf<OrchestrationAccountI['transfer']>} */

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -154,7 +154,15 @@ export interface OrchestrationAccountI {
    * @param amount - the amount to send
    * @returns void
    */
-  send: (toAccount: ChainAddress, amount: AmountArg) => Promise<void>;
+  send: (toAccount: ChainAddress, amounts: AmountArg) => Promise<void>;
+
+  /**
+   * Transfer multiple amounts to another account on the same chain. The promise settles when the transfer is complete.
+   * @param toAccount - the account to send the amount to. MUST be on the same chain
+   * @param amounts - the amounts to send
+   * @returns void
+   */
+  sendAll: (toAccount: ChainAddress, amounts: AmountArg[]) => Promise<void>;
 
   /**
    * Transfer an amount to another account, typically on another chain.

--- a/packages/orchestration/src/utils/orchestrationAccount.js
+++ b/packages/orchestration/src/utils/orchestrationAccount.js
@@ -18,6 +18,9 @@ export const orchestrationAccountMethods = {
   getBalance: M.call(M.any()).returns(Vow$(DenomAmountShape)),
   getBalances: M.call().returns(Vow$(M.arrayOf(DenomAmountShape))),
   send: M.call(ChainAddressShape, AmountArgShape).returns(VowShape),
+  sendAll: M.call(ChainAddressShape, M.arrayOf(AmountArgShape)).returns(
+    VowShape,
+  ),
   transfer: M.call(AmountArgShape, ChainAddressShape)
     .optional(M.record())
     .returns(VowShape),

--- a/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
+++ b/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
@@ -119,7 +119,7 @@ test('auto-stake-it - make accounts, register tap, return invitationMakers', asy
     'tokens transferred from LOA to COA',
   );
   await transmitTransferAck();
-  const { acknowledgement } = (await inspectDibcBridge()).at(
+  const { acknowledgement } = (await inspectDibcBridge()).bridgeEvents.at(
     -1,
   ) as IBCEvent<'acknowledgementPacket'>;
   // XXX consider checking ICA (dest|source)_channel, to verify the sender of

--- a/packages/orchestration/test/examples/stake-ica.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-ica.contract.test.ts
@@ -230,32 +230,3 @@ test('makeAccountInvitationMaker', async t => {
   t.truthy(vstorageEntry, 'vstorage account entry created');
   t.is(bootstrap.marshaller.fromCapData(JSON.parse(vstorageEntry!)), '');
 });
-
-test('CosmosOrchestrationAccount - not yet implemented', async t => {
-  const { bootstrap } = await commonSetup(t);
-  const { publicFacet } = await startContract(bootstrap);
-  const account = await E(publicFacet).makeAccount();
-  const mockChainAddress: ChainAddress = {
-    value: 'cosmos1test',
-    chainId: 'cosmoshub-4',
-    encoding: 'bech32',
-  };
-  const mockAmountArg: AmountArg = { value: 10n, denom: 'uatom' };
-
-  await t.throwsAsync(E(account).getBalances(), {
-    message: 'not yet implemented',
-  });
-  await t.throwsAsync(E(account).send(mockChainAddress, mockAmountArg), {
-    message: 'not yet implemented',
-  });
-  // XXX consider, positioning amount + address args the same for .send and .transfer
-  await t.throwsAsync(E(account).transfer(mockAmountArg, mockChainAddress), {
-    message: 'not yet implemented',
-  });
-  await t.throwsAsync(E(account).transferSteps(mockAmountArg, null as any), {
-    message: 'not yet implemented',
-  });
-  await t.throwsAsync(E(account).withdrawRewards(), {
-    message: 'Not Implemented. Try using withdrawReward.',
-  });
-});

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -13,6 +13,63 @@ test.beforeEach(async t => {
   t.context = await commonSetup(t);
 });
 
+test('CosmosOrchestrationAccount - send (to addr on same chain)', async t => {
+  const {
+    bootstrap,
+    brands: { ist },
+    utils: { inspectDibcBridge },
+  } = t.context;
+  const makeTestCOAKit = prepareMakeTestCOAKit(t, bootstrap);
+  const account = await makeTestCOAKit();
+  t.assert(account, 'account is returned');
+
+  const toAddress: ChainAddress = {
+    value: 'cosmos99test',
+    chainId: 'cosmoshub-4',
+    encoding: 'bech32',
+  };
+
+  // single send
+  t.is(
+    await E(account).send(toAddress, {
+      value: 10n,
+      denom: 'uatom',
+    } as AmountArg),
+    undefined,
+  );
+
+  // simulate timeout error
+  await t.throwsAsync(
+    E(account).send(toAddress, { value: 504n, denom: 'uatom' } as AmountArg),
+    // TODO #9629 decode error messages
+    { message: 'ABCI code: 5: error handling packet: see events for details' },
+  );
+
+  // ertp amounts not supported
+  await t.throwsAsync(
+    E(account).send(toAddress, ist.make(10n) as AmountArg),
+    // TODO #9211 lookup denom from brand
+    { message: 'Brands not currently supported.' },
+  );
+
+  // multi-send (sendAll)
+  t.is(
+    await E(account).sendAll(toAddress, [
+      { value: 10n, denom: 'uatom' } as AmountArg,
+      { value: 10n, denom: 'ibc/1234' } as AmountArg,
+    ]),
+    undefined,
+  );
+
+  const { bridgeDowncalls } = await inspectDibcBridge();
+
+  t.is(
+    bridgeDowncalls.filter(d => d.method === 'sendPacket').length,
+    3,
+    'sent 2 successful txs and 1 failed. 1 rejected before sending',
+  );
+});
+
 test('CosmosOrchestrationAccount - not yet implemented', async t => {
   const { bootstrap } = await commonSetup(t);
   const makeTestCOAKit = prepareMakeTestCOAKit(t, bootstrap);
@@ -25,9 +82,6 @@ test('CosmosOrchestrationAccount - not yet implemented', async t => {
   const mockAmountArg: AmountArg = { value: 10n, denom: 'uatom' };
 
   await t.throwsAsync(E(account).getBalances(), {
-    message: 'not yet implemented',
-  });
-  await t.throwsAsync(E(account).send(mockChainAddress, mockAmountArg), {
     message: 'not yet implemented',
   });
   // XXX consider, positioning amount + address args the same for .send and .transfer

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -1,0 +1,43 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import type { TestFn } from 'ava';
+import { heapVowE as E } from '@agoric/vow/vat.js';
+import { commonSetup } from '../supports.js';
+import type { AmountArg, ChainAddress } from '../../src/orchestration-api.js';
+import { prepareMakeTestCOAKit } from './make-test-coa-kit.js';
+
+type TestContext = Awaited<ReturnType<typeof commonSetup>>;
+
+const test = anyTest as TestFn<TestContext>;
+
+test.beforeEach(async t => {
+  t.context = await commonSetup(t);
+});
+
+test('CosmosOrchestrationAccount - not yet implemented', async t => {
+  const { bootstrap } = await commonSetup(t);
+  const makeTestCOAKit = prepareMakeTestCOAKit(t, bootstrap);
+  const account = await makeTestCOAKit();
+  const mockChainAddress: ChainAddress = {
+    value: 'cosmos1test',
+    chainId: 'cosmoshub-4',
+    encoding: 'bech32',
+  };
+  const mockAmountArg: AmountArg = { value: 10n, denom: 'uatom' };
+
+  await t.throwsAsync(E(account).getBalances(), {
+    message: 'not yet implemented',
+  });
+  await t.throwsAsync(E(account).send(mockChainAddress, mockAmountArg), {
+    message: 'not yet implemented',
+  });
+  // XXX consider, positioning amount + address args the same for .send and .transfer
+  await t.throwsAsync(E(account).transfer(mockAmountArg, mockChainAddress), {
+    message: 'not yet implemented',
+  });
+  await t.throwsAsync(E(account).transferSteps(mockAmountArg, null as any), {
+    message: 'not yet implemented',
+  });
+  await t.throwsAsync(E(account).withdrawRewards(), {
+    message: 'Not Implemented. Try using withdrawReward.',
+  });
+});

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -4,6 +4,7 @@ import { AmountMath } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { heapVowE as VE } from '@agoric/vow/vat.js';
 import { TargetApp } from '@agoric/vats/src/bridge-target.js';
+import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import { ChainAddress, type AmountArg } from '../../src/orchestration-api.js';
 import { NANOSECONDS_PER_SECOND } from '../../src/utils/time.js';
 import { commonSetup } from '../supports.js';
@@ -173,9 +174,12 @@ test('transfer', async t => {
   );
 
   await t.throwsAsync(
-    // XXX the bridge fakes the timeout response automatically for 504n
-    (await startTransfer({ denom: 'ubld', value: 504n }, destination))
-      .transferP,
+    (
+      await startTransfer(
+        { denom: 'ubld', value: SIMULATED_ERRORS.TIMEOUT },
+        destination,
+      )
+    ).transferP,
     {
       message: 'simulated unexpected MsgTransfer packet timeout',
     },
@@ -322,7 +326,7 @@ test('send', async t => {
   await t.throwsAsync(
     VE(account).send(toAddress, {
       denom: 'ibc/400',
-      value: 400n,
+      value: SIMULATED_ERRORS.BAD_REQUEST,
     }),
     {
       message: 'simulated error',

--- a/packages/orchestration/test/ibc-mocks.ts
+++ b/packages/orchestration/test/ibc-mocks.ts
@@ -16,6 +16,10 @@ import {
 } from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/tx.js';
 import type { Timestamp } from '@agoric/cosmic-proto/google/protobuf/timestamp.js';
 import {
+  MsgSend,
+  MsgSendResponse,
+} from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
+import {
   buildMsgResponseString,
   buildQueryResponseString,
   buildMsgErrorString,
@@ -50,6 +54,19 @@ const redelegation = {
     denom: 'uatom',
     amount: '10',
   },
+};
+const bankSend = {
+  fromAddress: 'cosmos1test',
+  toAddress: 'cosmos99test',
+  amount: [{ denom: 'uatom', amount: '10' }],
+};
+const bankSendMulti = {
+  fromAddress: 'cosmos1test',
+  toAddress: 'cosmos99test',
+  amount: [
+    { denom: 'uatom', amount: '10' },
+    { denom: 'ibc/1234', amount: '10' },
+  ],
 };
 
 export const UNBOND_PERIOD_SECONDS = 5n;
@@ -94,6 +111,14 @@ export const protoMsgMocks = {
     ack: buildQueryResponseString(QueryBalanceResponse, {
       balance: { amount: '0', denom: 'uatom' },
     }),
+  },
+  bankSend: {
+    msg: buildTxPacketString([MsgSend.toProtoMsg(bankSend)]),
+    ack: buildMsgResponseString(MsgSendResponse, {}),
+  },
+  bankSendMulti: {
+    msg: buildTxPacketString([MsgSend.toProtoMsg(bankSendMulti)]),
+    ack: buildMsgResponseString(MsgSendResponse, {}),
   },
 };
 

--- a/packages/orchestration/test/network-fakes.ts
+++ b/packages/orchestration/test/network-fakes.ts
@@ -142,6 +142,7 @@ type BridgeDowncalls = Array<
   | IBCMethod<'startChannelOpenInit'>
   | IBCMethod<'startChannelCloseInit'>
   | IBCMethod<'bindPort'>
+  | IBCMethod<'sendPacket'>
 >;
 
 /**

--- a/packages/orchestration/test/network-fakes.ts
+++ b/packages/orchestration/test/network-fakes.ts
@@ -132,7 +132,16 @@ export const ibcBridgeMocks: {
 };
 
 type BridgeEvents = Array<
-  IBCEvent<'channelOpenAck'> | IBCEvent<'acknowledgementPacket'>
+  | IBCEvent<'channelOpenAck'>
+  | IBCEvent<'acknowledgementPacket'>
+  | IBCEvent<'channelCloseConfirm'>
+  | IBCEvent<'sendPacket'>
+>;
+
+type BridgeDowncalls = Array<
+  | IBCMethod<'startChannelOpenInit'>
+  | IBCMethod<'startChannelCloseInit'>
+  | IBCMethod<'bindPort'>
 >;
 
 /**
@@ -148,7 +157,10 @@ export const makeFakeIBCBridge = (
   ScopedBridgeManagerMethods<'dibc'> & {
     setMockAck: (mockAckMap: Record<string, string>) => void;
     setAddressPrefix: (addressPrefix: string) => void;
-    inspectDibcBridge: () => BridgeEvents;
+    inspectDibcBridge: () => {
+      bridgeEvents: BridgeEvents;
+      bridgeDowncalls: BridgeDowncalls;
+    };
   }
 > => {
   let bridgeHandler: any;
@@ -180,11 +192,13 @@ export const makeFakeIBCBridge = (
    */
   let mockAckMap = defaultMockAckMap;
   let bridgeEvents: BridgeEvents = [];
+  let bridgeDowncalls: BridgeDowncalls = [];
 
   return zone.exo('Fake IBC Bridge Manager', undefined, {
     getBridgeId: () => BridgeId.DIBC,
     toBridge: async obj => {
       if (obj.type === 'IBC_METHOD') {
+        bridgeDowncalls = bridgeDowncalls.concat(obj);
         switch (obj.method) {
           case 'startChannelOpenInit': {
             const connectionChannelCount = remoteChannelMap[obj.hops[0]] || 0;
@@ -218,6 +232,7 @@ export const makeFakeIBCBridge = (
       return undefined;
     },
     fromBridge: async obj => {
+      bridgeEvents = bridgeEvents.concat(obj);
       if (!bridgeHandler) throw Error('no handler!');
       return bridgeHandler.fromBridge(obj);
     },
@@ -250,7 +265,7 @@ export const makeFakeIBCBridge = (
      * for debugging and testing
      */
     inspectDibcBridge() {
-      return bridgeEvents;
+      return { bridgeEvents, bridgeDowncalls };
     },
   });
 };

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -341,7 +341,7 @@ test(`delegate; redelegate using invitationMakers`, async t => {
   {
     const { validator: dst } = configRedelegate;
     const value = BigInt(Object.values(configRedelegate.delegations)[0].amount);
-    const anAmount = { brand: aBrand, value };
+    const anAmount = { denom: 'uatom', value };
     const toRedelegate = await E(invitationMakers).Redelegate(
       validator,
       dst,

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -8,6 +8,7 @@ import { Nat } from '@endo/nat';
 /**
  * @import {JsonSafe} from '@agoric/cosmic-proto';
  * @import {MsgDelegateResponse, MsgUndelegateResponse} from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
+ * @import {MsgSendResponse} from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
  * @import {BridgeHandler, ScopedBridgeManager} from '../src/types.js';
  * @import {Remote} from '@agoric/vow';
  */
@@ -180,6 +181,12 @@ export const fakeLocalChainBridgeTxMsgHandler = (message, sequence) => {
       return {
         sequence,
       };
+    }
+    case '/cosmos.bank.v1beta1.MsgSend': {
+      if (message.amount[0].amount === '400') {
+        throw Error('simulated error');
+      }
+      return /** @type {JsonSafe<MsgSendResponse>} */ ({});
     }
     case '/cosmos.staking.v1beta1.MsgDelegate': {
       if (message.amount.amount === '504') {

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -159,6 +159,17 @@ export const makeFakeIbcBridge = (zone, onToBridge) => {
 export const LOCALCHAIN_DEFAULT_ADDRESS = 'agoric1fakeLCAAddress';
 
 /**
+ * Constants that can be used to force an error state in a bridge transaction.
+ * Typically used for the LocalChainBridge which currently accepts all messages
+ * unless specified otherwise. Less useful for the DibcBridge which rejects all
+ * messages unless specified otherwise.
+ */
+export const SIMULATED_ERRORS = {
+  TIMEOUT: 504n,
+  BAD_REQUEST: 400n,
+};
+
+/**
  * Used to mock responses from Cosmos Golang back to SwingSet for for
  * E(lca).executeTx().
  *
@@ -173,7 +184,7 @@ export const fakeLocalChainBridgeTxMsgHandler = (message, sequence) => {
   switch (message['@type']) {
     // TODO #9402 reference bank to ensure caller has tokens they are transferring
     case '/ibc.applications.transfer.v1.MsgTransfer': {
-      if (message.token.amount === '504') {
+      if (message.token.amount === String(SIMULATED_ERRORS.TIMEOUT)) {
         throw Error('simulated unexpected MsgTransfer packet timeout');
       }
       // like `JsonSafe<MsgTransferResponse>`, but bigints are converted to numbers
@@ -183,13 +194,13 @@ export const fakeLocalChainBridgeTxMsgHandler = (message, sequence) => {
       };
     }
     case '/cosmos.bank.v1beta1.MsgSend': {
-      if (message.amount[0].amount === '400') {
+      if (message.amount[0].amount === String(SIMULATED_ERRORS.BAD_REQUEST)) {
         throw Error('simulated error');
       }
       return /** @type {JsonSafe<MsgSendResponse>} */ ({});
     }
     case '/cosmos.staking.v1beta1.MsgDelegate': {
-      if (message.amount.amount === '504') {
+      if (message.amount.amount === String(SIMULATED_ERRORS.TIMEOUT)) {
         throw Error('simulated packet timeout');
       }
       return /** @type {JsonSafe<MsgDelegateResponse>} */ ({});


### PR DESCRIPTION
refs: #9193

## Description

Implements `.send()` and `.sendAll()` methods on CosmosOrchestrationAccount and LocalOrchestrationAccount

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Includes unit tests

### Upgrade Considerations
n/a, yet to be released
