### PR TITLE
feat(ibc): implement channel open pipelining for IBC

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/initial.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/initial.test.js
@@ -3,10 +3,10 @@ import test from 'ava';
 import { getVatDetails } from '@agoric/synthetic-chain';
 
 const vats = {
-  network: { incarnation: 1 },
-  ibc: { incarnation: 1 },
+  network: { incarnation: 2 },
+  ibc: { incarnation: 2 },
   localchain: { incarnation: 1 },
-  orchestration: { incarnation: 0 },
+  orchestration: { incarnation: 1 },
   transfer: { incarnation: 1 },
   walletFactory: { incarnation: 5 },
   zoe: { incarnation: 3 },

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -197,6 +197,19 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 				)
 			}
 
+			// Upgrade for pieces of Orch to provide channel open pipelining.
+			pipelineOrchStep, err := buildProposalStepWithArgs(
+				"@agoric/builders/scripts/vats/upgrade-orch-core.js",
+				"defaultProposalBuilder",
+				map[string]any{
+					"bundleFilter": []string{"ibc", "network", "orchestration"},
+				},
+			)
+			if err != nil {
+				return nil, err
+			}
+			CoreProposalSteps = append(CoreProposalSteps, pipelineOrchStep)
+
 			// Each CoreProposalStep runs sequentially, and can be constructed from
 			// one or more modules executing in parallel within the step.
 			CoreProposalSteps = append(CoreProposalSteps,

--- a/golang/cosmos/x/vibc/types/expected_keepers.go
+++ b/golang/cosmos/x/vibc/types/expected_keepers.go
@@ -31,6 +31,7 @@ type ChannelKeeper interface {
 		portCap *capability.Capability, counterparty channel.Counterparty, version string) (string, *capability.Capability, error)
 	WriteOpenInitChannel(ctx sdk.Context, portID, channelID string, order channel.Order,
 		connectionHops []string, counterparty channel.Counterparty, version string)
+	WriteOpenConfirmChannel(ctx sdk.Context, portID, channelID string)
 	WriteOpenTryChannel(ctx sdk.Context, portID, channelID string, order channel.Order,
 		connectionHops []string, counterparty channel.Counterparty, version string)
 	ChanCloseInit(ctx sdk.Context, portID, channelID string, chanCap *capability.Capability) error

--- a/golang/cosmos/x/vibc/types/ibc_module.go
+++ b/golang/cosmos/x/vibc/types/ibc_module.go
@@ -98,16 +98,16 @@ func (im IBCModule) OnChanOpenInit(
 }
 
 type ChannelOpenTryEvent struct {
-	*vm.ActionHeader `actionType:"IBC_EVENT"`
-	Event            string                    `json:"event" default:"channelOpenTry"`
-	Target           string                    `json:"target,omitempty"`
-	Order            string                    `json:"order"`
-	ConnectionHops   []string                  `json:"connectionHops"`
-	PortID           string                    `json:"portID"`
-	ChannelID        string                    `json:"channelID"`
-	Counterparty     channeltypes.Counterparty `json:"counterparty"`
-	Version          string                    `json:"version"`
-	AsyncVersions    bool                      `json:"asyncVersions"`
+	*vm.ActionHeader    `actionType:"IBC_EVENT"`
+	Event               string                    `json:"event" default:"channelOpenTry"`
+	Target              string                    `json:"target,omitempty"`
+	Order               string                    `json:"order"`
+	ConnectionHops      []string                  `json:"connectionHops"`
+	PortID              string                    `json:"portID"`
+	ChannelID           string                    `json:"channelID"`
+	Counterparty        channeltypes.Counterparty `json:"counterparty"`
+	CounterpartyVersion string                    `json:"counterpartyVersion"`
+	AsyncVersions       bool                      `json:"asyncVersions"`
 }
 
 func (im IBCModule) OnChanOpenTry(
@@ -121,13 +121,13 @@ func (im IBCModule) OnChanOpenTry(
 	counterpartyVersion string,
 ) (string, error) {
 	event := ChannelOpenTryEvent{
-		Order:          orderToString(order),
-		ConnectionHops: connectionHops,
-		PortID:         portID,
-		ChannelID:      channelID,
-		Counterparty:   counterparty,
-		Version:        counterpartyVersion,
-		AsyncVersions:  AsyncVersions,
+		Order:               orderToString(order),
+		ConnectionHops:      connectionHops,
+		PortID:              portID,
+		ChannelID:           channelID,
+		Counterparty:        counterparty,
+		CounterpartyVersion: counterpartyVersion,
+		AsyncVersions:       AsyncVersions,
 	}
 
 	err := im.impl.PushAction(ctx, event)
@@ -142,7 +142,7 @@ func (im IBCModule) OnChanOpenTry(
 
 	if !event.AsyncVersions {
 		// We have to supply a synchronous version, so just echo back the one they sent.
-		return event.Version, nil
+		return event.CounterpartyVersion, nil
 	}
 
 	// Use an empty version string to indicate that the VM explicitly (possibly

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -461,9 +461,11 @@ export const makeSwingsetTestKit = async (
       case `${BridgeId.DIBC}:IBC_METHOD`:
       case `${BridgeId.VTRANSFER}:IBC_METHOD`: {
         switch (obj.method) {
-          case 'startChannelOpenInit':
-            pushInbound(BridgeId.DIBC, icaMocks.channelOpenAck(obj));
-            return undefined;
+          case 'startChannelOpenInit': {
+            const obj2 = icaMocks.channelOpenAck(obj);
+            pushInbound(BridgeId.DIBC, obj2);
+            return obj2.channelID;
+          }
           case 'sendPacket': {
             if (protoMsgMockMap[obj.packet.data]) {
               return ackLater(obj, protoMsgMockMap[obj.packet.data]);

--- a/packages/builders/scripts/vats/upgrade-orch-core.js
+++ b/packages/builders/scripts/vats/upgrade-orch-core.js
@@ -1,23 +1,36 @@
 import { makeHelpers } from '@agoric/deploy-script-support';
 
+const bundleSources = {
+  ibc: '@agoric/vats/src/vat-ibc.js',
+  network: '@agoric/vats/src/vat-network.js',
+  localchain: '@agoric/vats/src/vat-localchain.js',
+  orchestration: '@agoric/orchestration/src/vat-orchestration.js',
+  transfer: '@agoric/vats/src/vat-transfer.js',
+};
+
 /** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
-export const defaultProposalBuilder = async ({ publishRef, install }) =>
-  harden({
+export const defaultProposalBuilder = async (
+  { publishRef, install },
+  opts = {},
+) => {
+  /** @type {{ bundleFilter: string[] | undefined}} */
+  const { bundleFilter } = opts;
+  const bundleRefs = Object.fromEntries(
+    Object.entries(bundleSources)
+      .filter(([name]) => !bundleFilter || bundleFilter.includes(name))
+      .map(([name, source]) => [name, publishRef(install(source))]),
+  );
+  return harden({
     sourceSpec: '@agoric/vats/src/proposals/upgrade-orch-core-proposal.js',
     getManifestCall: [
       'getManifestForUpgradingOrchCore',
       {
-        bundleRefs: {
-          ibc: publishRef(install('@agoric/vats/src/vat-ibc.js')),
-          network: publishRef(install('@agoric/vats/src/vat-network.js')),
-          localchain: publishRef(install('@agoric/vats/src/vat-localchain.js')),
-          transfer: publishRef(install('@agoric/vats/src/vat-transfer.js')),
-        },
+        bundleRefs,
       },
     ],
   });
+};
 
-/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('upgrade-network', defaultProposalBuilder);

--- a/packages/network/src/shapes.js
+++ b/packages/network/src/shapes.js
@@ -43,8 +43,11 @@ export const Shape = /** @type {const} */ harden({
         .optional(Shape2.Opts)
         .returns(Shape2.Vow$(Shape2.Bytes)),
       close: M.callWhen().returns(Shape2.Vow$(M.undefined())),
-      getLocalAddress: M.call().returns(Shape2.Endpoint),
-      getRemoteAddress: M.call().returns(Shape2.Endpoint),
+      getLocalAddress: M.callWhen().returns(Shape2.Vow$(Shape2.Endpoint)),
+      getRemoteAddress: M.callWhen().returns(Shape2.Vow$(Shape2.Endpoint)),
+    }),
+    memoizeAddressWatcher: M.interface('MemoizeAddressWatcher', {
+      onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),
     }),
     openConnectionAckWatcher: M.interface('OpenConnectionAckWatcher', {
       onFulfilled: M.call(M.any()).rest(M.any()).returns(M.any()),

--- a/packages/network/src/types.js
+++ b/packages/network/src/types.js
@@ -5,7 +5,7 @@ export {};
 
 /**
  * @import {Passable, RemotableObject} from '@endo/pass-style';
- * @import {PromiseVow, Remote} from '@agoric/vow';
+ * @import {PromiseVow, Remote, Vow} from '@agoric/vow';
  */
 
 /**
@@ -86,9 +86,9 @@ export {};
  * ) => PromiseVow<Bytes>} send
  *   Send a packet on the connection
  * @property {() => PromiseVow<void>} close Close both ends of the connection
- * @property {() => Endpoint} getLocalAddress Get the locally bound name of this
+ * @property {() => PromiseVow<Endpoint>} getLocalAddress Get the locally bound name of this
  *   connection
- * @property {() => Endpoint} getRemoteAddress Get the name of the counterparty
+ * @property {() => PromiseVow<Endpoint>} getRemoteAddress Get the name of the counterparty
  */
 /**
  * @typedef {RemotableObject & ConnectionI} Connection
@@ -123,8 +123,8 @@ export {};
 /**
  * @typedef {object} AttemptDescription
  * @property {Remote<ConnectionHandler>} handler
- * @property {Endpoint} [remoteAddress]
- * @property {Endpoint} [localAddress]
+ * @property {Endpoint | Vow<Endpoint>} [remoteAddress]
+ * @property {Endpoint | Vow<Endpoint>} [localAddress]
  */
 
 /**

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -42,7 +42,7 @@ export const makeICAChannelAddress = (
     encoding,
     txType,
   });
-  return `/ibc-hop/${controllerConnectionId}/ibc-port/icahost/${ordering}/${connString}`;
+  return `/ibc-hop/${controllerConnectionId}/ibc-port/icahost/pipelining/true/${ordering}/${connString}`;
 };
 harden(makeICAChannelAddress);
 
@@ -58,7 +58,7 @@ export const makeICQChannelAddress = (
   version = DEFAULT_ICQ_VERSION,
 ) => {
   controllerConnectionId || Fail`controllerConnectionId is required`;
-  return `/ibc-hop/${controllerConnectionId}/ibc-port/icqhost/unordered/${version}`;
+  return `/ibc-hop/${controllerConnectionId}/ibc-port/icqhost/pipelining/true/unordered/${version}`;
 };
 harden(makeICQChannelAddress);
 

--- a/packages/orchestration/test/cosmos-interchain-service.test.ts
+++ b/packages/orchestration/test/cosmos-interchain-service.test.ts
@@ -252,6 +252,7 @@ test.serial(
       { version: 'ics27-2', ordering: 'unordered', encoding: 'json' },
     );
 
+    await eventLoopIteration(); // propagate channelOpenAck
     const { bridgeEvents: bridgeEvents0, bridgeDowncalls: bridgeDowncalls0 } =
       await inspectDibcBridge();
 
@@ -278,7 +279,8 @@ test.serial(
     const { event, ...channelInfo } = bridgeEvents0[0];
     // simulate channel closing from remote chain
     await E(ibcBridge).fromBridge(buildChannelCloseConfirmEvent(channelInfo));
-    await eventLoopIteration();
+    await eventLoopIteration(); // To propagate channelCloseConfirm
+    await eventLoopIteration(); // To propagate automatic channelOpenInit
 
     const { bridgeEvents: bridgeEvents1, bridgeDowncalls: bridgeDowncalls1 } =
       await inspectDibcBridge();

--- a/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
+++ b/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
@@ -119,6 +119,7 @@ test('make accounts, register tap, return invitationMakers', async t => {
     'tokens transferred from LOA to COA',
   );
   await transmitTransferAck();
+  await eventLoopIteration(); // propagate the ack
   const { acknowledgement } = (await inspectDibcBridge()).bridgeEvents.at(
     -1,
   ) as IBCEvent<'acknowledgementPacket'>;

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -70,7 +70,7 @@ test('findAddressField', t => {
       '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controller_connection_id":"connection-0","host_connection_id":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","tx_type":"sdk_multi_msg"}/ibc-channel/channel-1',
     ),
     'osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq',
-    'returns address when localAddrr is appended to version string',
+    'returns address when localAddr is appended to version string',
   );
   t.is(
     findAddressField(
@@ -103,7 +103,7 @@ test('makeICQChannelAddress', t => {
       ),
     {
       message:
-        /must be '\(\/ibc-hop\/CONNECTION\)\*\/ibc-port\/PORT\/\(ordered\|unordered\)\/VERSION'/,
+        /must be '\(\/ibc-hop\/CONNECTION\)\*\/ibc-port\/PORT\/\(pipelining\/\(true|false\)\/\)?\(ordered\|unordered\)\/VERSION'/,
     },
     'makeICQChannelAddress not hardened against malformed version. use `validateRemoteIbcAddress` to detect this, or expect IBC ProtocolImpl to throw',
   );

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -18,28 +18,28 @@ test('makeICAChannelAddress', t => {
   });
   t.is(
     makeICAChannelAddress('connection-1', 'connection-0'),
-    '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
     'returns connection string when controllerConnectionId and hostConnectionId are provided',
   );
   t.is(
     makeICAChannelAddress('connection-1', 'connection-0', {
       version: 'ics27-0',
     }),
-    '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-0","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{"version":"ics27-0","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
     'accepts custom version',
   );
   t.is(
     makeICAChannelAddress('connection-1', 'connection-0', {
       encoding: 'test',
     }),
-    '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"test","txType":"sdk_multi_msg"}',
+    '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"test","txType":"sdk_multi_msg"}',
     'accepts custom encoding',
   );
   t.is(
     makeICAChannelAddress('connection-1', 'connection-0', {
       ordering: 'unordered',
     }),
-    '/ibc-hop/connection-0/ibc-port/icahost/unordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+    '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/unordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
     'accepts custom ordering',
   );
 });
@@ -53,28 +53,28 @@ test('findAddressField', t => {
   );
   t.is(
     findAddressField(
-      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
+      '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"","encoding":"proto3","txType":"sdk_multi_msg"}',
     ),
     undefined,
     'returns undefined if address is an empty string',
   );
   t.is(
     findAddressField(
-      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","txType":"sdk_multi_msg"}',
+      '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{"version":"ics27-1","controllerConnectionId":"connection-0","hostConnectionId":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","txType":"sdk_multi_msg"}',
     ),
     'osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq',
     'returns address',
   );
   t.is(
     findAddressField(
-      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{"version":"ics27-1","controller_connection_id":"connection-0","host_connection_id":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","tx_type":"sdk_multi_msg"}/ibc-channel/channel-1',
+      '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{"version":"ics27-1","controller_connection_id":"connection-0","host_connection_id":"connection-1","address":"osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq","encoding":"proto3","tx_type":"sdk_multi_msg"}/ibc-channel/channel-1',
     ),
     'osmo1m30khedzqy9msu4502u74ugmep30v69pzee370jkas57xhmjfgjqe67ayq',
     'returns address when localAddr is appended to version string',
   );
   t.is(
     findAddressField(
-      '/ibc-hop/connection-0/ibc-port/icahost/ordered/{not valid JSON}',
+      '/ibc-hop/connection-0/ibc-port/icahost/pipelining/true/ordered/{not valid JSON}',
     ),
     undefined,
     'returns undefined when JSON is malformed',
@@ -88,12 +88,12 @@ test('makeICQChannelAddress', t => {
   });
   t.is(
     makeICQChannelAddress('connection-0'),
-    '/ibc-hop/connection-0/ibc-port/icqhost/unordered/icq-1',
+    '/ibc-hop/connection-0/ibc-port/icqhost/pipelining/true/unordered/icq-1',
     'returns connection string when controllerConnectionId is provided',
   );
   t.is(
     makeICQChannelAddress('connection-0', 'icq-2'),
-    '/ibc-hop/connection-0/ibc-port/icqhost/unordered/icq-2',
+    '/ibc-hop/connection-0/ibc-port/icqhost/pipelining/true/unordered/icq-2',
     'accepts custom version',
   );
   t.throws(

--- a/packages/vats/src/types.ts
+++ b/packages/vats/src/types.ts
@@ -179,10 +179,17 @@ export type IBCBridgeEvent =
   | 'sendPacket';
 
 type IBCPacketEvents = {
-  channelOpenInit: ConnectingInfo;
-  channelOpenTry: ConnectingInfo;
-  channelOpenAck: ConnectingInfo;
-  channelOpenConfirm: ConnectingInfo;
+  channelOpenInit: Omit<ConnectingInfo, 'counterpartyVersion'>;
+  channelOpenTry: Omit<ConnectingInfo, 'version'>;
+  channelOpenAck: Pick<
+    ConnectingInfo,
+    | 'portID'
+    | 'channelID'
+    | 'counterparty'
+    | 'counterpartyVersion'
+    | 'connectionHops'
+  >;
+  channelOpenConfirm: Pick<ConnectingInfo, 'portID' | 'channelID'>;
   receivePacket: {
     packet: IBCPacket;
   };
@@ -212,23 +219,22 @@ export type IBCEvent<E extends IBCBridgeEvent> = {
 export type IBCDowncallMethod =
   | 'sendPacket'
   | 'tryOpenExecuted'
+  | 'confirmOpenExecuted'
   | 'receiveExecuted'
   | 'startChannelOpenInit'
   | 'startChannelCloseInit'
   | 'bindPort'
-  | 'timeoutExecuted'
-  | 'initOpenExecuted';
+  | 'timeoutExecuted';
 
 type IBCMethodEvents = {
   sendPacket: SendPacketDownCall;
-  tryOpenExecuted: ChannelOpenAckDowncall;
   receiveExecuted: {}; // TODO update
   startChannelOpenInit: ChannelOpenInitDowncall;
+  tryOpenExecuted: ChannelOpenAckDowncall;
+  confirmOpenExecuted: ChannelConfirmDowncall;
   startChannelCloseInit: {}; // TODO update
   bindPort: { packet: { source_port: IBCPortID } };
   timeoutExecuted: {}; // TODO update
-  // XXX why isn't this in receiver.go?
-  initOpenExecuted: ChannelOpenAckDowncall;
 };
 
 export type IBCMethod<M extends IBCDowncallMethod> = {
@@ -265,8 +271,12 @@ type ChannelOpenAckDowncall = ChannelOpenDowncallBase & {
   >;
 };
 
+type ChannelConfirmDowncall = {
+  packet: Pick<IBCPacket, 'source_port' | 'source_channel'>;
+};
+
 type SendPacketDownCall = {
-  packet: IBCPacket;
+  packet: Omit<IBCPacket, 'destination_port' | 'destination_channel'>;
   relativeTimeoutNs: bigint;
 };
 

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -130,6 +130,8 @@ export const makeFakeBankBridge = (
  * @returns {ScopedBridgeManager<'dibc'>}
  */
 export const makeFakeIbcBridge = (zone, onToBridge) => {
+  let lastChannelNum = 0n;
+
   /** @type {Remote<BridgeHandler>} */
   let hndlr;
   return zone.exo('Fake IBC Bridge Manager', undefined, {
@@ -138,7 +140,11 @@ export const makeFakeIbcBridge = (zone, onToBridge) => {
       onToBridge(obj);
       const { method, type, ...params } = obj;
       assert.equal(type, 'IBC_METHOD');
-      if (method === 'sendPacket') {
+      if (method === 'startChannelOpenInit') {
+        lastChannelNum += 1n;
+        const channelId = `channel-${lastChannelNum}`;
+        return channelId;
+      } else if (method === 'sendPacket') {
         const { packet } = params;
         return { ...packet, sequence: '39' };
       } else if (method === 'startChannelCloseInit') {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

closes: #XXXX
refs: #XXXX

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Tighten up the `x/vibc` implementation to enable pipelining the channel handshake so that the connection initiator can continue with multiple sends and not pay an IBC round trip until awaiting an acknowledgement.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Before this PR, settling the `connection` object (chained channel handshake), sending a single packet on it, and getting its acknowledgement would be done with three IBC round-trips.

With this PR, settling the `connection` object (pipelined channel handshake), and sending several packets on it (pipelined sends) can be done without incurring any IBC network latency.  Awaiting the negotiated local or remote address, or the acknowledgment of a send costs only one round-trip after the pipelined send was submitted to `x/vibc`.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
A network connection to `/ibc-hop/connection-${N}/ibc-port/${portName}/pipelining/true/${order}/${version}` will opt-in to pipelining.  `.../pipelining/false/...` will explicitly opt-out, so that no behavior changes.  By default, pipelining is disabled in order to avoid breaking connection initiation assumptions.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
Client code will work the same if pipelining is not enabled.  Turning it on means that the initiator of a connection must be aware that `getLocalAddress()` and `getRemoteAddress()` will return Vows.  This is marked by the types so that client code can be updated accordingly (and thereby be compatible both with the implementation prior to this PR, and the pipelining option).
