### PR TITLE
feat: update auction in agoricNames, test that the boardId changed

### DIFF
--- a/a3p-integration/proposals/a:vaults-auctions/agd-tools.js
+++ b/a3p-integration/proposals/a:vaults-auctions/agd-tools.js
@@ -201,3 +201,18 @@ export const getProvisionPoolMetrics = async () => {
   const path = `published.provisionPool.metrics`;
   return getQuoteBody(path);
 };
+
+export const getAuctionInstance = async price => {
+  const instanceRec = await queryVstorage(`published.agoricNames.instance`);
+
+  const value = JSON.parse(instanceRec.value);
+  const body = JSON.parse(value.values.at(-1));
+
+  const feeds = JSON.parse(body.body.substring(1));
+
+  const key = Object.keys(feeds).find(k => feeds[k][0] === 'auctioneer');
+  if (key) {
+    return body.slots[key];
+  }
+  return null;
+};

--- a/a3p-integration/proposals/a:vaults-auctions/eval.sh
+++ b/a3p-integration/proposals/a:vaults-auctions/eval.sh
@@ -1,0 +1,9 @@
+# we have an eval.sh so we can run prepare.sh before the rest
+
+echo "[$PROPOSAL] Running prepare.sh"
+./prepare.sh
+
+echo "[$PROPOSAL] Running proposal declared in package.json"
+# copy to run in the proposal package so the dependencies can be resolved
+cp /usr/src/upgrade-test-scripts/eval_submission.js .
+./eval_submission.js

--- a/a3p-integration/proposals/a:vaults-auctions/prepare.sh
+++ b/a3p-integration/proposals/a:vaults-auctions/prepare.sh
@@ -4,3 +4,5 @@
 # actions are executed in the upgraded chain software and the effects are
 # persisted in the generated image for the upgrade, so they can be used in
 # later steps, such as the "test" step, or further proposal layers.
+
+./saveAuctionInstance.js

--- a/a3p-integration/proposals/a:vaults-auctions/saveAuctionInstance.js
+++ b/a3p-integration/proposals/a:vaults-auctions/saveAuctionInstance.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'fs/promises';
+import { getAuctionInstance } from './agd-tools.js';
+
+const { env } = process;
+
+const oldAuctionInstance = await getAuctionInstance();
+console.log('old auction instance ', oldAuctionInstance, env.HOME);
+
+await writeFile(
+  `${env.HOME}/.agoric/previousInstance.json`,
+  oldAuctionInstance,
+);

--- a/a3p-integration/proposals/a:vaults-auctions/upgradeVaults.test.js
+++ b/a3p-integration/proposals/a:vaults-auctions/upgradeVaults.test.js
@@ -7,6 +7,7 @@ import {
   openVault,
   USER1ADDR,
 } from '@agoric/synthetic-chain';
+import { readFile } from 'fs/promises';
 
 import {
   bankSend,
@@ -16,8 +17,11 @@ import {
   getVaultPrices,
   pushPrices,
   addPreexistingOracles,
+  getAuctionInstance,
 } from './agd-tools.js';
 import { getDetailsMatchingVats } from './vatDetails.js';
+
+const { env } = process;
 
 const oraclesByBrand = new Map();
 
@@ -103,6 +107,22 @@ const verifyVaultPriceUpdate = async t => {
   t.is(quote.value[0].amountOut.value, '+5200000');
 };
 
+const verifyAuctionInstance = async t => {
+  const newAuctionInstance = await getAuctionInstance();
+  const oldInstance = await readFile(
+    `${env.HOME}/.agoric/previousInstance.json`,
+    'utf-8',
+  );
+
+  console.log(
+    `new: ${newAuctionInstance} should be different from ${oldInstance}`,
+  );
+  t.true(
+    newAuctionInstance !== oldInstance,
+    `new: ${newAuctionInstance} should be different from ${oldInstance}`,
+  );
+};
+
 // test.serial() isn't guaranteed to run tests in order, so we run the intended tests here
 test('liquidation post upgrade', async t => {
   t.log('setup Oracles');
@@ -125,4 +145,7 @@ test('liquidation post upgrade', async t => {
 
   t.log('vault price updated');
   await verifyVaultPriceUpdate(t);
+
+  t.log('auction instance changed in agoricNames');
+  await verifyAuctionInstance(t);
 });

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -26,6 +26,7 @@ export const addAuction = async (
       chainStorage,
       chainTimerService,
       economicCommitteeCreatorFacet: electorateCreatorFacet,
+      econCharterKit,
       priceAuthority,
       zoe,
     },
@@ -153,19 +154,26 @@ export const addAuction = async (
     ),
   );
 
-  produceAuctioneerKit.reset();
-  produceAuctioneerKit.resolve(
-    harden({
-      label: 'auctioneer',
-      creatorFacet: governedCreatorFacet,
-      adminFacet: governorStartResult.adminFacet,
-      publicFacet: governedPublicFacet,
-      instance: governedInstance,
+  const kit = harden({
+    label: 'auctioneer',
+    creatorFacet: governedCreatorFacet,
+    adminFacet: governorStartResult.adminFacet,
+    publicFacet: governedPublicFacet,
+    instance: governedInstance,
 
-      governor: governorStartResult.instance,
-      governorCreatorFacet: governorStartResult.creatorFacet,
-      governorAdminFacet: governorStartResult.adminFacet,
-    }),
+    governor: governorStartResult.instance,
+    governorCreatorFacet: governorStartResult.creatorFacet,
+    governorAdminFacet: governorStartResult.adminFacet,
+  });
+  produceAuctioneerKit.reset();
+  produceAuctioneerKit.resolve(kit);
+
+  // introduce economic committee charter to new auctioneer
+  // cf addGovernorsToEconCharter() in committee-proposal.js
+  await E(E.get(econCharterKit).creatorFacet).addInstance(
+    kit.instance,
+    kit.governorCreatorFacet,
+    kit.label,
   );
 
   auctionInstance.reset();
@@ -187,6 +195,7 @@ export const ADD_AUCTION_MANIFEST = harden({
       board: true,
       chainStorage: true,
       chainTimerService: true,
+      econCharterKit: true,
       economicCommitteeCreatorFacet: true,
       priceAuthority: true,
       zoe: true,

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -20,6 +20,7 @@ const trace = makeTracer('NewAuction', true);
 export const addAuction = async (
   {
     consume: {
+      agoricNamesAdmin,
       auctioneerKit: legacyKitP,
       board,
       chainStorage,
@@ -31,6 +32,7 @@ export const addAuction = async (
     produce: { auctioneerKit: produceAuctioneerKit, auctionUpgradeNewInstance },
     instance: {
       consume: { reserve: reserveInstance },
+      produce: { auctioneer: auctionInstance },
     },
     installation: {
       consume: { contractGovernor: contractGovernorInstallation },
@@ -166,12 +168,21 @@ export const addAuction = async (
     }),
   );
 
+  auctionInstance.reset();
+  await auctionInstance.resolve(governedInstance);
+  // belt and suspenders; the above is supposed to also do this
+  await E(E(agoricNamesAdmin).lookupAdmin('instance')).update(
+    'auctioneer',
+    governedInstance,
+  );
+
   auctionUpgradeNewInstance.resolve(governedInstance);
 };
 
 export const ADD_AUCTION_MANIFEST = harden({
   [addAuction.name]: {
     consume: {
+      agoricNamesAdmin: true,
       auctioneerKit: true,
       board: true,
       chainStorage: true,
@@ -186,6 +197,7 @@ export const ADD_AUCTION_MANIFEST = harden({
     },
     instance: {
       consume: { reserve: true },
+      produce: { auctioneer: true },
     },
     installation: {
       consume: {


### PR DESCRIPTION
closes: #9963

## Description

The upgrade of auctions neglected to replace the agoricNames binding for the auction instance. This fixes that and tests that the boardId is different before and after the coreEval.

### Security Considerations

scary that we got that far through validation without noticing that the auction hadn't been updated in agoricNames.

### Scaling Considerations

None.

### Documentation Considerations

None.
