### PR TITLE
feat(vtransfer): extract base address from parameterized address

### DIFF
--- a/golang/cosmos/x/vtransfer/ibc_middleware_test.go
+++ b/golang/cosmos/x/vtransfer/ibc_middleware_test.go
@@ -331,18 +331,19 @@ func (s *IntegrationTestSuite) TestTransferFromAgdToAgd() {
 
 	s.Run("TransferFromAgdToAgd", func() {
 		// create a transfer packet's data contents
+		baseReceiver := s.chainB.SenderAccounts[1].SenderAccount.GetAddress().String()
 		transferData := ibctransfertypes.NewFungibleTokenPacketData(
 			"uosmo",
 			"1000000",
 			s.chainA.SenderAccount.GetAddress().String(),
-			s.chainB.SenderAccounts[1].SenderAccount.GetAddress().String(),
+			baseReceiver+"?what=arbitrary-data&why=to-test-bridge-targets",
 			`"This is a JSON memo"`,
 		)
 
 		// Register the sender and receiver as bridge targets on their specific
 		// chain.
 		s.RegisterBridgeTarget(s.chainA, transferData.Sender)
-		s.RegisterBridgeTarget(s.chainB, transferData.Receiver)
+		s.RegisterBridgeTarget(s.chainB, baseReceiver)
 
 		s.mintToAddress(s.chainA, s.chainA.SenderAccount.GetAddress(), transferData.Denom, transferData.Amount)
 
@@ -384,7 +385,7 @@ func (s *IntegrationTestSuite) TestTransferFromAgdToAgd() {
 							BlockTime:   writeAcknowledgementTime,
 						},
 						Event:           "writeAcknowledgement",
-						Target:          transferData.Receiver,
+						Target:          baseReceiver,
 						Packet:          packet,
 						Acknowledgement: ack.Acknowledgement(),
 					},

--- a/golang/cosmos/x/vtransfer/types/baseaddr.go
+++ b/golang/cosmos/x/vtransfer/types/baseaddr.go
@@ -1,0 +1,156 @@
+package types
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v6/modules/core/exported"
+)
+
+type AddressRole string
+
+const (
+	RoleSender   AddressRole = "Sender"
+	RoleReceiver AddressRole = "Receiver"
+)
+
+func trimSlashPrefix(s string) string {
+	return strings.TrimPrefix(s, "/")
+}
+
+// ExtractBaseAddress extracts the base address from a parameterized address.
+// It removes all subpath and query components from addr.
+func ExtractBaseAddress(addr string) (string, error) {
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return "", err
+	}
+
+	// Specify the fields and values we expect.  Unspecified fields will only
+	// match if they are zero values in order to be robust against extensions to
+	// the url.URL struct.
+	//
+	// Remove leading slashes from the path fields so that only parsed relative
+	// paths match the expected test.
+	expected := url.URL{
+		Path:        trimSlashPrefix(parsed.Path),
+		RawPath:     trimSlashPrefix(parsed.RawPath),
+		RawQuery:    parsed.RawQuery,
+		Fragment:    parsed.Fragment,
+		RawFragment: parsed.RawFragment,
+
+		// Skip over parsing control flags.
+		ForceQuery: parsed.ForceQuery,
+		OmitHost:   parsed.OmitHost,
+	}
+
+	if *parsed != expected {
+		return "", fmt.Errorf("address must be relative path with optional query and fragment, got %s", addr)
+	}
+
+	baseAddr, _, _ := strings.Cut(expected.Path, "/")
+	if baseAddr == "" {
+		return "", fmt.Errorf("base address cannot be empty")
+	}
+
+	return baseAddr, nil
+}
+
+// extractBaseTransferData returns the base address from the transferData.Sender
+// (if RoleSender) or transferData.Receiver (if RoleReceiver). Errors in
+// determining the base address are ignored... we then assume the base address
+// is exactly the original address.  If newTransferData is not nil, it will be
+// populated with a new FungibleTokenPacketData consisting of the role replaced
+// with its base address.
+func extractBaseTransferData(transferData transfertypes.FungibleTokenPacketData, role AddressRole, newTransferData *transfertypes.FungibleTokenPacketData) (string, error) {
+	var target string
+	sender := transferData.Sender
+	receiver := transferData.Receiver
+
+	switch role {
+	case RoleSender:
+		baseSender, err := ExtractBaseAddress(sender)
+		if err == nil {
+			sender = baseSender
+		}
+		target = sender
+
+	case RoleReceiver:
+		baseReceiver, err := ExtractBaseAddress(receiver)
+		if err == nil {
+			receiver = baseReceiver
+		}
+		target = receiver
+
+	default:
+		err := fmt.Errorf("invalid address role: %s", role)
+		return target, err
+	}
+
+	if newTransferData == nil {
+		return target, nil
+	}
+
+	// Create the new transfer data.
+	*newTransferData = transfertypes.NewFungibleTokenPacketData(
+		transferData.Denom,
+		transferData.Amount,
+		sender, receiver,
+		transferData.Memo,
+	)
+
+	return target, nil
+}
+
+// ExtractBaseAddressFromPacket returns the base address from a transfer
+// packet's data, either Sender (if role is RoleSender) or Receiver (if role is
+// RoleReceiver).
+// Errors in determining the base address are ignored... we then assume the base
+// address is exactly the original address.
+// If newPacket is not nil, it is populated with a new transfer packet whose
+// corresponding Sender or Receiver is replaced with the extracted base address.
+func ExtractBaseAddressFromPacket(cdc codec.Codec, packet ibcexported.PacketI, role AddressRole, newPacket *channeltypes.Packet) (string, error) {
+	transferData := transfertypes.FungibleTokenPacketData{}
+	if err := cdc.UnmarshalJSON(packet.GetData(), &transferData); err != nil {
+		return "", err
+	}
+
+	var newTransferData *transfertypes.FungibleTokenPacketData
+	if newPacket != nil {
+		// Capture the transfer data for the new packet.
+		newTransferData = &transfertypes.FungibleTokenPacketData{}
+	}
+	target, err := extractBaseTransferData(transferData, role, newTransferData)
+	if err != nil {
+		return target, err
+	}
+
+	if newPacket == nil {
+		return target, nil
+	}
+
+	// Create a new packet with the new transfer packet data.
+	// Re-serialize the packet data with the base addresses.
+	newData, err := cdc.MarshalJSON(newTransferData)
+	if err != nil {
+		return target, err
+	}
+
+	// Create the new packet.
+	th := packet.GetTimeoutHeight()
+	*newPacket = channeltypes.NewPacket(
+		newData, packet.GetSequence(),
+		packet.GetSourcePort(), packet.GetSourceChannel(),
+		packet.GetDestPort(), packet.GetDestChannel(),
+		clienttypes.NewHeight(th.GetRevisionNumber(), th.GetRevisionHeight()),
+		packet.GetTimeoutTimestamp(),
+	)
+
+	return target, nil
+}

--- a/golang/cosmos/x/vtransfer/types/baseaddr_test.go
+++ b/golang/cosmos/x/vtransfer/types/baseaddr_test.go
@@ -1,0 +1,167 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	codec "github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+
+	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vtransfer/types"
+)
+
+func TestExtractBaseAddress(t *testing.T) {
+	bases := []struct {
+		name string
+		addr string
+	}{
+		{"agoric address", "agoric1abcdefghiteaneas"},
+		{"cosmos address", "cosmos1abcdeffiharceuht"},
+		{"hex address", "0xabcdef198189818c93839ibia"},
+	}
+
+	prefixes := []struct {
+		prefix      string
+		baseIsWrong bool
+		isErr       bool
+	}{
+		{"", false, false},
+		{"/", false, true},
+		{"orch:/", false, true},
+		{"unexpected", true, false},
+		{"norch:/", false, true},
+		{"orch:", false, true},
+		{"norch:", false, true},
+		{"\x01", false, true},
+	}
+
+	suffixes := []struct {
+		suffix      string
+		baseIsWrong bool
+		isErr       bool
+	}{
+		{"", false, false},
+		{"/", false, false},
+		{"/sub/account", false, false},
+		{"?query=something&k=v&k2=v2", false, false},
+		{"?query=something&k=v&k2=v2#fragment", false, false},
+		{"unexpected", true, false},
+		{"\x01", false, true},
+	}
+
+	for _, b := range bases {
+		b := b
+		for _, p := range prefixes {
+			p := p
+			for _, s := range suffixes {
+				s := s
+				t.Run(b.name+" "+p.prefix+" "+s.suffix, func(t *testing.T) {
+					addr := p.prefix + b.addr + s.suffix
+					addr, err := types.ExtractBaseAddress(addr)
+					if p.isErr || s.isErr {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+						if p.baseIsWrong || s.baseIsWrong {
+							require.NotEqual(t, b.addr, addr)
+						} else {
+							require.Equal(t, b.addr, addr)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestExtractBaseAddressFromPacket(t *testing.T) {
+	ir := cdctypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(ir)
+	transfertypes.RegisterInterfaces(ir)
+	channeltypes.RegisterInterfaces(ir)
+	clienttypes.RegisterInterfaces(ir)
+
+	cases := []struct {
+		name  string
+		addrs map[types.AddressRole]struct{ addr, baseAddr string }
+	}{
+		{"sender has params",
+			map[types.AddressRole]struct{ addr, baseAddr string }{
+				types.RoleSender:   {"cosmos1abcdeffiharceuht?foo=bar&baz=bot#fragment", "cosmos1abcdeffiharceuht"},
+				types.RoleReceiver: {"agoric1abcdefghiteaneas", "agoric1abcdefghiteaneas"},
+			},
+		},
+		{"receiver has params",
+			map[types.AddressRole]struct{ addr, baseAddr string }{
+				types.RoleSender:   {"cosmos1abcdeffiharceuht", "cosmos1abcdeffiharceuht"},
+				types.RoleReceiver: {"agoric1abcdefghiteaneas?bingo=again", "agoric1abcdefghiteaneas"},
+			},
+		},
+		{"both are base",
+			map[types.AddressRole]struct{ addr, baseAddr string }{
+				types.RoleSender:   {"cosmos1abcdeffiharceuht", "cosmos1abcdeffiharceuht"},
+				types.RoleReceiver: {"agoric1abcdefghiteaneas", "agoric1abcdefghiteaneas"},
+			},
+		},
+		{"both have params",
+			map[types.AddressRole]struct{ addr, baseAddr string }{
+				types.RoleSender:   {"agoric1abcdefghiteaneas?bingo=again", "agoric1abcdefghiteaneas"},
+				types.RoleReceiver: {"cosmos1abcdeffiharceuht?foo=bar&baz=bot#fragment", "cosmos1abcdeffiharceuht"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ftPacketData := transfertypes.NewFungibleTokenPacketData("denom", "100", tc.addrs[types.RoleSender].addr, tc.addrs[types.RoleReceiver].addr, "my-favourite-memo")
+			packetBz, err := cdc.MarshalJSON(&ftPacketData)
+			require.NoError(t, err)
+			packet := channeltypes.NewPacket(packetBz, 1234, "my-port", "my-channel", "their-port", "their-channel", clienttypes.NewHeight(133, 445), 10999)
+
+			for role, addrs := range tc.addrs {
+				addrs := addrs
+				role := role
+
+				t.Run(string(role), func(t *testing.T) {
+					baseAddr, err := types.ExtractBaseAddress(addrs.addr)
+					require.NoError(t, err)
+					require.Equal(t, addrs.baseAddr, baseAddr)
+
+					packetBaseAddr, err := types.ExtractBaseAddressFromPacket(cdc, packet, role, nil)
+					require.NoError(t, err)
+					require.Equal(t, addrs.baseAddr, packetBaseAddr)
+
+					var newPacket channeltypes.Packet
+					packetBaseAddr2, err := types.ExtractBaseAddressFromPacket(cdc, packet, role, &newPacket)
+					require.NoError(t, err)
+					require.Equal(t, addrs.baseAddr, packetBaseAddr2)
+
+					var basePacketData transfertypes.FungibleTokenPacketData
+					err = cdc.UnmarshalJSON(newPacket.GetData(), &basePacketData)
+					require.NoError(t, err)
+
+					// Check that the only difference between the packet data is the baseAddr.
+					packetData := basePacketData
+					switch role {
+					case types.RoleSender:
+						require.Equal(t, addrs.baseAddr, basePacketData.Sender)
+						packetData.Sender = addrs.addr
+					case types.RoleReceiver:
+						require.Equal(t, addrs.baseAddr, basePacketData.Receiver)
+						packetData.Receiver = addrs.addr
+					default:
+						t.Fatal("unexpected role", role)
+					}
+
+					require.Equal(t, ftPacketData, packetData)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10249

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR allows ICS-20 fungible token transfer packets to contain inbound receiver and outbound sender addresses formatted as either:
- a standard bech32 address (`"agoric1bech32addr"`), or
- a base account with optional subpaths and query parameters (`"agoric1bech32addr/opt/account?k=v&k2=v2"`)

In these cases, the "base address" is `"agoric1bech32addr"`, and tokens are transferred to that base address.  The original address can be parsed by a listening contract into "address parameters" to use at its discretion.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Should be no impact.  If a transfer listener does not explicitly look for the data in an inbound packet, it will behave as if there are no address parameters.

Careful review of the code is critical, though, since it touches the powerful `x/vtransfer` module.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Increases the scalability of contracts that would ordinarily have to maintain a pool of multiple Local Chain Account (LCA) addresses to have a unique ID to map to some parameters.  Now, contracts can create just one LCA and have the sender supply the data as part of a parameterized address.

The ICS-20 transfer addresses are strings limited to at most [2048 bytes, and potentially even smaller if explicitly configured](https://github.com/informalsystems/hermes/pull/3765#issue-2073892055) by a relayer operator.  Thus, the total length of the encoded base address and all the address parameters cannot exceed that address string limit, or the packet will not be forwarded.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
Should be documented as a feature of `vtransfer`.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Unit tests with address parameter data tests have been implemented, testing both the address parser code and the IBC end-to-end packet relay process through the `x/vtransfer` module.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
This is a chain-level, backwards-compatible change, so no upgrade aspects must be addressed.  However, Agoric contracts will probably need to import an URL-parsing module to parse URL escaping and query parameters syntax (since the `globalThis.URL` constructor is not currently available in the SwingSet vat environment).
