### PR TITLE
import .ts modules with .js

### DIFF
--- a/packages/benchmark/benchmark/benchmark-liquidation.js
+++ b/packages/benchmark/benchmark/benchmark-liquidation.js
@@ -2,7 +2,7 @@
 import { bench } from '../src/benchmarkerator.js';
 
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { scale6 } from '@agoric/boot/tools/liquidation.ts';
+import { scale6 } from '@agoric/boot/tools/liquidation.js';
 
 const setupData = {
   vaults: [

--- a/packages/benchmark/src/benchmarkerator.js
+++ b/packages/benchmark/src/benchmarkerator.js
@@ -9,12 +9,12 @@ import '@agoric/cosmic-swingset/src/launch-chain.js';
 import { Fail } from '@endo/errors';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
-import { makeSwingsetTestKit } from '@agoric/boot/tools/supports.ts';
+import { makeSwingsetTestKit } from '@agoric/boot/tools/supports.js';
 import {
   makeWalletFactoryDriver,
   makeGovernanceDriver,
-} from '@agoric/boot/tools/drivers.ts';
-import { makeLiquidationTestKit } from '@agoric/boot/tools/liquidation.ts';
+} from '@agoric/boot/tools/drivers.js';
+import { makeLiquidationTestKit } from '@agoric/boot/tools/liquidation.js';
 
 // When I was a child my family took a lot of roadtrips around California to go
 // camping and backpacking and so on.  It was not uncommon in those days (nor is

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
     "checkJs": true,
   },
   "include": [
@@ -13,5 +12,6 @@
     "test/**/*.js",
     "test/**/*.ts",
     "tools/**/*.js",
+    "tools/**/*.ts",
   ],
 }

--- a/packages/boot/test/bootstrapTests/addAssets.test.ts
+++ b/packages/boot/test/bootstrapTests/addAssets.test.ts
@@ -6,8 +6,8 @@ import { TimeMath } from '@agoric/time';
 import {
   LiquidationTestContext,
   makeLiquidationTestContext,
-} from '../../tools/liquidation.ts';
-import { makeProposalExtractor } from '../../tools/supports.ts';
+} from '../../tools/liquidation.js';
+import { makeProposalExtractor } from '../../tools/supports.js';
 
 const test = anyTest as TestFn<
   LiquidationTestContext & {

--- a/packages/boot/test/bootstrapTests/demo-config.test.ts
+++ b/packages/boot/test/bootstrapTests/demo-config.test.ts
@@ -4,7 +4,7 @@ import { PowerFlags } from '@agoric/vats/src/walletFlags.js';
 
 import type { TestFn } from 'ava';
 
-import { keyArrayEqual, makeSwingsetTestKit } from '../../tools/supports.ts';
+import { keyArrayEqual, makeSwingsetTestKit } from '../../tools/supports.js';
 
 const { keys } = Object;
 

--- a/packages/boot/test/bootstrapTests/lca.test.ts
+++ b/packages/boot/test/bootstrapTests/lca.test.ts
@@ -9,7 +9,7 @@ import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
-} from './walletFactory.ts';
+} from './walletFactory.js';
 
 const test: TestFn<WalletFactoryTestContext> = anyTest;
 

--- a/packages/boot/test/bootstrapTests/liquidation-1.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-1.test.ts
@@ -12,7 +12,7 @@ import {
   makeLiquidationTestContext,
   scale6,
   LiquidationSetup,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/liquidation-2b.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-2b.test.ts
@@ -17,7 +17,7 @@ import {
   LiquidationTestContext,
   makeLiquidationTestContext,
   scale6,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/liquidation-concurrent-1.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-concurrent-1.test.ts
@@ -12,7 +12,7 @@ import {
   likePayouts,
   makeLiquidationTestContext,
   scale6,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/liquidation-concurrent-2b.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-concurrent-2b.test.ts
@@ -15,7 +15,7 @@ import {
   ensureVaultCollateral,
   makeLiquidationTestContext,
   scale6,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -7,7 +7,7 @@ import { createRequire } from 'module';
 import type { Baggage } from '@agoric/swingset-liveslots';
 import { M, makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
 
 const { entries, assign } = Object;
 

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -10,7 +10,7 @@ import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
-} from './walletFactory.ts';
+} from './walletFactory.js';
 
 const test: TestFn<WalletFactoryTestContext> = anyTest;
 

--- a/packages/boot/test/bootstrapTests/vat-orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/vat-orchestration.test.ts
@@ -17,7 +17,7 @@ import { M, matches } from '@endo/patterns';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
-} from './walletFactory.ts';
+} from './walletFactory.js';
 
 const test: TestFn<WalletFactoryTestContext> = anyTest;
 

--- a/packages/boot/test/bootstrapTests/vats-restart.test.ts
+++ b/packages/boot/test/bootstrapTests/vats-restart.test.ts
@@ -7,8 +7,8 @@ import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
 import { BridgeHandler, ScopedBridgeManager } from '@agoric/vats';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 // main/production config doesn't have initialPrice, upon which 'open vaults' depends
 const PLATFORM_CONFIG = '@agoric/vm-config/decentral-itest-vaults-config.json';

--- a/packages/boot/test/bootstrapTests/vaults-integration.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-integration.test.ts
@@ -14,8 +14,8 @@ import {
 import type { TestFn } from 'ava';
 import { ParamChangesOfferArgs } from '@agoric/inter-protocol/src/econCommitteeCharter.js';
 
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';

--- a/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
@@ -15,8 +15,8 @@ import { SECONDS_PER_YEAR } from '@agoric/inter-protocol/src/interest.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
 import { ExecutionContext, TestFn } from 'ava';
 import { FakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';

--- a/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
+++ b/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
@@ -5,7 +5,7 @@ import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
-} from './walletFactory.ts';
+} from './walletFactory.js';
 
 const test: TestFn<WalletFactoryTestContext> = anyTest;
 

--- a/packages/boot/test/bootstrapTests/vtransfer.test.ts
+++ b/packages/boot/test/bootstrapTests/vtransfer.test.ts
@@ -8,7 +8,7 @@ import type { TransferMiddleware } from '@agoric/vats/src/transfer.js';
 import type { TransferVat } from '@agoric/vats/src/vat-transfer.js';
 import { BridgeId } from '@agoric/internal';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
 
 const makeDefaultTestContext = async t => {
   const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {

--- a/packages/boot/test/bootstrapTests/walletFactory.ts
+++ b/packages/boot/test/bootstrapTests/walletFactory.ts
@@ -3,8 +3,8 @@ import {
   AgoricNamesRemotes,
   makeAgoricNamesRemotesFromFakeStorage,
 } from '@agoric/vats/tools/board-utils.js';
-import { makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeWalletFactoryDriver } from '../../tools/drivers.ts';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 
 export const makeWalletFactoryContext = async (
   t,

--- a/packages/boot/test/bootstrapTests/walletSurvivesZoeRestart.test.ts
+++ b/packages/boot/test/bootstrapTests/walletSurvivesZoeRestart.test.ts
@@ -10,7 +10,7 @@ import {
   LiquidationTestContext,
   makeLiquidationTestContext,
   LiquidationSetup,
-} from '../../tools/liquidation.ts';
+} from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
 

--- a/packages/boot/test/bootstrapTests/zcf-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/zcf-upgrade.test.ts
@@ -6,8 +6,8 @@ import path from 'path';
 
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
 import { TestFn } from 'ava';
-import { matchAmount, makeSwingsetTestKit } from '../../tools/supports.ts';
-import { makeZoeDriver } from '../../tools/drivers.ts';
+import { matchAmount, makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeZoeDriver } from '../../tools/drivers.js';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 

--- a/packages/boot/test/orchestration/restart-contracts.test.ts
+++ b/packages/boot/test/orchestration/restart-contracts.test.ts
@@ -7,7 +7,7 @@ import type { UpdateRecord } from '@agoric/smart-wallet/src/smartWallet.js';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
-} from '../bootstrapTests/walletFactory.ts';
+} from '../bootstrapTests/walletFactory.js';
 
 const test: TestFn<WalletFactoryTestContext> = anyTest;
 test.before(async t => {

--- a/packages/boot/test/upgrading/upgrade-vats.test.js
+++ b/packages/boot/test/upgrading/upgrade-vats.test.js
@@ -7,7 +7,7 @@ import { BridgeId } from '@agoric/internal';
 import { buildVatController } from '@agoric/swingset-vat';
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
-import { matchAmount, matchIter, matchRef } from '../../tools/supports.ts';
+import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
 
 /**
  * @type {import('ava').TestFn<{}>}

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -1,18 +1,16 @@
-// @ts-check
-import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+/* eslint-disable @jessie.js/safe-await-separator -- test */
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { Fail } from '@endo/errors';
-import { makeTagged } from '@endo/marshal';
 import { BridgeId } from '@agoric/internal';
 import { buildVatController } from '@agoric/swingset-vat';
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
+import { Fail } from '@endo/errors';
+import { makeTagged } from '@endo/marshal';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
+import type { IssuerKit } from '@agoric/ertp/src/types.js';
 import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
 
-/**
- * @type {import('ava').TestFn<{}>}
- */
-const test = anyTest;
+import type { buildRootObject as buildTestMintVat } from './vat-mint.js';
 
 const bfile = name => new URL(name, import.meta.url).pathname;
 const importSpec = spec =>
@@ -23,19 +21,12 @@ const makeCallOutbound = t => (srcID, obj) => {
   return obj;
 };
 
-/**
- * @param {any} t
- * @param {Partial<SwingSetConfig>} [kernelConfigOverrides]
- * @param {Record<string, unknown>} [deviceEndowments]
- * @returns {Promise<ReturnType<typeof makeRunUtils>>}
- */
 const makeScenario = async (
-  t,
-  kernelConfigOverrides = {},
-  deviceEndowments,
+  t: any,
+  kernelConfigOverrides: Partial<SwingSetConfig> = {},
+  deviceEndowments: Record<string, unknown> = {},
 ) => {
-  /** @type {SwingSetConfig} */
-  const config = {
+  const config: SwingSetConfig = {
     includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
@@ -274,18 +265,17 @@ test('upgrade vat-bank', async t => {
     bundleCapName: 'mint',
   };
   const bridgeRoot = await EV.vat('bootstrap').createVat(bridgeVatConfig);
-  const bankRoot = await EV.vat('bootstrap').createVat(bankVatConfig);
-  const mintRoot = await EV.vat('bootstrap').createVat(mintVatConfig);
+  const bankRoot: BankVat = await EV.vat('bootstrap').createVat(bankVatConfig);
+  const mintRoot: ReturnType<typeof buildTestMintVat> =
+    await EV.vat('bootstrap').createVat(mintVatConfig);
 
   t.log(`create a non-bridged bank manager`);
-  /** @type {ERef<BankManager>} */
   const noBridgeMgr = await EV(bankRoot).makeBankManager();
 
   t.log(`create a bridged bank manager`);
   const dev = await EV.vat('bootstrap').getDevice('bridge');
   const bridge1 = await EV(bridgeRoot).provideManagerForBridge(dev);
   const bankBridge = await EV(bridge1).register(BridgeId.BANK);
-  /** @type {ERef<BankManager>} */
   const bridgedMgr = await EV(bankRoot).makeBankManager(bankBridge);
 
   t.log('subscribe to no bridge asset lists');
@@ -293,8 +283,8 @@ test('upgrade vat-bank', async t => {
   const noBridgeIterator = await EV(noBridgeAssetSub1)[Symbol.asyncIterator]();
 
   t.log('add an asset to both');
-  const abcKit = await EV(mintRoot).makeIssuerKit('ABC');
-  const defKit = await EV(mintRoot).makeIssuerKit('DEF');
+  const abcKit = (await EV(mintRoot).makeIssuerKit('ABC')) as IssuerKit<'nat'>;
+  const defKit = (await EV(mintRoot).makeIssuerKit('DEF')) as IssuerKit<'nat'>;
   await EV(noBridgeMgr).addAsset('uabc', 'ABC', 'A Bank Coin', abcKit);
   await EV(bridgedMgr).addAsset('uabc', 'ABC', 'A Bank Coin', abcKit);
   await EV(bridgedMgr).addAsset('udef', 'DEF', 'Definitely a coin', defKit);
@@ -420,11 +410,10 @@ test('upgrade vat-priceAuthority', async t => {
     name: 'priceAuthority',
     bundleCapName: 'priceAuthority',
   };
-  const priceAuthorityRoot = await EV.vat('bootstrap').createVat(
-    priceAuthorityVatConfig,
-  );
+  const priceAuthorityRoot: PriceAuthorityVat = await EV.vat(
+    'bootstrap',
+  ).createVat(priceAuthorityVatConfig);
 
-  /** @type {import('@agoric/vats/src/priceAuthorityRegistry.js').PriceAuthorityRegistry} */
   const registry = await EV(priceAuthorityRoot).getRegistry();
 
   // Ideally we'd also test registering a PA and verifying the same one comes out the def end.
@@ -476,12 +465,11 @@ test('upgrade vat-vow', async t => {
   };
 
   t.log('test incarnation 0');
-  /** @type {Record<string, [settlementValue?: unknown, isRejection?: boolean]>} */
   const localPromises = {
     promiseForever: [],
     promiseFulfilled: ['hello'],
     promiseRejected: ['goodbye', true],
-  };
+  } as Record<string, [settlementValue?: unknown, isRejection?: boolean]>;
   const promiseKit = await EV.vat('bootstrap').makePromiseKit();
   const fakeVowKit = await makeFakeVowKit();
   const localVows = {

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -24,7 +24,7 @@ import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type { TimerService } from '@agoric/time';
 import type { OfferMaker } from '@agoric/smart-wallet/src/types.js';
 import type { RunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
-import type { SwingsetTestKit } from './supports.ts';
+import type { SwingsetTestKit } from './supports.js';
 
 export const makeWalletFactoryDriver = async (
   runUtils: RunUtils,

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
     "checkJs": true,
   },
   "include": [
@@ -11,5 +10,6 @@
     "test/**/*.js",
     "test/**/*.ts",
     "tools/**/*.js",
+    "tools/**/*.ts",
   ],
 }

--- a/packages/cosmic-proto/test/helpers.test-d.ts
+++ b/packages/cosmic-proto/test/helpers.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 import { typedJson } from '../src/helpers.js';
-import type { ResponseTo, TypedJson } from '../src/helpers.ts';
+import type { ResponseTo, TypedJson } from '../src/helpers.js';
 import type { JsonSafe } from '../src/codegen/json-safe.js';
 import type { Timestamp } from '../src/codegen/google/protobuf/timestamp.js';
 


### PR DESCRIPTION
_incidental_

## Description

A couple packages had `allowImportingTsExtensions: true`. It recently caused [some confusion](https://github.com/Agoric/agoric-sdk/pull/9882#discussion_r1714469928).

The reason we had it is so tests written in `.js` could import `.ts` modules. (Without this `.ts` import, the Ava transpiler config wouldn't try to resolve `.js` as a `.ts` module in a `.js` file.) But most of our tests in `boot` are `.ts` now and I think it would be best for them all to be.

This removes that allowance and brings the imports into conformity. It also converts the one test that was using `.ts` in `.js` to be a `.ts` test.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
CI

### Upgrade Considerations
n/a
