### PR TITLE
chore(xsnap): improve currentHeapCount in metering results

### DIFF
--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -287,7 +287,7 @@ export async function xsnap(options) {
    * @template T
    * @typedef {object} RunResult
    * @property {T} reply
-   * @property {{ meterType: string, allocate: number|null, compute: number|null, timestamps: number[]|null }} meterUsage
+   * @property {{ meterType: string, allocate: number|null, compute: number|null, currentHeapCount: number|null, timestamps: number[]|null }} meterUsage
    */
 
   /**
@@ -312,7 +312,12 @@ export async function xsnap(options) {
         xsnapProcess.kill();
         throw Error('xsnap protocol error: received empty message');
       } else if (message[0] === OK) {
-        let meterInfo = { compute: null, allocate: null, timestamps: [] };
+        let meterInfo = {
+          compute: null,
+          allocate: null,
+          currentHeapCount: null,
+          timestamps: [],
+        };
         const meterSeparator = message.indexOf(OK_SEPARATOR, 1);
         if (meterSeparator >= 0) {
           // The message is `.meterdata\1reply`.

--- a/packages/xsnap/test/xs-perf.test.js
+++ b/packages/xsnap/test/xs-perf.test.js
@@ -47,7 +47,7 @@ test('meter details', async t => {
 
   t.like(
     meters,
-    { compute: 1_380_185, allocate: 42_074_144 },
+    { compute: 1_380_185, allocate: 42_074_144, currentHeapCount: 103_930 },
     'compute, allocate meters should be stable; update METER_TYPE?',
   );
 


### PR DESCRIPTION
We landed the xsnap-native changes to add this field three years ago, but while cleaning up old branches, I found a test that should go along with it. Also an update to the types, and code to supply a null value if the delivery did not include any metering in the response.

refs #3910

and
https://github.com/Agoric/agoric-sdk/issues/3910#issuecomment-938045207 in particular
