### PR TITLE
feat: `vowTools.allSettled`

### DIFF
--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -52,11 +52,21 @@ export const prepareBasicVowTools = (zone, powers = {}) => {
     };
 
   /**
-   * Vow-tolerant implementation of Promise.all.
+   * Vow-tolerant implementation of Promise.all that takes an iterable of vows
+   * and other {@link Passable}s and returns a single {@link Vow}. It resolves
+   * with an array of values when all of the input's promises or vows are
+   * fulfilled and rejects when any of the input's promises or vows are
+   * rejected with the first rejection reason.
    *
-   * @param {EVow<unknown>[]} maybeVows
+   * @param {unknown[]} maybeVows
    */
-  const allVows = maybeVows => watchUtils.all(maybeVows);
+  const all = maybeVows => watchUtils.all(maybeVows);
+
+  /**
+   * @param {unknown[]} maybeVows
+   * @deprecated use `vowTools.all`
+   */
+  const allVows = all;
 
   /** @type {AsPromiseFunction} */
   const asPromise = (specimenP, ...watcherArgs) =>
@@ -66,6 +76,7 @@ export const prepareBasicVowTools = (zone, powers = {}) => {
     when,
     watch,
     makeVowKit,
+    all,
     allVows,
     asVow,
     asPromise,

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -7,6 +7,7 @@ import { makeWhen } from './when.js';
 
 /**
  * @import {Zone} from '@agoric/base-zone';
+ * @import {Passable} from '@endo/pass-style';
  * @import {IsRetryableReason, AsPromiseFunction, EVow, Vow, ERef} from './types.js';
  */
 
@@ -68,6 +69,16 @@ export const prepareBasicVowTools = (zone, powers = {}) => {
    */
   const allVows = all;
 
+  /**
+   * Vow-tolerant implementation of Promise.allSettled that takes an iterable
+   * of vows and other {@link Passable}s and returns a single {@link Vow}. It
+   * resolves when all of the input's promises or vows are settled with an
+   * array of settled outcome objects.
+   *
+   * @param {unknown[]} maybeVows
+   */
+  const allSettled = maybeVows => watchUtils.allSettled(maybeVows);
+
   /** @type {AsPromiseFunction} */
   const asPromise = (specimenP, ...watcherArgs) =>
     watchUtils.asPromise(specimenP, ...watcherArgs);
@@ -78,6 +89,7 @@ export const prepareBasicVowTools = (zone, powers = {}) => {
     makeVowKit,
     all,
     allVows,
+    allSettled,
     asVow,
     asPromise,
     retriable,

--- a/packages/vow/src/types.js
+++ b/packages/vow/src/types.js
@@ -66,6 +66,7 @@ export {};
  */
 
 /**
+ * Vows are objects that represent promises that can be stored durably.
  * @template [T=any]
  * @typedef {CopyTagged<'Vow', VowPayload<T>>} Vow
  */

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -10,7 +10,7 @@ const { Fail, bare, details: X } = assert;
  * @import {Zone} from '@agoric/base-zone';
  * @import {Watch} from './watch.js';
  * @import {When} from './when.js';
- * @import {VowKit, AsPromiseFunction, IsRetryableReason, EVow} from './types.js';
+ * @import {VowKit, AsPromiseFunction, IsRetryableReason, Vow} from './types.js';
  */
 
 const VowShape = M.tagged(
@@ -54,11 +54,16 @@ export const prepareWatchUtils = (
     {
       utils: M.interface('Utils', {
         all: M.call(M.arrayOf(M.any())).returns(VowShape),
+        allSettled: M.call(M.arrayOf(M.any())).returns(VowShape),
         asPromise: M.call(M.raw()).rest(M.raw()).returns(M.promise()),
       }),
       watcher: M.interface('Watcher', {
         onFulfilled: M.call(M.raw()).rest(M.raw()).returns(M.raw()),
         onRejected: M.call(M.raw()).rest(M.raw()).returns(M.raw()),
+      }),
+      helper: M.interface('Helper', {
+        createVow: M.call(M.arrayOf(M.any()), M.boolean()).returns(VowShape),
+        processResult: M.call(M.raw()).rest(M.raw()).returns(M.undefined()),
       }),
       retryRejectionPromiseWatcher: PromiseWatcherI,
     },
@@ -68,6 +73,7 @@ export const prepareWatchUtils = (
        * @property {number} remaining
        * @property {MapStore<number, any>} resultsMap
        * @property {VowKit['resolver']} resolver
+       * @property {boolean} [isAllSettled]
        */
       /** @type {MapStore<bigint, VowState>} */
       const idToVowState = detached.mapStore('idToVowState');
@@ -79,45 +85,15 @@ export const prepareWatchUtils = (
     },
     {
       utils: {
-        /**
-         * @param {EVow<unknown>[]} vows
-         */
-        all(vows) {
-          const { nextId: id, idToVowState } = this.state;
-          /** @type {VowKit<any[]>} */
-          const kit = makeVowKit();
-
-          // Preserve the order of the vow results.
-          for (let index = 0; index < vows.length; index += 1) {
-            watch(vows[index], this.facets.watcher, {
-              id,
-              index,
-              numResults: vows.length,
-            });
-          }
-
-          if (vows.length > 0) {
-            // Save the state until rejection or all fulfilled.
-            this.state.nextId += 1n;
-            idToVowState.init(
-              id,
-              harden({
-                resolver: kit.resolver,
-                remaining: vows.length,
-                resultsMap: detached.mapStore('resultsMap'),
-              }),
-            );
-            const idToNonStorableResults = provideLazyMap(
-              utilsToNonStorableResults,
-              this.facets.utils,
-              () => new Map(),
-            );
-            idToNonStorableResults.set(id, new Map());
-          } else {
-            // Base case: nothing to wait for.
-            kit.resolver.resolve(harden([]));
-          }
-          return kit.vow;
+        /** @param {unknown[]} specimens */
+        all(specimens) {
+          return this.facets.helper.createVow(specimens, false);
+        },
+        /** @param {unknown[]} specimens */
+        allSettled(specimens) {
+          return /** @type {Vow<({status: 'fulfilled', value: any} | {status: 'rejected', reason: any})[]>} */ (
+            this.facets.helper.createVow(specimens, true)
+          );
         },
         /** @type {AsPromiseFunction} */
         asPromise(specimenP, ...watcherArgs) {
@@ -133,13 +109,103 @@ export const prepareWatchUtils = (
         },
       },
       watcher: {
-        onFulfilled(value, { id, index, numResults }) {
+        /**
+         * @param {unknown} value
+         * @param {object} ctx
+         * @param {bigint} ctx.id
+         * @param {number} ctx.index
+         * @param {number} ctx.numResults
+         * @param {boolean} ctx.isAllSettled
+         */
+        onFulfilled(value, ctx) {
+          this.facets.helper.processResult(value, ctx, 'fulfilled');
+        },
+        /**
+         * @param {unknown} reason
+         * @param {object} ctx
+         * @param {bigint} ctx.id
+         * @param {number} ctx.index
+         * @param {number} ctx.numResults
+         * @param {boolean} ctx.isAllSettled
+         */
+        onRejected(reason, ctx) {
+          this.facets.helper.processResult(reason, ctx, 'rejected');
+        },
+      },
+      helper: {
+        /**
+         * @param {unknown[]} specimens
+         * @param {boolean} isAllSettled
+         */
+        createVow(specimens, isAllSettled) {
+          const { nextId: id, idToVowState } = this.state;
+          /** @type {VowKit<any[]>} */
+          const kit = makeVowKit();
+
+          // Preserve the order of the results.
+          for (let index = 0; index < specimens.length; index += 1) {
+            watch(specimens[index], this.facets.watcher, {
+              id,
+              index,
+              numResults: specimens.length,
+              isAllSettled,
+            });
+          }
+
+          if (specimens.length > 0) {
+            // Save the state until rejection or all fulfilled.
+            this.state.nextId += 1n;
+            idToVowState.init(
+              id,
+              harden({
+                resolver: kit.resolver,
+                remaining: specimens.length,
+                resultsMap: detached.mapStore('resultsMap'),
+                isAllSettled,
+              }),
+            );
+            const idToNonStorableResults = provideLazyMap(
+              utilsToNonStorableResults,
+              this.facets.utils,
+              () => new Map(),
+            );
+            idToNonStorableResults.set(id, new Map());
+          } else {
+            // Base case: nothing to wait for.
+            kit.resolver.resolve(harden([]));
+          }
+          return kit.vow;
+        },
+        /**
+         * @param {unknown} result
+         * @param {object} ctx
+         * @param {bigint} ctx.id
+         * @param {number} ctx.index
+         * @param {number} ctx.numResults
+         * @param {boolean} ctx.isAllSettled
+         * @param {'fulfilled' | 'rejected'} status
+         */
+        processResult(result, { id, index, numResults, isAllSettled }, status) {
           const { idToVowState } = this.state;
           if (!idToVowState.has(id)) {
             // Resolution of the returned vow happened already.
             return;
           }
           const { remaining, resultsMap, resolver } = idToVowState.get(id);
+          if (!isAllSettled && status === 'rejected') {
+            // For 'all', we reject immediately on the first rejection
+            idToVowState.delete(id);
+            resolver.reject(result);
+            return;
+          }
+
+          const possiblyWrappedResult = isAllSettled
+            ? harden({
+                status,
+                [status === 'fulfilled' ? 'value' : 'reason']: result,
+              })
+            : result;
+
           const idToNonStorableResults = provideLazyMap(
             utilsToNonStorableResults,
             this.facets.utils,
@@ -152,15 +218,16 @@ export const prepareWatchUtils = (
           );
 
           // Capture the fulfilled value.
-          if (zone.isStorable(value)) {
-            resultsMap.init(index, value);
+          if (zone.isStorable(possiblyWrappedResult)) {
+            resultsMap.init(index, possiblyWrappedResult);
           } else {
-            nonStorableResults.set(index, value);
+            nonStorableResults.set(index, possiblyWrappedResult);
           }
           const vowState = harden({
             remaining: remaining - 1,
             resultsMap,
             resolver,
+            isAllSettled,
           });
           if (vowState.remaining > 0) {
             idToVowState.set(id, vowState);
@@ -177,25 +244,18 @@ export const prepareWatchUtils = (
               results[i] = resultsMap.get(i);
             } else {
               numLost += 1;
+              results[i] = isAllSettled
+                ? { status: 'rejected', reason: 'Unstorable result was lost' }
+                : undefined;
             }
           }
-          if (numLost > 0) {
+          if (numLost > 0 && !isAllSettled) {
             resolver.reject(
               assert.error(X`${numLost} unstorable results were lost`),
             );
           } else {
             resolver.resolve(harden(results));
           }
-        },
-        onRejected(value, { id, index: _index, numResults: _numResults }) {
-          const { idToVowState } = this.state;
-          if (!idToVowState.has(id)) {
-            // First rejection wins.
-            return;
-          }
-          const { resolver } = idToVowState.get(id);
-          idToVowState.delete(id);
-          resolver.reject(value);
         },
       },
       retryRejectionPromiseWatcher: {

--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -57,8 +57,8 @@ export const prepareWatchUtils = (
         asPromise: M.call(M.raw()).rest(M.raw()).returns(M.promise()),
       }),
       watcher: M.interface('Watcher', {
-        onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
-        onRejected: M.call(M.any()).rest(M.any()).returns(M.any()),
+        onFulfilled: M.call(M.raw()).rest(M.raw()).returns(M.raw()),
+        onRejected: M.call(M.raw()).rest(M.raw()).returns(M.raw()),
       }),
       retryRejectionPromiseWatcher: PromiseWatcherI,
     },

--- a/packages/vow/test/types.test-d.ts
+++ b/packages/vow/test/types.test-d.ts
@@ -16,3 +16,18 @@ expectType<(p1: number, p2: string) => Vow<{ someValue: 'bar' }>>(
     Promise.resolve({ someValue: 'bar' } as const),
   ),
 );
+
+expectType<
+  Vow<
+    (
+      | { status: 'fulfilled'; value: any }
+      | { status: 'rejected'; reason: any }
+    )[]
+  >
+>(
+  vt.allSettled([
+    Promise.resolve(1),
+    Promise.reject(new Error('test')),
+    Promise.resolve('hello'),
+  ]),
+);

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -6,21 +6,21 @@ import { E, getInterfaceOf } from '@endo/far';
 
 import { prepareBasicVowTools } from '../src/tools.js';
 
-test('allVows waits for a single vow to complete', async t => {
+test('vowTools.all waits for a single vow to complete', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const testPromiseP = Promise.resolve('promise');
   const vowA = watch(testPromiseP);
 
-  const result = await when(allVows([vowA]));
+  const result = await when(all([vowA]));
   t.is(result.length, 1);
   t.is(result[0], 'promise');
 });
 
-test('allVows waits for an array of vows to complete', async t => {
+test('vowTools.all waits for an array of vows to complete', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const testPromiseAP = Promise.resolve('promiseA');
   const testPromiseBP = Promise.resolve('promiseB');
@@ -29,14 +29,14 @@ test('allVows waits for an array of vows to complete', async t => {
   const vowB = watch(testPromiseBP);
   const vowC = watch(testPromiseCP);
 
-  const result = await when(allVows([vowA, vowB, vowC]));
+  const result = await when(all([vowA, vowB, vowC]));
   t.is(result.length, 3);
   t.like(result, ['promiseA', 'promiseB', 'promiseC']);
 });
 
-test('allVows returns vows in order', async t => {
+test('vowTools.all returns vows in order', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows, makeVowKit } = prepareBasicVowTools(zone);
+  const { watch, when, all, makeVowKit } = prepareBasicVowTools(zone);
   const kit = makeVowKit();
 
   const testPromiseAP = Promise.resolve('promiseA');
@@ -48,14 +48,14 @@ test('allVows returns vows in order', async t => {
   // test promie A and B should already be resolved.
   kit.resolver.resolve('promiseC');
 
-  const result = await when(allVows([vowA, vowC, vowB]));
+  const result = await when(all([vowA, vowC, vowB]));
   t.is(result.length, 3);
   t.like(result, ['promiseA', 'promiseC', 'promiseB']);
 });
 
-test('allVows rejects upon first rejection', async t => {
+test('vowTools.all rejects upon first rejection', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const testPromiseAP = Promise.resolve('promiseA');
   const testPromiseBP = Promise.reject(Error('rejectedA'));
@@ -70,58 +70,58 @@ test('allVows rejects upon first rejection', async t => {
     },
   });
 
-  await when(watch(allVows([vowA, vowB, vowC]), watcher));
+  await when(watch(all([vowA, vowB, vowC]), watcher));
 });
 
-test('allVows can accept vows awaiting other vows', async t => {
+test('vowTools.all can accept vows awaiting other vows', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const testPromiseAP = Promise.resolve('promiseA');
   const testPromiseBP = Promise.resolve('promiseB');
   const vowA = watch(testPromiseAP);
   const vowB = watch(testPromiseBP);
-  const resultA = allVows([vowA, vowB]);
+  const resultA = all([vowA, vowB]);
 
   const testPromiseCP = Promise.resolve('promiseC');
   const vowC = when(watch(testPromiseCP));
-  const resultB = await when(allVows([resultA, vowC]));
+  const resultB = await when(all([resultA, vowC]));
 
   t.is(resultB.length, 2);
   t.like(resultB, [['promiseA', 'promiseB'], 'promiseC']);
 });
 
-test('allVows - works with just promises', async t => {
+test('vowTools.all - works with just promises', async t => {
   const zone = makeHeapZone();
-  const { when, allVows } = prepareBasicVowTools(zone);
+  const { when, all } = prepareBasicVowTools(zone);
 
   const result = await when(
-    allVows([Promise.resolve('promiseA'), Promise.resolve('promiseB')]),
+    all([Promise.resolve('promiseA'), Promise.resolve('promiseB')]),
   );
   t.is(result.length, 2);
   t.like(result, ['promiseA', 'promiseB']);
 });
 
-test('allVows - watch promises mixed with vows', async t => {
+test('vowTools.all - watch promises mixed with vows', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const testPromiseP = Promise.resolve('vow');
   const vowA = watch(testPromiseP);
 
-  const result = await when(allVows([vowA, Promise.resolve('promise')]));
+  const result = await when(all([vowA, Promise.resolve('promise')]));
   t.is(result.length, 2);
   t.like(result, ['vow', 'promise']);
 });
 
-test('allVows can accept passable data (PureData)', async t => {
+test('vowTools.all can accept passable data (PureData)', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const testPromiseP = Promise.resolve('vow');
   const vowA = watch(testPromiseP);
 
-  const result = await when(allVows([vowA, 'string', 1n, { obj: true }]));
+  const result = await when(all([vowA, 'string', 1n, { obj: true }]));
   t.is(result.length, 4);
   t.deepEqual(result, ['vow', 'string', 1n, { obj: true }]);
 });
@@ -133,9 +133,9 @@ const prepareAccount = zone =>
     },
   });
 
-test('allVows supports Promise pipelining', async t => {
+test('vowTools.all supports Promise pipelining', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   // makeAccount returns a Promise
   const prepareLocalChain = makeAccount => {
@@ -157,7 +157,7 @@ test('allVows supports Promise pipelining', async t => {
 
   const Localchain = prepareLocalChain(prepareAccount(zone));
   const lcaP = E(Localchain).makeAccount();
-  const results = await when(watch(allVows([lcaP, E(lcaP).getAddress()])));
+  const results = await when(watch(all([lcaP, E(lcaP).getAddress()])));
   t.is(results.length, 2);
   const [acct, address] = results;
   t.is(getInterfaceOf(acct), 'Alleged: Account');
@@ -168,9 +168,9 @@ test('allVows supports Promise pipelining', async t => {
   );
 });
 
-test('allVows does NOT support Vow pipelining', async t => {
+test('vowTools.all does NOT support Vow pipelining', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   // makeAccount returns a Vow
   const prepareLocalChainVowish = makeAccount => {
@@ -195,7 +195,7 @@ test('allVows does NOT support Vow pipelining', async t => {
   const lcaP = E(Localchain).makeAccount();
   // @ts-expect-error Property 'getAddress' does not exist on type
   // 'EMethods<Required<PassStyled<"tagged", "Vow"> & { payload: VowPayload<any>; }>>'.
-  await t.throwsAsync(when(watch(allVows([lcaP, E(lcaP).getAddress()]))), {
+  await t.throwsAsync(when(watch(all([lcaP, E(lcaP).getAddress()]))), {
     message: 'target has no method "getAddress", has []',
   });
 });
@@ -253,16 +253,16 @@ test('asPromise handles watcher arguments', async t => {
   t.true(watcherCalled);
 });
 
-test('allVows handles unstorable results', async t => {
+test('vowTools.all handles unstorable results', async t => {
   const zone = makeHeapZone();
-  const { watch, when, allVows } = prepareBasicVowTools(zone);
+  const { watch, when, all } = prepareBasicVowTools(zone);
 
   const nonPassable = () => 'i am a function';
 
   const specimenA = Promise.resolve('i am a promise');
   const specimenB = watch(nonPassable);
 
-  const result = await when(allVows([specimenA, specimenB]));
+  const result = await when(all([specimenA, specimenB]));
   t.is(result.length, 2);
   t.is(result[0], 'i am a promise');
   t.is(result[1], nonPassable);

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -252,3 +252,19 @@ test('asPromise handles watcher arguments', async t => {
   t.is(result, 'watcher test');
   t.true(watcherCalled);
 });
+
+test('allVows handles unstorable results', async t => {
+  const zone = makeHeapZone();
+  const { watch, when, allVows } = prepareBasicVowTools(zone);
+
+  const nonPassable = () => 'i am a function';
+
+  const specimenA = Promise.resolve('i am a promise');
+  const specimenB = watch(nonPassable);
+
+  const result = await when(allVows([specimenA, specimenB]));
+  t.is(result.length, 2);
+  t.is(result[0], 'i am a promise');
+  t.is(result[1], nonPassable);
+  t.is(result[1](), 'i am a function');
+});


### PR DESCRIPTION
## Description

- adds vowTools helper that mimics the behavior of `Promise.allSettled` to support #9902
- tests unstorable results path which resulted in a type guard change

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
Updates `vow/README.md` with information about `VowTools`

### Testing Considerations
Includes unit tests 

### Upgrade Considerations
n/a, library code
