### PR TITLE
feat: plumb `icqConnection` through `orchestrate` facade

### DIFF
--- a/packages/boot/test/orchestration/restart-contracts.test.ts
+++ b/packages/boot/test/orchestration/restart-contracts.test.ts
@@ -229,7 +229,7 @@ test.serial('basicFlows', async t => {
     },
     proposal: {},
     offerArgs: {
-      chainNames: ['agoric', 'cosmoshub'],
+      chainNames: ['agoric', 'cosmoshub', 'osmosis'],
     },
   });
   // no errors and no result yet
@@ -242,7 +242,8 @@ test.serial('basicFlows', async t => {
       result: undefined, // no property
     },
   });
-  t.is(getInboundQueueLength(), 2);
+  // 3x ICA Channel Opens, 1x ICQ Channel Open
+  t.is(getInboundQueueLength(), 4);
 
   t.log('restart basicFlows');
   await evalProposal(
@@ -264,7 +265,7 @@ test.serial('basicFlows', async t => {
       result: 'UNPUBLISHED',
     },
   });
-  t.is(await flushInboundQueue(1), 1);
+  t.is(await flushInboundQueue(3), 3);
   t.like(wallet.getLatestUpdateRecord(), {
     status: {
       id: id2,

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -1,4 +1,4 @@
-import type { AnyJson, TypedJson } from '@agoric/cosmic-proto';
+import type { AnyJson, TypedJson, JsonSafe } from '@agoric/cosmic-proto';
 import type {
   Delegation,
   Redelegation,
@@ -11,6 +11,10 @@ import type {
   Order,
 } from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
 import type { State as IBCConnectionState } from '@agoric/cosmic-proto/ibc/core/connection/v1/connection.js';
+import type {
+  RequestQuery,
+  ResponseQuery,
+} from '@agoric/cosmic-proto/tendermint/abci/types.js';
 import type { Brand, Purse, Payment, Amount } from '@agoric/ertp/src/types.js';
 import type { Port } from '@agoric/network';
 import type { IBCChannelID, IBCConnectionID } from '@agoric/vats';
@@ -265,3 +269,7 @@ export type CosmosChainAccountMethods<CCI extends CosmosChainInfo> =
   }
     ? StakingAccountActions
     : {};
+
+export type ICQQueryFunction = (
+  msgs: JsonSafe<RequestQuery>[],
+) => Promise<JsonSafe<ResponseQuery>[]>;

--- a/packages/orchestration/src/examples/basic-flows.contract.js
+++ b/packages/orchestration/src/examples/basic-flows.contract.js
@@ -40,6 +40,9 @@ const contract = async (
     M.interface('Basic Flows PF', {
       makeOrchAccountInvitation: M.callWhen().returns(InvitationShape),
       makePortfolioAccountInvitation: M.callWhen().returns(InvitationShape),
+      makeSendICQQueryInvitation: M.callWhen().returns(InvitationShape),
+      makeAccountAndSendBalanceQueryInvitation:
+        M.callWhen().returns(InvitationShape),
     }),
     {
       makeOrchAccountInvitation() {
@@ -52,6 +55,18 @@ const contract = async (
         return zcf.makeInvitation(
           orchFns.makePortfolioAccount,
           'Make an Orchestration Account',
+        );
+      },
+      makeSendICQQueryInvitation() {
+        return zcf.makeInvitation(
+          orchFns.sendQuery,
+          'Submit a query to a remote chain',
+        );
+      },
+      makeAccountAndSendBalanceQueryInvitation() {
+        return zcf.makeInvitation(
+          orchFns.makeAccountAndSendBalanceQuery,
+          'Make an account and submit a balance query',
         );
       },
     },

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -2,12 +2,14 @@
  * @file Primarily a testing fixture, but also serves as an example of how to
  *   leverage basic functionality of the Orchestration API with async-flow.
  */
+import { Fail } from '@endo/errors';
 import { M, mustMatch } from '@endo/patterns';
 
 /**
- * @import {Zone} from '@agoric/zone';
- * @import {OrchestrationAccount, OrchestrationFlow, Orchestrator} from '@agoric/orchestration';
+ * @import {DenomArg, OrchestrationAccount, OrchestrationFlow, Orchestrator} from '@agoric/orchestration';
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
+ * @import {JsonSafe} from '@agoric/cosmic-proto';
+ * @import {RequestQuery} from '@agoric/cosmic-proto/tendermint/abci/types.js';
  * @import {OrchestrationPowers} from '../utils/start-helper.js';
  * @import {MakePortfolioHolder} from '../exos/portfolio-holder-kit.js';
  * @import {OrchestrationTools} from '../utils/start-helper.js';
@@ -79,3 +81,56 @@ export const makePortfolioAccount = async (
   return portfolioHolder.asContinuingOffer();
 };
 harden(makePortfolioAccount);
+
+/**
+ * Send a query and get the response back in an offer result. This invitation is
+ * for testing only. In a real scenario it's better to use an RPC or API client
+ * and vstorage to retrieve data for a frontend. Queries should only be
+ * leveraged if contract logic requires it.
+ *
+ * @satisfies {OrchestrationFlow}
+ * @param {Orchestrator} orch
+ * @param {any} _ctx
+ * @param {ZCFSeat} seat
+ * @param {{ chainName: string; msgs: JsonSafe<RequestQuery>[] }} offerArgs
+ */
+export const sendQuery = async (orch, _ctx, seat, { chainName, msgs }) => {
+  seat.exit(); // no funds exchanged
+  mustMatch(chainName, M.string());
+  if (chainName === 'agoric') throw Fail`ICQ not supported on local chain`;
+  const remoteChain = await orch.getChain(chainName);
+  // @ts-expect-error FIXME implement Chain.query
+  const queryResponse = await remoteChain.query(msgs);
+  console.debug('sendQuery response:', queryResponse);
+  return queryResponse;
+};
+harden(sendQuery);
+
+/**
+ * Create an account and send a query and get the response back in an offer
+ * result. Like `sendQuery`, this invitation is for testing only. In a real
+ * scenario it doesn't make much sense to send a query immediately after the
+ * account is created - it won't have any funds.
+ *
+ * @satisfies {OrchestrationFlow}
+ * @param {Orchestrator} orch
+ * @param {any} _ctx
+ * @param {ZCFSeat} seat
+ * @param {{ chainName: string; denom: DenomArg }} offerArgs
+ */
+export const makeAccountAndSendBalanceQuery = async (
+  orch,
+  _ctx,
+  seat,
+  { chainName, denom },
+) => {
+  seat.exit(); // no funds exchanged
+  mustMatch(chainName, M.string());
+  if (chainName === 'agoric') throw Fail`ICQ not supported on local chain`;
+  const remoteChain = await orch.getChain(chainName);
+  const orchAccount = await remoteChain.makeAccount();
+  const queryResponse = await orchAccount.getBalance(denom);
+  console.debug('getBalance response:', queryResponse);
+  return queryResponse;
+};
+harden(makeAccountAndSendBalanceQuery);

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -99,7 +99,6 @@ export const sendQuery = async (orch, _ctx, seat, { chainName, msgs }) => {
   mustMatch(chainName, M.string());
   if (chainName === 'agoric') throw Fail`ICQ not supported on local chain`;
   const remoteChain = await orch.getChain(chainName);
-  // @ts-expect-error FIXME implement Chain.query
   const queryResponse = await remoteChain.query(msgs);
   console.debug('sendQuery response:', queryResponse);
   return queryResponse;

--- a/packages/orchestration/src/exos/icq-connection-kit.js
+++ b/packages/orchestration/src/exos/icq-connection-kit.js
@@ -2,6 +2,7 @@
 import { Fail } from '@endo/errors';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
+import { VowShape } from '@agoric/vow';
 import { NonNullish, makeTracer } from '@agoric/internal';
 import { makeQueryPacket, parseQueryPacket } from '../utils/packet.js';
 import { OutboundConnectionHandlerI } from '../typeGuards.js';
@@ -9,7 +10,7 @@ import { OutboundConnectionHandlerI } from '../typeGuards.js';
 /**
  * @import {Zone} from '@agoric/base-zone';
  * @import {Connection, Port} from '@agoric/network';
- * @import {Remote, VowTools} from '@agoric/vow';
+ * @import {Remote, Vow, VowTools} from '@agoric/vow';
  * @import {JsonSafe} from '@agoric/cosmic-proto';
  * @import {RequestQuery, ResponseQuery} from '@agoric/cosmic-proto/tendermint/abci/types.js';
  * @import {LocalIbcAddress, RemoteIbcAddress} from '@agoric/vats/tools/ibc-utils.js';
@@ -25,7 +26,7 @@ export const ICQMsgShape = M.splitRecord(
 export const ICQConnectionI = M.interface('ICQConnection', {
   getLocalAddress: M.call().returns(M.string()),
   getRemoteAddress: M.call().returns(M.string()),
-  query: M.call(M.arrayOf(ICQMsgShape)).returns(M.promise()),
+  query: M.call(M.arrayOf(ICQMsgShape)).returns(VowShape),
 });
 
 /**
@@ -53,7 +54,7 @@ export const ICQConnectionI = M.interface('ICQConnection', {
  * @param {Zone} zone
  * @param {VowTools} vowTools
  */
-export const prepareICQConnectionKit = (zone, { watch, when }) =>
+export const prepareICQConnectionKit = (zone, { watch, asVow }) =>
   zone.exoClassKit(
     'ICQConnectionKit',
     {
@@ -89,20 +90,17 @@ export const prepareICQConnectionKit = (zone, { watch, when }) =>
         },
         /**
          * @param {JsonSafe<RequestQuery>[]} msgs
-         * @returns {Promise<JsonSafe<ResponseQuery>[]>}
-         * @throws {Error} if packet fails to send or an error is returned
+         * @returns {Vow<JsonSafe<ResponseQuery>[]>}
          */
         query(msgs) {
-          const { connection } = this.state;
-          // TODO #9281 do not throw synchronously when returning a promise; return a rejected Vow
-          /// see https://github.com/Agoric/agoric-sdk/pull/9454#discussion_r1626898694
-          if (!connection) throw Fail`connection not available`;
-          return when(
-            watch(
+          return asVow(() => {
+            const { connection } = this.state;
+            if (!connection) throw Fail`connection not available`;
+            return watch(
               E(connection).send(makeQueryPacket(msgs)),
               this.facets.parseQueryPacketWatcher,
-            ),
-          );
+            );
+          });
         },
       },
       parseQueryPacketWatcher: {

--- a/packages/orchestration/src/exos/icq-connection-kit.js
+++ b/packages/orchestration/src/exos/icq-connection-kit.js
@@ -5,7 +5,7 @@ import { M } from '@endo/patterns';
 import { VowShape } from '@agoric/vow';
 import { NonNullish, makeTracer } from '@agoric/internal';
 import { makeQueryPacket, parseQueryPacket } from '../utils/packet.js';
-import { OutboundConnectionHandlerI } from '../typeGuards.js';
+import { ICQMsgShape, OutboundConnectionHandlerI } from '../typeGuards.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
@@ -17,11 +17,6 @@ import { OutboundConnectionHandlerI } from '../typeGuards.js';
  */
 
 const trace = makeTracer('Orchestration:ICQConnection');
-
-export const ICQMsgShape = M.splitRecord(
-  { path: M.string(), data: M.string() },
-  { height: M.string(), prove: M.boolean() },
-);
 
 export const ICQConnectionI = M.interface('ICQConnection', {
   getLocalAddress: M.call().returns(M.string()),
@@ -89,6 +84,8 @@ export const prepareICQConnectionKit = (zone, { watch, asVow }) =>
           );
         },
         /**
+         * Vow rejects if packet fails to send or an error is returned
+         *
          * @param {JsonSafe<RequestQuery>[]} msgs
          * @returns {Vow<JsonSafe<ResponseQuery>[]>}
          */

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -6,6 +6,7 @@ import { M } from '@endo/patterns';
 import { pickFacet } from '@agoric/vat-data';
 import { VowShape } from '@agoric/vow';
 
+import { Fail } from '@endo/errors';
 import { chainFacadeMethods } from '../typeGuards.js';
 
 /**
@@ -106,6 +107,10 @@ const prepareLocalChainFacadeKit = (
             allVows([lcaP, heapVowE(lcaP).getAddress()]),
             this.facets.makeAccountWatcher,
           );
+        },
+        query() {
+          // TODO https://github.com/Agoric/agoric-sdk/pull/9935
+          return asVow(() => Fail`not yet implemented`);
         },
         /** @type {HostOf<AgoricChainMethods['getVBankAssetInfo']>} */
         getVBankAssetInfo() {

--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -4,24 +4,23 @@ import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { pickFacet } from '@agoric/vat-data';
 import { VowShape } from '@agoric/vow';
-import { ChainAddressShape, ChainFacadeI } from '../typeGuards.js';
+import { ChainAddressShape, ChainFacadeI, ICQMsgShape } from '../typeGuards.js';
 
 /**
- * @import {HostInterface, HostOf} from '@agoric/async-flow';
+ * @import {HostOf} from '@agoric/async-flow';
  * @import {Zone} from '@agoric/base-zone';
+ * @import {JsonSafe} from '@agoric/cosmic-proto';
+ * @import {RequestQuery, ResponseQuery} from '@agoric/cosmic-proto/tendermint/abci/types.js';
  * @import {TimerService} from '@agoric/time';
  * @import {Remote} from '@agoric/internal';
  * @import {Vow, VowTools} from '@agoric/vow';
  * @import {CosmosInterchainService} from './cosmos-interchain-service.js';
  * @import {prepareCosmosOrchestrationAccount} from './cosmos-orchestration-account.js';
- * @import {ChainInfo, CosmosChainInfo, IBCConnectionInfo, OrchestrationAccount, ChainAddress, IcaAccount, Denom, Chain} from '../types.js';
+ * @import {CosmosChainInfo, IBCConnectionInfo, ChainAddress, IcaAccount, Chain, ICQConnection} from '../types.js';
  */
 
 const { Fail } = assert;
 const trace = makeTracer('RemoteChainFacade');
-
-/** @type {any} */
-const anyVal = null;
 
 /**
  * @typedef {{
@@ -33,6 +32,14 @@ const anyVal = null;
  *   timer: Remote<TimerService>;
  *   vowTools: VowTools;
  * }} RemoteChainFacadePowers
+ */
+
+/**
+ * @typedef {{
+ *   remoteChainInfo: CosmosChainInfo;
+ *   connectionInfo: IBCConnectionInfo;
+ *   icqConnection: ICQConnection | undefined;
+ * }} RemoteChainFacadeState
  */
 
 /**
@@ -48,30 +55,38 @@ const prepareRemoteChainFacadeKit = (
     // consider making an `accounts` childNode
     storageNode,
     timer,
-    vowTools: { asVow, watch },
+    vowTools: { allVows, asVow, watch },
   },
 ) =>
   zone.exoClassKit(
     'RemoteChainFacade',
     {
       public: ChainFacadeI,
-      makeAccountWatcher: M.interface('makeAccountWatcher', {
-        onFulfilled: M.call(M.remotable())
-          .optional(M.arrayOf(M.undefined())) // empty context
-          .returns(VowShape),
-      }),
+      makeICQConnectionQueryWatcher: M.interface(
+        'makeICQConnectionQueryWatcher',
+        {
+          onFulfilled: M.call(M.remotable(), M.arrayOf(ICQMsgShape)).returns(
+            VowShape,
+          ),
+        },
+      ),
+      makeAccountAndProvideQueryConnWatcher: M.interface(
+        'makeAccountAndProvideQueryConnWatcher',
+        {
+          onFulfilled: M.call([
+            M.remotable(),
+            M.or(M.remotable(), M.undefined()),
+          ]).returns(VowShape),
+        },
+      ),
       getAddressWatcher: M.interface('getAddressWatcher', {
-        onFulfilled: M.call(M.record())
-          .optional(M.remotable())
-          .returns(VowShape),
+        onFulfilled: M.call(ChainAddressShape, M.remotable()).returns(VowShape),
       }),
       makeChildNodeWatcher: M.interface('makeChildNodeWatcher', {
-        onFulfilled: M.call(M.remotable())
-          .optional({
-            account: M.remotable(),
-            chainAddress: ChainAddressShape,
-          })
-          .returns(M.remotable()),
+        onFulfilled: M.call(M.remotable(), {
+          account: M.remotable(),
+          chainAddress: ChainAddressShape,
+        }).returns(M.remotable()),
       }),
     },
     /**
@@ -80,7 +95,11 @@ const prepareRemoteChainFacadeKit = (
      */
     (remoteChainInfo, connectionInfo) => {
       trace('making a RemoteChainFacade');
-      return { remoteChainInfo, connectionInfo };
+      return /** @type {RemoteChainFacadeState} */ ({
+        remoteChainInfo,
+        connectionInfo,
+        icqConnection: undefined,
+      });
     },
     {
       public: {
@@ -94,33 +113,80 @@ const prepareRemoteChainFacadeKit = (
           return asVow(() => {
             const { remoteChainInfo, connectionInfo } = this.state;
             const stakingDenom = remoteChainInfo.stakingTokens?.[0]?.denom;
-            if (!stakingDenom) {
-              throw Fail`chain info lacks staking denom`;
-            }
+            if (!stakingDenom) throw Fail`chain info lacks staking denom`;
+
+            // icqConnection is ultimately retrieved from state, but let's
+            // create a connection if it doesn't exist
+            const icqConnOrUndefinedV =
+              remoteChainInfo.icqEnabled && !this.state.icqConnection
+                ? E(orchestration).provideICQConnection(
+                    connectionInfo.counterparty.connection_id,
+                  )
+                : undefined;
+
+            const makeAccountV = E(orchestration).makeAccount(
+              remoteChainInfo.chainId,
+              connectionInfo.counterparty.connection_id,
+              connectionInfo.id,
+            );
 
             return watch(
-              E(orchestration).makeAccount(
-                remoteChainInfo.chainId,
-                connectionInfo.counterparty.connection_id,
-                connectionInfo.id,
-              ),
-              this.facets.makeAccountWatcher,
+              allVows([makeAccountV, icqConnOrUndefinedV]),
+              this.facets.makeAccountAndProvideQueryConnWatcher,
             );
           });
         },
+        /** @type {ICQConnection['query']} */
+        query(msgs) {
+          return asVow(() => {
+            const {
+              remoteChainInfo: { icqEnabled, chainId },
+              connectionInfo,
+            } = this.state;
+            if (!icqEnabled) {
+              throw Fail`Queries not available for chain ${chainId}`;
+            }
+            // if none exists, make one and still send the query in the handler
+            if (!this.state.icqConnection) {
+              return watch(
+                E(orchestration).provideICQConnection(
+                  connectionInfo.counterparty.connection_id,
+                ),
+                this.facets.makeICQConnectionQueryWatcher,
+                msgs,
+              );
+            }
+            return watch(E(this.state.icqConnection).query(msgs));
+          });
+        },
       },
-      makeAccountWatcher: {
+      makeAccountAndProvideQueryConnWatcher: {
         /**
-         * XXX Pipeline vows allVows and E
-         *
-         * @param {IcaAccount} account
+         * @param {[IcaAccount, ICQConnection | undefined]} account
          */
-        onFulfilled(account) {
+        onFulfilled([account, icqConnection]) {
+          if (icqConnection && !this.state.icqConnection) {
+            this.state.icqConnection = icqConnection;
+            // no need to pass icqConnection in ctx; we can get it from state
+          }
           return watch(
             E(account).getAddress(),
             this.facets.getAddressWatcher,
             account,
           );
+        },
+      },
+      makeICQConnectionQueryWatcher: {
+        /**
+         * @param {ICQConnection} icqConnection
+         * @param {JsonSafe<RequestQuery>[]} msgs
+         * @returns {Vow<JsonSafe<ResponseQuery>[]>}
+         */
+        onFulfilled(icqConnection, msgs) {
+          if (!this.state.icqConnection) {
+            this.state.icqConnection = icqConnection;
+          }
+          return watch(E(icqConnection).query(msgs));
         },
       },
       getAddressWatcher: {
@@ -145,18 +211,15 @@ const prepareRemoteChainFacadeKit = (
          * }} ctx
          */
         onFulfilled(childNode, { account, chainAddress }) {
-          const { remoteChainInfo } = this.state;
+          const { remoteChainInfo, icqConnection } = this.state;
           const stakingDenom = remoteChainInfo.stakingTokens?.[0]?.denom;
-          if (!stakingDenom) {
-            throw Fail`chain info lacks staking denom`;
-          }
+          if (!stakingDenom) throw Fail`chain info lacks staking denom`;
+
           return makeCosmosOrchestrationAccount(chainAddress, stakingDenom, {
             account,
             // FIXME storage path https://github.com/Agoric/agoric-sdk/issues/9066
             storageNode: childNode,
-            // FIXME provide real ICQ connection
-            // FIXME make Query Connection available via chain, not orchestrationAccount
-            icqConnection: anyVal,
+            icqConnection,
             timer,
           });
         },

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -18,6 +18,7 @@ import type {
   IBCMsgTransferOptions,
   KnownChains,
   LocalAccountMethods,
+  ICQQueryFunction,
 } from './types.js';
 import type { ResolvedContinuingOfferResult } from './utils/zoe-tools.js';
 
@@ -87,6 +88,8 @@ export interface Chain<CI extends ChainInfo> {
    */
   makeAccount: () => Promise<OrchestrationAccount<CI>>;
   // FUTURE supply optional port object; also fetch port object
+
+  query: CI extends { icqEnabled: true } ? ICQQueryFunction : never;
 
   // TODO provide a way to get the local denom/brand/whatever for this chain
 }

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -117,9 +117,15 @@ export const DenomAmountShape = { denom: DenomShape, value: M.bigint() };
 
 export const AmountArgShape = M.or(AmountShape, DenomAmountShape);
 
+export const ICQMsgShape = M.splitRecord(
+  { path: M.string(), data: M.string() },
+  { height: M.string(), prove: M.boolean() },
+);
+
 export const chainFacadeMethods = harden({
   getChainInfo: M.call().returns(VowShape),
   makeAccount: M.call().returns(VowShape),
+  query: M.call(M.arrayOf(ICQMsgShape)).returns(VowShape),
 });
 
 /** @see {Chain} */

--- a/packages/orchestration/test/examples/basic-flows.contract.test.ts
+++ b/packages/orchestration/test/examples/basic-flows.contract.test.ts
@@ -4,6 +4,13 @@ import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
 import { E, getInterfaceOf } from '@endo/far';
 import path from 'path';
+import { JsonSafe, toRequestQueryJson } from '@agoric/cosmic-proto';
+import {
+  QueryBalanceRequest,
+  QueryBalanceResponse,
+} from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
+import type { ResponseQuery } from '@agoric/cosmic-proto/tendermint/abci/types.js';
+import { decodeBase64 } from '@endo/base64';
 import { commonSetup } from '../supports.js';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -20,7 +27,10 @@ type TestContext = Awaited<ReturnType<typeof commonSetup>> & {
 
 const test = anyTest as TestFn<TestContext>;
 
-test.before(async t => {
+const decodeBalanceQueryResponse = (results: JsonSafe<ResponseQuery>[]) =>
+  results.map(({ key }) => QueryBalanceResponse.decode(decodeBase64(key)));
+
+test.beforeEach(async t => {
   const setupContext = await commonSetup(t);
   const {
     bootstrap: { storage },
@@ -48,8 +58,9 @@ test.before(async t => {
 });
 
 const chainConfigs = {
-  agoric: { addressPrefix: 'agoric1fakeLCAAddress' },
-  cosmoshub: { addressPrefix: 'cosmos1test' },
+  agoric: { expectedAddress: 'agoric1fakeLCAAddress' },
+  cosmoshub: { expectedAddress: 'cosmos1test' },
+  osmosis: { expectedAddress: 'osmo1test' },
 };
 
 const orchestrationAccountScenario = test.macro({
@@ -78,7 +89,7 @@ const orchestrationAccountScenario = test.macro({
     const { description, storagePath, subscriber } = publicSubscribers.account;
     t.regex(description!, /Account holder/);
 
-    const expectedStoragePath = `mockChainStorageRoot.basic-flows.${config.addressPrefix}`;
+    const expectedStoragePath = `mockChainStorageRoot.basic-flows.${config.expectedAddress}`;
     t.is(storagePath, expectedStoragePath);
 
     t.regex(getInterfaceOf(subscriber)!, /Durable Publish Kit subscriber/);
@@ -87,3 +98,134 @@ const orchestrationAccountScenario = test.macro({
 
 test(orchestrationAccountScenario, 'agoric');
 test(orchestrationAccountScenario, 'cosmoshub');
+
+test('send query from chain object', async t => {
+  const {
+    bootstrap: { vowTools: vt },
+    zoe,
+    instance,
+    utils: { inspectDibcBridge },
+  } = t.context;
+  const publicFacet = await E(zoe).getPublicFacet(instance);
+  const balanceQuery = toRequestQueryJson(
+    QueryBalanceRequest.toProtoMsg({
+      address: 'cosmos1test',
+      denom: 'uatom',
+    }),
+  );
+  {
+    t.log('send query on chain with icqEnabled: true');
+    const inv = E(publicFacet).makeSendICQQueryInvitation();
+    const userSeat = E(zoe).offer(inv, {}, undefined, {
+      chainName: 'osmosis',
+      msgs: [balanceQuery],
+    });
+    const offerResult = await vt.when(E(userSeat).getOfferResult());
+    t.log(offerResult);
+    t.assert(offerResult[0].key, 'base64 encoded response returned');
+    const decodedResponse = decodeBalanceQueryResponse(offerResult);
+    t.deepEqual(decodedResponse, [
+      {
+        balance: {
+          amount: '0',
+          denom: 'uatom',
+        },
+      },
+    ]);
+  }
+  {
+    t.log('send query on chain with icqEnabled: false');
+    const inv = E(publicFacet).makeSendICQQueryInvitation();
+    const userSeat = E(zoe).offer(inv, {}, undefined, {
+      chainName: 'cosmoshub',
+      msgs: [balanceQuery],
+    });
+    await t.throwsAsync(vt.when(E(userSeat).getOfferResult()), {
+      message: 'Queries not available for chain "cosmoshub-4"',
+    });
+  }
+  {
+    t.log('sending subsequent queries should not result in new ICQ channels');
+    const inv = E(publicFacet).makeSendICQQueryInvitation();
+    const userSeat = E(zoe).offer(inv, {}, undefined, {
+      chainName: 'osmosis',
+      msgs: [balanceQuery],
+    });
+    await vt.when(E(userSeat).getOfferResult());
+    const { bridgeDowncalls } = await inspectDibcBridge();
+
+    const portBindings = bridgeDowncalls.filter(x => x.method === 'bindPort');
+    t.is(portBindings.length, 1, 'only one port bound');
+    t.regex(portBindings?.[0]?.packet.source_port, /icqcontroller-/);
+    const icqChannelInits = bridgeDowncalls.filter(
+      x => x.method === 'startChannelOpenInit' && x.version === 'icq-1',
+    );
+    t.is(icqChannelInits.length, 1, 'only one ICQ channel opened');
+    const sendPacketCalls = bridgeDowncalls.filter(
+      x =>
+        x.method === 'sendPacket' && x.packet.source_port === 'icqcontroller-1',
+    );
+    t.is(sendPacketCalls.length, 2, 'sent two queries');
+  }
+});
+
+test('send query from orch account in an async-flow', async t => {
+  const {
+    bootstrap: { vowTools: vt },
+    zoe,
+    instance,
+    utils: { inspectDibcBridge },
+  } = t.context;
+  const publicFacet = await E(zoe).getPublicFacet(instance);
+
+  {
+    t.log('send query from orchAccount on chain with icqEnabled: true');
+    const inv = E(publicFacet).makeAccountAndSendBalanceQueryInvitation();
+    const userSeat = E(zoe).offer(inv, {}, undefined, {
+      chainName: 'osmosis',
+      denom: 'uatom',
+    });
+    const offerResult = await vt.when(E(userSeat).getOfferResult());
+    t.deepEqual(offerResult, {
+      value: 0n,
+      denom: 'uatom',
+    });
+  }
+  {
+    t.log('send query from orchAccount that times out');
+    const inv = E(publicFacet).makeAccountAndSendBalanceQueryInvitation();
+    const userSeat = E(zoe).offer(inv, {}, undefined, {
+      chainName: 'osmosis',
+      denom: 'notarealdenom',
+    });
+    await t.throwsAsync(vt.when(E(userSeat).getOfferResult()), {
+      message: 'ABCI code: 5: error handling packet: see events for details',
+    });
+  }
+  {
+    t.log('send query from orchAccount on chain with icqEnabled: false');
+    const inv = E(publicFacet).makeAccountAndSendBalanceQueryInvitation();
+    const userSeat = E(zoe).offer(inv, {}, undefined, {
+      chainName: 'cosmoshub',
+      denom: 'uatom,',
+    });
+    await t.throwsAsync(vt.when(E(userSeat).getOfferResult()), {
+      message: 'Queries not available for chain "cosmoshub-4"',
+    });
+  }
+
+  t.log("creating add'l account should not result in new ICQ channels");
+  const { bridgeDowncalls } = await inspectDibcBridge();
+  const icqPortBindings = bridgeDowncalls.filter(
+    x =>
+      x.method === 'bindPort' && x.packet.source_port.includes('icqcontroller'),
+  );
+  t.is(icqPortBindings.length, 1, 'only one icq port bound');
+  const icqChannelInits = bridgeDowncalls.filter(
+    x => x.method === 'startChannelOpenInit' && x.version === 'icq-1',
+  );
+  t.is(icqChannelInits.length, 1, 'only one ICQ channel opened');
+});
+
+// needs design?
+test.todo('send query LocalChainFacade');

--- a/packages/orchestration/test/network-fakes.ts
+++ b/packages/orchestration/test/network-fakes.ts
@@ -179,6 +179,7 @@ export const makeFakeIBCBridge = (
    * @type {nubmer}
    */
   let channelCount = 0;
+  let icaAccountCount = 0;
   let bech32Prefix = 'cosmos';
 
   /**
@@ -205,13 +206,16 @@ export const makeFakeIBCBridge = (
             const connectionChannelCount = remoteChannelMap[obj.hops[0]] || 0;
             const ackEvent = ibcBridgeMocks.channelOpenAck(obj, {
               bech32Prefix,
-              sequence: channelCount,
+              sequence: icaAccountCount,
               channelID: `channel-${channelCount}`,
               counterpartyChannelID: `channel-${connectionChannelCount}`,
             });
             bridgeHandler?.fromBridge(ackEvent);
             bridgeEvents = bridgeEvents.concat(ackEvent);
             channelCount += 1;
+            if (obj.packet.source_port.includes('icacontroller')) {
+              icaAccountCount += 1;
+            }
             remoteChannelMap[obj.hops[0]] = connectionChannelCount + 1;
             return undefined;
           }

--- a/packages/vats/src/types.d.ts
+++ b/packages/vats/src/types.d.ts
@@ -223,7 +223,7 @@ type IBCMethodEvents = {
   receiveExecuted: {}; // TODO update
   startChannelOpenInit: ChannelOpenInitDowncall;
   startChannelCloseInit: {}; // TODO update
-  bindPort: {}; // TODO update
+  bindPort: { packet: { source_port: IBCPortID } };
   timeoutExecuted: {}; // TODO update
   // XXX why isn't this in receiver.go?
   initOpenExecuted: ChannelOpenAckDowncall;


### PR DESCRIPTION
closes: #9890

## Description
 - [x] ensure `CosmosOrchAccount` is given an `icqConnection` if `ChainConfig.icqEnabled` is true
 - [x] ensure `RemoteChainFacade` has `.query()` method available
 - ~~[ ] ensure `LocalChainFacade` has `.query()` method available~~ see https://github.com/Agoric/agoric-sdk/pull/9935

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Includes unit tests. Multichain tests would be a nice addition, but I wouldn't consider them a blocker for the PR.

### Upgrade Considerations
n/a, code is currently unreleased
