### PR TITLE
chore: fix remaining lint issues (#9632)

### DIFF
--- a/packages/agoric-cli/test/inter-cli.test.js
+++ b/packages/agoric-cli/test/inter-cli.test.js
@@ -252,7 +252,7 @@ test('amount parsing', t => {
   });
 });
 
-test.todo('want as max collateral wanted');
+// test.todo('want as max collateral wanted');  see https://github.com/Agoric/agoric-sdk/issues/9965
 
 /**
  * @type {import('@agoric/smart-wallet/src/offers.js').OfferStatus &
@@ -358,7 +358,7 @@ test('diagnostic for agd ENOENT', async t => {
   t.is(out.join('').trim(), '');
 });
 
-test.todo('agd ENOENT clue outside normalizeAddress');
+// test.todo('agd ENOENT clue outside normalizeAddress'); see https://github.com/Agoric/agoric-sdk/issues/9965
 
 const usageTest = (words, blurb = 'Command usage:') => {
   test(`Usage: ${words}`, async t => {
@@ -416,7 +416,7 @@ test('formatBid', t => {
   }
 });
 
-test.todo('fmtBid with error does not show result');
+// test.todo('fmtBid with error does not show result'); see https://github.com/Agoric/agoric-sdk/issues/9965
 /*
 _not_ like this:
 
@@ -607,7 +607,7 @@ test('README ex1: inter bid place by-price: printed offer is correct', async t =
   t.deepEqual(txt, expected);
 });
 
-test.todo('inter bid by-price shows tx, wallet status');
+// test.todo('inter bid by-price shows tx, wallet status'); see https://github.com/Agoric/agoric-sdk/issues/9965
 /*
 $ agops inter bid by-price --price 0.81 --give 0.5 --maxBuy 3 --from gov2
 2023-03-30T21:48:14.479332418Z not in block 49618 retrying...
@@ -617,12 +617,12 @@ first bid update:
 {"id":"bid-1680212903989","price":"0.81 IST/ATOM","give":{"Bid":"0.5IST"},"want":"3ATOM","result":"Your bid has been accepted"}
 */
 
-test.todo('execSwingsetTransaction returns non-0 code');
+// test.todo('execSwingsetTransaction returns non-0 code'); see https://github.com/Agoric/agoric-sdk/issues/9965
 
-test.todo('already cancelled bid');
+// test.todo('already cancelled bid'); see https://github.com/Agoric/agoric-sdk/issues/9965
 /*
 $ agops inter bid cancel --from gov2 bid-1680211556497
 bid-1680211556497 not in live offer ids: bid-1680211593489,bid-1680212903989,bid-1680213097499,bid-1680220217218,bid-1680220368714,bid-1680220406939
 */
 
-test.todo('--give without number');
+// test.todo('--give without number');  see https://github.com/Agoric/agoric-sdk/issues/9965

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -347,18 +347,22 @@ export const makeAnchorAsset = async (
     }),
   );
 
-  const { creatorFacet: mint, publicFacet: issuer } = /**
-   * @type {{
+  /**
+   * @typedef {{
    *   creatorFacet: ERef<Mint<'nat'>>;
    *   publicFacet: ERef<Issuer<'nat'>>;
-   * }}
-   */ (
-    await E(startUpgradable)({
-      installation: mintHolder,
-      label: keyword,
-      terms,
-    })
-  );
+   * }} StartUpgradableResponse
+   */
+
+  const { creatorFacet: mint, publicFacet: issuer } =
+    /** @type {StartUpgradableResponse} */
+    (
+      await E(startUpgradable)({
+        installation: mintHolder,
+        label: keyword,
+        terms,
+      })
+    );
 
   const brand = await E(issuer).getBrand();
   const kit = harden({ mint, issuer, brand });


### PR DESCRIPTION
closes: #9632 
refs: #9965 

## Description
Fixed the following two issues:

1. packages/inter-protocol/src/proposals/startPSM.js 351:1  warning  Expected JSDoc block to be aligned  jsdoc/check-alignment
- factored out typedef from the type cast so the cast is now a single-line comment.

2. packages/agoric-cli/test/inter-cli.test.js 255:1  warning  `test.todo()` should not be used  ava/no-todo-test 361:1  warning  `test.todo()` should not be used  ava/no-todo-test 419:1  warning  `test.todo()` should not be used  ava/no-todo-test 610:1  warning  `test.todo()` should not be used  ava/no-todo-test 620:1  warning  `test.todo()` should not be used  ava/no-todo-test 622:1  warning  `test.todo()` should not be used  ava/no-todo-test 628:1  warning  `test.todo()` should not be used  ava/no-todo-test
- Opened a new issue #9965 to create missing tests and commented out test.todo()'s

### Security Considerations
None.

### Scaling Considerations
None.

### Documentation Considerations
None.

### Testing Considerations
None: passed lint and type checker; actual code not affected.

### Upgrade Considerations
None.