### PR TITLE
chore(SwingSet): Improve anachrophobia messages

### DIFF
--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -97,7 +97,7 @@ export function makeSyscallSimulator(
   deliveryNum,
   transcriptEntry,
 ) {
-  const context = `anachrophobia in ${vatID} delivery ${deliveryNum}`;
+  const context = `anachrophobia in ${vatID} delivery d${deliveryNum}`;
   const syscallsExpected = [...transcriptEntry.sc]; // copy
   const syscallsMade = [];
   // syscallStatus's length will be max(syscallsExpected,
@@ -109,35 +109,35 @@ export function makeSyscallSimulator(
 
   const explain = () => {
     console.log(
-      `anachrophobia strikes ${vatID} syscalls for delivery ${deliveryNum}`,
+      `anachrophobia strikes ${vatID} delivery d${deliveryNum} syscalls`,
     );
     for (const [idx, status] of syscallStatus.entries()) {
       const expected = syscallsExpected[idx];
       const got = syscallsMade[idx];
       switch (status) {
         case 'ok': {
-          console.log(`sc[${idx}]: ok: ${djson.stringify(got)}`);
+          console.log(`sc${idx}: ok: ${djson.stringify(got)}`);
           break;
         }
         case 'wrong': {
           console.log(
             `
-sc[${idx}]: WRONG
+sc${idx}: WRONG
   expected: ${djson.stringify(expected.s)}
   got     : ${djson.stringify(got)}`.trimStart(),
           );
           break;
         }
         case 'extra': {
-          console.log(`sc[${idx}]: EXTRA: ${djson.stringify(got)}`);
+          console.log(`sc${idx}: EXTRA: ${djson.stringify(got)}`);
           break;
         }
         case 'missing': {
-          console.log(`sc[${idx}]: MISSING: ${djson.stringify(expected.s)}`);
+          console.log(`sc${idx}: MISSING: ${djson.stringify(expected.s)}`);
           break;
         }
         default:
-          Fail`bad ${status}`;
+          Fail`sc${idx}: bad status ${status}`;
       }
     }
   };
@@ -149,13 +149,13 @@ sc[${idx}]: WRONG
     const idx = syscallsMade.push(vso) - 1;
     if (!expected) {
       syscallStatus.push('extra');
-      const error = Error(`${context}: extra syscall at index ${idx}`);
+      const error = Error(`${context}: extra syscall at index sc${idx}`);
       replayError ||= error;
       throw error;
     }
     if (!syscallsAreIdentical(expected.s, vso)) {
       syscallStatus.push('wrong');
-      const error = Error(`${context}: wrong syscall at index ${idx}`);
+      const error = Error(`${context}: wrong syscall at index sc${idx}`);
       replayError ||= error;
       throw error;
     }
@@ -171,7 +171,7 @@ sc[${idx}]: WRONG
         syscallStatus.push('missing');
       }
       const error = Error(
-        `${context}: missing ${missing} syscall(s) at index ${syscallsMade.length}`,
+        `${context}: missing ${missing} syscall(s) at index sc${syscallsMade.length}`,
       );
       replayError ||= error;
     }


### PR DESCRIPTION
## Description
Extracted from an error investigation in #10165.

```diff
-anachrophobia strikes ${vatID} on delivery ${deliveryNum}
+anachrophobia strikes ${vatID} syscalls for delivery ${deliveryNum}
```

```diff
-anachrophobia in ${vatID}: {extra,wrong} syscall
+anachrophobia in ${vatID} delivery ${deliveryNum}: {extra,wrong} syscall at index ${idx}
```

```diff
-anachrophobia in ${vatID}: missing syscalls
+anachrophobia in missing ${missing} syscall(s) at index ${syscallsMade.length}
```

Also capitalizes `WRONG`/`MISSING`/`EXTRA` after `sc[${idx}]:`, for increased visual distinction.

### Security Considerations
None known; any consumer aware of vatIDs should also be allowed to know delivery numbers and constituent syscalls.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
None known; this kernel output should be independent of consensus (and will be consistent across nodes using the same kernel code anyway).