### PR TITLE
Repair Kread since we're upgrading Zoe

### DIFF
--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -158,6 +158,10 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 					// Upgrade Zoe (no new ZCF needed).
 					"@agoric/builders/scripts/vats/upgrade-zoe.js",
 				),
+                // Revive KREAd characters
+                vm.CoreProposalStepForModules(
+                    "@agoric/builders/scripts/vats/revive-kread.js",
+                ),
 				vm.CoreProposalStepForModules(
 					// Upgrade to new liveslots for repaired vow usage.
 					"@agoric/builders/scripts/vats/upgrade-orch-core.js",


### PR DESCRIPTION
refs: #10267

## Description

We'll be upgrading Zoe in the next SW upgrade. We need to reset the KREAd subscribers when we do that.

### Security Considerations

No broader security implications

### Scaling Considerations

Not a scaling concern

### Documentation Considerations

I should have remembered this when adding the Zoe upgrade.

### Testing Considerations

None

### Upgrade Considerations

There's a constraint that we need to enforce when we upgrade Zoe. So far, we've been remembering it, but it would be better to automate.
