### PR TITLE
test: increase attempts for rewards available condition

### DIFF
--- a/multichain-testing/tools/sleep.ts
+++ b/multichain-testing/tools/sleep.ts
@@ -16,7 +16,7 @@ export const sleep = (
     setTimeout(resolve, ms);
   });
 
-type RetryOptions = {
+export type RetryOptions = {
   maxRetries?: number;
   retryIntervalMs?: number;
 } & SleepOptions;


### PR DESCRIPTION
refs: #9934

## Description
- Increases overall timeout from 40s to 90s for "rewards available" condition in `/multichain-testing` staking flows test. This check happens after delegations are observed on the remote chain, but before we make an attempt to `WithdrawRewards`.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Goal is to minimize observed CI flakes.

### Upgrade Considerations
n/a
