### PR TITLE
chore: move PR template comment to the top

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,6 @@
 v                               ✰  Thanks for creating a PR! ✰
 ☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
-<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->
-
-closes: #XXXX
-refs: #XXXX
-
 <!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
 * (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
 * (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
@@ -15,6 +10,11 @@ refs: #XXXX
 
 These directives should be removed before adding a merge label, so final integration tests run against default targets.
 -->
+
+<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->
+
+closes: #XXXX
+refs: #XXXX
 
 ## Description
 <!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

_Incidental_

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
If an HTML comment in the PR description is multiline, Mergify will strip the text but leave the newlines behind in the resulting merge-commit comment.  As a special case, remaining whitespace at the beginning of the merge-commit comment will be trimmed.

So, this PR moves the multiline "Integration testing..." comment above the "closes:" and "refs:" and "## Description" text.
