### PR TITLE
chore: upgrade-17 RC1 cherry picks

### DIFF
--- a/packages/boot/test/bootstrapTests/vat-orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/vat-orchestration.test.ts
@@ -55,6 +55,11 @@ test.before(async t => {
     await evalProposal(
       buildProposal('@agoric/builders/scripts/vats/init-orchestration.js'),
     );
+    await evalProposal(
+      buildProposal(
+        '@agoric/builders/scripts/orchestration/write-chain-info.js',
+      ),
+    );
     const vatStore = await EV.vat('bootstrap').consumeItem('vatStore');
     t.true(await EV(vatStore).has('ibc'), 'ibc');
     t.true(await EV(vatStore).has('network'), 'network');

--- a/packages/builders/scripts/orchestration/write-chain-info.js
+++ b/packages/builders/scripts/orchestration/write-chain-info.js
@@ -1,0 +1,13 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async () =>
+  harden({
+    sourceSpec: '@agoric/orchestration/src/proposals/init-chain-info.js',
+    getManifestCall: ['getManifestForChainInfo'],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('gov-orchestration', defaultProposalBuilder);
+};

--- a/packages/orchestration/src/proposals/init-chain-info.js
+++ b/packages/orchestration/src/proposals/init-chain-info.js
@@ -1,0 +1,98 @@
+import { Fail } from '@endo/errors';
+import { E, Far } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
+import { makeTracer } from '@agoric/internal';
+import { registerKnownChains } from '../chain-info.js';
+import { CHAIN_KEY, CONNECTIONS_KEY } from '../exos/chain-hub.js';
+
+const trace = makeTracer('InitChainInfo', true);
+
+/**
+ * Similar to publishAgoricNamesToChainStorage but publishes a node per chain
+ * instead of one list of entries
+ */
+
+/**
+ * @param {ERef<import('@agoric/vats').NameHubKit['nameAdmin']>} agoricNamesAdmin
+ * @param {ERef<StorageNode | null>} chainStorageP
+ */
+const publishChainInfoToChainStorage = async (
+  agoricNamesAdmin,
+  chainStorageP,
+) => {
+  const chainStorage = await chainStorageP;
+  if (!chainStorage) {
+    console.warn('no chain storage, not registering chain info');
+    return;
+  }
+
+  const agoricNamesNode = await E(chainStorage).makeChildNode('agoricNames');
+
+  /**
+   * @param {string} subpath
+   */
+  const echoNameUpdates = async subpath => {
+    const chainNamesNode = E(agoricNamesNode).makeChildNode(subpath);
+    const { nameAdmin } = await E(agoricNamesAdmin).provideChild(subpath);
+
+    /**
+     * Previous entries, to prevent redundant updates
+     *
+     * @type {Record<string, string>} chainName => stringified chainInfo
+     */
+    const prev = {};
+
+    // XXX cannot be changed until we upgrade vat-agoricNames to allow it
+    await E(nameAdmin).onUpdate(
+      // XXX will live on the heap in the bootstrap vat. When we upgrade or kill
+      // that this handler will sever and vat-agoricNames will need to be upgraded
+      // to allow changing the handler, or to use pubsub mechanics instead.
+      Far('chain info writer', {
+        write(entries) {
+          // chainInfo has no cap data but we need to marshal bigints
+          const marshalData = makeMarshal(_val => Fail`data only`);
+          for (const [chainName, info] of entries) {
+            const value = JSON.stringify(marshalData.toCapData(info));
+            if (prev[chainName] === value) {
+              continue;
+            }
+            const chainNode = E(chainNamesNode).makeChildNode(chainName);
+            prev[chainName] = value;
+            void E(chainNode)
+              .setValue(value)
+              .catch(() => delete prev[chainName]);
+          }
+        },
+      }),
+    );
+  };
+  await echoNameUpdates(CHAIN_KEY);
+  await echoNameUpdates(CONNECTIONS_KEY);
+};
+
+/**
+ * @param {BootstrapPowers} powers
+ */
+export const initChainInfo = async ({
+  consume: { agoricNamesAdmin, chainStorage: chainStorageP },
+}) => {
+  trace('init-chainInfo');
+
+  // First set up callback to write updates to vstorage
+  await publishChainInfoToChainStorage(agoricNamesAdmin, chainStorageP);
+
+  // Now register the names
+  await registerKnownChains(agoricNamesAdmin, trace);
+};
+harden(initChainInfo);
+
+export const getManifestForChainInfo = () => ({
+  manifest: {
+    [initChainInfo.name]: {
+      consume: {
+        agoricNamesAdmin: true,
+        chainStorage: true,
+      },
+    },
+  },
+});

--- a/packages/orchestration/src/proposals/orchestration-proposal.js
+++ b/packages/orchestration/src/proposals/orchestration-proposal.js
@@ -1,9 +1,5 @@
-import { Fail } from '@endo/errors';
-import { E, Far } from '@endo/far';
-import { makeMarshal } from '@endo/marshal';
 import { makeTracer } from '@agoric/internal';
-import { registerKnownChains } from '../chain-info.js';
-import { CHAIN_KEY, CONNECTIONS_KEY } from '../exos/chain-hub.js';
+import { E } from '@endo/far';
 
 const trace = makeTracer('CoreEvalOrchestration', true);
 
@@ -27,14 +23,16 @@ export const setupOrchestrationVat = async (
     consume: { loadCriticalVat, portAllocator: portAllocatorP },
     produce: { orchestrationVat, ...produce },
   },
-  options,
+  { options },
 ) => {
-  const { orchestrationRef } = options.options;
+  trace('setupOrchestrationVat', options);
+  const { orchestrationRef } = options;
   const vats = {
     orchestration: E(loadCriticalVat)('orchestration', orchestrationRef),
   };
   // don't proceed if loadCriticalVat fails
   await Promise.all(Object.values(vats));
+  trace('setupOrchestrationVat got vats');
 
   orchestrationVat.reset();
   orchestrationVat.resolve(vats.orchestration);
@@ -49,86 +47,8 @@ export const setupOrchestrationVat = async (
 
   produce.cosmosInterchainService.reset();
   produce.cosmosInterchainService.resolve(cosmosInterchainService);
+  trace('setupOrchestrationVat complete');
 };
-
-/**
- * Similar to publishAgoricNamesToChainStorage but publishes a node per chain
- * instead of one list of entries
- */
-
-/**
- * @param {ERef<import('@agoric/vats').NameHubKit['nameAdmin']>} agoricNamesAdmin
- * @param {ERef<StorageNode | null>} chainStorageP
- */
-const publishChainInfoToChainStorage = async (
-  agoricNamesAdmin,
-  chainStorageP,
-) => {
-  const chainStorage = await chainStorageP;
-  if (!chainStorage) {
-    console.warn('no chain storage, not registering chain info');
-    return;
-  }
-
-  const agoricNamesNode = await E(chainStorage).makeChildNode('agoricNames');
-
-  /**
-   * @param {string} subpath
-   */
-  const echoNameUpdates = async subpath => {
-    const chainNamesNode = E(agoricNamesNode).makeChildNode(subpath);
-    const { nameAdmin } = await E(agoricNamesAdmin).provideChild(subpath);
-
-    /**
-     * Previous entries, to prevent redundant updates
-     *
-     * @type {Record<string, string>} chainName => stringified chainInfo
-     */
-    const prev = {};
-
-    // XXX cannot be changed until we upgrade vat-agoricNames to allow it
-    await E(nameAdmin).onUpdate(
-      // XXX will live on the heap in the bootstrap vat. When we upgrade or kill
-      // that this handler will sever and vat-agoricNames will need to be upgraded
-      // to allow changing the handler, or to use pubsub mechanics instead.
-      Far('chain info writer', {
-        write(entries) {
-          // chainInfo has no cap data but we need to marshal bigints
-          const marshalData = makeMarshal(_val => Fail`data only`);
-          for (const [chainName, info] of entries) {
-            const value = JSON.stringify(marshalData.toCapData(info));
-            if (prev[chainName] === value) {
-              continue;
-            }
-            const chainNode = E(chainNamesNode).makeChildNode(chainName);
-            prev[chainName] = value;
-            void E(chainNode)
-              .setValue(value)
-              .catch(() => delete prev[chainName]);
-          }
-        },
-      }),
-    );
-  };
-  await echoNameUpdates(CHAIN_KEY);
-  await echoNameUpdates(CONNECTIONS_KEY);
-};
-
-/**
- * @param {BootstrapPowers} powers
- */
-export const initChainInfo = async ({
-  consume: { agoricNamesAdmin, chainStorage: chainStorageP },
-}) => {
-  trace('init-chainInfo');
-
-  // First set up callback to write updates to vstorage
-  await publishChainInfoToChainStorage(agoricNamesAdmin, chainStorageP);
-
-  // Now register the names
-  await registerKnownChains(agoricNamesAdmin, trace);
-};
-harden(initChainInfo);
 
 export const getManifestForOrchestration = (_powers, { orchestrationRef }) => ({
   manifest: {
@@ -140,12 +60,6 @@ export const getManifestForOrchestration = (_powers, { orchestrationRef }) => ({
       produce: {
         cosmosInterchainService: 'cosmosInterchainService',
         orchestrationVat: 'orchestrationVat',
-      },
-    },
-    [initChainInfo.name]: {
-      consume: {
-        agoricNamesAdmin: true,
-        chainStorage: true,
       },
     },
   },

--- a/packages/vm-config/decentral-devnet-config.json
+++ b/packages/vm-config/decentral-devnet-config.json
@@ -13,7 +13,8 @@
         "@agoric/builders/scripts/vats/init-transfer.js"
       ],
       [
-        "@agoric/builders/scripts/vats/init-orchestration.js"
+        "@agoric/builders/scripts/vats/init-orchestration.js",
+        "@agoric/builders/scripts/orchestration/write-chain-info.js"
       ],
       [
         {

--- a/packages/vm-config/decentral-itest-orchestration-config.json
+++ b/packages/vm-config/decentral-itest-orchestration-config.json
@@ -8,6 +8,7 @@
         "@agoric/builders/scripts/vats/init-localchain.js",
         "@agoric/builders/scripts/vats/init-transfer.js",
         "@agoric/builders/scripts/vats/init-orchestration.js",
+        "@agoric/builders/scripts/orchestration/write-chain-info.js",
         {
             "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
             "entrypoint": "defaultProposalBuilder",


### PR DESCRIPTION
## Description

Includes commits from the following PRs:
* #10110

Does _not_ include a new upgrade name, because agoric-upgrade-17 has not yet been used in a proposal for any chain.

Constructed using the following `git rebase -i HEAD` todo list:
```
# pull request #10110 branch ta/defer-orchestration-agoricNames
label base-ta/defer-orchestration-agoricNames
pick fc1f3ce1fe03bb2018edd4eb55d6561312d5fbe8 fix: write-chain-info after u17
label ta/defer-orchestration-agoricNames
reset base-ta/defer-orchestration-agoricNames
merge -C 9cdb01dde5fdc3418fc9d615ab640d9f859555e6 ta/defer-orchestration-agoricNames # fix: write-chain-info after u17 (#10110)
```