### PR TITLE
Passable exo state

### DIFF
--- a/packages/cache/test/storage.test.js
+++ b/packages/cache/test/storage.test.js
@@ -27,13 +27,16 @@ harden(makeSimpleMarshaller);
 
 const setup = () => {
   const storageNodeState = {};
-  const chainStorage = makeChainStorageRoot(message => {
-    assert(message.method === 'set');
-    assert(message.args.length === 1);
-    const [[path, value]] = message.args;
-    assert(path === 'cache');
-    storageNodeState.cache = value;
-  }, 'cache');
+  const chainStorage = makeChainStorageRoot(
+    Far('ToStorage', message => {
+      assert(message.method === 'set');
+      assert(message.args.length === 1);
+      const [[path, value]] = message.args;
+      assert(path === 'cache');
+      storageNodeState.cache = value;
+    }),
+    'cache',
+  );
   const cache = makeCache(
     makeChainStorageCoordinator(chainStorage, makeSimpleMarshaller()),
   );

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -11,7 +11,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 import tmp from 'tmp';
 
 import { Fail, q } from '@endo/errors';
-import { E } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import { isNat } from '@endo/nat';
 import { M, mustMatch } from '@endo/patterns';
@@ -432,9 +432,9 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       }
     }
 
-    const toStorage = message => {
+    const toStorage = Far('BridgeStorageHandler', message => {
       return doOutboundBridge(BridgeId.STORAGE, message);
-    };
+    });
 
     const makeInstallationPublisher = () => {
       const installationStorageNode = makeChainStorageRoot(

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Fail } from '@endo/errors';
-import { E } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { M } from '@endo/patterns';
 import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import * as cb from './callback.js';
@@ -278,7 +278,10 @@ export function makeChainStorageRoot(
  */
 const makeNullStorageNode = () => {
   // XXX re-use "ChainStorage" methods above which don't actually depend on chains
-  return makeChainStorageRoot(() => null, 'null');
+  return makeChainStorageRoot(
+    Far('NullMessenger', () => null),
+    'null',
+  );
 };
 
 /**

--- a/packages/internal/test/callback.test.js
+++ b/packages/internal/test/callback.test.js
@@ -304,11 +304,11 @@ test('makeAttenuator', async t => {
     overrides: {
       m1: null,
       m2: cb.makeMethodCallback(
-        {
+        Far('Abc', {
           abc() {
             return 'return abc';
           },
-        },
+        }),
         'abc',
       ),
     },

--- a/packages/vow/test/disconnect.test.js
+++ b/packages/vow/test/disconnect.test.js
@@ -43,6 +43,23 @@ test('retry on disconnection', async t => {
       },
     },
   );
+  const makeFinalWatcher = zone.exoClass(
+    'FinalWatcher',
+    undefined,
+    final => ({ final }),
+    {
+      onFulfilled(value) {
+        t.is(this.state.final, 'happy');
+        t.is(value, 'resolved');
+        return value;
+      },
+      onRejected(reason) {
+        t.is(this.state.final, 'sad');
+        t.is(reason && reason.message, 'dejected');
+        return ['rejected', reason];
+      },
+    },
+  );
 
   const PLANS = [
     [0, 'happy'],
@@ -72,18 +89,7 @@ test('retry on disconnection', async t => {
       let resultP;
       switch (pattern) {
         case 'watch-with-handler': {
-          const resultW = watch(vow, {
-            onFulfilled(value) {
-              t.is(plan[final], 'happy');
-              t.is(value, 'resolved');
-              return value;
-            },
-            onRejected(reason) {
-              t.is(plan[final], 'sad');
-              t.is(reason && reason.message, 'dejected');
-              return ['rejected', reason];
-            },
-          });
+          const resultW = watch(vow, makeFinalWatcher(plan[final]));
           t.is('then' in resultW, false, 'watch resultW.then is undefined');
           resultP = when(resultW);
           break;

--- a/packages/vow/test/watch-utils.test.js
+++ b/packages/vow/test/watch-utils.test.js
@@ -256,14 +256,14 @@ test('asPromise handles watcher arguments', async t => {
   const vow = watch(testPromiseP);
 
   let watcherCalled = false;
-  const watcher = {
+  const watcher = zone.exo('Watcher', undefined, {
     onFulfilled(value, ctx) {
       watcherCalled = true;
       t.is(value, 'watcher test');
       t.deepEqual(ctx, ['ctx']);
       return value;
     },
-  };
+  });
 
   // XXX fix type: `watcherContext` doesn't need to be an array
   const result = await asPromise(vow, watcher, ['ctx']);

--- a/packages/vow/test/watch.test.js
+++ b/packages/vow/test/watch.test.js
@@ -232,18 +232,21 @@ test('disconnection of non-vow informs watcher', async t => {
 
   // Even though this promise is rejected with a retryable reason, there's no
   // vow before it to retry, so we pass the rejection up to the watcher.
-  /* eslint-disable-next-line prefer-promise-reject-errors */
-  const vow = watch(Promise.reject('disconnected'), {
-    onFulfilled(value) {
-      t.log(`onfulfilled ${value}`);
-      t.fail('should not fulfil');
-      return 'fulfilled';
-    },
-    onRejected(reason) {
-      t.is(reason, 'disconnected');
-      return `rejected ${reason}`;
-    },
-  });
+  const vow = watch(
+    /* eslint-disable-next-line prefer-promise-reject-errors */
+    Promise.reject('disconnected'),
+    zone.exo('Watcher', undefined, {
+      onFulfilled(value) {
+        t.log(`onfulfilled ${value}`);
+        t.fail('should not fulfil');
+        return 'fulfilled';
+      },
+      onRejected(reason) {
+        t.is(reason, 'disconnected');
+        return `rejected ${reason}`;
+      },
+    }),
+  );
 
   t.is(await when(vow), 'rejected disconnected');
 });


### PR DESCRIPTION
refs: #10170 
refs: https://github.com/endojs/endo/issues/1648

best reviewed by ignoring white space

## Description
After implementing a change to enforce that heap exo are passable, I found that some things currently stored in heap exos, mostly in tests, are not actually passable. Almost all of them are remotable like objects not marked as `Far`, usually related to storage nodes.

While I plan on moving the implementation of the checks into endo instead of landing it in agoric-sdk first, I figured we should already fix the issues found.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
See #10170 for passing tests with checks enabled

### Upgrade Considerations
As it's a heap zone change, cross upgrade behavior is not involved. In the future any code using a stricter heap zone would need to comply. However heaps zones are used as packages bundled by the contract, and are not provided by liveslots or zcf, so there is no compatibility risk.