### PR TITLE
test(fast-usdc): count computrons for advancement

### DIFF
--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -9,7 +9,7 @@
     "build": "exit 0",
     "clean": "rm -rf bundles/config.*",
     "test": "ava",
-    "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava test/bootstrapTests test/upgrading",
+    "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava test/bootstrapTests test/upgrading test/fast-usdc",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc",

--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -14,12 +14,34 @@ import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
 } from '../bootstrapTests/walletFactory.js';
+import {
+  makeSwingsetHarness,
+  insistManagerType,
+} from '../../tools/supports.js';
 
-const test: TestFn<WalletFactoryTestContext> = anyTest;
+const test: TestFn<
+  WalletFactoryTestContext & {
+    harness?: ReturnType<typeof makeSwingsetHarness>;
+  }
+> = anyTest;
+
+const {
+  SLOGFILE: slogFile,
+  SWINGSET_WORKER_TYPE: defaultManagerType = 'local',
+} = process.env;
 
 test.before('bootstrap', async t => {
   const config = '@agoric/vm-config/decentral-itest-orchestration-config.json';
-  t.context = await makeWalletFactoryContext(t, config);
+  insistManagerType(defaultManagerType);
+  const harness = ['xs-worker', 'xsnap'].includes(defaultManagerType)
+    ? makeSwingsetHarness()
+    : undefined;
+  const ctx = await makeWalletFactoryContext(t, config, {
+    slogFile,
+    defaultManagerType,
+    harness,
+  });
+  t.context = { ...ctx, harness };
 });
 test.after.always(t => t.context.shutdown?.());
 
@@ -129,7 +151,12 @@ test.serial('writes fee config to vstorage', async t => {
 });
 
 test.serial('makes usdc advance', async t => {
-  const { walletFactoryDriver: wd, storage, agoricNamesRemotes } = t.context;
+  const {
+    walletFactoryDriver: wd,
+    storage,
+    agoricNamesRemotes,
+    harness,
+  } = t.context;
   const oracles = await Promise.all([
     wd.provideSmartWallet('agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8'),
     wd.provideSmartWallet('agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr'),
@@ -167,7 +194,8 @@ test.serial('makes usdc advance', async t => {
   await eventLoopIteration();
 
   const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO();
-  // TODO - start counting computrons
+
+  harness?.useRunPolicy(true);
   await Promise.all(
     oracles.map(wallet =>
       wallet.sendOffer({
@@ -183,7 +211,12 @@ test.serial('makes usdc advance', async t => {
     ),
   );
   await eventLoopIteration();
-  // TODO - stop counting computrons
+  harness &&
+    t.log(
+      `fusdc advance computrons (${oracles.length} oracles)`,
+      harness.totalComputronCount(),
+    );
+  harness?.resetRunPolicy();
 
   const doc = {
     node: `fastUsdc.status`,

--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -1,8 +1,6 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import type { TestFn } from 'ava';
-import type { FastUSDCKit } from '@agoric/fast-usdc/src/fast-usdc.start.js';
-import type { CctpTxEvidence } from '@agoric/fast-usdc/src/types.js';
 import { MockCctpTxEvidences } from '@agoric/fast-usdc/test/fixtures.js';
 import { documentStorageSchema } from '@agoric/governance/tools/storageDoc.js';
 import { Fail } from '@endo/errors';


### PR DESCRIPTION
closes https://github.com/Agoric/agoric-sdk/issues/10511

### Testing

```
~/agoric-sdk/packages/boot$ SWINGSET_WORKER_TYPE=xsnap yarn test test/fast-usdc/

...

  ✔ makes usdc advance (5.5s)
    ℹ fusdc advance computrons (3 oracles) 46517841n
```