### PR TITLE
TypeScript 5.7 and fix coverage CI

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: generate test coverage report
-        run: ./scripts/ci/generage-test-coverage-report.sh
+        run: ./scripts/ci/generate-test-coverage-report.sh
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@google-cloud/monitoring": "^4.1.0",
     "@jessie.js/eslint-plugin": "^0.4.1",
     "@types/express": "^4.17.17",
-    "@types/node": "^22.0.0",
+    "@types/node": "^22.9.0",
     "ava": "^5.3.0",
     "c8": "^10.1.2",
     "conventional-changelog-conventionalcommits": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "type-coverage": "^2.27.1",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
-    "typescript": "^5.6.2",
+    "typescript": "~5.7.1",
     "typescript-eslint": "^7.18.0"
   },
   "resolutions": {

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -36,6 +36,7 @@ workerLog(`supervisor started`);
 
 function makeNetstringReader({ fd, encoding }) {
   const input = Buffer.alloc(32 * 1024);
+  /** @type {Buffer<ArrayBufferLike>} */
   let buffered = Buffer.alloc(0);
   let decoded = [];
 

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -153,7 +153,7 @@
     "rimraf": "^5.0.0",
     "tsd": "^0.31.1",
     "tsimp": "^2.0.11",
-    "typescript": "~5.6.2"
+    "typescript": "~5.7.1"
   },
   "dependencies": {
     "@endo/base64": "^1.0.9",

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -37,6 +37,15 @@ const FIRST_LOWER_NEAR_KEYWORD = /^[a-z][a-zA-Z0-9_$]*$/;
  * @import {Bank, BankManager} from '@agoric/vats/src/vat-bank.js'
  */
 
+// XXX when inferred, error TS2742: cannot be named without a reference to '../../../node_modules/@endo/exo/src/get-interface.js'. This is likely not portable. A type annotation is necessary.
+/**
+ * @typedef {{
+ *   machine: any;
+ *   helper: any;
+ *   public: any;
+ * }} ProvisionPoolKit
+ */
+
 /**
  * @typedef {import('@agoric/zoe/src/zoeService/utils.js').Instance<
  *   import('@agoric/inter-protocol/src/psm/psm.js').start
@@ -506,6 +515,7 @@ export const prepareProvisionPoolKit = (
    * @param {object} opts
    * @param {Brand<'nat'>} opts.poolBrand
    * @param {ERef<StorageNode>} opts.storageNode
+   * @returns {Promise<ProvisionPoolKit>}
    */
   const makeProvisionPoolKit = async ({ poolBrand, storageNode }) => {
     const fundPurse = await E(poolBank).getPurse(poolBrand);

--- a/packages/inter-protocol/src/reserve/params.js
+++ b/packages/inter-protocol/src/reserve/params.js
@@ -2,8 +2,10 @@
 
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 
-const makeReserveTerms = (poserInvitationAmount, timer) => ({
-  timer,
+/**
+ * @param {InvitationAmount} poserInvitationAmount
+ */
+const makeReserveTerms = poserInvitationAmount => ({
   governedParams: harden({
     [CONTRACT_ELECTORATE]: {
       type: ParamTypes.INVITATION,

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -100,8 +100,8 @@ export const setupPsm = async (
   brand.produce.IST.resolve(istBrand);
   issuer.produce.IST.resolve(istIssuer);
 
+  // @ts-expect-error mock
   space.produce.provisionPoolStartResult.resolve({
-    // @ts-expect-error mock
     creatorFacet: Far('dummy', {
       initPSM: () => {
         t.log('dummy provisionPool.initPSM');

--- a/packages/internal/src/netstring.js
+++ b/packages/internal/src/netstring.js
@@ -89,6 +89,7 @@ export function decode(data, optMaxChunkSize) {
  */
 // input is a byte pipe, output is a sequence of Buffers
 export function netstringDecoderStream(optMaxChunkSize) {
+  /** @type {Buffer<ArrayBufferLike>} */
   let buffered = Buffer.from('');
   /**
    * @param {Buffer} chunk

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -100,11 +100,11 @@ const meterControl = makeMeterControl();
 /**
  * Wrap byte-level protocols with tagged array codec.
  *
- * @param {(cmd: ArrayBuffer) => ArrayBuffer} issueCommand as from xsnap
+ * @param {(cmd: ArrayBufferLike) => ArrayBuffer} issueCommand as from xsnap
  * @typedef { [unknown, ...unknown[]] } Tagged tagged array
  */
 function managerPort(issueCommand) {
-  /** @type { (item: Tagged) => ArrayBuffer } */
+  /** @type { (item: Tagged) => ArrayBufferLike } */
   const encode = item => {
     let txt;
     try {

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -112,7 +112,7 @@ async function runTestScript(
   /**
    * Handle callback "command" from xsnap subprocess.
    *
-   * @type { (msg: ArrayBuffer) => Promise<ArrayBuffer> }
+   * @type { (msg: ArrayBuffer) => Promise<Uint8Array<ArrayBufferLike>> }
    */
   async function handleCommand(message) {
     /**

--- a/packages/xsnap/src/globals.d.ts
+++ b/packages/xsnap/src/globals.d.ts
@@ -1,5 +1,5 @@
-declare var issueCommand: (msg: ArrayBuffer) => ArrayBuffer;
+declare var issueCommand: (msg: ArrayBufferLike) => ArrayBuffer;
 
 namespace global {
-  declare var issueCommand: (msg: ArrayBuffer) => ArrayBuffer;
+  declare var issueCommand: (msg: ArrayBufferLike) => ArrayBuffer;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,12 +3774,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=13.7.0":
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.0.0.tgz#04862a2a71e62264426083abe1e27e87cac05a30"
-  integrity sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^22.9.0":
+  version "22.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
+  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
   dependencies:
-    undici-types "~6.11.1"
+    undici-types "~6.19.8"
 
 "@types/node@22.7.5":
   version "22.7.5"
@@ -3787,13 +3787,6 @@
   integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
   dependencies:
     undici-types "~6.19.2"
-
-"@types/node@^22.9.0":
-  version "22.9.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
-  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
-  dependencies:
-    undici-types "~6.19.8"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -12186,7 +12179,7 @@ typescript-eslint@^7.18.0, typescript-eslint@^7.3.1:
     "@typescript-eslint/parser" "7.18.0"
     "@typescript-eslint/utils" "7.18.0"
 
-"typescript@5.1.6 - 5.6.x", typescript@^5.4.5, typescript@~5.6.3:
+"typescript@5.1.6 - 5.6.x", typescript@~5.6.3:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
@@ -12196,7 +12189,7 @@ typescript-eslint@^7.18.0, typescript-eslint@^7.3.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@~5.7.1:
+typescript@^5.4.5, typescript@~5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,12 +3774,26 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@22.7.5", "@types/node@>=13.7.0", "@types/node@^22.0.0":
+"@types/node@*", "@types/node@>=13.7.0":
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.0.0.tgz#04862a2a71e62264426083abe1e27e87cac05a30"
+  integrity sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==
+  dependencies:
+    undici-types "~6.11.1"
+
+"@types/node@22.7.5":
   version "22.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
   integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
   dependencies:
     undici-types "~6.19.2"
+
+"@types/node@^22.9.0":
+  version "22.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
+  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
+  dependencies:
+    undici-types "~6.19.8"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -12172,7 +12186,7 @@ typescript-eslint@^7.18.0, typescript-eslint@^7.3.1:
     "@typescript-eslint/parser" "7.18.0"
     "@typescript-eslint/utils" "7.18.0"
 
-"typescript@5.1.6 - 5.6.x", typescript@^5.4.5, typescript@~5.6.2, typescript@~5.6.3:
+"typescript@5.1.6 - 5.6.x", typescript@^5.4.5, typescript@~5.6.3:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
@@ -12207,7 +12221,7 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-undici-types@~6.19.2:
+undici-types@~6.19.2, undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12172,7 +12172,7 @@ typescript-eslint@^7.18.0, typescript-eslint@^7.3.1:
     "@typescript-eslint/parser" "7.18.0"
     "@typescript-eslint/utils" "7.18.0"
 
-"typescript@5.1.6 - 5.6.x", typescript@^5.4.5, typescript@^5.6.2, typescript@~5.6.2, typescript@~5.6.3:
+"typescript@5.1.6 - 5.6.x", typescript@^5.4.5, typescript@~5.6.2, typescript@~5.6.3:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
@@ -12181,6 +12181,11 @@ typescript-eslint@^7.18.0, typescript-eslint@^7.3.1:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@~5.7.1:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
evergreen

## Description

Bump Typescript to the 5.7 release
https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/

This also corrects [a typo in the `coverage` job](https://github.com/Agoric/agoric-sdk/actions/runs/11991054038/job/33429229279) from https://github.com/Agoric/agoric-sdk/pull/10560


### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none