### PR TITLE
rotate voting rights for EC committee

### DIFF
--- a/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
+++ b/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
@@ -1,0 +1,407 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { TestFn } from 'ava';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import {
+  makeAgoricNamesRemotesFromFakeStorage,
+  slotToBoardRemote,
+  unmarshalFromVstorage,
+} from '@agoric/vats/tools/board-utils.js';
+import { makeMarshal } from '@endo/marshal';
+
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import {
+  makeGovernanceDriver,
+  makeWalletFactoryDriver,
+} from '../../tools/drivers.js';
+
+const wallets = [
+  'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
+  'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',
+  'agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a',
+  'agoric13p9adwk0na5npfq64g22l6xucvqdmu3xqe70wq',
+  'agoric1el6zqs8ggctj5vwyukyk4fh50wcpdpwgugd5l5',
+  'agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc',
+];
+
+const highPrioritySenderKey = 'highPrioritySenders';
+
+const offerIds = {
+  propose: { outgoing: 'outgoing_propose' },
+  vote: { outgoing: 'outgoing_vote', incoming: 'incoming_vote' },
+};
+
+const getQuestionId = id => `propose-question-${id}`;
+const getVoteId = id => `vote-${id}`;
+
+export const makeZoeTestContext = async t => {
+  console.time('ZoeTestContext');
+  const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
+    configSpecifier: '@agoric/vm-config/decentral-main-vaults-config.json',
+  });
+
+  const { runUtils, storage } = swingsetTestKit;
+  console.timeLog('DefaultTestContext', 'swingsetTestKit');
+  const { EV } = runUtils;
+
+  await eventLoopIteration();
+
+  // We don't need vaults, but this gets the brand, which is checked somewhere
+  // Wait for ATOM to make it into agoricNames
+  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
+  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
+
+  // has to be late enough for agoricNames data to have been published
+  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
+
+  console.timeEnd('DefaultTestContext');
+  const walletFactoryDriver = await makeWalletFactoryDriver(
+    runUtils,
+    storage,
+    agoricNamesRemotes,
+  );
+
+  const { fromCapData } = makeMarshal(undefined, slotToBoardRemote);
+
+  const getUpdatedDebtLimit = () => {
+    const atomGovernance = unmarshalFromVstorage(
+      storage.data,
+      'published.vaultFactory.managers.manager0.governance',
+      fromCapData,
+      -1,
+    );
+    return atomGovernance.current.DebtLimit.value.value;
+  };
+
+  const governanceDriver = await makeGovernanceDriver(
+    swingsetTestKit,
+    agoricNamesRemotes,
+    walletFactoryDriver,
+    wallets,
+  );
+
+  return {
+    ...swingsetTestKit,
+    storage,
+    getUpdatedDebtLimit,
+    governanceDriver,
+  };
+};
+const test = anyTest as TestFn<Awaited<ReturnType<typeof makeZoeTestContext>>>;
+
+test.before(async t => {
+  t.context = await makeZoeTestContext(t);
+});
+
+test.serial('normal running of committee', async t => {
+  const { advanceTimeBy, storage, getUpdatedDebtLimit, governanceDriver } =
+    t.context;
+
+  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+  const { VaultFactory, economicCommittee } = agoricNamesRemotes.instance;
+  const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
+
+  const committee = governanceDriver.ecMembers;
+
+  t.log('Accepting all invitations for original committee');
+  await null;
+  for (const member of committee) {
+    await member.acceptCharterInvitation(offerIds.propose.outgoing);
+    await member.acceptCommitteeInvitation(offerIds.vote.outgoing);
+  }
+
+  t.log('Proposing a question using first wallet');
+  await governanceDriver.proposeParams(
+    VaultFactory,
+    { DebtLimit: { brand: debtBrand, value: 100_000_000n } },
+    { paramPath: { key: { collateralBrand } } },
+    committee[0],
+    getQuestionId(1),
+    offerIds.propose.outgoing,
+  );
+
+  t.log('Checking if question proposal passed');
+  t.like(committee[0].getLatestUpdateRecord(), {
+    status: { id: getQuestionId(1), numWantsSatisfied: 1 },
+  });
+
+  t.log('Voting on question using first 3 wallets');
+  await governanceDriver.enactLatestProposal(
+    committee,
+    getVoteId(1),
+    offerIds.vote.outgoing,
+  );
+
+  t.log('Checking if votes passed');
+  for (const w of committee.slice(0, 3)) {
+    t.like(w.getLatestUpdateRecord(), {
+      status: { id: getVoteId(1), numWantsSatisfied: 1 },
+    });
+  }
+
+  t.log('Waiting for period to end');
+  await advanceTimeBy(1, 'minutes');
+
+  t.log('Verifying outcome');
+
+  const lastOutcome = await governanceDriver.getLatestOutcome();
+  console.log(lastOutcome);
+  t.deepEqual(getUpdatedDebtLimit(), 100_000_000n);
+  t.assert(lastOutcome.outcome === 'win');
+});
+
+test.serial(
+  'check high priority senders before replacing committee',
+  async t => {
+    const { storage } = t.context;
+
+    const data: any = storage.toStorage({
+      method: 'children',
+      args: [highPrioritySenderKey],
+    });
+    t.deepEqual(data.sort(), [...wallets].sort());
+  },
+);
+
+test.serial('replace committee', async t => {
+  const { buildProposal, evalProposal, storage } = t.context;
+
+  const preEvalAgoricNames = makeAgoricNamesRemotesFromFakeStorage(storage);
+  await evalProposal(
+    buildProposal(
+      '@agoric/builders/scripts/inter-protocol/replace-electorate-core.js',
+      ['BOOTSTRAP_TEST'],
+    ),
+  );
+  await eventLoopIteration();
+
+  const postEvalAgoricNames = makeAgoricNamesRemotesFromFakeStorage(storage);
+
+  t.not(
+    preEvalAgoricNames.instance.economicCommittee,
+    postEvalAgoricNames.instance.economicCommittee,
+  );
+});
+
+test.serial(
+  'check high priority senders after replacing committee',
+  async t => {
+    const { storage } = t.context;
+
+    const data: any = storage.toStorage({
+      method: 'children',
+      args: [highPrioritySenderKey],
+    });
+    t.deepEqual(data.sort(), wallets.slice(0, 3).sort());
+  },
+);
+
+test.serial('successful vote by 2 continuing members', async t => {
+  const { storage, advanceTimeBy, getUpdatedDebtLimit, governanceDriver } =
+    t.context;
+  const newCommittee = governanceDriver.ecMembers.slice(0, 3);
+
+  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+  const { economicCommittee, VaultFactory } = agoricNamesRemotes.instance;
+  const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
+
+  t.log('Accepting all new invitations for voters');
+  await null;
+  for (const member of newCommittee) {
+    await member.acceptCommitteeInvitation(
+      offerIds.vote.incoming,
+      economicCommittee,
+    );
+  }
+
+  t.log('Proposing question using old charter invitation');
+  await governanceDriver.proposeParams(
+    VaultFactory,
+    { DebtLimit: { brand: debtBrand, value: 200_000_000n } },
+    { paramPath: { key: { collateralBrand } } },
+    newCommittee[0],
+    getQuestionId(2),
+    offerIds.propose.outgoing,
+  );
+
+  t.like(newCommittee[0].getLatestUpdateRecord(), {
+    status: { id: getQuestionId(2), numWantsSatisfied: 1 },
+  });
+
+  t.log('Voting on question using first 2 wallets');
+  await governanceDriver.enactLatestProposal(
+    newCommittee.slice(0, 2),
+    getVoteId(2),
+    offerIds.vote.incoming,
+  );
+  for (const w of newCommittee.slice(0, 2)) {
+    t.like(w.getLatestUpdateRecord(), {
+      status: { id: getVoteId(2), numWantsSatisfied: 1 },
+    });
+  }
+
+  t.log('Waiting for period to end');
+  await advanceTimeBy(1, 'minutes');
+
+  t.log('Verifying outcome');
+  const lastOutcome = await governanceDriver.getLatestOutcome();
+  t.deepEqual(getUpdatedDebtLimit(), 200_000_000n);
+  t.assert(lastOutcome.outcome === 'win');
+});
+
+test.serial('unsuccessful vote by 2 outgoing members', async t => {
+  const { governanceDriver, storage, advanceTimeBy, getUpdatedDebtLimit } =
+    t.context;
+  const outgoingCommittee = governanceDriver.ecMembers.slice(3);
+
+  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+  const { VaultFactory } = agoricNamesRemotes.instance;
+  const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
+
+  t.log('Proposing question using old charter invitation');
+  await governanceDriver.proposeParams(
+    VaultFactory,
+    { DebtLimit: { brand: debtBrand, value: 300_000_000n } },
+    { paramPath: { key: { collateralBrand } } },
+    outgoingCommittee[0],
+    getQuestionId(3),
+    offerIds.propose.outgoing,
+  );
+  t.like(outgoingCommittee[0].getLatestUpdateRecord(), {
+    status: { id: getQuestionId(3), numWantsSatisfied: 1 },
+  });
+
+  t.log('Voting on question using first 2 wallets');
+  t.log('voting is done by invitations already present and should fail');
+  const votePromises = outgoingCommittee
+    .slice(0, 2)
+    .map(member =>
+      member.voteOnLatestProposal(getVoteId(3), offerIds.vote.outgoing),
+    );
+
+  await t.throwsAsync(votePromises[0]);
+  await t.throwsAsync(votePromises[1]);
+
+  for (const w of outgoingCommittee.slice(0, 2)) {
+    t.like(w.getLatestUpdateRecord(), {
+      status: { id: getVoteId(3), numWantsSatisfied: 1 },
+    });
+  }
+
+  t.log('Waiting for period to end');
+  await advanceTimeBy(1, 'minutes');
+
+  const lastOutcome = await governanceDriver.getLatestOutcome();
+  t.notDeepEqual(getUpdatedDebtLimit(), 300_000_000n);
+  t.assert(lastOutcome.outcome === 'fail');
+});
+
+test.serial(
+  'successful vote by 2 continuing and 1 outgoing members',
+  async t => {
+    const { storage, advanceTimeBy, getUpdatedDebtLimit, governanceDriver } =
+      t.context;
+    const committee = [
+      ...governanceDriver.ecMembers.slice(0, 2),
+      governanceDriver.ecMembers[3],
+    ];
+
+    const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+    const { VaultFactory } = agoricNamesRemotes.instance;
+    const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
+
+    t.log('Proposing question using old charter invitation');
+    await governanceDriver.proposeParams(
+      VaultFactory,
+      { DebtLimit: { brand: debtBrand, value: 400_000_000n } },
+      { paramPath: { key: { collateralBrand } } },
+      committee[0],
+      getQuestionId(4),
+      offerIds.propose.outgoing,
+    );
+    t.like(committee[0].getLatestUpdateRecord(), {
+      status: { id: getQuestionId(4), numWantsSatisfied: 1 },
+    });
+
+    t.log('Voting on question using first all wallets');
+    t.log('first 2 should pass, last should fail');
+    const votePromises = committee.map((member, index) =>
+      member.voteOnLatestProposal(
+        getVoteId(4),
+        index === 2 ? offerIds.vote.outgoing : offerIds.vote.incoming,
+      ),
+    );
+
+    await votePromises[0];
+    await votePromises[1];
+    await t.throwsAsync(votePromises[2]);
+
+    for (const w of committee) {
+      t.like(w.getLatestUpdateRecord(), {
+        status: { id: getVoteId(4), numWantsSatisfied: 1 },
+      });
+    }
+
+    t.log('Waiting for period to end');
+    await advanceTimeBy(1, 'minutes');
+
+    const lastOutcome = await governanceDriver.getLatestOutcome();
+    t.deepEqual(getUpdatedDebtLimit(), 400_000_000n);
+    t.assert(lastOutcome.outcome === 'win');
+  },
+);
+
+test.serial(
+  'unsuccessful vote by 1 continuing and 2 outgoing members',
+  async t => {
+    const { storage, advanceTimeBy, getUpdatedDebtLimit, governanceDriver } =
+      t.context;
+    const committee = [
+      governanceDriver.ecMembers[0],
+      ...governanceDriver.ecMembers.slice(3, 5),
+    ];
+
+    const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+    const { VaultFactory } = agoricNamesRemotes.instance;
+    const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
+
+    t.log('Proposing question using old charter invitation');
+    await governanceDriver.proposeParams(
+      VaultFactory,
+      { DebtLimit: { brand: debtBrand, value: 500_000_000n } },
+      { paramPath: { key: { collateralBrand } } },
+      committee[0],
+      getQuestionId(5),
+      offerIds.propose.outgoing,
+    );
+    t.like(committee[0].getLatestUpdateRecord(), {
+      status: { id: getQuestionId(5), numWantsSatisfied: 1 },
+    });
+
+    t.log('Voting on question using first all wallets');
+    t.log('first 2 should fail, last should pass');
+    const votePromises = committee.map((member, index) =>
+      member.voteOnLatestProposal(
+        getVoteId(5),
+        index === 0 ? offerIds.vote.incoming : offerIds.vote.outgoing,
+      ),
+    );
+
+    await votePromises[0];
+    await t.throwsAsync(votePromises[1]);
+    await t.throwsAsync(votePromises[2]);
+
+    for (const w of committee) {
+      t.like(w.getLatestUpdateRecord(), {
+        status: { id: getVoteId(5), numWantsSatisfied: 1 },
+      });
+    }
+
+    t.log('Waiting for period to end');
+    await advanceTimeBy(1, 'minutes');
+
+    const lastOutcome = await governanceDriver.getLatestOutcome();
+    t.notDeepEqual(getUpdatedDebtLimit(), 500_000_000n);
+    t.assert(lastOutcome.outcome === 'fail');
+  },
+);

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -163,6 +163,7 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
     outputDir: string,
     scriptPath: string,
     env: NodeJS.ProcessEnv,
+    cliArgs: string[] = [],
   ) => {
     console.info('running package script:', scriptPath);
     const out = childProcess.execFileSync('yarn', ['bin', 'agoric'], {
@@ -171,7 +172,7 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
     });
     return childProcess.execFileSync(
       out.toString().trim(),
-      ['run', scriptPath],
+      ['run', scriptPath, ...cliArgs],
       {
         cwd: outputDir,
         env,
@@ -202,7 +203,7 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
     return { evals, bundles };
   };
 
-  const buildAndExtract = async (builderPath: string) => {
+  const buildAndExtract = async (builderPath: string, args: string[] = []) => {
     const tmpDir = await fsAmbientPromises.mkdtemp(
       join(getPkgPath('builders'), 'proposal-'),
     );
@@ -212,6 +213,7 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
         tmpDir,
         await importSpec(builderPath),
         process.env,
+        args,
       ).toString(),
     );
 

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -57,7 +57,7 @@ const configurations = {
     },
     highPrioritySendersConfig: {
       addressesToAdd: [],
-      addressesToRemove: [],
+      addressesToRemove: ['agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277'],
     },
   },
   BOOTSTRAP_TEST: {
@@ -82,7 +82,8 @@ const { keys } = Object;
 const Usage = `agoric run replace-electorate-core.js ${keys(configurations).join(' | ')}`;
 export default async (homeP, endowments) => {
   const { scriptArgs } = endowments;
-  const config = configurations[scriptArgs?.[0]];
+  const variant = scriptArgs?.[0];
+  const config = configurations[variant];
   if (!config) {
     console.error(Usage);
     process.exit(1);
@@ -91,7 +92,7 @@ export default async (homeP, endowments) => {
 
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval('replace-committee', (utils, opts) =>
+  await writeCoreEval(`replace-committee-${variant}`, (utils, opts) =>
     defaultProposalBuilder(utils, { ...opts, ...config }),
   );
 };

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -82,8 +82,7 @@ const { keys } = Object;
 const Usage = `agoric run replace-electorate-core.js ${keys(configurations).join(' | ')}`;
 export default async (homeP, endowments) => {
   const { scriptArgs } = endowments;
-  const key = scriptArgs?.[0] || process.env.CONFIG_KEY;
-  const config = configurations[key];
+  const config = configurations[scriptArgs?.[0]];
   if (!config) {
     console.error(Usage);
     process.exit(1);

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -38,7 +38,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }, opts) => {
 const configurations = {
   MAINNET: {
     committeeName: 'Economic Committee',
-    // TODO: Update the addresses after confirmation
+    // UNTIL https://github.com/Agoric/agoric-sdk/issues/10194
     voterAddresses: {
       gov1: 'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
       gov2: 'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -1,0 +1,26 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { getManifestForReplaceElectorate } from '@agoric/inter-protocol/src/proposals/replaceElectorate.js';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }, opts) => {
+  return harden({
+    sourceSpec: '@agoric/inter-protocol/src/proposals/replaceElectorate.js',
+    getManifestCall: [
+      getManifestForReplaceElectorate.name,
+      {
+        ...opts,
+        economicCommitteeRef: publishRef(
+          install(
+            '@agoric/governance/src/committee.js',
+            '../bundles/bundle-committee.js',
+          ),
+        ),
+      },
+    ],
+  });
+};
+
+export default async (homeP, endowments) => {
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('replace-committee', defaultProposalBuilder);
+};

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -1,12 +1,27 @@
+/**
+ * @file build core eval script to replace EC committee and charter
+ * Usage:
+ *   To run this script, use the following command format in the CLI:
+ *   agoric run replace-electorate-core.js [ENVIRONMENT]
+ *   where [ENVIRONMENT] is one of the following:
+ *     - MAINNET
+ *     - DEVNET
+ *     - A3P_INTEGRATION
+ *     - BOOTSTRAP_TEST
+ *
+ *   Example:
+ *     agoric run replace-electorate-core.js MAINNET
+ */
+/* global process */
 import { makeHelpers } from '@agoric/deploy-script-support';
-import { getManifestForReplaceElectorate } from '@agoric/inter-protocol/src/proposals/replaceElectorate.js';
+import { getManifestForReplaceAllElectorates } from '@agoric/inter-protocol/src/proposals/replaceElectorate.js';
 
 /** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
 export const defaultProposalBuilder = async ({ publishRef, install }, opts) => {
   return harden({
     sourceSpec: '@agoric/inter-protocol/src/proposals/replaceElectorate.js',
     getManifestCall: [
-      getManifestForReplaceElectorate.name,
+      getManifestForReplaceAllElectorates.name,
       {
         ...opts,
         economicCommitteeRef: publishRef(

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -20,7 +20,79 @@ export const defaultProposalBuilder = async ({ publishRef, install }, opts) => {
   });
 };
 
+const configurations = {
+  MAINNET: {
+    committeeName: 'Economic Committee',
+    // TODO: Update the addresses after confirmation
+    voterAddresses: {
+      gov1: 'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
+      gov2: 'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',
+      gov3: 'agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a',
+    },
+    highPrioritySendersConfig: {
+      addressesToAdd: [],
+      addressesToRemove: [
+        'agoric13p9adwk0na5npfq64g22l6xucvqdmu3xqe70wq',
+        'agoric1el6zqs8ggctj5vwyukyk4fh50wcpdpwgugd5l5',
+        'agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc',
+      ],
+    },
+  },
+  DEVNET: {
+    committeeName: 'Economic Committee',
+    // TODO: Update the addresses after confirmation
+    voterAddresses: {
+      gov1: 'agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce',
+      gov2: 'agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang',
+    },
+    highPrioritySendersConfig: {
+      addressesToAdd: [],
+      addressesToRemove: ['agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h'],
+    },
+  },
+  A3P_INTEGRATION: {
+    committeeName: 'Economic Committee',
+    voterAddresses: {
+      gov1: 'agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q',
+    },
+    highPrioritySendersConfig: {
+      addressesToAdd: [],
+      addressesToRemove: [],
+    },
+  },
+  BOOTSTRAP_TEST: {
+    committeeName: 'Economic Committee',
+    voterAddresses: {
+      gov1: 'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
+      gov2: 'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',
+      gov3: 'agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a',
+    },
+    highPrioritySendersConfig: {
+      addressesToAdd: [],
+      addressesToRemove: [
+        'agoric13p9adwk0na5npfq64g22l6xucvqdmu3xqe70wq',
+        'agoric1el6zqs8ggctj5vwyukyk4fh50wcpdpwgugd5l5',
+        'agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc',
+      ],
+    },
+  },
+};
+
+const { keys } = Object;
+const Usage = `agoric run replace-electorate-core.js ${keys(configurations).join(' | ')}`;
 export default async (homeP, endowments) => {
+  const { scriptArgs } = endowments;
+  const key = scriptArgs?.[0] || process.env.CONFIG_KEY;
+  const config = configurations[key];
+  if (!config) {
+    console.error(Usage);
+    process.exit(1);
+  }
+  console.log('replace-committee', scriptArgs, config);
+
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
-  await writeCoreEval('replace-committee', defaultProposalBuilder);
+
+  await writeCoreEval('replace-committee', (utils, opts) =>
+    defaultProposalBuilder(utils, { ...opts, ...config }),
+  );
 };

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -187,7 +187,7 @@ export const replaceElectorate = async (permittedPowers, config) => {
 
   await inviteECMembers(permittedPowers, {
     options: {
-      voterAddresses: voterAddresses,
+      voterAddresses,
       economicCommitteeCreatorFacet,
     },
   });

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -182,10 +182,18 @@ export const replaceElectorate = async permittedPowers => {
 
   await Promise.all(
     creatorFacets.map(async creatorFacet => {
+      trace(
+        'Getting PoserInvitation from economicCommitteeCreatorFacet...',
+        creatorFacet,
+      );
       const newElectoratePoser = await E(
         economicCommitteeCreatorFacet,
       ).getPoserInvitation();
+      trace('Successfully received newElectoratePoser');
+
+      trace('Replace electorate');
       await E(creatorFacet).replaceElectorate(newElectoratePoser);
+      trace('Successfully replaced electorate');
     }),
   );
 

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { E } from '@endo/eventual-send';
 import { reserveThenDeposit } from './utils.js';
+
 const { Fail } = assert;
 
 const runConfig = {
@@ -49,7 +50,7 @@ const handlehighPrioritySendersList = async ({
   const { addressesToAdd, addressesToRemove } =
     runConfig.highPrioritySendersConfig;
 
-  for (let addr of addressesToAdd) {
+  for (const addr of addressesToAdd) {
     trace(`Adding ${addr} to High Priority Senders list`);
     await E(highPrioritySendersManager).add(
       HIGH_PRIORITY_SENDERS_NAMESPACE,
@@ -57,7 +58,7 @@ const handlehighPrioritySendersList = async ({
     );
   }
 
-  for (let addr of addressesToRemove) {
+  for (const addr of addressesToRemove) {
     trace(`Removing ${addr} from High Priority Senders list`);
     await E(highPrioritySendersManager).remove(
       HIGH_PRIORITY_SENDERS_NAMESPACE,

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -1,0 +1,238 @@
+// @ts-check
+import { E } from '@endo/eventual-send';
+import { reserveThenDeposit } from './utils.js';
+import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
+const { Fail } = assert;
+
+const runConfig = {
+  committeeName: 'Economic Committee',
+  economicCommitteeAddresses: {
+    gov1: 'agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q',
+  },
+  economicCommitteeAddressesToRemove: {
+    gov1: 'agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277',
+  },
+};
+
+const trace = (...args) => console.log('GovReplaceCommiteeAndCharter', ...args);
+
+const { values } = Object;
+
+/** @type {<X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
+const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
+
+const pathSegmentPattern = /^[a-zA-Z0-9_-]{1,100}$/;
+
+/** @type {(name: string) => void} */
+const assertPathSegment = name => {
+  pathSegmentPattern.test(name) ||
+    Fail`Path segment names must consist of 1 to 100 characters limited to ASCII alphanumerics, underscores, and/or dashes: ${name}`;
+};
+
+/** @type {(name: string) => string} */
+const sanitizePathSegment = name => {
+  const candidate = name.replace(/[ ,]/g, '_');
+  assertPathSegment(candidate);
+  return candidate;
+};
+
+const handlehighPrioritySendersList = async ({
+  consume: { highPrioritySendersManager: highPrioritySendersManagerP },
+}) => {
+  const HIGH_PRIORITY_SENDERS_NAMESPACE = 'economicCommittee';
+  const highPrioritySendersManager = await highPrioritySendersManagerP;
+
+  if (!highPrioritySendersManager) {
+    throw Error('highPrioritySendersManager is not defined');
+  }
+
+  const { economicCommitteeAddresses, economicCommitteeAddressesToRemove } =
+    runConfig;
+
+  const addSet = new Set(Object.values(economicCommitteeAddresses));
+  const removeSet = new Set(Object.values(economicCommitteeAddressesToRemove));
+
+  const uniqueAddAddresses = Array.from(addSet).filter(
+    address => !removeSet.has(address),
+  );
+  const uniqueRemoveAddresses = Array.from(removeSet).filter(
+    address => !addSet.has(address),
+  );
+
+  for (let addr of uniqueAddAddresses) {
+    trace(`Adding ${addr} to High Priority Senders list`);
+    await E(highPrioritySendersManager).add(
+      HIGH_PRIORITY_SENDERS_NAMESPACE,
+      addr,
+    );
+  }
+
+  for (let addr of uniqueRemoveAddresses) {
+    trace(`Removing ${addr} from High Priority Senders list`);
+    await E(highPrioritySendersManager).remove(
+      HIGH_PRIORITY_SENDERS_NAMESPACE,
+      addr,
+    );
+  }
+};
+
+const inviteECMembers = async (
+  { consume: { namesByAddressAdmin, economicCommitteeCreatorFacet } },
+  { options: { voterAddresses = {} } },
+) => {
+  trace('Create invitations for new committee');
+
+  const invitations = await E(
+    economicCommitteeCreatorFacet,
+  ).getVoterInvitations();
+  assert.equal(invitations.length, values(voterAddresses).length);
+
+  trace('Distribute invitations');
+  /** @param {[string, Promise<Invitation>][]} addrInvitations */
+  const distributeInvitations = async addrInvitations => {
+    await Promise.all(
+      addrInvitations.map(async ([addr, invitationP]) => {
+        const [voterInvitation] = await Promise.all([invitationP]);
+        trace('Sending voting invitations to', addr);
+        await reserveThenDeposit(
+          `econ committee member ${addr}`,
+          namesByAddressAdmin,
+          addr,
+          [voterInvitation],
+        );
+      }),
+    );
+  };
+
+  await distributeInvitations(zip(values(voterAddresses), invitations));
+};
+
+const startNewEconomicCommittee = async ({
+  consume: { board, chainStorage, zoe },
+  produce: { economicCommitteeCreatorFacet, economicCommitteeKit },
+  installation: {
+    consume: { committee },
+  },
+  instance: {
+    produce: { economicCommittee },
+  },
+}) => {
+  const COMMITTEES_ROOT = 'committees';
+
+  trace('startNewEconomicCommittee');
+
+  const { committeeName } = runConfig;
+  const committeeSize = Object.values(
+    runConfig.economicCommitteeAddresses,
+  ).length;
+
+  const committeesNode = await makeStorageNodeChild(
+    chainStorage,
+    COMMITTEES_ROOT,
+  );
+  const storageNode = await E(committeesNode).makeChildNode(
+    sanitizePathSegment(committeeName),
+  );
+
+  const marshaller = await E(board).getPublishingMarshaller();
+
+  trace('Starting new EC Committee Instance');
+
+  const { instance, creatorFacet } = await E(zoe).startInstance(
+    committee,
+    {},
+    { committeeName, committeeSize },
+    {
+      storageNode,
+      marshaller,
+    },
+    'economicCommittee',
+  );
+
+  trace('Started new EC Committee Instance Successfully');
+
+  economicCommitteeKit.reset();
+  economicCommitteeKit.resolve(
+    harden({ ...startResult, label: 'economicCommittee' }),
+  );
+
+  economicCommittee.reset();
+  economicCommittee.resolve(instance);
+
+  economicCommitteeCreatorFacet.reset();
+  economicCommitteeCreatorFacet.resolve(creatorFacet);
+};
+
+export const replaceElectorate = async permittedPowers => {
+  await startNewEconomicCommittee(permittedPowers);
+
+  const psmKitMap = await permittedPowers.consume.psmKit;
+
+  const creatorFacets = [
+    E.get(permittedPowers.consume.reserveKit).governorCreatorFacet,
+    E.get(permittedPowers.consume.auctioneerKit).governorCreatorFacet,
+    E.get(permittedPowers.consume.vaultFactoryKit).governorCreatorFacet,
+    E.get(permittedPowers.consume.provisionPoolStartResult)
+      .governorCreatorFacet,
+    ...[...psmKitMap.values()].map(psmKit => psmKit.psmGovernorCreatorFacet),
+  ];
+
+  const economicCommitteeCreatorFacet =
+    await permittedPowers.consume.economicCommitteeCreatorFacet;
+
+  await Promise.all(
+    creatorFacets.map(async creatorFacet => {
+      const newElectoratePoser = await E(
+        economicCommitteeCreatorFacet,
+      ).getPoserInvitation();
+      await E(creatorFacet).replaceElectorate(newElectoratePoser);
+    }),
+  );
+
+  await inviteECMembers(permittedPowers, {
+    options: {
+      voterAddresses: runConfig.economicCommitteeAddresses,
+    },
+  });
+
+  await handlehighPrioritySendersList(permittedPowers);
+
+  trace('Installed New Economic Committee');
+};
+
+harden(replaceElectorate);
+
+export const getManifestForReplaceElectorate = async (
+  { economicCommitteeRef: _economicCommitteeRef },
+  options,
+) => ({
+  manifest: {
+    [replaceElectorate.name]: {
+      consume: {
+        reserveKit: true,
+        auctioneerKit: true,
+        vaultFactoryKit: true,
+        psmKit: true,
+        provisionPoolStartResult: true,
+
+        board: true,
+        chainStorage: true,
+        diagnostics: true,
+        zoe: true,
+        highPrioritySendersManager: true,
+        namesByAddressAdmin: true,
+      },
+      produce: {
+        economicCommitteeKit: true,
+        economicCommitteeCreatorFacet: 'economicCommittee',
+      },
+      installation: {
+        consume: { committee: 'zoe' },
+      },
+      instance: {
+        produce: { economicCommittee: 'economicCommittee' },
+      },
+    },
+  },
+  options: { ...options },
+});

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -1,16 +1,16 @@
 // @ts-check
 import { E } from '@endo/eventual-send';
 import { reserveThenDeposit } from './utils.js';
-import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 const { Fail } = assert;
 
 const runConfig = {
   committeeName: 'Economic Committee',
-  economicCommitteeAddresses: {
+  voterAddresses: {
     gov1: 'agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q',
   },
-  economicCommitteeAddressesToRemove: {
-    gov1: 'agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277',
+  highPrioritySendersConfig: {
+    addressesToAdd: [],
+    addressesToRemove: ['agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277'],
   },
 };
 
@@ -46,20 +46,10 @@ const handlehighPrioritySendersList = async ({
     throw Error('highPrioritySendersManager is not defined');
   }
 
-  const { economicCommitteeAddresses, economicCommitteeAddressesToRemove } =
-    runConfig;
+  const { addressesToAdd, addressesToRemove } =
+    runConfig.highPrioritySendersConfig;
 
-  const addSet = new Set(Object.values(economicCommitteeAddresses));
-  const removeSet = new Set(Object.values(economicCommitteeAddressesToRemove));
-
-  const uniqueAddAddresses = Array.from(addSet).filter(
-    address => !removeSet.has(address),
-  );
-  const uniqueRemoveAddresses = Array.from(removeSet).filter(
-    address => !addSet.has(address),
-  );
-
-  for (let addr of uniqueAddAddresses) {
+  for (let addr of addressesToAdd) {
     trace(`Adding ${addr} to High Priority Senders list`);
     await E(highPrioritySendersManager).add(
       HIGH_PRIORITY_SENDERS_NAMESPACE,
@@ -67,7 +57,7 @@ const handlehighPrioritySendersList = async ({
     );
   }
 
-  for (let addr of uniqueRemoveAddresses) {
+  for (let addr of addressesToRemove) {
     trace(`Removing ${addr} from High Priority Senders list`);
     await E(highPrioritySendersManager).remove(
       HIGH_PRIORITY_SENDERS_NAMESPACE,
@@ -122,14 +112,13 @@ const startNewEconomicCommittee = async ({
   trace('startNewEconomicCommittee');
 
   const { committeeName } = runConfig;
-  const committeeSize = Object.values(
-    runConfig.economicCommitteeAddresses,
-  ).length;
+  trace(`committeeName ${committeeName}`);
 
-  const committeesNode = await makeStorageNodeChild(
-    chainStorage,
-    COMMITTEES_ROOT,
-  );
+  const committeeSize = values(runConfig.voterAddresses).length;
+  trace(`committeeSize ${committeeSize}`);
+
+  const committeesNode = await E(chainStorage).makeChildNode(COMMITTEES_ROOT);
+
   const storageNode = await E(committeesNode).makeChildNode(
     sanitizePathSegment(committeeName),
   );
@@ -199,7 +188,7 @@ export const replaceElectorate = async permittedPowers => {
 
   await inviteECMembers(permittedPowers, {
     options: {
-      voterAddresses: runConfig.economicCommitteeAddresses,
+      voterAddresses: runConfig.voterAddresses,
     },
   });
 

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -1,21 +1,10 @@
 // @ts-check
 import { E } from '@endo/eventual-send';
-import { reserveThenDeposit } from './utils.js';
 import {
   assertPathSegment,
   makeStorageNodeChild,
 } from '@agoric/internal/src/lib-chainStorage.js';
-
-const runConfig = {
-  committeeName: 'Economic Committee',
-  voterAddresses: {
-    gov1: 'agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q',
-  },
-  highPrioritySendersConfig: {
-    addressesToAdd: [],
-    addressesToRemove: ['agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277'],
-  },
-};
+import { reserveThenDeposit } from './utils.js';
 
 const trace = (...args) => console.log('GovReplaceCommiteeAndCharter', ...args);
 
@@ -31,9 +20,10 @@ const sanitizePathSegment = name => {
   return candidate;
 };
 
-const handlehighPrioritySendersList = async ({
-  consume: { highPrioritySendersManager: highPrioritySendersManagerP },
-}) => {
+const handlehighPrioritySendersList = async (
+  { consume: { highPrioritySendersManager: highPrioritySendersManagerP } },
+  { options: { highPrioritySendersConfig } },
+) => {
   const HIGH_PRIORITY_SENDERS_NAMESPACE = 'economicCommittee';
   const highPrioritySendersManager = await highPrioritySendersManagerP;
 
@@ -41,8 +31,7 @@ const handlehighPrioritySendersList = async ({
     throw Error('highPrioritySendersManager is not defined');
   }
 
-  const { addressesToAdd, addressesToRemove } =
-    runConfig.highPrioritySendersConfig;
+  const { addressesToAdd, addressesToRemove } = highPrioritySendersConfig;
 
   for (const addr of addressesToAdd) {
     trace(`Adding ${addr} to High Priority Senders list`);
@@ -92,24 +81,24 @@ const inviteECMembers = async (
   await distributeInvitations(zip(values(voterAddresses), invitations));
 };
 
-const startNewEconomicCommittee = async ({
-  consume: { board, chainStorage, zoe },
-  produce: { economicCommitteeCreatorFacet, economicCommitteeKit },
-  installation: {
-    consume: { committee },
+const startNewEconomicCommittee = async (
+  {
+    consume: { board, chainStorage, zoe },
+    produce: { economicCommitteeKit, economicCommitteeCreatorFacet },
+    installation: {
+      consume: { committee },
+    },
+    instance: {
+      produce: { economicCommittee },
+    },
   },
-  instance: {
-    produce: { economicCommittee },
-  },
-}) => {
+  { options: { committeeName, committeeSize } },
+) => {
   const COMMITTEES_ROOT = 'committees';
 
   trace('startNewEconomicCommittee');
 
-  const { committeeName } = runConfig;
   trace(`committeeName ${committeeName}`);
-
-  const committeeSize = values(runConfig.voterAddresses).length;
   trace(`committeeSize ${committeeSize}`);
 
   const committeesNode = await makeStorageNodeChild(
@@ -154,9 +143,19 @@ const startNewEconomicCommittee = async ({
   return creatorFacet;
 };
 
-export const replaceElectorate = async permittedPowers => {
-  const economicCommitteeCreatorFacet =
-    await startNewEconomicCommittee(permittedPowers);
+export const replaceElectorate = async (permittedPowers, config) => {
+  const { committeeName, voterAddresses, highPrioritySendersConfig } =
+    config.options;
+
+  const economicCommitteeCreatorFacet = await startNewEconomicCommittee(
+    permittedPowers,
+    {
+      options: {
+        committeeName,
+        committeeSize: values(voterAddresses).length,
+      },
+    },
+  );
 
   const psmKitMap = await permittedPowers.consume.psmKit;
 
@@ -188,12 +187,16 @@ export const replaceElectorate = async permittedPowers => {
 
   await inviteECMembers(permittedPowers, {
     options: {
-      voterAddresses: runConfig.voterAddresses,
+      voterAddresses: voterAddresses,
       economicCommitteeCreatorFacet,
     },
   });
 
-  await handlehighPrioritySendersList(permittedPowers);
+  await handlehighPrioritySendersList(permittedPowers, {
+    options: {
+      highPrioritySendersConfig,
+    },
+  });
 
   trace('Installed New Economic Committee');
 };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10134
refs: #10134

## Description
This PR implements the following:

- Core eval script to replace the committee.
- Builder script for setting up the core eval.
- Bootstrap test to verify the functionality of the implementation.

### Security Considerations
The Economic Committee plays a crucial role in managing the Inter-Protocol. The current committee doesn't easily support a smooth transition when members must retire or be replaced. An incomplete transition to a new committee could severely hamper the chain operations.

Accidentally providing access to the wrong parties (or failing to remove parties whose terms have expired) could make it hard to ensure that the right committee members have control. Other chains have been sunk or badly damaged when the stakeholders couldn't restrict some people from making changes.

### Testing Considerations
Bootstrap tests have been added in this PR to run in CI for testing.

### Documentation Considerations
Specific documentation concerns belong in #10138. It’s important to ensure the proposal is clearly documented to avoid confusion, especially with the old committee still being around.

### Upgrade Considerations:
There is minimal risk of regression because the core-eval materials are introduced in new files. The changes introduced particularly the new builder script, can be seamlessly included in any upcoming release.

### Scaling Considerations
The core eval script’s performance depends on the number of Economic Committee (EC) members. Since the committee is limited to a maximum of 12 members, the script’s complexity is treated as constant because it won’t have to handle more than 12 people.

Also, the script is executed approximately once a year, and all stakers receive a 3-day notice before it runs, making the scaling impact negligible.

