### PR TITLE
using governedContractKits in core eval replacing committee and charter

### DIFF
--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -201,12 +201,12 @@ const addGovernorsToEconCharter = async (
   { consume: { psmKit, governedContractKits } },
   { options: { econCharterKit } },
 ) => {
-  const { creatorFacet } = E.get(econCharterKit);
+  const { creatorFacet: ecCreatorFacet } = E.get(econCharterKit);
 
   const psmKitMap = await psmKit;
 
   for (const { psm, psmGovernorCreatorFacet, label } of psmKitMap.values()) {
-    E(creatorFacet).addInstance(psm, psmGovernorCreatorFacet, label);
+    E(ecCreatorFacet).addInstance(psm, psmGovernorCreatorFacet, label);
   }
 
   const governedContractKitMap = await governedContractKits;
@@ -216,7 +216,7 @@ const addGovernorsToEconCharter = async (
     governorCreatorFacet,
     label,
   } of governedContractKitMap.values()) {
-    E(creatorFacet).addInstance(instance, governorCreatorFacet, label);
+    E(ecCreatorFacet).addInstance(instance, governorCreatorFacet, label);
   }
 };
 
@@ -237,8 +237,6 @@ export const replaceElectorate = async (permittedPowers, config) => {
   const governedContractKitsMap =
     await permittedPowers.consume.governedContractKits;
   const psmKitMap = await permittedPowers.consume.psmKit;
-
-  console.log('RABI', [...governedContractKitsMap.values()]);
 
   const creatorFacets = [
     ...[...governedContractKitsMap.values()].map(

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -5,7 +5,6 @@ import {
   makeStorageNodeChild,
 } from '@agoric/internal/src/lib-chainStorage.js';
 import { reserveThenDeposit } from './utils.js';
-import { deeplyFulfilledObject } from '@agoric/internal';
 
 const trace = (...args) => console.log('GovReplaceCommiteeAndCharter', ...args);
 

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -5,6 +5,7 @@ import {
   makeStorageNodeChild,
 } from '@agoric/internal/src/lib-chainStorage.js';
 import { reserveThenDeposit } from './utils.js';
+import { deeplyFulfilledObject } from '@agoric/internal';
 
 const trace = (...args) => console.log('GovReplaceCommiteeAndCharter', ...args);
 
@@ -198,18 +199,7 @@ const startNewEconCharter = async ({
 };
 
 const addGovernorsToEconCharter = async (
-  {
-    consume: {
-      reserveKit,
-      vaultFactoryKit,
-      auctioneerKit,
-      psmKit,
-      provisionPoolStartResult,
-    },
-    instance: {
-      consume: { reserve, VaultFactory, auctioneer, provisionPool },
-    },
-  },
+  { consume: { psmKit, governedContractKits } },
   { options: { econCharterKit } },
 ) => {
   const { creatorFacet } = E.get(econCharterKit);
@@ -220,34 +210,15 @@ const addGovernorsToEconCharter = async (
     E(creatorFacet).addInstance(psm, psmGovernorCreatorFacet, label);
   }
 
-  await Promise.all(
-    [
-      {
-        label: 'reserve',
-        instanceP: reserve,
-        facetP: E.get(reserveKit).governorCreatorFacet,
-      },
-      {
-        label: 'VaultFactory',
-        instanceP: VaultFactory,
-        facetP: E.get(vaultFactoryKit).governorCreatorFacet,
-      },
-      {
-        label: 'auctioneer',
-        instanceP: auctioneer,
-        facetP: E.get(auctioneerKit).governorCreatorFacet,
-      },
-      {
-        label: 'provisionPool',
-        instanceP: provisionPool,
-        facetP: E.get(provisionPoolStartResult).governorCreatorFacet,
-      },
-    ].map(async ({ label, instanceP, facetP }) => {
-      const [instance, govFacet] = await Promise.all([instanceP, facetP]);
+  const governedContractKitMap = await governedContractKits;
 
-      return E(creatorFacet).addInstance(instance, govFacet, label);
-    }),
-  );
+  for (const {
+    instance,
+    governorCreatorFacet,
+    label,
+  } of governedContractKitMap.values()) {
+    E(creatorFacet).addInstance(instance, governorCreatorFacet, label);
+  }
 };
 
 export const replaceElectorate = async (permittedPowers, config) => {
@@ -264,14 +235,16 @@ export const replaceElectorate = async (permittedPowers, config) => {
     },
   );
 
+  const governedContractKitsMap =
+    await permittedPowers.consume.governedContractKits;
   const psmKitMap = await permittedPowers.consume.psmKit;
 
+  console.log('RABI', [...governedContractKitsMap.values()]);
+
   const creatorFacets = [
-    E.get(permittedPowers.consume.reserveKit).governorCreatorFacet,
-    E.get(permittedPowers.consume.auctioneerKit).governorCreatorFacet,
-    E.get(permittedPowers.consume.vaultFactoryKit).governorCreatorFacet,
-    E.get(permittedPowers.consume.provisionPoolStartResult)
-      .governorCreatorFacet,
+    ...[...governedContractKitsMap.values()].map(
+      governedContractKit => governedContractKit.governorCreatorFacet,
+    ),
     ...[...psmKitMap.values()].map(psmKit => psmKit.psmGovernorCreatorFacet),
   ];
 
@@ -317,11 +290,8 @@ export const getManifestForReplaceElectorate = async (_, options) => ({
   manifest: {
     [replaceElectorate.name]: {
       consume: {
-        reserveKit: true,
-        auctioneerKit: true,
-        vaultFactoryKit: true,
         psmKit: true,
-        provisionPoolStartResult: true,
+        governedContractKits: true,
 
         board: true,
         chainStorage: true,
@@ -346,12 +316,6 @@ export const getManifestForReplaceElectorate = async (_, options) => ({
         produce: {
           economicCommittee: true,
           econCommitteeCharter: true,
-        },
-        consume: {
-          reserve: true,
-          VaultFactory: true,
-          auctioneer: true,
-          provisionPool: true,
         },
       },
     },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


refs: #10134  #10133 

## Description
This pull request builds on #10166 and #10164. It updates the core eval code to utilize the `governorCreatorFacet` for the governed contracts via the `governedContractKit`. Initially, the aim was to use the `governedContractKit` to access facets from price feed contracts. But since it also includes facets for other governed contracts, I expanded the code to incorporate these as well.

### Security Considerations
Same as #10166 and #10164 

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
Same as specified in #10164 

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
