### PR TITLE
fix(cosmic-swingset)!: Extend and partition cosmos-sdk configuration for cosmic-swingset

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -314,9 +314,18 @@ func NewGaiaApp(
 }
 
 func NewAgoricApp(
-	sendToController vm.Sender, agdServer *vm.AgdServer,
-	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool, skipUpgradeHeights map[int64]bool,
-	homePath string, invCheckPeriod uint, encodingConfig gaiaappparams.EncodingConfig, appOpts servertypes.AppOptions, baseAppOptions ...func(*baseapp.BaseApp),
+	sendToController vm.Sender,
+	agdServer *vm.AgdServer,
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	loadLatest bool,
+	skipUpgradeHeights map[int64]bool,
+	homePath string,
+	invCheckPeriod uint,
+	encodingConfig gaiaappparams.EncodingConfig,
+	appOpts servertypes.AppOptions,
+	baseAppOptions ...func(*baseapp.BaseApp),
 ) *GaiaApp {
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
@@ -929,9 +938,9 @@ type cosmosInitAction struct {
 	vm.ActionHeader `actionType:"AG_COSMOS_INIT"`
 	ChainID         string          `json:"chainID"`
 	IsBootstrap     bool            `json:"isBootstrap"`
-	UpgradeDetails  *upgradeDetails `json:"upgradeDetails,omitempty"`
 	Params          swingset.Params `json:"params"`
 	SupplyCoins     sdk.Coins       `json:"supplyCoins"`
+	UpgradeDetails  *upgradeDetails `json:"upgradeDetails,omitempty"`
 	// CAVEAT: Every property ending in "Port" is saved in chain-main.js/portNums
 	// with a key consisting of this name with the "Port" stripped.
 	StoragePort     int `json:"storagePort"`

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -45,7 +45,14 @@ var AppName = "agd"
 var OnStartHook func(*vm.AgdServer, log.Logger, servertypes.AppOptions) error
 var OnExportHook func(*vm.AgdServer, log.Logger, servertypes.AppOptions) error
 
-type cobraRun func(cmd *cobra.Command, args []string)
+// CustomAppConfig extends the base config struct.
+type CustomAppConfig struct {
+	serverconfig.Config `mapstructure:",squash"`
+	// Swingset must be named as expected by swingset.DefaultConfigTemplate
+	// and must use a mapstructure key matching swingset.ConfigPrefix.
+	Swingset swingset.SwingsetConfig `mapstructure:"swingset"`
+}
+
 type cobraRunE func(cmd *cobra.Command, args []string) error
 
 func appendToPreRunE(cmd *cobra.Command, fn cobraRunE) {
@@ -126,15 +133,9 @@ func initAppConfig() (string, interface{}) {
 	// startup, forcing each validator to set their own value).
 	srvCfg.MinGasPrices = "0uist"
 
-	// CustomAppConfig extends the base config struct.
-	type CustomAppConfig struct {
-		serverconfig.Config `mapstructure:",squash"`
-		// Swingset must use a mapstructure key matching swingset.ConfigPrefix.
-		Swingset            *swingset.SwingsetConfig `mapstructure:"swingset"`
-	}
 	customAppConfig := CustomAppConfig{
 		Config:   *srvCfg,
-		Swingset: &swingset.DefaultSwingsetConfig,
+		Swingset: swingset.DefaultSwingsetConfig,
 	}
 
 	// Config TOML.

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -144,7 +144,7 @@ func initRootCmd(sender vm.Sender, rootCmd *cobra.Command, encodingConfig params
 		snapshot.Cmd(ac.newSnapshotsApp),
 	)
 
-	server.AddCommands(rootCmd, gaia.DefaultNodeHome, ac.newApp, ac.appExport, addModuleInitFlags)
+	server.AddCommands(rootCmd, gaia.DefaultNodeHome, ac.newApp, ac.appExport, addStartFlags)
 
 	for _, command := range rootCmd.Commands() {
 		switch command.Name() {
@@ -197,7 +197,7 @@ func addAgoricVMFlags(cmd *cobra.Command) {
 	)
 }
 
-func addModuleInitFlags(startCmd *cobra.Command) {
+func addStartFlags(startCmd *cobra.Command) {
 	addAgoricVMFlags(startCmd)
 }
 
@@ -282,11 +282,12 @@ func (ac appCreator) newApp(
 
 	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
 
-	// Set a default value for FlagSwingStoreExportDir based on the homePath
+	// Set a default value for FlagSwingStoreExportDir based on homePath
 	// in case we need to InitGenesis with swing-store data
 	viper, ok := appOpts.(*viper.Viper)
-	if ok && cast.ToString(appOpts.Get(gaia.FlagSwingStoreExportDir)) == "" {
-		viper.Set(gaia.FlagSwingStoreExportDir, filepath.Join(homePath, "config", ExportedSwingStoreDirectoryName))
+	if ok && viper.GetString(gaia.FlagSwingStoreExportDir) == "" {
+		exportDir := filepath.Join(homePath, "config", ExportedSwingStoreDirectoryName)
+		viper.Set(gaia.FlagSwingStoreExportDir, exportDir)
 	}
 
 	return gaia.NewAgoricApp(

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -129,6 +129,7 @@ func initAppConfig() (string, interface{}) {
 	// CustomAppConfig extends the base config struct.
 	type CustomAppConfig struct {
 		serverconfig.Config `mapstructure:",squash"`
+		// Swingset must use a mapstructure key matching swingset.ConfigPrefix.
 		Swingset            *swingset.SwingsetConfig `mapstructure:"swingset"`
 	}
 	customAppConfig := CustomAppConfig{

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tendermint/tendermint v0.34.29
@@ -133,7 +134,6 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect

--- a/golang/cosmos/util/util.go
+++ b/golang/cosmos/util/util.go
@@ -4,9 +4,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-func NewFileOnlyViper(v1 *viper.Viper) *viper.Viper {
+func NewFileOnlyViper(v1 *viper.Viper) (*viper.Viper, error) {
 	v2 := viper.New()
 	v2.SetConfigFile(v1.ConfigFileUsed())
-	v2.ReadInConfig()
-	return v2
+	err := v2.ReadInConfig()
+	return v2, err
 }

--- a/golang/cosmos/util/util.go
+++ b/golang/cosmos/util/util.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"github.com/spf13/viper"
+)
+
+func NewFileOnlyViper(v1 *viper.Viper) *viper.Viper {
+	v2 := viper.New()
+	v2.SetConfigFile(v1.ConfigFileUsed())
+	v2.ReadInConfig()
+	return v2
+}

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -15,9 +15,9 @@ const (
 // See https://github.com/cosmos/cosmos-sdk/issues/20097 for auto-synchronization ideas.
 const DefaultConfigTemplate = `
 
-	[swingset]
-	# slogfile is the absolute path at which a SwingSet log "slog" file should be written.
-	slogfile = ""
+[swingset]
+# slogfile is the absolute path at which a SwingSet log "slog" file should be written.
+slogfile = ""
 `
 
 // SwingsetConfig defines configuration for the SwingSet VM.

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -53,7 +53,9 @@ func SwingsetConfigFromViper(resolvedConfig any) (*SwingsetConfig, error) {
 	}
 	v.MustBindEnv(FlagSlogfile, "SLOGFILE")
 	wrapper := struct{ Swingset SwingsetConfig }{}
-	v.Unmarshal(&wrapper)
+	if err := v.Unmarshal(&wrapper); err != nil {
+		return nil, err
+	}
 	config := &wrapper.Swingset
 
 	// Interpret relative paths from config files against the application home
@@ -66,7 +68,11 @@ func SwingsetConfigFromViper(resolvedConfig any) (*SwingsetConfig, error) {
 		}
 		if v.InConfig(configKey) {
 			if fileOnlyViper == nil {
-				fileOnlyViper = util.NewFileOnlyViper(v)
+				var err error
+				fileOnlyViper, err = util.NewFileOnlyViper(v)
+				if err != nil {
+					return "", err
+				}
 			}
 			pathFromFile := fileOnlyViper.GetString(configKey)
 			if path == pathFromFile {

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/util"
 )
@@ -43,10 +44,14 @@ var DefaultSwingsetConfig = SwingsetConfig{
 	SlogFile: "",
 }
 
-func SwingsetConfigFromViper(resolvedConfig any) (*SwingsetConfig, error) {
+func SwingsetConfigFromViper(resolvedConfig servertypes.AppOptions) (*SwingsetConfig, error) {
 	v, ok := resolvedConfig.(*viper.Viper)
 	if !ok {
-		return nil, fmt.Errorf("expected an instance of viper!")
+		// Tolerate an apparently empty configuration such as
+		// cosmos/cosmos-sdk/simapp EmptyAppOptions, but otherwise require viper.
+		if resolvedConfig.Get(flags.FlagHome) != nil {
+			return nil, fmt.Errorf("expected an instance of viper!")
+		}
 	}
 	if v == nil {
 		return nil, nil

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -12,12 +12,17 @@ const (
 )
 
 // DefaultConfigTemplate defines a default TOML configuration section for the SwingSet VM.
+// Values are pulled from a "Swingset" property, in accord with CustomAppConfig from
+// ../../daemon/cmd/root.go.
 // See https://github.com/cosmos/cosmos-sdk/issues/20097 for auto-synchronization ideas.
 const DefaultConfigTemplate = `
+###############################################################################
+###                         SwingSet Configuration                          ###
+###############################################################################
 
 [swingset]
 # slogfile is the absolute path at which a SwingSet log "slog" file should be written.
-slogfile = ""
+slogfile = "{{ .Swingset.SlogFile }}"
 `
 
 // SwingsetConfig defines configuration for the SwingSet VM.

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -1,0 +1,45 @@
+package swingset
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+	"path/filepath"
+)
+
+const (
+	ConfigPrefix = "swingset"
+	FlagSlogfile = "swingset.slogfile"
+)
+
+// DefaultConfigTemplate defines a default TOML configuration section for the SwingSet VM.
+// See https://github.com/cosmos/cosmos-sdk/issues/20097 for auto-synchronization ideas.
+const DefaultConfigTemplate = `
+
+	[swingset]
+	# slogfile is the absolute path at which a SwingSet log "slog" file should be written.
+	slogfile = ""
+`
+
+// SwingsetConfig defines configuration for the SwingSet VM.
+// TODO: Consider extensions from docs/env.md.
+type SwingsetConfig struct {
+	// SlogFile is the absolute path at which a SwingSet log "slog" file should be written.
+	SlogFile string `mapstructure:"slogfile"`
+}
+
+var DefaultSwingsetConfig = SwingsetConfig{
+	SlogFile: "",
+}
+
+func SwingsetConfigFromViper(viper *viper.Viper) (*SwingsetConfig, error) {
+	if err := viper.BindEnv(FlagSlogfile, "SLOGFILE"); err != nil {
+		return nil, err
+	}
+	slogfile := viper.GetString(FlagSlogfile)
+	if slogfile != "" && !filepath.IsAbs(slogfile) {
+		return nil, fmt.Errorf("slogfile must be an absolute path")
+	}
+	return &SwingsetConfig{
+		SlogFile: slogfile,
+	}, nil
+}

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -77,6 +77,7 @@ const makeBootMsg = initAction => {
     blockHeight,
     chainID,
     params,
+    // NB: resolvedConfig is independent of consensus and MUST NOT be included
     supplyCoins,
   } = initAction;
   return {

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -65,6 +65,31 @@ const toNumber = specimen => {
 };
 
 /**
+ * A boot message consists of cosmosInitAction fields that are subject to
+ * consensus. See cosmosInitAction in {@link ../../../golang/cosmos/app/app.go}.
+ *
+ * @param {any} initAction
+ */
+const makeBootMsg = initAction => {
+  const {
+    type,
+    blockTime,
+    blockHeight,
+    chainID,
+    params,
+    supplyCoins,
+  } = initAction;
+  return {
+    type,
+    blockTime,
+    blockHeight,
+    chainID,
+    params,
+    supplyCoins,
+  };
+};
+
+/**
  * @template {unknown} [T=unknown]
  * @param {(req: string) => string} call
  * @param {string} prefix
@@ -365,7 +390,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     };
 
     const argv = {
-      bootMsg: initAction,
+      bootMsg: makeBootMsg(initAction),
     };
     const getVatConfig = async () => {
       const vatHref = await importMetaResolve(

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -278,6 +278,11 @@ export default async function main(progname, args, { env, homedir, agcc }) {
   // here so 'sendToChainStorage' can close over the single mutable instance,
   // when we updated the 'portNums.storage' value each time toSwingSet was called.
   async function launchAndInitializeSwingSet(initAction) {
+    // As a kludge, back-propagate selected configuration into environment variables.
+    const { slogfile } = initAction.resolvedConfig || {};
+    // eslint-disable-next-line dot-notation
+    if (slogfile) env['SLOGFILE'] = slogfile;
+
     const sendToChainStorage = msg => chainSend(portNums.storage, msg);
     // this object is used to store the mailbox state.
     const fromBridgeMailbox = data => {


### PR DESCRIPTION
Fixes #9946

## Description
* Share runtime cosmos-sdk [viper] configuration with cosmic-swingset in the AG_COSMOS_INIT message
* Exclude non-consensus configuration from bootstrap vat arguments

### Security Considerations
I believe that cosmic-swingset should be considered as a peer of the Go parts of agd, and thus entitled to full runtime configuration. If we have reason to consider it otherwise, then filtering will be warranted.

### Scaling Considerations
This increases the size of AG_COSMOS_INIT messages by up to several KB (but those messages are one-per-process-start).

### Documentation Considerations
We'll want cross-referencing of any config values that are accessed by cosmic-swingset.

### Testing Considerations
TBD

### Upgrade Considerations
This changes the bootstrap vat arguments (which are subject to consensus) for any new chain instance to exclude the "port" settings. However, it should not affect any existing chain, and the bootstrap vat does not use that configuration.