### PR TITLE
lint multichain-testing

### DIFF
--- a/multichain-testing/.gitignore
+++ b/multichain-testing/.gitignore
@@ -1,7 +1,7 @@
 .yarn/*
 !.yarn/patches/*
 # fetched chain info from running starship
-starship-chain-info*
+starship-chain-info.js
 # output of build script to get update running chain info
 revise-chain-info*
 start*

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -4,9 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "exit 0",
-    "lint": "yarn lint:types && yarn lint:eslint",
-    "lint:eslint": "eslint .",
-    "lint:types": "tsc --noEmit",
+    "lint": "yarn tsc && yarn eslint .",
     "lint-fix": "yarn lint:eslint --fix",
     "test": "echo 'Run specific test suites:\nyarn test:main (needs `make start`)\nyarn test:fast-usdc (needs `make start FILE=config.fusdc.yaml`)'",
     "test:main": "ava --config ava.main.config.js",

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -29,7 +29,7 @@
     "@endo/ses-ava": "^1.2.8",
     "@types/eslint": "^8",
     "@types/fs-extra": "^11",
-    "@types/node": "^20.11.13",
+    "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "ava": "^6.2.0",

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -41,7 +41,7 @@
     "starshipjs": "2.4.1",
     "ts-blank-space": "^0.4.4",
     "tsx": "^4.15.6",
-    "typescript": "^5.3.3"
+    "typescript": "~5.6.2"
   },
   "resolutions": {
     "axios": "1.6.7"

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "exit 0",
-    "lint": "yarn lint:eslint",
+    "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint .",
     "lint:types": "tsc --noEmit",
     "lint-fix": "yarn lint:eslint --fix",

--- a/multichain-testing/starship-chain-info.d.ts
+++ b/multichain-testing/starship-chain-info.d.ts
@@ -1,0 +1,2 @@
+/* @file types so linting works when the real info hasn't been fetched */
+export default {} as Record<string, CosmosChainInfo>;

--- a/multichain-testing/test/chain-queries.test.ts
+++ b/multichain-testing/test/chain-queries.test.ts
@@ -247,6 +247,7 @@ test.serial('Send Local Query from chain object', async t => {
     },
   );
   const balanceProto3JsonQuery = typedJson(
+    // @ts-expect-error outdated cosmic-proto dep
     '/cosmos.bank.v1beta1.QueryBalanceRequest',
     {
       address: agoricAddr,

--- a/multichain-testing/tools/batchQuery.js
+++ b/multichain-testing/tools/batchQuery.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { assert } from '@endo/errors';
 import { E } from '@endo/far';
 

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -1,3 +1,4 @@
+// @ts-check
 /** global harden */
 import { assert } from '@endo/errors';
 import { E, Far } from '@endo/far';
@@ -123,6 +124,7 @@ const installBundle = async (fullPath, opts) => {
  *   chainId?: string;
  *   whale?: string;
  *   progress?: typeof console.log;
+ *   q?: import('./queryKit.js').QueryTool;
  * }} opts
  */
 export const provisionSmartWallet = async (
@@ -474,6 +476,7 @@ export const makeE2ETools = async (
         // name,
         id: fullPath,
         installHeight: tx.height,
+        // @ts-expect-error confirm is a boolean?
         installed: confirm.installed,
       });
     }

--- a/multichain-testing/tools/makeHttpClient.js
+++ b/multichain-testing/tools/makeHttpClient.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { assert } from '@endo/errors';
 import { Far } from '@endo/far';
 

--- a/multichain-testing/tools/marshalTables.js
+++ b/multichain-testing/tools/marshalTables.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file marshal tools for vstorage clients
  *

--- a/multichain-testing/tools/queryKit.js
+++ b/multichain-testing/tools/queryKit.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E, Far } from '@endo/far';
 import { batchVstorageQuery } from './batchQuery.js';
 import { makeClientMarshaller } from './marshalTables.js';

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -3983,7 +3983,7 @@ __metadata:
     starshipjs: "npm:2.4.1"
     ts-blank-space: "npm:^0.4.4"
     tsx: "npm:^4.15.6"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:~5.6.2"
   languageName: unknown
   linkType: soft
 
@@ -4450,13 +4450,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:~5.6.2":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
   languageName: node
   linkType: hard
 
@@ -4470,13 +4470,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+"typescript@patch:typescript@npm%3A~5.6.2#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
+  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -938,7 +938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
+"@types/node@npm:*, @types/node@npm:^22.0.0":
   version: 22.7.8
   resolution: "@types/node@npm:22.7.8"
   dependencies:
@@ -947,7 +947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:>=13.7.0, @types/node@npm:^20.11.13":
+"@types/node@npm:>=13.7.0":
   version: 20.14.2
   resolution: "@types/node@npm:20.14.2"
   dependencies:
@@ -3971,7 +3971,7 @@ __metadata:
     "@endo/ses-ava": "npm:^1.2.8"
     "@types/eslint": "npm:^8"
     "@types/fs-extra": "npm:^11"
-    "@types/node": "npm:^20.11.13"
+    "@types/node": "npm:^22.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.20.0"
     "@typescript-eslint/parser": "npm:^6.20.0"
     ava: "npm:^6.2.0"


### PR DESCRIPTION
incidental

## Description

https://github.com/Agoric/agoric-sdk/pull/10305 used `bypass:integration` because it was just a change to linting, which should run before integration tests.

Unfortunately, that [broke master](https://github.com/Agoric/agoric-sdk/actions/runs/11465689840/job/31904707630) because `multichain-testing` uses the same tsconfig and isn't run until integration.

Then I noticed its lint doesn't include TypeScript and had many errors.

This adds `tsc` to its `yarn lint` and fixes everything needed to get it passing.

It still doesn't bring linting of `multichain-testing` earlier than the **Multichain E2E Tests** workflow. So I still wouldn't have noticed the type import failure under `bypass:integration`. I don't think solving that is really worth the effort at this point.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
n/a