### PR TITLE
fix(swing-store): Delete transcript spans in stopUsingTranscript as in rollover

### DIFF
--- a/packages/internal/tools/ava-assertions.js
+++ b/packages/internal/tools/ava-assertions.js
@@ -1,0 +1,26 @@
+/**
+ * Assert that the contents of `array` are
+ * [like]{@link https://github.com/avajs/ava/blob/main/docs/03-assertions.md#likeactual-selector-message}
+ * those of `expected`, including having matching lengths, with pretty diffs in
+ * case of mismatch.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {unknown[]} array
+ * @param {unknown[]} expected
+ * @param {string} [message]
+ */
+export const arrayIsLike = (t, array, expected, message) => {
+  const actualLength = array.length;
+  const expectedLength = expected.length;
+  const actualExcess = actualLength - expectedLength;
+  const comparable =
+    actualExcess > 0
+      ? [...expected, ...Array.from({ length: actualExcess })]
+      : expected;
+  t.like(array, comparable, message);
+
+  if (actualLength === expectedLength) return;
+
+  const extended = [...array, ...Array.from({ length: -actualExcess })];
+  t.deepEqual(extended, array, message);
+};

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -288,8 +288,8 @@ export function makeTranscriptStore(
     closeSpan(vatID, bounds);
 
     // create a new (empty) DB row, with isCurrent=1
-    const incarnationToUse = isNewIncarnation ? incarnation + 1 : incarnation;
-    sqlWriteSpan.run(vatID, endPos, endPos, initialHash, 1, incarnationToUse);
+    const newSpanIncarnation = isNewIncarnation ? incarnation + 1 : incarnation;
+    sqlWriteSpan.run(vatID, endPos, endPos, initialHash, 1, newSpanIncarnation);
 
     // overwrite the transcript.${vatID}.current record with new span
     const rec = spanRec(
@@ -298,7 +298,7 @@ export function makeTranscriptStore(
       endPos,
       initialHash,
       true,
-      incarnationToUse,
+      newSpanIncarnation,
     );
     noteExport(spanMetadataKey(rec), JSON.stringify(rec));
 
@@ -311,7 +311,7 @@ export function makeTranscriptStore(
       // that doesn't include them.
       sqlDeleteOldItems.run(vatID, startPos, endPos);
     }
-    return incarnationToUse;
+    return newSpanIncarnation;
   }
 
   /**

--- a/packages/swing-store/test/deletion.test.js
+++ b/packages/swing-store/test/deletion.test.js
@@ -433,7 +433,7 @@ const testSlowTranscriptDeletion = test.macro({
   exec: execSlowTranscriptDeletion,
 });
 test(testSlowTranscriptDeletion, { keepTranscripts: true });
-test.failing(testSlowTranscriptDeletion, { keepTranscripts: false });
+test(testSlowTranscriptDeletion, { keepTranscripts: false });
 
 test('slow deletion without stopUsingTranscript', async t => {
   // slow deletion should work even without stopUsingTranscript


### PR DESCRIPTION
Fixes #10054

## Description
The first commits from #10055, [by request](https://github.com/Agoric/agoric-sdk/pull/10055#pullrequestreview-2293616954), culminating in a fix of #10054 by introducing a `closeSpan` helper to support both span rollover and `stopUsingTranscript`.

### Security Considerations
None known.

### Scaling Considerations
If anything, a negligible reduction in transcriptStore size.

### Documentation Considerations
None known.

### Testing Considerations
Covered by unit tests.

### Upgrade Considerations
This is kernel code that can be used at any node restart (i.e., because the configuration is consensus-independent, it doesn't even need to wait for a chain software upgrade).