### PR TITLE
types!: `Chain` takes `KnownChainName` generic parameter instead of `ChainInfo`

### DIFF
--- a/packages/orchestration/src/chain-info.js
+++ b/packages/orchestration/src/chain-info.js
@@ -28,6 +28,10 @@ const knownChains = /** @satisfies {Record<string, ChainInfo>} */ (
  * @internal
  */
 
+/**
+ * @typedef {keyof KnownChains} KnownChainName
+ */
+
 // TODO(#9966, #9967): include this in registerChain
 /**
  * Register chain assets into agoricNames

--- a/packages/orchestration/src/examples/auto-stake-it-tap-kit.js
+++ b/packages/orchestration/src/examples/auto-stake-it-tap-kit.js
@@ -20,7 +20,7 @@ const trace = makeTracer('AutoStakeItTap');
 /**
  * @typedef {{
  *   stakingAccount: ERef<OrchestrationAccount<any> & StakingAccountActions>;
- *   localAccount: ERef<OrchestrationAccount<{ chainId: 'agoric' }>>;
+ *   localAccount: ERef<OrchestrationAccount<'agoric'>>;
  *   validator: CosmosValidatorAddress;
  *   localChainAddress: ChainAddress;
  *   remoteChainAddress: ChainAddress;

--- a/packages/orchestration/src/examples/auto-stake-it.flows.js
+++ b/packages/orchestration/src/examples/auto-stake-it.flows.js
@@ -4,7 +4,7 @@ import { denomHash } from '../utils/denomHash.js';
 /**
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
  * @import {GuestInterface} from '@agoric/async-flow';
- * @import {CosmosValidatorAddress, Orchestrator, CosmosInterchainService, Denom, OrchestrationAccount, StakingAccountActions, OrchestrationFlow} from '@agoric/orchestration';
+ * @import {CosmosValidatorAddress, Orchestrator, OrchestrationAccount, StakingAccountActions, OrchestrationFlow, KnownChainName} from '@agoric/orchestration';
  * @import {MakeStakingTap} from './auto-stake-it-tap-kit.js';
  * @import {MakePortfolioHolder} from '../exos/portfolio-holder-kit.js';
  * @import {ChainHub} from '../exos/chain-hub.js';
@@ -20,7 +20,7 @@ import { denomHash } from '../utils/denomHash.js';
  * }} ctx
  * @param {ZCFSeat} seat
  * @param {{
- *   chainName: string;
+ *   chainName: KnownChainName;
  *   validator: CosmosValidatorAddress;
  * }} offerArgs
  */

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -9,7 +9,7 @@ import { M, mustMatch } from '@endo/patterns';
 const trace = makeTracer('BasicFlows');
 
 /**
- * @import {OrchestrationAccount, OrchestrationFlow, Orchestrator} from '@agoric/orchestration';
+ * @import {KnownChainName, OrchestrationAccount, OrchestrationFlow, Orchestrator} from '@agoric/orchestration';
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
  * @import {MakePortfolioHolder} from '../exos/portfolio-holder-kit.js';
  */
@@ -22,7 +22,7 @@ const trace = makeTracer('BasicFlows');
  * @param {Orchestrator} orch
  * @param {any} _ctx
  * @param {ZCFSeat} seat
- * @param {{ chainName: string }} offerArgs
+ * @param {{ chainName: KnownChainName }} offerArgs
  */
 export const makeOrchAccount = async (orch, _ctx, seat, { chainName }) => {
   trace('makeOrchAccount', chainName);
@@ -45,7 +45,7 @@ harden(makeOrchAccount);
  * @param {object} ctx
  * @param {MakePortfolioHolder} ctx.makePortfolioHolder
  * @param {ZCFSeat} seat
- * @param {{ chainNames: string[] }} offerArgs
+ * @param {{ chainNames: KnownChainName[] }} offerArgs
  */
 export const makePortfolioAccount = async (
   orch,

--- a/packages/orchestration/src/examples/send-anywhere.flows.js
+++ b/packages/orchestration/src/examples/send-anywhere.flows.js
@@ -7,7 +7,7 @@ import { M, mustMatch } from '@endo/patterns';
  * @import {Vow} from '@agoric/vow';
  * @import {LocalOrchestrationAccountKit} from '../exos/local-orchestration-account.js';
  * @import {ZoeTools} from '../utils/zoe-tools.js';
- * @import {Orchestrator, OrchestrationFlow, LocalAccountMethods} from '../types.js';
+ * @import {Orchestrator, OrchestrationFlow, LocalAccountMethods, KnownChainName} from '../types.js';
  */
 
 const { entries } = Object;
@@ -23,7 +23,7 @@ const { entries } = Object;
  * @param {GuestInterface<ZoeTools>} ctx.zoeTools
  * @param {GuestOf<(msg: string) => Vow<void>>} ctx.log
  * @param {ZCFSeat} seat
- * @param {{ chainName: string; destAddr: string }} offerArgs
+ * @param {{ chainName: KnownChainName; destAddr: string }} offerArgs
  */
 export const sendIt = async (
   orch,

--- a/packages/orchestration/src/examples/staking-combinations.flows.js
+++ b/packages/orchestration/src/examples/staking-combinations.flows.js
@@ -1,6 +1,6 @@
 /**
  * @import {GuestInterface} from '@agoric/async-flow';
- * @import {Orchestrator, OrchestrationFlow, AmountArg, CosmosValidatorAddress, ChainAddress, LocalAccountMethods, OrchestrationAccountI} from '../types.js'
+ * @import {Orchestrator, OrchestrationFlow, AmountArg, CosmosValidatorAddress, ChainAddress, LocalAccountMethods, OrchestrationAccountI, KnownChainName} from '../types.js'
  * @import {ContinuingOfferResult, InvitationMakers} from '@agoric/smart-wallet/src/types.js';
  * @import {LocalOrchestrationAccountKit} from '../exos/local-orchestration-account.js';
  * @import {MakeCombineInvitationMakers} from '../exos/combine-invitation-makers.js';
@@ -23,7 +23,7 @@ const trace = makeTracer('StakingCombinationsFlows');
  *   makeExtraInvitationMaker: (account: any) => InvitationMakers;
  * }} ctx
  * @param {ZCFSeat} _seat
- * @param {{ chainName: string }} offerArgs
+ * @param {{ chainName: KnownChainName }} offerArgs
  * @returns {Promise<ResolvedContinuingOfferResult>}
  */
 export const makeAccount = async (orch, ctx, _seat, { chainName }) => {

--- a/packages/orchestration/src/exos/local-chain-facade.js
+++ b/packages/orchestration/src/exos/local-chain-facade.js
@@ -110,7 +110,7 @@ const prepareLocalChainFacadeKit = (
             this.facets.makeAccountWatcher,
           );
         },
-        /** @type {HostOf<Chain<{ chainId: 'agoriclocal' }>['query']>} */
+        /** @type {HostOf<Chain<'agoric'>['query']>} */
         query(requests) {
           return watch(E(localchain).queryMany(requests));
         },

--- a/packages/orchestration/src/exos/orchestrator.js
+++ b/packages/orchestration/src/exos/orchestrator.js
@@ -126,6 +126,7 @@ const prepareOrchestratorKit = (
             return asVow(() => chainByName.get(name));
           }
           if (name === 'agoric') {
+            // @ts-expect-error types of property 'chainId' are incompatible (string vs a chainId const)
             return watch(
               chainHub.getChainInfo('agoric'),
               this.facets.makeLocalChainFacadeWatcher,

--- a/packages/orchestration/src/fixtures/query-flows.flows.js
+++ b/packages/orchestration/src/fixtures/query-flows.flows.js
@@ -8,7 +8,7 @@ import { M, mustMatch } from '@endo/patterns';
 const trace = makeTracer('BasicFlows');
 
 /**
- * @import {Chain, DenomArg, OrchestrationFlow, Orchestrator, ICQQueryFunction, CosmosChainInfo} from '@agoric/orchestration';
+ * @import {Chain, DenomArg, OrchestrationFlow, Orchestrator, ICQQueryFunction, CosmosChainInfo, KnownChainName} from '@agoric/orchestration';
  * @import {QueryManyFn} from '@agoric/vats/src/localchain.js';
  */
 
@@ -22,16 +22,18 @@ const trace = makeTracer('BasicFlows');
  * @param {Orchestrator} orch
  * @param {any} _ctx
  * @param {ZCFSeat} seat
- * @param {{ chainName: string; msgs: Parameters<ICQQueryFunction>[0] }} offerArgs
+ * @param {{
+ *   chainName: KnownChainName;
+ *   msgs: Parameters<ICQQueryFunction>[0];
+ * }} offerArgs
  */
 export const sendICQQuery = async (orch, _ctx, seat, { chainName, msgs }) => {
   seat.exit(); // no funds exchanged
   mustMatch(chainName, M.string());
   if (chainName === 'agoric') throw Fail`ICQ not supported on local chain`;
-  const remoteChain =
-    /** @type {Chain<CosmosChainInfo & { icqEnabled: true }>} */ (
-      await orch.getChain(chainName)
-    );
+  const remoteChain = /** @type {Chain<'osmosis'>} */ (
+    await orch.getChain(chainName)
+  );
   const queryResponse = await remoteChain.query(msgs);
   trace('SendICQQuery response:', queryResponse);
   // `quote` to ensure offerResult (array) is visible in smart-wallet
@@ -49,7 +51,7 @@ harden(sendICQQuery);
  * @param {Orchestrator} orch
  * @param {any} _ctx
  * @param {ZCFSeat} seat
- * @param {{ chainName: string; denom: DenomArg }} offerArgs
+ * @param {{ chainName: KnownChainName; denom: DenomArg }} offerArgs
  */
 export const makeAccountAndGetBalanceQuery = async (
   orch,
@@ -78,7 +80,7 @@ harden(makeAccountAndGetBalanceQuery);
  * @param {Orchestrator} orch
  * @param {any} _ctx
  * @param {ZCFSeat} seat
- * @param {{ chainName: string }} offerArgs
+ * @param {{ chainName: KnownChainName }} offerArgs
  */
 export const makeAccountAndGetBalancesQuery = async (
   orch,

--- a/packages/orchestration/test/facade-durability.test.ts
+++ b/packages/orchestration/test/facade-durability.test.ts
@@ -73,6 +73,7 @@ test.serial('chain info', async t => {
   );
 
   const handle = orchestrate('mock', {}, async orc => {
+    // @ts-expect-error 'mock' not in KnownChainNames
     return orc.getChain('mock');
   });
 
@@ -117,6 +118,7 @@ test.serial('faulty chain info', async t => {
   );
 
   const handle = orchestrate('mock', {}, async orc => {
+    // @ts-expect-error 'mock' not in KnownChainNames
     const chain = await orc.getChain('mock');
     const account = await chain.makeAccount();
     return account;
@@ -179,6 +181,7 @@ test.serial('asset / denom info', async t => {
     { brand },
     // eslint-disable-next-line no-shadow
     async (orc, { brand }) => {
+      // @ts-expect-error 'mock-id' not in KnownChainNames
       const c1 = await orc.getChain(mockChainInfo.chainId);
 
       {

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -111,9 +111,9 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 {
   // HostInterface
 
-  const chain: Chain<ChainInfo> = null as any;
+  const chain: Chain<'agoric'> = null as any;
   expectType<Promise<ChainInfo>>(chain.getChainInfo());
-  const chainHostInterface: HostInterface<Chain<ChainInfo>> = null as any;
+  const chainHostInterface: HostInterface<Chain<'agoric'>> = null as any;
   expectType<Vow<ChainInfo>>(chainHostInterface.getChainInfo());
 
   const publicTopicRecord: HostInterface<
@@ -193,7 +193,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 
 // Test LocalChain.query()
 {
-  type ChainFacade = Chain<{ chainId: 'agoriclocal' }>;
+  type ChainFacade = Chain<'agoric'>;
   const localChain: ChainFacade = null as any;
   const results = localChain.query([
     typedJson('/cosmos.bank.v1beta1.QueryBalanceRequest', {
@@ -212,7 +212,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 
 // Test RemoteCosmosChain.query() (icqEnabled: true)
 {
-  type ChainFacade = Chain<CosmosChainInfo & { icqEnabled: true }>;
+  type ChainFacade = Chain<'osmosis'>;
   const remoteChain: ChainFacade = null as any;
   const results = remoteChain.query([
     {
@@ -236,7 +236,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 
 // Test RemoteCosmosChain.query() (icqEnabled: false)
 {
-  type ChainFacade = Chain<CosmosChainInfo>;
+  type ChainFacade = Chain<'cosmoshub'>;
   const remoteChain: ChainFacade = null as any;
 
   expectType<never>(remoteChain.query);


### PR DESCRIPTION
closes: #9992

## Description
Changes generic parameter for `Chain` from `ChainInfo` to `KnownChainName`.  The `KnownChainName` type is `keyof KnownChains`, the fetched-chain-info from cosmos chain-registry.

### Security Considerations
n/a

### Scaling Considerations
n/a, types

### Documentation Considerations
Helps make typedoc docs more readable.

### Testing Considerations
Updates existing type tests.

### Upgrade Considerations
library code for an npm orch release
