### PR TITLE
chore(a3p-integration): use USDC_axl in fast-usdc if --noNoble

### DIFF
--- a/packages/builders/scripts/fast-usdc/fast-usdc-update.build.js
+++ b/packages/builders/scripts/fast-usdc/fast-usdc-update.build.js
@@ -3,6 +3,7 @@ import { getManifestForUpdateFastUsdcPolicy } from '@agoric/fast-usdc/src/fast-u
 import { toExternalConfig } from '@agoric/fast-usdc/src/utils/config-marshal.js';
 import { FeedPolicyShape } from '@agoric/fast-usdc/src/type-guards.js';
 import { makeHelpers } from '@agoric/deploy-script-support';
+import { mustMatch } from '@endo/patterns';
 
 /**
  * @import {CoreEvalBuilder, DeployScriptFunction} from '@agoric/deploy-script-support/src/externalTypes.js'
@@ -22,10 +23,10 @@ const feedPolicyUsage = 'use --feedPolicy <policy> ...';
  * }} FastUSDCUpdateOpts
  */
 
-/** @type {CoreEvalBuilder} */
+/** @satisfies {CoreEvalBuilder} */
 export const updateProposalBuilder = async (
   _utils,
-  /** @type {FastUSDCConfig} */ config,
+  /** @type {Pick<FastUSDCConfig, 'feedPolicy'>} */ config,
 ) => {
   return harden({
     sourceSpec: '@agoric/fast-usdc/src/fast-usdc-policy.core.js',
@@ -52,7 +53,9 @@ export default async (homeP, endowments) => {
 
   const parseFeedPolicy = () => {
     if (typeof feedPolicy !== 'string') throw Error(feedPolicyUsage);
-    return JSON.parse(feedPolicy);
+    const policy = JSON.parse(feedPolicy);
+    mustMatch(policy, FeedPolicyShape);
+    return policy;
   };
   const config = harden({ feedPolicy: parseFeedPolicy() });
   await writeCoreEval('eval-fast-usdc-policy-update', utils =>

--- a/packages/builders/scripts/fast-usdc/init-fast-usdc.js
+++ b/packages/builders/scripts/fast-usdc/init-fast-usdc.js
@@ -39,7 +39,6 @@ const options = {
   chainInfo: { type: 'string' },
   assetInfo: { type: 'string' },
   noNoble: { type: 'boolean', default: false },
-  usdcIssuer: { type: 'string', default: 'USDC' },
 };
 const oraclesUsage = 'use --oracle name:address ...';
 
@@ -62,7 +61,6 @@ const assetInfoUsage =
  *   chainInfo?: string;
  *   assetInfo?: string;
  *   noNoble: boolean;
- *   usdcIssuer: string;
  * }} FastUSDCOpts
  */
 
@@ -116,7 +114,6 @@ export default async (homeP, endowments) => {
       chainInfo,
       assetInfo,
       noNoble,
-      usdcIssuer: issuerName,
       ...fees
     },
   } = parseArgs({ args: scriptArgs, options });
@@ -185,13 +182,6 @@ export default async (homeP, endowments) => {
     return JSON.parse(assetInfo);
   };
 
-  const parseIssuer = () => {
-    const name = `issuer.${issuerName}`;
-    if (!(name === 'issuer.USDC' || name === 'issuer.USDC_axl'))
-      throw Error(`unknown issuer ${issuerName}`);
-    return crossVatContext[name];
-  };
-
   /** @type {FastUSDCConfig} */
   const config = harden({
     oracles: parseOracleArgs(),
@@ -203,7 +193,7 @@ export default async (homeP, endowments) => {
     chainInfo: parseChainInfo(),
     assetInfo: parseAssetInfo(),
     noNoble,
-    usdcIssuer: parseIssuer(),
+    usdcIssuer: crossVatContext[noNoble ? `issuer.USDC_axl` : 'issuer.USDC'],
   });
 
   await writeCoreEval('start-fast-usdc', utils =>

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -142,17 +142,17 @@ export const startFastUSDC = async (
   trace('startFastUSDC');
 
   await null;
-  /** @type {Issuer<'nat'>} */
-  const USDCissuer = await E(agoricNames).lookup('issuer', 'USDC');
-  const brands = harden({
-    USDC: await E(USDCissuer).getBrand(),
-  });
+  /** @type {[string, Issuer][]} */
+  const issuerEntries = await E(E(agoricNames).lookup('issuer')).entries();
+  /** @type {[string, Brand][]} */
+  const brandEntries = await E(E(agoricNames).lookup('brand')).entries();
+  const xVatContext = Object.fromEntries([
+    ...issuerEntries.map(([n, i]) => [`issuer.${n}`, i]),
+    ...brandEntries.map(([n, i]) => [`brand.${n}`, i]),
+  ]);
 
-  const { terms, oracles, feeConfig, feedPolicy, ...net } = fromExternalConfig(
-    config.options,
-    brands,
-    FastUSDCConfigShape,
-  );
+  const { usdcIssuer, terms, oracles, feeConfig, feedPolicy, ...net } =
+    fromExternalConfig(config.options, xVatContext, FastUSDCConfigShape);
   trace('using terms', terms);
   trace('using fee config', feeConfig);
 
@@ -196,7 +196,7 @@ export const startFastUSDC = async (
   const kit = await E(startUpgradable)({
     label: contractName,
     installation: fastUsdc,
-    issuerKeywordRecord: harden({ USDC: USDCissuer }),
+    issuerKeywordRecord: { USDC: usdcIssuer },
     terms,
     privateArgs,
   });

--- a/packages/fast-usdc/src/types.ts
+++ b/packages/fast-usdc/src/types.ts
@@ -73,6 +73,7 @@ export interface FeedPolicy {
 }
 
 export type FastUSDCConfig = {
+  usdcIssuer: Issuer<'nat'>; // allow using USDC_axl where no USDC is available
   terms: FastUsdcTerms;
   oracles: Record<string, string>;
   feeConfig: FeeConfig;


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

If there's no connection to noble, there are no USDC tokens in a3p.
a3p has USDC_axl at genesis, since vaults were launched with a USDC_axl PSM. So we can use that.

DRAFT until:

 - [ ] XYZ Considerations are filled out

### Security Considerations


<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
