### PR TITLE
Record instances that will be replaced so we can manage them

### DIFF
--- a/a3p-integration/proposals/z:acceptance/.gitignore
+++ b/a3p-integration/proposals/z:acceptance/.gitignore
@@ -2,3 +2,4 @@
 restart-valueVow
 start-valueVow
 localchaintest-submission
+recorded-instances-submission

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -3,6 +3,7 @@
     "type": "/agoric.swingset.CoreEvalProposal",
     "sdk-generate": [
       "testing/start-valueVow.js start-valueVow",
+      "testing/recorded-retired-instances.js recorded-instances-submission",
       "vats/test-localchain.js localchaintest-submission",
       "testing/restart-valueVow.js restart-valueVow"
     ]

--- a/a3p-integration/proposals/z:acceptance/recorded-retired.test.js
+++ b/a3p-integration/proposals/z:acceptance/recorded-retired.test.js
@@ -1,0 +1,11 @@
+import test from 'ava';
+
+import { evalBundles } from '@agoric/synthetic-chain';
+
+const SUBMISSION_DIR = 'recorded-instances-submission';
+
+test(`recorded instances in u18`, async t => {
+  const result = await evalBundles(SUBMISSION_DIR);
+  console.log('recorded retired instance result:', result);
+  t.pass('checked names');
+});

--- a/a3p-integration/proposals/z:acceptance/test.sh
+++ b/a3p-integration/proposals/z:acceptance/test.sh
@@ -12,6 +12,9 @@ yarn ava core-eval.test.js
 
 scripts/test-vaults.ts
 
+echo ACCEPTANCE TESTING recorded instances
+yarn ava recorded-retired.test.js
+
 echo ACCEPTANCE TESTING kread
 yarn ava kread.test.js
 

--- a/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
+++ b/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
@@ -105,7 +105,7 @@ test.serial('setupVaults; run updatePriceFeeds proposals', async t => {
 
   t.log('building all relevant CoreEvals');
   const coreEvals = await Promise.all([
-    buildProposal(priceFeedBuilder, ['MAINNET']),
+    buildProposal(priceFeedBuilder, ['BOOT_TEST']),
     buildProposal('@agoric/builders/scripts/vats/upgradeVaults.js'),
     buildProposal('@agoric/builders/scripts/vats/add-auction.js'),
   ]);

--- a/packages/boot/test/bootstrapTests/updateGovernedParams.test.ts
+++ b/packages/boot/test/bootstrapTests/updateGovernedParams.test.ts
@@ -134,7 +134,7 @@ test('modify manager & director params; update vats, check', async t => {
   const priceFeedBuilder =
     '@agoric/builders/scripts/inter-protocol/updatePriceFeeds.js';
   const coreEvals = await Promise.all([
-    buildProposal(priceFeedBuilder, ['MAINNET']),
+    buildProposal(priceFeedBuilder, ['BOOT_TEST']),
     buildProposal('@agoric/builders/scripts/vats/upgradeVaults.js'),
     buildProposal('@agoric/builders/scripts/vats/add-auction.js'),
   ]);

--- a/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
+++ b/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
@@ -41,6 +41,16 @@ const configurations = {
     ],
     inBrandNames: ['ATOM', 'stATOM', 'stOSMO', 'stTIA', 'stkATOM'],
   },
+  BOOT_TEST: {
+    oracleAddresses: [
+      'agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78', // DSRV
+      'agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p', // Stakin
+      'agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8', // 01node
+      'agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr', // Simply Staking
+      'agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj', // P2P
+    ],
+    inBrandNames: ['ATOM'],
+  },
 };
 
 const { keys } = Object;

--- a/packages/builders/scripts/testing/recorded-retired-instances.js
+++ b/packages/builders/scripts/testing/recorded-retired-instances.js
@@ -1,0 +1,73 @@
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+
+const trace = makeTracer('RecordedRetired', true);
+
+/**
+ * @param {BootstrapPowers &
+ *   PromiseSpaceOf<{ retiredContractInstances: MapStore<string, Instance>;
+ *   }>
+ * } powers
+ */
+export const testRecordedRetiredInstances = async ({
+  consume: {
+    contractKits,
+    // governedContractKits,
+    retiredContractInstances: retiredContractInstancesP,
+  },
+}) => {
+  trace('Start');
+  const retiredContractInstances = await retiredContractInstancesP;
+
+  const auctionIDs = Array.from(retiredContractInstances.keys()).filter(k =>
+    k.startsWith('auction'),
+  );
+  assert(auctionIDs);
+  assert(auctionIDs.length === 1);
+  const auctionInstance = retiredContractInstances.get(auctionIDs[0]);
+  trace({ auctionInstance });
+  // I don't know why it's neither in governedContractKits nor contractKits
+  // assert(await E(governedContractKits).get(auctionInstance));
+
+  const committeeIDs = Array.from(retiredContractInstances.keys()).filter(k =>
+    k.startsWith('economicCommittee'),
+  );
+  assert(committeeIDs);
+  assert(committeeIDs.length === 1);
+  const committeeInstance = retiredContractInstances.get(committeeIDs[0]);
+  assert(await E(contractKits).get(committeeInstance));
+
+  trace('done');
+};
+harden(testRecordedRetiredInstances);
+
+export const getManifestForRecordedRetiredInstances = () => {
+  return {
+    manifest: {
+      [testRecordedRetiredInstances.name]: {
+        consume: {
+          contractKits: true,
+          // governedContractKits: true,
+          retiredContractInstances: true,
+        },
+      },
+    },
+  };
+};
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const defaultProposalBuilder = async () =>
+  harden({
+    sourceSpec:
+      '@agoric/builders/scripts/testing/recorded-retired-instances.js',
+    getManifestCall: ['getManifestForRecordedRetiredInstances', {}],
+  });
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  // import dynamically so the module can work in CoreEval environment
+  const dspModule = await import('@agoric/deploy-script-support');
+  const { makeHelpers } = dspModule;
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('recorded-retired', defaultProposalBuilder);
+};

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -3,6 +3,7 @@ import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/far';
 import { Stable } from '@agoric/internal/src/tokens.js';
 import { makeGovernedTerms as makeGovernedATerms } from '../auction/params.js';
+import { parallelCreateMap } from './utils.js';
 
 const trace = makeTracer('NewAuction', true);
 
@@ -11,6 +12,7 @@ const trace = makeTracer('NewAuction', true);
  *   auctionUpgradeNewInstance: Instance;
  *   auctionUpgradeNewGovCreator: any;
  *   newContractGovBundleId: string;
+ *   retiredContractInstances: MapStore<string, Instance>;
  * }>} interlockPowers
  */
 
@@ -35,6 +37,7 @@ export const addAuction = async (
       economicCommitteeCreatorFacet: electorateCreatorFacet,
       governedContractKits: governedContractKitsP,
       priceAuthority8400,
+      retiredContractInstances: retiredContractInstancesP,
       zoe,
     },
     produce: {
@@ -42,6 +45,7 @@ export const addAuction = async (
       auctionUpgradeNewInstance,
       auctionUpgradeNewGovCreator,
       newContractGovBundleId,
+      retiredContractInstances: produceRetiredInstances,
     },
     instance: {
       consume: { reserve: reserveInstance },
@@ -78,6 +82,13 @@ export const addAuction = async (
     legacyKitP,
     auctioneerInstallationP,
   ]);
+
+  await parallelCreateMap(produceRetiredInstances, 'retiredContractInstances');
+
+  // save the auctioneer instance so we can manage it later
+  const boardID = await E(board).getId(legacyKit.instance);
+  const identifier = `auctioneer-${boardID}`;
+  await E(retiredContractInstancesP).init(identifier, legacyKit.instance);
 
   // Each field has an extra layer of type +  value:
   // AuctionStartDelay: { type: 'relativeTime', value: { relValue: 2n, timerBrand: Object [Alleged: timerBrand] {} } }
@@ -210,6 +221,7 @@ export const ADD_AUCTION_MANIFEST = harden({
       economicCommitteeCreatorFacet: true,
       governedContractKits: true,
       priceAuthority8400: true,
+      retiredContractInstances: true,
       zoe: true,
     },
     produce: {
@@ -217,6 +229,7 @@ export const ADD_AUCTION_MANIFEST = harden({
       auctionUpgradeNewInstance: true,
       auctionUpgradeNewGovCreator: true,
       newContractGovBundleId: true,
+      retiredContractInstances: true,
     },
     instance: {
       consume: { reserve: true },

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -1,9 +1,9 @@
 import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
-import { E } from '@endo/far';
 import { Stable } from '@agoric/internal/src/tokens.js';
+import { E } from '@endo/far';
 import { makeGovernedTerms as makeGovernedATerms } from '../auction/params.js';
-import { parallelCreateMap } from './utils.js';
+import { provideRetiredInstances } from './utils.js';
 
 const trace = makeTracer('NewAuction', true);
 
@@ -83,12 +83,15 @@ export const addAuction = async (
     auctioneerInstallationP,
   ]);
 
-  await parallelCreateMap(produceRetiredInstances, 'retiredContractInstances');
+  const retiredInstances = await provideRetiredInstances(
+    retiredContractInstancesP,
+    produceRetiredInstances,
+  );
 
   // save the auctioneer instance so we can manage it later
   const boardID = await E(board).getId(legacyKit.instance);
   const identifier = `auctioneer-${boardID}`;
-  await E(retiredContractInstancesP).init(identifier, legacyKit.instance);
+  retiredInstances.init(identifier, legacyKit.instance);
 
   // Each field has an extra layer of type +  value:
   // AuctionStartDelay: { type: 'relativeTime', value: { relValue: 2n, timerBrand: Object [Alleged: timerBrand] {} } }

--- a/packages/inter-protocol/src/proposals/deploy-price-feeds.js
+++ b/packages/inter-protocol/src/proposals/deploy-price-feeds.js
@@ -5,7 +5,7 @@ import { E } from '@endo/far';
 import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import {
   oracleBrandFeedName,
-  parallelCreateMap,
+  provideRetiredInstances,
   reserveThenDeposit,
   sanitizePathSegment,
 } from './utils.js';
@@ -109,6 +109,7 @@ const startPriceAggregatorInstance = async (
       retiredContractInstances: retiredContractInstancesP,
     },
     instance: { produce: produceInstance },
+    produce: { retiredContractInstances: produceRetiredInstances },
   },
   { AGORIC_INSTANCE_NAME, contractTerms, brandIn, brandOut },
   installation,
@@ -143,7 +144,10 @@ const startPriceAggregatorInstance = async (
     // @ts-expect-error GovernableStartFn vs. fluxAggregatorContract.js start
     installation,
   });
-  const retiredContractInstances = await retiredContractInstancesP;
+  const retiredContractInstances = await provideRetiredInstances(
+    retiredContractInstancesP,
+    produceRetiredInstances,
+  );
 
   // save the instance so we can manage it later
   const retiringInstance = await E(agoricNames).lookup(
@@ -238,11 +242,6 @@ export const deployPriceFeeds = async (powers, config) => {
   const installation = await installPriceAggregator(
     powers,
     priceAggregatorRef.bundleID,
-  );
-
-  await parallelCreateMap(
-    powers.produce.retiredContractInstances,
-    'retiredContractInstances',
   );
 
   const { priceAuthorityAdmin, priceAuthority } = powers.consume;

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -15,7 +15,7 @@ import {
   assertPathSegment,
   makeStorageNodeChild,
 } from '@agoric/internal/src/lib-chainStorage.js';
-import { parallelCreateMap, reserveThenDeposit } from './utils.js';
+import { provideRetiredInstances, reserveThenDeposit } from './utils.js';
 
 /** @import {EconomyBootstrapPowers} from './econ-behaviors.js' */
 /** @import {EconCharterStartResult} from './econ-behaviors.js' */
@@ -226,14 +226,15 @@ const startNewEconomicCommittee = async (
   trace(`committeeName ${committeeName}`);
   trace(`committeeSize ${committeeSize}`);
 
-  await parallelCreateMap(produceRetiredInstances, 'retiredContractInstances');
+  const retiredInstances = await provideRetiredInstances(
+    retiredInstancesP,
+    produceRetiredInstances,
+  );
 
-  // get the actual retiredContractInstances
-  const retiredInstances = await retiredInstancesP;
   // Record the retired electorate instance so we can manage it later.
   const economicCommitteeOriginal = await economicCommitteeOriginalP;
   const boardID = await E(board).getId(economicCommitteeOriginal);
-  await E(retiredInstances).init(
+  retiredInstances.init(
     `economicCommittee-${boardID}`,
     economicCommitteeOriginal,
   );

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -174,14 +174,20 @@ export const sanitizePathSegment = name => {
 };
 
 /**
- * Idempotently create and store a durable MapStore for the promise space.
- * `resolve()` silently fails if called again after a successful call, so it's
- * safe for multiple proposals to call in parallel, as long as they all use the
- * value from consume rather than the value they produced.
+ * Idempotently provide an empty MapStore for the `retiredContractInstances`
+ * value in promise space
  *
- * @param {Producer<MapStore>} producer
- * @param {string} [name]
+ * @param {Promise<MapStore>} consume
+ * @param {Producer<MapStore>} produce
+ * @returns {Promise<MapStore>}
  */
-export const parallelCreateMap = async (producer, name = 'mapStore') => {
-  await producer.resolve(makeScalarBigMapStore(name, { durable: true }));
+export const provideRetiredInstances = async (consume, produce) => {
+  // Promise space has no way to look for an existing value other than awaiting a promise,
+  // but it does allow extra production so it's safe to do this redundantly.
+  produce.resolve(
+    makeScalarBigMapStore('retiredContractInstances', {
+      durable: true,
+    }),
+  );
+  return consume;
 };

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -3,6 +3,7 @@ import { E } from '@endo/far';
 import { WalletName } from '@agoric/internal';
 import { getCopyMapEntries, makeCopyMap } from '@agoric/store';
 import { assertPathSegment } from '@agoric/internal/src/lib-chainStorage.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 /** @import {CopyMap} from '@endo/patterns'; */
 
@@ -170,4 +171,17 @@ export const sanitizePathSegment = name => {
   const candidate = name.replace(/ /g, '_');
   assertPathSegment(candidate);
   return candidate;
+};
+
+/**
+ * Idempotently create and store a durable MapStore for the promise space.
+ * `resolve()` silently fails if called again after a successful call, so it's
+ * safe for multiple proposals to call in parallel, as long as they all use the
+ * value from consume rather than the value they produced.
+ *
+ * @param {Producer<MapStore>} producer
+ * @param {string} [name]
+ */
+export const parallelCreateMap = async (producer, name = 'mapStore') => {
+  await producer.resolve(makeScalarBigMapStore(name, { durable: true }));
 };


### PR DESCRIPTION
closes: #10669

## Description

Record instances of contracts that will be replaced so we can find them later and be able to manage them.

### Security Considerations

We've lost the handle to some vats before, and it's a hassle.

### Scaling Considerations

The problem gets worse as we upgrade more vats.

### Documentation Considerations

None.

### Testing Considerations

Verified that Auctions and Committee are present. The priceFeeds vary too much across test environments to be worth checking.

### Upgrade Considerations

Yes..