### PR TITLE
feat: add zoe upgrade to upgrade.go

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/initial.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/initial.test.js
@@ -9,7 +9,7 @@ const vats = {
   orchestration: { incarnation: 0 },
   transfer: { incarnation: 1 },
   walletFactory: { incarnation: 4 },
-  zoe: { incarnation: 2 },
+  zoe: { incarnation: 3 },
 };
 
 test(`vat details`, async t => {

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -93,6 +93,10 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 			// one or more modules executing in parallel within the step.
 			CoreProposalSteps = []vm.CoreProposalStep{
 				vm.CoreProposalStepForModules(
+					// Upgrade Zoe (no new ZCF needed).
+					"@agoric/builders/scripts/vats/upgrade-zoe.js",
+				),
+				vm.CoreProposalStepForModules(
 					// Upgrade to new liveslots for repaired vow usage.
 					"@agoric/builders/scripts/vats/upgrade-orch-core.js",
 				),


### PR DESCRIPTION
refs: #10267

## Description

Upgrade Zoe as part of the next software upgrade.

### Security Considerations

The new Zoe will add the ability to terminate vats from bootstrap space. 

### Scaling Considerations

Terminating vats will allow us to address some space leakage issues.

### Documentation Considerations

The new behavior is accessible on a facet that is only exposed to the bootstrap space. Doesn't need to impact developer docs.

### Testing Considerations

Tested in a bootstrap test.

### Upgrade Considerations

We expect to include this change with the next software upgrade, so we can start making use of the ability to remove unneeded vats.