### PR TITLE
fix(address-hooks): version robustness and hardening

### DIFF
--- a/packages/cosmic-proto/src/address-hooks.js
+++ b/packages/cosmic-proto/src/address-hooks.js
@@ -39,13 +39,13 @@ if ((ADDRESS_HOOK_VERSION & 0x0f) !== ADDRESS_HOOK_VERSION) {
   throw Error(`ADDRESS_HOOK_VERSION ${ADDRESS_HOOK_VERSION} exceeds 0x0f`);
 }
 
-// AddressHookMagic is a magic byte prefix that identifies a hooked address.
+// ADDRESS_HOOK_BYTE_PREFIX is a magic prefix that identifies a hooked address.
 // Chosen to make bech32 address hooks that look like "agoric10rch..."
-const ADDRESS_HOOK_MAGIC = new Uint8Array([
+const ADDRESS_HOOK_BYTE_PREFIX = [
   0x78,
   0xf1,
-  0x70 | ADDRESS_HOOK_VERSION,
-]);
+  0x70, // | ADDRESS_HOOK_VERSION
+];
 
 /**
  * The default maximum number of characters in a bech32-encoded hooked address.
@@ -140,13 +140,14 @@ export const joinHookedAddress = (
     throw RangeError(`Hook data length ${hd} is not a non-negative integer`);
   }
 
-  const magicLength = ADDRESS_HOOK_MAGIC.length;
+  const prefixLength = ADDRESS_HOOK_BYTE_PREFIX.length;
   const hookBuf = new Uint8Array(
-    magicLength + b + hd + BASE_ADDRESS_LENGTH_BYTES,
+    prefixLength + b + hd + BASE_ADDRESS_LENGTH_BYTES,
   );
-  hookBuf.set(ADDRESS_HOOK_MAGIC, 0);
-  hookBuf.set(bytes, magicLength);
-  hookBuf.set(hookData, magicLength + b);
+  hookBuf.set(ADDRESS_HOOK_BYTE_PREFIX, 0);
+  hookBuf[prefixLength - 1] |= ADDRESS_HOOK_VERSION;
+  hookBuf.set(bytes, prefixLength);
+  hookBuf.set(hookData, prefixLength + b);
 
   // Append the address length bytes, since we've already ensured these do not
   // exceed maxBaseAddressLength above.  These are big-endian because the length
@@ -195,56 +196,55 @@ export const decodeAddressHook = (addressHook, charLimit) => {
 /**
  * @param {string} specimen
  * @param {number} [charLimit]
- * @returns {string | { baseAddress: string; hookData: Uint8Array }}
+ * @returns {{ baseAddress: string; hookData: Uint8Array }}
  */
-export const splitHookedAddressUnsafe = (
+export const splitHookedAddress = (
   specimen,
   charLimit = DEFAULT_HOOKED_ADDRESS_CHAR_LIMIT,
 ) => {
   const { prefix, bytes } = decodeBech32(specimen, charLimit);
 
-  const magicLength = ADDRESS_HOOK_MAGIC.length;
-  for (let i = 0; i < magicLength; i += 1) {
-    if (bytes[i] !== ADDRESS_HOOK_MAGIC[i]) {
+  const prefixLength = ADDRESS_HOOK_BYTE_PREFIX.length;
+  let version = 0xff;
+  for (let i = 0; i < prefixLength; i += 1) {
+    let maybeMagicByte = bytes[i];
+    if (i === prefixLength - 1) {
+      // Final byte has a low version nibble and a high magic nibble.
+      version = maybeMagicByte & 0x0f;
+      maybeMagicByte &= 0xf0;
+    }
+    if (maybeMagicByte !== ADDRESS_HOOK_BYTE_PREFIX[i]) {
       return { baseAddress: specimen, hookData: new Uint8Array() };
     }
+  }
+
+  if (version !== ADDRESS_HOOK_VERSION) {
+    throw TypeError(`Unsupported address hook version ${version}`);
   }
 
   let len = 0;
   for (let i = BASE_ADDRESS_LENGTH_BYTES - 1; i >= 0; i -= 1) {
     const byte = bytes.at(-i - 1);
     if (byte === undefined) {
-      return `Cannot get base address length from byte ${-i - 1} of ${bytes.length}`;
+      throw TypeError(
+        `Cannot get base address length from byte ${-i - 1} of ${bytes.length}`,
+      );
     }
     len <<= 8;
     len |= byte;
   }
 
   const b = len;
-  if (b > bytes.length - BASE_ADDRESS_LENGTH_BYTES - magicLength) {
-    return `Base address length 0x${b.toString(16)} is longer than specimen length ${bytes.length - BASE_ADDRESS_LENGTH_BYTES - magicLength}`;
+  if (b > bytes.length - BASE_ADDRESS_LENGTH_BYTES - prefixLength) {
+    throw TypeError(
+      `Base address length 0x${b.toString(16)} is longer than specimen length ${bytes.length - BASE_ADDRESS_LENGTH_BYTES - prefixLength}`,
+    );
   }
 
-  const baseAddressBuf = bytes.subarray(magicLength, magicLength + b);
+  const baseAddressBuf = bytes.subarray(prefixLength, prefixLength + b);
   const baseAddress = encodeBech32(prefix, baseAddressBuf, charLimit);
 
-  const hookData = bytes.subarray(magicLength + b, -BASE_ADDRESS_LENGTH_BYTES);
+  const hookData = bytes.subarray(prefixLength + b, -BASE_ADDRESS_LENGTH_BYTES);
 
   return { baseAddress, hookData };
-};
-
-/**
- * @param {string} specimen
- * @param {number} [charLimit]
- * @returns {{
- *   baseAddress: string;
- *   hookData: Uint8Array;
- * }}
- */
-export const splitHookedAddress = (specimen, charLimit) => {
-  const result = splitHookedAddressUnsafe(specimen, charLimit);
-  if (typeof result === 'object') {
-    return result;
-  }
-  throw Error(result);
 };

--- a/packages/cosmic-proto/test/address-hooks.test.js
+++ b/packages/cosmic-proto/test/address-hooks.test.js
@@ -44,6 +44,62 @@ test.before(async t => {
 
 /**
  * @type {import('ava').Macro<
+ *  [addressHook: string, baseAddress: string, hookDataStr: string, error?: any],
+ *   { addressHooks: import('../src/address-hooks.js') }
+ * >}
+ */
+const splitMacro = test.macro({
+  title(providedTitle = '', addressHook, _baseAddress, _hookDataStr, _error) {
+    return `${providedTitle} split ${addressHook}`;
+  },
+  exec(t, addressHook, baseAddress, hookDataStr, error) {
+    const { splitHookedAddress } = t.context.addressHooks;
+    if (error) {
+      t.throws(() => splitHookedAddress(addressHook), error);
+      return;
+    }
+    const { baseAddress: ba, hookData: hd } = splitHookedAddress(addressHook);
+    t.is(ba, baseAddress);
+    const hookData = new TextEncoder().encode(hookDataStr);
+    t.deepEqual(hd, hookData);
+  },
+});
+
+test('empty', splitMacro, '', '', '', { message: ' too short' });
+test('no hook', splitMacro, 'agoric1qqp0e5ys', 'agoric1qqp0e5ys', '', '');
+test(
+  'Fast USDC',
+  splitMacro,
+  'agoric10rchp4vc53apxn32q42c3zryml8xq3xshyzuhjk6405wtxy7tl3d7e0f8az423padaek6me38qekget2vdhx66mtvy6kg7nrw5uhsaekd4uhwufswqex6dtsv44hxv3cd4jkuqpqvduyhf',
+  'agoric16kv2g7snfc4q24vg3pjdlnnqgngtjpwtetd2h689nz09lcklvh5s8u37ek',
+  '?EUD=osmo183dejcnmkka5dzcu9xw6mywq0p2m5peks28men',
+);
+test(
+  'version 0',
+  splitMacro,
+  'agoric10rchqqqpqgpsgpgxquyqjzstpsxsurcszyfpxpqrqgqsq9qx0p9wp',
+  'agoric1qqqsyqcyq5rqwzqfpg9scrgwpugpzysn3tn9p0',
+  '\x04\x03\x02\x01',
+);
+test(
+  'version 1 reject',
+  splitMacro,
+  'agoric10rchzqqpqgpsgpgxquyqjzstpsxsurcszyfpxpqrqgqsq9q04n2fg',
+  '',
+  '',
+  { message: 'Unsupported address hook version 1' },
+);
+test(
+  'version 15 reject',
+  splitMacro,
+  'agoric10rch7qqpqgpsgpgxquyqjzstpsxsurcszyfpxpqrqgqsq9q25ez2d',
+  '',
+  '',
+  { message: 'Unsupported address hook version 15' },
+);
+
+/**
+ * @type {import('ava').Macro<
  *   [string, ArrayLike<number> | undefined, ArrayLike<number>, string],
  *   { addressHooks: import('../src/address-hooks.js') }
  * >}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10681

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Be more robust for Address Hook version compatibility: return an error if the magic bytes match but the version number is unsupported.  If the magic bytes don't match, it is not an address hook, so pass through the specimen as the `baseAddress` with empty `hookData`.

Also, `harden` the exports and returned objects if running under HardenedJS.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Stronger Address Hook classification helps prevent accidental collisions.  Hardened return objects and exported functions have fewer mutability concerns.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
n/a

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Some unhappy-path testing has been added to verify at least these issues have been addressed.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
n/a