### PR TITLE
chore: prepareVowTools is deprecated

### DIFF
--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -6,7 +6,7 @@ import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/record
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { prepareVowTools, heapVowE as E } from '@agoric/vow/vat.js';
+import { prepareSwingsetVowTools, heapVowE as E } from '@agoric/vow/vat.js';
 import { deeplyFulfilled } from '@endo/marshal';
 import { M } from '@endo/patterns';
 import { prepareLocalOrchestrationAccountKit } from '../exos/local-orchestration-account.js';
@@ -39,7 +39,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     baggage,
     privateArgs.marshaller,
   );
-  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const vowTools = prepareSwingsetVowTools(zone.subZone('vows'));
 
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     zone,

--- a/packages/orchestration/src/examples/stakeIca.contract.js
+++ b/packages/orchestration/src/examples/stakeIca.contract.js
@@ -2,7 +2,7 @@
 
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
 import { TimerServiceShape } from '@agoric/time';
-import { heapVowE as E, prepareVowTools } from '@agoric/vow/vat.js';
+import { heapVowE as E, prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import {
   prepareRecorderKitMakers,
   provideAll,
@@ -89,7 +89,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
 
-  const vowTools = prepareVowTools(zone.subZone('vows'));
+  const vowTools = prepareSwingsetVowTools(zone.subZone('vows'));
 
   const chainHub = makeChainHub(agoricNames, vowTools);
 

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -1,6 +1,6 @@
 import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { prepareVowTools } from '@agoric/vow';
+import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import { makeChainHub } from '../exos/chain-hub.js';
@@ -46,7 +46,7 @@ export const startStakeAtom = async ({
   const storageNode = await makeStorageNodeChild(chainStorage, VSTORAGE_PATH);
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const vt = prepareVowTools(makeHeapZone());
+  const vt = prepareSwingsetVowTools(makeHeapZone());
   const chainHub = makeChainHub(await agoricNames, vt);
 
   const [_, cosmoshub, connectionInfo] = await vt.when(

--- a/packages/orchestration/src/proposals/start-stakeOsmo.js
+++ b/packages/orchestration/src/proposals/start-stakeOsmo.js
@@ -1,6 +1,6 @@
 import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { prepareVowTools } from '@agoric/vow';
+import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import { makeChainHub } from '../exos/chain-hub.js';
@@ -51,7 +51,7 @@ export const startStakeOsmo = async ({
   const storageNode = await makeStorageNodeChild(chainStorage, VSTORAGE_PATH);
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const vt = prepareVowTools(makeHeapZone());
+  const vt = prepareSwingsetVowTools(makeHeapZone());
   const chainHub = makeChainHub(await agoricNames, vt);
 
   const [_, osmosis, connectionInfo] = await vt.when(

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -1,5 +1,5 @@
 import { prepareAsyncFlowTools } from '@agoric/async-flow';
-import { prepareVowTools } from '@agoric/vow';
+import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { makeChainHub } from '../exos/chain-hub.js';
@@ -72,7 +72,7 @@ export const provideOrchestration = (
 
   const { agoricNames, timerService } = remotePowers;
 
-  const vowTools = prepareVowTools(zones.vows);
+  const vowTools = prepareSwingsetVowTools(zones.vows);
 
   const chainHub = makeChainHub(agoricNames, vowTools);
 

--- a/packages/orchestration/test/network-fakes.test.ts
+++ b/packages/orchestration/test/network-fakes.test.ts
@@ -1,9 +1,8 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import type { TestFn } from 'ava';
-import { heapVowE as E } from '@agoric/vow/vat.js';
+import { heapVowE as E, prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { makeHeapZone } from '@agoric/zone';
 import { getInterfaceOf } from '@endo/far';
-import { prepareVowTools } from '@agoric/vow';
 import { setupFakeNetwork } from './network-fakes.js';
 import { makeICAChannelAddress } from '../src/utils/address.js';
 
@@ -11,7 +10,7 @@ const test = anyTest as TestFn<ReturnType<typeof setupFakeNetwork>>;
 
 test.before(async t => {
   const zone = makeHeapZone();
-  const vowTools = prepareVowTools(zone.subZone('vow'));
+  const vowTools = prepareSwingsetVowTools(zone.subZone('vow'));
   t.context = setupFakeNetwork(zone, { vowTools });
   await t.context.setupIBCProtocol();
 });

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -16,7 +16,7 @@ import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import type { TimestampRecord, TimestampValue } from '@agoric/time';
 import { makeScalarBigMapStore, type Baggage } from '@agoric/vat-data';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
-import { prepareVowTools, heapVowE as E } from '@agoric/vow/vat.js';
+import { prepareSwingsetVowTools, heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
@@ -200,7 +200,7 @@ const makeScenario = () => {
     sequence: false,
   });
 
-  const vowTools = prepareVowTools(zone.subZone('VowTools'));
+  const vowTools = prepareSwingsetVowTools(zone.subZone('VowTools'));
 
   const icqConnection = Far('ICQConnection', {}) as ICQConnection;
 


### PR DESCRIPTION
refs: #9449

## Description
Prefer `prepareSwingsetVowTools` to `prepareVowTools` in `packages/orchestration`

### Security Considerations
This change ensures code that uses vows in a SwingSet environment is resumable.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This unblocks failing tests on an open PR.

### Upgrade Considerations
n/a
