### PR TITLE
Telemetry fixes

### DIFF
--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -29,7 +29,7 @@ async function run() {
     return;
   }
 
-  const [slogFile] = args;
+  const slogFile = args[0] === '-' ? undefined : args[0];
   const slogSender = await makeSlogSender({
     serviceName,
     stateDir: '.',

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -78,7 +78,7 @@ async function run() {
     fs.writeFileSync(progressFileName, JSON.stringify(progress));
   };
 
-  console.log(`parsing`, slogFileName);
+  console.warn(`parsing`, slogFileName);
 
   let update = false;
   const maybeUpdateStats = async now => {
@@ -136,7 +136,7 @@ async function run() {
   }
 
   await stats(true);
-  console.log(
+  console.warn(
     `done parsing`,
     slogFileName,
     `(${lineCount} lines, ${byteCount} bytes)`,

--- a/packages/telemetry/src/slog-file.js
+++ b/packages/telemetry/src/slog-file.js
@@ -11,7 +11,7 @@ export const makeSlogSender = async ({ env: { SLOGFILE } = {} } = {}) => {
 
   const slogSender = (slogObj, jsonObj = serializeSlogObj(slogObj)) => {
     // eslint-disable-next-line prefer-template
-    void stream.write(jsonObj + '\n');
+    stream.write(jsonObj + '\n').catch(() => {});
   };
 
   return Object.assign(slogSender, {


### PR DESCRIPTION
refs: #10300

Incidental

Best reviewed commit-by-commit

## Description

While verifying #10300 I ran into some errors and lack of stdout streaming features. This is what I arrived at to let me process some slog files manually.

### Security Considerations

None

### Scaling Considerations

None production impacting

This adds a new block throttle mechanism to the ingest-slog tool, while relaxing the line based throttle.

### Documentation Considerations

None

### Testing Considerations

Manually tested with the slog sender detailed in https://github.com/Agoric/agoric-sdk/pull/10300#pullrequestreview-2397868644.

### Upgrade Considerations

Affects chain software, but only the optional telemetry side. Not consensus affecting.