### PR TITLE
feat(fast-usdc): core-eval, builder script

### DIFF
--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -1,0 +1,100 @@
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import type { TestFn } from 'ava';
+import type { FastUSDCKit } from '@agoric/fast-usdc/src/fast-usdc.start.js';
+import { Fail } from '@endo/errors';
+import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
+import { makeMarshal } from '@endo/marshal';
+import {
+  makeWalletFactoryContext,
+  type WalletFactoryTestContext,
+} from '../bootstrapTests/walletFactory.js';
+
+const test: TestFn<WalletFactoryTestContext> = anyTest;
+
+test.before('bootstrap', async t => {
+  const config = '@agoric/vm-config/decentral-itest-orchestration-config.json';
+  t.context = await makeWalletFactoryContext(t, config);
+});
+test.after.always(t => t.context.shutdown?.());
+
+test.serial('oracles provision before contract deployment', async t => {
+  const { walletFactoryDriver: wd } = t.context;
+  const watcherWallet = await wd.provideSmartWallet('agoric1watcher1');
+  t.truthy(watcherWallet);
+});
+
+test.serial(
+  'contract starts; adds to agoricNames; sends invitation',
+  async t => {
+    const {
+      agoricNamesRemotes,
+      evalProposal,
+      buildProposal,
+      refreshAgoricNamesRemotes,
+      storage,
+      walletFactoryDriver: wd,
+    } = t.context;
+
+    const watcherWallet = await wd.provideSmartWallet('agoric1watcher1');
+
+    const materials = buildProposal(
+      '@agoric/builders/scripts/fast-usdc/init-fast-usdc.js',
+      ['--oracle', 'a:agoric1watcher1'],
+    );
+    await evalProposal(materials);
+
+    // update now that fastUSDC is instantiated
+    refreshAgoricNamesRemotes();
+    t.truthy(agoricNamesRemotes.instance.fastUSDC);
+    t.truthy(agoricNamesRemotes.brand.FastLP);
+
+    const { EV } = t.context.runUtils;
+    const agoricNames = await EV.vat('bootstrap').consumeItem('agoricNames');
+    const board = await EV.vat('bootstrap').consumeItem('board');
+    const getBoardAux = async name => {
+      const brand = await EV(agoricNames).lookup('brand', name);
+      const id = await EV(board).getId(brand);
+      t.truthy(storage.data.get(`published.boardAux.${id}`));
+      return unmarshalFromVstorage(
+        storage.data,
+        `published.boardAux.${id}`,
+        makeMarshal().fromCapData,
+        -1,
+      );
+    };
+    t.like(
+      await getBoardAux('FastLP'),
+      {
+        allegedName: 'PoolShares', // misnomer, in some contexts
+        displayInfo: {
+          assetKind: 'nat',
+          decimalPlaces: 6,
+        },
+      },
+      'brand displayInfo available in boardAux',
+    );
+
+    const current = watcherWallet.getCurrentWalletRecord();
+
+    // XXX We should be able to compare objects by identity like this:
+    //
+    // const invitationPurse = current.purses.find(
+    //   p => p.brand === agoricNamesRemotes.brand.Invitation,
+    // );
+    //
+    // But agoricNamesRemotes and walletFactoryDriver
+    // don't share a marshal context.
+    // We should be able to map between them using
+    // const walletStuff = w.fromCapData(a.toCapData(aStuff))
+    // but the marshallers don't even preserve identity within themselves.
+
+    current.purses.length === 1 || Fail`test limited to 1 purse`;
+    const [thePurse] = current.purses;
+    const details = thePurse.balance.value as Array<any>;
+    Array.isArray(details) || Fail`expected SET value`;
+    t.is(details.length, 1, 'oracle wallet has 1 invitation');
+    t.is(details[0].description, 'oracle operator invitation');
+    // XXX t.is(details.instance, agoricNames.instance.fastUSDC) should work
+  },
+);

--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -44,9 +44,9 @@ test.serial(
     );
     await evalProposal(materials);
 
-    // update now that fastUSDC is instantiated
+    // update now that fastUsdc is instantiated
     refreshAgoricNamesRemotes();
-    t.truthy(agoricNamesRemotes.instance.fastUSDC);
+    t.truthy(agoricNamesRemotes.instance.fastUsdc);
     t.truthy(agoricNamesRemotes.brand.FastLP);
 
     const { EV } = t.context.runUtils;
@@ -95,6 +95,14 @@ test.serial(
     Array.isArray(details) || Fail`expected SET value`;
     t.is(details.length, 1, 'oracle wallet has 1 invitation');
     t.is(details[0].description, 'oracle operator invitation');
-    // XXX t.is(details.instance, agoricNames.instance.fastUSDC) should work
+    // XXX t.is(details.instance, agoricNames.instance.fastUsdc) should work
   },
 );
+
+test.serial('restart contract', async t => {
+  const { EV } = t.context.runUtils;
+  await null;
+  const kit = await EV.vat('bootstrap').consumeItem('fastUsdcKit');
+  const actual = await EV(kit.adminFacet).restartContract(kit.privateArgs);
+  t.deepEqual(actual, { incarnationNumber: 1 });
+});

--- a/packages/boot/test/orchestration/contract-upgrade.test.ts
+++ b/packages/boot/test/orchestration/contract-upgrade.test.ts
@@ -82,7 +82,7 @@ test('resume', async t => {
 
   t.deepEqual(getLogged(), [
     'sending {0} from cosmoshub to cosmos1whatever',
-    'got info for denoms: ibc/toyatom, ibc/toyusdc, ubld, uist',
+    'got info for denoms: ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9, ibc/toyatom, ibc/toyusdc, ubld, uist',
     'got info for chain: cosmoshub cosmoshub-4',
     'completed transfer to localAccount',
   ]);
@@ -99,7 +99,7 @@ test('resume', async t => {
 
   t.deepEqual(getLogged(), [
     'sending {0} from cosmoshub to cosmos1whatever',
-    'got info for denoms: ibc/toyatom, ibc/toyusdc, ubld, uist',
+    'got info for denoms: ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9, ibc/toyatom, ibc/toyusdc, ubld, uist',
     'got info for chain: cosmoshub cosmoshub-4',
     'completed transfer to localAccount',
     'completed transfer to cosmos1whatever',

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -46,15 +46,18 @@ import type { SwingsetController } from '@agoric/swingset-vat/src/controller/con
 import type { BridgeHandler, IBCMethod } from '@agoric/vats';
 import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
 import type { EProxy } from '@endo/eventual-send';
+import type { FastUSDCCorePowers } from '@agoric/fast-usdc/src/fast-usdc.start.js';
 import { icaMocks, protoMsgMockMap, protoMsgMocks } from './ibc/mocks.js';
 
 const trace = makeTracer('BSTSupport', false);
 
 type ConsumeBootrapItem = <N extends string>(
   name: N,
-) => N extends keyof EconomyBootstrapPowers['consume']
-  ? EconomyBootstrapPowers['consume'][N]
-  : unknown;
+) => N extends keyof FastUSDCCorePowers['consume']
+  ? FastUSDCCorePowers['consume'][N]
+  : N extends keyof EconomyBootstrapPowers['consume']
+    ? EconomyBootstrapPowers['consume'][N]
+    : unknown;
 
 // XXX should satisfy EVProxy from run-utils.js but that's failing to import
 /**

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -24,6 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/ertp": "^0.16.2",
+    "@agoric/fast-usdc": "0.1.0",
     "@agoric/internal": "^0.3.2",
     "@agoric/notifier": "^0.6.2",
     "@agoric/smart-wallet": "^0.5.3",
@@ -36,6 +37,7 @@
     "@endo/far": "^1.1.8",
     "@endo/init": "^1.1.6",
     "@endo/marshal": "^1.6.1",
+    "@endo/patterns": "^1.4.6",
     "@endo/promise-kit": "^1.1.7",
     "@endo/stream": "^1.2.7",
     "import-meta-resolve": "^2.2.1"

--- a/packages/builders/scripts/fast-usdc/init-fast-usdc.js
+++ b/packages/builders/scripts/fast-usdc/init-fast-usdc.js
@@ -1,0 +1,105 @@
+// @ts-check
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { AmountMath } from '@agoric/ertp';
+import {
+  FastUSDCConfigShape,
+  getManifestForFastUSDC,
+} from '@agoric/fast-usdc/src/fast-usdc.start.js';
+import { toExternalConfig } from '@agoric/fast-usdc/src/utils/config-marshal.js';
+import { objectMap } from '@agoric/internal';
+import {
+  multiplyBy,
+  parseRatio,
+} from '@agoric/zoe/src/contractSupport/ratio.js';
+import { Far } from '@endo/far';
+import { parseArgs } from 'node:util';
+
+/**
+ * @import {CoreEvalBuilder, DeployScriptFunction} from '@agoric/deploy-script-support/src/externalTypes.js'
+ * @import {ParseArgsConfig} from 'node:util'
+ * @import {FastUSDCConfig} from '@agoric/fast-usdc/src/fast-usdc.start.js'
+ */
+
+/** @type {ParseArgsConfig['options']} */
+const options = {
+  contractFee: { type: 'string', default: '0.01' },
+  poolFee: { type: 'string', default: '0.01' },
+  oracle: { type: 'string', multiple: true },
+};
+const oraclesRequiredUsage = 'use --oracle name:address ...';
+/**
+ * @typedef {{
+ *   contractFee: string;
+ *   poolFee: string;
+ *   oracle?: string[];
+ * }} FastUSDCOpts
+ */
+
+const crossVatContext = /** @type {const} */ ({
+  /** @type {Brand<'nat'>} */
+  USDC: Far('USDC Brand'),
+});
+const { USDC } = crossVatContext;
+const USDC_DECIMALS = 6;
+const unit = AmountMath.make(USDC, 10n ** BigInt(USDC_DECIMALS));
+
+/** @type {CoreEvalBuilder} */
+export const defaultProposalBuilder = async (
+  { publishRef, install },
+  /** @type {FastUSDCConfig} */ config,
+) => {
+  return harden({
+    sourceSpec: '@agoric/fast-usdc/src/fast-usdc.start.js',
+    /** @type {[string, Parameters<typeof getManifestForFastUSDC>[1]]} */
+    getManifestCall: [
+      getManifestForFastUSDC.name,
+      {
+        options: toExternalConfig(config, crossVatContext, FastUSDCConfigShape),
+        installKeys: {
+          fastUsdc: publishRef(
+            install('@agoric/fast-usdc/src/fast-usdc.contract.js'),
+          ),
+        },
+      },
+    ],
+  });
+};
+
+/** @type {DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  const { scriptArgs } = endowments;
+
+  /** @type {{ values: FastUSDCOpts }} */
+  // @ts-expect-error ensured by options
+  const {
+    values: { oracle: oracleArgs, ...fees },
+  } = parseArgs({ args: scriptArgs, options });
+
+  const parseOracleArgs = () => {
+    if (!oracleArgs) throw Error(oraclesRequiredUsage);
+    return Object.fromEntries(
+      oracleArgs.map(arg => {
+        const result = arg.match(/(?<name>[^:]+):(?<address>.+)/);
+        if (!(result && result.groups)) throw Error(oraclesRequiredUsage);
+        const { name, address } = result.groups;
+        return [name, address];
+      }),
+    );
+  };
+
+  /** @type {FastUSDCConfig} */
+  const config = harden({
+    oracles: parseOracleArgs(),
+    terms: {
+      ...objectMap(fees, numeral =>
+        multiplyBy(unit, parseRatio(numeral, USDC)),
+      ),
+      usdcDenom: 'ibc/usdconagoric',
+    },
+  });
+
+  await writeCoreEval('start-fast-usdc', utils =>
+    defaultProposalBuilder(utils, config),
+  );
+};

--- a/packages/fast-usdc/package.json
+++ b/packages/fast-usdc/package.json
@@ -54,7 +54,6 @@
     "@endo/patterns": "^1.4.6",
     "@endo/promise-kit": "^1.1.7",
     "@nick134-bit/noblejs": "0.0.2",
-    "agoric": "^0.21.1",
     "bech32": "^2.0.0",
     "commander": "^12.1.0",
     "ethers": "^6.13.4"

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -1,17 +1,16 @@
 import { AssetKind } from '@agoric/ertp';
-import { BrandShape } from '@agoric/ertp/src/typeGuards.js';
 import { assertAllDefined, makeTracer } from '@agoric/internal';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import { withOrchestration } from '@agoric/orchestration';
 import { provideSingleton } from '@agoric/zoe/src/contractSupport/durability.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { M } from '@endo/patterns';
 import { prepareAdvancer } from './exos/advancer.js';
 import { prepareLiquidityPoolKit } from './exos/liquidity-pool.js';
 import { prepareSettler } from './exos/settler.js';
 import { prepareStatusManager } from './exos/status-manager.js';
 import { prepareTransactionFeedKit } from './exos/transaction-feed.js';
 import { defineInertInvitation } from './utils/zoe.js';
+import { FastUSDCTermsShape } from './type-guards.js';
 
 const trace = makeTracer('FastUsdc');
 
@@ -30,13 +29,8 @@ const trace = makeTracer('FastUsdc');
  *   usdcDenom: Denom;
  * }} FastUsdcTerms
  */
-const NatAmountShape = { brand: BrandShape, value: M.nat() };
 export const meta = {
-  customTermsShape: {
-    contractFee: NatAmountShape,
-    poolFee: NatAmountShape,
-    usdcDenom: M.string(),
-  },
+  customTermsShape: FastUSDCTermsShape,
 };
 harden(meta);
 

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -1,0 +1,259 @@
+import { deeplyFulfilledObject, makeTracer, objectMap } from '@agoric/internal';
+import { Fail } from '@endo/errors';
+import { E } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
+import { M } from '@endo/patterns';
+import { FastUSDCTermsShape } from './type-guards.js';
+import { fromExternalConfig } from './utils/config-marshal.js';
+
+/**
+ * @import {DepositFacet} from '@agoric/ertp/src/types.js'
+ * @import {TypedPattern} from '@agoric/internal'
+ * @import {Instance, StartParams} from '@agoric/zoe/src/zoeService/utils'
+ * @import {Board} from '@agoric/vats'
+ * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
+ * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js'
+ * @import {LegibleCapData} from './utils/config-marshal.js'
+ * @import {FastUsdcSF, FastUsdcTerms} from './fast-usdc.contract.js'
+ */
+
+const trace = makeTracer('FUSD-Start', true);
+
+const contractName = 'fastUsdc';
+
+/**
+ * @typedef {{
+ *   terms: FastUsdcTerms;
+ *   oracles: Record<string, string>;
+ * }} FastUSDCConfig
+ */
+/** @type {TypedPattern<FastUSDCConfig>} */
+export const FastUSDCConfigShape = M.splitRecord({
+  terms: FastUSDCTermsShape,
+  oracles: M.recordOf(M.string(), M.string()),
+});
+
+/**
+ * XXX Shouldn't the bridge or board vat handle this?
+ *
+ * @param {string} path
+ * @param {{
+ *   chainStorage: ERef<StorageNode>;
+ *   board: ERef<Board>;
+ * }} io
+ */
+const makePublishingStorageKit = async (path, { chainStorage, board }) => {
+  const storageNode = await E(chainStorage).makeChildNode(path);
+
+  const marshaller = await E(board).getPublishingMarshaller();
+  return { storageNode, marshaller };
+};
+
+const BOARD_AUX = 'boardAux';
+const marshalData = makeMarshal(_val => Fail`data only`);
+/**
+ * @param {Brand} brand
+ * @param {Pick<BootstrapPowers['consume'], 'board' | 'chainStorage'>} powers
+ */
+const publishDisplayInfo = async (brand, { board, chainStorage }) => {
+  // chainStorage type includes undefined, which doesn't apply here.
+  // @ts-expect-error UNTIL https://github.com/Agoric/agoric-sdk/issues/8247
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  const [id, displayInfo, allegedName] = await Promise.all([
+    E(board).getId(brand),
+    E(brand).getDisplayInfo(),
+    E(brand).getAllegedName(),
+  ]);
+  const node = E(boardAux).makeChildNode(id);
+  const aux = marshalData.toCapData(harden({ allegedName, displayInfo }));
+  await E(node).setValue(JSON.stringify(aux));
+};
+
+/**
+ * @typedef { PromiseSpaceOf<{
+ *   fastUsdcKit: FastUSDCKit
+ *  }> & {
+ *   installation: PromiseSpaceOf<{ fastUsdc: Installation<FastUsdcSF> }>;
+ *   instance: PromiseSpaceOf<{ fastUsdc: Instance<FastUsdcSF> }>;
+ *   issuer: PromiseSpaceOf<{ FastLP: Issuer }>;
+ *   brand: PromiseSpaceOf<{ FastLP: Brand }>;
+ * }} FastUSDCCorePowers
+ *
+ * @typedef {StartedInstanceKitWithLabel & {
+ *   privateArgs: StartParams<FastUsdcSF>['privateArgs'];
+ * }} FastUSDCKit
+ */
+
+/**
+ * @throws if oracle smart wallets are not yet provisioned
+ *
+ * @param {BootstrapPowers & FastUSDCCorePowers } powers
+ * @param {{ options: LegibleCapData<FastUSDCConfig> }} config
+ */
+export const startFastUSDC = async (
+  {
+    produce: { fastUsdcKit },
+    consume: {
+      agoricNames,
+      namesByAddress,
+      board,
+      chainStorage,
+      chainTimerService: timerService,
+      localchain,
+      cosmosInterchainService,
+      startUpgradable,
+      zoe,
+    },
+    issuer: {
+      produce: { FastLP: produceShareIssuer },
+    },
+    brand: {
+      produce: { FastLP: produceShareBrand },
+    },
+    installation: {
+      consume: { fastUsdc },
+    },
+    instance: {
+      produce: { fastUsdc: produceInstance },
+    },
+  },
+  config,
+) => {
+  trace('startFastUSDC');
+
+  await null;
+  /** @type {Issuer<'nat'>} */
+  const USDCissuer = await E(agoricNames).lookup('issuer', 'USDC');
+  const brands = harden({
+    USDC: await E(USDCissuer).getBrand(),
+  });
+
+  const { terms, oracles } = fromExternalConfig(
+    config?.options, // just in case config is missing somehow
+    brands,
+    FastUSDCConfigShape,
+  );
+  trace('using terms', terms);
+
+  trace('look up oracle deposit facets');
+  const oracleDepositFacets = await deeplyFulfilledObject(
+    objectMap(oracles, async address => {
+      /** @type {DepositFacet} */
+      const depositFacet = await E(namesByAddress).lookup(
+        address,
+        'depositFacet',
+      );
+      return depositFacet;
+    }),
+  );
+
+  const { storageNode, marshaller } = await makePublishingStorageKit(
+    contractName,
+    {
+      board,
+      // @ts-expect-error Promise<null> case is vestigial
+      chainStorage,
+    },
+  );
+
+  const privateArgs = await deeplyFulfilledObject(
+    harden({
+      agoricNames,
+      localchain,
+      orchestrationService: cosmosInterchainService,
+      storageNode,
+      timerService,
+      marshaller,
+    }),
+  );
+
+  const kit = await E(startUpgradable)({
+    label: contractName,
+    installation: fastUsdc,
+    issuerKeywordRecord: harden({ USDC: USDCissuer }),
+    terms,
+    privateArgs,
+  });
+  fastUsdcKit.resolve(harden({ ...kit, privateArgs }));
+  const { instance, creatorFacet } = kit;
+
+  const {
+    issuers: { PoolShares: shareIssuer },
+    brands: { PoolShares: shareBrand },
+  } = await E(zoe).getTerms(instance);
+  produceShareIssuer.resolve(shareIssuer);
+  produceShareBrand.resolve(shareBrand);
+  await publishDisplayInfo(shareBrand, { board, chainStorage });
+
+  await Promise.all(
+    Object.entries(oracleDepositFacets).map(async ([name, depositFacet]) => {
+      const address = oracles[name];
+      trace('making invitation for', name, address);
+      const toWatch = await E(creatorFacet).makeOperatorInvitation(address);
+
+      const amt = await E(depositFacet).receive(toWatch);
+      trace('sent', amt, 'to', name);
+    }),
+  );
+
+  produceInstance.reset();
+  produceInstance.resolve(instance);
+  trace('startFastUSDC done', instance);
+};
+harden(startFastUSDC);
+
+/**
+ * @param {{
+ *   restoreRef: (b: ERef<ManifestBundleRef>) => Promise<Installation>;
+ * }} utils
+ * @param {{
+ *   installKeys: { fastUsdc: ERef<ManifestBundleRef> };
+ *   options: LegibleCapData<FastUSDCConfig>;
+ * }} param1
+ */
+export const getManifestForFastUSDC = (
+  { restoreRef },
+  { installKeys, options },
+) => {
+  return {
+    /** @type {BootstrapManifest} */
+    manifest: {
+      [startFastUSDC.name]: {
+        produce: {
+          fastUsdcKit: true,
+        },
+        consume: {
+          chainStorage: true,
+          chainTimerService: true,
+          localchain: true,
+          cosmosInterchainService: true,
+
+          // limited distribution durin MN2: contract installation
+          startUpgradable: true,
+          zoe: true, // only getTerms() is needed. XXX should be split?
+
+          // widely shared: name services
+          agoricNames: true,
+          namesByAddress: true,
+          board: true,
+        },
+        issuer: {
+          produce: { FastLP: true }, // UNTIL #10432
+        },
+        brand: {
+          produce: { FastLP: true }, // UNTIL #10432
+        },
+        instance: {
+          produce: { fastUsdc: true },
+        },
+        installation: {
+          consume: { fastUsdc: true },
+        },
+      },
+    },
+    installations: {
+      fastUsdc: restoreRef(installKeys.fastUsdc),
+    },
+    options,
+  };
+};

--- a/packages/fast-usdc/src/type-guards.js
+++ b/packages/fast-usdc/src/type-guards.js
@@ -1,8 +1,10 @@
 import { M } from '@endo/patterns';
+import { BrandShape } from '@agoric/ertp';
 
 /**
  * @import {TypedPattern} from '@agoric/internal'
  * @import {USDCProposalShapes} from './pool-share-math'
+ * @import {FastUsdcTerms} from './fast-usdc.contract'
  */
 
 /**
@@ -26,3 +28,11 @@ export const makeProposalShapes = ({ PoolShares, USDC }) => {
   });
   return harden({ deposit, withdraw });
 };
+
+const NatAmountShape = { brand: BrandShape, value: M.nat() };
+/** @type {TypedPattern<FastUsdcTerms>} */
+export const FastUSDCTermsShape = harden({
+  contractFee: NatAmountShape,
+  poolFee: NatAmountShape,
+  usdcDenom: M.string(),
+});

--- a/packages/fast-usdc/src/utils/config-marshal.js
+++ b/packages/fast-usdc/src/utils/config-marshal.js
@@ -1,0 +1,130 @@
+import { Fail } from '@endo/errors';
+import { makeMarshal } from '@endo/marshal';
+import { mustMatch } from '@endo/patterns';
+
+// TODO(#7309): move to make available beyond fast-usdc.
+
+/**
+ * @import {Marshal, CapData, Passable} from '@endo/marshal';
+ * @import { RemotableBrand } from '@endo/eventual-send';
+ * @import {TypedPattern} from '@agoric/internal'
+ */
+const { entries } = Object;
+
+/**
+ * To configure amounts such as terms or ratios,
+ * we need to refer to objects such as brands.
+ *
+ * If parties agree on names, any party that doesn't have
+ * an actual presence for an object can make one up:
+ *
+ * const remotes = { USDC: Far('USDC Brand') };
+ *
+ * and use it in local computation:
+ *
+ * const terms = { fee1: AmountMath.make(remotes.USDC, 1234n) }
+ *
+ * Then we can pass references across using marshal conventions, using
+ * the names as slots.
+ *
+ * @param {Record<string, Passable>} slotToVal a record that gives names to stand-ins for objects in another vat
+ * @returns {Marshal<string>}
+ */
+export const makeMarshalFromRecord = slotToVal => {
+  const convertSlotToVal = slot => {
+    slot in slotToVal || Fail`unknown slot ${slot}`;
+    return slotToVal[slot];
+  };
+  const valToSlot = new Map(entries(slotToVal).map(([k, v]) => [v, k]));
+  const convertValToSlot = v => {
+    valToSlot.has(v) || Fail`unknown value: ${v}`;
+    return valToSlot.get(v);
+  };
+  return makeMarshal(convertValToSlot, convertSlotToVal, {
+    serializeBodyFormat: 'smallcaps',
+  });
+};
+
+/**
+ * @typedef {`\$${number}${string}`} SmallCapsSlotRef
+ */
+
+/**
+ * @template T
+ * @typedef {{ [KeyType in keyof T]: T[KeyType] } & {}} Simplify flatten the
+ *   type output to improve type hints shown in editors
+ *   https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ */
+
+/**
+ * @template T
+ * @template R
+ * @typedef {T extends R
+ *     ? SmallCapsSlotRef
+ *     : T extends {}
+ *       ? Simplify<SmallCapsStructureOf<T, R>>
+ *       : Awaited<T>} SmallCapsStructureOf
+ */
+
+/**
+ * The smallCaps body is a string, which simplifies some usage.
+ * But it's hard to read and write.
+ *
+ * The parsed structure makes a convenient notation for configuration etc.
+ *
+ * @template {Passable} [T=Passable]
+ * @template [R=RemotableBrand]
+ * @typedef {{
+ *   structure: SmallCapsStructureOf<T, R>;
+ *   slots: string[];
+ * }} LegibleCapData
+ */
+
+/**
+ * @template {Passable} [T=Passable]
+ * @template [R=RemotableBrand]
+ * @param {CapData<string>} capData
+ * @returns {LegibleCapData<T, R>}
+ */
+export const toLegible = ({ body, slots }) =>
+  harden({ structure: JSON.parse(body.replace(/^#/, '')), slots });
+
+/**
+ * @template {Passable} [T=Passable]
+ * @template [R=RemotableBrand]
+ * @param {LegibleCapData<T,R>} legible
+ * @returns {CapData<string>}
+ */
+export const fromLegible = ({ structure, slots }) =>
+  harden({ body: `#${JSON.stringify(structure)}`, slots });
+
+/**
+ * @template {Passable} [T=Passable]
+ * @template [R=RemotableBrand]
+ * @param {T} config
+ * @param {Record<string, Passable>} context
+ * @param {TypedPattern<T>} [shape]
+ * @returns {LegibleCapData<T,R>}
+ */
+export const toExternalConfig = (config, context, shape) => {
+  if (shape) {
+    mustMatch(config, shape);
+  }
+  return toLegible(makeMarshalFromRecord(context).toCapData(config));
+};
+
+/**
+ * @template {Passable} [T=Passable]
+ * @template [R=RemotableBrand]
+ * @param {LegibleCapData<T,R>} repr
+ * @param {Record<string, Passable>} context
+ * @param {TypedPattern<T>} [shape]
+ * @returns {T}
+ */
+export const fromExternalConfig = (repr, context, shape) => {
+  const config = makeMarshalFromRecord(context).fromCapData(fromLegible(repr));
+  if (shape) {
+    mustMatch(config, shape);
+  }
+  return config;
+};

--- a/packages/fast-usdc/test/config-marshal.test.js
+++ b/packages/fast-usdc/test/config-marshal.test.js
@@ -1,0 +1,49 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { Far } from '@endo/pass-style';
+import { mustMatch } from '@endo/patterns';
+import { AmountMath } from '@agoric/ertp';
+import { FastUSDCTermsShape } from '../src/type-guards.js';
+import {
+  fromLegible,
+  makeMarshalFromRecord,
+  toLegible,
+} from '../src/utils/config-marshal.js';
+
+/** @import {SmallCapsStructureOf} from '../src/utils/config-marshal.js' */
+
+const testMatches = (t, specimen, pattern) => {
+  t.notThrows(() => mustMatch(specimen, pattern));
+};
+
+test('cross-vat configuration of Fast USDC terms', t => {
+  const context = /** @type {const} */ ({
+    /** @type {Brand<'nat'>} */
+    USDC: Far('USDC Brand'),
+  });
+
+  const { USDC } = context;
+  const { make } = AmountMath;
+  const config = harden({
+    poolFee: make(USDC, 150n),
+    contractFee: make(USDC, 200n),
+    usdcDenom: 'ibc/usdconagoric',
+  });
+  testMatches(t, config, FastUSDCTermsShape);
+
+  const m = makeMarshalFromRecord(context);
+  /** @type {any} */ // XXX struggling with recursive type
+  const legible = toLegible(m.toCapData(config));
+
+  t.deepEqual(legible, {
+    structure: {
+      contractFee: { brand: '$0.Alleged: USDC Brand', value: '+200' },
+      poolFee: { brand: '$0', value: '+150' },
+      usdcDenom: 'ibc/usdconagoric',
+    },
+    slots: ['USDC'],
+  });
+  t.deepEqual(legible.slots, Object.keys(context));
+
+  const actual = m.fromCapData(fromLegible(legible));
+  t.deepEqual(actual, config);
+});

--- a/packages/vm-config/decentral-itest-orchestration-config.json
+++ b/packages/vm-config/decentral-itest-orchestration-config.json
@@ -54,6 +54,20 @@
             ]
         },
         {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "psmProposalBuilder",
+            "args": [
+                {
+                    "anchorOptions": {
+                        "denom": "ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9",
+                        "decimalPlaces": 6,
+                        "keyword": "USDC",
+                        "proposedName": "USDC"
+                    }
+                }
+            ]
+        },
+        {
             "$comment": "XXX orchesration works without oracles but some test setup dependency fails to resolve without this",
             "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
             "entrypoint": "defaultProposalBuilder",


### PR DESCRIPTION
closes: #10301

## Description

 - feat(fast-usdc): .start.js core-eval w/oracle invitations
    - the pool share brand is called `FastLP` , at least **UNTIL #10432**
    - needed contract tweak: STUB! makeOracleInvitation , so perhaps this should wait for #10478
 - feat(builders): fast-usdc builder w/CLI config for fees, oracle addresses

Also, rather than yet another ad-hoc way of passing terms containing amounts from builders to core-eval, this includes `LegibleCapData`, an approach for...

   -  #7309

### Security Considerations

Oracle invitations are sent do parties identified by addresses, so the usual key management issues apply. In order to reduce "which address is for which operator?" hassle, configuration uses a record, like we do for `voterAddresses`, rather than a plain array as in price feed core-eval code.

The core eval produces a `fastUSDCKit` including `privateArgs`; this was prompted by testing difficulties: `instancePrivateArgs` is a heap map, not a remotable, so `EV(instancePrivateArgs).get(instance)` is a no-go. But it also usefully avoids handing out all of `instancePrivateArgs` to any core-eval for upgrading this contract.

### Scaling Considerations

The core-eval is O(1), I think. It's O(n) in the number of oracle operators, but that number is fixed by proposal time.

### Documentation Considerations

The builder CLI args are lightly documented, in the source:

```js
/** @type {ParseArgsConfig['options']} */
const optionsConfig = {
  contractFee: { type: 'string', default: '0.01' },
  poolFee: { type: 'string', default: '0.01' },
  oracle: { type: 'string', multiple: true },
};
const oraclesRequiredUsage = 'use --oracle name:address ...';
```


### Testing Considerations

 - [x] test(boot): fast-usdc core eval
   - needed chore: include noble USDC in orch integration test config
 - [x] test(boot): restart fastUSDC
 - [x] unit tests for config marshal 

### Upgrade Considerations

Restart is a pre-requisite for upgrade, so this is progress on testing upgrade of fastUSDC.
