### PR TITLE
fix 'self' in prepareExo

### DIFF
--- a/packages/fast-usdc/package.json
+++ b/packages/fast-usdc/package.json
@@ -74,6 +74,7 @@
     ],
     "timeout": "20m"
   },
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -289,7 +289,10 @@ export const makeExoUtils = VatData => {
    * @param {Baggage} baggage
    * @param {string} kindName
    * @param {InterfaceGuard | undefined} interfaceGuard
-   * @param {M} methods
+   * @param {M &
+   *   ThisType<{
+   *     self: RemotableObject & M;
+   *   }>} methods
    * @param {DefineKindOptions<{ self: M }>} [options]
    * @returns {import('@endo/exo').Guarded<M>}
    */

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -101,7 +101,6 @@ export const makeInstallationStorage = (getBundleCapForID, zoeBaggage) => {
     InstallationStorageI,
     {
       async installBundle(allegedBundle, bundleLabel) {
-        // @ts-expect-error TS doesn't understand context
         const { self } = this;
         // Bundle is a very open-ended type and we must decide here whether to
         // treat it as either a HashBundle or SourceBundle. So we have to
@@ -149,7 +148,6 @@ export const makeInstallationStorage = (getBundleCapForID, zoeBaggage) => {
         }
       },
       async getBundleIDFromInstallation(allegedInstallation) {
-        // @ts-expect-error TS doesn't understand context
         const { self } = this;
         const { bundleID } = await self.unwrapInstallation(allegedInstallation);
         // AWAIT


### PR DESCRIPTION
_incidental_

## Description
Fix the type for `prepareExo` so `this.self` works.

### Security Considerations
n/a
### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
CI

### Upgrade Considerations
n/a