### PR TITLE
chore(agoric-cli): Document external consumption of gettingStartedWorkflowTest

### DIFF
--- a/packages/agoric-cli/integration-tests/workflow.test.js
+++ b/packages/agoric-cli/integration-tests/workflow.test.js
@@ -2,5 +2,5 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { gettingStartedWorkflowTest } from '../tools/getting-started.js';
 
-test('workflow', t =>
+test('"getting started" workflow', t =>
   gettingStartedWorkflowTest(t, { testUnsafePlugins: true }));

--- a/packages/agoric-cli/integration-tests/workflow.test.js
+++ b/packages/agoric-cli/integration-tests/workflow.test.js
@@ -2,5 +2,4 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { gettingStartedWorkflowTest } from '../tools/getting-started.js';
 
-test('"getting started" workflow', t =>
-  gettingStartedWorkflowTest(t, { testUnsafePlugins: true }));
+test('"getting started" workflow', t => gettingStartedWorkflowTest(t));

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -62,6 +62,13 @@ const getLatestBlockHeight = url =>
     req.end();
   });
 
+/**
+ * Test the "getting started" workflow. Note that this function may be imported
+ * by external repositories.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {{ init?: string[], install?: string[] }} [options]
+ */
 export const gettingStartedWorkflowTest = async (t, options = {}) => {
   const { init: initOptions = [], install: installOptions = [] } = options;
   const pspawn = makePspawn({ spawn });


### PR DESCRIPTION
## Description
Without this, packages/agoric-cli/integration-tests/workflow.test.js is an essentially empty wrapper.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
n/a

### Upgrade Considerations
n/a