### PR TITLE
fix(liveslots): collection.clear(pattern) vs getSize

### DIFF
--- a/packages/swingset-liveslots/test/collections.test.js
+++ b/packages/swingset-liveslots/test/collections.test.js
@@ -503,8 +503,7 @@ test('map clear', t => {
   t.is(testStore.getSize(), 0);
 });
 
-// see #10007
-test.failing('map clear with pattern', t => {
+test('map clear with pattern', t => {
   const testStore = makeScalarBigMapStore('cmap', { keyShape: M.any() });
   testStore.init('a', 'ax');
   testStore.init('b', 'bx');
@@ -529,8 +528,7 @@ test('set clear', t => {
   t.is(testStore.getSize(), 0);
 });
 
-// see #10007
-test.failing('set clear with pattern', t => {
+test('set clear with pattern', t => {
   const testStore = makeScalarBigSetStore('cset', { keyShape: M.any() });
   testStore.add('a');
   testStore.add('b');


### PR DESCRIPTION
The `.clear()` method, on (strong) collections, will delete all entries. But it can also be called with `keyPatt` and/or `valuePatt` argument, and only the matching entries will be deleted.

Previously, the `|entryCount` metadata field was unconditionally set to zero for any call to `.clear()`, even those with patterns which caused some entries to be retained. This caused a subsequent `collection.getSize()` to return the wrong value, yielding zero even if the collection still had entries.

This commit fixes the logic to decrement the `|entryCount` field by the number of entries actually deleted. As an optimization, it is still set directly to zero if `clear()` is not limited by patterns.

fixes #10007
