### PR TITLE
Clean up after smartWalllet incarnation2 repair

### DIFF
--- a/packages/smart-wallet/test/invitation1.test.js
+++ b/packages/smart-wallet/test/invitation1.test.js
@@ -129,8 +129,6 @@ const makeTestContext = async t => {
   /** @type {import('@agoric/vat-data').Baggage} */
   const swBaggage = makeScalarMapStore('smart-wallet');
 
-  const secretWalletFactoryKey = Far('Key', {});
-
   const { brand: brandSpace, issuer: issuerSpace } = bootKit.powers;
   /** @type {Issuer<'set'>} */
   // @ts-expect-error cast
@@ -147,7 +145,6 @@ const makeTestContext = async t => {
     invitationIssuer,
     publicMarshaller,
     zoe,
-    secretWalletFactoryKey,
     registry,
   });
 

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
@@ -85,13 +85,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   const registry = makeAssetRegistry(assetPublisher);
 
-  // An object known only to walletFactory and smartWallets. The WalletFactory
-  // only has the self facet for the pre-existing wallets that must be repaired.
-  // Self is too accessible, so use of the repair function requires use of a
-  // secret that clients won't have. This can be removed once the upgrade has
-  // taken place.
-  const upgradeToIncarnation2Key = harden({});
-
   const shared = harden({
     agoricNames,
     invitationBrand,
@@ -100,7 +93,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     publicMarshaller,
     registry,
     zoe,
-    secretWalletFactoryKey: upgradeToIncarnation2Key,
   });
 
   /**


### PR DESCRIPTION
closes: #9404

## Description

In #8445, we repaired legacy smartWallets. This removes the code that ran in upgrade15 that did the cleanup.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

No tests should be removed.

### Upgrade Considerations

There is no hurry to merge this code on chain. If the PR merges soon, it'll be included in upgrade 18.