### PR TITLE
refactor(internal): Make better use of endo makeError

### DIFF
--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -110,9 +110,10 @@ const makeAggregateError =
   typeof AggregateError === 'function'
     ? (errors, message, options) => AggregateError(errors, message, options)
     : (errors, message, options) => {
-        const err = makeError(message ?? 'multiple errors', undefined, options);
-        annotateError(err, X`${errors}`);
-        return err;
+        return makeError(message ?? 'multiple errors', undefined, {
+          ...options,
+          errors,
+        });
       };
 
 /**


### PR DESCRIPTION
Ref #10055

## Description
The internal `makeAggregateError` introduced by #10055 properly logged fake-AggregateError errors, but failed to expose them on the error object. But this is [already supported in endo](https://github.com/endojs/endo/blob/4406f5dde521d539a5effeb8ab68c1316e45261d/packages/ses/src/error/assert.js#L321), so we should use it.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
n/a