### PR TITLE
chore: upgrade v8, the priceAuthorityRegistry

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/registry.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/registry.test.js
@@ -1,0 +1,20 @@
+// @ts-check
+import test from 'ava';
+import '@endo/init/debug.js';
+
+import {
+  getDetailsMatchingVats,
+  getIncarnation,
+} from '@agoric/synthetic-chain';
+
+/**
+ * @file
+ * A test of upgrading vat-priceAuthority, which is planned to ship in Upgrade 9
+ */
+
+test('priceAuthorityRegistry upgrade', async t => {
+  t.is(await getIncarnation('priceAuthority'), 1);
+
+  const priceAuthorityVats = await getDetailsMatchingVats('priceAuthority');
+  t.is(priceAuthorityVats.length, 1);
+});

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -219,6 +219,9 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 				vm.CoreProposalStepForModules(
 					"@agoric/builders/scripts/inter-protocol/replace-feeDistributor.js",
 				),
+				vm.CoreProposalStepForModules(
+					"@agoric/builders/scripts/vats/upgrade-paRegistry.js",
+				),
 			)
 		}
 

--- a/packages/builders/scripts/vats/upgrade-paRegistry.js
+++ b/packages/builders/scripts/vats/upgrade-paRegistry.js
@@ -1,0 +1,21 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    sourceSpec: '@agoric/vats/src/proposals/upgrade-paRegistry-proposal.js',
+    getManifestCall: [
+      'getManifestForUpgradingRegistry',
+      {
+        registryRef: publishRef(
+          install('@agoric/vats/src/vat-priceAuthority.js'),
+        ),
+      },
+    ],
+  });
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('upgrade-paRegistry', defaultProposalBuilder);
+};

--- a/packages/vats/src/proposals/upgrade-paRegistry-proposal.js
+++ b/packages/vats/src/proposals/upgrade-paRegistry-proposal.js
@@ -1,0 +1,65 @@
+// @ts-check
+import { E } from '@endo/far';
+import { AmountMath } from '@agoric/ertp';
+import { Stable } from '@agoric/internal/src/tokens.js';
+
+/**
+ * @param {BootstrapPowers & {
+ *   consume: {
+ *     vatAdminSvc: VatAdminSvc;
+ *     vatStore: MapStore<
+ *       string,
+ *       import('@agoric/swingset-vat').CreateVatResults
+ *     >;
+ *   };
+ * }} powers
+ * @param {object} options
+ * @param {{ registryRef: VatSourceRef }} options.options
+ */
+export const upgradePriceAuthorityRegistry = async (
+  {
+    consume: { vatAdminSvc, vatStore, priceAuthority, agoricNames },
+    brand: {
+      consume: { [Stable.symbol]: stableBrandP },
+    },
+  },
+  options,
+) => {
+  const { registryRef } = options.options;
+
+  assert(registryRef.bundleID);
+  console.log(`PriceAuthorityRegistry BUNDLE ID: `, registryRef.bundleID);
+
+  const [{ adminNode }, stableBrand, atomBrand, bundleCap] = await Promise.all([
+    E(vatStore).get('priceAuthority'),
+    stableBrandP,
+    E(agoricNames).lookup('brand', 'ATOM'),
+    E(vatAdminSvc).getBundleCap(registryRef.bundleID),
+  ]);
+
+  await E(adminNode).upgrade(bundleCap, {});
+
+  const oneATOM = AmountMath.make(atomBrand, 1_000_000n);
+  const quoteAtom = await E(priceAuthority).quoteGiven(oneATOM, stableBrand);
+  console.log('paRegistry quote', quoteAtom);
+
+  assert(quoteAtom.quoteAmount.value, 'insist on getting a quote');
+};
+
+const par = 'paRegistry';
+export const getManifestForUpgradingRegistry = (_powers, { registryRef }) => ({
+  manifest: {
+    [upgradePriceAuthorityRegistry.name]: {
+      consume: {
+        agoricNames: par,
+        vatAdminSvc: par,
+        vatStore: par,
+        priceAuthority: 'par',
+      },
+      brand: { consume: { [Stable.symbol]: par } },
+    },
+  },
+  options: {
+    registryRef,
+  },
+});

--- a/packages/vats/src/proposals/upgrade-paRegistry-proposal.js
+++ b/packages/vats/src/proposals/upgrade-paRegistry-proposal.js
@@ -4,15 +4,7 @@ import { AmountMath } from '@agoric/ertp';
 import { Stable } from '@agoric/internal/src/tokens.js';
 
 /**
- * @param {BootstrapPowers & {
- *   consume: {
- *     vatAdminSvc: VatAdminSvc;
- *     vatStore: MapStore<
- *       string,
- *       import('@agoric/swingset-vat').CreateVatResults
- *     >;
- *   };
- * }} powers
+ * @param {BootstrapPowers} powers
  * @param {object} options
  * @param {{ registryRef: VatSourceRef }} options.options
  */
@@ -54,7 +46,7 @@ export const getManifestForUpgradingRegistry = (_powers, { registryRef }) => ({
         agoricNames: par,
         vatAdminSvc: par,
         vatStore: par,
-        priceAuthority: 'par',
+        priceAuthority: par,
       },
       brand: { consume: { [Stable.symbol]: par } },
     },


### PR DESCRIPTION
closes: #10401

## Description

Upgrade the priceAuthorityRegistry

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

Does need to be mentioned in the upgrade description.

### Testing Considerations

As issue #10401 directs, we verify that `quoteWanted()` continues to work.

Existing tests in `z:acceptance` verify that prices continue to be received by vaults.

### Upgrade Considerations

This should be included in upgrade 19.