### PR TITLE
Add missing trigger slog events

### DIFF
--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -915,7 +915,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       case 'cosmic-swingset-upgrade-finish': {
-        spans.pop(['slogAttrs.blockHeight', slogAttrs.blockHeight]);
+        spans.pop(['upgrade', slogAttrs.blockHeight]);
         dbTransactionManager.end();
         break;
       }

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -971,6 +971,16 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         spans.pop('bridge-inbound');
         break;
       }
+      case 'cosmic-swingset-timer-poll': {
+        spans.push(['timer-poll', slogAttrs.blockTime]);
+        spans.pop('timer-poll');
+        break;
+      }
+      case 'cosmic-swingset-install-bundle': {
+        spans.push(['install-bundle', slogAttrs.endoZipBase64Sha512]);
+        spans.pop('install-bundle');
+        break;
+      }
       case 'cosmic-swingset-end-block-start': {
         // Add `end-block` as an event onto the encompassing `block` span
         spans.top()?.addEvent('end-block-action', cleanAttrs(slogAttrs), now);


### PR DESCRIPTION
closes: #10332 
closes: #8272
refs: #9569

## Description

Adds slog events for the bundle install and timer poll run triggers.
Add more context to the bridge and deliver inbound triggers.
Fixes the otel trace processing of upgrade events.

### Security Considerations
None

### Scaling Considerations
This adds a little more data to our slogs, but relatively minor compared to the amount of data we already generate.

### Documentation Considerations
None

### Testing Considerations

The integration test has limited coverage of the otel slog processor. I will repurpose #9569 to add testing in a3p, but in the mean time this change cannot affect operations and at worse the modification are not sufficient to our needs.

### Upgrade Considerations
Requires a chain software upgrade but the changes do not affect consensus and could be locally cherry-picked.
