### PR TITLE
feat: `localOrchAccount.getBalance` (non-vbank assets) and `localOrchAccount.getBalances`

### DIFF
--- a/multichain-testing/test/account-balance-queries.test.ts
+++ b/multichain-testing/test/account-balance-queries.test.ts
@@ -77,16 +77,15 @@ const queryAccountBalances = test.macro({
     const { icqEnabled } = (chainInfo as Record<string, CosmosChainInfo>)[
       chainName
     ];
+    const expectValidResult = icqEnabled || chainName === 'agoric';
     t.log(
-      icqEnabled
-        ? 'ICQ Enabled expecting offer result.'
-        : 'ICQ Disabled expecting offer error',
+      `Expecting offer ${expectValidResult ? 'result' : 'error'} for ${chainName}`,
     );
 
     const {
       status: { result, error },
     } = offerResult;
-    if (icqEnabled) {
+    if (expectValidResult) {
       t.is(error, undefined, 'No error observed for supported chain');
       const balances = JSON.parse(result);
       t.truthy(balances, 'Result is parsed successfully');
@@ -156,16 +155,16 @@ const queryAccountBalance = test.macro({
     const { icqEnabled } = (chainInfo as Record<string, CosmosChainInfo>)[
       chainName
     ];
+
+    const expectValidResult = icqEnabled || chainName === 'agoric';
     t.log(
-      icqEnabled
-        ? 'ICQ Enabled, expecting offer result.'
-        : 'ICQ Disabled, expecting offer error',
+      `Expecting offer ${expectValidResult ? 'result' : 'error'} for ${chainName}`,
     );
 
     const {
       status: { result, error },
     } = offerResult;
-    if (icqEnabled) {
+    if (expectValidResult) {
       t.is(error, undefined, 'No error observed for supported chain');
       const parsedBalance = JSON.parse(result);
       t.truthy(parsedBalance, 'Result is parsed successfully');
@@ -186,5 +185,7 @@ const queryAccountBalance = test.macro({
 
 test.serial(queryAccountBalances, 'osmosis');
 test.serial(queryAccountBalances, 'cosmoshub');
+test.serial(queryAccountBalances, 'agoric');
 test.serial(queryAccountBalance, 'osmosis');
 test.serial(queryAccountBalance, 'cosmoshub');
+test.serial(queryAccountBalance, 'agoric');

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -240,7 +240,7 @@ test.serial('stakeAtom - smart wallet', async t => {
       proposal: {},
     }),
     {
-      message: 'No denomination for brand [object Alleged: ATOM brand]',
+      message: 'No denom for brand [object Alleged: ATOM brand]',
     },
   );
 });

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -44,13 +44,17 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const chainHub = makeChainHub(privateArgs.agoricNames, vowTools);
 
+  const { localchain, timerService } = privateArgs;
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     zone,
-    makeRecorderKit,
-    zcf,
-    privateArgs.timerService,
-    vowTools,
-    chainHub,
+    {
+      makeRecorderKit,
+      zcf,
+      timerService,
+      vowTools,
+      chainHub,
+      localchain,
+    },
   );
 
   // ----------------

--- a/packages/orchestration/src/exos/README.md
+++ b/packages/orchestration/src/exos/README.md
@@ -96,6 +96,7 @@ classDiagram
       executeTx()
       getAddress()
       getBalance()
+      getBalances()
       getPublicTopics()
       monitorTransfers()
       send()

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -167,8 +167,8 @@ const ChainHubI = M.interface('ChainHub', {
   getConnectionInfo: M.call(ChainIdArgShape, ChainIdArgShape).returns(VowShape),
   getChainsAndConnection: M.call(M.string(), M.string()).returns(VowShape),
   registerAsset: M.call(M.string(), DenomDetailShape).returns(),
-  lookupAsset: M.call(M.string()).returns(DenomDetailShape),
-  lookupDenom: M.call(BrandShape).returns(M.or(M.string(), M.undefined())),
+  getAsset: M.call(M.string()).returns(DenomDetailShape),
+  getDenom: M.call(BrandShape).returns(M.or(M.string(), M.undefined())),
 });
 
 /**
@@ -396,7 +396,7 @@ export const makeChainHub = (agoricNames, vowTools) => {
      * @param {Denom} denom
      * @returns {DenomDetail}
      */
-    lookupAsset(denom) {
+    getAsset(denom) {
       return denomDetails.get(denom);
     },
     /**
@@ -405,7 +405,7 @@ export const makeChainHub = (agoricNames, vowTools) => {
      * @param {Brand} brand
      * @returns {string | undefined}
      */
-    lookupDenom(brand) {
+    getDenom(brand) {
       if (brandDenoms.has(brand)) {
         return brandDenoms.get(brand);
       }

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -167,7 +167,7 @@ const ChainHubI = M.interface('ChainHub', {
   getConnectionInfo: M.call(ChainIdArgShape, ChainIdArgShape).returns(VowShape),
   getChainsAndConnection: M.call(M.string(), M.string()).returns(VowShape),
   registerAsset: M.call(M.string(), DenomDetailShape).returns(),
-  getAsset: M.call(M.string()).returns(DenomDetailShape),
+  getAsset: M.call(M.string()).returns(M.or(DenomDetailShape, M.undefined())),
   getDenom: M.call(BrandShape).returns(M.or(M.string(), M.undefined())),
 });
 
@@ -394,16 +394,19 @@ export const makeChainHub = (agoricNames, vowTools) => {
      * Retrieve holding, issuing chain names etc. for a denom.
      *
      * @param {Denom} denom
-     * @returns {DenomDetail}
+     * @returns {DenomDetail | undefined}
      */
     getAsset(denom) {
-      return denomDetails.get(denom);
+      if (denomDetails.has(denom)) {
+        return denomDetails.get(denom);
+      }
+      return undefined;
     },
     /**
-     * Retrieve holding, issuing chain names etc. for a denom.
+     * Retrieve denom (string) for a Brand.
      *
      * @param {Brand} brand
-     * @returns {string | undefined}
+     * @returns {Denom | undefined}
      */
     getDenom(brand) {
       if (brandDenoms.has(brand)) {

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -34,7 +34,11 @@ import {
   IBCTransferOptionsShape,
 } from '../typeGuards.js';
 import { coerceCoin, coerceDenom } from '../utils/amounts.js';
-import { maxClockSkew, tryDecodeResponse } from '../utils/cosmos.js';
+import {
+  maxClockSkew,
+  tryDecodeResponse,
+  toDenomAmount,
+} from '../utils/cosmos.js';
 import { orchestrationAccountMethods } from '../utils/orchestrationAccount.js';
 import { makeTimestampHelper } from '../utils/time.js';
 
@@ -106,9 +110,6 @@ export const IcaAccountHolderI = M.interface('IcaAccountHolder', {
 const PUBLIC_TOPICS = {
   account: ['Staking Account holder status', M.any()],
 };
-
-/** @type {(c: { denom: string; amount: string }) => DenomAmount} */
-const toDenomAmount = c => ({ denom: c.denom, value: BigInt(c.amount) });
 
 /**
  * @param {Zone} zone

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -387,8 +387,8 @@ export const prepareLocalOrchestrationAccountKit = (
         getBalance(denomArg) {
           const [brand, denom] =
             typeof denomArg === 'string'
-              ? [chainHub.lookupAsset(denomArg).brand, denomArg]
-              : [denomArg, chainHub.lookupDenom(denomArg)];
+              ? [chainHub.getAsset(denomArg).brand, denomArg]
+              : [denomArg, chainHub.getDenom(denomArg)];
 
           if (!brand) {
             throw Fail`No brand for ${denomArg}`;

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -387,7 +387,7 @@ export const prepareLocalOrchestrationAccountKit = (
         getBalance(denomArg) {
           const [brand, denom] =
             typeof denomArg === 'string'
-              ? [chainHub.getAsset(denomArg).brand, denomArg]
+              ? [chainHub.getAsset(denomArg)?.brand, denomArg]
               : [denomArg, chainHub.getDenom(denomArg)];
 
           if (!brand) {

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -385,23 +385,25 @@ export const prepareLocalOrchestrationAccountKit = (
          * @type {HostOf<OrchestrationAccountI['getBalance']>}
          */
         getBalance(denomArg) {
-          const [brand, denom] =
-            typeof denomArg === 'string'
-              ? [chainHub.getAsset(denomArg)?.brand, denomArg]
-              : [denomArg, chainHub.getDenom(denomArg)];
+          return asVow(() => {
+            const [brand, denom] =
+              typeof denomArg === 'string'
+                ? [chainHub.getAsset(denomArg)?.brand, denomArg]
+                : [denomArg, chainHub.getDenom(denomArg)];
 
-          if (!brand) {
-            throw Fail`No brand for ${denomArg}`;
-          }
-          if (!denom) {
-            throw Fail`No denom for ${denomArg}`;
-          }
+            if (!brand) {
+              throw Fail`No brand for ${denomArg}`;
+            }
+            if (!denom) {
+              throw Fail`No denom for ${denomArg}`;
+            }
 
-          return watch(
-            E(this.state.account).getBalance(brand),
-            this.facets.getBalanceWatcher,
-            denom,
-          );
+            return watch(
+              E(this.state.account).getBalance(brand),
+              this.facets.getBalanceWatcher,
+              denom,
+            );
+          });
         },
         /** @type {HostOf<OrchestrationAccountI['getBalances']>} */
         getBalances() {

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -143,7 +143,7 @@ const prepareOrchestratorKit = (
         /** @type {HostOf<Orchestrator['getDenomInfo']>} */
         getDenomInfo(denom) {
           const { chainName, baseName, baseDenom, brand } =
-            chainHub.lookupAsset(denom);
+            chainHub.getAsset(denom);
           chainByName.has(chainName) ||
             Fail`use getChain(${q(chainName)}) before getDenomInfo(${q(denom)})`;
           const chain = chainByName.get(chainName);

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -142,8 +142,9 @@ const prepareOrchestratorKit = (
         },
         /** @type {HostOf<Orchestrator['getDenomInfo']>} */
         getDenomInfo(denom) {
-          const { chainName, baseName, baseDenom, brand } =
-            chainHub.getAsset(denom);
+          const denomDetail = chainHub.getAsset(denom);
+          if (!denomDetail) throw Fail`No denom detail for ${q(denom)}`;
+          const { chainName, baseName, baseDenom, brand } = denomDetail;
           chainByName.has(chainName) ||
             Fail`use getChain(${q(chainName)}) before getDenomInfo(${q(denom)})`;
           const chain = chainByName.get(chainName);

--- a/packages/orchestration/src/fixtures/query-flows.flows.js
+++ b/packages/orchestration/src/fixtures/query-flows.flows.js
@@ -59,11 +59,10 @@ export const makeAccountAndGetBalanceQuery = async (
 ) => {
   seat.exit(); // no funds exchanged
   mustMatch(chainName, M.string());
-  if (chainName === 'agoric') throw Fail`ICQ not supported on local chain`;
-  const remoteChain = await orch.getChain(chainName);
-  const orchAccount = await remoteChain.makeAccount();
+  const chain = await orch.getChain(chainName);
+  const orchAccount = await chain.makeAccount();
   const queryResponse = await orchAccount.getBalance(denom);
-  trace('ICQ Balance Query response:', queryResponse);
+  trace('Balance Query response:', queryResponse);
   // `quote` to ensure offerResult (record) is visible in smart-wallet
   return q(queryResponse).toString();
 };
@@ -79,7 +78,7 @@ harden(makeAccountAndGetBalanceQuery);
  * @param {Orchestrator} orch
  * @param {any} _ctx
  * @param {ZCFSeat} seat
- * @param {{ chainName: string; denom: DenomArg }} offerArgs
+ * @param {{ chainName: string }} offerArgs
  */
 export const makeAccountAndGetBalancesQuery = async (
   orch,
@@ -89,11 +88,10 @@ export const makeAccountAndGetBalancesQuery = async (
 ) => {
   seat.exit(); // no funds exchanged
   mustMatch(chainName, M.string());
-  if (chainName === 'agoric') throw Fail`ICQ not supported on local chain`;
-  const remoteChain = await orch.getChain(chainName);
-  const orchAccount = await remoteChain.makeAccount();
+  const chain = await orch.getChain(chainName);
+  const orchAccount = await chain.makeAccount();
   const queryResponse = await orchAccount.getBalances();
-  trace('ICQ All Balances Query response:', queryResponse);
+  trace('All Balances Query response:', queryResponse);
   // `quote` to ensure offerResult (record) is visible in smart-wallet
   return q(queryResponse).toString();
 };

--- a/packages/orchestration/src/utils/amounts.js
+++ b/packages/orchestration/src/utils/amounts.js
@@ -19,7 +19,7 @@ export const coerceDenom = (chainHub, denomArg) => {
   }
   const denom = chainHub.getDenom(denomArg);
   if (!denom) {
-    throw makeError(`No denomination for brand ${denomArg}`);
+    throw makeError(`No denom for brand ${denomArg}`);
   }
   return denom;
 };

--- a/packages/orchestration/src/utils/amounts.js
+++ b/packages/orchestration/src/utils/amounts.js
@@ -10,6 +10,8 @@ import { makeError } from '@endo/errors';
  * @param {ChainHub} chainHub
  * @param {DenomArg} denomArg
  * @returns {Denom}
+ * @throws {Error} if Brand is provided and ChainHub doesn't contain Brand:Denom
+ *   mapping
  */
 export const coerceDenom = (chainHub, denomArg) => {
   if (typeof denomArg === 'string') {
@@ -26,6 +28,8 @@ export const coerceDenom = (chainHub, denomArg) => {
  * @param {ChainHub} chainHub
  * @param {DenomAmount | Amount<'nat'>} amount
  * @returns {DenomAmount}
+ * @throws {Error} if ERTP Amount is provided and ChainHub doesn't contain
+ *   Brand:Denom mapping
  */
 export const coerceDenomAmount = (chainHub, amount) => {
   if ('denom' in amount) {
@@ -40,8 +44,10 @@ export const coerceDenomAmount = (chainHub, amount) => {
 
 /**
  * @param {ChainHub} chainHub
- * @param {AmountArg | Amount<'nat'>} amount
+ * @param {AmountArg} amount
  * @returns {Coin}
+ * @throws {Error} if ERTP Amount is provided and ChainHub doesn't contain
+ *   Brand:Denom mapping
  */
 export const coerceCoin = (chainHub, amount) => {
   const denom =

--- a/packages/orchestration/src/utils/amounts.js
+++ b/packages/orchestration/src/utils/amounts.js
@@ -15,7 +15,7 @@ export const coerceDenom = (chainHub, denomArg) => {
   if (typeof denomArg === 'string') {
     return denomArg;
   }
-  const denom = chainHub.lookupDenom(denomArg);
+  const denom = chainHub.getDenom(denomArg);
   if (!denom) {
     throw makeError(`No denomination for brand ${denomArg}`);
   }

--- a/packages/orchestration/src/utils/cosmos.js
+++ b/packages/orchestration/src/utils/cosmos.js
@@ -2,6 +2,11 @@ import { makeError } from '@endo/errors';
 import { decodeBase64, encodeBase64 } from '@endo/base64';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 
+/**
+ * @import {DenomAmount} from '../types.js';
+ * @import {Coin} from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js'
+ */
+
 /** maximum clock skew, in seconds, for unbonding time reported from other chain */
 export const maxClockSkew = 10n * 60n;
 
@@ -34,3 +39,10 @@ export const tryDecodeResponse = (ackStr, fromProtoMsg) => {
     throw makeError(`bad response: ${ackStr}`, undefined, { cause });
   }
 };
+
+/**
+ * Transform a cosmos-sdk {@link Coin} object into a {@link DenomAmount}
+ *
+ * @type {(c: { denom: string; amount: string }) => DenomAmount}
+ */
+export const toDenomAmount = c => ({ denom: c.denom, value: BigInt(c.amount) });

--- a/packages/orchestration/src/utils/cosmos.js
+++ b/packages/orchestration/src/utils/cosmos.js
@@ -1,5 +1,5 @@
 import { makeError } from '@endo/errors';
-import { decodeBase64, encodeBase64 } from '@endo/base64';
+import { decodeBase64 } from '@endo/base64';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 
 /**
@@ -9,19 +9,6 @@ import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 
 /** maximum clock skew, in seconds, for unbonding time reported from other chain */
 export const maxClockSkew = 10n * 60n;
-
-/**
- * @param {unknown} response
- * @param {(msg: any) => Any} toProtoMsg
- * @returns {string}
- */
-export const encodeTxResponse = (response, toProtoMsg) => {
-  const protoMsg = toProtoMsg(response);
-  const any1 = Any.fromPartial(protoMsg);
-  const any2 = Any.fromPartial({ value: Any.encode(any1).finish() });
-  const ackStr = encodeBase64(Any.encode(any2).finish());
-  return ackStr;
-};
 
 /**
  * @template T

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -70,7 +70,7 @@ export const provideOrchestration = (
     };
   })();
 
-  const { agoricNames, timerService } = remotePowers;
+  const { agoricNames, timerService, localchain } = remotePowers;
 
   const vowTools = prepareVowTools(zones.vows);
 
@@ -81,11 +81,7 @@ export const provideOrchestration = (
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     zones.orchestration,
-    makeRecorderKit,
-    zcf,
-    timerService,
-    vowTools,
-    chainHub,
+    { makeRecorderKit, zcf, timerService, vowTools, chainHub, localchain },
   );
 
   const asyncFlowTools = prepareAsyncFlowTools(zones.asyncFlow, {

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -95,7 +95,7 @@ test.serial('getConnectionInfo', async t => {
   t.deepEqual(await vt.when(chainHub.getConnectionInfo(b, a)), ba);
 });
 
-test('getDenomInfo support', async t => {
+test('getAsset denom info support', async t => {
   const { chainHub } = setup();
 
   const denom = 'utok1';
@@ -112,7 +112,7 @@ test('getDenomInfo support', async t => {
   };
   chainHub.registerAsset('utok1', info);
 
-  const actual = chainHub.lookupAsset('utok1');
+  const actual = chainHub.getAsset('utok1');
   t.deepEqual(actual, info);
 });
 
@@ -135,7 +135,7 @@ test('toward asset info in agoricNames (#9572)', async t => {
   registerAssets(chainHub, 'cosmoshub', details);
 
   {
-    const actual = chainHub.lookupAsset('uatom');
+    const actual = chainHub.getAsset('uatom');
     t.deepEqual(actual, {
       chainName: 'cosmoshub',
       baseName: 'cosmoshub',
@@ -144,7 +144,7 @@ test('toward asset info in agoricNames (#9572)', async t => {
   }
 
   {
-    const actual = chainHub.lookupAsset(
+    const actual = chainHub.getAsset(
       'ibc/F04D72CF9B5D9C849BB278B691CDFA2241813327430EC9CDC83F8F4CA4CDC2B0',
     );
     t.deepEqual(actual, {

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -71,7 +71,7 @@ test('send (to addr on same chain)', async t => {
 
   // IST not registered
   await t.throwsAsync(E(account).send(toAddress, ist.make(10n) as AmountArg), {
-    message: 'No denomination for brand [object Alleged: IST brand]',
+    message: 'No denom for brand [object Alleged: IST brand]',
   });
 
   // multi-send (sendAll)
@@ -280,7 +280,7 @@ test('transfer', async t => {
 
   t.log('transfer throws if asset is not in its chainHub');
   await t.throwsAsync(E(account).transfer(ist.make(10n), mockDestination), {
-    message: 'No denomination for brand [object Alleged: IST brand]',
+    message: 'No denom for brand [object Alleged: IST brand]',
   });
   chainHub.registerAsset('uist', {
     baseDenom: 'uist',

--- a/packages/orchestration/test/exos/make-test-loa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-loa-kit.ts
@@ -32,12 +32,15 @@ export const prepareMakeTestLOAKit = (
 
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     rootZone,
-    makeRecorderKit,
-    // @ts-expect-error mocked zcf. use `stake-bld.contract.test.ts` to test LCA with offer
-    zcf,
-    timer,
-    vowTools,
-    chainHub,
+    {
+      makeRecorderKit,
+      // @ts-expect-error mocked zcf. use `stake-bld.contract.test.ts` to test LCA with offer
+      zcf,
+      timerService: timer,
+      vowTools,
+      chainHub,
+      localchain,
+    },
   );
 
   return async ({

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -10,6 +10,7 @@ import {
   MsgDelegateResponse,
   MsgUndelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeNotifierFromSubscriber } from '@agoric/notifier';
@@ -20,15 +21,27 @@ import { prepareVowTools, heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { decodeBase64 } from '@endo/base64';
+import { decodeBase64, encodeBase64 } from '@endo/base64';
 import { Far } from '@endo/far';
 import { Timestamp } from '@agoric/cosmic-proto/google/protobuf/timestamp.js';
 import { makeNameHubKit } from '@agoric/vats';
 import { prepareCosmosOrchestrationAccountKit } from '../src/exos/cosmos-orchestration-account.js';
 import type { ChainAddress, IcaAccount, ICQConnection } from '../src/types.js';
-import { encodeTxResponse } from '../src/utils/cosmos.js';
 import { MILLISECONDS_PER_SECOND } from '../src/utils/time.js';
 import { makeChainHub } from '../src/exos/chain-hub.js';
+
+/**
+ * @param {unknown} response
+ * @param {(msg: any) => Any} toProtoMsg
+ * @returns {string}
+ */
+const encodeTxResponse = (response, toProtoMsg) => {
+  const protoMsg = toProtoMsg(response);
+  const any1 = Any.fromPartial(protoMsg);
+  const any2 = Any.fromPartial({ value: Any.encode(any1).finish() });
+  const ackStr = encodeBase64(Any.encode(any2).finish());
+  return ackStr;
+};
 
 const trivialDelegateResponse = encodeTxResponse(
   {},

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -155,9 +155,7 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
    * Register BLD if it's not already registered
    */
   const registerAgoricBld = () => {
-    try {
-      chainHub.getAsset('ubld');
-    } catch {
+    if (!chainHub.getAsset('ubld')) {
       chainHub.registerChain('agoric', fetchedChainInfo.agoric);
       chainHub.registerAsset('ubld', {
         chainName: 'agoric',

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -156,7 +156,7 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
    */
   const registerAgoricBld = () => {
     try {
-      chainHub.lookupAsset('ubld');
+      chainHub.getAsset('ubld');
     } catch {
       chainHub.registerChain('agoric', fetchedChainInfo.agoric);
       chainHub.registerAsset('ubld', {

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -265,8 +265,11 @@ export const fakeLocalChainBridgeQueryHandler = message => {
         reply: {
           '@type': '/cosmos.bank.v1beta1.QueryBalanceResponse',
           balance: {
+            denom: message.denom,
+            // return 10 for all denoms, somewhat arbitrarily.
+            // if a denom is not known to cosmos bank, we'd expect to see
+            // `{denom, amount: '0'}` returned
             amount: '10',
-            denom: 'ubld',
           },
         },
       };

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -227,6 +227,17 @@ export const fakeLocalChainBridgeTxMsgHandler = (message, sequence) => {
   }
 };
 
+export const LOCALCHAIN_QUERY_ALL_BALANCES_RESPONSE = [
+  {
+    value: 10n,
+    denom: 'ubld',
+  },
+  {
+    value: 10n,
+    denom: 'uist',
+  },
+];
+
 /**
  * Used to mock responses from Cosmos Golang back to SwingSet for for
  * E(lca).query() and E(lca).queryMany().
@@ -244,16 +255,10 @@ export const fakeLocalChainBridgeQueryHandler = message => {
         height: '1',
         reply: {
           '@type': '/cosmos.bank.v1beta1.QueryAllBalancesResponse',
-          balances: [
-            {
-              amount: '10',
-              denom: 'ubld',
-            },
-            {
-              amount: '10',
-              denom: 'uist',
-            },
-          ],
+          balances: LOCALCHAIN_QUERY_ALL_BALANCES_RESPONSE.map(x => ({
+            denom: x.denom,
+            amount: String(x.value),
+          })),
           pagination: { nextKey: null, total: '2' },
         },
       };


### PR DESCRIPTION
closes: #9610

## Description
- updates `LocalOrchestrationAccount.getBalance()` to support non-vbank assets (using `localchain.query()` to ask cosmos bank)
- implements `LocalOrchestrationAccount.getBalances()`
- BREAKING: renames `ChainHub.lookupDenom` and `ChainHub.lookupAsset` to `getDenom` and `getAsset`
- BREAKING: `ChainHub.getAsset` returns undefined instead of throwing when lookup fails

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
Updates pertinent jsodc and `exos/README.md`

### Testing Considerations
Includes unit and e2e tests

### Upgrade Considerations
n/a, unreleased code
