### PR TITLE
9211 lookup denom

### DIFF
--- a/multichain-testing/test/auto-stake-it.test.ts
+++ b/multichain-testing/test/auto-stake-it.test.ts
@@ -11,6 +11,7 @@ import {
 import { makeQueryClient } from '../tools/query.js';
 import type { SetupContextWithWallets } from './support.js';
 import { chainConfig, commonSetup } from './support.js';
+import { AUTO_STAKE_IT_DELEGATIONS_TIMEOUT } from './config.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 
@@ -179,7 +180,8 @@ const autoStakeItScenario = test.macro({
     const { delegation_responses } = await retryUntilCondition(
       () => remoteQueryClient.queryDelegations(icaAddress),
       ({ delegation_responses }) => !!delegation_responses.length,
-      `delegations visible on ${chainName}`,
+      `auto-stake-it delegations visible on ${chainName}`,
+      AUTO_STAKE_IT_DELEGATIONS_TIMEOUT,
     );
     t.log('delegation balance', delegation_responses[0]?.balance);
     t.like(

--- a/multichain-testing/test/config.ts
+++ b/multichain-testing/test/config.ts
@@ -1,0 +1,32 @@
+import type { RetryOptions } from '../tools/sleep.js';
+
+/**
+ * Wait 90 seconds to ensure staking rewards are available.
+ *
+ * While we expect staking rewards to be available after a
+ * single block (~5-12 seconds for most chains), this provides additional
+ * padding after observed failures in CI
+ * (https://github.com/Agoric/agoric-sdk/issues/9934).
+ *
+ * A more robust approach might consider Distribution params and the
+ * {@link FAUCET_POUR} constant to determine how many blocks it should take for
+ * rewards to be available.
+ */
+export const STAKING_REWARDS_TIMEOUT: RetryOptions = {
+  retryIntervalMs: 5000,
+  maxRetries: 18,
+};
+
+/**
+ * Wait 2 minutes to ensure:
+ * - IBC Transfer from LocalAccount -> ICA Account Completes
+ * - Delegation from ICA Account (initiated from SwingSet) Completes
+ * - Delegations are visible via LCD (API Endpoint)
+ *
+ * Most of the time this finishes in <7 seconds, but other times it
+ * appears to take much longer.
+ */
+export const AUTO_STAKE_IT_DELEGATIONS_TIMEOUT: RetryOptions = {
+  retryIntervalMs: 5000,
+  maxRetries: 24,
+};

--- a/multichain-testing/test/stake-ica.test.ts
+++ b/multichain-testing/test/stake-ica.test.ts
@@ -7,28 +7,12 @@ import {
 } from './support.js';
 import { makeDoOffer } from '../tools/e2e-tools.js';
 import { makeQueryClient } from '../tools/query.js';
-import { sleep, type RetryOptions } from '../tools/sleep.js';
+import { sleep } from '../tools/sleep.js';
+import { STAKING_REWARDS_TIMEOUT } from './config.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 
 const accounts = ['user1', 'user2'];
-
-/**
- * Wait 90 seconds to ensure staking rewards are available.
- *
- * While we expect staking rewards to be available after a
- * single block (~5-12 seconds for most chains), this provide additional
- * padding after observed failures in CI
- * (https://github.com/Agoric/agoric-sdk/issues/9934).
- *
- * A more robust approach might consider Distribution params and the
- * {@link FAUCET_POUR} constant to determine how many blocks it should take for
- * rewards to be available.
- */
-export const STAKING_REWARDS_TIMEOUT: RetryOptions = {
-  retryIntervalMs: 5000,
-  maxRetries: 18,
-};
 
 test.before(async t => {
   const { deleteTestKeys, setupTestKeys, ...rest } = await commonSetup(t);

--- a/multichain-testing/tools/ibc-transfer.ts
+++ b/multichain-testing/tools/ibc-transfer.ts
@@ -37,12 +37,14 @@ type SimpleChainAddress = {
   chainName: string;
 };
 
-export const DEFAULT_TIMEOUT_NS = 1893456000000000000n;
+// 2030-01-01T00:00:00Z
+export const DEFAULT_TIMEOUT_NS =
+  1893456000n * NANOSECONDS_PER_MILLISECOND * MILLISECONDS_PER_SECOND;
 
 /**
  * @param {number} [ms] current time in ms (e.g. Date.now())
  * @param {bigint} [minutes=5n] number of minutes in the future
- * @returns {bigint} nanosecond timestamp 5 mins in the future */
+ * @returns {bigint} nanosecond timestamp absolute since Unix epoch */
 export const getTimeout = (ms: number = 0, minutes = 5n) => {
   // UNTIL #9200. timestamps are getting clobbered somewhere along the way
   // and we are observing failed transfers with timeouts years in the past.

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -240,9 +240,8 @@ test.serial('stakeAtom - smart wallet', async t => {
       proposal: {},
     }),
     {
-      message: 'Brands not currently supported.',
+      message: 'No denomination for brand [object Alleged: ATOM brand]',
     },
-    'brands not currently supported',
   );
 });
 

--- a/packages/orchestration/src/examples/auto-stake-it.flows.js
+++ b/packages/orchestration/src/examples/auto-stake-it.flows.js
@@ -1,4 +1,5 @@
 import { Fail } from '@endo/errors';
+import { denomHash } from '../utils/denomHash.js';
 
 /**
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
@@ -21,19 +22,13 @@ import { Fail } from '@endo/errors';
  * @param {{
  *   chainName: string;
  *   validator: CosmosValidatorAddress;
- *   localDenom: Denom;
  * }} offerArgs
  */
 export const makeAccounts = async (
   orch,
   { makeStakingTap, makePortfolioHolder, chainHub },
   seat,
-  {
-    chainName,
-    validator,
-    // TODO localDenom is user supplied, until #9211
-    localDenom,
-  },
+  { chainName, validator },
 ) => {
   seat.exit(); // no funds exchanged
   const [agoric, remoteChain] = await Promise.all([
@@ -64,6 +59,8 @@ export const makeAccounts = async (
     chainId,
   );
   assert(transferChannel.counterPartyChannelId, 'unable to find sourceChannel');
+
+  const localDenom = `ibc/${denomHash({ denom: remoteDenom, channelId: transferChannel.channelId })}`;
 
   // Every time the `localAccount` receives `remoteDenom` over IBC, delegate it.
   const tap = makeStakingTap({

--- a/packages/orchestration/src/exos/chain-hub-admin.js
+++ b/packages/orchestration/src/exos/chain-hub-admin.js
@@ -1,13 +1,14 @@
 /* we expect promises to resolved promptly,  */
 /* eslint-disable no-restricted-syntax */
-import { M } from '@endo/patterns';
 import { heapVowE } from '@agoric/vow/vat.js';
+import { M } from '@endo/patterns';
 import { CosmosChainInfoShape } from '../typeGuards.js';
+import { DenomDetailShape } from './chain-hub.js';
 
 /**
  * @import {Zone} from '@agoric/zone';
- * @import {CosmosChainInfo, IBCConnectionInfo} from '@agoric/orchestration';
- * @import {ChainHub} from './chain-hub.js';
+ * @import {CosmosChainInfo, Denom, IBCConnectionInfo} from '@agoric/orchestration';
+ * @import {ChainHub, DenomDetail} from './chain-hub.js';
  */
 
 /**
@@ -28,6 +29,7 @@ export const prepareChainHubAdmin = (zone, chainHub) => {
         CosmosChainInfoShape,
         ConnectionInfoShape,
       ).returns(M.undefined()),
+      registerAsset: M.call(M.string(), DenomDetailShape).returns(M.promise()),
     }),
     {
       /**
@@ -47,6 +49,19 @@ export const prepareChainHubAdmin = (zone, chainHub) => {
           chainInfo.chainId,
           connectionInfo,
         );
+      },
+      /**
+       * Register an asset that may be held on a chain other than the issuing
+       * chain.
+       *
+       * @param {Denom} denom - on the holding chain, whose name is given in
+       *   `detail.chainName`
+       * @param {DenomDetail} detail - chainName and baseName must be registered
+       */
+      async registerAsset(denom, detail) {
+        // XXX async work necessary before the synchronous call
+        await heapVowE.when(chainHub.getChainInfo('agoric'));
+        chainHub.registerAsset(denom, detail);
       },
     },
   );

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -31,7 +31,7 @@ import { CosmosChainInfoShape, IBCConnectionInfoShape } from '../typeGuards.js';
  * @property {string} baseName - name of issuing chain; e.g. cosmoshub
  * @property {Denom} baseDenom - e.g. uatom
  * @property {string} chainName - name of holding chain; e.g. agoric
- * @property {Brand} [brand] - vbank brand, if registered
+ * @property {Brand<'nat'>} [brand] - vbank brand, if registered
  * @see {ChainHub} `registerAsset` method
  */
 /** @type {TypedPattern<DenomDetail>} */

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -4,6 +4,7 @@ import {
   QueryBalanceRequest,
   QueryBalanceResponse,
 } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
+import { MsgSend } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
 import {
   MsgWithdrawDelegatorReward,
   MsgWithdrawDelegatorRewardResponse,
@@ -15,7 +16,6 @@ import {
   MsgUndelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
-import { MsgSend } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
 import { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
 import { makeTracer, NonNullish } from '@agoric/internal';
 import { Shape as NetworkShape } from '@agoric/network';
@@ -31,6 +31,7 @@ import {
   DenomAmountShape,
   IBCTransferOptionsShape,
 } from '../typeGuards.js';
+import { coerceDenom } from '../utils/amounts.js';
 import { maxClockSkew, tryDecodeResponse } from '../utils/cosmos.js';
 import { orchestrationAccountMethods } from '../utils/orchestrationAccount.js';
 import { makeTimestampHelper } from '../utils/time.js';
@@ -576,14 +577,11 @@ export const prepareCosmosOrchestrationAccountKit = (
             if (!icqConnection) {
               throw Fail`Queries not available for chain ${chainAddress.chainId}`;
             }
-            // TODO #9211 lookup denom from brand
-            assert.typeof(denom, 'string');
-
             const results = E(icqConnection).query([
               toRequestQueryJson(
                 QueryBalanceRequest.toProtoMsg({
                   address: chainAddress.value,
-                  denom,
+                  denom: coerceDenom(chainHub, denom),
                 }),
               ),
             ]);

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -17,7 +17,7 @@ import {
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { MsgSend } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/tx.js';
 import { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
-import { makeTracer } from '@agoric/internal';
+import { makeTracer, NonNullish } from '@agoric/internal';
 import { Shape as NetworkShape } from '@agoric/network';
 import { M } from '@agoric/vat-data';
 import { VowShape } from '@agoric/vow';
@@ -242,13 +242,15 @@ export const prepareCosmosOrchestrationAccountKit = (
          * @returns {Coin}
          */
         amountToCoin(amount) {
-          if (!('denom' in amount)) {
-            // FIXME(#9211) look up values from brands
-            trace('TODO #9211: handle brand', amount);
-            throw Fail`Brands not currently supported.`;
-          }
+          const denom =
+            'denom' in amount
+              ? amount.denom
+              : NonNullish(
+                  chainHub.lookupDenom(amount.brand),
+                  `No denomination for brand ${amount.brand}`,
+                );
           return harden({
-            denom: amount.denom,
+            denom,
             amount: String(amount.value),
           });
         },

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -17,7 +17,7 @@ import {
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
-import { makeTracer, NonNullish } from '@agoric/internal';
+import { makeTracer } from '@agoric/internal';
 import { Shape as NetworkShape } from '@agoric/network';
 import { M } from '@agoric/vat-data';
 import { VowShape } from '@agoric/vow';
@@ -31,7 +31,7 @@ import {
   DenomAmountShape,
   IBCTransferOptionsShape,
 } from '../typeGuards.js';
-import { coerceDenom } from '../utils/amounts.js';
+import { coerceCoin, coerceDenom } from '../utils/amounts.js';
 import { maxClockSkew, tryDecodeResponse } from '../utils/cosmos.js';
 import { orchestrationAccountMethods } from '../utils/orchestrationAccount.js';
 import { makeTimestampHelper } from '../utils/time.js';
@@ -243,17 +243,7 @@ export const prepareCosmosOrchestrationAccountKit = (
          * @returns {Coin}
          */
         amountToCoin(amount) {
-          const denom =
-            'denom' in amount
-              ? amount.denom
-              : NonNullish(
-                  chainHub.lookupDenom(amount.brand),
-                  `No denomination for brand ${amount.brand}`,
-                );
-          return harden({
-            denom,
-            amount: String(amount.value),
-          });
+          return coerceCoin(chainHub, amount);
         },
       },
       balanceQueryWatcher: {

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -20,6 +20,7 @@ import { orchestrationAccountMethods } from '../utils/orchestrationAccount.js';
 import { makeTimestampHelper } from '../utils/time.js';
 import { preparePacketTools } from './packet-tools.js';
 import { prepareIBCTools } from './ibc-packet.js';
+import { coerceCoin, coerceDenomAmount } from '../utils/amounts.js';
 
 /**
  * @import {HostOf} from '@agoric/async-flow';
@@ -175,15 +176,7 @@ export const prepareLocalOrchestrationAccountKit = (
          * @returns {Coin}
          */
         amountToCoin(amount) {
-          if (!('denom' in amount)) {
-            // FIXME(#9211) look up values from brands
-            trace('TODO #9211: handle brand', amount);
-            throw Fail`Brands not currently supported.`;
-          }
-          return harden({
-            denom: amount.denom,
-            amount: String(amount.value),
-          });
+          return coerceCoin(chainHub, amount);
         },
       },
       invitationMakers: {
@@ -440,12 +433,9 @@ export const prepareLocalOrchestrationAccountKit = (
          * @param {Amount<'nat'>} ertpAmount
          */
         delegate(validatorAddress, ertpAmount) {
-          // TODO #9211 lookup denom from brand
-          const amount = {
-            amount: String(ertpAmount.value),
-            denom: 'ubld',
-          };
           const { account: lca } = this.state;
+
+          const amount = coerceCoin(chainHub, ertpAmount);
 
           return watch(
             E(lca).executeTx([
@@ -465,11 +455,7 @@ export const prepareLocalOrchestrationAccountKit = (
          * @returns {Vow<void | TimestampRecord>}
          */
         undelegate(validatorAddress, ertpAmount) {
-          // TODO #9211 lookup denom from brand
-          const amount = {
-            amount: String(ertpAmount.value),
-            denom: 'ubld',
-          };
+          const amount = coerceCoin(chainHub, ertpAmount);
           const { account: lca } = this.state;
           return watch(
             E(lca).executeTx([
@@ -560,8 +546,6 @@ export const prepareLocalOrchestrationAccountKit = (
         transfer(amount, destination, opts) {
           return asVow(() => {
             trace('Transferring funds from LCA over IBC');
-            // TODO #9211 lookup denom from brand
-            if ('brand' in amount) throw Fail`ERTP Amounts not yet supported`;
 
             const connectionInfoV = watch(
               chainHub.getConnectionInfo(
@@ -583,7 +567,11 @@ export const prepareLocalOrchestrationAccountKit = (
             const resultV = watch(
               allVows([connectionInfoV, timeoutTimestampVowOrValue]),
               this.facets.transferWatcher,
-              { opts, amount, destination },
+              {
+                opts,
+                amount: coerceDenomAmount(chainHub, amount),
+                destination,
+              },
             );
             return resultV;
           });

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -392,12 +392,17 @@ export const prepareLocalOrchestrationAccountKit = (
          * @type {HostOf<OrchestrationAccountI['getBalance']>}
          */
         getBalance(denomArg) {
-          // FIXME look up real values
-          // UNTIL https://github.com/Agoric/agoric-sdk/issues/9211
           const [brand, denom] =
             typeof denomArg === 'string'
-              ? [/** @type {any} */ (null), denomArg]
-              : [denomArg, 'FIXME'];
+              ? [chainHub.lookupAsset(denomArg).brand, denomArg]
+              : [denomArg, chainHub.lookupDenom(denomArg)];
+
+          if (!brand) {
+            throw Fail`No brand for ${denomArg}`;
+          }
+          if (!denom) {
+            throw Fail`No denom for ${denomArg}`;
+          }
 
           return watch(
             E(this.state.account).getBalance(brand),

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -25,7 +25,6 @@ import {
  * @import {Remote} from '@agoric/internal';
  * @import {PickFacet} from '@agoric/swingset-liveslots';
  * @import {CosmosInterchainService} from './cosmos-interchain-service.js';
- * @import {MakeLocalOrchestrationAccountKit} from './local-orchestration-account.js';
  * @import {MakeLocalChainFacade} from './local-chain-facade.js';
  * @import {MakeRemoteChainFacade} from './remote-chain-facade.js';
  * @import {Chain, ChainInfo, IBCConnectionInfo, Orchestrator} from '../types.js';

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -7,7 +7,7 @@ import { Fail, q } from '@endo/errors';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import {
-  BrandInfoShape,
+  DenomInfoShape,
   ChainInfoShape,
   DenomAmountShape,
   DenomShape,
@@ -37,7 +37,7 @@ const trace = makeTracer('Orchestrator');
 export const OrchestratorI = M.interface('Orchestrator', {
   getChain: M.call(M.string()).returns(Vow$(ChainInfoShape)),
   makeLocalAccount: M.call().returns(Vow$(LocalChainAccountShape)),
-  getBrandInfo: M.call(DenomShape).returns(BrandInfoShape),
+  getDenomInfo: M.call(DenomShape).returns(DenomInfoShape),
   asAmount: M.call(DenomAmountShape).returns(AmountShape),
 });
 
@@ -140,15 +140,15 @@ const prepareOrchestratorKit = (
         makeLocalAccount() {
           return watch(E(localchain).makeAccount());
         },
-        /** @type {HostOf<Orchestrator['getBrandInfo']>} */
-        getBrandInfo(denom) {
+        /** @type {HostOf<Orchestrator['getDenomInfo']>} */
+        getDenomInfo(denom) {
           const { chainName, baseName, baseDenom, brand } =
             chainHub.lookupAsset(denom);
           chainByName.has(chainName) ||
-            Fail`use getChain(${q(chainName)}) before getBrandInfo(${q(denom)})`;
+            Fail`use getChain(${q(chainName)}) before getDenomInfo(${q(denom)})`;
           const chain = chainByName.get(chainName);
           chainByName.has(baseName) ||
-            Fail`use getChain(${q(baseName)}) before getBrandInfo(${q(denom)})`;
+            Fail`use getChain(${q(baseName)}) before getDenomInfo(${q(denom)})`;
           const base = chainByName.get(baseName);
           return harden({ chain, base, brand, baseDenom });
         },

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -101,7 +101,7 @@ export interface Chain<CI extends ChainInfo> {
   // TODO provide a way to get the local denom/brand/whatever for this chain
 }
 
-export interface BrandInfo<
+export interface DenomInfo<
   HoldingChain extends keyof KnownChains,
   IssuingChain extends keyof KnownChains,
 > {
@@ -133,12 +133,12 @@ export interface Orchestrator {
    * issues the corresponding asset.
    * @param denom
    */
-  getBrandInfo: <
+  getDenomInfo: <
     HoldingChain extends keyof KnownChains,
     IssuingChain extends keyof KnownChains,
   >(
     denom: Denom,
-  ) => BrandInfo<HoldingChain, IssuingChain>;
+  ) => DenomInfo<HoldingChain, IssuingChain>;
   // TODO preload the mapping so this can be synchronous
   /**
    * Convert an amount described in native data to a local, structured Amount.

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -44,7 +44,7 @@ export type Denom = string; // ibc/... or uist
  * In many cases, either a denom string or a local Brand can be used to
  * designate a remote token type.
  */
-export type DenomArg = Denom | Brand;
+export type DenomArg = Denom | Brand<'nat'>;
 
 /**
  * Count of some fungible token on some blockchain.
@@ -57,7 +57,7 @@ export type DenomAmount = {
 };
 
 /** Amounts can be provided as pure data using denoms or as ERTP Amounts */
-export type AmountArg = DenomAmount | Amount;
+export type AmountArg = DenomAmount | Amount<'nat'>;
 
 /** An address on some blockchain, e.g., cosmos, eth, etc. */
 export type ChainAddress = {

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -101,6 +101,20 @@ export interface Chain<CI extends ChainInfo> {
   // TODO provide a way to get the local denom/brand/whatever for this chain
 }
 
+export interface BrandInfo<
+  HoldingChain extends keyof KnownChains,
+  IssuingChain extends keyof KnownChains,
+> {
+  /** The well-known Brand on Agoric for the direct asset */
+  brand?: Brand;
+  /** The Chain at which the argument `denom` exists (where the asset is currently held) */
+  chain: Chain<KnownChains[HoldingChain]>;
+  /** The Chain that is the issuer of the underlying asset */
+  base: Chain<KnownChains[IssuingChain]>;
+  /** the Denom for the underlying asset on its issuer chain */
+  baseDenom: Denom;
+}
+
 /**
  * Provided in the callback to `orchestrate()`.
  */
@@ -124,16 +138,7 @@ export interface Orchestrator {
     IssuingChain extends keyof KnownChains,
   >(
     denom: Denom,
-  ) => {
-    /** The well-known Brand on Agoric for the direct asset */
-    brand?: Brand;
-    /** The Chain at which the argument `denom` exists (where the asset is currently held) */
-    chain: Chain<KnownChains[HoldingChain]>;
-    /** The Chain that is the issuer of the underlying asset */
-    base: Chain<KnownChains[IssuingChain]>;
-    /** the Denom for the underlying asset on its issuer chain */
-    baseDenom: Denom;
-  };
+  ) => BrandInfo<HoldingChain, IssuingChain>;
   // TODO preload the mapping so this can be synchronous
   /**
    * Convert an amount described in native data to a local, structured Amount.

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -4,7 +4,7 @@ import { M } from '@endo/patterns';
 
 /**
  * @import {TypedPattern} from '@agoric/internal';
- * @import {ChainAddress, CosmosAssetInfo, ChainInfo, CosmosChainInfo, DenomAmount} from './types.js';
+ * @import {ChainAddress, CosmosAssetInfo, Chain, ChainInfo, CosmosChainInfo, DenomAmount, DenomDetail, BrandInfo} from './types.js';
  * @import {Delegation} from '@agoric/cosmic-proto/cosmos/staking/v1beta1/staking.js';
  * @import {TxBody} from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
  * @import {TypedJson} from '@agoric/cosmic-proto';
@@ -111,8 +111,14 @@ export const ChainInfoShape = M.splitRecord({
 });
 export const LocalChainAccountShape = M.remotable('LocalChainAccount');
 export const DenomShape = M.string();
-// TODO define for #9211
-export const BrandInfoShape = M.any();
+
+/** @type {TypedPattern<BrandInfo<any, any>>} */
+export const BrandInfoShape = {
+  chain: M.remotable('Chain'),
+  base: M.remotable('Chain'),
+  brand: M.or(M.remotable('Brand'), M.undefined()),
+  baseDenom: M.string(),
+};
 
 /** @type {TypedPattern<DenomAmount>} */
 export const DenomAmountShape = { denom: DenomShape, value: M.bigint() };

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -4,7 +4,7 @@ import { M } from '@endo/patterns';
 
 /**
  * @import {TypedPattern} from '@agoric/internal';
- * @import {ChainAddress, CosmosAssetInfo, Chain, ChainInfo, CosmosChainInfo, DenomAmount, DenomDetail, BrandInfo} from './types.js';
+ * @import {ChainAddress, CosmosAssetInfo, Chain, ChainInfo, CosmosChainInfo, DenomAmount, DenomDetail, DenomInfo} from './types.js';
  * @import {Delegation} from '@agoric/cosmic-proto/cosmos/staking/v1beta1/staking.js';
  * @import {TxBody} from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
  * @import {TypedJson} from '@agoric/cosmic-proto';
@@ -112,8 +112,8 @@ export const ChainInfoShape = M.splitRecord({
 export const LocalChainAccountShape = M.remotable('LocalChainAccount');
 export const DenomShape = M.string();
 
-/** @type {TypedPattern<BrandInfo<any, any>>} */
-export const BrandInfoShape = {
+/** @type {TypedPattern<DenomInfo<any, any>>} */
+export const DenomInfoShape = {
   chain: M.remotable('Chain'),
   base: M.remotable('Chain'),
   brand: M.or(M.remotable('Brand'), M.undefined()),

--- a/packages/orchestration/src/utils/amounts.js
+++ b/packages/orchestration/src/utils/amounts.js
@@ -1,0 +1,53 @@
+import { makeError } from '@endo/errors';
+
+/**
+ * @import {ChainHub} from "../types.js";
+ * @import {AmountArg, Denom, DenomAmount, DenomArg} from "../orchestration-api.js";
+ * @import {Coin} from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
+ */
+
+/**
+ * @param {ChainHub} chainHub
+ * @param {DenomArg} denomArg
+ * @returns {Denom}
+ */
+export const coerceDenom = (chainHub, denomArg) => {
+  if (typeof denomArg === 'string') {
+    return denomArg;
+  }
+  const denom = chainHub.lookupDenom(denomArg);
+  if (!denom) {
+    throw makeError(`No denomination for brand ${denomArg}`);
+  }
+  return denom;
+};
+
+/**
+ * @param {ChainHub} chainHub
+ * @param {DenomAmount | Amount<'nat'>} amount
+ * @returns {DenomAmount}
+ */
+export const coerceDenomAmount = (chainHub, amount) => {
+  if ('denom' in amount) {
+    return amount;
+  }
+  const denom = coerceDenom(chainHub, amount.brand);
+  return harden({
+    denom,
+    value: amount.value,
+  });
+};
+
+/**
+ * @param {ChainHub} chainHub
+ * @param {AmountArg | Amount<'nat'>} amount
+ * @returns {Coin}
+ */
+export const coerceCoin = (chainHub, amount) => {
+  const denom =
+    'denom' in amount ? amount.denom : coerceDenom(chainHub, amount.brand);
+  return harden({
+    denom,
+    amount: String(amount.value),
+  });
+};

--- a/packages/orchestration/src/utils/orchestrationAccount.js
+++ b/packages/orchestration/src/utils/orchestrationAccount.js
@@ -1,7 +1,8 @@
-import { M } from '@endo/patterns';
+import { BrandShape } from '@agoric/ertp';
 import { Shape as NetworkShape } from '@agoric/network';
 import { VowShape } from '@agoric/vow';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/topics.js';
+import { M } from '@endo/patterns';
 import {
   AmountArgShape,
   ChainAddressShape,
@@ -16,7 +17,9 @@ const { Vow$ } = NetworkShape; // TODO #9611
 /** @see {OrchestrationAccountI} */
 export const orchestrationAccountMethods = {
   getAddress: M.call().returns(ChainAddressShape),
-  getBalance: M.call(M.any()).returns(Vow$(DenomAmountShape)),
+  getBalance: M.call(M.or(BrandShape, M.string())).returns(
+    Vow$(DenomAmountShape),
+  ),
   getBalances: M.call().returns(Vow$(M.arrayOf(DenomAmountShape))),
   send: M.call(ChainAddressShape, AmountArgShape).returns(VowShape),
   sendAll: M.call(ChainAddressShape, M.arrayOf(AmountArgShape)).returns(

--- a/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
+++ b/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
@@ -51,8 +51,6 @@ test('auto-stake-it - make accounts, register tap, return invitationMakers', asy
       value: 'cosmosvaloper1test',
       encoding: 'bech32',
     },
-    // TODO user supplied until #9211
-    localDenom: 'ibc/fakeuatomhash',
   });
   const result = await heapVowE(userSeat).getOfferResult();
 
@@ -114,7 +112,9 @@ test('auto-stake-it - make accounts, register tap, return invitationMakers', asy
       receiver: 'cosmos1test',
       sender: execAddr,
       sourceChannel: 'channel-5',
-      token: { amount: '10', denom: 'ibc/fakeuatomhash' },
+      token: {
+        amount: '10',
+      },
     },
     'tokens transferred from LOA to COA',
   );
@@ -139,8 +139,6 @@ test('auto-stake-it - make accounts, register tap, return invitationMakers', asy
       value: 'cosmosvaloper1test',
       encoding: 'bech32',
     },
-    // TODO user supplied until #9211
-    localDenom: 'ibc/fakeuatomhash',
   });
   const { publicSubscribers: pubSubs2 } =
     await heapVowE(userSeat2).getOfferResult();

--- a/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
+++ b/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
@@ -19,7 +19,7 @@ const contractFile = `${dirname}/../../src/examples/${contractName}.contract.js`
 type StartFn =
   typeof import('../../src/examples/auto-stake-it.contract.js').start;
 
-test('auto-stake-it - make accounts, register tap, return invitationMakers', async t => {
+test('make accounts, register tap, return invitationMakers', async t => {
   t.log('bootstrap, orchestration core-eval');
   const {
     bootstrap: { storage },

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -57,8 +57,11 @@ test('makeAccount, deposit, withdraw', async t => {
   const depositResp = await E(account).deposit(
     await utils.pourPayment(bld.units(100)),
   );
-  // FIXME #9211
-  // t.deepEqual(await E(account).getBalance('ubld'), bld.units(100));
+  t.deepEqual(await E(account).getBalance('ubld'), {
+    denom: 'ubld',
+    value: bld.units(100).value,
+  });
+
   // XXX races in the bridge
   await eventLoopIteration();
 

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -95,7 +95,7 @@ test.serial('getConnectionInfo', async t => {
   t.deepEqual(await vt.when(chainHub.getConnectionInfo(b, a)), ba);
 });
 
-test('getBrandInfo support', async t => {
+test('getDenomInfo support', async t => {
   const { chainHub } = setup();
 
   const denom = 'utok1';

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -60,8 +60,8 @@ test('CosmosOrchestrationAccount - send (to addr on same chain)', async t => {
   // ertp amounts not supported
   await t.throwsAsync(
     E(account).send(toAddress, ist.make(10n) as AmountArg),
-    // TODO #9211 lookup denom from brand
-    { message: 'Brands not currently supported.' },
+    // TODO #9211 register asset before sending
+    { message: 'No denomination for brand [object Alleged: IST brand]' },
   );
 
   // multi-send (sendAll)
@@ -260,7 +260,8 @@ test('CosmosOrchestrationAccount - transfer', async t => {
 
   t.log("transfer doesn't support ERTP brands yet. see #9211");
   await t.throwsAsync(E(account).transfer(ist.make(10n), mockDestination), {
-    message: 'Brands not currently supported.',
+    // TODO #9211 register asset before transfer
+    message: 'No denomination for brand [object Alleged: IST brand]',
   });
 
   t.log('transfer timeout error recieved and handled from the bridge');

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -25,7 +25,7 @@ test.beforeEach(async t => {
   t.context = await commonSetup(t);
 });
 
-test('CosmosOrchestrationAccount - send (to addr on same chain)', async t => {
+test('send (to addr on same chain)', async t => {
   const {
     bootstrap,
     brands: { ist },
@@ -82,7 +82,7 @@ test('CosmosOrchestrationAccount - send (to addr on same chain)', async t => {
   );
 });
 
-test('CosmosOrchestrationAccount - transfer', async t => {
+test('transfer', async t => {
   const {
     brands: { ist },
     bootstrap,
@@ -285,7 +285,7 @@ test('CosmosOrchestrationAccount - transfer', async t => {
   );
 });
 
-test('CosmosOrchestrationAccount - not yet implemented', async t => {
+test('not yet implemented', async t => {
   const { bootstrap } = await commonSetup(t);
   const makeTestCOAKit = prepareMakeTestCOAKit(t, bootstrap);
   const account = await makeTestCOAKit();

--- a/packages/orchestration/test/exos/make-test-coa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-coa-kit.ts
@@ -1,10 +1,10 @@
-import { Far } from '@endo/far';
+/* eslint-disable jsdoc/require-param -- ts types */
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
+import { Far } from '@endo/far';
 import type { ExecutionContext } from 'ava';
-import { commonSetup } from '../supports.js';
 import { prepareCosmosOrchestrationAccount } from '../../src/exos/cosmos-orchestration-account.js';
-import { makeChainHub } from '../../src/exos/chain-hub.js';
+import { commonSetup } from '../supports.js';
 
 /**
  * A testing utility that creates a (Cosmos)ChainAccount and makes a
@@ -13,25 +13,14 @@ import { makeChainHub } from '../../src/exos/chain-hub.js';
  *
  * Helps reduce boilerplate in test files, and retains testing context through
  * parameterized endowments.
- *
- * @param t
- * @param bootstrap
- * @param opts
- * @param opts.zcf
  */
 export const prepareMakeTestCOAKit = (
   t: ExecutionContext,
-  bootstrap: Awaited<ReturnType<typeof commonSetup>>['bootstrap'],
+  { bootstrap, facadeServices, utils }: Awaited<ReturnType<typeof commonSetup>>,
   { zcf = Far('MockZCF', {}) } = {},
 ) => {
-  const {
-    cosmosInterchainService,
-    marshaller,
-    rootZone,
-    timer,
-    vowTools,
-    agoricNames,
-  } = bootstrap;
+  const { cosmosInterchainService, marshaller, rootZone, timer, vowTools } =
+    bootstrap;
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     rootZone.mapStore('CosmosOrchAccountRecorder'),
@@ -41,7 +30,7 @@ export const prepareMakeTestCOAKit = (
   const makeCosmosOrchestrationAccount = prepareCosmosOrchestrationAccount(
     rootZone.subZone('CosmosOrchAccount'),
     {
-      chainHub: makeChainHub(agoricNames, vowTools),
+      chainHub: facadeServices.chainHub,
       makeRecorderKit,
       timerService: timer,
       vowTools,
@@ -82,6 +71,9 @@ export const prepareMakeTestCOAKit = (
         timer,
       },
     );
+
+    t.log('register Agoric chain and BLD in ChainHub');
+    utils.registerAgoricBld();
 
     return holder;
   };

--- a/packages/orchestration/test/exos/make-test-loa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-loa-kit.ts
@@ -1,9 +1,9 @@
+/* eslint-disable jsdoc/require-param -- ts types */
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { Far } from '@endo/far';
 import { ExecutionContext } from 'ava';
 import { prepareLocalOrchestrationAccountKit } from '../../src/exos/local-orchestration-account.js';
-import { makeChainHub } from '../../src/exos/chain-hub.js';
 import { commonSetup } from '../supports.js';
 
 /**
@@ -13,19 +13,17 @@ import { commonSetup } from '../supports.js';
  *
  * Helps reduce boilerplate in test files, and retains testing context through
  * parameterized endowments.
- *
- * @param t
- * @param bootstrap
- * @param opts
- * @param opts.zcf
  */
 export const prepareMakeTestLOAKit = (
   t: ExecutionContext,
-  bootstrap: Awaited<ReturnType<typeof commonSetup>>['bootstrap'],
+  {
+    bootstrap,
+    facadeServices: { chainHub },
+    utils,
+  }: Awaited<ReturnType<typeof commonSetup>>,
   { zcf = Far('MockZCF', {}) } = {},
 ) => {
-  const { timer, localchain, marshaller, rootZone, vowTools, agoricNames } =
-    bootstrap;
+  const { timer, localchain, marshaller, rootZone, vowTools } = bootstrap;
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     rootZone.mapStore('recorder'),
@@ -39,7 +37,7 @@ export const prepareMakeTestLOAKit = (
     zcf,
     timer,
     vowTools,
-    makeChainHub(agoricNames, vowTools),
+    chainHub,
   );
 
   return async ({
@@ -61,6 +59,9 @@ export const prepareMakeTestLOAKit = (
       }),
       storageNode: storageNode.makeChildNode(address),
     });
+
+    t.log('register Agoric chain and BLD in ChainHub');
+    utils.registerAgoricBld();
     return account;
   };
 };

--- a/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
+++ b/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
@@ -23,7 +23,7 @@ test('portfolio holder kit behaviors', async t => {
     },
   });
 
-  const makeTestCOAKit = prepareMakeTestCOAKit(t, common.bootstrap, {
+  const makeTestCOAKit = prepareMakeTestCOAKit(t, common, {
     zcf: mockZcf,
   });
   const makeTestLOAKit = prepareMakeTestLOAKit(t, common, { zcf: mockZcf });

--- a/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
+++ b/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
@@ -7,8 +7,8 @@ import { prepareMakeTestLOAKit } from './make-test-loa-kit.js';
 import { prepareMakeTestCOAKit } from './make-test-coa-kit.js';
 
 test('portfolio holder kit behaviors', async t => {
-  const { bootstrap } = await commonSetup(t);
-  const { rootZone, storage, vowTools } = bootstrap;
+  const common = await commonSetup(t);
+  const { rootZone, storage, vowTools } = common.bootstrap;
   const storageNode = storage.rootNode.makeChildNode('accounts');
 
   /**
@@ -23,8 +23,10 @@ test('portfolio holder kit behaviors', async t => {
     },
   });
 
-  const makeTestCOAKit = prepareMakeTestCOAKit(t, bootstrap, { zcf: mockZcf });
-  const makeTestLOAKit = prepareMakeTestLOAKit(t, bootstrap, { zcf: mockZcf });
+  const makeTestCOAKit = prepareMakeTestCOAKit(t, common.bootstrap, {
+    zcf: mockZcf,
+  });
+  const makeTestLOAKit = prepareMakeTestLOAKit(t, common, { zcf: mockZcf });
   const makeCosmosAccount = async ({
     chainId,
     hostConnectionId,

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -185,7 +185,7 @@ test.serial('asset / denom info', async t => {
       const c1 = await orc.getChain(mockChainInfo.chainId);
 
       {
-        const actual = orc.getBrandInfo('utoken1');
+        const actual = orc.getDenomInfo('utoken1');
         console.log('actual', actual);
         const info = await actual.chain.getChainInfo();
         t.deepEqual(info, mockChainInfo);
@@ -200,7 +200,7 @@ test.serial('asset / denom info', async t => {
 
       const ag = await orc.getChain('agoric');
       {
-        const actual = orc.getBrandInfo(agDenom);
+        const actual = orc.getDenomInfo(agDenom);
 
         t.deepEqual(actual, {
           chain: ag,
@@ -223,11 +223,11 @@ test.serial('asset / denom info', async t => {
   });
 
   const missingGetChain = orchestrate('missing getChain', {}, async orc => {
-    const actual = orc.getBrandInfo('utoken2');
+    const actual = orc.getDenomInfo('utoken2');
   });
 
   await t.throwsAsync(vt.when(missingGetChain()), {
-    message: 'use getChain("anotherChain") before getBrandInfo("utoken2")',
+    message: 'use getChain("anotherChain") before getDenomInfo("utoken2")',
   });
 });
 

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -186,6 +186,7 @@ test.serial('asset / denom info', async t => {
 
       {
         const actual = orc.getBrandInfo('utoken1');
+        console.log('actual', actual);
         const info = await actual.chain.getChainInfo();
         t.deepEqual(info, mockChainInfo);
 

--- a/packages/orchestration/test/ibc-mocks.test.ts
+++ b/packages/orchestration/test/ibc-mocks.test.ts
@@ -15,14 +15,14 @@ import {
   buildQueryPacketString,
 } from '../tools/ibc-mocks.js';
 
-test('ibc-mocks - buildMsgResponseString matches observed values in e2e testing', t => {
+test('buildMsgResponseString matches observed values in e2e testing', t => {
   t.is(
     buildMsgResponseString(MsgDelegateResponse, {}),
     'eyJyZXN1bHQiOiJFaTBLS3k5amIzTnRiM011YzNSaGEybHVaeTUyTVdKbGRHRXhMazF6WjBSbGJHVm5ZWFJsVW1WemNHOXVjMlU9In0=',
   );
 });
 
-test('ibc-mocks - buildMsgErrorString matches observed values in e2e testing', t => {
+test('buildMsgErrorString matches observed values in e2e testing', t => {
   t.is(
     buildMsgErrorString(),
     'eyJlcnJvciI6IkFCQ0kgY29kZTogNTogZXJyb3IgaGFuZGxpbmcgcGFja2V0OiBzZWUgZXZlbnRzIGZvciBkZXRhaWxzIn0=',
@@ -37,7 +37,7 @@ test('ibc-mocks - buildMsgErrorString matches observed values in e2e testing', t
   );
 });
 
-test('ibcMocks - buildQueryResponseString matches observed values in e2e testing', t => {
+test('buildQueryResponseString matches observed values in e2e testing', t => {
   t.is(
     buildQueryResponseString(QueryBalanceResponse, {
       balance: { amount: '0', denom: 'uatom' },
@@ -47,7 +47,7 @@ test('ibcMocks - buildQueryResponseString matches observed values in e2e testing
   );
 });
 
-test('ibcMocks - build Tx Packet', t => {
+test('build Tx Packet', t => {
   t.is(
     buildTxPacketString([
       MsgDelegate.toProtoMsg({
@@ -63,7 +63,7 @@ test('ibcMocks - build Tx Packet', t => {
   );
 });
 
-test('ibcMocks - build Query Packet', t => {
+test('build Query Packet', t => {
   t.is(
     buildQueryPacketString([
       QueryBalanceRequest.toProtoMsg({

--- a/packages/orchestration/test/ibc-mocks.ts
+++ b/packages/orchestration/test/ibc-mocks.ts
@@ -1,3 +1,4 @@
+/** @file The mocks used in these tests */
 import {
   QueryBalanceRequest,
   QueryBalanceResponse,

--- a/packages/orchestration/test/network-fakes.test.ts
+++ b/packages/orchestration/test/network-fakes.test.ts
@@ -16,7 +16,7 @@ test.before(async t => {
   await t.context.setupIBCProtocol();
 });
 
-test('network fakes - echo connection', async t => {
+test('echo connection', async t => {
   const { portAllocator, networkVat } = t.context;
 
   // Allocate an echo port
@@ -36,13 +36,13 @@ test('network fakes - echo connection', async t => {
   t.is(response, message, 'Echo returns the same message');
 });
 
-test('network fakes - port allocator', async t => {
+test('port allocator', async t => {
   const { portAllocator } = t.context;
   const customPort = await E(portAllocator).allocateCustomIBCPort('test-port');
   t.is(await E(customPort).getLocalAddress(), '/ibc-port/custom-test-port');
 });
 
-test('network fakes - ibc connection', async t => {
+test('ibc connection', async t => {
   const { portAllocator } = t.context;
 
   // allocate ICA controller port and connect to remote chain

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -101,8 +101,8 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
   // Negative test
   expectNotType<() => Promise<number>>(vowFn);
 
-  const getBrandInfo: HostOf<Orchestrator['getBrandInfo']> = null as any;
-  const chainHostOf = getBrandInfo('uatom').chain;
+  const getDenomInfo: HostOf<Orchestrator['getDenomInfo']> = null as any;
+  const chainHostOf = getDenomInfo('uatom').chain;
   expectType<Vow<any>>(chainHostOf.getChainInfo());
 }
 

--- a/packages/orchestration/tools/ibc-mocks.ts
+++ b/packages/orchestration/tools/ibc-mocks.ts
@@ -1,3 +1,4 @@
+/** @file Tools to support making IBC mocks */
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { CosmosResponse } from '@agoric/cosmic-proto/icq/v1/packet.js';
 import {


### PR DESCRIPTION
closes: #9211

## Description

Uses ChainHub for lookup of denoms and brands (from the other).

Adds some coercion utilities to get the desired shape within the exos and contract, using a ChainHub.


### Security Considerations
Contracts control their ChainHub and can specify any mapping of brand to denom.


### Scaling Considerations
If contracts import the whole Known Chains module, that will increase bundle size. I think this will be unlikely in production. We'll have on-chain lookup by then.

### Documentation Considerations
not yet

### Testing Considerations
existing coverage

### Upgrade Considerations
None of this is deployed yet
