### PR TITLE
Specify a bundle to use when upgrading auctions

### DIFF
--- a/a3p-integration/proposals/a:vaults-auctions/upgradeVaults.test.js
+++ b/a3p-integration/proposals/a:vaults-auctions/upgradeVaults.test.js
@@ -73,19 +73,20 @@ const triggerAuction = async t => {
   t.is(atomOut, '+5200000');
 };
 
-function newAuctioneerFromNewBundle(details) {
+// contract vat names are based on bundleID
+const ORIGINAL_AUCTION_VAT_NAME = 'zcf-b1-a5683-auctioneer';
+
+const newAuctioneerFromNewBundle = details => {
   for (const detail of details) {
-    // contract vat names are based on bundleID
-    const originalAuctionVatName = 'zcf-b1-a5683-auctioneer';
     if (
       !detail.vatName.includes('governor') &&
-      detail.vatName !== originalAuctionVatName
+      detail.vatName !== ORIGINAL_AUCTION_VAT_NAME
     ) {
       return true;
     }
   }
   return false;
-}
+};
 
 const checkAuctionVat = async t => {
   const details = await getDetailsMatchingVats('auctioneer');

--- a/a3p-integration/proposals/a:vaults-auctions/upgradeVaults.test.js
+++ b/a3p-integration/proposals/a:vaults-auctions/upgradeVaults.test.js
@@ -73,9 +73,24 @@ const triggerAuction = async t => {
   t.is(atomOut, '+5200000');
 };
 
+function newAuctioneerFromNewBundle(details) {
+  for (const detail of details) {
+    // contract vat names are based on bundleID
+    const originalAuctionVatName = 'zcf-b1-a5683-auctioneer';
+    if (
+      !detail.vatName.includes('governor') &&
+      detail.vatName !== originalAuctionVatName
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const checkAuctionVat = async t => {
   const details = await getDetailsMatchingVats('auctioneer');
 
+  t.true(newAuctioneerFromNewBundle(details));
   // This query matches both the auction and its governor, so double the count
   t.true(Object.keys(details).length > 2);
 };

--- a/packages/builders/scripts/vats/add-auction.js
+++ b/packages/builders/scripts/vats/add-auction.js
@@ -1,10 +1,20 @@
 import { makeHelpers } from '@agoric/deploy-script-support';
 
 /** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
-export const defaultProposalBuilder = async () => {
+export const defaultProposalBuilder = async ({ publishRef, install }) => {
   return harden({
     sourceSpec: '@agoric/inter-protocol/src/proposals/add-auction.js',
-    getManifestCall: ['getManifestForAddAuction'],
+    getManifestCall: [
+      'getManifestForAddAuction',
+      {
+        auctionsRef: publishRef(
+          install(
+            '@agoric/inter-protocol/src/auction/auctioneer.js',
+            '../../inter-protocol/bundles/bundle-auctioneer.js',
+          ),
+        ),
+      },
+    ],
   });
 };
 

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -28,7 +28,7 @@ export const addAuction = async (
       economicCommitteeCreatorFacet: electorateCreatorFacet,
       auctioneerKit: legacyKitP,
     },
-    produce: { newAuctioneerKit, auctionsUpgradeComplete },
+    produce: { auctioneerKit: produceAuctioneerKit, auctionsUpgradeComplete },
     instance: {
       consume: { reserve: reserveInstance },
     },
@@ -151,7 +151,8 @@ export const addAuction = async (
     ),
   );
 
-  newAuctioneerKit.resolve(
+  produceAuctioneerKit.reset();
+  produceAuctioneerKit.resolve(
     harden({
       label: 'auctioneer',
       creatorFacet: governedCreatorFacet,
@@ -182,7 +183,7 @@ export const ADD_AUCTION_MANIFEST = harden({
       auctioneerKit: true,
     },
     produce: {
-      newAuctioneerKit: true,
+      auctioneerKit: true,
       auctionsUpgradeComplete: true,
     },
     instance: {
@@ -190,7 +191,6 @@ export const ADD_AUCTION_MANIFEST = harden({
     },
     installation: {
       consume: {
-        auctioneer: true,
         contractGovernor: true,
       },
       produce: { auctioneer: true },

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -26,7 +26,6 @@ export const addAuction = async (
       priceAuthority,
       chainStorage,
       economicCommitteeCreatorFacet: electorateCreatorFacet,
-      agoricNamesAdmin,
       auctioneerKit: legacyKitP,
     },
     produce: { newAuctioneerKit, auctionsUpgradeComplete },
@@ -35,6 +34,7 @@ export const addAuction = async (
     },
     installation: {
       consume: { contractGovernor: contractGovernorInstallation },
+      produce: { auctioneer: produceInstallation },
     },
     issuer: {
       consume: { [Stable.symbol]: stableIssuerP },
@@ -54,6 +54,8 @@ export const addAuction = async (
    * >}
    */
   const installationP = E(zoe).installBundleID(bundleID);
+  produceInstallation.reset();
+  produceInstallation.resolve(installationP);
 
   const [
     initialPoserInvitation,
@@ -66,16 +68,6 @@ export const addAuction = async (
     stableIssuerP,
     legacyKitP,
   ]);
-
-  await E.when(
-    installationP,
-    installation =>
-      E(E(agoricNamesAdmin).lookupAdmin('installation')).update(
-        'auctioneer',
-        installation,
-      ),
-    err => console.error(`🚨 failed to update vaultFactory installation`, err),
-  );
 
   // Each field has an extra layer of type +  value:
   // AuctionStartDelay: { type: 'relativeTime', value: { relValue: 2n, timerBrand: Object [Alleged: timerBrand] {} } }
@@ -187,7 +179,6 @@ export const ADD_AUCTION_MANIFEST = harden({
       priceAuthority: true,
       chainStorage: true,
       economicCommitteeCreatorFacet: true,
-      agoricNamesAdmin: true,
       auctioneerKit: true,
     },
     produce: {
@@ -202,6 +193,7 @@ export const ADD_AUCTION_MANIFEST = harden({
         auctioneer: true,
         contractGovernor: true,
       },
+      produce: { auctioneer: true },
     },
     issuer: {
       consume: { [Stable.symbol]: true },

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -2,33 +2,8 @@ import { E } from '@endo/far';
 import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { AmountMath } from '@agoric/ertp/src/index.js';
 import { makeTracer } from '@agoric/internal/src/index.js';
-import { isUpgradeDisconnection } from '@agoric/internal/src/upgrade-api.js';
 
 const trace = makeTracer('upgrade Vaults proposal');
-
-// stand-in for Promise.any() which isn't available at this point.
-/** @param {Promise<any>[]} promises */
-const any = promises =>
-  new Promise((resolve, reject) => {
-    for (const promise of promises) {
-      void promise.then(resolve, () => {});
-    }
-    void Promise.allSettled(promises).then(results => {
-      const rejects = /** @type {PromiseRejectedResult[]} */ (
-        results.filter(({ status }) => status === 'rejected')
-      );
-      if (rejects.length === results.length) {
-        const messages = rejects.map(
-          ({ reason: { message } }) => message || 'no error message',
-        );
-        const aggregate = new Error(messages.join(';'));
-        /** @type {any} */ (aggregate).errors = rejects.map(
-          ({ reason }) => reason,
-        );
-        reject(aggregate);
-      }
-    });
-  });
 
 /**
  * @typedef {PromiseSpaceOf<{
@@ -44,35 +19,26 @@ const any = promises =>
 export const upgradeVaults = async (
   {
     consume: {
-      agoricNamesAdmin,
-      newAuctioneerKit: auctioneerKitP,
-      priceAuthority,
       vaultFactoryKit,
       zoe,
       economicCommitteeCreatorFacet: electorateCreatorFacet,
       reserveKit,
       auctionsUpgradeComplete,
     },
-    produce: {
-      auctioneerKit: auctioneerKitProducer,
-      newAuctioneerKit: tempAuctioneerKit,
-      auctionsUpgradeComplete: auctionsUpgradeCompleteProducer,
-    },
     installation: {
       produce: { VaultFactory: produceVaultInstallation },
     },
     instance: {
-      produce: { auctioneer: auctioneerProducer },
+      consume: { auctioneer: auctioneerInstanceP },
     },
   },
   { options },
 ) => {
   const { vaultsRef } = options;
   const kit = await vaultFactoryKit;
-  const auctioneerKit = await auctioneerKitP;
   const { instance: directorInstance } = kit;
   const allBrands = await E(zoe).getBrands(directorInstance);
-  const { Minted: istBrand, ...vaultBrands } = allBrands;
+  const { Minted: _istBrand, ...vaultBrands } = allBrands;
 
   const bundleID = vaultsRef.bundleID;
   console.log(`upgradeVaults: bundleId`, bundleID);
@@ -164,14 +130,15 @@ export const upgradeVaults = async (
       E.get(reserveKit).creatorFacet,
     ).makeShortfallReportingInvitation();
 
-    const poserInvitation = await E(
-      electorateCreatorFacet,
-    ).getPoserInvitation();
+    const [poserInvitation, auctioneerInstance] = await Promise.all([
+      E(electorateCreatorFacet).getPoserInvitation(),
+      auctioneerInstanceP,
+    ]);
+
     /** @type {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract['privateArgs']} */
     const newPrivateArgs = harden({
       ...privateArgs,
-      // @ts-expect-error It has a value until reset after the upgrade
-      auctioneerInstance: auctioneerKit.instance,
+      auctioneerInstance,
       initialPoserInvitation: poserInvitation,
       initialShortfallInvitation: shortfallInvitation,
       managerParams: managerParamValues,
@@ -186,60 +153,7 @@ export const upgradeVaults = async (
     trace('upgraded vaultFactory.', upgradeResult);
   };
 
-  // Wait for at least one new price feed to be ready before upgrading Vaults
-  void E.when(
-    any(
-      Object.values(vaultBrands).map(async brand => {
-        const getQuote = async lastRejectionReason => {
-          await null;
-          try {
-            return await E(priceAuthority).quoteGiven(
-              AmountMath.make(brand, 10n),
-              istBrand,
-            );
-          } catch (reason) {
-            if (
-              isUpgradeDisconnection(reason) &&
-              (!lastRejectionReason ||
-                reason.incarnationNumber >
-                  lastRejectionReason.incarnationNumber)
-            ) {
-              return getQuote(reason);
-            }
-            throw reason;
-          }
-        };
-        return getQuote(null);
-      }),
-    ),
-    async price => {
-      trace(`upgrading after delay`, price);
-      await upgradeVaultFactory();
-      auctioneerKitProducer.reset();
-      // @ts-expect-error auctioneerKit is non-null except between auctioneerKitProducer.reset() and auctioneerKitProducer.resolve()
-      auctioneerKitProducer.resolve(auctioneerKit);
-      auctioneerProducer.reset();
-      // @ts-expect-error auctioneerKit is non-null except between auctioneerKitProducer.reset() and auctioneerKitProducer.resolve()
-      auctioneerProducer.resolve(auctioneerKit.instance);
-      // We wanted it to be valid for only a short while.
-      tempAuctioneerKit.reset();
-      await E(E(agoricNamesAdmin).lookupAdmin('instance')).update(
-        'auctioneer',
-        // @ts-expect-error auctioneerKit is non-null except between auctioneerKitProducer.reset() and auctioneerKitProducer.resolve()
-        auctioneerKit.instance,
-      );
-      trace(`upgrading complete`, price);
-    },
-    error => {
-      console.error(
-        'Failed to upgrade vaultFactory',
-        error.message,
-        ...(error.errors || []),
-      );
-    },
-  );
-
-  console.log(`upgradeVaults scheduled; waiting for priceFeeds`);
+  await upgradeVaultFactory();
 };
 
 const uV = 'upgradeVaults';
@@ -256,25 +170,17 @@ export const getManifestForUpgradeVaults = async (
   manifest: {
     [upgradeVaults.name]: {
       consume: {
-        agoricNamesAdmin: uV,
-        newAuctioneerKit: uV,
         economicCommitteeCreatorFacet: uV,
-        priceAuthority: uV,
         reserveKit: uV,
         vaultFactoryKit: uV,
-        board: uV,
         zoe: uV,
         auctionsUpgradeComplete: uV,
       },
-      produce: {
-        auctioneerKit: uV,
-        newAuctioneerKit: uV,
-        auctionsUpgradeComplete: uV,
-      },
+      produce: { auctionsUpgradeComplete: uV },
       installation: {
         produce: { VaultFactory: true },
       },
-      instance: { produce: { auctioneer: uV, newAuctioneerKit: uV } },
+      instance: { consume: { auctioneer: uV } },
     },
   },
   options: { ...vaultUpgradeOptions },

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -58,6 +58,9 @@ export const upgradeVaults = async (
       newAuctioneerKit: tempAuctioneerKit,
       auctionsUpgradeComplete: auctionsUpgradeCompleteProducer,
     },
+    installation: {
+      produce: { VaultFactory: produceVaultInstallation },
+    },
     instance: {
       produce: { auctioneer: auctioneerProducer },
     },
@@ -78,26 +81,12 @@ export const upgradeVaults = async (
    *   Installation<import('../../src/vaultFactory/vaultFactory.js')['start']>
    * >}
    */
-  let installationP;
+  const installationP = E(zoe).installBundleID(bundleID);
+  produceVaultInstallation.reset();
+  produceVaultInstallation.resolve(installationP);
 
   await auctionsUpgradeComplete;
   auctionsUpgradeCompleteProducer.reset();
-
-  if (vaultsRef) {
-    if (bundleID) {
-      installationP = E(zoe).installBundleID(bundleID);
-      await E.when(
-        installationP,
-        installation =>
-          E(E(agoricNamesAdmin).lookupAdmin('installation')).update(
-            'vaultFactory',
-            installation,
-          ),
-        err =>
-          console.error(`🚨 failed to update vaultFactory installation`, err),
-      );
-    }
-  }
 
   const readCurrentDirectorParams = async () => {
     const { publicFacet: directorPF } = kit;
@@ -281,6 +270,9 @@ export const getManifestForUpgradeVaults = async (
         auctioneerKit: uV,
         newAuctioneerKit: uV,
         auctionsUpgradeComplete: uV,
+      },
+      installation: {
+        produce: { VaultFactory: true },
       },
       instance: { produce: { auctioneer: uV, newAuctioneerKit: uV } },
     },

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -41,8 +41,8 @@ const any = promises =>
  *     interlockPowers} powers
  * @param {{ options: { vaultsRef: { bundleID: string } } }} options
  */
-export const upgradeVaults = async (powers, { options }) => {
-  const {
+export const upgradeVaults = async (
+  {
     consume: {
       agoricNamesAdmin,
       newAuctioneerKit: auctioneerKitP,
@@ -61,7 +61,9 @@ export const upgradeVaults = async (powers, { options }) => {
     instance: {
       produce: { auctioneer: auctioneerProducer },
     },
-  } = powers;
+  },
+  { options },
+) => {
   const { vaultsRef } = options;
   const kit = await vaultFactoryKit;
   const auctioneerKit = await auctioneerKitP;

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -25,6 +25,7 @@ export const upgradeVaults = async (
       reserveKit,
       auctionsUpgradeComplete,
     },
+    produce: { auctionsUpgradeComplete: auctionsUpgradeCompleteProducer },
     installation: {
       produce: { VaultFactory: produceVaultInstallation },
     },


### PR DESCRIPTION
closes: #9936

## Description

Upload new auction code for the coreEval.

### Security Considerations

N/A

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

Added a test that the new vat has a different bundle ID. I couldn't find any accessible behavioral differences to test.

### Upgrade Considerations

verify that upgrade happened.