### PR TITLE
test(multichain-testing): `stir` for no AVA timeout in long awaits

### DIFF
--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -58,8 +58,7 @@
       "**/*.test.ts"
     ],
     "concurrency": 1,
-    "serial": true,
-    "timeout": "125s"
+    "serial": true
   },
   "eslintConfig": {
     "root": true,

--- a/multichain-testing/scripts/deploy-cli.ts
+++ b/multichain-testing/scripts/deploy-cli.ts
@@ -7,6 +7,7 @@ import childProcess from 'node:child_process';
 
 import { makeAgdTools } from '../tools/agd-tools.js';
 import { makeDeployBuilder } from '../tools/deploy.js';
+import type { ExecSync } from '../tools/agd-lib.js';
 
 async function main() {
   const builder = process.argv[2];
@@ -17,7 +18,9 @@ async function main() {
   }
 
   try {
-    const agdTools = await makeAgdTools(console.log, childProcess);
+    const agdTools = await makeAgdTools(console.log, {
+      execFileSync: childProcess.execFileSync as ExecSync,
+    });
     const deployBuilder = makeDeployBuilder(agdTools, fse.readJSON, execa);
     await deployBuilder(builder);
   } catch (err) {

--- a/multichain-testing/test/chain-queries.test.ts
+++ b/multichain-testing/test/chain-queries.test.ts
@@ -247,6 +247,7 @@ test.serial('Send Local Query from chain object', async t => {
     },
   );
   const balanceProto3JsonQuery = typedJson(
+    // @ts-expect-error Not assignable to `keyof Proto3Shape`
     '/cosmos.bank.v1beta1.QueryBalanceRequest',
     {
       address: agoricAddr,

--- a/multichain-testing/test/stake-ica.test.ts
+++ b/multichain-testing/test/stake-ica.test.ts
@@ -243,7 +243,10 @@ const stakeScenario = test.macro(async (t, scenario: StakeIcaScenario) => {
 
   console.log('waiting for unbonding period');
   // XXX reference `120000` from chain state + `maxClockSkew`
-  await sleep(120000);
+  await sleep(120000, {
+    stir: description =>
+      t.pass(`stirring while waiting for unbonding period: ${description}`),
+  });
   const { balances: rewardsWithUndelegations } = await retryUntilCondition(
     () => queryClient.queryBalances(address),
     ({ balances }) => {

--- a/multichain-testing/test/stir.test.ts
+++ b/multichain-testing/test/stir.test.ts
@@ -1,0 +1,22 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+import { sleep } from '../tools/sleep.js';
+
+test('sleep without tripping AVA timeout', async t => {
+  const stirred: string[] = [];
+  t.timeout(500);
+  const sleepTime = 4_000;
+  await sleep(sleepTime, {
+    log: t.log,
+    stirEveryMs: 300,
+    stir: description => {
+      stirred.push(description);
+      t.pass(description);
+    },
+  });
+  const stirs = new Array(13);
+  for (let i = 0; i < stirs.length; i += 1) {
+    stirs[i] = `stir #${i + 1}`;
+  }
+  const expected = [`sleeping for ${sleepTime}ms...`, ...stirs];
+  t.deepEqual(stirred, expected);
+});

--- a/multichain-testing/tools/agd-tools.ts
+++ b/multichain-testing/tools/agd-tools.ts
@@ -1,19 +1,28 @@
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeE2ETools } from './e2e-tools.js';
+import type { ExecAsync, ExecSync } from './agd-lib.js';
 
 export const makeAgdTools = async (
   log: typeof console.log,
   {
-    execFile,
     execFileSync,
-  }: Pick<typeof import('child_process'), 'execFile' | 'execFileSync'>,
+    delay,
+    fetch = globalThis.fetch,
+    execFileAsync,
+  }: {
+    execFileSync: ExecSync;
+    delay?: (ms: number) => Promise<void>;
+    fetch?: typeof globalThis.fetch;
+    execFileAsync?: ExecAsync;
+  },
 ) => {
   const bundleCache = await unsafeMakeBundleCache('bundles');
   const tools = await makeE2ETools(log, bundleCache, {
     execFileSync,
-    execFile,
+    execFileAsync,
     fetch,
     setTimeout,
+    delay,
   });
   return tools;
 };

--- a/multichain-testing/tools/sleep.ts
+++ b/multichain-testing/tools/sleep.ts
@@ -1,20 +1,90 @@
 const ambientSetTimeout = globalThis.setTimeout;
 
+// Derived from the fact that AVA's "default timeout is 10 seconds."
+// https://github.com/avajs/ava/blob/main/docs/07-test-timeouts.md#test-timeouts
+export const DEFAULT_STIR_EVERY_MS = 8_000;
+
 type Log = (...values: unknown[]) => void;
 
 type SleepOptions = {
   log?: Log;
   setTimeout?: typeof ambientSetTimeout;
+  stirEveryMs?: number;
+  /**
+   * Call every `stirEveryMs` during sleeping so that the sleeper isn't timed
+   * out by, e.g. a test runner.
+   * @param description - A bit of context as to why we're stirring.
+   */
+  stir?: (description: string) => void;
 };
 
-export const sleep = (
+/**
+ *
+ * @param {number} ms Sleep duration in milliseconds
+ * @param {SleepOptions} opts
+ * @returns {Promise<void>}
+ */
+const deepSleep = (
   ms: number,
-  { log = () => {}, setTimeout = ambientSetTimeout }: SleepOptions = {},
+  { setTimeout = ambientSetTimeout }: SleepOptions = {},
 ) =>
   new Promise(resolve => {
-    log(`Sleeping for ${ms}ms...`);
     setTimeout(resolve, ms);
   });
+
+export const stirUntilSettled = async <T>(
+  result: T,
+  {
+    log = () => {},
+    setTimeout = ambientSetTimeout,
+    stirEveryMs = DEFAULT_STIR_EVERY_MS,
+    stir,
+  }: SleepOptions = {},
+): Promise<Awaited<T>> => {
+  const resultP = Promise.resolve(result);
+  if (!stir) {
+    return resultP;
+  }
+  let keepStirring = !!stir;
+  try {
+    // Ensure that we stop stirring when the result is settled.
+    resultP.finally(() => (keepStirring = false));
+
+    log(`start stirring`);
+    let nStirs = 0;
+    while (keepStirring) {
+      await new Promise(resolve => {
+        setTimeout(resolve, stirEveryMs);
+      });
+      nStirs += 1;
+      await (keepStirring && stir(`stir #${nStirs}`));
+    }
+    log(`done stirring`);
+    return resultP;
+  } finally {
+    keepStirring = false;
+  }
+};
+
+export const sleep = async (
+  ms: number,
+  {
+    log = () => {},
+    stir,
+    stirEveryMs = DEFAULT_STIR_EVERY_MS,
+    setTimeout = ambientSetTimeout,
+  }: SleepOptions = {},
+) => {
+  log(`Sleeping for ${ms}ms...`);
+  await (stir && stir(`sleeping for ${ms}ms...`));
+  const slept = deepSleep(ms, { setTimeout });
+  await stirUntilSettled(slept, {
+    log,
+    stir,
+    stirEveryMs,
+    setTimeout,
+  });
+};
 
 export type RetryOptions = {
   maxRetries?: number;
@@ -29,6 +99,8 @@ const retryUntilCondition = async <T>(
     maxRetries = 6,
     retryIntervalMs = 3500,
     log = () => {},
+    stirEveryMs,
+    stir,
     setTimeout = ambientSetTimeout,
   }: RetryOptions = {},
 ): Promise<T> => {
@@ -37,7 +109,13 @@ const retryUntilCondition = async <T>(
 
   while (retries < maxRetries) {
     try {
-      const result = await operation();
+      const resultP = operation();
+      const result = await stirUntilSettled(resultP, {
+        log,
+        stirEveryMs,
+        stir,
+        setTimeout,
+      });
       if (condition(result)) {
         return result;
       }
@@ -53,7 +131,7 @@ const retryUntilCondition = async <T>(
     console.log(
       `Retry ${retries}/${maxRetries} - Waiting for ${retryIntervalMs}ms for ${message}...`,
     );
-    await sleep(retryIntervalMs, { log, setTimeout });
+    await sleep(retryIntervalMs, { log, setTimeout, stirEveryMs, stir });
   }
 
   throw Error(`${message} condition failed after ${maxRetries} retries.`);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #9934

## Description
Reviewing the fact that [AVA's "default timeout is 10 seconds"](https://github.com/avajs/ava/blob/main/docs/07-test-timeouts.md#test-timeouts), if no assertions are made during that timeout, AVA fails the test.  The `multichain-testing` tests encounter this timeout when performing long synchronous calls (such as `execFileSync`) or `await`s (notably during sleeps or during waiting for retry conditions that may take a long time).

Rather than attempting to solve this flake by trial-and-error moving AVA's `timeout` setting until the tests pass, this PR replaces `execFileSync` with `execFileAsync`, and allows the long "safe" `await`s (`execFileAsync`, `sleep`, `delay`, `retryUntilCondition`, etc.) to "stir".  That is, the test itself can specify a callback that will be invoked periodically when in a long safe await (that is, it already uses its own timeout/retry system). In those cases, the AVA assertion timeout gets in the way.  If the `stir` callback contains a trivial AVA assertion, that will reset AVA's internal assertion clock to postpone failure by AVA timeout.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
n/a

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
n/a

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
A simple test of stirring while sleeping past the AVA timeout shows that this feature works.  If this also helps avoid #9934, we should see fewer reports of flaky multichain-e2e tests.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a