### PR TITLE
Make maxVatsOnline customizable to optimize resource usage #9574

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -361,6 +361,10 @@ func NewAgoricApp(
 		tkeys:             tkeys,
 		memKeys:           memKeys,
 	}
+	// The VM is entitled to full awareness of runtime configuration.
+	if resolvedConfig, ok := appOpts.(*viper.Viper); ok {
+		app.resolvedConfig = resolvedConfig.AllSettings()
+	}
 
 	app.ParamsKeeper = initParamsKeeper(
 		appCodec,

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -361,10 +361,6 @@ func NewAgoricApp(
 		tkeys:             tkeys,
 		memKeys:           memKeys,
 	}
-	// The VM is entitled to full awareness of runtime configuration.
-	if resolvedConfig, ok := appOpts.(*viper.Viper); ok {
-		app.resolvedConfig = resolvedConfig.AllSettings()
-	}
 
 	app.ParamsKeeper = initParamsKeeper(
 		appCodec,

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -33,7 +33,7 @@ const DefaultConfigTemplate = `
 slogfile = "{{ .Swingset.SlogFile }}"
 
 # maxVatsOnline is the maximum number of vats that SwingSet kernel will bring online
-maxVatsOnline = 50
+maxVatsOnline = {{ .Swingset.MaxVatsOnline }}
 `
 
 // SwingsetConfig defines configuration for the SwingSet VM.
@@ -41,10 +41,14 @@ maxVatsOnline = 50
 type SwingsetConfig struct {
 	// SlogFile is the absolute path at which a SwingSet log "slog" file should be written.
 	SlogFile string `mapstructure:"slogfile" json:"slogfile,omitempty"`
+	// MaxVatsOnline is the maximum number of vats that the SwingSet kernel will have online
+	// at any given time.
+	MaxVatsOnline int `mapstructure:"maxVatsOnline" json:"maxVatsOnline,omitempty"`
 }
 
 var DefaultSwingsetConfig = SwingsetConfig{
-	SlogFile: "",
+	SlogFile:      "",
+	MaxVatsOnline: 50,
 }
 
 func SwingsetConfigFromViper(resolvedConfig servertypes.AppOptions) (*SwingsetConfig, error) {

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -31,6 +31,9 @@ const DefaultConfigTemplate = `
 # If relative, it is interpreted against the application home directory
 # (e.g., ~/.agoric).
 slogfile = "{{ .Swingset.SlogFile }}"
+
+# maxVatsOnline is the maximum number of vats that SwingSet kernel will bring online
+maxVatsOnline = 50
 `
 
 // SwingsetConfig defines configuration for the SwingSet VM.

--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -32,8 +32,10 @@ const DefaultConfigTemplate = `
 # (e.g., ~/.agoric).
 slogfile = "{{ .Swingset.SlogFile }}"
 
-# maxVatsOnline is the maximum number of vats that SwingSet kernel will bring online
-maxVatsOnline = {{ .Swingset.MaxVatsOnline }}
+# The maximum number of vats that the SwingSet kernel will bring online. A lower number
+# requires less memory but may have a negative performance impact if vats need to
+# be frequently paged out to remain under this limit.
+max_vats_online = {{ .Swingset.MaxVatsOnline }}
 `
 
 // SwingsetConfig defines configuration for the SwingSet VM.
@@ -43,7 +45,7 @@ type SwingsetConfig struct {
 	SlogFile string `mapstructure:"slogfile" json:"slogfile,omitempty"`
 	// MaxVatsOnline is the maximum number of vats that the SwingSet kernel will have online
 	// at any given time.
-	MaxVatsOnline int `mapstructure:"maxVatsOnline" json:"maxVatsOnline,omitempty"`
+	MaxVatsOnline int `mapstructure:"max_vats_online" json:"maxVatsOnline,omitempty"`
 }
 
 var DefaultSwingsetConfig = SwingsetConfig{

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -94,10 +94,10 @@ const makeBootMsg = initAction => {
  * Extract local Swingset-specific configuration which is
  * not part of the consensus.
  *
- * @param {any} initAction
+ * @param {any} resolvedConfig
  */
-const makeSwingsetConfig = initAction => {
-  const { maxVatsOnline = 50 } = initAction.resolvedConfig || {};
+const makeSwingsetConfig = resolvedConfig => {
+  const { maxVatsOnline } = resolvedConfig || {};
   return {
     maxVatsOnline,
   };
@@ -295,6 +295,8 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     const { slogfile } = initAction.resolvedConfig || {};
     // eslint-disable-next-line dot-notation
     if (slogfile) env['SLOGFILE'] = slogfile;
+
+    const swingsetConfig = makeSwingsetConfig(initAction.resolvedConfig);
 
     const sendToChainStorage = msg => chainSend(portNums.storage, msg);
     // this object is used to store the mailbox state.
@@ -508,8 +510,6 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         return {};
       }
     };
-
-    const swingsetConfig = makeSwingsetConfig(initAction);
 
     const s = await launch({
       actionQueueStorage,

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -86,6 +86,7 @@ const makeBootMsg = initAction => {
     blockHeight,
     chainID,
     params,
+    resolvedConfig,
     supplyCoins,
   };
 };

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -92,6 +92,21 @@ const makeBootMsg = initAction => {
 };
 
 /**
+ * Extract local Swingset-specific configuration which is
+ * not part of the consensus.
+ *
+ * @param {any} initAction
+ */
+const makeSwingsetConfig = initAction => {
+  const {
+    maxVatsOnline = 50,
+  } = initAction;
+  return {
+    maxVatsOnline,
+  };
+};
+
+/**
  * @template {unknown} [T=unknown]
  * @param {(req: string) => string} call
  * @param {string} prefix
@@ -497,6 +512,8 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       }
     };
 
+    const swingsetConfig = makeSwingsetConfig(initAction);
+
     const s = await launch({
       actionQueueStorage,
       highPriorityQueueStorage,
@@ -516,6 +533,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       swingStoreTraceFile,
       keepSnapshots,
       afterCommitCallback,
+      swingsetConfig,
     });
 
     const { blockingSend, shutdown } = s;

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -94,7 +94,7 @@ const makeBootMsg = initAction => {
  * Extract local Swingset-specific configuration which is
  * not part of the consensus.
  *
- * @param {any} resolvedConfig
+ * @param {CosmosSwingsetConfig} [resolvedConfig]
  */
 const makeSwingsetConfig = resolvedConfig => {
   const { maxVatsOnline } = resolvedConfig || {};

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -65,6 +65,16 @@ const toNumber = specimen => {
 };
 
 /**
+ * The swingset config object parsed and resolved by cosmos in
+ * `golang/cosmos/x/swingset/config.go`. The shape should be kept in sync
+ * with `SwingsetConfig` defined there.
+ *
+ * @typedef {object} CosmosSwingsetConfig
+ * @property {string} [slogfile]
+ * @property {number} [maxVatsOnline]
+ */
+
+/**
  * A boot message consists of cosmosInitAction fields that are subject to
  * consensus. See cosmosInitAction in {@link ../../../golang/cosmos/app/app.go}.
  *

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -86,7 +86,6 @@ const makeBootMsg = initAction => {
     blockHeight,
     chainID,
     params,
-    resolvedConfig,
     supplyCoins,
   };
 };
@@ -100,7 +99,7 @@ const makeBootMsg = initAction => {
 const makeSwingsetConfig = initAction => {
   const {
     maxVatsOnline = 50,
-  } = initAction;
+  } = initAction.resolvedConfig || {};
   return {
     maxVatsOnline,
   };

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -97,9 +97,7 @@ const makeBootMsg = initAction => {
  * @param {any} initAction
  */
 const makeSwingsetConfig = initAction => {
-  const {
-    maxVatsOnline = 50,
-  } = initAction.resolvedConfig || {};
+  const { maxVatsOnline = 50 } = initAction.resolvedConfig || {};
   return {
     maxVatsOnline,
   };

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -119,6 +119,7 @@ export async function buildSwingset(
     verbose,
     profileVats,
     debugVats,
+    warehousePolicy,
   },
 ) {
   const debugPrefix = debugName === undefined ? '' : `${debugName}:`;
@@ -226,6 +227,7 @@ export async function buildSwingset(
       verbose,
       profileVats,
       debugVats,
+      warehousePolicy,
     },
   );
 
@@ -330,6 +332,7 @@ export async function launch({
   swingStoreExportCallback,
   keepSnapshots,
   afterCommitCallback = async () => ({}),
+  swingsetConfig,
 }) {
   console.info('Launching SwingSet kernel');
 
@@ -394,6 +397,9 @@ export async function launch({
   });
 
   console.debug(`buildSwingset`);
+  const warehousePolicy = {
+    maxVatsOnline: swingsetConfig.maxVatsOnline,
+  };
   const {
     coreProposals: bootstrapCoreProposals,
     controller,
@@ -411,6 +417,7 @@ export async function launch({
       debugName,
       slogCallbacks,
       slogSender,
+      warehousePolicy,
     },
   );
 


### PR DESCRIPTION
closes: #9574
refs: #9946

## Description
This change set builds on top of PR #9987 to plumb maxVatsOnline into JS side of SwingSet.

### Security Considerations
A new locally-customizable configuration item is being passed to SwingSet from golang via initAction message.

### Scaling Considerations
New config variable is read from a local config file, parsed, and included in the initAction message. However, the variable is not part of consensus and passed along to the SwingSet only once. 

### Documentation Considerations
new variable `maxVatsOnline` is added to `[swingset]` section of `config/app.toml`

### Testing Considerations
Tested manually by watching total number of vats running as measured by looking at ps aux | grep -c 'xsnap-worker v'  while running make scenario2-run-chain for different values of maxVatsOnline in the config.

### Upgrade Considerations
None, since the default value is the same as previously hardcoded one.