### PR TITLE
fix(vlocalchain): refuse to use existing account

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -655,6 +655,7 @@ func NewAgoricApp(
 		keys[vlocalchain.StoreKey],
 		app.BaseApp.MsgServiceRouter(),
 		app.BaseApp.GRPCQueryRouter(),
+		app.AccountKeeper,
 	)
 	app.vlocalchainPort = app.AgdServer.MustRegisterPortHandler(
 		"vlocalchain",

--- a/golang/cosmos/vm/action.go
+++ b/golang/cosmos/vm/action.go
@@ -86,7 +86,7 @@ func PopulateAction(ctx sdk.Context, action Action) Action {
 		var headerPtr *ActionHeader
 		if fieldType.Type == actionHeaderType {
 			headerPtr = field.Addr().Interface().(*ActionHeader)
-		} else if fieldType.Type == reflect.PtrTo(actionHeaderType) {
+		} else if fieldType.Type == reflect.PointerTo(actionHeaderType) {
 			if field.IsNil() {
 				headerPtr = &ActionHeader{}
 			} else {

--- a/golang/cosmos/x/vlocalchain/keeper/keeper_test.go
+++ b/golang/cosmos/x/vlocalchain/keeper/keeper_test.go
@@ -10,7 +10,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-
 func TestKeeper_ParseRequestTypeURL(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -46,7 +45,7 @@ func TestKeeper_DeserializeTxMessages(t *testing.T) {
 
 	banktypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 
-	keeper := NewKeeper(cdc, nil, nil, nil)
+	keeper := NewKeeper(cdc, nil, nil, nil, nil)
 
 	expectedMsgSend := []sdk.Msg{
 		&banktypes.MsgSend{
@@ -63,22 +62,22 @@ func TestKeeper_DeserializeTxMessages(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "camelCase keys",
-			json: `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","fromAddress":"cosmos1abc","toAddress":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
+			name:     "camelCase keys",
+			json:     `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","fromAddress":"cosmos1abc","toAddress":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
 			expected: expectedMsgSend,
-			wantErr: false,
+			wantErr:  false,
 		},
 		{
-			name: "snake_case keys",
-			json: `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_address":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
+			name:     "snake_case keys",
+			json:     `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_address":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
 			expected: expectedMsgSend,
-			wantErr: false,
+			wantErr:  false,
 		},
 		{
-			name: "misspelled key",
-			json: `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_addresss":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
+			name:     "misspelled key",
+			json:     `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_addresss":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
 			expected: expectedMsgSend,
-			wantErr: true,
+			wantErr:  true,
 		},
 	}
 

--- a/golang/cosmos/x/vlocalchain/types/expected_keepers.go
+++ b/golang/cosmos/x/vlocalchain/types/expected_keepers.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+type AccountKeeper interface {
+	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	HasAccount(ctx sdk.Context, addr sdk.AccAddress) bool
+	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10246

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Changes `VLOCALCHAIN_ALLOCATE_ADDRESS` to continue using pseudorandom inputs to generate a likely-unused account address, but increments the sequence number until the address does not correspond to an existing account.  Then, atomically, create a new account with that address.

This prevents localchain account addresses from clashing with preexisting accounts or ones that were created after the address was known but before any deposit activity.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Removes a race condition.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Scanning for existing accounts should not be expensive, because in order for it to be repeated indefinitely, the account addresses would need to be predicted, and the prior messages to create those clashing accounts would still require gas payments.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
n/a

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Added tests for collision detection and account creation via mock AccountKeeper.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a