### PR TITLE
Chore: Update gen-github-release.sh for usage and awk portability

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -326,7 +326,7 @@ to pass and for reviewer approval.
 
   Generate a template:
   ```sh
-  ./scripts/gen-github-release.sh <release-label> > release.md
+  ./scripts/gen-github-release.sh {prerelease | latest} <release-label> > release.md
   ```
   Then replace the remaining `$`-prefixed placeholders, filling in
   the [_**validator oriented release description**_](#describe-the-release) and using

--- a/scripts/gen-github-release.sh
+++ b/scripts/gen-github-release.sh
@@ -59,7 +59,7 @@ declare -r AWK_REPLACE_PLACEHOLDERS='
   BEGIN {
     for (i = 1; i < ARGC; i++) {
       arg = ARGV[i];
-      if (!match(arg, /^[^/=]+=/)) continue;
+      if (!match(arg, "^[^/=]+=")) continue;
       placeholder = "$" substr(arg, 1, RLENGTH - 1);
       placeholders[placeholder] = 1;
       subs[placeholder] = substr(arg, RLENGTH + 1, length(arg) - RLENGTH);


### PR DESCRIPTION
## Description
The AWK script had an unescaped slash that some implementations of `awk` reject, and MAINTAINERS.md failed to document the required maturity parameter.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
The only reference to this script has been updated.

### Testing Considerations
Verified manually.

### Upgrade Considerations
n/a