### PR TITLE
build proposals for PriceFeed coreEvals on multiple platforms.

### DIFF
--- a/a3p-integration/.gitignore
+++ b/a3p-integration/.gitignore
@@ -22,5 +22,5 @@ proposals/*/.yarn/*
 !proposals/*/.yarn/versions
 
 # build artifacts
-proposals/*/mainnet/*
-proposals/*/devnet/*
+proposals/*/mainNet/*
+proposals/*/devMet/*

--- a/a3p-integration/.gitignore
+++ b/a3p-integration/.gitignore
@@ -23,4 +23,4 @@ proposals/*/.yarn/*
 
 # build artifacts
 proposals/*/mainNet/*
-proposals/*/devMet/*
+proposals/*/devNet/*

--- a/a3p-integration/.gitignore
+++ b/a3p-integration/.gitignore
@@ -20,3 +20,7 @@ proposals/*/.yarn/*
 !proposals/*/.yarn/releases
 !proposals/*/.yarn/sdks
 !proposals/*/.yarn/versions
+
+# build artifacts
+proposals/*/mainnet/*
+proposals/*/devnet/*

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -4,11 +4,11 @@
     "fromTag": "use-vaults-auctions"
   },
   "scripts": {
-    "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
+    "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain && yarn run build:priceFeeds-for-mainnet && yarn run build:priceFeeds-for-devnet",
     "build:sdk": "make -C ../packages/deployment docker-build-sdk",
     "build:submissions": "scripts/build-all-submissions.sh",
-    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js f:mainNet UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js f:mainNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js f:mainNet",
-    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js f:devNet UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js f:devNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js f:devNet",
+    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js mainNet UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js mainNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js mainNet",
+    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js devNet UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js devNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js devNet",
     "build:synthetic-chain": "yarn synthetic-chain build",
     "test": "yarn synthetic-chain test",
     "doctor": "yarn synthetic-chain doctor"

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -4,9 +4,9 @@
     "fromTag": "use-vaults-auctions"
   },
   "scripts": {
-    "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain && yarn run build:priceFeeds-for-mainnet && yarn run build:priceFeeds-for-devnet",
+    "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
     "build:sdk": "make -C ../packages/deployment docker-build-sdk",
-    "build:submissions": "scripts/build-all-submissions.sh",
+    "build:submissions": "scripts/build-all-submissions.sh && yarn run build:priceFeeds-for-mainnet && yarn run build:priceFeeds-for-devnet",
     "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
     "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
     "build:synthetic-chain": "yarn synthetic-chain build",

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -7,8 +7,8 @@
     "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
     "build:sdk": "make -C ../packages/deployment docker-build-sdk",
     "build:submissions": "scripts/build-all-submissions.sh && yarn run build:priceFeeds-for-mainnet && yarn run build:priceFeeds-for-devnet",
-    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
-    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
+    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission/main main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js submission/main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js submission/main",
+    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission/devnet devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js submission/devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js submission/devnet",
     "build:synthetic-chain": "yarn synthetic-chain build",
     "test": "yarn synthetic-chain test",
     "doctor": "yarn synthetic-chain doctor"

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -7,8 +7,8 @@
     "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
     "build:sdk": "make -C ../packages/deployment docker-build-sdk",
     "build:submissions": "scripts/build-all-submissions.sh && yarn run build:priceFeeds-for-mainnet && yarn run build:priceFeeds-for-devnet",
-    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
-    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
+    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
+    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
     "build:synthetic-chain": "yarn synthetic-chain build",
     "test": "yarn synthetic-chain test",
     "doctor": "yarn synthetic-chain doctor"

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -7,8 +7,8 @@
     "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain && yarn run build:priceFeeds-for-mainnet && yarn run build:priceFeeds-for-devnet",
     "build:sdk": "make -C ../packages/deployment docker-build-sdk",
     "build:submissions": "scripts/build-all-submissions.sh",
-    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js mainNet UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js mainNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js mainNet",
-    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js devNet UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js devNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js devNet",
+    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
+    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js submission UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js",
     "build:synthetic-chain": "yarn synthetic-chain build",
     "test": "yarn synthetic-chain test",
     "doctor": "yarn synthetic-chain doctor"

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -7,6 +7,8 @@
     "build": "yarn run build:sdk && yarn run build:submissions && yarn run build:synthetic-chain",
     "build:sdk": "make -C ../packages/deployment docker-build-sdk",
     "build:submissions": "scripts/build-all-submissions.sh",
+    "build:priceFeeds-for-mainnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js f:mainNet UNRELEASED_main; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js f:mainNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js f:mainNet",
+    "build:priceFeeds-for-devnet": "scripts/build-submission.sh proposals/f:replace-price-feeds inter-protocol/updatePriceFeeds.js f:devNet UNRELEASED_devnet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/add-auction.js f:devNet; scripts/build-submission.sh proposals/f:replace-price-feeds vats/upgradeVaults.js f:devNet",
     "build:synthetic-chain": "yarn synthetic-chain build",
     "test": "yarn synthetic-chain test",
     "doctor": "yarn synthetic-chain doctor"

--- a/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
+++ b/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
@@ -77,7 +77,10 @@ export default async (homeP, endowments) => {
 
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval('gov-price-feeds', (utils, opts) =>
+  const match = scriptArgs[0].match(/UNRELEASED_(.*)/);
+  const variant = match ? match[1] : scriptArgs;
+
+  await writeCoreEval(`gov-price-feeds-${variant}`, (utils, opts) =>
     defaultProposalBuilder(utils, { ...opts, ...config }),
   );
 };


### PR DESCRIPTION
closes: #10076
refs: #10074

## Description

Build platform-dependent proposals for the PriceFeed coreEval. 

For each platform (not counting A3P) defined in `updatePriceFeeds.js`, a command is added, which invokes `scripts/build-submission.sh` three times to build each of the required proposals (updatePriceFeeds.js, add-auction.js, and upgradeVaults.js). The invocation for updatePriceFeeds takes a parameter specifying the platform.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

Not user-visible

### Testing Considerations

test on DevNet and MainFork

### Upgrade Considerations

It's all about upgrade. This coreEval has code that varies depending on the collaterals and oracles present, so we have to build separate proposals for each platform.
