### PR TITLE
feat: add null upgrade of vaultFactoryGovernor to upgrade-vaults.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,14 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
-.yarn-integrity
+# Yarn (https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # dotenv environment variables file
 .env

--- a/a3p-integration/proposals/z:acceptance/lib/vaults.mts
+++ b/a3p-integration/proposals/z:acceptance/lib/vaults.mts
@@ -1,0 +1,209 @@
+/* eslint-disable @jessie.js/safe-await-separator */
+/* eslint-env node */
+
+import { strict as assert } from 'node:assert';
+
+import {
+  addUser,
+  agops,
+  agoric,
+  ATOM_DENOM,
+  executeOffer,
+  GOV1ADDR,
+  GOV2ADDR,
+  GOV3ADDR,
+  provisionSmartWallet,
+  waitForBlock,
+} from '@agoric/synthetic-chain';
+
+const govAccounts = [GOV1ADDR, GOV2ADDR, GOV3ADDR];
+
+export const ISTunit = 1_000_000n; // aka displayInfo: { decimalPlaces: 6 }
+
+// XXX likely longer than necessary
+const VOTING_WAIT_MS = 65 * 1000;
+
+const proposeNewAuctionParams = async (
+  address: string,
+  startFequency: any,
+  clockStep: any,
+  priceLockPeriod: any,
+) => {
+  const charterAcceptOfferId = await agops.ec(
+    'find-continuing-id',
+    '--for',
+    `${'charter\\ member\\ invitation'}`,
+    '--from',
+    address,
+  );
+
+  return executeOffer(
+    address,
+    agops.auctioneer(
+      'proposeParamChange',
+      '--charterAcceptOfferId',
+      charterAcceptOfferId,
+      '--start-frequency',
+      startFequency,
+      '--clock-step',
+      clockStep,
+      '--price-lock-period',
+      priceLockPeriod,
+    ),
+  );
+};
+
+const voteForNewParams = (accounts: string[], position: number) => {
+  console.log('ACTIONS voting for position', position, 'using', accounts);
+  return Promise.all(
+    accounts.map((account: string) =>
+      agops.ec('vote', '--forPosition', position, '--send-from', account),
+    ),
+  );
+};
+
+const paramChangeOfferGeneration = async (
+  previousOfferId: string,
+  voteDur: number,
+  debtLimit: number | bigint,
+) => {
+  const voteDurSec = BigInt(voteDur);
+  const debtLimitValue = BigInt(debtLimit) * ISTunit;
+  const toSec = (ms: number) => BigInt(Math.round(ms / 1000));
+
+  const id = `propose-${Date.now()}`;
+  const deadline = toSec(Date.now()) + voteDurSec;
+
+  const zip = (xs: any[], ys: { [x: string]: any }) =>
+    xs.map((x: any, i: string | number) => [x, ys[i]]);
+  const fromSmallCapsEntries = (txt: string) => {
+    const { body, slots } = JSON.parse(txt);
+    const theEntries = zip(JSON.parse(body.slice(1)), slots).map(
+      ([[name, ref], boardID]) => {
+        const iface = ref.replace(/^\$\d+\./, '');
+        return [name, { iface, boardID }];
+      },
+    );
+    return Object.fromEntries(theEntries);
+  };
+
+  const slots = [] as string[]; // XXX global mutable state
+  const smallCaps = {
+    Nat: (n: any) => `+${n}`,
+    // XXX mutates obj
+    ref: (obj: { ix: string; boardID: any; iface: any }) => {
+      if (obj.ix) return obj.ix;
+      const ix = slots.length;
+      slots.push(obj.boardID);
+      obj.ix = `$${ix}.Alleged: ${obj.iface}`;
+      return obj.ix;
+    },
+  };
+
+  const instance = fromSmallCapsEntries(
+    await agoric.follow('-lF', ':published.agoricNames.instance', '-o', 'text'),
+  );
+  assert(instance.VaultFactory);
+
+  const brand = fromSmallCapsEntries(
+    await agoric.follow('-lF', ':published.agoricNames.brand', '-o', 'text'),
+  );
+  assert(brand.IST);
+  assert(brand.ATOM);
+
+  const body = {
+    method: 'executeOffer',
+    offer: {
+      id,
+      invitationSpec: {
+        invitationMakerName: 'VoteOnParamChange',
+        previousOffer: previousOfferId,
+        source: 'continuing',
+      },
+      offerArgs: {
+        deadline: smallCaps.Nat(deadline),
+        instance: smallCaps.ref(instance.VaultFactory),
+        params: {
+          DebtLimit: {
+            brand: smallCaps.ref(brand.IST),
+            value: smallCaps.Nat(debtLimitValue),
+          },
+        },
+        path: {
+          paramPath: {
+            key: {
+              collateralBrand: smallCaps.ref(brand.ATOM),
+            },
+          },
+        },
+      },
+      proposal: {},
+    },
+  };
+
+  const capData = { body: `#${JSON.stringify(body)}`, slots };
+  return JSON.stringify(capData);
+};
+export const provisionWallet = async (user: string) => {
+  const userAddress = await addUser(user);
+
+  await provisionSmartWallet(
+    userAddress,
+    `20000000ubld,100000000${ATOM_DENOM}`,
+  );
+  await waitForBlock();
+};
+
+export const implementNewAuctionParams = async (
+  address: string,
+  oracles: { address: string; id: string }[],
+  startFequency: number,
+  clockStep: number,
+  priceLockPeriod: number,
+) => {
+  await waitForBlock(3);
+
+  await proposeNewAuctionParams(
+    address,
+    startFequency,
+    clockStep,
+    priceLockPeriod,
+  );
+
+  console.log('ACTIONS voting for new auction params');
+  await voteForNewParams(govAccounts, 0);
+
+  console.log('ACTIONS wait for the vote deadline to pass');
+  await new Promise(r => setTimeout(r, VOTING_WAIT_MS));
+};
+
+export const proposeNewDebtCeiling = async (
+  address: string,
+  debtLimit: number | bigint,
+) => {
+  const charterAcceptOfferId = await agops.ec(
+    'find-continuing-id',
+    '--for',
+    `${'charter\\ member\\ invitation'}`,
+    '--from',
+    address,
+  );
+
+  return executeOffer(
+    address,
+    paramChangeOfferGeneration(charterAcceptOfferId, 30, debtLimit),
+  );
+};
+
+export const setDebtLimit = async (
+  address: string,
+  debtLimit: number | bigint,
+) => {
+  console.log('ACTIONS Setting debt limit');
+
+  await proposeNewDebtCeiling(address, debtLimit);
+  await voteForNewParams(govAccounts, 0);
+
+  console.log('ACTIONS wait for the vote to pass');
+  await new Promise(r => setTimeout(r, VOTING_WAIT_MS));
+};

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -18,5 +18,8 @@
   "scripts": {
     "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops"
   },
-  "packageManager": "yarn@4.2.2"
+  "packageManager": "yarn@4.2.2",
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
 }

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/synthetic-chain": "^0.1.0",
-    "ava": "^6.1.2"
+    "ava": "^6.1.2",
+    "tsx": "^4.17.0"
   },
   "ava": {
     "concurrency": 1,

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -1,6 +1,6 @@
 {
   "agoricProposal": {
-    "type": "/cosmos.params.v1beta1.ParameterChangeProposal"
+    "type": "/agoric.swingset.CoreEvalProposal"
   },
   "type": "module",
   "license": "Apache-2.0",

--- a/a3p-integration/proposals/z:acceptance/scripts/test-vaults.mts
+++ b/a3p-integration/proposals/z:acceptance/scripts/test-vaults.mts
@@ -1,0 +1,55 @@
+#!/usr/bin/env tsx
+/* eslint-disable @jessie.js/safe-await-separator */
+
+import {
+  agoric,
+  GOV1ADDR,
+  GOV2ADDR,
+  newOfferId,
+} from '@agoric/synthetic-chain';
+import assert from 'node:assert/strict';
+import {
+  implementNewAuctionParams,
+  ISTunit,
+  provisionWallet,
+  setDebtLimit,
+} from '../lib/vaults.mjs';
+
+const START_FREQUENCY = 600; // StartFrequency: 600s (auction runs every 10m)
+const CLOCK_STEP = 20; // ClockStep: 20s (ensures auction completes in time)
+const PRICE_LOCK_PERIOD = 300;
+const oraclesAddresses = [GOV1ADDR, GOV2ADDR];
+
+const oracles = [] as { address: string; id: string }[];
+for (const oracle of oraclesAddresses) {
+  const offerId = await newOfferId();
+  oracles.push({ address: oracle, id: offerId });
+}
+
+console.log('Ensure user2 provisioned');
+await provisionWallet('user2');
+
+console.log('Ensure auction params have changed');
+await implementNewAuctionParams(
+  GOV1ADDR,
+  oracles,
+  START_FREQUENCY,
+  CLOCK_STEP,
+  PRICE_LOCK_PERIOD,
+);
+
+const govParams = await agoric.follow('-lF', ':published.auction.governance');
+assert.equal(govParams.current.ClockStep.value.relValue, CLOCK_STEP.toString());
+assert.equal(
+  govParams.current.StartFrequency.value.relValue,
+  START_FREQUENCY.toString(),
+);
+
+console.log('Ensure debt ceiling changes');
+const limit = 45_000_000n;
+await setDebtLimit(GOV1ADDR, limit);
+const params = await agoric.follow(
+  '-lF',
+  ':published.vaultFactory.managers.manager0.governance',
+);
+assert.equal(params.current.DebtLimit.value.value, String(limit * ISTunit));

--- a/a3p-integration/proposals/z:acceptance/test.sh
+++ b/a3p-integration/proposals/z:acceptance/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -ueo pipefail
 # Place here any test that should be executed using the executed proposal.
 # The effects of this step are not persisted in further proposal layers.
 
@@ -9,6 +9,9 @@ yarn ava initial.test.js
 # test more, in ways that change system state
 GLOBIGNORE=initial.test.js
 yarn ava ./*.test.js
+
+npm install -g tsx
+scripts/test-vaults.mts
 
 ./create-kread-item-test.sh
 

--- a/a3p-integration/proposals/z:acceptance/tsconfig.json
+++ b/a3p-integration/proposals/z:acceptance/tsconfig.json
@@ -2,11 +2,14 @@
   "compilerOptions": {
     "noEmit": true,
     "target": "esnext",
-    "module": "esnext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "checkJs": true,
     "strict": false,
     "strictNullChecks": true,
-    "noImplicitThis": true
+    "noImplicitThis": true,
+    // XXX synthetic-chain has some errors
+    "skipLibCheck": true,
   }
 }

--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -26,6 +26,174 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/aix-ppc64@npm:0.23.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm64@npm:0.23.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm@npm:0.23.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-x64@npm:0.23.1"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-arm64@npm:0.23.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-x64@npm:0.23.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.23.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-x64@npm:0.23.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm64@npm:0.23.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm@npm:0.23.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ia32@npm:0.23.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-loong64@npm:0.23.1"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-mips64el@npm:0.23.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ppc64@npm:0.23.1"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-riscv64@npm:0.23.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-s390x@npm:0.23.1"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-x64@npm:0.23.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/netbsd-x64@npm:0.23.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-x64@npm:0.23.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/sunos-x64@npm:0.23.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-arm64@npm:0.23.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-ia32@npm:0.23.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-x64@npm:0.23.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -772,6 +940,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.23.0":
+  version: 0.23.1
+  resolution: "esbuild@npm:0.23.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.23.1"
+    "@esbuild/android-arm": "npm:0.23.1"
+    "@esbuild/android-arm64": "npm:0.23.1"
+    "@esbuild/android-x64": "npm:0.23.1"
+    "@esbuild/darwin-arm64": "npm:0.23.1"
+    "@esbuild/darwin-x64": "npm:0.23.1"
+    "@esbuild/freebsd-arm64": "npm:0.23.1"
+    "@esbuild/freebsd-x64": "npm:0.23.1"
+    "@esbuild/linux-arm": "npm:0.23.1"
+    "@esbuild/linux-arm64": "npm:0.23.1"
+    "@esbuild/linux-ia32": "npm:0.23.1"
+    "@esbuild/linux-loong64": "npm:0.23.1"
+    "@esbuild/linux-mips64el": "npm:0.23.1"
+    "@esbuild/linux-ppc64": "npm:0.23.1"
+    "@esbuild/linux-riscv64": "npm:0.23.1"
+    "@esbuild/linux-s390x": "npm:0.23.1"
+    "@esbuild/linux-x64": "npm:0.23.1"
+    "@esbuild/netbsd-x64": "npm:0.23.1"
+    "@esbuild/openbsd-arm64": "npm:0.23.1"
+    "@esbuild/openbsd-x64": "npm:0.23.1"
+    "@esbuild/sunos-x64": "npm:0.23.1"
+    "@esbuild/win32-arm64": "npm:0.23.1"
+    "@esbuild/win32-ia32": "npm:0.23.1"
+    "@esbuild/win32-x64": "npm:0.23.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/08c2ed1105cc3c5e3a24a771e35532fe6089dd24a39c10097899072cef4a99f20860e41e9294e000d86380f353b04d8c50af482483d7f69f5208481cce61eec7
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -951,6 +1202,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:~2.3.3":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "gauge@npm:^3.0.0":
   version: 3.0.2
   resolution: "gauge@npm:3.0.2"
@@ -986,6 +1256,15 @@ __metadata:
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.7.6
+  resolution: "get-tsconfig@npm:4.7.6"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/2240e1b13e996dfbb947d177f422f83d09d1f93c9ce16959ebb3c2bdf8bdf4f04f98eba043859172da1685f9c7071091f0acfa964ebbe4780394d83b7dc3f58a
   languageName: node
   linkType: hard
 
@@ -1932,6 +2211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -1963,6 +2249,7 @@ __metadata:
   dependencies:
     "@agoric/synthetic-chain": "npm:^0.1.0"
     ava: "npm:^6.1.2"
+    tsx: "npm:^4.17.0"
     typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
@@ -2296,6 +2583,22 @@ __metadata:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.17.0":
+  version: 4.17.0
+  resolution: "tsx@npm:4.17.0"
+  dependencies:
+    esbuild: "npm:~0.23.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/ad720b81d6447c7695d24c27947fa1a2b6db9d2ef03216389edd6fa0006aa479bc0d8348a1ac9975a08edef4ce791ff5629a24d8dccbb0987f42e5407785cfa4
   languageName: node
   linkType: hard
 

--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -1963,6 +1963,7 @@ __metadata:
   dependencies:
     "@agoric/synthetic-chain": "npm:^0.1.0"
     ava: "npm:^6.1.2"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2311,6 +2312,26 @@ __metadata:
   version: 0.13.1
   resolution: "type-fest@npm:0.13.1"
   checksum: 10c0/0c0fa07ae53d4e776cf4dac30d25ad799443e9eef9226f9fddbb69242db86b08584084a99885cfa5a9dfe4c063ebdc9aa7b69da348e735baede8d43f1aeae93b
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=b45daf"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/10dd9881baba22763de859e8050d6cb6e2db854197495c6f1929b08d1eb2b2b00d0b5d9b0bcee8472f1c3f4a7ef6a5d7ebe0cfd703f853aa5ae465b8404bc1ba
   languageName: node
   linkType: hard
 

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -169,6 +169,21 @@ export const upgradeVaults = async (
   };
 
   await upgradeVaultFactory();
+
+  // @ts-expect-error It's saved in econ-behaviors.js:startVaultFactory()
+  const vaultFactoryPrivateArgs = kit.privateArgs;
+  console.log('UPGV upgraded vaults, restarting governor');
+
+  const ecf = await electorateCreatorFacet;
+  // restart vaultFactory governor
+  await E(kit.governorAdminFacet).restartContract(
+    harden({
+      electorateCreatorFacet: ecf,
+      governed: vaultFactoryPrivateArgs,
+    }),
+  );
+
+  console.log('UPGV restarted governor');
 };
 
 const uV = 'upgradeVaults';


### PR DESCRIPTION
refs: #5200

## Description

Do a null upgrade of the vaultFactory governor contract in the coreEval  that upgrades the vaultFactory contract.

### Security Considerations

If the governor is correctly connected to the contract (tests in process), and can govern parameters and enable offer filters, then everything is connected as it was, and there are no new security issues.

### Scaling Considerations

None.

### Documentation Considerations

No user-visible changes.

### Testing Considerations

Test governance of the vaultFactory thoroughly on a testnet.

### Upgrade Considerations

It appears that contract governor may be upgradeable..
