### PR TITLE
ci: added priority rules to mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,9 +17,6 @@ shared:
           - and: # breakage fails like we thought
               - check-failure=breakage
               - label=proto:expect-breakage
-    high_priority_queue_conditions: &high-priority-queue-conditions
-      - and: *queue-conditions
-      - label=priority:high
     merge_conditions: &merge-conditions
       - base=master
       # Rebase PRs with fixup commits are allowed to enter the merge queue but 
@@ -48,31 +45,13 @@ shared:
       - base=master
       - label=automerge:squash
 
+priority_rules:
+  - name: high_priority
+    conditions:
+      - label=priority:high
+    priority: high
+
 queue_rules:
-  - name: high_priority_rebase
-    commit_message_template: *commit-message-template
-    queue_conditions: *high-priority-queue-conditions
-    merge_conditions: *merge-conditions
-    merge_method: merge
-    update_method: rebase
-
-  - name: high_priority_merge
-    commit_message_template: *commit-message-template
-    queue_conditions: *high-priority-queue-conditions
-    merge_conditions: *merge-conditions
-    disallow_checks_interruption_from_queues:
-      - high_priority_rebase
-    merge_method: merge
-
-  - name: high_priority_squash
-    commit_message_template: *commit-message-template
-    queue_conditions: *high-priority-queue-conditions
-    merge_conditions: *merge-conditions
-    disallow_checks_interruption_from_queues:
-      - high_priority_rebase
-      - high_priority_merge
-    merge_method: squash
-
   - name: rebase
     commit_message_template: *commit-message-template
     queue_conditions: *queue-conditions
@@ -84,41 +63,15 @@ queue_rules:
     commit_message_template: *commit-message-template
     queue_conditions: *queue-conditions
     merge_conditions: *merge-conditions
-    disallow_checks_interruption_from_queues:
-      - rebase
     merge_method: merge
 
   - name: squash
     commit_message_template: *commit-message-template
     queue_conditions: *queue-conditions
     merge_conditions: *merge-conditions
-    disallow_checks_interruption_from_queues:
-      - rebase
-      - merge
     merge_method: squash
 
 pull_request_rules:
-  - name:  high priority - merge to master
-    conditions:
-      - and: *pr-queue-merge-conditions
-      - label=priority:high
-    actions:
-      queue:
-        name: high_priority_merge
-  - name: high priority - rebase updates then merge to master
-    conditions:
-      - and: *pr-queue-rebase-conditions
-      - label=priority:high
-    actions:
-      queue:
-        name: high_priority_rebase
-  - name: high priority - squash to master
-    conditions:
-      - and: *pr-queue-squash-conditions
-      - label=priority:high
-    actions:
-      queue:
-        name: high_priority_squash
   - name: merge to master
     conditions: *pr-queue-merge-conditions
     actions:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Mergify has recently added priority rules feature to mergify configuration

This allows us to define priority rules of each item in our merge queue, independent of the the priority of the queue

What this means for us is that we can remove all the separate high priority queues and simplify our configuration

Also created a [PR in Agoric/mergify-experiments](https://github.com/Agoric/mergify-experiements/pull/25) that the updates made here

### Testing

This configuration has been tested out on [frazarshad/mergify-experiments ](https://github.com/frazarshad/mergify-experiements)
![image](https://github.com/user-attachments/assets/3a88ec98-62ce-4373-9954-36dc99746017)

Similarly I also tested that the queues don't have any priority base on their order in the configuration and don't preempt each other
![image](https://github.com/user-attachments/assets/5332df09-973e-497b-b44f-8e918444b2f4)


