### PR TITLE
fix c8-all

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -8,9 +8,16 @@ source-to-source transforms (such as `@endo/bundle-source`,
 
 ## Reports
 
+### Whole repo
 Coverage reports for the current main branch are
 published by CI to: https://agoric-sdk-coverage.netlify.app
 
+It's made by a CI job calling `test:c8-all` in the project root. That in turn
+calls `test:c8` in each package, with `$C8_OPTIONS` set to a common coverage
+directory and to leave temp files so they can accumulate. The job then uses that
+output in another call to c8 to generate a report.
+
+## Per package
 You can create a report in any package:
 
 ```sh

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -12,7 +12,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 $C8_OPTIONS ava",
+    "test:c8": "c8 --all ava",
     "test:xs": "yarn test:xs-worker",
     "test:xs-unit": "exit 0",
     "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 test/swingsetTests",

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -12,7 +12,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "yarn test:xs-worker",
     "test:xs-unit": "exit 0",
     "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 test/swingsetTests",

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint": "run-s --continue-on-error lint:*",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "node ./scripts/get-sdk-package-names.js > src/sdk-package-names.js",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "integration-test": "ava --config .ava-integration-test.config.js",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -10,7 +10,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -10,7 +10,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -11,7 +11,7 @@
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "demo": "node -e 'import(\"./test/fake-rpc-server.js\").then(ns => ns.develop())'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/create-dapp/package.json
+++ b/packages/create-dapp/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/fast-usdc/package.json
+++ b/packages/fast-usdc/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -13,7 +13,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint": "yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -13,7 +13,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/kmarshal/package.json
+++ b/packages/kmarshal/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -10,7 +10,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 $C8_OPTIONS ava",
+    "test:c8": "c8 --all ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -10,7 +10,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -12,7 +12,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -14,7 +14,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc",

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -11,7 +11,7 @@
     "build": "yarn build:bundles",
     "build:bundles": "node scripts/build-bundles.js",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint": "run-s --continue-on-error lint:*",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -19,7 +19,7 @@
     "lint:types": "tsc",
     "lint-fix": "eslint --fix 'lib/**/*.js' 'src/**/*.js' 'scripts/**/*.js' 'test/**/*.js'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0"
   },
   "devDependencies": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -11,7 +11,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 $C8_OPTIONS ava",
+    "test:c8": "c8 --all ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -11,7 +11,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/vm-config/package.json
+++ b/packages/vm-config/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -16,7 +16,7 @@
     "lint:types": "tsc",
     "lint-fix": "eslint --fix 'src/**/*.js' 'lib/**/*.js' 'scripts/**/*.js' 'test/**/*.js'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0"
   },
   "devDependencies": {

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -24,7 +24,7 @@
     "lint:types": "tsc",
     "lint-fix": "eslint --fix 'src/**/*.js' 'test/**/*.js' api.js",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0"
   },
   "dependencies": {

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -13,7 +13,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava --verbose",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:unit": "ava 'test/unitTests' -T 1m --verbose",
     "test:swingset": "ava 'test/swingsetTests' -T 10m --verbose",
     "test:xs": "yarn test:xs-worker",

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -10,7 +10,7 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
-    "test:c8": "c8 --all ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",


### PR DESCRIPTION
followup: #10556

## Description
https://github.com/Agoric/agoric-sdk/pull/10556 removed C8_OPTIONS without looking closely at the fence. That parameter was used by the `test:c8-all` command to stitch together the package coverage collections.

This restores that and adds some documentation.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
[manual trigger the after-merge branch](https://github.com/Agoric/agoric-sdk/actions/runs/11984250775) to verify the build output at https://agoric-sdk-coverage.netlify.app/ before merging. UPDATE: `coverage` only runs on `push` so the manual trigger didn't work. I suppose so a random branch doesn't overwrite the master coverage report.

### Upgrade Considerations
none