### PR TITLE
test(boot): Add entropy to Swingset config file names for uniqueness in concurrent testing

### DIFF
--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/Agoric/agoric-sdk",
   "scripts": {
     "build": "exit 0",
+    "clean": "rm -rf bundles/config.*",
     "test": "ava",
     "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava test/bootstrapTests test/upgrading",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -98,11 +98,12 @@ export const keyArrayEqual = (
   return t.deepEqual(aobj, bobj, message);
 };
 
-export const getNodeTestVaultsConfig = async (
+export const getNodeTestVaultsConfig = async ({
   bundleDir = 'bundles',
   specifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
   defaultManagerType = 'local' as ManagerType,
-) => {
+  discriminator = '',
+}) => {
   const fullPath = await importMetaResolve(specifier, import.meta.url).then(
     u => new URL(u).pathname,
   );
@@ -129,7 +130,15 @@ export const getNodeTestVaultsConfig = async (
     );
   }
 
-  const testConfigPath = `${bundleDir}/${basename(specifier)}`;
+  // make an almost-certainly-unique file name with a fixed-length prefix
+  const configFilenameParts = [
+    'config',
+    discriminator,
+    new Date().toISOString().replaceAll(/[^0-9TZ]/g, ''),
+    `${Math.random()}`.replace(/.*[.]/, '').padEnd(8, '0').slice(0, 8),
+    basename(specifier),
+  ].filter(s => !!s);
+  const testConfigPath = `${bundleDir}/${configFilenameParts.join('.')}`;
   await fsAmbientPromises.writeFile(
     testConfigPath,
     JSON.stringify(config),
@@ -287,6 +296,7 @@ export const matchIter = (t: AvaT, iter, valueRef) => {
  * @param bundleDir directory to write bundles and config to
  * @param [options]
  * @param [options.configSpecifier] bootstrap config specifier
+ * @param [options.label] bootstrap config specifier
  * @param [options.storage]
  * @param [options.verbose]
  * @param [options.slogFile]
@@ -299,6 +309,7 @@ export const makeSwingsetTestKit = async (
   bundleDir = 'bundles',
   {
     configSpecifier = undefined as string | undefined,
+    label = undefined as string | undefined,
     storage = makeFakeStorageKit('bootstrapTests'),
     verbose = false,
     slogFile = undefined as string | undefined,
@@ -308,11 +319,12 @@ export const makeSwingsetTestKit = async (
   } = {},
 ) => {
   console.time('makeBaseSwingsetTestKit');
-  const configPath = await getNodeTestVaultsConfig(
+  const configPath = await getNodeTestVaultsConfig({
     bundleDir,
-    configSpecifier,
+    specifier: configSpecifier,
+    discriminator: label,
     defaultManagerType,
-  );
+  });
   const swingStore = initSwingStore();
   const { kernelStorage, hostStorage } = swingStore;
   const { fromCapData } = boardSlottingMarshaller(slotToBoardRemote);


### PR DESCRIPTION
Fixes #10092

## Description
Rather than having concurrently-running tests fight over e.g. **bundles/decentral-itest-vaults-config.json**, add some entropy to the file name. In this PR, I've chosen **bundles/config.${optionalLabel}.${dateTime}.${randomDigits}.decentral-itest-vaults-config.json**, although no current test is taking advantage of the label option.

### Security Considerations
n/a

### Scaling Considerations
There's a chance that local `bundles` directories fill up with identical config files. They're easily cleaned up by hand, but if this becomes an actual problem then we can add package.json `clean` scripts for that, or even update `getNodeTestVaultsConfig` to check for and reuse such files.

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
n/a