### PR TITLE
refactor: Add mailbox types and differentiate use of maps from map-like stores

### DIFF
--- a/packages/SwingSet/src/devices/mailbox/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/mailbox.js
@@ -71,6 +71,23 @@ import { Nat } from '@endo/nat';
 // replace it with one that tracks which parts of the state have been
 // modified, to build more efficient Merkle proofs.
 
+/**
+ * @typedef {object} Mailbox
+ * @property {bigint} ack
+ * @property {Map<bigint, unknown>} outbox
+ */
+
+/**
+ * @typedef {object} MailboxExport
+ * @property {number} ack
+ * @property {Array<[number, unknown]>} outbox
+ */
+
+/**
+ * @param {MailboxExport} data
+ * @param {Partial<Mailbox>} [inout]
+ * @returns {Mailbox}
+ */
 export function importMailbox(data, inout = {}) {
   const outbox = new Map();
   for (const m of data.outbox) {
@@ -78,10 +95,15 @@ export function importMailbox(data, inout = {}) {
   }
   inout.ack = Nat(data.ack);
   inout.outbox = outbox;
-  return inout;
+  return /** @type {Mailbox} */ (inout);
 }
 
+/**
+ * @param {Mailbox} inout
+ * @returns {MailboxExport}
+ */
 export function exportMailbox(inout) {
+  /** @type {MailboxExport['outbox']} */
   const messages = [];
   for (const [msgnum, body] of inout.outbox) {
     messages.push([Number(msgnum), body]);
@@ -93,64 +115,75 @@ export function exportMailbox(inout) {
   };
 }
 
-export function buildMailboxStateMap(state = harden(new Map())) {
-  function getOrCreatePeer(peer) {
-    if (!state.has(peer)) {
-      const inout = {
-        outbox: harden(new Map()),
-        ack: 0n,
-      };
-      state.set(peer, inout);
-    }
-    return state.get(peer);
+/**
+ * @param {Map<string, Mailbox>} state
+ */
+export function exportMailboxData(state) {
+  /** @type {Record<string, {inboundAck: MailboxExport['ack'], outbox: MailboxExport['outbox']}>} */
+  const data = {};
+  for (const [peer, inout] of state.entries()) {
+    const exported = exportMailbox(inout);
+    data[peer] = {
+      inboundAck: exported.ack,
+      outbox: exported.outbox,
+    };
   }
+  return harden(data);
+}
 
+function getOrCreatePeer(state, peer) {
+  if (!state.has(peer)) {
+    const inout = {
+      outbox: harden(new Map()),
+      ack: 0n,
+    };
+    state.set(peer, inout);
+  }
+  return state.get(peer);
+}
+
+/**
+ * @param {ReturnType<exportMailboxData>} data
+ * @returns {Map<string, Mailbox>}
+ */
+export function makeEphemeralMailboxStorage(data) {
+  const state = harden(new Map());
+  for (const peer of Object.getOwnPropertyNames(data)) {
+    const inout = getOrCreatePeer(state, peer);
+    const d = data[peer];
+    importMailbox(
+      {
+        ack: d.inboundAck,
+        outbox: d.outbox,
+      },
+      inout,
+    );
+  }
+  return state;
+}
+
+/**
+ * @template [T=unknown]
+ * @param {Pick<Map<string, T>, 'has' | 'get'> & {set: (key: string, value: T) => void}} [state]
+ */
+export function buildMailboxStateMap(state = harden(new Map())) {
   function add(peer, msgnum, body) {
-    getOrCreatePeer(`${peer}`).outbox.set(Nat(msgnum), `${body}`);
+    getOrCreatePeer(state, `${peer}`).outbox.set(Nat(msgnum), `${body}`);
   }
 
   function remove(peer, msgnum) {
-    const messages = getOrCreatePeer(`${peer}`).outbox;
+    const messages = getOrCreatePeer(state, `${peer}`).outbox;
     messages.delete(Nat(msgnum));
   }
 
   function setAcknum(peer, msgnum) {
-    getOrCreatePeer(`${peer}`).ack = Nat(msgnum);
-  }
-
-  function exportToData() {
-    const data = {};
-    for (const [peer, inout] of state.entries()) {
-      const exported = exportMailbox(inout);
-      data[peer] = {
-        inboundAck: exported.ack,
-        outbox: exported.outbox,
-      };
-    }
-    return harden(data);
-  }
-
-  function populateFromData(data) {
-    !state.size || Fail`cannot populateFromData: outbox is not empty`;
-    for (const peer of Object.getOwnPropertyNames(data)) {
-      const inout = getOrCreatePeer(peer);
-      const d = data[peer];
-      importMailbox(
-        {
-          ack: d.inboundAck,
-          outbox: d.outbox,
-        },
-        inout,
-      );
-    }
+    getOrCreatePeer(state, `${peer}`).ack = Nat(msgnum);
   }
 
   return harden({
     add,
     remove,
     setAcknum,
-    exportToData,
-    populateFromData,
   });
 }
 

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -13,6 +13,8 @@ export { upgradeSwingset } from './controller/upgradeSwingset.js';
 export {
   buildMailboxStateMap,
   buildMailbox,
+  exportMailboxData,
+  makeEphemeralMailboxStorage,
 } from './devices/mailbox/mailbox.js';
 export { buildTimer } from './devices/timer/timer.js';
 export { buildBridge } from './devices/bridge/bridge.js';

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -284,6 +284,13 @@ export {};
  */
 
 /**
+ * @typedef { import('./devices/mailbox/mailbox.js').Mailbox } Mailbox
+ */
+/**
+ * @typedef { import('./devices/mailbox/mailbox.js').MailboxExport } MailboxExport
+ */
+
+/**
  * Vat Creation and Management
  *
  * @typedef { string } BundleID

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -511,8 +511,10 @@ export const makeSwingsetTestKit = async (
       },
     });
   }
+  const mailboxStorage = new Map();
   const { controller, timer, bridgeInbound } = await buildSwingset(
-    new Map(),
+    // @ts-expect-error missing method 'getNextKey'
+    mailboxStorage,
     bridgeOutbound,
     kernelStorage,
     configPath,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -52,7 +52,8 @@ import { makeQueue, makeQueueStorageMock } from './helpers/make-queue.js';
 import { exportStorage } from './export-storage.js';
 import { parseLocatedJson } from './helpers/json.js';
 
-/** @import {RunPolicy} from '@agoric/swingset-vat' */
+/** @import { Mailbox, RunPolicy, SwingSetConfig } from '@agoric/swingset-vat' */
+/** @import { KVStore } from './helpers/bufferedStorage.js' */
 
 const console = anylogger('launch-chain');
 const blockManagerConsole = anylogger('block-manager');
@@ -74,8 +75,6 @@ const parseUpgradePlanInfo = (upgradePlan, prefix = '') => {
   return harden(upgradePlanInfo || {});
 };
 
-/** @import {SwingSetConfig} from '@agoric/swingset-vat' */
-
 /**
  * @typedef {object} CosmicSwingsetConfig
  * @property {import('@agoric/deploy-script-support/src/extract-proposal.js').ConfigProposal[]} [coreProposals]
@@ -96,7 +95,7 @@ const parseUpgradePlanInfo = (upgradePlan, prefix = '') => {
 const getHostKey = path => `host.${path}`;
 
 /**
- * @param {Map<*, *>} mailboxStorage
+ * @param {KVStore<Mailbox>} mailboxStorage
  * @param {((dstID: string, obj: any) => any)} bridgeOutbound
  * @param {SwingStoreKernelStorage} kernelStorage
  * @param {string | (() => string | Promise<string>)} vatconfig absolute path or thunk

--- a/packages/solo/src/outbound.js
+++ b/packages/solo/src/outbound.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 import anylogger from 'anylogger';
-
 import { Fail } from '@endo/errors';
+import { exportMailboxData } from '@agoric/swingset-vat';
 
 // Limit the debug log length.
 const SOLO_MAX_DEBUG_LENGTH =
@@ -22,8 +22,8 @@ const log = anylogger('outbound');
  */
 const knownTargets = new Map();
 
-export function deliver(mbs) {
-  const data = mbs.exportToData();
+export function deliver(mailboxStorage) {
+  const data = exportMailboxData(mailboxStorage);
   log.debug(`deliver`, data);
   for (const target of Object.getOwnPropertyNames(data)) {
     if (!knownTargets.has(target)) {

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -28,6 +28,8 @@ import {
   buildMailbox,
   buildPlugin,
   buildTimer,
+  exportMailboxData,
+  makeEphemeralMailboxStorage,
 } from '@agoric/swingset-vat';
 import { openSwingStore } from '@agoric/swing-store';
 import { makeWithQueue } from '@agoric/internal/src/queue.js';
@@ -110,8 +112,8 @@ const buildSwingset = async (
     fs.readFileSync(mailboxStateFile, 'utf8'),
   );
 
-  const mbs = buildMailboxStateMap();
-  mbs.populateFromData(initialMailboxState);
+  const mailboxStorage = makeEphemeralMailboxStorage(initialMailboxState);
+  const mbs = buildMailboxStateMap(mailboxStorage);
   const mb = buildMailbox(mbs);
   const cm = buildCommand(broadcast);
   const timer = buildTimer();
@@ -235,13 +237,13 @@ const buildSwingset = async (
   });
 
   async function saveState() {
-    const ms = JSON.stringify(mbs.exportToData());
+    const ms = JSON.stringify(exportMailboxData(mailboxStorage));
     await atomicReplaceFile(mailboxStateFile, ms);
     await hostStorage.commit();
   }
 
   function deliverOutbound() {
-    deliver(mbs);
+    deliver(mailboxStorage);
   }
 
   const policy = neverStop();


### PR DESCRIPTION
(split from #10165)

## Description
chain-main.js passes a [non-map `mailboxStorage`](https://github.com/Agoric/agoric-sdk/blob/94aaebcd255840daf13514ab1050282b985684d2/packages/cosmic-swingset/src/chain-main.js#L351-L359) to `launch`, which [threads it into mailbox code](https://github.com/Agoric/agoric-sdk/blob/94aaebcd255840daf13514ab1050282b985684d2/packages/cosmic-swingset/src/launch-chain.js#L126) that returns [methods expecting a map-like `entries` method and `size` property](https://github.com/Agoric/agoric-sdk/blob/94aaebcd255840daf13514ab1050282b985684d2/packages/SwingSet/src/devices/mailbox/mailbox.js#L121-L146). This PR adds type data to reject such issues and refactors mailbox code accordingly by converting those methods into independent functions that accept appropriate backing maps.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Existing tests should continue to pass.

### Upgrade Considerations
This code does not affect any vat and is safe to include in the next release.