### PR TITLE
fix(swingset): retain vatParameters for vat creation and upgrade

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -752,6 +752,8 @@ export default function buildKernel(
       kdebug(`vat ${vatID} terminated before startVat delivered`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
+    const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
+    vatKeeper.setVatParameters(vatParameters);
     const { meterID } = vatInfo;
     /** @type { KernelDeliveryStartVat } */
     const kd = harden(['startVat', vatParameters]);
@@ -1052,6 +1054,7 @@ export default function buildKernel(
     });
     const vatOptions = harden({ ...origOptions, workerOptions });
     vatKeeper.setSourceAndOptions(source, vatOptions);
+    vatKeeper.setVatParameters(vatParameters);
     // TODO: decref the bundleID once setSourceAndOptions increfs it
 
     // pause, take a deep breath, appreciate this moment of silence

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -119,6 +119,8 @@ export const CURRENT_SCHEMA_VERSION = 3;
 // old (v0): v$NN.reapCountdown = $NN or 'never'
 // v$NN.reapDirt = JSON({ deliveries, gcKrefs, computrons }) // missing keys treated as zero
 // (leave room for v$NN.snapshotDirt and options.snapshotDirtThreshold for #6786)
+// v$NN.vatParameters = JSON(capdata) // missing for vats created/upgraded before #8947
+//
 // exclude from consensus
 // local.*
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -7,6 +7,7 @@ import { isObject } from '@endo/marshal';
 import { parseKernelSlot } from '../parseKernelSlots.js';
 import { makeVatSlot, parseVatSlot } from '../../lib/parseVatSlots.js';
 import { insistVatID } from '../../lib/id.js';
+import { insistCapData } from '../../lib/capdata.js';
 import { kdebug } from '../../lib/kdebug.js';
 import {
   parseReachableAndVatSlot,
@@ -171,6 +172,35 @@ export function makeVatKeeper(
     /** @type { RecordedVatOptions } */
     const options = JSON.parse(getRequired(`${vatID}.options`));
     return harden(options);
+  }
+
+  /**
+   * @param {SwingSetCapData} newVPCD
+   */
+  function setVatParameters(newVPCD) {
+    insistCapData(newVPCD);
+    const key = `${vatID}.vatParameters`;
+    // increment-before-decrement to minimize spurious rc=0 checks
+    for (const kref of newVPCD.slots) {
+      incrementRefCount(kref, `${vatID}.vatParameters`);
+    }
+    const old = kvStore.get(key) || '{"slots":[]}';
+    for (const kref of JSON.parse(old).slots) {
+      decrementRefCount(kref, `${vatID}.vatParameters`);
+    }
+    kvStore.set(key, JSON.stringify(newVPCD));
+  }
+
+  /**
+   * @returns {SwingSetCapData | undefined} vpcd
+   */
+  function getVatParameters() {
+    const key = `${vatID}.vatParameters`;
+    const old = kvStore.get(key);
+    if (old) {
+      return JSON.parse(old);
+    }
+    return undefined;
   }
 
   // This is named "addDirt" because it should increment all dirt
@@ -768,6 +798,8 @@ export function makeVatKeeper(
     setSourceAndOptions,
     getSourceAndOptions,
     getOptions,
+    setVatParameters,
+    getVatParameters,
     addDirt,
     getReapDirt,
     clearReapDirt,

--- a/packages/SwingSet/test/upgrade/bootstrap-scripted-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-scripted-upgrade.js
@@ -43,6 +43,8 @@ export const buildRootObject = () => {
       vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
     },
 
+    nop: () => 0,
+
     getMarker: () => marker,
 
     getImportSensors: () => importSensors,
@@ -281,6 +283,27 @@ export const buildRootObject = () => {
       const paramB = await E(root).getParameters();
 
       return [paramA, paramB];
+    },
+
+    buildV1WithVatParameters: async () => {
+      const bcap1 = await E(vatAdmin).getNamedBundleCap('ulrik1');
+      const vp1 = { number: 1, marker };
+      const options1 = { vatParameters: vp1 };
+      const res = await E(vatAdmin).createVat(bcap1, options1);
+      ulrikAdmin = res.adminNode;
+      ulrikRoot = res.root;
+      const param1 = await E(ulrikRoot).getParameters();
+      return param1;
+    },
+
+    upgradeV2WithVatParameters: async () => {
+      const bcap2 = await E(vatAdmin).getNamedBundleCap('ulrik2');
+      const vp2 = { number: 2, marker };
+      const options2 = { vatParameters: vp2 };
+      await E(ulrikAdmin).upgrade(bcap2, options2);
+      const param2 = await E(ulrikRoot).getParameters();
+
+      return param2;
     },
   });
 };

--- a/packages/SwingSet/test/vat-admin/slow-termination/slow-termination.test.js
+++ b/packages/SwingSet/test/vat-admin/slow-termination/slow-termination.test.js
@@ -152,9 +152,9 @@ async function doSlowTerminate(t, mode) {
       .get(vatID);
 
   // 20*2 for imports, 21*2 for exports, 20*2 for promises, 20*1 for
-  // vatstore = 142.  Plus 21 for the usual liveslots stuff, and 6 for
+  // vatstore = 142.  Plus 21 for the usual liveslots stuff, and 7 for
   // kernel stuff like vNN.source/options
-  const initialKVCount = 169;
+  const initialKVCount = 170;
 
   t.is(remainingKV().length, initialKVCount);
   t.false(JSON.parse(kvStore.get('vats.terminated')).includes(vatID));
@@ -253,36 +253,36 @@ async function doSlowTerminate(t, mode) {
   await cleanKV(10, 5); // 5 c-list promises
 
   // that finishes the promises, so the next clean will delete the
-  // first five of our 47 other kv entries (20 vatstore plus 27
-  // liveslots overhead
+  // first five of our 48 other kv entries (20 vatstore plus 28
+  // overhead)
 
   await cleanKV(5, 5); // 5 other kv
-  // now there are 42 other kv entries left
-  t.is(remainingKV().length, 42);
+  // now there are 43 other kv entries left
+  t.is(remainingKV().length, 43);
 
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 37);
+  t.is(remainingKV().length, 38);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 32);
+  t.is(remainingKV().length, 33);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 27);
+  t.is(remainingKV().length, 28);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 22);
+  t.is(remainingKV().length, 23);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 17);
+  t.is(remainingKV().length, 18);
   checkTS();
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 12);
+  t.is(remainingKV().length, 13);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 7);
+  t.is(remainingKV().length, 8);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 2);
+  t.is(remainingKV().length, 3);
 
   checkTS();
 
-  // there are two kv left, so this clean will delete those, then 5 of
-  // the 7 snapshots
-  await cleanKV(2, 7); // 2 final kv, and 5 snapshots
+  // there are three kv left, so this clean will delete those, then 5
+  // of the 7 snapshots
+  await cleanKV(3, 8); // 3 final kv, and 5 snapshots
   t.deepEqual(remainingKV(), []);
   t.is(kernelStorage.kvStore.get(`${vatID}.options`), undefined);
   expectedRemainingSnapshots -= 5;


### PR DESCRIPTION
fix(swingset): retain vatParameters for vat creation and upgrade

All vats have `vatParameters`, a mostly-arbitrary data record,
delivered as the second argument to their `buildRootObject()`
function. Dynamic vats get their vatParameters from the options bag
given to `E(vatAdminSvc).createVat()`. Static vats get them from the
kernel config record. When a vat is upgraded, the new incarnation gets
new vatParameters; these come from the options bag on
`E(adminNode).upgrade()`.

When received via `createVat()` or `upgrade()`, the vatParameters
can contain object and device references. VatParameters cannot include
promises.

Previously, the kernel delivered vatParameters to the vat, but did not
keep a copy. With this commit, the kernel retains a copy of
vatParameters (including a refcount on any kernel objects
therein). Internally, `vatKeeper.getVatParameters()` can be used to
retrieve this copy.  Only vats created or upgraded after this commit
lands will get retained vatParameters: for older vats this will return
`undefined`.

Retained vat parameters should make it easier to implement "upgrade
all vats", where the kernel perform a unilateral `upgrade()` on all
vats without userspace asking for it. When this is implemented, the
new incarnations will receive the same vatParameters as their
predecessors.

fixes #8947
