### PR TITLE
chore: let makeRunUtils caller provide run policy

### DIFF
--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -2,12 +2,18 @@ import { Fail, q } from '@endo/errors';
 import { kunser } from '@agoric/kmarshal';
 import { makeQueue } from '@endo/stream';
 
-/** @import { ERef } from '@endo/far' */
+/**
+ * @import { ERef } from '@endo/far'
+ * @import { RunPolicy } from '../src/types-external.js'
+ */
+
+/** @typedef {{ provideRunPolicy: () => RunPolicy | undefined }} RunPolicyMaker */
 
 /**
  * @param {import('../src/controller/controller.js').SwingsetController} controller
+ * @param {RunPolicyMaker} [perfTool]
  */
-export const makeRunUtils = controller => {
+export const makeRunUtils = (controller, perfTool) => {
   const mutex = makeQueue();
   const logRunFailure = reason =>
     console.log('controller.run() failure', reason);
@@ -25,7 +31,8 @@ export const makeRunUtils = controller => {
   const queueAndRun = async (deliveryThunk, voidResult = false) => {
     await mutex.get();
     const kpid = await deliveryThunk();
-    const runResultP = controller.run();
+    const runPolicy = perfTool && perfTool.provideRunPolicy();
+    const runResultP = controller.run(runPolicy);
     mutex.put(runResultP.catch(logRunFailure));
     await runResultP;
 

--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -17,7 +17,7 @@ export const makeRunUtils = controller => {
    * Wait for exclusive access to the controller, then before relinquishing that access,
    * enqueue and process a delivery and return the result.
    *
-   * @param {() => ERef<void | ReturnType<controller['queueToVatObject']>>} deliveryThunk
+   * @param {() => ERef<void | ReturnType<typeof controller['queueToVatObject']>>} deliveryThunk
    * function for enqueueing a delivery and returning the result kpid (if any)
    * @param {boolean} [voidResult] whether to ignore the result
    * @returns {Promise<any>}

--- a/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
+++ b/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
@@ -64,6 +64,7 @@ test.serial('setupVaults; run updatePriceFeeds proposals', async t => {
     setupVaults,
     governanceDriver: gd,
     readPublished,
+    perfTool,
   } = t.context;
 
   await setupVaults(collateralBrandKey, managerIndex, setup);
@@ -74,7 +75,10 @@ test.serial('setupVaults; run updatePriceFeeds proposals', async t => {
     roundId: 1n,
   });
 
+  perfTool && perfTool.usePolicy(true);
   await priceFeedDrivers[collateralBrandKey].setPrice(15.99);
+  perfTool && t.log('setPrice computrons', perfTool.totalCount());
+  perfTool && perfTool.usePolicy(false);
 
   t.like(readPublished('priceFeed.ATOM-USD_price_feed.latestRound'), {
     roundId: 2n,

--- a/packages/boot/test/bootstrapTests/walletFactory.ts
+++ b/packages/boot/test/bootstrapTests/walletFactory.ts
@@ -9,9 +9,11 @@ import { makeWalletFactoryDriver } from '../../tools/drivers.js';
 export const makeWalletFactoryContext = async (
   t,
   configSpecifier = '@agoric/vm-config/decentral-main-vaults-config.json',
+  opts = {},
 ) => {
   const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
     configSpecifier,
+    ...opts,
   });
 
   const { runUtils, storage } = swingsetTestKit;

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -9,6 +9,7 @@ import {
 } from '@agoric/vats/tools/board-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import type { ExecutionContext } from 'ava';
+import { insistManagerType, makeRunPolicyProvider } from './supports.js';
 import { type SwingsetTestKit, makeSwingsetTestKit } from './supports.js';
 import {
   type GovernanceDriver,
@@ -305,13 +306,28 @@ export const makeLiquidationTestKit = async ({
   };
 };
 
+// asserts x is type doesn't work when using arrow functions
+// https://github.com/microsoft/TypeScript/issues/34523
+function assertManagerType(specimen: string): asserts specimen is ManagerType {
+  insistManagerType(specimen);
+}
+
 export const makeLiquidationTestContext = async (
   t,
   io: { env?: Record<string, string | undefined> } = {},
 ) => {
   const { env = {} } = io;
+  const {
+    SLOGFILE: slogFile,
+    SWINGSET_WORKER_TYPE: defaultManagerType = 'local',
+  } = env;
+  assertManagerType(defaultManagerType);
+  const perfTool =
+    defaultManagerType === 'xsnap' ? makeRunPolicyProvider() : undefined;
   const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
-    slogFile: env.SLOGFILE,
+    slogFile,
+    defaultManagerType,
+    perfTool,
   });
   console.time('DefaultTestContext');
 
@@ -369,6 +385,7 @@ export const makeLiquidationTestContext = async (
     refreshAgoricNamesRemotes,
     walletFactoryDriver,
     governanceDriver,
+    perfTool,
   };
 };
 

--- a/packages/cosmic-swingset/src/computron-counter.js
+++ b/packages/cosmic-swingset/src/computron-counter.js
@@ -1,0 +1,115 @@
+// @ts-check
+
+import { assert } from '@endo/errors';
+import {
+  BeansPerBlockComputeLimit,
+  BeansPerVatCreation,
+  BeansPerXsnapComputron,
+} from './sim-params.js';
+
+const { hasOwn } = Object;
+
+/**
+ * @typedef {object} BeansPerUnit
+ * @property {bigint} blockComputeLimit
+ * @property {bigint} vatCreation
+ * @property {bigint} xsnapComputron
+ */
+
+/**
+ * Return a stateful run policy that supports two phases: first allow
+ * non-cleanup work (presumably deliveries) until an overrideable computron
+ * budget is exhausted, then (iff no work was done and at least one vat cleanup
+ * budget field is positive) a cleanup phase that allows cleanup work (and
+ * presumably nothing else) until one of those fields is exhausted.
+ * https://github.com/Agoric/agoric-sdk/issues/8928#issuecomment-2053357870
+ *
+ * @param {object} params
+ * @param {BeansPerUnit} params.beansPerUnit
+ * @param {import('@agoric/swingset-vat').CleanupBudget} [params.vatCleanupBudget]
+ * @param {boolean} [ignoreBlockLimit]
+ * @returns {import('./launch-chain.js').ChainRunPolicy}
+ */
+export function computronCounter(
+  { beansPerUnit, vatCleanupBudget },
+  ignoreBlockLimit = false,
+) {
+  const {
+    [BeansPerBlockComputeLimit]: blockComputeLimit,
+    [BeansPerVatCreation]: vatCreation,
+    [BeansPerXsnapComputron]: xsnapComputron,
+  } = beansPerUnit;
+  assert.typeof(blockComputeLimit, 'bigint');
+  assert.typeof(vatCreation, 'bigint');
+  assert.typeof(xsnapComputron, 'bigint');
+
+  let totalBeans = 0n;
+  const shouldRun = () => ignoreBlockLimit || totalBeans < blockComputeLimit;
+
+  const remainingCleanups = { default: Infinity, ...vatCleanupBudget };
+  const defaultCleanupBudget = remainingCleanups.default;
+  let cleanupStarted = false;
+  let cleanupDone = false;
+  const cleanupPossible =
+    Object.values(remainingCleanups).length > 0
+      ? Object.values(remainingCleanups).some(n => n > 0)
+      : defaultCleanupBudget > 0;
+  if (!cleanupPossible) cleanupDone = true;
+  /** @type {() => (false | import('@agoric/swingset-vat').CleanupBudget)} */
+  const allowCleanup = () =>
+    cleanupStarted && !cleanupDone && { ...remainingCleanups };
+  const startCleanup = () => {
+    assert(!cleanupStarted);
+    cleanupStarted = true;
+    return totalBeans === 0n && !cleanupDone;
+  };
+  const didCleanup = details => {
+    for (const [phase, count] of Object.entries(details.cleanups)) {
+      if (phase === 'total') continue;
+      if (!hasOwn(remainingCleanups, phase)) {
+        // TODO: log unknown phases?
+        remainingCleanups[phase] = defaultCleanupBudget;
+      }
+      remainingCleanups[phase] -= count;
+      if (remainingCleanups[phase] <= 0) cleanupDone = true;
+    }
+    // We return true to allow processing of any BOYD/GC prompted by cleanup,
+    // even if cleanup as such is now done.
+    return true;
+  };
+
+  const policy = harden({
+    vatCreated() {
+      totalBeans += vatCreation;
+      return shouldRun();
+    },
+    crankComplete(details = {}) {
+      assert.typeof(details, 'object');
+      if (details.computrons) {
+        assert.typeof(details.computrons, 'bigint');
+
+        // TODO: xsnapComputron should not be assumed here.
+        // Instead, SwingSet should describe the computron model it uses.
+        totalBeans += details.computrons * xsnapComputron;
+      }
+      return shouldRun();
+    },
+    crankFailed() {
+      const failedComputrons = 1000000n; // who knows, 1M is as good as anything
+      totalBeans += failedComputrons * xsnapComputron;
+      return shouldRun();
+    },
+    emptyCrank() {
+      return shouldRun();
+    },
+    allowCleanup,
+    didCleanup,
+
+    shouldRun,
+    remainingBeans: () =>
+      ignoreBlockLimit ? undefined : blockComputeLimit - totalBeans,
+    totalBeans: () => totalBeans,
+    startCleanup,
+  });
+  return policy;
+}

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -43,17 +43,11 @@ import {
   makeSlogCallbacks,
 } from './kernel-stats.js';
 
-import {
-  BeansPerBlockComputeLimit,
-  BeansPerVatCreation,
-  BeansPerXsnapComputron,
-} from './sim-params.js';
 import { parseParams } from './params.js';
 import { makeQueue, makeQueueStorageMock } from './helpers/make-queue.js';
 import { exportStorage } from './export-storage.js';
 import { parseLocatedJson } from './helpers/json.js';
-
-const { hasOwn } = Object;
+import { computronCounter } from './computron-counter.js';
 
 /** @import { BlockInfo } from '@agoric/internal/src/chain-utils.js' */
 /** @import { Mailbox, RunPolicy, SwingSetConfig } from '@agoric/swingset-vat' */
@@ -281,111 +275,6 @@ export async function buildSwingset(
  *   startCleanup(): boolean;
  * }} ChainRunPolicy
  */
-
-/**
- * @typedef {object} BeansPerUnit
- * @property {bigint} blockComputeLimit
- * @property {bigint} vatCreation
- * @property {bigint} xsnapComputron
- */
-
-/**
- * Return a stateful run policy that supports two phases: first allow
- * non-cleanup work (presumably deliveries) until an overrideable computron
- * budget is exhausted, then (iff no work was done and at least one vat cleanup
- * budget field is positive) a cleanup phase that allows cleanup work (and
- * presumably nothing else) until one of those fields is exhausted.
- * https://github.com/Agoric/agoric-sdk/issues/8928#issuecomment-2053357870
- *
- * @param {object} params
- * @param {BeansPerUnit} params.beansPerUnit
- * @param {import('@agoric/swingset-vat').CleanupBudget} [params.vatCleanupBudget]
- * @param {boolean} [ignoreBlockLimit]
- * @returns {ChainRunPolicy}
- */
-function computronCounter(
-  { beansPerUnit, vatCleanupBudget },
-  ignoreBlockLimit = false,
-) {
-  const {
-    [BeansPerBlockComputeLimit]: blockComputeLimit,
-    [BeansPerVatCreation]: vatCreation,
-    [BeansPerXsnapComputron]: xsnapComputron,
-  } = beansPerUnit;
-  assert.typeof(blockComputeLimit, 'bigint');
-  assert.typeof(vatCreation, 'bigint');
-  assert.typeof(xsnapComputron, 'bigint');
-
-  let totalBeans = 0n;
-  const shouldRun = () => ignoreBlockLimit || totalBeans < blockComputeLimit;
-
-  const remainingCleanups = { default: Infinity, ...vatCleanupBudget };
-  const defaultCleanupBudget = remainingCleanups.default;
-  let cleanupStarted = false;
-  let cleanupDone = false;
-  const cleanupPossible =
-    Object.values(remainingCleanups).length > 0
-      ? Object.values(remainingCleanups).some(n => n > 0)
-      : defaultCleanupBudget > 0;
-  if (!cleanupPossible) cleanupDone = true;
-  /** @type {() => (false | import('@agoric/swingset-vat').CleanupBudget)} */
-  const allowCleanup = () =>
-    cleanupStarted && !cleanupDone && { ...remainingCleanups };
-  const startCleanup = () => {
-    assert(!cleanupStarted);
-    cleanupStarted = true;
-    return totalBeans === 0n && !cleanupDone;
-  };
-  const didCleanup = details => {
-    for (const [phase, count] of Object.entries(details.cleanups)) {
-      if (phase === 'total') continue;
-      if (!hasOwn(remainingCleanups, phase)) {
-        // TODO: log unknown phases?
-        remainingCleanups[phase] = defaultCleanupBudget;
-      }
-      remainingCleanups[phase] -= count;
-      if (remainingCleanups[phase] <= 0) cleanupDone = true;
-    }
-    // We return true to allow processing of any BOYD/GC prompted by cleanup,
-    // even if cleanup as such is now done.
-    return true;
-  };
-
-  const policy = harden({
-    vatCreated() {
-      totalBeans += vatCreation;
-      return shouldRun();
-    },
-    crankComplete(details = {}) {
-      assert.typeof(details, 'object');
-      if (details.computrons) {
-        assert.typeof(details.computrons, 'bigint');
-
-        // TODO: xsnapComputron should not be assumed here.
-        // Instead, SwingSet should describe the computron model it uses.
-        totalBeans += details.computrons * xsnapComputron;
-      }
-      return shouldRun();
-    },
-    crankFailed() {
-      const failedComputrons = 1000000n; // who knows, 1M is as good as anything
-      totalBeans += failedComputrons * xsnapComputron;
-      return shouldRun();
-    },
-    emptyCrank() {
-      return shouldRun();
-    },
-    allowCleanup,
-    didCleanup,
-
-    shouldRun,
-    remainingBeans: () =>
-      ignoreBlockLimit ? undefined : blockComputeLimit - totalBeans,
-    totalBeans: () => totalBeans,
-    startCleanup,
-  });
-  return policy;
-}
 
 /**
  * @template [T=unknown]


### PR DESCRIPTION
## Description

Support computron measurements in boostrap tests for performance testing by letting `makeRunUtils` caller provide a way to make a run policy.

### Security Considerations

A swingset controller relies on the run policy to be well-behaved. But the caller of `makeRunUtils` can only shoot themselves in the foot.

### Scaling Considerations

helps measure scaling issues

### Documentation Considerations

JSDocs with static types provide adequate docs for an internal tool such as this.

### Testing Considerations

Integration with a couple bootstrap tests is included.
See also #10254 .

### Upgrade Considerations

n/a