### PR TITLE
improve slow-deletion runPolicy cleanup budget API

### DIFF
--- a/packages/SwingSet/src/lib/runPolicies.js
+++ b/packages/SwingSet/src/lib/runPolicies.js
@@ -4,7 +4,7 @@ export function foreverPolicy() {
   /** @type { RunPolicy } */
   return harden({
     allowCleanup() {
-      return {}; // unlimited budget
+      return true; // unlimited budget
     },
     vatCreated(_details) {
       return true;
@@ -31,7 +31,7 @@ export function crankCounter(
   /** @type { RunPolicy } */
   const policy = harden({
     allowCleanup() {
-      return { budget: 100 }; // limited budget
+      return { default: 100 }; // limited budget
     },
     vatCreated() {
       vats += 1;
@@ -64,7 +64,7 @@ export function computronCounter(limit, options = {}) {
   /** @type { RunPolicy } */
   const policy = harden({
     allowCleanup() {
-      return { budget: cleanupBudget }; // limited budget
+      return { default: cleanupBudget }; // limited budget
     },
     vatCreated() {
       total += vatCreatedComputrons;
@@ -93,7 +93,7 @@ export function wallClockWaiter(seconds) {
   const timeout = Date.now() + 1000 * seconds;
   /** @type { RunPolicy } */
   const policy = harden({
-    allowCleanup: () => ({}), // unlimited budget
+    allowCleanup: () => true, // unlimited budget
     vatCreated: () => Date.now() < timeout,
     crankComplete: () => Date.now() < timeout,
     crankFailed: () => Date.now() < timeout,
@@ -121,7 +121,7 @@ export function someCleanup(budget) {
     allowCleanup: () => {
       if (once) {
         once = false;
-        return { budget };
+        return { default: budget };
       }
       return false;
     },

--- a/packages/SwingSet/src/types-internal.js
+++ b/packages/SwingSet/src/types-internal.js
@@ -143,8 +143,9 @@ export {};
  * @typedef { { type: 'retireImports', vatID: VatID, krefs: string[] } } RunQueueEventRetireImports
  * @typedef { { type: 'negated-gc-action', vatID?: VatID } } RunQueueEventNegatedGCAction
  * @typedef { { type: 'bringOutYourDead', vatID: VatID } } RunQueueEventBringOutYourDead
+ * @import {CleanupBudget} from './types-external.js';
  * @typedef { { type: 'cleanup-terminated-vat', vatID: VatID,
- *              budget: number | undefined } } RunQueueEventCleanupTerminatedVat
+ *              budget: CleanupBudget } } RunQueueEventCleanupTerminatedVat
  * @typedef { RunQueueEventNotify | RunQueueEventSend | RunQueueEventCreateVat |
  *            RunQueueEventUpgradeVat | RunQueueEventChangeVatOptions | RunQueueEventStartVat |
  *            RunQueueEventDropExports | RunQueueEventRetireExports | RunQueueEventRetireImports |

--- a/packages/swing-store/docs/snapstore.md
+++ b/packages/swing-store/docs/snapstore.md
@@ -42,7 +42,7 @@ The SnapStore doesn't provide an explicit API to call when a vat is first create
 
 When terminating a vat, the kernel should first call `snapStore.stopUsingLastSnapshot(vatID)`, the same call it would make at the end of an incarnation, to indicate that we're no longer using the last snapshot. This results in zero in-use snapshots.
 
-Then, the kernel must either call `snapStore.deleteVatSnapshots(vatID, undefined)` to delete everything at once, or make a series of calls (spread out over time/blocks) to `snapStore.deleteVatSnapshots(vatID, budget)`. Each will return `{ done, cleanups }`, which can be used to manage the rate-limiting and know when the process is finished.
+Then, the kernel must either call `snapStore.deleteVatSnapshots(vatID)` or `deleteVatSnapshots(vatID, Infinity)` to delete everything at once, or make a series of calls (spread out over time/blocks) to `snapStore.deleteVatSnapshots(vatID, budget)`. Each will return `{ done, cleanups }`, which can be used to manage the rate-limiting and know when the process is finished.
 
 The `stopUsingLastSnapshot()` is a performance improvement, but is not mandatory. If omitted, exports will continue to include the vat's snapshot artifacts until the first call to `deleteVatSnapshots()`, after which they will go away. Snapshots are deleted in descending `snapPos` order, so the first call will delete the only `inUse = 1` snapshot, after which exports will omit all artifacts for the vatID. `stopUsingLastSnapshot()` is idempotent, and extra calls will leave the DB unchanged.
 

--- a/packages/swing-store/docs/transcriptstore.md
+++ b/packages/swing-store/docs/transcriptstore.md
@@ -63,7 +63,7 @@ Unlike the [SnapStore](./snapstore.md), the TranscriptStore *does* have an expli
 
 When a vat is terminated, the kernel should first call `transcriptStore.stopUsingTranscript(vatID)`. This will mark the single current span as `isCurrent = 0`. The kernel must not attempt to read, add, or rollover spans or items while in this state. While in this state, exports (export for `mode = debug`) will not emit artifacts for this VatID: export-data records will still exist for all spans, as these must be deleted slowly, however there will be no associated artifacts or artifact names.
 
-Then, the kernel should either call `transcriptStore.deleteVatTranscripts(vatID, undefined)` exactly once, or it should call `transcriptStore.deleteVatTranscripts(vatID, budget)` until it returns `{ done: true }`.
+Then, the kernel should either call `transcriptStore.deleteVatTranscripts(vatID)` exactly once, or it should call `transcriptStore.deleteVatTranscripts(vatID, budget)` until it returns `{ done: true }`.
 
 As with snapshots, the `stopUsingTranscript()` is a non-mandatory performance improvement. If omitted, exports will continue to include (many) span artifacts for this vat until the first call to `deleteVatTranscripts()` removes the one `isCurrent = 1` span (since spans are deleted most-recent-first). After that point, exports will stop including any artifacts for the vatID. `stopUsingTranscript()` is idempotent, and extra calls will leave the DB unchanged.
 

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -393,9 +393,9 @@ export function makeSnapStore(
    * @param {number} [budget]
    * @returns {{ done: boolean, cleanups: number }}
    */
-  function deleteVatSnapshots(vatID, budget = undefined) {
+  function deleteVatSnapshots(vatID, budget = Infinity) {
     ensureTxn();
-    const deleteAll = budget === undefined;
+    const deleteAll = budget === Infinity;
     assert(deleteAll || budget >= 1, 'budget must be undefined or positive');
     // We can't use .iterate because noteExport can write to the DB,
     // and overlapping queries are not supported.

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -394,9 +394,9 @@ export function makeTranscriptStore(
    * @param {number} [budget]
    * @returns {{ done: boolean, cleanups: number }}
    */
-  function deleteVatTranscripts(vatID, budget = undefined) {
+  function deleteVatTranscripts(vatID, budget = Infinity) {
     ensureTxn();
-    const deleteAll = budget === undefined;
+    const deleteAll = budget === Infinity;
     assert(deleteAll || budget >= 1, 'budget must be undefined or positive');
     // We can't use .iterate because noteExport can write to the DB,
     // and overlapping queries are not supported.


### PR DESCRIPTION
This improves the `runPolicy` APIs that control slow vat deletion (`runPolicy.allowCleanup()`), and the reporting of cleanup results (`.didCleanup()`). The new API allows individual phases to get different budgets, so e.g. we can restrict the expensive `exports` and `imports` phases to 5 deletions per run, while letting the cheaper `kv` phase to do 50 per run, so overall deletion happens faster. Experiments show this should allow our old large price-feed vats to be deleted in about 5 months, rather than 6 years.

The swing-store deletion calls (`snapStore.deleteVatSnapshots(budget)` and `transcriptStore.deleteVatTranscripts(budget)`) were changed to accept `budget = Infinity`, and use Infinity as a default, to allow swingset to use Infinity in policies. This seems less error-prone than using `undefined` to mean "unlimited".

See run-policy.md for the new API and examples of how a host application should use it.

refs #8928 
