### PR TITLE
fix(orchestration): subscribeToTransfers() atomically

### DIFF
--- a/packages/orchestration/src/exos/packet-tools.js
+++ b/packages/orchestration/src/exos/packet-tools.js
@@ -327,8 +327,6 @@ export const preparePacketTools = (zone, vowTools) => {
           }
           this.state.pending = 0;
           this.state.upcallQueue = null;
-          // FIXME when it returns undefined this causes an error:
-          // In "unsubscribeFromTransfers" method of (PacketToolsKit utils): result: undefined "[undefined]" - Must be a promise
           return watch(this.facets.utils.unsubscribeFromTransfers());
         },
         subscribeToTransfers() {


### PR DESCRIPTION
refs: #10391

## Description

There was a race in subscribeToTransfers. Use a `Vow` to avoid the race.

### Security / Scaling / Upgrade / Documentation Considerations

can't think of any

### Testing Considerations

I'm not sure how to make a test for this. The purpose of this fix is mostly to stop other tests from failing.
