### PR TITLE
10143 require extensions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -75,8 +75,12 @@ module.exports = {
     tsconfigRootDir: __dirname,
     extraFileExtensions: ['.cjs'],
   },
-  plugins: ['@typescript-eslint', 'prettier'],
-  extends: ['@agoric', 'plugin:ava/recommended'],
+  plugins: ['@typescript-eslint', 'prettier', 'require-extensions'],
+  extends: [
+    '@agoric',
+    'plugin:ava/recommended',
+    'plugin:require-extensions/recommended',
+  ],
   // XXX false positive: Unused eslint-disable directive (no problems were reported from 'max-len')
   reportUnusedDisableDirectives: true,
 

--- a/multichain-testing/scripts/pod-readiness.ts
+++ b/multichain-testing/scripts/pod-readiness.ts
@@ -1,5 +1,5 @@
 import { execa } from 'execa';
-import { sleep } from '../tools/sleep.ts';
+import { sleep } from '../tools/sleep.js';
 
 const checkPodsReadiness = async (): Promise<boolean> => {
   const { stdout } = await execa('kubectl', ['get', 'pods']);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsdoc": "^48.5.2",
     "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-require-extensions": "^0.1.3",
     "lerna": "^5.6.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.2",

--- a/packages/orchestration/src/exos/exo-interfaces.ts
+++ b/packages/orchestration/src/exos/exo-interfaces.ts
@@ -1,6 +1,6 @@
 import type { IBCConnectionID } from '@agoric/vats';
 import type { Vow } from '@agoric/vow';
-import type { IcaAccount } from '../cosmos-api.ts';
+import type { IcaAccount } from '../cosmos-api.js';
 import type { ICAChannelAddressOpts } from '../utils/address.js';
 import type { ICQConnection } from './icq-connection-kit.js';
 

--- a/packages/orchestration/src/exos/exo-interfaces.ts
+++ b/packages/orchestration/src/exos/exo-interfaces.ts
@@ -1,8 +1,8 @@
 import type { IBCConnectionID } from '@agoric/vats';
 import type { Vow } from '@agoric/vow';
 import type { IcaAccount } from '../cosmos-api.ts';
-import type { ICAChannelAddressOpts } from '../utils/address';
-import type { ICQConnection } from './icq-connection-kit';
+import type { ICAChannelAddressOpts } from '../utils/address.js';
+import type { ICQConnection } from './icq-connection-kit.js';
 
 /**
  * Authority to make a Cosmos interchain account or an interchain query connection.

--- a/packages/zoe/src/zoeService/utils.test-d.ts
+++ b/packages/zoe/src/zoeService/utils.test-d.ts
@@ -1,5 +1,5 @@
 import { E } from '@endo/far';
-import type { StartedInstanceKit } from './utils';
+import type { StartedInstanceKit } from './utils.js';
 
 const someContractStartFn = (
   zcf: ZCF,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6021,6 +6021,11 @@ eslint-plugin-prettier@^5.0.0, eslint-plugin-prettier@^5.1.3:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.8.6"
 
+eslint-plugin-require-extensions@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz#394aeab433f996797a6ceba0a3f75640d4846bc8"
+  integrity sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==
+
 eslint-rule-docs@^1.1.5:
   version "1.1.231"
   resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.231.tgz#648b978bc5a1bb740be5f28d07470f0926b9cdf1"


### PR DESCRIPTION
closes: #10143

## Description

The local tsconfig using `moduleResolution: bundler` doesn't require it but consumers of these packages can have other moduleResolution configs that do. For example, dapp-orchestration-basics in #10143.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
nothing

### Testing Considerations
ran `lint-fix` locally to test that it works.

### Upgrade Considerations
none