### PR TITLE
fix(vaultFactory): don't prevent repayment based on DebtLimit

### DIFF
--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -67,8 +67,13 @@ export const allEmpty = amounts => {
  * @param {Amount<'nat'>} totalDebt
  * @param {Amount<'nat'>} toMint
  * @throws if minting would exceed total debt
+ *
+ *   Note: Succeeds regardless of debtLimit if toMint is empty.
  */
 export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
+  if (AmountMath.isEmpty(toMint)) {
+    return;
+  }
   const debtPost = AmountMath.add(totalDebt, toMint);
   AmountMath.isGTE(debtLimit, debtPost) ||
     Fail`Minting ${q(toMint)} past ${q(

--- a/packages/inter-protocol/test/contractSupport.test.js
+++ b/packages/inter-protocol/test/contractSupport.test.js
@@ -20,3 +20,8 @@ test('checkDebtLimit allows at limit', t => {
 test('checkDebtLimit throws above', t => {
   t.throws(() => checkDebtLimit(limit, prior, debt.make(3n)));
 });
+
+test('checkDebtLimit always succeeds if there is nothing to mint', t => {
+  const bigPrior = debt.make(5n);
+  t.notThrows(() => checkDebtLimit(limit, bigPrior, debt.make(0n)));
+});


### PR DESCRIPTION
closes: #9837

## Description

DebtLimit should not impact a vault owner's ability to repay, so refine `checkDebtLimit` to succeed regardless of `debtLimit` if `toMint` is empty.

### Security / Scaling Considerations

none

### Testing Considerations

straightforward unit test that failed before the fix

### Upgrade / Documentation Considerations

Straightforward upgrade; no state changes. See:
 - #9887

This fix should be cited in release notes.
