### PR TITLE
drop node-fetch

### DIFF
--- a/a3p-integration/proposals/s:stake-bld/package.json
+++ b/a3p-integration/proposals/s:stake-bld/package.json
@@ -18,8 +18,7 @@
     "@endo/init": "^1.0.4",
     "agoric": "0.21.2-dev-5676146.0",
     "ava": "^5.3.1",
-    "execa": "^8.0.1",
-    "node-fetch": "^3.3.2"
+    "execa": "^8.0.1"
   },
   "ava": {
     "concurrency": 1

--- a/a3p-integration/proposals/s:stake-bld/test-lib/index.js
+++ b/a3p-integration/proposals/s:stake-bld/test-lib/index.js
@@ -1,5 +1,4 @@
-/* global setTimeout */
-import fetch from 'node-fetch';
+/* eslint-env node */
 import { execFileSync } from 'child_process';
 import { makeWalletUtils } from './wallet.js';
 

--- a/a3p-integration/proposals/s:stake-bld/yarn.lock
+++ b/a3p-integration/proposals/s:stake-bld/yarn.lock
@@ -2394,13 +2394,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-uri-to-buffer@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "data-uri-to-buffer@npm:4.0.1"
-  checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
-  languageName: node
-  linkType: hard
-
 "date-time@npm:^3.1.0":
   version: 3.1.0
   resolution: "date-time@npm:3.1.0"
@@ -2773,16 +2766,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
-  version: 3.2.0
-  resolution: "fetch-blob@npm:3.2.0"
-  dependencies:
-    node-domexception: "npm:^1.0.0"
-    web-streams-polyfill: "npm:^3.0.3"
-  checksum: 10c0/60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
-  languageName: node
-  linkType: hard
-
 "figures@npm:^3.0.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -2863,15 +2846,6 @@ __metadata:
     combined-stream: "npm:^1.0.8"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
-  languageName: node
-  linkType: hard
-
-"formdata-polyfill@npm:^4.0.10":
-  version: 4.0.10
-  resolution: "formdata-polyfill@npm:4.0.10"
-  dependencies:
-    fetch-blob: "npm:^3.1.2"
-  checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
   languageName: node
   linkType: hard
 
@@ -3989,13 +3963,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-domexception@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "node-domexception@npm:1.0.0"
-  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^2.6.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -4007,17 +3974,6 @@ __metadata:
     encoding:
       optional: true
   checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "node-fetch@npm:3.3.2"
-  dependencies:
-    data-uri-to-buffer: "npm:^4.0.0"
-    fetch-blob: "npm:^3.1.4"
-    formdata-polyfill: "npm:^4.0.10"
-  checksum: 10c0/f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
   languageName: node
   linkType: hard
 
@@ -4592,7 +4548,6 @@ __metadata:
     agoric: "npm:0.21.2-dev-5676146.0"
     ava: "npm:^5.3.1"
     execa: "npm:^8.0.1"
-    node-fetch: "npm:^3.3.2"
   languageName: unknown
   linkType: soft
 
@@ -5204,13 +5159,6 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
-  languageName: node
-  linkType: hard
-
-"web-streams-polyfill@npm:^3.0.3":
-  version: 3.3.3
-  resolution: "web-streams-polyfill@npm:3.3.3"
-  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
   languageName: node
   linkType: hard
 

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -42,7 +42,6 @@
     "typescript": "^5.3.3"
   },
   "resolutions": {
-    "node-fetch": "2.6.12",
     "axios": "1.6.7"
   },
   "ava": {

--- a/multichain-testing/scripts/fetch-starship-chain-info.ts
+++ b/multichain-testing/scripts/fetch-starship-chain-info.ts
@@ -1,14 +1,12 @@
 #!/usr/bin/env tsx
+/* eslint-env node */
 
-import nodeFetch from 'node-fetch';
 import fsp from 'node:fs/promises';
 import prettier from 'prettier';
 
 import { convertChainInfo } from '@agoric/orchestration/src/utils/registry.js';
 
 import type { IBCInfo, Chains } from '@chain-registry/types';
-
-const fetch = nodeFetch.default;
 
 /**
  * Chain registry running in Starship

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -3312,9 +3312,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.12":
-  version: 2.6.12
-  resolution: "node-fetch@npm:2.6.12"
+"node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7, node-fetch@npm:^2.6.9":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
   dependencies:
     whatwg-url: "npm:^5.0.0"
   peerDependencies:
@@ -3322,7 +3322,7 @@ __metadata:
   peerDependenciesMeta:
     encoding:
       optional: true
-  checksum: 10c0/10372e4b5ee07acadc15e6b2bc6fd8940582eea7b9b2a331f4e3665fdcd968498c1656f79f2fa572080ebb37ea80e1474a6478b3b36057ef901b63f4be8fd899
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
   languageName: node
   linkType: hard
 

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -6,7 +6,6 @@
 
 import '@endo/init/pre.js';
 
-import '@agoric/casting/node-fetch-shim.js';
 import '@endo/init';
 
 import { E } from '@endo/far';

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -5,7 +5,6 @@
 
 import '@endo/init/pre.js';
 import 'esm';
-import '@agoric/casting/node-fetch-shim.js';
 import '@endo/init/legacy.js';
 
 import path from 'path';

--- a/packages/agoric-cli/test/main.test.js
+++ b/packages/agoric-cli/test/main.test.js
@@ -1,5 +1,4 @@
 /* global globalThis */
-import '@agoric/casting/node-fetch-shim.js';
 import '@endo/init/pre.js';
 import 'esm';
 import '@endo/init/debug.js';

--- a/packages/casting/README.md
+++ b/packages/casting/README.md
@@ -13,7 +13,6 @@ An example of following an on-chain mailbox in code (using this package) is:
 ```js
 // First, obtain a Hardened JS environment via Endo.
 import '@endo/init/pre-remoting.js'; // needed only for the next line
-import '@agoric/casting/node-fetch-shim.js'; // needed for Node.js
 import '@endo/init';
 
 import {

--- a/packages/casting/node-fetch-shim.js
+++ b/packages/casting/node-fetch-shim.js
@@ -1,7 +1,0 @@
-// @jessie-check
-
-/* global globalThis */
-import fetch from 'node-fetch';
-
-// @ts-expect-error node-fetch does not exactly match W3C Fetch
-globalThis.fetch = fetch;

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -34,13 +34,11 @@
     "@endo/init": "^1.1.4",
     "@endo/lockdown": "^1.0.10",
     "@endo/marshal": "^1.5.3",
-    "@endo/promise-kit": "^1.1.5",
-    "node-fetch": "^2.6.0"
+    "@endo/promise-kit": "^1.1.5"
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.4.0",
     "@endo/ses-ava": "^1.2.5",
-    "@types/node-fetch": "^2.6.2",
     "ava": "^5.3.0",
     "c8": "^9.1.0",
     "express": "^4.17.1",

--- a/packages/casting/test/lockdown.js
+++ b/packages/casting/test/lockdown.js
@@ -1,3 +1,2 @@
 import '@endo/init/pre-remoting.js';
-import '../node-fetch-shim.js';
 import '@endo/init';

--- a/packages/casting/test/mvp.test.js
+++ b/packages/casting/test/mvp.test.js
@@ -155,7 +155,7 @@ test('missing rpc server', async t => {
         jitter: null,
       }),
     {
-      message: /^invalid json response body/,
+      message: /^Unexpected token/,
     },
   );
 });

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -27,7 +27,6 @@
     "deterministic-json": "^1.0.5",
     "inquirer": "^8.2.2",
     "minimist": "^1.2.0",
-    "node-fetch": "^2.6.0",
     "temp": "^0.9.0"
   },
   "publishConfig": {

--- a/packages/deployment/src/entrypoint.js
+++ b/packages/deployment/src/entrypoint.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-/* global setInterval */
+/* eslint-env node */
 
 import '@endo/init';
 
@@ -9,7 +9,6 @@ import temp from 'temp';
 import process from 'process';
 import { exec, spawn } from 'child_process';
 import inquirer from 'inquirer';
-import fetch from 'node-fetch';
 
 import { running } from './run.js';
 import { setup } from './setup.js';
@@ -22,7 +21,7 @@ deploy(process.argv[1], process.argv.splice(2), {
   rd: files.reading(fs, path),
   wr: files.writing(fs, path, temp),
   setup: setup({ resolve: path.resolve, env: process.env, setInterval }),
-  running: running(process, { exec, process, spawn }),
+  running: running(process, { exec, spawn }),
   inquirer,
   fetch,
 }).then(

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -50,7 +50,6 @@
     "import-meta-resolve": "^2.2.1",
     "minimist": "^1.2.0",
     "morgan": "^1.10.0",
-    "node-fetch": "^2.6.0",
     "temp": "^0.9.1",
     "tmp": "^0.2.1",
     "ws": "^7.2.0"

--- a/packages/solo/src/add-chain.js
+++ b/packages/solo/src/add-chain.js
@@ -1,5 +1,4 @@
-/* global process */
-import fetch from 'node-fetch';
+/* eslint-env node */
 import crypto from 'crypto';
 import djson from 'deterministic-json';
 import path from 'path';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,14 +3609,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
-  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*", "@types/node@>=13.7.0", "@types/node@^18.19.24":
   version "18.19.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.24.tgz#707d8a4907e55901466e60e8f7a62bc6197ace95"
@@ -6538,15 +6530,6 @@ foreground-child@^3.1.0, foreground-child@^3.1.1:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -9069,7 +9052,7 @@ node-addon-api@^6.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
   integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
+node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
_evergreen_

## Description

`fetch` is now global in Node 18. Stop using `node-fetch`

This leaves the patch because some packages still transitively import it.

### Security Considerations
fewer deps

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
Had to update a test that was checking the particular error message string

### Upgrade Considerations
none