### PR TITLE
feat(localOrchAccount): Deposit, Withdraw invitationMakers

### DIFF
--- a/packages/orchestration/src/examples/send-anywhere.contract.js
+++ b/packages/orchestration/src/examples/send-anywhere.contract.js
@@ -1,23 +1,23 @@
 import { makeSharedStateRecord } from '@agoric/async-flow';
-import { AmountShape } from '@agoric/ertp';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { M } from '@endo/patterns';
 import { withOrchestration } from '../utils/start-helper.js';
 import * as flows from './send-anywhere.flows.js';
 import { prepareChainHubAdmin } from '../exos/chain-hub-admin.js';
+import { AnyNatAmountShape } from '../typeGuards.js';
 
 /**
  * @import {Zone} from '@agoric/zone';
  * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
  */
 
-export const SingleAmountRecord = M.and(
-  M.recordOf(M.string(), AmountShape, {
+export const SingleNatAmountRecord = M.and(
+  M.recordOf(M.string(), AnyNatAmountShape, {
     numPropertiesLimit: 1,
   }),
   M.not(harden({})),
 );
-harden(SingleAmountRecord);
+harden(SingleNatAmountRecord);
 
 /**
  * Orchestration contract to be wrapped by withOrchestration for Zoe
@@ -61,7 +61,7 @@ const contract = async (
           orchFns.sendIt,
           'send',
           undefined,
-          M.splitRecord({ give: SingleAmountRecord }),
+          M.splitRecord({ give: SingleNatAmountRecord }),
         );
       },
     },

--- a/packages/orchestration/src/examples/stakeBld.contract.js
+++ b/packages/orchestration/src/examples/stakeBld.contract.js
@@ -12,6 +12,7 @@ import { M } from '@endo/patterns';
 import { makeChainHub } from '../exos/chain-hub.js';
 import { prepareLocalOrchestrationAccountKit } from '../exos/local-orchestration-account.js';
 import fetchedChainInfo from '../fetched-chain-info.js';
+import { makeZoeTools } from '../utils/zoe-tools.js';
 
 /**
  * @import {NameHub} from '@agoric/vats';
@@ -43,6 +44,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const vowTools = prepareVowTools(zone.subZone('vows'));
 
   const chainHub = makeChainHub(privateArgs.agoricNames, vowTools);
+  const zoeTools = makeZoeTools(zcf, vowTools);
 
   const { localchain, timerService } = privateArgs;
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
@@ -54,6 +56,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       vowTools,
       chainHub,
       localchain,
+      zoeTools,
     },
   );
 

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -180,3 +180,13 @@ export const TxBodyOptsShape = M.splitRecord(
     nonCriticalExtensionOptions: M.arrayOf(M.any()),
   },
 );
+
+/**
+ * Ensures at least one {@link AmountKeywordRecord} entry is present and only
+ * permits Nat (fungible) amounts.
+ */
+export const AnyNatAmountsRecord = M.and(
+  M.recordOf(M.string(), AnyNatAmountShape),
+  M.not(harden({})),
+);
+harden(AnyNatAmountsRecord);

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -79,7 +79,15 @@ export const provideOrchestration = (
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
   const makeLocalOrchestrationAccountKit = prepareLocalOrchestrationAccountKit(
     zones.orchestration,
-    { makeRecorderKit, zcf, timerService, vowTools, chainHub, localchain },
+    {
+      makeRecorderKit,
+      zcf,
+      timerService,
+      vowTools,
+      chainHub,
+      localchain,
+      zoeTools,
+    },
   );
 
   const asyncFlowTools = prepareAsyncFlowTools(zones.asyncFlow, {

--- a/packages/orchestration/test/examples/basic-flows.contract.test.ts
+++ b/packages/orchestration/test/examples/basic-flows.contract.test.ts
@@ -4,6 +4,11 @@ import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
 import { E, getInterfaceOf } from '@endo/far';
 import path from 'path';
+import { makeIssuerKit } from '@agoric/ertp';
+import {
+  type AmountUtils,
+  withAmountUtils,
+} from '@agoric/zoe/tools/test-utils.js';
 import { commonSetup } from '../supports.js';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -16,6 +21,9 @@ type StartFn =
 type TestContext = Awaited<ReturnType<typeof commonSetup>> & {
   zoe: ZoeService;
   instance: Instance<StartFn>;
+  brands: Awaited<ReturnType<typeof commonSetup>>['brands'] & {
+    moolah: AmountUtils;
+  };
 };
 
 const test = anyTest as TestFn<TestContext>;
@@ -23,9 +31,12 @@ const test = anyTest as TestFn<TestContext>;
 test.beforeEach(async t => {
   const setupContext = await commonSetup(t);
   const {
+    brands: { bld, ist },
     bootstrap: { storage },
     commonPrivateArgs,
   } = setupContext;
+
+  const moolah = withAmountUtils(makeIssuerKit('MOO'));
 
   const { zoe, bundleAndInstall } = await setUpZoeForTest();
 
@@ -35,7 +46,7 @@ test.beforeEach(async t => {
   const storageNode = await E(storage.rootNode).makeChildNode(contractName);
   const { instance } = await E(zoe).startInstance(
     installation,
-    undefined,
+    { Stable: ist.issuer, Stake: bld.issuer, Moo: moolah.issuer },
     {},
     { ...commonPrivateArgs, storageNode },
   );
@@ -44,6 +55,7 @@ test.beforeEach(async t => {
     ...setupContext,
     zoe,
     instance,
+    brands: { ...setupContext.brands, moolah },
   };
 });
 
@@ -88,3 +100,137 @@ const orchestrationAccountScenario = test.macro({
 
 test(orchestrationAccountScenario, 'agoric');
 test(orchestrationAccountScenario, 'cosmoshub');
+
+test('Deposit, Withdraw - LocalOrchAccount', async t => {
+  const {
+    brands: { bld, ist },
+    bootstrap: { vowTools: vt },
+    zoe,
+    instance,
+    utils: { inspectBankBridge, pourPayment },
+  } = t.context;
+  const publicFacet = await E(zoe).getPublicFacet(instance);
+  const inv = E(publicFacet).makeOrchAccountInvitation();
+  const userSeat = E(zoe).offer(inv, {}, undefined, { chainName: 'agoric' });
+  const { invitationMakers } = await vt.when(E(userSeat).getOfferResult());
+
+  const twentyIST = ist.make(20n);
+  const tenBLD = bld.make(10n);
+  const Stable = await pourPayment(twentyIST);
+  const Stake = await pourPayment(tenBLD);
+
+  const depositInv = await E(invitationMakers).Deposit();
+
+  const depositSeat = E(zoe).offer(
+    depositInv,
+    {
+      give: { Stable: twentyIST, Stake: tenBLD },
+      want: {},
+    },
+    { Stable, Stake },
+  );
+  const depositRes = await vt.when(E(depositSeat).getOfferResult());
+  t.is(depositRes, undefined, 'undefined on success');
+
+  t.deepEqual(
+    inspectBankBridge().slice(-2),
+    [
+      {
+        type: 'VBANK_GIVE',
+        recipient: 'agoric1fakeLCAAddress',
+        denom: 'uist',
+        amount: '20',
+      },
+      {
+        type: 'VBANK_GIVE',
+        recipient: 'agoric1fakeLCAAddress',
+        denom: 'ubld',
+        amount: '10',
+      },
+    ],
+    'funds deposited to LCA',
+  );
+
+  const depositPayouts = await E(depositSeat).getPayouts();
+  t.is((await ist.issuer.getAmountOf(depositPayouts.Stable)).value, 0n);
+  t.is((await bld.issuer.getAmountOf(depositPayouts.Stake)).value, 0n);
+
+  // withdraw the payments we just deposited
+  const withdrawInv = await E(invitationMakers).Withdraw();
+  const withdrawSeat = E(zoe).offer(withdrawInv, {
+    give: {},
+    want: { Stable: twentyIST, Stake: tenBLD },
+  });
+  const withdrawRes = await vt.when(E(withdrawSeat).getOfferResult());
+  t.is(withdrawRes, undefined, 'undefined on success');
+
+  const withdrawPayouts = await E(withdrawSeat).getPayouts();
+  t.deepEqual(await ist.issuer.getAmountOf(withdrawPayouts.Stable), twentyIST);
+  t.deepEqual(await bld.issuer.getAmountOf(withdrawPayouts.Stake), tenBLD);
+});
+
+test('Deposit, Withdraw errors - LocalOrchAccount', async t => {
+  const {
+    brands: { ist, moolah },
+    bootstrap: { vowTools: vt },
+    zoe,
+    instance,
+  } = t.context;
+  const publicFacet = await E(zoe).getPublicFacet(instance);
+  const inv = E(publicFacet).makeOrchAccountInvitation();
+  const userSeat = E(zoe).offer(inv, {}, undefined, { chainName: 'agoric' });
+  const { invitationMakers } = await vt.when(E(userSeat).getOfferResult());
+
+  // deposit non-vbank asset (not supported)
+  const tenMoolah = moolah.make(10n);
+  const Moo = await E(moolah.mint).mintPayment(tenMoolah);
+  const depositInv = await E(invitationMakers).Deposit();
+  const depositSeat = E(zoe).offer(
+    depositInv,
+    {
+      give: { Moo: tenMoolah },
+      want: {},
+    },
+    { Moo },
+  );
+  await t.throwsAsync(vt.when(E(depositSeat).getOfferResult()), {
+    message:
+      'One or more deposits failed ["[Error: key \\"[Alleged: MOO brand]\\" not found in collection \\"brandToAssetRecord\\"]"]',
+  });
+  const depositPayouts = await E(depositSeat).getPayouts();
+  t.deepEqual(
+    await moolah.issuer.getAmountOf(depositPayouts.Moo),
+    tenMoolah,
+    'deposit returned on failure',
+  );
+
+  {
+    // withdraw more than balance (insufficient funds)
+    const tenIST = ist.make(10n);
+    const withdrawInv = await E(invitationMakers).Withdraw();
+    const withdrawSeat = E(zoe).offer(withdrawInv, {
+      give: {},
+      want: { Stable: tenIST },
+    });
+    await t.throwsAsync(vt.when(E(withdrawSeat).getOfferResult()), {
+      message:
+        'One or more withdrawals failed ["[RangeError: -10 is negative]"]',
+    });
+    const payouts = await E(withdrawSeat).getPayouts();
+    t.deepEqual((await ist.issuer.getAmountOf(payouts.Stable)).value, 0n);
+  }
+  {
+    // withdraw non-vbank asset
+    const withdrawInv = await E(invitationMakers).Withdraw();
+    const withdrawSeat = E(zoe).offer(withdrawInv, {
+      give: {},
+      want: { Moo: tenMoolah },
+    });
+    await t.throwsAsync(vt.when(E(withdrawSeat).getOfferResult()), {
+      message:
+        'One or more withdrawals failed ["[Error: key \\"[Alleged: MOO brand]\\" not found in collection \\"brandToAssetRecord\\"]"]',
+    });
+    const payouts = await E(withdrawSeat).getPayouts();
+    t.deepEqual((await moolah.issuer.getAmountOf(payouts.Moo)).value, 0n);
+  }
+});

--- a/packages/orchestration/test/examples/send-anywhere.test.ts
+++ b/packages/orchestration/test/examples/send-anywhere.test.ts
@@ -13,7 +13,7 @@ import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { CosmosChainInfo, IBCConnectionInfo } from '../../src/cosmos-api.js';
 import { commonSetup } from '../supports.js';
-import { SingleAmountRecord } from '../../src/examples/send-anywhere.contract.js';
+import { SingleNatAmountRecord } from '../../src/examples/send-anywhere.contract.js';
 import { registerChain } from '../../src/chain-info.js';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -48,10 +48,10 @@ test('single amount proposal shape (keyword record)', async t => {
     ],
   });
   for (const give of cases.good) {
-    t.notThrows(() => mustMatch(give, SingleAmountRecord));
+    t.notThrows(() => mustMatch(give, SingleNatAmountRecord));
   }
   for (const { give, msg } of cases.bad) {
-    t.throws(() => mustMatch(give, SingleAmountRecord), {
+    t.throws(() => mustMatch(give, SingleNatAmountRecord), {
       message: msg,
     });
   }


### PR DESCRIPTION
refs: #9193

## Description
Adds `Deposit` and `Withdraw` invitationMakers to `LocalOrchestrationAccount`, leveraging `ZoeTools.localTransfer` and `ZoeTools.withdrawToSeat`

### Security Considerations
Involves withdrawing payments to a temporary seat, which can be risky.  Leverages `ZoeTools` which rolls back allocations in failure and partial failure scenarios.

### Scaling Considerations
n/a

### Documentation Considerations
I'm not sure how well we document the platform-provided `invitationMakers` and `.asContinuingOffer()` helper. We might consider doing so in the future.

### Testing Considerations
Includes new unit tests. Wallet Driver tests in an e2e environment are coming in a future PR after #9966 lands

### Upgrade Considerations
n/a, library code
