### PR TITLE
chore: mark zcf.reallocate() deprecated in types-ambient

### DIFF
--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -85,7 +85,10 @@ type ZCF<CT extends unknown = Record<string, unknown>> = {
   getOfferFilter: () => Promise<Array<string>>;
   getInstance: () => Instance;
 };
+
 /**
+ * @deprecated Use atomicRearrange instead
+ *
  * The contract can reallocate over seats, which commits the staged
  * allocation for each seat. On commit, the staged allocation becomes
  * the current allocation and the staged allocation is deleted.


### PR DESCRIPTION
refs: #6678

## Description

We've already marked zcf.reallocate() as deprecated in many places, but I found another while searching on our docs site.

https://docs.agoric.com/reference/agoric-sdk/modules/agoric_zoe.src_contractFacet_types_ambient.html#type-declaration-4next/

### Security Considerations

None.

### Scaling Considerations

N/A

### Documentation Considerations

Cleaning up docs.

### Testing Considerations

N/A

### Upgrade Considerations

None.