### PR TITLE
chore(dependabot): operate only on workspace roots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
+    # Just yarn workspaces (paths that have a yarn.lock)
+    # When we had all package, '/packages/*',' the job timed out (~55 minutes).
+    # As long as the yarn.lock is updated, the actual deps are updated,
+    # even if the the version ranges in the package.json are not.
     directories:
       - '/'
-      - '/packages/*'
+      - '/a3p-integration/'
+      - '/multichain-testing/'
     schedule:
       interval: 'weekly'
     groups:


### PR DESCRIPTION
incidental

## Description

[#10186](https://github.com/Agoric/agoric-sdk/issues/10186) ran but timed out: https://github.com/Agoric/agoric-sdk/actions/runs/11150379306/job/30991381517

Reviewing the logs it looks like it did a lot of duplicate work querying for each package. Maybe that's a bug in Dependabot. Meanwhile, we only need to update the yarn.lock so this leaves out the 'packages" wildcard. It adds two other top-level directories that are Yarn workspaces.

### Security Considerations
none
### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
have to test in master

### Upgrade Considerations
none