### PR TITLE
ci: updated fixup check to only run for up to date PR

### DIFF
--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -107,11 +107,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Check for fixup commits
         id: fixup-commits
         run: |
-          if [[ $(git rev-list "$BASE_SHA".."$HEAD_SHA" --grep="^\(fixup\|amend\|squash\)! " | wc -l) -eq 0 ]]; then
+          if ! git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+             echo "PR is not up to date with target branch, skipping fixup commit check"
+          elif [[ $(git rev-list "$BASE_SHA".."$HEAD_SHA" --grep="^\(fixup\|amend\|squash\)! " | wc -l) -eq 0 ]]; then
             echo "No fixup/amend/squash commits found in commit history"
           else
             echo "fixup/amend/squash commits found in commit history"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Adds a condition to the fixup commit check in `mergify-ready.yml` which prevents the fixup commit check from running on any PR that is out of date with the master branch

When branch is not up to date:
![image](https://github.com/user-attachments/assets/66c29d69-f5a3-48f1-b0cb-23d066032971)

When branch is up to date:
![image](https://github.com/user-attachments/assets/0115c394-4028-4522-b3cd-c0aa47eea16a)

