### PR TITLE
fix(xsnap): Accommodate spaces in installation path

### DIFF
--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -9,6 +9,7 @@ Usage:
 import '@endo/init';
 
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { tmpName } from 'tmp';
 
 import { assert, q, Fail } from '@endo/errors';
@@ -21,7 +22,7 @@ const avaHandler = `./avaHandler.cjs`;
 
 /** @type { (ref: string, readFile: typeof import('fs').promises.readFile ) => Promise<string> } */
 const asset = (ref, readFile) =>
-  readFile(new URL(ref, import.meta.url).pathname, 'utf8');
+  readFile(fileURLToPath(new URL(ref, import.meta.url)), 'utf8');
 
 /**
  * When we bundle test scripts, we leave these externals

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 /* global process */
 import * as childProcessTop from 'child_process';
+import { fileURLToPath } from 'url';
 import fsTop from 'fs';
 import osTop from 'os';
 
 const { freeze } = Object;
 
 /** @param {string} path */
-const asset = path => new URL(path, import.meta.url).pathname;
+const asset = path => fileURLToPath(new URL(path, import.meta.url));
 
 const ModdableSDK = {
   MODDABLE: asset('../moddable'),

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -13,6 +13,7 @@ import osPowers from 'os';
 import fsPowers from 'fs';
 import { Readable } from 'stream';
 import { tmpName as tmpNamePower } from 'tmp';
+import { fileURLToPath } from 'url';
 import { makeQueue } from '@endo/stream';
 import { xsnap, DEFAULT_CRANK_METERING_LIMIT } from './xsnap.js';
 
@@ -38,7 +39,9 @@ function makeSyncStorage(path, { writeFileSync }) {
     file: fn => {
       /** @param {Uint8Array} data */
       const put = data =>
-        writeFileSync(new URL(fn, base).pathname, data, { flag: 'wx' });
+        writeFileSync(fileURLToPath(new URL(fn, base)), data, {
+          flag: 'wx',
+        });
 
       return freeze({
         put,
@@ -60,14 +63,18 @@ function makeSyncAccess(path, { readdirSync, readFileSync }) {
   const base = new URL(path, 'file://');
   /** @param {string} fn */
   const file = fn => {
-    const fullname = new URL(fn, base).pathname;
+    const fullname = fileURLToPath(new URL(fn, base));
 
     return freeze({
       getData: () => readFileSync(fullname),
       getText: () => readFileSync(fullname, 'utf-8'),
     });
   };
-  return freeze({ path, file, readdir: () => readdirSync(base.pathname) });
+  return freeze({
+    path,
+    file,
+    readdir: () => readdirSync(fileURLToPath(base)),
+  });
 }
 
 /**
@@ -320,7 +327,7 @@ export async function main(
 }
 
 /* global process */
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === fileURLToPath(new URL(import.meta.url))) {
   main([...process.argv.slice(2)], {
     spawn: childProcessPowers.spawn,
     fs: { ...fsPowers, ...fsPowers.promises },

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -4,6 +4,7 @@
 import { finished } from 'stream/promises';
 import { PassThrough, Readable } from 'stream';
 import { promisify } from 'util';
+import { fileURLToPath } from 'url';
 import { Fail, q } from '@endo/errors';
 import { makeNetstringReader, makeNetstringWriter } from '@endo/netstring';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
@@ -174,12 +175,14 @@ export async function xsnap(options) {
     throw Error(`xsnap does not support platform ${os}`);
   }
 
-  let bin = new URL(
-    `../xsnap-native/xsnap/build/bin/${platform}/${
-      debug ? 'debug' : 'release'
-    }/xsnap-worker`,
-    import.meta.url,
-  ).pathname;
+  let bin = fileURLToPath(
+    new URL(
+      `../xsnap-native/xsnap/build/bin/${platform}/${
+        debug ? 'debug' : 'release'
+      }/xsnap-worker`,
+      import.meta.url,
+    ),
+  );
 
   /** @type {PromiseKit<void>} */
   const vatExit = makePromiseKit();


### PR DESCRIPTION

## Description

When installed on a Mac via npm in nvm, the path to the xsnap binary inevitably includes a space as in `Application Support`. The pattern `new URL(location).pathname` does not account for URL encoded spaces in the input URL, as will occur based on `import.meta.url`. This pivots xsnap to use `url.fileURLToPath` instead which does take these into account as well as Windows drive letters.

### Security Considerations
None.

### Scaling Considerations
None.

### Documentation Considerations
None.

### Testing Considerations

I created a git worktree named `agoric sdk` for the development of this branch. The xsnap tests failed under that directory name before this change, and worked afterward.

### Upgrade Considerations
None.