### PR TITLE
test(boot): simulate incoming vtransfer bridge events

### DIFF
--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -627,6 +627,9 @@ export const makeSwingsetTestKit = async (
       console.log('🧻');
       return i;
     },
+    async runInbound(bridgeId: BridgeIdValue, msg: unknown) {
+      await runUtils.queueAndRun(() => inbound(bridgeId, msg), true);
+    },
   };
 
   return {

--- a/packages/orchestration/tools/ibc-mocks.ts
+++ b/packages/orchestration/tools/ibc-mocks.ts
@@ -6,7 +6,7 @@ import {
   ResponseQuery,
 } from '@agoric/cosmic-proto/tendermint/abci/types.js';
 import { encodeBase64, btoa, atob, decodeBase64 } from '@endo/base64';
-import { toRequestQueryJson } from '@agoric/cosmic-proto';
+import { type JsonSafe, toRequestQueryJson } from '@agoric/cosmic-proto';
 import {
   IBCChannelID,
   IBCEvent,
@@ -156,14 +156,15 @@ type BuildVTransferEventParams = {
   event?: VTransferIBCEvent['event'];
   /* defaults to cosmos1AccAddress. set to `agoric1fakeLCAAddress` to simulate an outgoing transfer event */
   sender?: ChainAddress['value'];
-  /**  defaults to agoric1fakeLCAAddress. set to a different value to simulate an outgoing transfer event */
+  /*  defaults to agoric1fakeLCAAddress. set to a different value to simulate an outgoing transfer event */
   receiver?: ChainAddress['value'];
   target?: ChainAddress['value'];
   amount?: bigint;
   denom?: string;
   destinationChannel?: IBCChannelID;
   sourceChannel?: IBCChannelID;
-  sequence?: PacketSDKType['sequence'];
+  /* support bigint and string, to facilitate bootstrap testing */
+  sequence?: PacketSDKType['sequence'] | JsonSafe<PacketSDKType['sequence']>;
 };
 
 /**


### PR DESCRIPTION
closes: #10131

## Description
- adds `runInbound` to `bridgeUtils` in bootstrap test support to simulate an incoming bridge events, like a packet acknowledgement
- updates `send-anywhere` boot test so it's no longer failing
   - leaves contract upgrade aspect of test TODO until #9303

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Addreses a `test.failing` checked in

### Upgrade Considerations
n/a, example contract and test support tools
