### PR TITLE
chore(x/swingset): Include "default" in vat-transcript-retention invalid value error message

### DIFF
--- a/golang/cosmos/x/swingset/config.go
+++ b/golang/cosmos/x/swingset/config.go
@@ -175,9 +175,10 @@ func SwingsetConfigFromViper(resolvedConfig servertypes.AppOptions) (*SwingsetCo
 		}
 	}
 	if util.IndexOf(transcriptRetentionValues, ssConfig.VatTranscriptRetention) == -1 {
+		valuesCopy := append([]string{}, transcriptRetentionValues...)
 		err := fmt.Errorf(
 			"value for vat-transcript-retention must be in %q",
-			transcriptRetentionValues,
+			append(valuesCopy, "default"),
 		)
 		return nil, err
 	}


### PR DESCRIPTION
Ref #10032

## Description
```diff
-value for vat-transcript-retention must be in ["archival" "operational"]
+value for vat-transcript-retention must be in ["archival" "operational" "default"]
```

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
n/a