### PR TITLE
chore(dependabot): revise configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directory: '/'
+    directories:
+      - '/'
+      - '/packages/*'
     schedule:
-      interval: 'daily'
-    allow:
-      - dependency-type: 'production'
-        dependency-name: '*'
+      interval: 'weekly'
+    groups:
+      patches:
+        update-types:
+          - 'patch'
+
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:


### PR DESCRIPTION
_incidental_

## Description
To reduce manual effort to keep dependencies green.

There was already a dependabot config file but it seems inoperational. 

This changes it to
- Operate on all package directories
- Update devDependencies too
- Weekly instead of daily
- Only "patch" level bug fixes for now

If that doesn't start it running I'll dig in more

### Security Considerations

Trusts Github to only update patch releases. Increases rate of supply chain updates.

But this is just automating what we do already. PRs will still be reviewed.

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
Needs master to test

### Upgrade Considerations
none
