### PR TITLE
fix(swing-store): Create archive files with .tmp suffixes in their final directory

### DIFF
--- a/packages/swing-store/src/archiver.js
+++ b/packages/swing-store/src/archiver.js
@@ -23,8 +23,9 @@ export const makeArchiveSnapshot = (dirPath, powers) => {
         fd,
         removeCallback,
       } = tmp.fileSync({
+        tmpdir: dirPath,
         prefix: name,
-        postfix: '.gz',
+        postfix: '.gz.tmp',
         detachDescriptor: true,
       });
       addCleanup(() => removeCallback());
@@ -59,8 +60,9 @@ export const makeArchiveTranscript = (dirPath, powers) => {
         fd,
         removeCallback,
       } = tmp.fileSync({
+        tmpdir: dirPath,
         prefix: spanName,
-        postfix: '.gz',
+        postfix: '.gz.tmp',
         detachDescriptor: true,
       });
       addCleanup(() => removeCallback());


### PR DESCRIPTION
Fixes #10239

## Description
Use the `tmpdir` option to create vat snapshot and transcript span archive files in the correct destination directory, with a ".tmp" suffix until a final atomic rename.

### Security Considerations
n/a

### Scaling Considerations
None; the archive functions were already waiting for the final rename to complete.

### Documentation Considerations
I don't think there's anything worth documenting here... we _could_ consider being clear that vat snapshot and transcript span archives ignore TMPDIR, but that seems unnecessary.

### Testing Considerations
I don't want to set up testing where TMPDIR is arranged such that the error of #10239 will be encountered, so I think we'll just rely on continued success of the existing tests.

### Upgrade Considerations
This consensus-independent kernel code is safe to adopt at any time, including in between chain-halting upgrades and by an arbitrary subset of validator nodes.