### PR TITLE
feat(zoe): cache bundles in bundleAndInstall of setUpZoeForTest

### DIFF
--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Fail } from '@endo/errors';
-import { makeIssuerKit } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 import {
   deeplyFulfilledObject,
@@ -15,13 +15,13 @@ import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { withAmountUtils } from '../../supports.js';
 
 const trace = makeTracer('BootFAUpg');
 
 export const arV1BundleName = 'assetReserveV1';
 
-const moola = withAmountUtils(makeIssuerKit('moola'));
+const moola = makeIssuerKit('moola');
+const { make } = AmountMath;
 
 export const buildRootObject = async () => {
   const storageKit = makeFakeStorageKit('assetReserveUpgradeTest');
@@ -226,7 +226,7 @@ export const buildRootObject = async () => {
 
       await E(arLimitedFacet).addIssuer(moola.issuer, 'Moola');
 
-      const amt = moola.make(100_000n);
+      const amt = make(moola.brand, 100_000n);
       const collateralSeat = addCollateral(amt);
 
       assert.equal(
@@ -275,7 +275,7 @@ export const buildRootObject = async () => {
       assert.equal(metricsRecord.updateCount, 2n);
 
       // add more collateral
-      const amt = moola.make(20_000n);
+      const amt = make(moola.brand, 20_000n);
       const collateralSeat = addCollateral(amt);
 
       assert.equal(

--- a/packages/zoe/tools/setup-zoe.js
+++ b/packages/zoe/tools/setup-zoe.js
@@ -1,7 +1,7 @@
 import { E, makeLoopback } from '@endo/captp';
 
 import { makeScalarBigMapStore } from '@agoric/vat-data';
-import bundleSource from '@endo/bundle-source';
+import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 import { makeDurableZoeKit } from '../src/zoeService/zoe.js';
 import fakeVatAdmin, { makeFakeVatAdmin } from './fakeVatAdmin.js';
 
@@ -31,12 +31,14 @@ export const makeZoeForTest = vatAdminSvc =>
  * @param {FeeIssuerConfig} [options.feeIssuerConfig]
  * @param {VatAdminSvc} [options.vatAdminSvc]
  * @param {boolean} [options.useNearRemote]
+ * @param {string} [options.bundlesDir]
  */
 export const setUpZoeForTest = async ({
   setJig = () => {},
   feeIssuerConfig,
   vatAdminSvc,
   useNearRemote = false,
+  bundlesDir = 'bundles',
 } = {}) => {
   const { makeFar, makeNear } = makeLoopback('zoeTest');
 
@@ -56,12 +58,14 @@ export const setUpZoeForTest = async ({
     }),
   );
 
+  const bundleCache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+
   /**
    * @param {string} path
    * @returns {Promise<Installation>}
    */
   const bundleAndInstall = async path => {
-    const bundle = await bundleSource(path);
+    const bundle = await bundleCache.load(path);
     const id = `b1-${path}`;
     assert(vatAdminState, 'installBundle called before vatAdminState defined');
     vatAdminState.installBundle(id, bundle);


### PR DESCRIPTION
DRAFT; goal:
closes: #10427
refs: #10550

## Description / Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

 - [x] Make `bundleAndInstall` cache.
 - [ ] Remove pre-caching from tests using `bundleAndInstall`.
 - [ ] migrate direct uses of `E(zoe).install(bundle)` to use `setUpZoeForTest` and its caching `bundleAndInstall`.

### Security / Documentation Considerations

It's not clear that the cache works correctly with multiple concurrent tests.
There's a `bundleDir` option, but using that would largely defeat the purpose.

### Scaling Considerations

should make at least fast-usdc contract tests (#10550) run faster

### Upgrade Considerations

n/a. test only