### PR TITLE
fix publishing to NPM

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -77,6 +77,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 91.23
+    "atLeast": 91.76
   }
 }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -101,6 +101,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 75.82
+    "atLeast": 76.19
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -100,6 +100,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 77.44
+    "atLeast": 77.45
   }
 }

--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -60,6 +60,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 76.93
+    "atLeast": 77.11
   }
 }

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -91,6 +91,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 90.38
+    "atLeast": 90.58
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -79,6 +79,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 82.43
+    "atLeast": 89.69
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -47,6 +47,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 94.12
+    "atLeast": 94.13
   }
 }

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -58,6 +58,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 88.9
+    "atLeast": 88.91
   }
 }

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Utilities for building Agoric clients",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "src/main.js",
   "files": [

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -69,6 +69,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 80.55
+    "atLeast": 80.52
   }
 }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -72,6 +72,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 82.6
+    "atLeast": 83.71
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -76,6 +76,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 89.35
+    "atLeast": 89.46
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 95.8
+    "atLeast": 95.71
   }
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -57,6 +57,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.42
+    "atLeast": 93.22
   }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -66,6 +66,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.15
+    "atLeast": 91.16
   }
 }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -76,6 +76,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 90.71
+    "atLeast": 90.77
   }
 }

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -93,6 +93,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 97.3
+    "atLeast": 97.23
   }
 }

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -70,6 +70,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 94.51
+    "atLeast": 94.64
   }
 }

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -77,6 +77,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 73.54
+    "atLeast": 74.05
   }
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -49,6 +49,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 79.08
+    "atLeast": 79.04
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -66,6 +66,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 87.03
+    "atLeast": 88.87
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -77,6 +77,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.5
+    "atLeast": 91.52
   }
 }

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -55,6 +55,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 91.85
+    "atLeast": 91.62
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -98,6 +98,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 85.01
+    "atLeast": 85
   }
 }

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -55,6 +55,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 96.58
+    "atLeast": 98.56
   }
 }


### PR DESCRIPTION
incidental

## Description
A couple days ago https://github.com/Agoric/agoric-sdk/pull/10407 merged a new package, `@agoric/client-utils`. It wasn't marked private, but it didn't have `publishConfig` so the job that publishes to NPM was failing,
```
E402 You must sign up for private packages
```

This adds the necessary `publishConfig`. It also includes a couple other pending cleanups.

### Security Considerations
Publishing another package. It's under the `@agoric` org so it can't be squatted.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
We might want to have caught this problem in the PR but I don't think it's worth the effort. It was caught soon enough.

### Upgrade Considerations
n/a