### PR TITLE
feat(SwingSet): Support SLOG* environment variables when running tests

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,6 +21,7 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
+    "@agoric/telemetry": "^0.6.2",
     "@types/better-sqlite3": "^7.6.9",
     "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",

--- a/packages/SwingSet/test/vat-admin/terminate/terminate.test.js
+++ b/packages/SwingSet/test/vat-admin/terminate/terminate.test.js
@@ -6,11 +6,11 @@ import { kser, kunser } from '@agoric/kmarshal';
 import { initSwingStore } from '@agoric/swing-store';
 
 import {
-  buildVatController,
   loadSwingsetConfigFile,
   buildKernelBundles,
 } from '../../../src/index.js';
 import { enumeratePrefixedKeys } from '../../../src/kernel/state/storageHelper.js';
+import { buildTestVatController } from '../../../tools/test-vat-controller.js';
 import { restartVatAdminVat } from '../../util.js';
 
 test.before(async t => {
@@ -44,7 +44,7 @@ async function doTerminateNonCritical(
   const config = await loadSwingsetConfigFile(configPath);
   config.defaultReapInterval = 'never';
   const kernelStorage = initSwingStore().kernelStorage;
-  const controller = await buildVatController(config, [], {
+  const controller = await buildTestVatController(config, [], {
     ...t.context.data,
     kernelStorage,
   });
@@ -108,7 +108,7 @@ async function doTerminateCritical(
   const config = await loadSwingsetConfigFile(configPath);
   config.defaultReapInterval = 'never';
   const kernelStorage = initSwingStore().kernelStorage;
-  const controller = await buildVatController(config, [], {
+  const controller = await buildTestVatController(config, [], {
     ...t.context.data,
     kernelStorage,
   });
@@ -382,7 +382,7 @@ test.serial('exit with presence', async t => {
     .pathname;
   const config = await loadSwingsetConfigFile(configPath);
   config.defaultReapInterval = 'never';
-  const controller = await buildVatController(config, [], t.context.data);
+  const controller = await buildTestVatController(config, [], t.context.data);
   t.teardown(controller.shutdown);
   await controller.run();
   t.deepEqual(controller.dump().log, [
@@ -401,7 +401,7 @@ test.serial('dispatches to the dead do not harm kernel', async t => {
 
   const ss1 = initSwingStore();
   {
-    const c1 = await buildVatController(config, [], {
+    const c1 = await buildTestVatController(config, [], {
       kernelStorage: ss1.kernelStorage,
       kernelBundles: t.context.data.kernelBundles,
     });
@@ -420,7 +420,7 @@ test.serial('dispatches to the dead do not harm kernel', async t => {
   const serialized = ss1.debug.serialize();
   const ss2 = initSwingStore(null, { serialized });
   {
-    const c2 = await buildVatController(config, [], {
+    const c2 = await buildTestVatController(config, [], {
       kernelStorage: ss2.kernelStorage,
       kernelBundles: t.context.data.kernelBundles,
     });
@@ -442,7 +442,7 @@ test.serial('invalid criticalVatKey causes vat creation to fail', async t => {
     .pathname;
   const config = await loadSwingsetConfigFile(configPath);
   config.defaultReapInterval = 'never';
-  const controller = await buildVatController(config, [], t.context.data);
+  const controller = await buildTestVatController(config, [], t.context.data);
   t.teardown(controller.shutdown);
   await t.throwsAsync(() => controller.run(), {
     message: /invalid criticalVatKey/,
@@ -456,7 +456,7 @@ test.serial('dead vat state removed', async t => {
   config.defaultReapInterval = 'never';
   const { kernelStorage, debug } = initSwingStore();
 
-  const controller = await buildVatController(config, [], {
+  const controller = await buildTestVatController(config, [], {
     kernelStorage,
     kernelBundles: t.context.data.kernelBundles,
   });
@@ -492,7 +492,7 @@ test.serial('terminate with presence', async t => {
   ).pathname;
   const config = await loadSwingsetConfigFile(configPath);
   config.defaultReapInterval = 'never';
-  const controller = await buildVatController(config, [], t.context.data);
+  const controller = await buildTestVatController(config, [], t.context.data);
   t.teardown(controller.shutdown);
   await controller.run();
   t.deepEqual(controller.dump().log, [

--- a/packages/SwingSet/tools/test-vat-controller.js
+++ b/packages/SwingSet/tools/test-vat-controller.js
@@ -1,0 +1,23 @@
+import process from 'node:process';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { makeSlogSender } from '@agoric/telemetry';
+import { buildVatController } from '../src/index.js';
+
+export const buildTestVatController = async (
+  config,
+  argv,
+  runtimeOptions,
+  deviceEndowments,
+) => {
+  const { env = process.env, slogSender: explicitSlogSender } = runtimeOptions;
+  await null;
+  if (
+    !explicitSlogSender &&
+    (env.SLOGFILE || env.SLOGSENDER || env.SLOGSENDER_AGENT)
+  ) {
+    const slogSender = await makeSlogSender({ env });
+    runtimeOptions = { ...runtimeOptions, slogSender };
+  }
+  return buildVatController(config, argv, runtimeOptions, deviceEndowments);
+};
+harden(buildTestVatController);


### PR DESCRIPTION
## Description
Provides a `buildTestVatController` test helper that wraps `buildVatController` in order to inject a `slogSender` option as requested by [`SLOGFILE`/`SLOGSENDER`/`SLOGSENDER_AGENT` environment variables](https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md#slogfile).

### Security Considerations
Minimal; this is testing code and nobody will be looking for a slog file they didn't request. The worst plausible scenario I can think of is someone having an exported environment variable and being surprised that running tests unexpectedly affects a file.

### Scaling Considerations
n/a

### Documentation Considerations
This is already documented at [docs/env.md](https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md), but perhaps the "Affects:" details should be updated to mention SwingSet tests?

### Testing Considerations
This is currently limited to the file where I needed it, but could easily cover much more.

### Upgrade Considerations
n/a