### PR TITLE
fix(agoric-cli): wrong URL in agops oracle setPrice, find-continuing-id

### DIFF
--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -207,11 +207,10 @@ export const makeOracleCommand = (logger, io = {}) => {
       s => s.split('.'),
     )
     .action(async opts => {
-      const { readLatestHead, lookupPriceAggregatorInstance } =
-        await rpcTools();
+      const { readPublished, lookupPriceAggregatorInstance } = await rpcTools();
       const instance = lookupPriceAggregatorInstance(opts.pair);
 
-      const offerId = await findOracleCap(instance, opts.from, readLatestHead);
+      const offerId = await findOracleCap(instance, opts.from, readPublished);
       if (!offerId) {
         console.error('No continuing ids found');
       }
@@ -272,8 +271,12 @@ export const makeOracleCommand = (logger, io = {}) => {
          * }}
          */ { pair, keys, price },
       ) => {
-        const { readLatestHead, networkConfig, lookupPriceAggregatorInstance } =
-          await rpcTools();
+        const {
+          readLatestHead,
+          readPublished,
+          networkConfig,
+          lookupPriceAggregatorInstance,
+        } = await rpcTools();
         const wutil = await makeWalletUtils({ fetch, delay }, networkConfig);
         const unitPrice = scaleDecimals(price);
 
@@ -338,7 +341,7 @@ export const makeOracleCommand = (logger, io = {}) => {
           adminOfferIds[from] = await findOracleCap(
             instance,
             from,
-            readLatestHead,
+            readPublished,
           );
           if (!adminOfferIds[from]) {
             console.error(


### PR DESCRIPTION
refs:
 - #10592
 - #10450

## Description

It looks like #10450 changed the URL used to get oracle operator wallet info from

`https://emerynet.rpc.agoric.net:443/abci_query?path=%22/custom/vstorage/data/published.wallet.agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce.current%22&height=0`

to

`https://emerynet.rpc.agoric.net:443/abci_query?path=%22/custom/vstorage/data/wallet.agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce.current%22&height=0`

This PR uses `readPublished` consistently in order to restore the `published.` prefix.

### Security / Scaling / Documentation Considerations

none

### Testing Considerations

I'm a little surprised that we don't have `z:acceptance` tests that rely on this testing tool.

### Upgrade Considerations

This is client-side only code.
