### PR TITLE
docs(swingset): fix run-policy docs, didCleanup returns keep-going

### DIFF
--- a/packages/SwingSet/docs/run-policy.md
+++ b/packages/SwingSet/docs/run-policy.md
@@ -208,6 +208,7 @@ function makeSlowTerminationPolicy() {
     },
     didCleanup(details) {
       cleanups -= details.cleanups.total;
+      return true;
     },
   });
   return policy;
@@ -252,6 +253,7 @@ function makeCleanupOnlyPolicy() {
     },
     didCleanup(details) {
       cleanups -= details.cleanups.total;
+      return true;
     },
   });
   return policy;


### PR DESCRIPTION
Fix the run-policy docs, my `didCleanup()` examples need to show `return true` to allow execution to continue after a cleanup crank.