### PR TITLE
chore: `provisionSmartWallet` flake

### DIFF
--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -50,17 +50,13 @@ test.before(async t => {
   const wallets = await setupTestKeys(accounts, values(oracleMnemonics));
 
   // provision oracle wallets first so invitation deposits don't fail
-  const oracleWdPs = keys(oracleMnemonics).map(n =>
-    provisionSmartWallet(wallets[n], {
-      BLD: 100n,
-    }),
+  const oracleWds = await Promise.all(
+    keys(oracleMnemonics).map(n =>
+      provisionSmartWallet(wallets[n], {
+        BLD: 100n,
+      }),
+    ),
   );
-  // execute sequentially, to avoid "published.wallet.${addr}.current: fetch failed"
-  const oracleWds: WalletDriver[] = [];
-  for (const p of oracleWdPs) {
-    const wd = await p;
-    oracleWds.push(wd);
-  }
 
   // calculate denomHash and channelId for privateArgs / builder opts
   const { getTransferChannelId, toDenomHash } = makeDenomTools(chainInfo);

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -8,8 +8,12 @@ import { flags, makeAgd, makeCopyFiles } from './agd-lib.js';
 import { makeHttpClient, makeAPI } from './makeHttpClient.js';
 import { dedup, makeQueryKit, poll } from './queryKit.js';
 import { makeVStorage } from './batchQuery.js';
+import { makeRetryUntilCondition } from './sleep.js';
 
-/** @import { EnglishMnemonic } from '@cosmjs/crypto'; */
+/**
+ * @import { EnglishMnemonic } from '@cosmjs/crypto';
+ * @import { RetryUntilCondition } from './sleep.js';
+ */
 
 const BLD = '000000ubld';
 
@@ -121,6 +125,7 @@ const installBundle = async (fullPath, opts) => {
  *   blockTool: BlockTool;
  *   lcd: import('./makeHttpClient.js').LCD;
  *   delay: (ms: number) => Promise<void>;
+ *   retryUntilCondition: RetryUntilCondition;
  *   chainId?: string;
  *   whale?: string;
  *   progress?: typeof console.log;
@@ -139,6 +144,7 @@ export const provisionSmartWallet = async (
     whale = 'faucet',
     progress = console.log,
     q = makeQueryKit(makeVStorage(lcd)).query,
+    retryUntilCondition,
   },
 ) => {
   // TODO: skip this query if balances is {}
@@ -187,7 +193,12 @@ export const provisionSmartWallet = async (
     { chainId, from: address, yes: true },
   );
 
-  const info = await q.queryData(`published.wallet.${address}.current`);
+  const info = await retryUntilCondition(
+    () => q.queryData(`published.wallet.${address}.current`),
+    result => !!result,
+    `wallet in vstorage ${address}`,
+    { log: () => {} }, // suppress logs as this is already noisy
+  );
   progress({
     provisioned: address,
     purses: info.purses.length,
@@ -428,6 +439,7 @@ const runCoreEval = async (
  * @param {string} [io.rpcAddress]
  * @param {string} [io.apiAddress]
  * @param {(...parts: string[]) => string} [io.join]
+ * * @param {RetryUntilCondition} [io.retryUntilCondition]
  */
 export const makeE2ETools = async (
   log,
@@ -438,6 +450,7 @@ export const makeE2ETools = async (
     setTimeout,
     rpcAddress = 'http://localhost:26657',
     apiAddress = 'http://localhost:1317',
+    retryUntilCondition = makeRetryUntilCondition({ log, setTimeout }),
   },
 ) => {
   const agd = makeAgd({ execFileSync }).withOpts({ keyringBackend: 'test' });
@@ -535,6 +548,7 @@ export const makeE2ETools = async (
         lcd,
         delay,
         q: vstorageClient,
+        retryUntilCondition,
       }),
     /**
      * @param {string} name

--- a/multichain-testing/tools/sleep.ts
+++ b/multichain-testing/tools/sleep.ts
@@ -28,11 +28,11 @@ const retryUntilCondition = async <T>(
   {
     maxRetries = 6,
     retryIntervalMs = 3500,
-    log = () => {},
+    log = console.log,
     setTimeout = ambientSetTimeout,
   }: RetryOptions = {},
 ): Promise<T> => {
-  console.log({ maxRetries, retryIntervalMs, message });
+  log({ maxRetries, retryIntervalMs, message });
   let retries = 0;
 
   while (retries < maxRetries) {
@@ -50,7 +50,7 @@ const retryUntilCondition = async <T>(
     }
 
     retries++;
-    console.log(
+    log(
       `Retry ${retries}/${maxRetries} - Waiting for ${retryIntervalMs}ms for ${message}...`,
     );
     await sleep(retryIntervalMs, { log, setTimeout });

--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -187,7 +187,7 @@ test.serial('writes account addresses to vstorage', async t => {
   await documentStorageSchema(t, storage, doc);
 });
 
-test.skip('makes usdc advance', async t => {
+test.serial('makes usdc advance', async t => {
   const {
     walletFactoryDriver: wd,
     storage,


### PR DESCRIPTION
## Description
- motivated after observing `cannot read data of published.wallet.${addr}.current: fetch failed` in [10638](https://github.com/Agoric/agoric-sdk/actions/runs/12313012295/job/34369641775?pr=10638)

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
None

### Upgrade Considerations
None