### PR TITLE
chore(provisionPool): allow overriding PerAccountInitialAmount during contract upgrade

### DIFF
--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -250,6 +250,7 @@ const facetHelpers = (zcf, paramManager) => {
  * @param {M} paramTypesMap
  * @param {ERef<StorageNode>} [storageNode]
  * @param {ERef<Marshaller>} [marshaller]
+ * @param {object} [overrides]
  */
 const handleParamGovernance = (
   zcf,
@@ -257,6 +258,7 @@ const handleParamGovernance = (
   paramTypesMap,
   storageNode,
   marshaller,
+  overrides,
 ) => {
   /** @type {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} */
   const publisherKit = makeStoredPublisherKit(
@@ -269,6 +271,7 @@ const handleParamGovernance = (
     zcf,
     { Electorate: initialPoserInvitation },
     paramTypesMap,
+    overrides,
   );
 
   return facetHelpers(zcf, paramManager);

--- a/packages/inter-protocol/src/provisionPool.js
+++ b/packages/inter-protocol/src/provisionPool.js
@@ -53,6 +53,7 @@ harden(meta);
  *   storageNode: StorageNode;
  *   marshaller: Marshal<any>;
  *   metricsOverride?: import('./provisionPoolKit.js').MetricsNotification;
+ *   governedParamOverrides?: Record<string, Amount | undefined>;
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
@@ -74,6 +75,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       },
       privateArgs.storageNode,
       privateArgs.marshaller,
+      privateArgs.governedParamOverrides,
     );
 
   const zone = makeDurableZone(baggage);

--- a/packages/vats/src/proposals/upgrade-provisionPool-proposal.js
+++ b/packages/vats/src/proposals/upgrade-provisionPool-proposal.js
@@ -60,15 +60,10 @@ export const upgradeProvisionPool = async (
     E(electorateCreatorFacet).getPoserInvitation(),
   ]);
 
-  const readCurrentGovernedParams = async () => {
-    await null;
-
-    const params = await E(ppPublicFacet).getGovernedParams();
-    return harden({
-      PerAccountInitialAmount: params.PerAccountInitialAmount.value,
-    });
-  };
-  const governedParamOverrides = await readCurrentGovernedParams();
+  const params = await E(ppPublicFacet).getGovernedParams();
+  const governedParamOverrides = harden({
+    PerAccountInitialAmount: params.PerAccountInitialAmount.value,
+  });
   trace('governedParamOverrides: ', { governedParamOverrides });
 
   const newPrivateArgs = harden({

--- a/packages/vats/src/proposals/upgrade-provisionPool-proposal.js
+++ b/packages/vats/src/proposals/upgrade-provisionPool-proposal.js
@@ -2,7 +2,7 @@ import { E } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 import { makeTracer } from '@agoric/internal';
 
-const tracer = makeTracer('UpgradeProvisionPool');
+const trace = makeTracer('UpgradeProvisionPool');
 
 /**
  * @param {BootstrapPowers & {
@@ -30,7 +30,7 @@ export const upgradeProvisionPool = async (
   const { provisionPoolRef } = options.options;
 
   assert(provisionPoolRef.bundleID);
-  tracer(`PROVISION POOL BUNDLE ID: `, provisionPoolRef);
+  trace(`PROVISION POOL BUNDLE ID: `, provisionPoolRef);
 
   const [
     provisionPoolStartResult,
@@ -49,6 +49,7 @@ export const upgradeProvisionPool = async (
     adminFacet,
     instance,
     creatorFacet: ppCreatorFacet,
+    publicFacet: ppPublicFacet,
   } = provisionPoolStartResult;
   const { creatorFacet: wfCreatorFacet } = walletFactoryStartResult;
 
@@ -59,9 +60,21 @@ export const upgradeProvisionPool = async (
     E(electorateCreatorFacet).getPoserInvitation(),
   ]);
 
+  const readCurrentGovernedParams = async () => {
+    await null;
+
+    const params = await E(ppPublicFacet).getGovernedParams();
+    return harden({
+      PerAccountInitialAmount: params.PerAccountInitialAmount.value,
+    });
+  };
+  const governedParamOverrides = await readCurrentGovernedParams();
+  trace('governedParamOverrides: ', { governedParamOverrides });
+
   const newPrivateArgs = harden({
     ...originalPrivateArgs,
     initialPoserInvitation: poserInvitation,
+    governedParamOverrides,
   });
 
   const upgradeResult = await E(adminFacet).upgradeContract(
@@ -69,7 +82,7 @@ export const upgradeProvisionPool = async (
     newPrivateArgs,
   );
 
-  tracer('ProvisionPool upgraded: ', upgradeResult);
+  trace('ProvisionPool upgraded: ', upgradeResult);
 
   const references = {
     bankManager,
@@ -77,17 +90,17 @@ export const upgradeProvisionPool = async (
     walletFactory: wfCreatorFacet,
   };
 
-  tracer('Calling setReferences with: ', references);
+  trace('Calling setReferences with: ', references);
   await E(ppCreatorFacet).setReferences(references);
 
-  tracer('Creating bridgeHandler...');
+  trace('Creating bridgeHandler...');
   const bridgeHandler = await E(ppCreatorFacet).makeHandler();
 
-  tracer('Setting new bridgeHandler...');
+  trace('Setting new bridgeHandler...');
   // @ts-expect-error casting
   await E(provisionWalletBridgeManager).setHandler(bridgeHandler);
 
-  tracer('Done.');
+  trace('Done.');
 };
 
 export const getManifestForUpgradingProvisionPool = (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10562 

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

This PR introduces changes to the provisionPool contract to allow the overriding of the PerAccountInitialAmount parameter, governed by the Economic Committee, during a contract upgrade.

To achieve the above functionality, this PR introduces the following changes:

- The PerAccountInitialAmount can now be injected into the contract through privateArgs by defining governedParamOverrides.
- The handleParamGovernance method from the governance package was updated to include an aditional optional argument called `overrides` so it can be passed to the makeParamManagerFromTerms to manage the governed parameter during contract upgrades.

The core-eval proposal used to upgrade provisionPool was also updated to fetch the current value of PerAccountInitialAmount set on Vstorage and include it on the new privateArgs.
If the governedParamOverrides is not provided to the privateArgs during the contract upgrade, the value of PerAccountInitialAmount will reset to the default one set on the contract terms.


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

The existing unit tests for the inter-protocol and vats packages, as well as the a3p-integration tests, have been verified to continue passing with these changes.

Additionally, these changes were tested against the governance acceptance tests in the a3p-integration which ensures that governed parameter values remain intact after a contract upgrade, as well as testing that, if not included in the governedParamOverrides on the core-eval proposal, the value of PerAccountInitialAmount will reset to the default one set on the contract terms.

To maintain the scope of this PR, that test is not included here, however, it will be introduced in PR #10555, which is planned to be opened once this is merged.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
