### PR TITLE
chore: upgrade-18 cherry-picks round 2

### DIFF
--- a/a3p-integration/proposals/a:upgrade-18/prepare.sh
+++ b/a3p-integration/proposals/a:upgrade-18/prepare.sh
@@ -7,3 +7,6 @@ set -uxeo pipefail
 # actions are executed in the previous chain software, and the effects are
 # persisted so they can be used in the steps after the upgrade is complete,
 # such as in the "use" or "test" steps, or further proposal layers.
+
+yarn
+node ./addGov4

--- a/a3p-integration/proposals/a:upgrade-18/use.sh
+++ b/a3p-integration/proposals/a:upgrade-18/use.sh
@@ -3,8 +3,6 @@
 # Exit when any command fails
 set -uxeo pipefail
 
-node ./addGov4
-
 # Econ Committee accept invitations for Committee and Charter
 ./acceptInvites.js
 

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -18,6 +18,7 @@ var upgradeNamesOfThisVersion = []string{
 	"agoric-upgrade-18-devnet",
 	"agoric-upgrade-18-emerynet",
 	"agoric-upgrade-18-basic",
+	"agoric-upgrade-18-basic-2",
 	"agoric-upgrade-18-a3p",
 }
 
@@ -58,6 +59,8 @@ func isPrimaryUpgradeName(name string) bool {
 		validUpgradeName("agoric-upgrade-18-basic"),
 		validUpgradeName("agoric-upgrade-18-a3p"):
 		return true
+	case validUpgradeName("agoric-upgrade-18-basic-2"):
+		return false
 	default:
 		panic(fmt.Errorf("unexpected upgrade name %s", validUpgradeName(name)))
 	}

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -33,7 +33,6 @@ export const addAuction = async (
       chainStorage,
       chainTimerService,
       economicCommitteeCreatorFacet: electorateCreatorFacet,
-      econCharterKit,
       governedContractKits: governedContractKitsP,
       priceAuthority8400,
       zoe,
@@ -183,14 +182,6 @@ export const addAuction = async (
   });
   produceAuctioneerKit.reset();
   produceAuctioneerKit.resolve(kit);
-
-  // introduce economic committee charter to new auctioneer
-  // cf addGovernorsToEconCharter() in committee-proposal.js
-  await E(E.get(econCharterKit).creatorFacet).addInstance(
-    kit.instance,
-    kit.governorCreatorFacet,
-    kit.label,
-  );
 
   auctionInstance.reset();
   await auctionInstance.resolve(governedInstance);

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -976,6 +976,11 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         spans.pop('timer-poll');
         break;
       }
+      case 'cosmic-swinget-inject-kernel-upgrade-events': {
+        spans.push('kernel-upgrade-events');
+        spans.pop('kernel-upgrade-events');
+        break;
+      }
       case 'cosmic-swingset-install-bundle': {
         spans.push(['install-bundle', slogAttrs.endoZipBase64Sha512]);
         spans.pop('install-bundle');


### PR DESCRIPTION
## Description

Cherry-picks the following commits from master:
 - https://github.com/Agoric/agoric-sdk/pull/10454  (https://github.com/Agoric/agoric-sdk/commit/d16781f0100b831638b3032837da28c23beabb7b)
 - https://github.com/Agoric/agoric-sdk/pull/10455 (https://github.com/Agoric/agoric-sdk/commit/1aec8d05036f6b3c3e3730339d1829da6b4a9051)
 
Also adds a new upgrade name `agoric-upgrade-18-basic-2`. Also, moves provisioning GOV4 from USE to PREPARE.

used `git cherry-pick` for the above commits

 [Draft PR with reapply upgrade on top of rc0](https://github.com/Agoric/agoric-sdk/pull/10484)
