### PR TITLE
`parseTxPacket` returns a promise

### DIFF
--- a/packages/orchestration/src/exos/ica-account-kit.js
+++ b/packages/orchestration/src/exos/ica-account-kit.js
@@ -61,10 +61,10 @@ export const prepareIcaAccountKit = (zone, { watch, asVow }) =>
     {
       account: IcaAccountI,
       connectionHandler: OutboundConnectionHandlerI,
-      parseTxPacketWatcher: M.interface('ParseTxPacketWatcher', {
+      sendPacketWatcher: M.interface('SendPacketWatcher', {
         onFulfilled: M.call(M.string())
           .optional(M.arrayOf(M.undefined())) // does not need watcherContext
-          .returns(M.string()),
+          .returns(VowShape),
       }),
     },
     /**
@@ -83,10 +83,10 @@ export const prepareIcaAccountKit = (zone, { watch, asVow }) =>
         localAddress: undefined,
       }),
     {
-      parseTxPacketWatcher: {
+      sendPacketWatcher: {
         /** @param {string} ack */
         onFulfilled(ack) {
-          return parseTxPacket(ack);
+          return watch(parseTxPacket(ack));
         },
       },
       account: {
@@ -131,7 +131,7 @@ export const prepareIcaAccountKit = (zone, { watch, asVow }) =>
             if (!connection) throw Fail`connection not available`;
             return watch(
               E(connection).send(makeTxPacket(msgs, opts)),
-              this.facets.parseTxPacketWatcher,
+              this.facets.sendPacketWatcher,
             );
           });
         },


### PR DESCRIPTION
refs: #9449 

## Description

- refactor `parseTxPacket` to return a rejected promise instead of a synchronous error in the event of an error. Since `parseTxPacket` is currently used in conjunction with a series of vows/promises, it seems best to be consistent. This change was not motivated by observed uncaught errors.
- feat: ensure `IcqConnection.query()` returns a vow

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
`vat-orchestration` is currently unreleased
