### PR TITLE
test: make durable Orch tests able to run concurrently

### DIFF
--- a/packages/orchestration/test/durability.ts
+++ b/packages/orchestration/test/durability.ts
@@ -1,0 +1,25 @@
+/**
+ * Importing this module reincarnates the "vat" (global env) to have strict durability rules.
+ */
+import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
+import type { Zone } from '@agoric/zone';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+
+// all orchestration tests have strict durability rules
+const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });
+
+/**
+ * Reincarnate without relaxDurabilityRules and provide a durable zone in the incarnation.
+ * @param key
+ */
+export const provideDurableZone = (key: string): Zone => {
+  const root = fakeVomKit.cm.provideBaggage();
+  const zone = makeDurableZone(root);
+  return zone.subZone(key);
+};
+
+let zoneCounter = 0;
+export const provideFreshRootZone = (): Zone => {
+  zoneCounter += 1;
+  return provideDurableZone(`root${zoneCounter}`);
+};

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -8,7 +8,7 @@ import { E } from '@endo/far';
 import { makeIssuerKit } from '@agoric/ertp';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeChainHub, registerAssets } from '../../src/exos/chain-hub.js';
-import { provideDurableZone } from '../supports.js';
+import { provideFreshRootZone } from '../durability.js';
 import {
   registerChainAssets,
   registerKnownChains,
@@ -22,7 +22,7 @@ import { assets as assetFixture } from '../assets.fixture.js';
 
 // fresh state for each test
 const setup = () => {
-  const zone = provideDurableZone('root');
+  const zone = provideFreshRootZone();
   const vt = prepareSwingsetVowTools(zone.subZone('vows'));
   const { nameHub, nameAdmin } = makeNameHubKit();
   const chainHub = makeChainHub(zone.subZone('chainHub'), nameHub, vt);
@@ -30,7 +30,7 @@ const setup = () => {
   return { chainHub, nameAdmin, vt };
 };
 
-test.serial('getChainInfo', async t => {
+test('getChainInfo', async t => {
   const { chainHub, nameAdmin, vt } = setup();
   // use fetched chain info
   await registerKnownChains(nameAdmin);
@@ -39,7 +39,7 @@ test.serial('getChainInfo', async t => {
   t.like(await vt.asPromise(vow), { chainId: 'celestia' });
 });
 
-test.serial('concurrency', async t => {
+test('concurrency', async t => {
   const { chainHub, nameAdmin, vt } = setup();
   // use fetched chain info
   await registerKnownChains(nameAdmin);
@@ -52,7 +52,7 @@ test.serial('concurrency', async t => {
   ]);
 });
 
-test.serial('getConnectionInfo', async t => {
+test('getConnectionInfo', async t => {
   const { chainHub, vt } = setup();
 
   // https://mapofzones.com/zones/celestia/peers
@@ -75,7 +75,7 @@ test.serial('getConnectionInfo', async t => {
   t.deepEqual(await vt.when(chainHub.getConnectionInfo(b, a)), ba);
 });
 
-test.serial('denom info support via getAsset and getDenom', async t => {
+test('denom info support via getAsset and getDenom', async t => {
   const { chainHub } = setup();
 
   const denom = 'utok1';
@@ -121,7 +121,7 @@ test.serial('denom info support via getAsset and getDenom', async t => {
   );
 });
 
-test.serial('toward asset info in agoricNames (#9572)', async t => {
+test('toward asset info in agoricNames (#9572)', async t => {
   const { chainHub, nameAdmin, vt } = setup();
   // use fetched chain info
   await registerKnownChains(nameAdmin);
@@ -160,7 +160,7 @@ test.serial('toward asset info in agoricNames (#9572)', async t => {
   }
 });
 
-test.serial('getChainInfoByAddress', async t => {
+test('getChainInfoByAddress', async t => {
   const { chainHub, nameAdmin, vt } = setup();
   // use fetched chain info
   await registerKnownChains(nameAdmin);

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -1,7 +1,7 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeNameHubKit } from '@agoric/vats';
 import { prepareBridgeTargetModule } from '@agoric/vats/src/bridge-target.js';
 import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
@@ -17,17 +17,15 @@ import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import type { Installation } from '@agoric/zoe/src/zoeService/utils.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
-import { makeHeapZone, type Zone } from '@agoric/zone';
-import { makeDurableZone } from '@agoric/zone/durable.js';
+import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import type { ExecutionContext } from 'ava';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { registerKnownChains } from '../src/chain-info.js';
-import { prepareCosmosInterchainService } from '../src/exos/cosmos-interchain-service.js';
-import { setupFakeNetwork } from './network-fakes.js';
-import { buildVTransferEvent } from '../tools/ibc-mocks.js';
 import { makeChainHub } from '../src/exos/chain-hub.js';
+import { prepareCosmosInterchainService } from '../src/exos/cosmos-interchain-service.js';
 import fetchedChainInfo from '../src/fetched-chain-info.js';
+import { buildVTransferEvent } from '../tools/ibc-mocks.js';
+import { setupFakeNetwork } from './network-fakes.js';
 
 export {
   makeFakeLocalchainBridge,
@@ -236,14 +234,3 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
 };
 
 export const makeDefaultContext = <SF>(contract: Installation<SF>) => {};
-
-/**
- * Reincarnate without relaxDurabilityRules and provide a durable zone in the incarnation.
- * @param key
- */
-export const provideDurableZone = (key: string): Zone => {
-  const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });
-  const root = fakeVomKit.cm.provideBaggage();
-  const zone = makeDurableZone(root);
-  return zone.subZone(key);
-};

--- a/packages/orchestration/test/utils/zcf-tools.test.ts
+++ b/packages/orchestration/test/utils/zcf-tools.test.ts
@@ -1,15 +1,15 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit } from '@agoric/ertp';
 import { prepareSwingsetVowTools } from '@agoric/vow';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { makeHeapZone } from '@agoric/zone';
 import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 import { E, Far } from '@endo/far';
 import type { TestFn } from 'ava';
 import { createRequire } from 'node:module';
 import { makeZcfTools } from '../../src/utils/zcf-tools.js';
-import { provideDurableZone } from '../supports.js';
 
 const nodeRequire = createRequire(import.meta.url);
 const contractEntry = nodeRequire.resolve('../fixtures/zcfTester.contract.js');
@@ -34,10 +34,10 @@ const makeTestContext = async () => {
 
   const zcf: ZCF = testJig.zcf;
 
-  const zone = provideDurableZone('root');
+  const zone = makeHeapZone();
   const vt = prepareSwingsetVowTools(zone);
   const zcfTools = makeZcfTools(zcf, vt);
-  return { zoe, zcf, stuff, feeMintAccess, zcfTools, vt };
+  return { zoe, zcf, zcfTools, vt };
 };
 
 type TestContext = Awaited<ReturnType<typeof makeTestContext>>;
@@ -47,7 +47,7 @@ const test = anyTest as TestFn<TestContext>;
 test.before('set up context', async t => (t.context = await makeTestContext()));
 
 test('unchanged: atomicRearrange(), assertUniqueKeyword()', async t => {
-  const { zcf, zcfTools } = t.context;
+  const { zcfTools } = t.context;
 
   t.notThrows(() => zcfTools.atomicRearrange([]));
 
@@ -56,7 +56,7 @@ test('unchanged: atomicRearrange(), assertUniqueKeyword()', async t => {
 });
 
 test('changed: makeInvitation: watch promise', async t => {
-  const { zoe, zcf, zcfTools, vt } = t.context;
+  const { zoe, zcfTools, vt } = t.context;
 
   const handler = Far('Trade', { handle: seat => {} });
   const toTradeVow = zcfTools.makeInvitation(handler, 'trade');


### PR DESCRIPTION
incidental

## Description

Some orchestration tests were serialized to work around `reincarnate` hacks around `setupZCFTest` that wasn't compatible with durable baggage. E.g. `fakeVatAdmin` and its bundle caps were not durable.

The test don't need a full ZCF, so this instead creates a fake one. It also refactors the reincarnation so only modules that need durability get it (and just once).

The upshot is that none of these tests need to be `.serial` now.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
none

### Upgrade Considerations
none
