### PR TITLE
feat: allow getBundleIDFromInstallation to be called with a promise

### DIFF
--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -352,7 +352,7 @@ export const ZoeServiceI = M.interface('ZoeService', {
   getInstallationForInstance: M.callWhen(M.await(InstanceHandleShape)).returns(
     M.eref(M.remotable('Installation')),
   ),
-  getBundleIDFromInstallation: M.call(InstallationShape).returns(
+  getBundleIDFromInstallation: M.callWhen(M.await(InstallationShape)).returns(
     M.eref(M.string()),
   ),
 


### PR DESCRIPTION
refs: #10256

## Description

While working on #10256, I noticed that `getBundleIDFromInstallation` is documented to take an Installation or a promise, it doesn't actually handle a promise. This changes the guard to resolve a promise before proceeding.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Make the code match the declaration

### Testing Considerations

I didn't.

### Upgrade Considerations

This makes the code slightly more liberal. It shouldn't break anything.