### PR TITLE
fix: use controllerConnectionId for ICQConnection

### DIFF
--- a/packages/orchestration/src/exos/remote-chain-facade.js
+++ b/packages/orchestration/src/exos/remote-chain-facade.js
@@ -125,9 +125,7 @@ const prepareRemoteChainFacadeKit = (
             // create a connection if it doesn't exist
             const icqConnOrUndefinedV =
               remoteChainInfo.icqEnabled && !this.state.icqConnection
-                ? E(orchestration).provideICQConnection(
-                    connectionInfo.counterparty.connection_id,
-                  )
+                ? E(orchestration).provideICQConnection(connectionInfo.id)
                 : undefined;
 
             const makeAccountV = E(orchestration).makeAccount(
@@ -155,9 +153,7 @@ const prepareRemoteChainFacadeKit = (
             // if none exists, make one and still send the query in the handler
             if (!this.state.icqConnection) {
               return watch(
-                E(orchestration).provideICQConnection(
-                  connectionInfo.counterparty.connection_id,
-                ),
+                E(orchestration).provideICQConnection(connectionInfo.id),
                 this.facets.makeICQConnectionQueryWatcher,
                 msgs,
               );


### PR DESCRIPTION
refs: #9815

## Description
Ensures we are passing `controllerConnectionId`, and not `hostConnectionId`, to `provideICQConnection`. _Was previously passing in CI since there's a 50/50 chance controllerConnectionId will equal hostConnectionId._

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Addresses a "flake" that's really a bug.

### Upgrade Considerations
n/a, unreleased code
