### PR TITLE
fix(telemetry): Empty context persisted when remaining beans are negative after run finish

### DIFF
--- a/packages/telemetry/src/context-aware-slog-file.js
+++ b/packages/telemetry/src/context-aware-slog-file.js
@@ -29,10 +29,10 @@ export const makeSlogSender = async options => {
    * @param {import('./context-aware-slog.js').Slog} slog
    */
   const slogSender = slog => {
-    const contextualizedSlog = contextualSlogProcessor(slog);
+    const { timestamp: time, ...rest } = contextualSlogProcessor(slog);
 
     // eslint-disable-next-line prefer-template
-    stream.write(serializeSlogObj(contextualizedSlog) + '\n').catch(() => {});
+    stream.write(serializeSlogObj({ time, ...rest }) + '\n').catch(() => {});
   };
 
   return Object.assign(slogSender, {

--- a/packages/telemetry/src/context-aware-slog-file.js
+++ b/packages/telemetry/src/context-aware-slog-file.js
@@ -29,10 +29,10 @@ export const makeSlogSender = async options => {
    * @param {import('./context-aware-slog.js').Slog} slog
    */
   const slogSender = slog => {
-    const { timestamp: time, ...rest } = contextualSlogProcessor(slog);
+    const contextualizedSlog = contextualSlogProcessor(slog);
 
     // eslint-disable-next-line prefer-template
-    stream.write(serializeSlogObj({ time, ...rest }) + '\n').catch(() => {});
+    stream.write(serializeSlogObj(contextualizedSlog) + '\n').catch(() => {});
   };
 
   return Object.assign(slogSender, {

--- a/packages/telemetry/src/context-aware-slog.js
+++ b/packages/telemetry/src/context-aware-slog.js
@@ -135,9 +135,9 @@ export const makeContextualSlogProcessor = (
 
   /**
    * @param {Slog} slog
-   * @returns {{ attributes: T & LogAttributes, body: Partial<Slog>; timestamp: Slog['time'] }}
+   * @returns {{ attributes: T & LogAttributes, body: Partial<Slog>; time: Slog['time'] }}
    */
-  const slogProcessor = ({ monotime, time: timestamp, ...body }) => {
+  const slogProcessor = ({ monotime, time, ...body }) => {
     const finalBody = { ...body };
 
     /** @type {{'crank.syscallNum'?: Slog['syscallNum']}} */
@@ -321,13 +321,13 @@ export const makeContextualSlogProcessor = (
 
     const logAttributes = {
       ...staticContext,
-      'process.uptime': monotime,
       ...initContext, // Optional prelude
       ...blockContext, // Block is the first level of execution nesting
       ...triggerContext, // run and trigger info is nested next
       ...crankContext, // Finally cranks are the last level of nesting
       ...replayContext, // Replay is a substitute for crank context during vat page in
       ...eventLogAttributes,
+      'process.uptime': monotime,
     };
 
     /**
@@ -377,9 +377,9 @@ export const makeContextualSlogProcessor = (
     }
 
     return {
-      attributes: /** @type {T & LogAttributes} */ (logAttributes),
       body: finalBody,
-      timestamp,
+      attributes: /** @type {T & LogAttributes} */ (logAttributes),
+      time,
     };
   };
 

--- a/packages/telemetry/src/context-aware-slog.js
+++ b/packages/telemetry/src/context-aware-slog.js
@@ -356,7 +356,11 @@ export const makeContextualSlogProcessor = (
       // eslint-disable-next-line no-restricted-syntax
       case SLOG_TYPES.COSMIC_SWINGSET.RUN.FINISH: {
         assert(!!triggerContext);
-        persistContext(finalBody.remainingBeans ? {} : triggerContext);
+        persistContext(
+          finalBody.remainingBeans && finalBody.remainingBeans > 0
+            ? {}
+            : triggerContext,
+        );
         triggerContext = null;
         break;
       }

--- a/packages/telemetry/src/otel-context-aware-slog.js
+++ b/packages/telemetry/src/otel-context-aware-slog.js
@@ -82,9 +82,9 @@ export const makeSlogSender = async options => {
    * @param {import('./context-aware-slog.js').Slog} slog
    */
   const slogSender = slog => {
-    const { timestamp, ...logRecord } = contextualSlogProcessor(slog);
+    const { time, ...logRecord } = contextualSlogProcessor(slog);
 
-    const [secondsStr, fractionStr] = String(timestamp).split('.');
+    const [secondsStr, fractionStr] = String(time).split('.');
     const seconds = parseInt(secondsStr, 10);
     const nanoSeconds = parseInt(
       (fractionStr || String(0)).padEnd(9, String(0)).slice(0, 9),


### PR DESCRIPTION
refs: #10300

## Description
Due to a faulty condition, empty context was persisted in case remaining beans were negative after a run finish
This PR also renames `timestamp` to `time` in the `context-aware-slog-file.js` slogger so that the timestamp is automatically picked up by GCP Stack driver as the time of the log

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
None

### Upgrade Considerations
None
