### PR TITLE
repair app.go after Upgrade 16

### DIFF
--- a/a3p-integration/proposals/a:upgrade-next/initial.test.js
+++ b/a3p-integration/proposals/a:upgrade-next/initial.test.js
@@ -7,7 +7,7 @@ const vats = {
   ibc: { incarnation: 0 },
   localchain: { incarnation: 0 },
   walletFactory: { incarnation: 3 },
-  zoe: { incarnation: 2 },
+  zoe: { incarnation: 3 },
 };
 
 test(`vat details`, async t => {


### PR DESCRIPTION
## Description

In CI and local tests after some post-upgrade-16 repairs and cleanups we were seeing

```
failed to load latest version: failed to load latest version: failed to load store: initial version set to 1143, but found earlier version 1102
```

@mfig suggested this fix, commenting
>That was leftover on master from u16, which needs to be removed before a u16-based [ghcr.io/agoric/agoric-3-proposals:latest](http://ghcr.io/agoric/agoric-3-proposals:latest) will work with agoric-sdk/a3p-integration.

### Security Considerations

Not security-relevant

### Scaling Considerations

No affect.

### Documentation Considerations

none

### Testing Considerations

repairs tests

### Upgrade Considerations

makes upgrade testing possible.