### PR TITLE
chore: fusdc recovery paths

### DIFF
--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -3,7 +3,6 @@ import { assertAllDefined, makeTracer } from '@agoric/internal';
 import { AnyNatAmountShape, ChainAddressShape } from '@agoric/orchestration';
 import { pickFacet } from '@agoric/vat-data';
 import { VowShape } from '@agoric/vow';
-import { q } from '@endo/errors';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import {
@@ -153,6 +152,7 @@ export const prepareAdvancerKit = (
               recipientAddress,
               EudParamShape,
             );
+            log(`decoded EUD: ${EUD}`);
             // throws if the bech32 prefix is not found
             const destination = chainHub.makeChainAddress(EUD);
 
@@ -182,8 +182,8 @@ export const prepareAdvancerKit = (
               tmpSeat,
               txHash: evidence.txHash,
             });
-          } catch (e) {
-            log('Advancer error:', q(e).toString());
+          } catch (error) {
+            log('Advancer error:', error);
             statusManager.observe(evidence);
           }
         },
@@ -217,13 +217,13 @@ export const prepareAdvancerKit = (
          */
         onRejected(error, { tmpSeat }) {
           // TODO return seat allocation from ctx to LP?
-          log('🚨 advance deposit failed', q(error).toString());
+          log(
+            '⚠️ deposit to localOrchAccount failed, attempting to return payment to LP',
+            error,
+          );
           // TODO #10510 (comprehensive error testing) determine
           // course of action here
-          log(
-            'TODO live payment on seat to return to LP',
-            q(tmpSeat).toString(),
-          );
+          log('TODO live payment on seat to return to LP', tmpSeat);
         },
       },
       transferHandler: {
@@ -234,10 +234,11 @@ export const prepareAdvancerKit = (
         onFulfilled(result, ctx) {
           const { notifyFacet } = this.state;
           const { advanceAmount, destination, ...detail } = ctx;
-          log(
-            'Advance transfer fulfilled',
-            q({ advanceAmount, destination, result }).toString(),
-          );
+          log('Advance transfer fulfilled', {
+            advanceAmount,
+            destination,
+            result,
+          });
           // During development, due to a bug, this call threw.
           // The failure was silent (no diagnostics) due to:
           //  - #10576 Vows do not report unhandled rejections
@@ -252,7 +253,7 @@ export const prepareAdvancerKit = (
          */
         onRejected(error, ctx) {
           const { notifyFacet } = this.state;
-          log('Advance transfer rejected', q(error).toString());
+          log('Advance transfer rejected', error);
           notifyFacet.notifyAdvancingResult(ctx, false);
         },
       },

--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -161,9 +161,8 @@ export const prepareAdvancerKit = (
             const advanceAmount = feeTools.calculateAdvance(fullAmount);
 
             const { zcfSeat: tmpSeat } = zcf.makeEmptySeatKit();
-            const amountKWR = harden({ USDC: advanceAmount });
             // throws if the pool has insufficient funds
-            borrowerFacet.borrow(tmpSeat, amountKWR);
+            borrowerFacet.borrow(tmpSeat, advanceAmount);
 
             // this cannot throw since `.isSeen()` is called in the same turn
             statusManager.advance(evidence);
@@ -172,7 +171,7 @@ export const prepareAdvancerKit = (
               tmpSeat,
               // @ts-expect-error LocalAccountMethods vs OrchestrationAccount
               poolAccount,
-              amountKWR,
+              harden({ USDC: advanceAmount }),
             );
             void watch(depositV, this.facets.depositHandler, {
               fullAmount,
@@ -230,10 +229,7 @@ export const prepareAdvancerKit = (
           try {
             const { borrowerFacet, notifyFacet } = this.state;
             notifyFacet.notifyAdvancingResult(restCtx, false);
-            borrowerFacet.returnToPool(
-              tmpSeat,
-              harden({ USDC: advanceAmount }),
-            );
+            borrowerFacet.returnToPool(tmpSeat, advanceAmount);
           } catch (e) {
             log('🚨 deposit to localOrchAccount failure recovery failed', e);
           }

--- a/packages/fast-usdc/src/exos/settler.js
+++ b/packages/fast-usdc/src/exos/settler.js
@@ -237,13 +237,13 @@ export const prepareSettler = (
           const split = calculateSplit(received);
           log('disbursing', split);
 
-          // TODO: what if this throws?
-          // arguably, it cannot. Even if deposits
-          // and notifications get out of order,
-          // we don't ever withdraw more than has been deposited.
+          // If this throws, which arguably can't occur since we don't ever
+          // withdraw more than has been deposited (as denoted by
+          // `FungibleTokenPacketData`), funds will remain in the
+          // `settlementAccount`. A remediation can occur in a future upgrade.
           await vowTools.when(
             withdrawToSeat(
-              // @ts-expect-error Vow vs. Promise stuff. TODO: is this OK???
+              // @ts-expect-error LocalAccountMethods vs OrchestrationAccount
               settlementAccount,
               settlingSeat,
               harden({ In: received }),

--- a/packages/fast-usdc/test/exos/advancer.test.ts
+++ b/packages/fast-usdc/test/exos/advancer.test.ts
@@ -106,11 +106,11 @@ const createTestExtensions = (t, common: CommonSetup) => {
   } = { borrow: [], returnToPool: [] };
 
   const mockBorrowerF = Far('LiquidityPool Borrow Facet', {
-    borrow: (seat: ZCFSeat, amounts: { USDC: NatAmount }) => {
-      mockBorrowerFacetCalls.borrow.push([seat, amounts]);
+    borrow: (seat: ZCFSeat, amount: NatAmount) => {
+      mockBorrowerFacetCalls.borrow.push([seat, amount]);
     },
-    returnToPool: (seat: ZCFSeat, amounts: { USDC: NatAmount }) => {
-      mockBorrowerFacetCalls.returnToPool.push([seat, amounts]);
+    returnToPool: (seat: ZCFSeat, amount: NatAmount) => {
+      mockBorrowerFacetCalls.returnToPool.push([seat, amount]);
     },
   });
 
@@ -236,9 +236,9 @@ test('updates status to OBSERVED on insufficient pool funds', async t => {
   } = t.context;
 
   const mockBorrowerFacet = Far('LiquidityPool Borrow Facet', {
-    borrow: (seat: ZCFSeat, amounts: { USDC: NatAmount }) => {
+    borrow: (seat: ZCFSeat, amount: NatAmount) => {
       throw new Error(
-        `Cannot borrow. Requested ${q(amounts.USDC)} must be less than pool balance ${q(usdc.make(1n))}.`,
+        `Cannot borrow. Requested ${q(amount)} must be less than pool balance ${q(usdc.make(1n))}.`,
       );
     },
     returnToPool: () => {}, // not expecting this to be called
@@ -460,7 +460,7 @@ test('returns payment to LP if zoeTools.localTransfer fails', async t => {
 
   const expectedArguments = [
     Far('MockZCFSeat', {}),
-    { USDC: usdc.make(146999999n) }, // net of fees
+    usdc.make(146999999n), // net of fees
   ];
 
   t.is(borrow.length, 1, 'borrow is called before zt.localTransfer fails');
@@ -503,12 +503,12 @@ test('alerts if `returnToPool` fallback fails', async t => {
   } = t.context;
 
   const mockBorrowerFacet = Far('LiquidityPool Borrow Facet', {
-    borrow: (seat: ZCFSeat, amounts: { USDC: NatAmount }) => {
+    borrow: (seat: ZCFSeat, amount: NatAmount) => {
       // note: will not be tracked by `inspectBorrowerFacetCalls`
     },
-    returnToPool: (seat: ZCFSeat, amounts: { USDC: NatAmount }) => {
+    returnToPool: (seat: ZCFSeat, amount: NatAmount) => {
       throw new Error(
-        `⚠️ borrowSeatAllocation ${q({ USDC: usdc.make(0n) })} less than amountKWR ${q(amounts)}`,
+        `⚠️ borrowSeatAllocation ${q({ USDC: usdc.make(0n) })} less than amountKWR ${q(amount)}`,
       );
     },
   });
@@ -536,7 +536,7 @@ test('alerts if `returnToPool` fallback fails', async t => {
     [
       '🚨 deposit to localOrchAccount failure recovery failed',
       Error(
-        `⚠️ borrowSeatAllocation ${q({ USDC: usdc.make(0n) })} less than amountKWR ${q({ USDC: usdc.make(146999999n) })}`,
+        `⚠️ borrowSeatAllocation ${q({ USDC: usdc.make(0n) })} less than amountKWR ${q(usdc.make(146999999n))}`,
       ),
     ],
   ]);

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -690,7 +690,7 @@ export const prepareLocalOrchestrationAccountKit = (
               'agoric',
               forwardOpts,
             );
-            trace('got transfer route', q(route).toString());
+            trace('got transfer route', route);
 
             // set a `timeoutTimestamp` if caller does not supply either `timeoutHeight` or `timeoutTimestamp`
             // TODO #9324 what's a reasonable default? currently 5 minutes


### PR DESCRIPTION
closes: #10624

## Description
- handles potential failure in `zoeTools.localTransfer` during FUSDC Advance flow by returning funds to LP
- documents why it's OK to fail during a potential `zoeTools.withdrawToSeat` failure in `.disperse()`
- removes `zcf.shutdownWithFailure()` in catch blocks around `zcf.atomicRearrange`. This is only necessary when commits are not atomic.

### Security Considerations
- Improves handling of Payments during unexpected, but potential, failure paths.
- Ensures FUSDC contract will not shutdown during unexpected failures.

### Scaling Considerations
N/A

### Documentation Considerations
N/A

### Testing Considerations
Includes a unit test that ensures the advancer performs the expected calls after `zoeTools.localTransfer` fails.

Does not include unit tests for the new liquidity pool `borrower.returnToPool` as those have been deemed too expensive. The risk here seems low as the call is effectively passed through to `repayer.repay`, which has tests, modulo the KWR arrangement which is protected by the interface guard.

### Upgrade Considerations
None, FUSDC is unreleased.
