### PR TITLE
chore: upgrade 18 cherrypicks round 4

### DIFF
--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -19,6 +19,7 @@ var upgradeNamesOfThisVersion = []string{
 	"agoric-upgrade-18-emerynet",
 	"agoric-upgrade-18-basic",
 	"agoric-upgrade-18-basic-2",
+	"agoric-upgrade-18-emerynet-rc3",
 	"agoric-upgrade-18-a3p",
 }
 
@@ -59,7 +60,8 @@ func isPrimaryUpgradeName(name string) bool {
 		validUpgradeName("agoric-upgrade-18-basic"),
 		validUpgradeName("agoric-upgrade-18-a3p"):
 		return true
-	case validUpgradeName("agoric-upgrade-18-basic-2"):
+	case validUpgradeName("agoric-upgrade-18-basic-2"),
+		validUpgradeName("agoric-upgrade-18-emerynet-rc3"):
 		return false
 	default:
 		panic(fmt.Errorf("unexpected upgrade name %s", validUpgradeName(name)))

--- a/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
+++ b/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
@@ -32,7 +32,7 @@ const configurations = {
       'agoric1qj07c7vfk3knqdral0sej7fa6eavkdn8vd8etf', // Simply Staking
       'agoric10vjkvkmpp9e356xeh6qqlhrny2htyzp8hf88fk', // P2P
     ],
-    inBrandNames: ['ATOM', 'stTIA', 'stkATOM'],
+    inBrandNames: ['ATOM', 'stTIA', 'stkATOM', 'dATOM'],
   },
   EMERYNET: {
     oracleAddresses: [

--- a/packages/telemetry/src/context-aware-slog.js
+++ b/packages/telemetry/src/context-aware-slog.js
@@ -135,9 +135,9 @@ export const makeContextualSlogProcessor = (
 
   /**
    * @param {Slog} slog
-   * @returns {{ attributes: T & LogAttributes, body: Partial<Slog>; timestamp: Slog['time'] }}
+   * @returns {{ attributes: T & LogAttributes, body: Partial<Slog>; time: Slog['time'] }}
    */
-  const slogProcessor = ({ monotime, time: timestamp, ...body }) => {
+  const slogProcessor = ({ monotime, time, ...body }) => {
     const finalBody = { ...body };
 
     /** @type {{'crank.syscallNum'?: Slog['syscallNum']}} */
@@ -321,13 +321,13 @@ export const makeContextualSlogProcessor = (
 
     const logAttributes = {
       ...staticContext,
-      'process.uptime': monotime,
       ...initContext, // Optional prelude
       ...blockContext, // Block is the first level of execution nesting
       ...triggerContext, // run and trigger info is nested next
       ...crankContext, // Finally cranks are the last level of nesting
       ...replayContext, // Replay is a substitute for crank context during vat page in
       ...eventLogAttributes,
+      'process.uptime': monotime,
     };
 
     /**
@@ -356,7 +356,11 @@ export const makeContextualSlogProcessor = (
       // eslint-disable-next-line no-restricted-syntax
       case SLOG_TYPES.COSMIC_SWINGSET.RUN.FINISH: {
         assert(!!triggerContext);
-        persistContext(finalBody.remainingBeans ? {} : triggerContext);
+        persistContext(
+          finalBody.remainingBeans && finalBody.remainingBeans > 0
+            ? {}
+            : triggerContext,
+        );
         triggerContext = null;
         break;
       }
@@ -373,9 +377,9 @@ export const makeContextualSlogProcessor = (
     }
 
     return {
-      attributes: /** @type {T & LogAttributes} */ (logAttributes),
       body: finalBody,
-      timestamp,
+      attributes: /** @type {T & LogAttributes} */ (logAttributes),
+      time,
     };
   };
 

--- a/packages/telemetry/src/otel-context-aware-slog.js
+++ b/packages/telemetry/src/otel-context-aware-slog.js
@@ -82,9 +82,9 @@ export const makeSlogSender = async options => {
    * @param {import('./context-aware-slog.js').Slog} slog
    */
   const slogSender = slog => {
-    const { timestamp, ...logRecord } = contextualSlogProcessor(slog);
+    const { time, ...logRecord } = contextualSlogProcessor(slog);
 
-    const [secondsStr, fractionStr] = String(timestamp).split('.');
+    const [secondsStr, fractionStr] = String(time).split('.');
     const seconds = parseInt(secondsStr, 10);
     const nanoSeconds = parseInt(
       (fractionStr || String(0)).padEnd(9, String(0)).slice(0, 9),

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -976,7 +976,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         spans.pop('timer-poll');
         break;
       }
-      case 'cosmic-swinget-inject-kernel-upgrade-events': {
+      case 'cosmic-swingset-inject-kernel-upgrade-events': {
         spans.push('kernel-upgrade-events');
         spans.pop('kernel-upgrade-events');
         break;


### PR DESCRIPTION
### Description

Cherry-picks the following commits from master:
 - https://github.com/Agoric/agoric-sdk/pull/10551 (9e19321ea8fed32d445d44169b32f5d94a93d61e)
 - https://github.com/Agoric/agoric-sdk/pull/10635 (ad4e83e0b6dff9716da91fd65d367d3acad1772e)
 - https://github.com/Agoric/agoric-sdk/pull/10615 (e596a010f6b0885db9f8a8aa1cc4cb2f232e8f91 )
 - https://github.com/Agoric/agoric-sdk/pull/10634 (a1856f3df1266deeb80210d9fdcb50ed2a1a992f)

Since we plan to verify this rc on devnet rather than emerynet, there is no apparent need for a new upgrade name. Not aware of any deployments on devnet before so can reuse the previous upgrade name. However, skipping emerynet is dependent on comms with the validators so I have added a new upgrade name `agoric-ugprade-18-emerynet-rc3` just in case. Only added to bypass the need for a new rc if for some reason emerynet validation is needed anyways - best case scenario is that it remains unused.

commits added using git cherry-pick 