### PR TITLE
feat: look up last value of vault parameters when upgrading

### DIFF
--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -77,15 +77,13 @@ export const upgradeVaults = async (
 
     const subscription = E(directorPF).getElectorateSubscription();
     const notifier = makeNotifierFromAsyncIterable(subscription);
-    let { value, updateCount } = await notifier.getUpdateSince(0n);
-    // @ts-expect-error It's an amount.
-    while (AmountMath.isEmpty(value.current.MinInitialDebt.value)) {
-      ({ value, updateCount } = await notifier.getUpdateSince(updateCount));
-      trace(
-        `minInitialDebt was empty, retried`,
-        value.current.MinInitialDebt.value,
-      );
-    }
+    const { value, updateCount } = await notifier.getUpdateSince();
+    trace(
+      `minInitialDebt retrieved`,
+      updateCount,
+      value.current.MinInitialDebt.value,
+      value,
+    );
 
     return harden({
       MinInitialDebt: value.current.MinInitialDebt.value,
@@ -108,19 +106,31 @@ export const upgradeVaults = async (
         collateralBrand,
       });
       const notifier = makeNotifierFromAsyncIterable(subscription);
-      let { value, updateCount } = await notifier.getUpdateSince(0n);
+      let { value, updateCount } = await notifier.getUpdateSince();
+      trace(
+        `debtLimit first request`,
+        kwd,
+        updateCount,
+        value.current.DebtLimit.value,
+      );
       // @ts-expect-error It's an amount.
       if (AmountMath.isEmpty(value.current.DebtLimit.value)) {
         // The parameters might have been empty at start, and the notifier might
         // give the first state before the current state.
-        trace(`debtLimit was empty, retrying`, value.current.DebtLimit.value);
-        ({ value, updateCount } = await notifier.getUpdateSince(updateCount));
+        trace(
+          `debtLimit was empty, retrying`,
+          kwd,
+          updateCount,
+          value.current.DebtLimit.value,
+          value,
+        );
 
-        // @ts-expect-error It's an amount.
-        if (AmountMath.isEmpty(value.current.DebtLimit.value)) {
-          trace('debtLimit was empty after retrying');
-          throw Error('🚨Governed parameters empty after retry, Giving up');
-        }
+        // unroll a loop
+        ({ value, updateCount } = await notifier.getUpdateSince(updateCount));
+        trace(` retrying`, updateCount, value.current.DebtLimit.value);
+
+        ({ value, updateCount } = await notifier.getUpdateSince());
+        trace(` retrying`, updateCount, value.current.DebtLimit.value);
       }
       trace(kwd, 'params at', updateCount, 'are', value.current);
       params[kwd] = harden({


### PR DESCRIPTION
closes: #10031

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

### Security Considerations

The values of the VaultManager parameters was lost on upgrade. They're recoverable, but I'll probably start from this code when upgrading other contracts.

### Scaling Considerations

N/A

### Documentation Considerations
N/A

### Testing Considerations

Verifying my hypothesis in a3p tests.

### Upgrade Considerations

yes
