### PR TITLE
improve agd build handling of corepack

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "node": "^18.12 || ^20.9"
   },
-  "packageManager": "yarn@1.22.19",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "test": "exit 0",
     "build:all": "make",

--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -80,6 +80,9 @@ else
 fi
 
 if $need_nodejs; then
+  export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+  export COREPACK_ENABLE_NETWORK=$($SKIP_DOWNLOAD && echo 0 || echo 1)
+
   # We need to get node at the script top level because it's used by the daemon
   # as well.
   case $(node --version 2> /dev/null) in


### PR DESCRIPTION
closes: #10009

## Description
Makes sure all packages in the repo use the same yarn version when using corepack
Prevent the `agd build` script from hanging if corepack is enabled but the package manager is not installed.
Fail if autodownload not allowed, install otherwise.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
We need to review this as part of #9769, but an error is better than a hang. I'm not sure why I started hitting this issue now.

### Testing Considerations
Manually tested. I don't think any CI exercises `agd build`, and even less with `corepack enable`d

### Upgrade Considerations
None
