### PR TITLE
fix: contractGovernor can change params after contract is upgraded

### DIFF
--- a/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
+++ b/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
@@ -81,6 +81,13 @@ test.serial('setupVaults; run updatePriceFeeds proposals', async t => {
   const SOME_GUI = 'someGUIHASH';
   await updateVaultDirectorParams(t, gd, SOME_GUI);
 
+  const { EV } = t.context.runUtils;
+  const agoricNames = await EV.vat('bootstrap').consumeItem('agoricNames');
+  const oldVaultInstallation = await EV(agoricNames).lookup(
+    'installation',
+    'VaultFactory',
+  );
+
   t.log('building all relevant CoreEvals');
   const coreEvals = await Promise.all([
     buildProposal(priceFeedBuilder, ['main']),
@@ -99,6 +106,16 @@ test.serial('setupVaults; run updatePriceFeeds proposals', async t => {
   t.not(instancePre, instancePost);
 
   await priceFeedDrivers[collateralBrandKey].refreshInvitations();
+
+  const newVaultInstallation = await EV(agoricNames).lookup(
+    'installation',
+    'VaultFactory',
+  );
+
+  t.notDeepEqual(
+    newVaultInstallation.getKref(),
+    oldVaultInstallation.getKref(),
+  );
 });
 
 test.serial('1. place bid', async t => {

--- a/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
+++ b/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
@@ -11,16 +11,12 @@ import type { TestFn } from 'ava';
 import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils';
 import { Fail } from '@endo/errors';
 
-import { AmountMath } from '@agoric/ertp/src';
 import { makeSwingsetTestKit } from '../../tools/supports.js';
 import {
   makeGovernanceDriver,
   makeWalletFactoryDriver,
 } from '../../tools/drivers.js';
-import {
-  updateVaultDirectorParams,
-  updateVaultManagerParams,
-} from '../tools/changeVaultParams';
+import { updateVaultManagerParams } from '../tools/changeVaultParams.js';
 
 const makeDefaultTestContext = async t => {
   console.time('DefaultTestContext');

--- a/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
+++ b/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @file The goal of this test is to show that #9982 is fixed
+ * We change a parameter so that provideParamGovernance() is called once, and
+ * paramGoverance has been set. Then upgrade vaultFactory, so any ephemeral
+ * objects from the contract held by the governor are gone, then try to change
+ * param again, to show that the bug is fixedd.
+ */
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import type { TestFn } from 'ava';
+import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils';
+import { Fail } from '@endo/errors';
+
+import { AmountMath } from '@agoric/ertp/src';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import {
+  makeGovernanceDriver,
+  makeWalletFactoryDriver,
+} from '../../tools/drivers.js';
+import {
+  updateVaultDirectorParams,
+  updateVaultManagerParams,
+} from '../tools/changeVaultParams';
+
+const makeDefaultTestContext = async t => {
+  console.time('DefaultTestContext');
+  const swingsetTestKit = await makeSwingsetTestKit(t.log);
+
+  const { runUtils, storage } = swingsetTestKit;
+  console.timeLog('DefaultTestContext', 'swingsetTestKit');
+  const { EV } = runUtils;
+
+  // Wait for ATOM to make it into agoricNames
+  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
+  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
+
+  // has to be late enough for agoricNames data to have been published
+  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(
+    swingsetTestKit.storage,
+  );
+  agoricNamesRemotes.brand.ATOM || Fail`ATOM missing from agoricNames`;
+  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
+
+  const walletFactoryDriver = await makeWalletFactoryDriver(
+    runUtils,
+    storage,
+    agoricNamesRemotes,
+  );
+  console.timeLog('DefaultTestContext', 'walletFactoryDriver');
+
+  console.timeEnd('DefaultTestContext');
+
+  const gd = await makeGovernanceDriver(
+    swingsetTestKit,
+    agoricNamesRemotes,
+    walletFactoryDriver,
+    [
+      'agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce',
+      'agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang',
+      'agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h',
+    ],
+  );
+
+  return { ...swingsetTestKit, agoricNamesRemotes, gd };
+};
+
+const test = anyTest as TestFn<
+  Awaited<ReturnType<typeof makeDefaultTestContext>>
+>;
+
+test.before(async t => {
+  t.context = await makeDefaultTestContext(t);
+});
+test.after.always(t => {
+  return t.context.shutdown && t.context.shutdown();
+});
+
+const outcome = {
+  bids: [{ payouts: { Bid: 0, Collateral: 1.800828 } }],
+};
+
+test('restart vaultFactory, change params', async t => {
+  const { runUtils, gd, agoricNamesRemotes } = t.context;
+  const { EV } = runUtils;
+  const vaultFactoryKit =
+    await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
+
+  const { ATOM } = agoricNamesRemotes.brand;
+  ATOM || Fail`ATOM missing from agoricNames`;
+
+  const reserveKit = await EV.vat('bootstrap').consumeItem('reserveKit');
+  const bootstrapVat = EV.vat('bootstrap');
+  const electorateCreatorFacet = await bootstrapVat.consumeItem(
+    'economicCommitteeCreatorFacet',
+  );
+
+  const poserInvitation = await EV(electorateCreatorFacet).getPoserInvitation();
+  const creatorFacet1 = await EV.get(reserveKit).creatorFacet;
+  const shortfallInvitation =
+    await EV(creatorFacet1).makeShortfallReportingInvitation();
+
+  const zoe: ZoeService = await EV.vat('bootstrap').consumeItem('zoe');
+  const brands = await EV(zoe).getBrands(vaultFactoryKit.instance);
+  const getDebtLimitValue = async () => {
+    const params = await EV(vaultFactoryKit.publicFacet).getGovernedParams({
+      collateralBrand: brands.ATOM,
+    });
+
+    // @ts-expect-error getGovernedParams doesn't declare these fields
+    return params.DebtLimit.value.value;
+  };
+
+  // Change the value of a param before the upgrade so paramGovernance is set
+  t.is(await getDebtLimitValue(), 1_000_000_000n);
+  await updateVaultManagerParams(t, gd, ATOM, 50_000_000n);
+
+  t.is(await getDebtLimitValue(), 50_000_000n);
+
+  const privateArgs = {
+    // @ts-expect-error cast XXX missing from type
+    ...vaultFactoryKit.privateArgs,
+    initialPoserInvitation: poserInvitation,
+    initialShortfallInvitation: shortfallInvitation,
+  };
+
+  const vfAdminFacet = await EV(
+    vaultFactoryKit.governorCreatorFacet,
+  ).getAdminFacet();
+
+  t.log('awaiting VaultFactory restartContract');
+  const upgradeResult = await EV(vfAdminFacet).restartContract(privateArgs);
+  t.deepEqual(upgradeResult, { incarnationNumber: 1 });
+
+  await updateVaultManagerParams(t, gd, ATOM, 150_000_000n);
+  t.is(await getDebtLimitValue(), 150_000_000n);
+});

--- a/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
@@ -286,10 +286,15 @@ test.serial('restart vaultFactory', async t => {
   const vaultFactoryKit =
     await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
 
-  const reserveKit = await EV.vat('bootstrap').consumeItem('reserveKit');
   const bootstrapVat = EV.vat('bootstrap');
+  const reserveKit = await bootstrapVat.consumeItem('reserveKit');
   const electorateCreatorFacet = await bootstrapVat.consumeItem(
     'economicCommitteeCreatorFacet',
+  );
+  const agoricNames = await EV.vat('bootstrap').consumeItem('agoricNames');
+  const oldVaultInstallation = await EV(agoricNames).lookup(
+    'installation',
+    'VaultFactory',
   );
 
   const poserInvitation = await EV(electorateCreatorFacet).getPoserInvitation();
@@ -319,6 +324,13 @@ test.serial('restart vaultFactory', async t => {
   const upgradeResult = await EV(vfAdminFacet).restartContract(privateArgs);
   t.deepEqual(upgradeResult, { incarnationNumber: 1 });
   t.like(readCollateralMetrics(0), keyMetrics); // unchanged
+
+  const newVaultInstallation = await EV(agoricNames).lookup(
+    'installation',
+    'VaultFactory',
+  );
+
+  t.notDeepEqual(newVaultInstallation, oldVaultInstallation);
 });
 
 test.serial('restart contractGovernor', async t => {

--- a/packages/builders/scripts/vats/add-auction.js
+++ b/packages/builders/scripts/vats/add-auction.js
@@ -13,6 +13,12 @@ export const defaultProposalBuilder = async ({ publishRef, install }) => {
             '../../inter-protocol/bundles/bundle-auctioneer.js',
           ),
         ),
+        governorRef: publishRef(
+          install(
+            '@agoric/governance/src/contractGovernor.js',
+            '../bundles/bundle-contractGovernor.js',
+          ),
+        ),
       },
     ],
   });

--- a/packages/builders/scripts/vats/add-auction.js
+++ b/packages/builders/scripts/vats/add-auction.js
@@ -7,13 +7,13 @@ export const defaultProposalBuilder = async ({ publishRef, install }) => {
     getManifestCall: [
       'getManifestForAddAuction',
       {
-        auctionsRef: publishRef(
+        auctioneerRef: publishRef(
           install(
             '@agoric/inter-protocol/src/auction/auctioneer.js',
             '../../inter-protocol/bundles/bundle-auctioneer.js',
           ),
         ),
-        governorRef: publishRef(
+        contractGovernorRef: publishRef(
           install(
             '@agoric/governance/src/contractGovernor.js',
             '../bundles/bundle-contractGovernor.js',

--- a/packages/builders/scripts/vats/upgradeVaults.js
+++ b/packages/builders/scripts/vats/upgradeVaults.js
@@ -7,13 +7,13 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
     getManifestCall: [
       'getManifestForUpgradeVaults',
       {
-        vaultsRef: publishRef(
+        VaultFactoryRef: publishRef(
           install(
             '@agoric/inter-protocol/src/vaultFactory/vaultFactory.js',
             '../bundles/bundle-vaultFactory.js',
           ),
         ),
-        governorRef: publishRef(
+        contractGovernorRef: publishRef(
           install(
             '@agoric/governance/src/contractGovernor.js',
             '../bundles/bundle-contractGovernor.js',

--- a/packages/builders/scripts/vats/upgradeVaults.js
+++ b/packages/builders/scripts/vats/upgradeVaults.js
@@ -13,6 +13,12 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
             '../bundles/bundle-vaultFactory.js',
           ),
         ),
+        governorRef: publishRef(
+          install(
+            '@agoric/governance/src/contractGovernor.js',
+            '../bundles/bundle-contractGovernor.js',
+          ),
+        ),
       },
     ],
   });

--- a/packages/deploy-script-support/src/coreProposalBehavior.js
+++ b/packages/deploy-script-support/src/coreProposalBehavior.js
@@ -167,6 +167,7 @@ export const makeCoreProposalBehavior = ({
       const installAdmin = E(agoricNamesAdmin).lookupAdmin('installation');
       await Promise.all(
         installationEntries.map(([key, value]) => {
+          produceInstallations[key].reset();
           produceInstallations[key].resolve(value);
           return E(installAdmin).update(key, value);
         }),

--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -55,14 +55,14 @@ const assertBallotConcernsParam = (paramSpec, questionSpec) => {
 };
 
 /**
- * @param {ERef<ParamManagerRetriever>} paramManagerRetriever
+ * @param {() => ERef<ParamManagerRetriever>} paramManagerRetrieverAccessor
  * @param {Instance} contractInstance
  * @param {import('@agoric/time').TimerService} timer
  * @param {() => Promise<PoserFacet>} getUpdatedPoserFacet
  * @returns {ParamGovernor}
  */
 const setupParamGovernance = (
-  paramManagerRetriever,
+  paramManagerRetrieverAccessor,
   contractInstance,
   timer,
   getUpdatedPoserFacet,
@@ -76,6 +76,7 @@ const setupParamGovernance = (
     deadline,
     paramSpec,
   ) => {
+    const paramManagerRetriever = paramManagerRetrieverAccessor();
     const paramMgr = await E(paramManagerRetriever).get(paramSpec.paramPath);
     /** @type {import('@endo/marshal').Passable} */
     const changePs = {};

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -160,7 +160,7 @@ export const prepareContractGovernorKit = (baggage, powers) => {
             const { timer } = powers;
             const { creatorFacet, instance } = this.state;
             paramGovernance = setupParamGovernance(
-              E(creatorFacet).getParamMgrRetriever(),
+              () => E(creatorFacet).getParamMgrRetriever(),
               instance,
               timer,
               () => this.facets.helper.getUpdatedPoserFacet(),

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -15,71 +15,52 @@ const trace = makeTracer('NewAuction', true);
 /**
  * @param {import('./econ-behaviors.js').EconomyBootstrapPowers &
  *   interlockPowers} powers
- * @param {{
- *   options: {
- *     auctionsRef: { bundleID: string };
- *     governorRef: { bundleID: string };
- *   };
- * }} options
  */
-export const addAuction = async (
-  {
+export const addAuction = async ({
+  consume: {
+    agoricNamesAdmin,
+    auctioneerKit: legacyKitP,
+    board,
+    chainStorage,
+    chainTimerService,
+    economicCommitteeCreatorFacet: electorateCreatorFacet,
+    econCharterKit,
+    priceAuthority8400,
+    zoe,
+  },
+  produce: { auctioneerKit: produceAuctioneerKit, auctionUpgradeNewInstance },
+  instance: {
+    consume: { reserve: reserveInstance },
+    produce: { auctioneer: auctionInstance },
+  },
+  installation: {
     consume: {
-      agoricNamesAdmin,
-      auctioneerKit: legacyKitP,
-      board,
-      chainStorage,
-      chainTimerService,
-      economicCommitteeCreatorFacet: electorateCreatorFacet,
-      econCharterKit,
-      priceAuthority8400,
-      zoe,
-    },
-    produce: { auctioneerKit: produceAuctioneerKit, auctionUpgradeNewInstance },
-    instance: {
-      consume: { reserve: reserveInstance },
-      produce: { auctioneer: auctionInstance },
-    },
-    installation: {
-      produce: {
-        auctioneer: produceAuctionInstallation,
-        contractGovernor: produceGovernorInstallation,
-      },
-    },
-    issuer: {
-      consume: { [Stable.symbol]: stableIssuerP },
+      auctioneer: auctioneerInstallationP,
+      contractGovernor: governorInstallationP,
     },
   },
-  { options },
-) => {
-  trace('addAuction start', options);
+  issuer: {
+    consume: { [Stable.symbol]: stableIssuerP },
+  },
+}) => {
+  trace('addAuction start');
   const STORAGE_PATH = 'auction';
-  const { auctionsRef, governorRef } = options;
 
   const poserInvitationP = E(electorateCreatorFacet).getPoserInvitation();
-  const auctioneerBundleID = auctionsRef.bundleID;
-  const governorBundleID = governorRef.bundleID;
-  /**
-   * @type {Promise<
-   *   Installation<import('../../src/auction/auctioneer.js')['start']>
-   * >}
-   */
-  const auctioneerInstallationP = E(zoe).installBundleID(auctioneerBundleID);
-  const governorInstallationP = E(zoe).installBundleID(governorBundleID);
-  produceAuctionInstallation.reset();
-  produceAuctionInstallation.resolve(auctioneerInstallationP);
-  produceGovernorInstallation.reset();
-  produceGovernorInstallation.resolve(governorInstallationP);
   const [
     initialPoserInvitation,
     electorateInvitationAmount,
     stableIssuer,
     legacyKit,
+    auctioneerInstallation,
+    governorInstallation,
   ] = await Promise.all([
     poserInvitationP,
     E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
     stableIssuerP,
     legacyKitP,
+    auctioneerInstallationP,
+    governorInstallationP,
   ]);
 
   // Each field has an extra layer of type +  value:
@@ -114,11 +95,6 @@ export const addAuction = async (
     },
   );
 
-  const [auctioneerInstallation, governorInstallation] = await Promise.all([
-    auctioneerInstallationP,
-    governorInstallationP,
-  ]);
-
   const governorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
@@ -149,12 +125,17 @@ export const addAuction = async (
     'auctioneer.governor',
   );
 
-  const [governedInstance, governedCreatorFacet, governedPublicFacet] =
-    await Promise.all([
-      E(governorStartResult.creatorFacet).getInstance(),
-      E(governorStartResult.creatorFacet).getCreatorFacet(),
-      E(governorStartResult.creatorFacet).getPublicFacet(),
-    ]);
+  const [
+    governedInstance,
+    governedCreatorFacet,
+    governedPublicFacet,
+    governedAdminFacet,
+  ] = await Promise.all([
+    E(governorStartResult.creatorFacet).getInstance(),
+    E(governorStartResult.creatorFacet).getCreatorFacet(),
+    E(governorStartResult.creatorFacet).getPublicFacet(),
+    E(governorStartResult.creatorFacet).getAdminFacet(),
+  ]);
 
   const allIssuers = await E(zoe).getIssuers(legacyKit.instance);
   const { Bid: _istIssuer, ...auctionIssuers } = allIssuers;
@@ -170,7 +151,7 @@ export const addAuction = async (
   const kit = harden({
     label: 'auctioneer',
     creatorFacet: governedCreatorFacet,
-    adminFacet: governorStartResult.adminFacet,
+    adminFacet: governedAdminFacet,
     publicFacet: governedPublicFacet,
     instance: governedInstance,
 
@@ -222,10 +203,7 @@ export const ADD_AUCTION_MANIFEST = harden({
       produce: { auctioneer: true },
     },
     installation: {
-      consume: {
-        contractGovernor: true,
-      },
-      produce: { auctioneer: true },
+      consume: { contractGovernor: true, auctioneer: true },
     },
     issuer: {
       consume: { [Stable.symbol]: true },
@@ -236,12 +214,20 @@ export const ADD_AUCTION_MANIFEST = harden({
 /**
  * Add a new auction to a chain that already has one.
  *
- * @param {object} _ign
+ * @param {object} utils
+ * @param {any} utils.restoreRef
  * @param {any} addAuctionOptions
  */
-export const getManifestForAddAuction = async (_ign, addAuctionOptions) => {
+export const getManifestForAddAuction = async (
+  { restoreRef },
+  { auctioneerRef, contractGovernorRef },
+) => {
   return {
     manifest: ADD_AUCTION_MANIFEST,
-    options: addAuctionOptions,
+    options: { auctioneerRef, contractGovernorRef },
+    installations: {
+      auctioneer: restoreRef(auctioneerRef),
+      contractGovernor: restoreRef(contractGovernorRef),
+    },
   };
 };

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -39,7 +39,7 @@ export const upgradeVaults = async (
       consume: { auctioneer: auctioneerInstanceP },
     },
   },
-  { options: { VaultFactoryBundle, contractGovernorBundle } },
+  { options: { VaultFactoryBundle: vaultBundleRef, contractGovernorBundle } },
 ) => {
   const kit = await vaultFactoryKit;
   const { instance: directorInstance } = kit;
@@ -139,7 +139,7 @@ export const upgradeVaults = async (
     });
 
     const upgradeResult = await E(kit.adminFacet).upgradeContract(
-      VaultFactoryBundle.bundleID,
+      vaultBundleRef.bundleID,
       newPrivateArgs,
     );
 

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -16,7 +16,12 @@ const trace = makeTracer('upgrade Vaults proposal');
 /**
  * @param {import('../../src/proposals/econ-behaviors').EconomyBootstrapPowers &
  *     interlockPowers} powers
- * @param {{ options: { vaultsRef: { bundleID: string } } }} options
+ * @param {{
+ *   options: {
+ *     vaultsRef: { bundleID: string };
+ *     governorRef: { bundleID: string };
+ *   };
+ * }} options
  */
 export const upgradeVaults = async (
   {
@@ -39,7 +44,7 @@ export const upgradeVaults = async (
   },
   { options },
 ) => {
-  const { vaultsRef } = options;
+  const { vaultsRef, governorRef } = options;
   const kit = await vaultFactoryKit;
   const { instance: directorInstance } = kit;
   const allBrands = await E(zoe).getBrands(directorInstance);
@@ -162,8 +167,9 @@ export const upgradeVaults = async (
   trace('restarting governor');
 
   const ecf = await electorateCreatorFacet;
-  // restart vaultFactory governor
-  await E(kit.governorAdminFacet).restartContract(
+  // upgrade vaultFactory governor. Won't be needed next time: see #10063
+  await E(kit.governorAdminFacet).upgradeContract(
+    governorRef.bundleID,
     harden({
       electorateCreatorFacet: ecf,
       governed: vaultFactoryPrivateArgs,

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -18,8 +18,8 @@ const trace = makeTracer('upgrade Vaults proposal');
  *     interlockPowers} powers
  * @param {{
  *   options: {
- *     vaultsRef: { bundleID: string };
- *     governorRef: { bundleID: string };
+ *     VaultFactoryBundle: { bundleID: string };
+ *     contractGovernorBundle: { bundleID: string };
  *   };
  * }} options
  */
@@ -35,33 +35,18 @@ export const upgradeVaults = async (
       priceAuthority8400,
     },
     produce: { auctionUpgradeNewInstance: auctionUpgradeNewInstanceProducer },
-    installation: {
-      produce: { VaultFactory: produceVaultInstallation },
-    },
     instance: {
       consume: { auctioneer: auctioneerInstanceP },
     },
   },
-  { options },
+  { options: { VaultFactoryBundle, contractGovernorBundle } },
 ) => {
-  const { vaultsRef, governorRef } = options;
   const kit = await vaultFactoryKit;
   const { instance: directorInstance } = kit;
   const allBrands = await E(zoe).getBrands(directorInstance);
   const { Minted: _istBrand, ...vaultBrands } = allBrands;
 
   await priceAuthority8400;
-
-  const bundleID = vaultsRef.bundleID;
-  console.log(`upgradeVaults: bundleId`, bundleID);
-  /**
-   * @type {Promise<
-   *   Installation<import('../../src/vaultFactory/vaultFactory.js')['start']>
-   * >}
-   */
-  const installationP = E(zoe).installBundleID(bundleID);
-  produceVaultInstallation.reset();
-  produceVaultInstallation.resolve(installationP);
 
   const [auctionOldInstance, auctionNewInstance] = await Promise.all([
     auctioneerInstanceP,
@@ -154,7 +139,7 @@ export const upgradeVaults = async (
     });
 
     const upgradeResult = await E(kit.adminFacet).upgradeContract(
-      bundleID,
+      VaultFactoryBundle.bundleID,
       newPrivateArgs,
     );
 
@@ -169,7 +154,7 @@ export const upgradeVaults = async (
   const ecf = await electorateCreatorFacet;
   // upgrade vaultFactory governor. Won't be needed next time: see #10063
   await E(kit.governorAdminFacet).upgradeContract(
-    governorRef.bundleID,
+    contractGovernorBundle.bundleID,
     harden({
       electorateCreatorFacet: ecf,
       governed: vaultFactoryPrivateArgs,
@@ -183,30 +168,37 @@ const uV = 'upgradeVaults';
 /**
  * Return the manifest, installations, and options for upgrading Vaults.
  *
- * @param {object} _ign
+ * @param {object} utils
+ * @param {any} utils.restoreRef
  * @param {any} vaultUpgradeOptions
  */
 export const getManifestForUpgradeVaults = async (
-  _ign,
-  vaultUpgradeOptions,
-) => ({
-  manifest: {
-    [upgradeVaults.name]: {
-      consume: {
-        priceAuthority8400: uV,
-        auctionUpgradeNewInstance: uV,
-        chainTimerService: uV,
-        economicCommitteeCreatorFacet: uV,
-        reserveKit: uV,
-        vaultFactoryKit: uV,
-        zoe: uV,
+  { restoreRef },
+  { VaultFactoryRef, contractGovernorRef },
+) => {
+  return {
+    manifest: {
+      [upgradeVaults.name]: {
+        consume: {
+          priceAuthority8400: uV,
+          auctionUpgradeNewInstance: uV,
+          chainTimerService: uV,
+          economicCommitteeCreatorFacet: uV,
+          reserveKit: uV,
+          vaultFactoryKit: uV,
+          zoe: uV,
+        },
+        produce: { auctionUpgradeNewInstance: uV },
+        instance: { consume: { auctioneer: uV } },
       },
-      produce: { auctionUpgradeNewInstance: uV },
-      installation: {
-        produce: { VaultFactory: true },
-      },
-      instance: { consume: { auctioneer: true } },
     },
-  },
-  options: { ...vaultUpgradeOptions },
-});
+    installations: {
+      VaultFactory: restoreRef(VaultFactoryRef),
+      contractGovernor: restoreRef(contractGovernorRef),
+    },
+    options: {
+      VaultFactoryBundle: VaultFactoryRef,
+      contractGovernorBundle: contractGovernorRef,
+    },
+  };
+};


### PR DESCRIPTION
closes: #9982
closes: #10172

## Description

When a governed contract is upgraded, its paramManager (which was ephemeral) is replaced, and the contractGovernor needs to get a fresh copy.

### Security Considerations

This bug caused us to need to cut RC2 when preparing the vaultFactory release. That time, the fix was to upgrade the contractGovernor when upgrading a governed contract.  

### Scaling Considerations

No scaling impacts.

### Testing Considerations

added a new test, which fails without the fix.

### Upgrade Considerations

This is staged on top of #10074, and the goal is to include it with the priceFeed coreEval. Recent commits have updated the coreEval to include upgrading and installing the contractGovernor code.