### PR TITLE
Consistent store order

### DIFF
--- a/packages/SwingSet/tools/fakeSwingStoreStorage.js
+++ b/packages/SwingSet/tools/fakeSwingStoreStorage.js
@@ -1,0 +1,54 @@
+import { initSwingStore } from '@agoric/swing-store';
+import { serializedCommit } from '@agoric/swingset-liveslots/tools/fakeStorage.js';
+
+/**
+ * @import { LiveFakeStorage, SerializedFakeStorage } from '@agoric/swingset-liveslots/tools/fakeStorage.js';
+ */
+
+/**
+ * @param {Uint8Array} [buffer]
+ * @returns {SerializedFakeStorage<Uint8Array>}
+ */
+export const initSerializedFakeSwingStoreStorage = buffer => {
+  const serialized = buffer;
+  return harden({
+    kvStore: undefined,
+    serialized,
+    commit: serializedCommit,
+    // eslint-disable-next-line no-use-before-define
+    init: initLiveFakeSwingStoreStorage,
+  });
+};
+
+/**
+ * @param {Uint8Array} [serialized]
+ * @returns {LiveFakeStorage<Uint8Array>}
+ */
+export const initLiveFakeSwingStoreStorage = serialized => {
+  const {
+    debug,
+    hostStorage,
+    kernelStorage: { kvStore },
+  } = initSwingStore(null, { serialized });
+
+  const commit = () => {
+    const notSyncCommit = Promise.reject(
+      Error('swing-store commit was not synchronous'),
+    );
+    const committed = hostStorage.commit();
+
+    // Cause an unhandled rejection if swing-store commit took more than one turn.
+    void Promise.race([committed, notSyncCommit]);
+
+    // Assumes the commit above was synchronous
+    const buffer = debug.serialize();
+    return initSerializedFakeSwingStoreStorage(buffer);
+  };
+
+  return harden({
+    kvStore,
+    serialized: undefined,
+    commit,
+    init: initLiveFakeSwingStoreStorage,
+  });
+};

--- a/packages/swingset-liveslots/test/baggage.test.js
+++ b/packages/swingset-liveslots/test/baggage.test.js
@@ -25,13 +25,17 @@ test.serial('exercise baggage', async t => {
     { forceGC: true },
   );
   const { fakestore } = v;
-  const get = key => fakestore.get(key);
+  const get = key => {
+    const result = fakestore.get(key);
+    assert(result !== undefined);
+    return result;
+  };
   const getLabel = key => kunser(JSON.parse(get(key))).label;
 
-  const baggageVref = fakestore.get('baggageID');
+  const baggageVref = get('baggageID');
   const { subid } = parseVatSlot(baggageVref);
   const baggageID = Number(subid);
-  const kindIDs = JSON.parse(fakestore.get('storeKindIDTable'));
+  const kindIDs = JSON.parse(get('storeKindIDTable'));
   // baggage is the first collection created, a scalarDurableMapStore
   t.is(baggageVref, `o+d${kindIDs.scalarDurableMapStore}/1`);
   t.is(getLabel(`vc.${baggageID}.|schemata`), 'baggage');

--- a/packages/swingset-liveslots/test/collection-schema-refcount.test.js
+++ b/packages/swingset-liveslots/test/collection-schema-refcount.test.js
@@ -65,7 +65,9 @@ const shapetest = test.macro(async (t, collectionType, remotableType) => {
   const mapVref = testHooks.valToSlot.get(map);
   const collectionID = parseVatSlot(mapVref).subid;
   const schemaKey = `vc.${collectionID}.|schemata`;
-  const schemataData = JSON.parse(fakestore.get(schemaKey));
+  const encodedSchemata = fakestore.get(schemaKey);
+  t.not(encodedSchemata, undefined);
+  const schemataData = JSON.parse(/** @type {string} */ (encodedSchemata));
   t.deepEqual(schemataData.slots, [vref]);
 
   // and it should hold a refcount

--- a/packages/swingset-liveslots/test/gc-helpers.js
+++ b/packages/swingset-liveslots/test/gc-helpers.js
@@ -158,12 +158,23 @@ export function mapRef(idx) {
 // (excluding the prefix itself)
 
 export function* enumerateKeysWithPrefix(fakestore, prefix) {
-  const keys = [...fakestore.keys()];
-  keys.sort();
-  for (const key of keys) {
-    if (key.startsWith(prefix)) {
+  if ('getNextKey' in fakestore) {
+    let key = prefix;
+    while (true) {
+      key = fakestore.getNextKey(key);
+      if (!key || !key.startsWith(prefix)) {
+        break;
+      }
       yield key;
     }
+  } else if ('keys' in fakestore) {
+    for (const key of fakestore.keys()) {
+      if (!key.startsWith(prefix)) {
+        yield key;
+      }
+    }
+  } else {
+    throw Error('fakestore is not a usable KVStore');
   }
 }
 harden(enumerateKeysWithPrefix);

--- a/packages/swingset-liveslots/test/initial-vrefs.test.js
+++ b/packages/swingset-liveslots/test/initial-vrefs.test.js
@@ -54,7 +54,11 @@ test('initial vatstore contents', async t => {
     forceGC: true,
   });
   const { fakestore } = v;
-  const get = key => fakestore.get(key);
+  const get = key => {
+    const result = fakestore.get(key);
+    assert(result !== undefined);
+    return result;
+  };
   const getLabel = key => kunser(JSON.parse(get(key))).label;
 
   // an empty buildRootObject should create 4 collections, and some metadata
@@ -109,12 +113,16 @@ test('vrefs', async t => {
   );
   // const { fakestore, dumpFakestore } = v;
   const { fakestore } = v;
-  const get = key => fakestore.get(key);
+  const get = key => {
+    const result = fakestore.get(key);
+    assert(result !== undefined);
+    return result;
+  };
   const getLabel = key => kunser(JSON.parse(get(key))).label;
 
-  const kindIDID = JSON.parse(fakestore.get('kindIDID'));
-  const initialKindIDs = JSON.parse(fakestore.get('storeKindIDTable'));
-  const initialCounters = JSON.parse(fakestore.get(`idCounters`));
+  const kindIDID = JSON.parse(get('kindIDID'));
+  const initialKindIDs = JSON.parse(get('storeKindIDTable'));
+  const initialCounters = JSON.parse(get(`idCounters`));
   const firstObjID = initialCounters.exportID;
 
   // we expect makeVK1 (virtual, non-durable) to get firstObjID
@@ -147,5 +155,5 @@ test('vrefs', async t => {
   const expectedStore1Vref = `o+v${initialKindIDs.scalarMapStore}/5`;
   const store1Vref = (await run('getStore1')).slots[0];
   t.is(store1Vref, expectedStore1Vref);
-  t.is(kunser(JSON.parse(fakestore.get(`vc.5.s${'key'}`))), 'value');
+  t.is(kunser(JSON.parse(get(`vc.5.s${'key'}`))), 'value');
 });

--- a/packages/swingset-liveslots/tools/fakeStorage.js
+++ b/packages/swingset-liveslots/tools/fakeStorage.js
@@ -1,0 +1,106 @@
+/**
+ * @import { KVStore } from '@agoric/swing-store'
+ */
+
+// Vendor until https://github.com/endojs/endo/pull/2008 is merged
+// then we can import the endo implementation.
+const compareByCodePoints = (left, right) => {
+  const leftIter = left[Symbol.iterator]();
+  const rightIter = right[Symbol.iterator]();
+  for (;;) {
+    const { value: leftChar } = leftIter.next();
+    const { value: rightChar } = rightIter.next();
+    if (leftChar === undefined && rightChar === undefined) {
+      return 0;
+    } else if (leftChar === undefined) {
+      // left is a prefix of right.
+      return -1;
+    } else if (rightChar === undefined) {
+      // right is a prefix of left.
+      return 1;
+    }
+    const leftCodepoint = /** @type {number} */ (leftChar.codePointAt(0));
+    const rightCodepoint = /** @type {number} */ (rightChar.codePointAt(0));
+    if (leftCodepoint < rightCodepoint) return -1;
+    if (leftCodepoint > rightCodepoint) return 1;
+  }
+};
+
+/**
+ * @param {Map<string, string>} map
+ */
+export function makeKVStoreFromMap(map) {
+  let sortedKeys;
+  let priorKeyReturned;
+  let priorKeyIndex;
+
+  function ensureSorted() {
+    if (!sortedKeys) {
+      sortedKeys = [];
+      for (const key of map.keys()) {
+        sortedKeys.push(key);
+      }
+      sortedKeys.sort(compareByCodePoints);
+    }
+  }
+
+  function clearGetNextKeyCache() {
+    priorKeyReturned = undefined;
+    priorKeyIndex = -1;
+  }
+  clearGetNextKeyCache();
+
+  function clearSorted() {
+    sortedKeys = undefined;
+    clearGetNextKeyCache();
+  }
+
+  /** @type {KVStore} */
+  const fakeStore = harden({
+    has(key) {
+      return map.has(key);
+    },
+    get(key) {
+      return map.get(key);
+    },
+    getNextKey(priorKey) {
+      assert.typeof(priorKey, 'string');
+      ensureSorted();
+      // TODO: binary search for priorKey (maybe missing), then get
+      // the one after that. For now we go simple and slow. But cache
+      // a starting point, because the main use case is a full
+      // iteration. OTOH, the main use case also deletes everything,
+      // which will clobber the cache on each deletion, so it might
+      // not help.
+      const start = priorKeyReturned === priorKey ? priorKeyIndex : 0;
+      let result;
+      for (let i = start; i < sortedKeys.length; i += 1) {
+        const key = sortedKeys[i];
+        if (compareByCodePoints(key, priorKey) > 0) {
+          priorKeyReturned = key;
+          priorKeyIndex = i;
+          result = key;
+          break;
+        }
+      }
+      if (!result) {
+        // reached end without finding the key, so clear our cache
+        clearGetNextKeyCache();
+      }
+      return result;
+    },
+    set(key, value) {
+      if (!map.has(key)) {
+        clearSorted();
+      }
+      map.set(key, value);
+    },
+    delete(key) {
+      if (map.has(key)) {
+        clearSorted();
+      }
+      map.delete(key);
+    },
+  });
+  return fakeStore;
+}

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -9,6 +9,7 @@ import { makeVirtualReferenceManager } from '../src/virtualReferences.js';
 import { makeWatchedPromiseManager } from '../src/watchedPromises.js';
 import { makeFakeVirtualObjectManager } from './fakeVirtualObjectManager.js';
 import { makeFakeCollectionManager } from './fakeCollectionManager.js';
+import { makeKVStoreFromMap } from './fakeStorage.js';
 
 /**
  * @import { KVStore } from '@agoric/swing-store'
@@ -41,109 +42,6 @@ class FakeWeakRef {
   deref() {
     return this.#target; // strong ref
   }
-}
-
-// Vendor until https://github.com/endojs/endo/pull/2008 is merged
-// then we can import the endo implementation.
-const compareByCodePoints = (left, right) => {
-  const leftIter = left[Symbol.iterator]();
-  const rightIter = right[Symbol.iterator]();
-  for (;;) {
-    const { value: leftChar } = leftIter.next();
-    const { value: rightChar } = rightIter.next();
-    if (leftChar === undefined && rightChar === undefined) {
-      return 0;
-    } else if (leftChar === undefined) {
-      // left is a prefix of right.
-      return -1;
-    } else if (rightChar === undefined) {
-      // right is a prefix of left.
-      return 1;
-    }
-    const leftCodepoint = /** @type {number} */ (leftChar.codePointAt(0));
-    const rightCodepoint = /** @type {number} */ (rightChar.codePointAt(0));
-    if (leftCodepoint < rightCodepoint) return -1;
-    if (leftCodepoint > rightCodepoint) return 1;
-  }
-};
-
-/**
- * @param {Map<string, string>} map
- */
-export function makeKVStoreFromMap(map) {
-  let sortedKeys;
-  let priorKeyReturned;
-  let priorKeyIndex;
-
-  function ensureSorted() {
-    if (!sortedKeys) {
-      sortedKeys = [];
-      for (const key of map.keys()) {
-        sortedKeys.push(key);
-      }
-      sortedKeys.sort(compareByCodePoints);
-    }
-  }
-
-  function clearGetNextKeyCache() {
-    priorKeyReturned = undefined;
-    priorKeyIndex = -1;
-  }
-  clearGetNextKeyCache();
-
-  function clearSorted() {
-    sortedKeys = undefined;
-    clearGetNextKeyCache();
-  }
-
-  /** @type {KVStore} */
-  const fakeStore = harden({
-    has(key) {
-      return map.has(key);
-    },
-    get(key) {
-      return map.get(key);
-    },
-    getNextKey(priorKey) {
-      assert.typeof(priorKey, 'string');
-      ensureSorted();
-      // TODO: binary search for priorKey (maybe missing), then get
-      // the one after that. For now we go simple and slow. But cache
-      // a starting point, because the main use case is a full
-      // iteration. OTOH, the main use case also deletes everything,
-      // which will clobber the cache on each deletion, so it might
-      // not help.
-      const start = priorKeyReturned === priorKey ? priorKeyIndex : 0;
-      let result;
-      for (let i = start; i < sortedKeys.length; i += 1) {
-        const key = sortedKeys[i];
-        if (compareByCodePoints(key, priorKey) > 0) {
-          priorKeyReturned = key;
-          priorKeyIndex = i;
-          result = key;
-          break;
-        }
-      }
-      if (!result) {
-        // reached end without finding the key, so clear our cache
-        clearGetNextKeyCache();
-      }
-      return result;
-    },
-    set(key, value) {
-      if (!map.has(key)) {
-        clearSorted();
-      }
-      map.set(key, value);
-    },
-    delete(key) {
-      if (map.has(key)) {
-        clearSorted();
-      }
-      map.delete(key);
-    },
-  });
-  return fakeStore;
 }
 
 /** @typedef {Omit<KVStore,'set' | 'delete'> & Map<string, string>} EnhancedKVStore */

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -146,6 +146,8 @@ export function makeKVStoreFromMap(map) {
   return fakeStore;
 }
 
+/** @typedef {Omit<KVStore,'set' | 'delete'> & Map<string, string>} EnhancedKVStore */
+
 /**
  * Create a Map backed by a sorted KVStore while keeping the getNextKey method
  * specific to a KVStore making it mostly compatible with both.
@@ -158,7 +160,7 @@ export function makeKVStoreFromMap(map) {
  * @param {KVStore} fakeStore
  */
 export function makeEnhancedKVStore(fakeStore) {
-  /** @type {Omit<KVStore,'set' | 'delete'> & Map<string, string>} */
+  /** @type {EnhancedKVStore} */
   const map = harden({
     ...fakeStore,
     set(key, value) {
@@ -216,7 +218,7 @@ export function makeEnhancedKVStore(fakeStore) {
 
 /**
  *
- * @param {Map<string, string> | KVStore} [mapOrKvStore]
+ * @param {Map<string, string> | KVStore | EnhancedKVStore} [mapOrKvStore]
  */
 export function provideEnhancedKVStore(mapOrKvStore = new Map()) {
   if (!('getNextKey' in mapOrKvStore)) {
@@ -227,7 +229,7 @@ export function provideEnhancedKVStore(mapOrKvStore = new Map()) {
     mapOrKvStore = makeEnhancedKVStore(mapOrKvStore);
   }
 
-  return /** @type {ReturnType<typeof makeEnhancedKVStore>} */ (mapOrKvStore);
+  return /** @type {EnhancedKVStore} */ (mapOrKvStore);
 }
 
 export function makeFakeLiveSlotsStuff(options = {}) {
@@ -478,7 +480,7 @@ export function makeFakeWatchedPromiseManager(
  * @param {object} [options]
  * @param {number} [options.cacheSize]
  * @param {boolean} [options.relaxDurabilityRules]
- * @param {Map<string, string> | KVStore} [options.fakeStore]
+ * @param {Map<string, string> | KVStore | EnhancedKVStore} [options.fakeStore]
  * @param {WeakMapConstructor} [options.WeakMap]
  * @param {WeakSetConstructor} [options.WeakSet]
  * @param {boolean} [options.weak]

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.32.2",
+    "@agoric/swingset-liveslots": "^0.10.2",
     "@endo/patterns": "^1.4.4",
     "ava": "^5.3.0"
   },

--- a/packages/zone/test/store.test.js
+++ b/packages/zone/test/store.test.js
@@ -1,0 +1,60 @@
+import {
+  annihilate,
+  getBaggage,
+  test,
+} from '@agoric/swingset-vat/tools/prepare-strict-test-env-ava.js';
+
+import { initSerializedFakeSwingStoreStorage } from '@agoric/swingset-vat/tools/fakeSwingStoreStorage.js';
+import { initSerializedFakeStorageFromMap } from '@agoric/swingset-liveslots/tools/fakeStorage.js';
+
+import { makeDurableZone } from '../durable.js';
+import { makeHeapZone } from '../heap.js';
+import { makeVirtualZone } from '../virtual.js';
+
+/** @import {Zone} from '../src/index.js' */
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {Zone} rootZone
+ */
+const testSetStoreOrder = (t, rootZone) => {
+  const store = rootZone.setStore('test');
+  store.add('\u{ff42}'); // Fullwidth Latin Small Letter B
+  store.add('\u{1d5ba}'); // Mathematical Sans-Serif Small A
+  store.add('\u{63}'); // Latin Small Letter C
+
+  t.deepEqual([...store.keys()], ['\u{63}', '\u{ff42}', '\u{1d5ba}']);
+};
+
+// Failing until https://github.com/endojs/endo/issues/2113
+test.failing('heapZone', t => {
+  testSetStoreOrder(t, makeHeapZone());
+});
+
+test.serial('virtualZone - fake Map KVStore', t => {
+  const fakeStorage = initSerializedFakeStorageFromMap();
+  annihilate({ fakeStorage });
+  testSetStoreOrder(t, makeVirtualZone());
+});
+
+test.serial('virtualZone - swing-store KVStore', t => {
+  const fakeStorage = initSerializedFakeSwingStoreStorage();
+  annihilate({ fakeStorage });
+  testSetStoreOrder(t, makeVirtualZone());
+});
+
+test.serial('durableZone - fake Map KVStore', t => {
+  const fakeStorage = initSerializedFakeStorageFromMap();
+  annihilate({ fakeStorage });
+  const rootBaggage = getBaggage();
+  const rootDurableZone = makeDurableZone(rootBaggage);
+  testSetStoreOrder(t, rootDurableZone);
+});
+
+test.serial('durableZone - swing-store KVStore', t => {
+  const fakeStorage = initSerializedFakeSwingStoreStorage();
+  annihilate({ fakeStorage });
+  const rootBaggage = getBaggage();
+  const rootDurableZone = makeDurableZone(rootBaggage);
+  testSetStoreOrder(t, rootDurableZone);
+});


### PR DESCRIPTION
refs: https://github.com/endojs/endo/issues/2113

Draft until I polish a few things, but the gist of it is ready for review.
Best reviewed commit-by-commit.

## Description
Fixes the fake liveslots store to use a sort order by codepoint which is equivalent to the swing-store's SQLite sort order of strings (no collation enabled, so byte order of utf-8 encoded strings).

Add a test to zone to verify that all kinds of zone (heap, virtual, durable) behave the same, regardless of their backing store (fake liveslots or swing-store)

### Security Considerations
None

### Scaling Considerations
This updates the fake liveslots tool to always create upgraded incarnations based on the manually sorted entries, which is possibly inefficient, but this only affects tests.

### Documentation Considerations
Added a new options to fakeLiveslots reincarnation to allow not cloning the fakeStore, enabling using a DB backed store.

### Testing Considerations
Only affects testing tools. All tests should remain passing. A new test is added, including a failing one showing the discrepancy between heap and virtual stores.

### Upgrade Considerations
None