### PR TITLE
get auction instance from promise space after auction startup completes

### DIFF
--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -29,9 +29,8 @@ export const upgradeVaults = async (
     installation: {
       produce: { VaultFactory: produceVaultInstallation },
     },
-    instance: {
-      consume: { auctioneer: auctioneerInstanceP },
-    },
+    // We want the auction instance after auctionsUpgradeComplete resolves
+    instance: { consume: consumeInstance },
   },
   { options },
 ) => {
@@ -131,9 +130,10 @@ export const upgradeVaults = async (
       E.get(reserveKit).creatorFacet,
     ).makeShortfallReportingInvitation();
 
+    // we want the auctioneer instance after auctionsUpgradeComplete settles
     const [poserInvitation, auctioneerInstance] = await Promise.all([
       E(electorateCreatorFacet).getPoserInvitation(),
-      auctioneerInstanceP,
+      E.get(consumeInstance).auctioneer,
     ]);
 
     /** @type {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract['privateArgs']} */
@@ -181,7 +181,7 @@ export const getManifestForUpgradeVaults = async (
       installation: {
         produce: { VaultFactory: true },
       },
-      instance: { consume: { auctioneer: uV } },
+      instance: { consume: true },
     },
   },
   options: { ...vaultUpgradeOptions },


### PR DESCRIPTION
refs: #9937

## Description

#9937 unintentionally upgraded the vaultFactory with the instance of the old auction. This change asks the promise space for the auction instance after the new auction startup is complete.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations
none

### Testing Considerations

This will be tested on Ollinet and emerynet before deployment. 

I tested locally on `a3p` by watching the logs to see that the vaults synced to the new auction schedule.

### Upgrade Considerations

upgrade vaults and auctions so they work together.