### PR TITLE
test: try agoric-sdk with "no-passable-symbols" endo

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -394,9 +394,7 @@ export async function makeSwingsetController(
      */
     queueToVatRoot(vatName, method, args = [], resultPolicy = 'ignore') {
       const vatID = kernel.vatNameToID(vatName);
-      if (typeof method !== 'symbol') {
-        assert.typeof(method, 'string');
-      }
+      assert.typeof(method, 'string');
       const kref = kernel.getRootObject(vatID);
       const kpid = kernel.queueToKref(kref, method, args, resultPolicy);
       if (kpid) {
@@ -417,9 +415,7 @@ export async function makeSwingsetController(
     queueToVatObject(target, method, args = [], resultPolicy = 'ignore') {
       const targetKref = krefOf(target);
       assert.typeof(targetKref, 'string');
-      if (typeof method !== 'symbol') {
-        assert.typeof(method, 'string');
-      }
+      assert.typeof(method, 'string');
       const kpid = kernel.queueToKref(targetKref, method, args, resultPolicy);
       if (kpid) {
         kernel.kpRegisterInterest(kpid);

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -114,7 +114,7 @@ export function makeDeviceSlots(
     return {
       get(_target, prop) {
         lsdebug(`PreH proxy.get(${String(prop)})`);
-        if (typeof prop !== 'string' && typeof prop !== 'symbol') {
+        if (typeof prop !== 'string') {
           return undefined;
         }
         const p = (...args) => {

--- a/packages/SwingSet/src/lib/kdebug.js
+++ b/packages/SwingSet/src/lib/kdebug.js
@@ -35,10 +35,6 @@ export function legibilizeValue(val, slots, smallcaps) {
             return val.digits;
           case 'slot':
             return `@${slots[val.index]}`;
-          case 'symbol':
-            return `[${val.name}]`;
-          case '@@asyncIterator':
-            return `[Symbol.asyncIterator]`;
           case 'error':
             return `new ${val.name}('${val.message}')`;
           default:
@@ -112,8 +108,6 @@ export function legibilizeMethod(method, smallcaps) {
         default:
           return method;
       }
-    } else if (typeof method === 'symbol') {
-      return `[${method.toString()}]`;
     } else if (method === undefined) {
       return '<funcall>';
     } else if (typeof method === 'object') {
@@ -123,10 +117,6 @@ export function legibilizeMethod(method, smallcaps) {
       const qclass = method['@qclass'];
       if (qclass === 'undefined') {
         return '<funcall>';
-      } else if (qclass === 'symbol') {
-        return `[${method.name}]`;
-      } else if (qclass === '@@asyncIterator') {
-        return `[Symbol.asyncIterator]`;
       } else {
         return '<invalid method type>';
       }

--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -133,6 +133,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../../tools/bootstrap-relay.js', {
     defaultManagerType,

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { Fail, makeError, q } from '@endo/errors';
 import { E } from '@endo/far';
-import { isObject, isPassableSymbol } from '@endo/marshal';
+import { isObject } from '@endo/marshal';
 import { getInterfaceMethodKeys } from '@endo/patterns';
 
 /** @import {ERef} from '@endo/far' */
@@ -128,8 +128,7 @@ export const makeSyncMethodCallback = (target, methodName, ...bound) => {
   isObject(target) ||
     Fail`sync method callback target must be an object: ${target}`;
   typeof methodName === 'string' ||
-    isPassableSymbol(methodName) ||
-    Fail`method name must be a string or passable symbol: ${methodName}`;
+    Fail`method name must be a string: ${methodName}`;
   /** @type {unknown} */
   const cb = harden({ target, methodName, bound, isSync: true });
   return /** @type {SyncCallback<I>} */ (cb);
@@ -153,8 +152,7 @@ harden(makeSyncMethodCallback);
 export const makeMethodCallback = (target, methodName, ...bound) => {
   isObject(target) || Fail`method callback target must be an object: ${target}`;
   typeof methodName === 'string' ||
-    isPassableSymbol(methodName) ||
-    Fail`method name must be a string or passable symbol: ${methodName}`;
+    Fail`method name must be a string: ${methodName}`;
   /** @type {unknown} */
   const cb = harden({ target, methodName, bound });
   return /** @type {Callback<I>} */ (cb);
@@ -172,9 +170,7 @@ export const isCallback = callback => {
   const { target, methodName, bound } = callback;
   return (
     isObject(target) &&
-    (methodName === undefined ||
-      typeof methodName === 'string' ||
-      isPassableSymbol(methodName)) &&
+    (methodName === undefined || typeof methodName === 'string') &&
     Array.isArray(bound)
   );
 };

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -190,7 +190,6 @@ export const prepareOfferWatcher = (baggage, vowTools) => {
             case 'null':
             case 'number':
             case 'string':
-            case 'symbol':
             case 'undefined':
               facets.helper.updateStatus({ result });
               break;

--- a/packages/swingset-liveslots/src/facetiousness.js
+++ b/packages/swingset-liveslots/src/facetiousness.js
@@ -23,11 +23,7 @@ export function assessFacetiousness(obj) {
     let resultFromProp;
     if (typeof value === 'function') {
       resultFromProp = 'one';
-    } else if (
-      // symbols are not permitted as facet names
-      typeof prop !== 'symbol' &&
-      assessFacetiousness(value) === 'one'
-    ) {
+    } else if (assessFacetiousness(value) === 'one') {
       resultFromProp = 'many';
     } else {
       return 'not';

--- a/packages/swingset-liveslots/src/kdebug.js
+++ b/packages/swingset-liveslots/src/kdebug.js
@@ -35,10 +35,6 @@ export function legibilizeValue(val, slots, smallcaps) {
             return val.digits;
           case 'slot':
             return `@${slots[val.index]}`;
-          case 'symbol':
-            return `[${val.name}]`;
-          case '@@asyncIterator':
-            return `[Symbol.asyncIterator]`;
           case 'error':
             return `new ${val.name}('${val.message}')`;
           default:
@@ -111,8 +107,6 @@ export function legibilizeMethod(method, smallcaps) {
         default:
           return method;
       }
-    } else if (typeof method === 'symbol') {
-      return `[${method.toString()}]`;
     } else if (method === undefined) {
       return '<funcall>';
     } else if (typeof method === 'object') {
@@ -122,10 +116,6 @@ export function legibilizeMethod(method, smallcaps) {
       const qclass = method['@qclass'];
       if (qclass === 'undefined') {
         return '<funcall>';
-      } else if (qclass === 'symbol') {
-        return `[${method.name}]`;
-      } else if (qclass === '@@asyncIterator') {
-        return `[Symbol.asyncIterator]`;
       } else {
         return '<invalid method type>';
       }

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -853,7 +853,7 @@ function build(
   function DeviceHandler(slot) {
     return {
       get(target, prop) {
-        if (typeof prop !== 'string' && typeof prop !== 'symbol') {
+        if (typeof prop !== 'string') {
           return undefined;
         }
         return (...args) => {

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -353,12 +353,6 @@ export function main() {
             case 'slot':
               result = pref(slots[val.index]);
               break;
-            case 'symbol':
-              result = `[${val.name}]`;
-              break;
-            case '@@asyncIterator':
-              result = `[Symbol.asyncIterator]`;
-              break;
             case 'error':
               result = `new ${val.name}('${val.message}')`;
               break;
@@ -438,8 +432,6 @@ export function main() {
           default:
             return method;
         }
-      } else if (typeof method === 'symbol') {
-        return `[${method.toString()}]`;
       } else if (method === undefined) {
         return '<funcall>';
       } else if (typeof method === 'object') {
@@ -449,10 +441,6 @@ export function main() {
         const qclass = method['@qclass'];
         if (qclass === 'undefined') {
           return '<funcall>';
-        } else if (qclass === 'symbol') {
-          return `[${method.name}]`;
-        } else if (qclass === '@@asyncIterator') {
-          return `[Symbol.asyncIterator]`;
         } else {
           return '<invalid method type>';
         }

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -163,7 +163,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
   /** @typedef {ReturnType<typeof parseMsg>} ParsedMessage */
   /** @param {import('@agoric/swingset-vat').Message | OldMessage} msg */
   const parseMsg = msg => {
-    /** @type {string | symbol | null} */
+    /** @type {string | null} */
     let method = null;
     /** @type {unknown[]} */
     let args;
@@ -201,10 +201,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
     const sendKind = (sync && 'D') || (result && 'E') || 'SO';
     const prefix = detailsPrefix ? `${detailsPrefix}: ` : '';
     let methodDetail;
-    if (typeof method === 'symbol') {
-      method = String(method);
-      methodDetail = `[${method}]`;
-    } else if (method == null) {
+    if (method == null) {
       methodDetail = '';
     } else {
       methodDetail = `.${method}`;

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -140,10 +140,8 @@ export const extract = (template, specimen, path = []) => {
     );
     return new Proxy(target, {
       get: (t, propName) => {
-        if (typeof propName !== 'symbol') {
-          propName in t ||
-            Fail`${q(propName)} not permitted, only ${q(keys(template))}`;
-        }
+        propName in t ||
+          Fail`${q(propName)} not permitted, only ${q(keys(template))}`;
         return t[propName];
       },
     });


### PR DESCRIPTION
#endo-branch: markm-no-passable-symbols


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2452

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
