### PR TITLE
prevent patch-package warnings

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -156,6 +156,14 @@ runs:
         fi
         yarn install
 
+        # Verify there are no warnings about the applied patches.
+        # This isn't strictly necessary but it avoids distracting messages for developers.
+        if yarn patch-package 2>&1 | tee /dev/stderr | grep -qi "warning"; then
+          echo "Error: 'warning' detected applying patches. Please address the warnings before proceeding."
+          echo "If the patch applied cleanly and all tests pass, you can forward a patch with 'yarn patch-package'."
+          exit 1
+        fi
+
         # In the event that the package.json has been modified by Endo
         # replacements, we need to have a yarn-installed timestamp that
         # corresponds to the unmodified package.json.  As long as we don't

--- a/patches/express+4.21.0.patch
+++ b/patches/express+4.21.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/express/lib/router/index.js b/node_modules/express/lib/router/index.js
-index 5174c34..84076b7 100644
+index abb3a6f..be10092 100644
 --- a/node_modules/express/lib/router/index.js
 +++ b/node_modules/express/lib/router/index.js
 @@ -515,12 +515,17 @@ proto.route = function route(path) {


### PR DESCRIPTION
closes: #10243

## Description

Adds a check to CI after `yarn install` that there were no warnings from `patch-package`.

Also forwards a patch that had produced a warning (resulting from Dependabot updates which are tested only in CI and not locally)

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none