### PR TITLE
chore: include test-multichain-e2e in finalize-integration-result

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -299,6 +299,7 @@ jobs:
       - getting-started
       - deployment-test
       - test-docker-build
+      - test-multichain-e2e
     if: >-
       always() &&
       needs.pre_check.result == 'success' &&


### PR DESCRIPTION
incidental 

see: https://github.com/Agoric/agoric-sdk/commit/442a27aa83e726df3cd7c0cb07d6acf1ce63bbc8#r144447494

## Description
Includes `test-multichain-e2e` in `finalize-integration-result` to ensure it's required.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This ensures multichain tests are required to pass for finalize-integration-result.

### Upgrade Considerations
n/a
