### PR TITLE
SPIKE: factor out Orch contract core-eval boilerplate

### DIFF
--- a/packages/builders/scripts/fast-usdc/init-fast-usdc.js
+++ b/packages/builders/scripts/fast-usdc/init-fast-usdc.js
@@ -1,10 +1,8 @@
 // @ts-check
 import { makeHelpers } from '@agoric/deploy-script-support';
 import { AmountMath } from '@agoric/ertp';
-import {
-  FastUSDCConfigShape,
-  getManifestForFastUSDC,
-} from '@agoric/fast-usdc/src/fast-usdc.start.js';
+import { getManifestForFastUSDC } from '@agoric/fast-usdc/src/fast-usdc.start.js';
+import { FastUSDCConfigShape } from '@agoric/fast-usdc/src/fast-usdc.contract.meta.js';
 import { toExternalConfig } from '@agoric/fast-usdc/src/utils/config-marshal.js';
 import { configurations } from '@agoric/fast-usdc/src/utils/deploy-config.js';
 import {

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -2,10 +2,6 @@ import { AssetKind } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import {
-  CosmosChainInfoShape,
-  DenomDetailShape,
-  DenomShape,
-  OrchestrationPowersShape,
   registerChainsAndAssets,
   withOrchestration,
 } from '@agoric/orchestration';
@@ -14,14 +10,13 @@ import { provideSingleton } from '@agoric/zoe/src/contractSupport/durability.js'
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { Fail } from '@endo/errors';
 import { E } from '@endo/far';
-import { M } from '@endo/patterns';
 import { prepareAdvancer } from './exos/advancer.js';
 import { prepareLiquidityPoolKit } from './exos/liquidity-pool.js';
 import { prepareSettler } from './exos/settler.js';
 import { prepareStatusManager } from './exos/status-manager.js';
 import { prepareTransactionFeedKit } from './exos/transaction-feed.js';
+import { meta } from './fast-usdc.contract.meta.js';
 import * as flows from './fast-usdc.flows.js';
-import { FastUSDCTermsShape, FeeConfigShape } from './type-guards.js';
 import { defineInertInvitation } from './utils/zoe.js';
 
 const trace = makeTracer('FastUsdc');
@@ -48,20 +43,7 @@ const ADDRESSES_BAGGAGE_KEY = 'addresses';
  * }} FastUsdcTerms
  */
 
-/** @type {ContractMeta<typeof start>} */
-export const meta = {
-  // @ts-expect-error TypedPattern not recognized as record
-  customTermsShape: FastUSDCTermsShape,
-  privateArgsShape: {
-    // @ts-expect-error TypedPattern not recognized as record
-    ...OrchestrationPowersShape,
-    assetInfo: M.arrayOf([DenomShape, DenomDetailShape]),
-    chainInfo: M.recordOf(M.string(), CosmosChainInfoShape),
-    feeConfig: FeeConfigShape,
-    marshaller: M.remotable(),
-    poolMetricsNode: M.remotable(),
-  },
-};
+export { meta };
 harden(meta);
 
 /**

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -6,11 +6,28 @@ import {
   OrchestrationPowersShape,
 } from '@agoric/orchestration';
 import { M } from '@endo/patterns';
-import { FastUSDCTermsShape, FeeConfigShape } from './type-guards.js';
+import {
+  FastUSDCTermsShape,
+  FeeConfigShape,
+  FeedPolicyShape,
+} from './type-guards.js';
 
 /**
+ * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
+ * @import {TypedPattern} from '@agoric/internal'
  * @import {FastUsdcSF} from './fast-usdc.contract.js';
+ * @import {FastUSDCConfig} from './types.js'
  */
+
+/** @type {TypedPattern<FastUSDCConfig>} */
+export const FastUSDCConfigShape = M.splitRecord({
+  terms: FastUSDCTermsShape,
+  oracles: M.recordOf(M.string(), M.string()),
+  feeConfig: FeeConfigShape,
+  feedPolicy: FeedPolicyShape,
+  chainInfo: M.recordOf(M.string(), CosmosChainInfoShape),
+  assetInfo: M.arrayOf([DenomShape, DenomDetailShape]),
+});
 
 /** @satisfies {ContractMeta<FastUsdcSF>} */
 export const meta = {
@@ -25,15 +42,12 @@ export const meta = {
     marshaller: M.remotable(),
     poolMetricsNode: M.remotable(),
   },
+  deployConfigShape: FastUSDCConfigShape,
   adminRoles: {
     oracles: 'makeOperatorInvitation',
   },
 };
 harden(meta);
-
-/**
- * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
- */
 
 /** @satisfies {BootstrapManifestPermit} */
 export const permit = {

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -49,6 +49,7 @@ export const meta = /** @type {const} */ ({
     poolMetricsNode: M.remotable(),
   },
   deployConfigShape: FastUSDCConfigShape,
+  /** @type {Record<keyof FastUSDCConfig, keyof StartedInstanceKit<FastUsdcSF>['creatorFacet']>} */
   adminRoles: {
     oracles: 'makeOperatorInvitation',
   },

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -30,7 +30,8 @@ export const FastUSDCConfigShape = M.splitRecord({
 });
 
 /** @satisfies {ContractMeta<FastUsdcSF>} */
-export const meta = {
+export const meta = /** @type {const} */ ({
+  name: 'fastUsdc',
   // @ts-expect-error TypedPattern not recognized as record
   customTermsShape: FastUSDCTermsShape,
   privateArgsShape: {
@@ -46,7 +47,7 @@ export const meta = {
   adminRoles: {
     oracles: 'makeOperatorInvitation',
   },
-};
+});
 harden(meta);
 
 /** @satisfies {BootstrapManifestPermit} */

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -56,6 +56,7 @@ export const permit = {
     board: true,
   },
   issuer: {
+    consume: { USDC: true },
     produce: { FastLP: true }, // UNTIL #10432
   },
   brand: {

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -1,0 +1,68 @@
+/** ContractMeta, Permit for Fast USDC */
+import {
+  CosmosChainInfoShape,
+  DenomDetailShape,
+  DenomShape,
+  OrchestrationPowersShape,
+} from '@agoric/orchestration';
+import { M } from '@endo/patterns';
+import { FastUSDCTermsShape, FeeConfigShape } from './type-guards.js';
+
+/**
+ * @import {FastUsdcSF} from './fast-usdc.contract.js';
+ */
+
+/** @type {ContractMeta<FastUsdcSF>} */
+export const meta = {
+  // @ts-expect-error TypedPattern not recognized as record
+  customTermsShape: FastUSDCTermsShape,
+  privateArgsShape: {
+    // @ts-expect-error TypedPattern not recognized as record
+    ...OrchestrationPowersShape,
+    assetInfo: M.arrayOf([DenomShape, DenomDetailShape]),
+    chainInfo: M.recordOf(M.string(), CosmosChainInfoShape),
+    feeConfig: FeeConfigShape,
+    marshaller: M.remotable(),
+    poolMetricsNode: M.remotable(),
+  },
+};
+harden(meta);
+
+/**
+ * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
+ */
+
+/** @satisfies {BootstrapManifestPermit} */
+export const permit = {
+  produce: {
+    fastUsdcKit: true,
+  },
+  consume: {
+    chainStorage: true,
+    chainTimerService: true,
+    localchain: true,
+    cosmosInterchainService: true,
+
+    // limited distribution durin MN2: contract installation
+    startUpgradable: true,
+    zoe: true, // only getTerms() is needed. XXX should be split?
+
+    // widely shared: name services
+    agoricNames: true,
+    namesByAddress: true,
+    board: true,
+  },
+  issuer: {
+    produce: { FastLP: true }, // UNTIL #10432
+  },
+  brand: {
+    produce: { FastLP: true }, // UNTIL #10432
+  },
+  instance: {
+    produce: { fastUsdc: true },
+  },
+  installation: {
+    consume: { fastUsdc: true },
+  },
+};
+harden(permit);

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -68,7 +68,7 @@ export const permit = /** @type {const} */ ({
   consume: { ...orchPermit, ...adminPermit },
   instance: { produce: { [meta.name]: true } },
   installation: { consume: { [meta.name]: true } },
-  issuer: { produce: { FastLP: true }, consume: { USDC: true } },
-  brand: { produce: { FastLP: true } },
+  issuer: { produce: { FastLP: 'PoolShares' }, consume: { USDC: true } },
+  brand: { produce: { FastLP: 'PoolShares' } },
 });
 harden(permit);

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -14,6 +14,7 @@ import {
 } from './type-guards.js';
 
 /**
+ * @import {Instance, StartParams} from '@agoric/zoe/src/zoeService/utils'
  * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
  * @import {TypedPattern} from '@agoric/internal'
  * @import {Marshaller} from '@agoric/internal/src/lib-chainStorage.js'
@@ -53,6 +54,21 @@ export const meta = /** @type {const} */ ({
   },
 });
 harden(meta);
+
+/**
+ * @typedef { PromiseSpaceOf<{
+ *   fastUsdcKit: FastUSDCKit
+ *  }> & {
+ *   installation: PromiseSpaceOf<{ fastUsdc: Installation<FastUsdcSF> }>;
+ *   instance: PromiseSpaceOf<{ fastUsdc: Instance<FastUsdcSF> }>;
+ *   issuer: PromiseSpaceOf<{ FastLP: Issuer }>;
+ *   brand: PromiseSpaceOf<{ FastLP: Brand }>;
+ * }} FastUSDCCorePowers
+ *
+ * @typedef {StartedInstanceKitWithLabel & {
+ *   privateArgs: StartParams<FastUsdcSF>['privateArgs'];
+ * }} FastUSDCKit
+ */
 
 /** @satisfies {BootstrapManifestPermit} */
 export const permit = {

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -12,6 +12,7 @@ import {
   FeeConfigShape,
   FeedPolicyShape,
 } from './type-guards.js';
+import { startOrchContractG } from './fast-usdc.start.js';
 
 /**
  * @import {StartParams} from '@agoric/zoe/src/zoeService/utils'
@@ -21,6 +22,11 @@ import {
  * @import {OrchestrationPowers} from '@agoric/orchestration';
  * @import {FastUsdcSF} from './fast-usdc.contract.js';
  * @import {FeedPolicy, FastUSDCConfig} from './types.js'
+ */
+
+/**
+ * @import {LegibleCapData} from './utils/config-marshal.js'
+ * @import {CorePowersG} from './fast-usdc.start.js';
  */
 
 /** @type {TypedPattern<FastUSDCConfig>} */
@@ -147,7 +153,7 @@ const publishFeedPolicy = async (node, policy) => {
  * } kit
  * @param {(...args: any[]) => void} trace
  */
-export const finishDeploy = async (config, kit, trace) => {
+export const finishDeploy = async (config, kit, trace = console.log) => {
   const { storageNode } = kit.privateArgs;
   const { feedPolicy } = config;
   await publishFeedPolicy(storageNode, feedPolicy);
@@ -159,4 +165,21 @@ export const finishDeploy = async (config, kit, trace) => {
     const addr = await E(creatorFacet).connectToNoble();
     trace('noble intermediate recipient', addr);
   }
+};
+
+/**
+ * @param {BootstrapPowers & CorePowersG<'fastUsdc', FastUsdcSF, typeof permit>} permitted
+ * @param {{ options: LegibleCapData<FastUSDCConfig> }} config
+ */
+const startFastUSDC = async (permitted, config) => {
+  const { config: conf, kit } = await startOrchContractG(
+    meta,
+    permit,
+    makePrivateArgs,
+    permitted,
+    config,
+  );
+  // TODO: inline finishDeploy?
+  // TODO: make a tracer?
+  await finishDeploy(conf, kit);
 };

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -57,37 +57,42 @@ export const meta = /** @type {const} */ ({
 harden(meta);
 
 /** @satisfies {BootstrapManifestPermit} */
+const orchPermit = /** @type {const} */ ({
+  localchain: true,
+  cosmosInterchainService: true,
+  chainStorage: true,
+  chainTimerService: true,
+  agoricNames: true,
+
+  // for publishing Brands and other remote object references
+  board: true,
+
+  // limited distribution durin MN2: contract installation
+  startUpgradable: true,
+  zoe: true, // only getTerms() is needed. XXX should be split?
+});
+
+/**
+ * to find deposit facets for admin invitations
+ *
+ * @satisfies {BootstrapManifestPermit}
+ */
+const adminPermit = /** @type {const} */ ({
+  namesByAddress: true,
+});
+
+/** @satisfies {BootstrapManifestPermit} */
 export const permit = /** @type {const} */ ({
-  produce: {
-    fastUsdcKit: true,
-  },
-  consume: {
-    chainStorage: true,
-    chainTimerService: true,
-    localchain: true,
-    cosmosInterchainService: true,
-
-    // limited distribution durin MN2: contract installation
-    startUpgradable: true,
-    zoe: true, // only getTerms() is needed. XXX should be split?
-
-    // widely shared: name services
-    agoricNames: true,
-    namesByAddress: true,
-    board: true,
-  },
+  produce: { [`${meta.name}Kit`]: true },
+  consume: { ...orchPermit, ...adminPermit },
+  instance: { produce: { [meta.name]: true } },
+  installation: { consume: { [meta.name]: true } },
   issuer: {
     consume: { USDC: true },
     produce: { FastLP: true }, // UNTIL #10432
   },
   brand: {
     produce: { FastLP: true }, // UNTIL #10432
-  },
-  instance: {
-    produce: { fastUsdc: true },
-  },
-  installation: {
-    consume: { fastUsdc: true },
   },
 });
 harden(permit);

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -12,7 +12,7 @@ import { FastUSDCTermsShape, FeeConfigShape } from './type-guards.js';
  * @import {FastUsdcSF} from './fast-usdc.contract.js';
  */
 
-/** @type {ContractMeta<FastUsdcSF>} */
+/** @satisfies {ContractMeta<FastUsdcSF>} */
 export const meta = {
   // @ts-expect-error TypedPattern not recognized as record
   customTermsShape: FastUSDCTermsShape,
@@ -24,6 +24,9 @@ export const meta = {
     feeConfig: FeeConfigShape,
     marshaller: M.remotable(),
     poolMetricsNode: M.remotable(),
+  },
+  adminRoles: {
+    oracles: 'makeOperatorInvitation',
   },
 };
 harden(meta);

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -121,35 +121,3 @@ export const makePrivateArgs = async (
   });
 };
 harden(makePrivateArgs);
-
-const { fromEntries, keys } = Object;
-
-/**
- * possible generic form of makePrivateArgs
- *
- * TODO: figure out type safety
- *
- * @param {OrchestrationPowers} orchestrationPowers
- * @param {import('@endo/pass-style').CopyRecord} internalConfig
- */
-export const customPrivateArgs = (orchestrationPowers, internalConfig) => {
-  const extraNodeKeys = keys(meta.privateArgsShape).filter(
-    prop => prop !== 'storageNode' && prop.endsWith('Node'),
-  );
-  const { storageNode } = orchestrationPowers;
-  const extraNodeArgs = fromEntries(
-    extraNodeKeys.map(key => [
-      key,
-      E(storageNode).makeChildNode(key.slice(0, -'Node'.length)),
-    ]),
-  );
-  const configKeys = keys(meta.privateArgsShape).filter(
-    key =>
-      key in internalConfig &&
-      !(key in orchestrationPowers || key in extraNodeArgs),
-  );
-  const configArgs = fromEntries(
-    configKeys.map(key => [key, internalConfig[key]]),
-  );
-  return harden({ ...extraNodeArgs, ...configArgs });
-};

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -5,18 +5,18 @@ import {
   DenomShape,
   OrchestrationPowersShape,
 } from '@agoric/orchestration';
-import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import {
   FastUSDCTermsShape,
   FeeConfigShape,
   FeedPolicyShape,
 } from './type-guards.js';
-import { startOrchContractG } from './fast-usdc.start.js';
+import { adminPermit, orchPermit } from './orch.start.js';
 
 /**
  * @import {StartParams} from '@agoric/zoe/src/zoeService/utils'
- * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
+ * @import {BootstrapManifest, BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
+ * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
  * @import {TypedPattern, Remote} from '@agoric/internal'
  * @import {Marshaller} from '@agoric/internal/src/lib-chainStorage.js'
  * @import {OrchestrationPowers} from '@agoric/orchestration';
@@ -26,7 +26,7 @@ import { startOrchContractG } from './fast-usdc.start.js';
 
 /**
  * @import {LegibleCapData} from './utils/config-marshal.js'
- * @import {CorePowersG} from './fast-usdc.start.js';
+ * @import {CorePowersG} from './orch.start.js';
  */
 
 /** @type {TypedPattern<FastUSDCConfig>} */
@@ -63,123 +63,12 @@ export const meta = /** @type {const} */ ({
 harden(meta);
 
 /** @satisfies {BootstrapManifestPermit} */
-const orchPermit = /** @type {const} */ ({
-  localchain: true,
-  cosmosInterchainService: true,
-  chainStorage: true,
-  chainTimerService: true,
-  agoricNames: true,
-
-  // for publishing Brands and other remote object references
-  board: true,
-
-  // limited distribution durin MN2: contract installation
-  startUpgradable: true,
-  zoe: true, // only getTerms() is needed. XXX should be split?
-});
-
-/**
- * to find deposit facets for admin invitations
- *
- * @satisfies {BootstrapManifestPermit}
- */
-const adminPermit = /** @type {const} */ ({
-  namesByAddress: true,
-});
-
-/** @satisfies {BootstrapManifestPermit} */
 export const permit = /** @type {const} */ ({
   produce: { [`${meta.name}Kit`]: true },
   consume: { ...orchPermit, ...adminPermit },
   instance: { produce: { [meta.name]: true } },
   installation: { consume: { [meta.name]: true } },
-  issuer: {
-    consume: { USDC: true },
-    produce: { FastLP: true }, // UNTIL #10432
-  },
-  brand: {
-    produce: { FastLP: true }, // UNTIL #10432
-  },
+  issuer: { produce: { FastLP: true }, consume: { USDC: true } },
+  brand: { produce: { FastLP: true } },
 });
 harden(permit);
-
-const POOL_METRICS = 'poolMetrics';
-
-/**
- *
- * @param {OrchestrationPowers} orchestrationPowers
- * @param {Marshaller} marshaller
- * @param {FastUSDCConfig} config
- * @param {(...args: any[]) => void} trace
- * @returns {Promise<StartParams<FastUsdcSF>['privateArgs']>}
- */
-export const makePrivateArgs = async (
-  orchestrationPowers,
-  marshaller,
-  config,
-  trace,
-) => {
-  const { storageNode } = orchestrationPowers;
-  const poolMetricsNode = await E(storageNode).makeChildNode(POOL_METRICS);
-  const { feeConfig } = config;
-  trace('using fee config', feeConfig);
-
-  return harden({
-    ...orchestrationPowers,
-    feeConfig,
-    poolMetricsNode,
-    marshaller,
-    chainInfo: config.chainInfo,
-    assetInfo: config.assetInfo,
-  });
-};
-harden(makePrivateArgs);
-
-const FEED_POLICY = 'feedPolicy';
-
-/**
- * @param {Remote<StorageNode>} node
- * @param {FeedPolicy} policy
- */
-const publishFeedPolicy = async (node, policy) => {
-  const feedPolicy = E(node).makeChildNode(FEED_POLICY);
-  await E(feedPolicy).setValue(JSON.stringify(policy));
-};
-
-/**
- * @param {FastUSDCConfig} config
- * @param {StartedInstanceKit<FastUsdcSF> &
- *  { privateArgs: StartParams<FastUsdcSF>['privateArgs'] }
- * } kit
- * @param {(...args: any[]) => void} trace
- */
-export const finishDeploy = async (config, kit, trace = console.log) => {
-  const { storageNode } = kit.privateArgs;
-  const { feedPolicy } = config;
-  await publishFeedPolicy(storageNode, feedPolicy);
-
-  const { creatorFacet } = kit;
-  const addresses = await E(creatorFacet).publishAddresses();
-  trace('contract orch account addresses', addresses);
-  if (!config.noNoble) {
-    const addr = await E(creatorFacet).connectToNoble();
-    trace('noble intermediate recipient', addr);
-  }
-};
-
-/**
- * @param {BootstrapPowers & CorePowersG<'fastUsdc', FastUsdcSF, typeof permit>} permitted
- * @param {{ options: LegibleCapData<FastUSDCConfig> }} config
- */
-const startFastUSDC = async (permitted, config) => {
-  const { config: conf, kit } = await startOrchContractG(
-    meta,
-    permit,
-    makePrivateArgs,
-    permitted,
-    config,
-  );
-  // TODO: inline finishDeploy?
-  // TODO: make a tracer?
-  await finishDeploy(conf, kit);
-};

--- a/packages/fast-usdc/src/fast-usdc.contract.meta.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.meta.js
@@ -32,6 +32,7 @@ export const FastUSDCConfigShape = M.splitRecord({
 /** @satisfies {ContractMeta<FastUsdcSF>} */
 export const meta = /** @type {const} */ ({
   name: 'fastUsdc',
+  abbr: 'FUSD', // for tracer(s)
   // @ts-expect-error TypedPattern not recognized as record
   customTermsShape: FastUSDCTermsShape,
   privateArgsShape: {

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -8,13 +8,12 @@ import { fromExternalConfig } from './utils/config-marshal.js';
 
 /**
  * @import {DepositFacet} from '@agoric/ertp/src/types.js'
- * @import {Instance, StartParams} from '@agoric/zoe/src/zoeService/utils'
  * @import {Board} from '@agoric/vats'
  * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
  * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js'
  * @import {LegibleCapData} from './utils/config-marshal.js'
- * @import {FastUsdcSF} from './fast-usdc.contract.js'
  * @import {FeedPolicy, FastUSDCConfig as ContractConfig} from './types.js'
+ * @import {FastUSDCCorePowers as CorePowers} from './fast-usdc.contract.meta.js';
  */
 
 const { entries, fromEntries, keys, values } = Object; // XXX move up
@@ -111,24 +110,9 @@ const makeAdminRole = (role, namesByAddress, nameToAddress) => {
 };
 
 /**
- * @typedef { PromiseSpaceOf<{
- *   fastUsdcKit: FastUSDCKit
- *  }> & {
- *   installation: PromiseSpaceOf<{ fastUsdc: Installation<FastUsdcSF> }>;
- *   instance: PromiseSpaceOf<{ fastUsdc: Instance<FastUsdcSF> }>;
- *   issuer: PromiseSpaceOf<{ FastLP: Issuer }>;
- *   brand: PromiseSpaceOf<{ FastLP: Brand }>;
- * }} FastUSDCCorePowers
- *
- * @typedef {StartedInstanceKitWithLabel & {
- *   privateArgs: StartParams<FastUsdcSF>['privateArgs'];
- * }} FastUSDCKit
- */
-
-/**
  * @throws if admin role smart wallets are not yet provisioned
  *
- * @param {BootstrapPowers & FastUSDCCorePowers } powers
+ * @param {BootstrapPowers & CorePowers } powers
  * @param {{ options: LegibleCapData<ContractConfig> }} config
  */
 export const startFastUSDC = async (

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -14,7 +14,7 @@ import { meta, permit } from './fast-usdc.contract.meta.js';
  * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js'
  * @import {LegibleCapData} from './utils/config-marshal.js'
  * @import {FastUsdcSF} from './fast-usdc.contract.js'
- * @import {FeedPolicy, FastUSDCConfig} from './types.js'
+ * @import {FeedPolicy, FastUSDCConfig as ContractConfig} from './types.js'
  */
 
 const { entries, fromEntries, keys, values } = Object; // XXX move up
@@ -130,7 +130,7 @@ const makeAdminRole = (role, namesByAddress, nameToAddress) => {
  * @throws if admin role smart wallets are not yet provisioned
  *
  * @param {BootstrapPowers & FastUSDCCorePowers } powers
- * @param {{ options: LegibleCapData<FastUSDCConfig> }} config
+ * @param {{ options: LegibleCapData<ContractConfig> }} config
  */
 export const startFastUSDC = async (
   {
@@ -258,7 +258,7 @@ harden(startFastUSDC);
  * }} utils
  * @param {{
  *   installKeys: { fastUsdc: ERef<ManifestBundleRef> };
- *   options: LegibleCapData<FastUSDCConfig>;
+ *   options: LegibleCapData<ContractConfig>;
  * }} param1
  */
 export const getManifestForFastUSDC = (

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -14,6 +14,7 @@ import {
   FeedPolicyShape,
 } from './type-guards.js';
 import { fromExternalConfig } from './utils/config-marshal.js';
+import { permit } from './fast-usdc.contract.meta.js';
 
 /**
  * @import {DepositFacet} from '@agoric/ertp/src/types.js'
@@ -252,43 +253,8 @@ export const getManifestForFastUSDC = (
 ) => {
   return {
     /** @type {BootstrapManifest} */
-    manifest: {
-      [startFastUSDC.name]: {
-        produce: {
-          fastUsdcKit: true,
-        },
-        consume: {
-          chainStorage: true,
-          chainTimerService: true,
-          localchain: true,
-          cosmosInterchainService: true,
-
-          // limited distribution durin MN2: contract installation
-          startUpgradable: true,
-          zoe: true, // only getTerms() is needed. XXX should be split?
-
-          // widely shared: name services
-          agoricNames: true,
-          namesByAddress: true,
-          board: true,
-        },
-        issuer: {
-          produce: { FastLP: true }, // UNTIL #10432
-        },
-        brand: {
-          produce: { FastLP: true }, // UNTIL #10432
-        },
-        instance: {
-          produce: { fastUsdc: true },
-        },
-        installation: {
-          consume: { fastUsdc: true },
-        },
-      },
-    },
-    installations: {
-      fastUsdc: restoreRef(installKeys.fastUsdc),
-    },
+    manifest: { [startFastUSDC.name]: permit },
+    installations: { [contractName]: restoreRef(installKeys[contractName]) },
     options,
   };
 };

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -117,7 +117,7 @@ const makeAdminRole = (role, namesByAddress, nameToAddress) => {
  */
 export const startFastUSDC = async (
   {
-    produce: { fastUsdcKit },
+    produce,
     consume: {
       agoricNames,
       namesByAddress,
@@ -197,7 +197,7 @@ export const startFastUSDC = async (
     terms,
     privateArgs,
   });
-  fastUsdcKit.resolve(harden({ ...kit, privateArgs }));
+  produce[`${contractName}Kit`].resolve(harden({ ...kit, privateArgs }));
   const { instance, creatorFacet } = kit;
 
   await publishFeedPolicy(storageNode, feedPolicy);

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -12,7 +12,10 @@ import {
 import { fromExternalConfig } from './utils/config-marshal.js';
 
 /**
- * @import {Instance, StartParams, StartedInstanceKit} from '@agoric/zoe/src/zoeService/utils'
+ * @import {CopyRecord} from '@endo/pass-style';
+ * @import {TypedPattern} from '@agoric/internal';
+ * @import {OrchestrationPowers} from '@agoric/orchestration';
+ * @import {ContractStartFunction, Instance, StartParams, StartedInstanceKit} from '@agoric/zoe/src/zoeService/utils'
  * @import {DepositFacet} from '@agoric/ertp/src/types.js'
  * @import {Board} from '@agoric/vats'
  * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
@@ -121,6 +124,206 @@ const makeAdminRole = (role, namesByAddress, nameToAddress) => {
  *   privateArgs: StartParams<TheSF>['privateArgs'];
  * }} TheContractKit
  */
+
+/**
+ * @template {{}} T
+ * @param {T} obj
+ * @param {<K extends keyof T>(entry: [k: K, v: T[K]], index: number, es: [PropertyKey, unknown][]) => Partial<T>} pred
+ * @returns {Partial<T>}
+ */
+const objectFilter = (obj, pred) => {
+  /** @type {Partial<T>} */
+  // @ts-expect-error pred type too narrow
+  const found = harden(fromEntries(entries(obj).filter(pred)));
+  return found;
+};
+
+/**
+ * @template {PermitG} P
+ * @param {Pick<BootstrapPowers['consume'], 'agoricNames'>} consume
+ * @param {P} permitG
+ */
+export const permittedIssuers = async ({ agoricNames }, permitG) => {
+  const permittedKeys = keys(permitG?.issuer?.consume || {});
+  const agoricIssuers = await E(E(agoricNames).lookup('issuer')).entries();
+  /** @type {Record<keyof P['issuer']['produce'], Issuer>} */
+  // @ts-expect-error by construction
+  const issuerKeywordRecord = fromEntries(
+    agoricIssuers.filter(([n, _v]) => permittedKeys.includes(n)),
+  );
+  return issuerKeywordRecord;
+};
+
+/**
+ * @template {string} CN contract name
+ * @template {ContractStartFunction} SF typeof start
+ * @template {CopyRecord} CFG
+ * @typedef {ContractMeta & {name: CN} & {
+ *   adminRoles?: Record<keyof CFG, keyof StartedInstanceKit<SF>['creatorFacet']>,
+ *   deployConfigShape?: TypedPattern<CFG>,
+ * }} ContractMetaG
+ */
+
+/**
+ * @template {ContractStartFunction} SF typeof start
+ * @typedef {StartedInstanceKit<SF> & {
+ *   label: string,
+ *   privateArgs: Parameters<SF>[1];
+ * }} UpgradeKit
+ *
+ */
+
+/**
+ * @typedef {BootstrapManifest &
+ *   { issuer: BootstrapManifest} &
+ *   { brand: BootstrapManifest }
+ * } PermitG generic permit constraints
+ */
+
+/**
+ * @template {string} CN contract name
+ * @template {ContractStartFn} SF typeof start
+ * @template {PermitG} P permit
+ * @typedef { PromiseSpaceOf<Record<`${CN}Kit`, UpgradeKit<SF>>> & {
+ *   installation: PromiseSpaceOf<Record<CN, Installation<SF>>>;
+ *   instance: PromiseSpaceOf<Record<CN, Instance<SF>>>;
+ *   issuer: PromiseSpaceOf<Record<keyof P['issuer']['produce'], Issuer>>;
+ *   brand: PromiseSpaceOf<Record<keyof P['brand']['produce'], Brand>>;
+ * }} CorePowersG
+ */
+
+/**
+ * @template {ContractStartFn} SF typeof start
+ * @template {CopyRecord} CFG
+ * @typedef {(op: OrchestrationPowers, m: Marshaller, cfg: CFG, log: typeof trace) => Parameters<SF>[1]} MakePrivateArgs
+ */
+
+/**
+ * @throws if admin role smart wallets are not yet provisioned
+ *
+ * @template {string} CN contract name
+ * @template {ContractStartFn} SF typeof start
+ * @template {CopyRecord} CFG
+ * @template {PermitG} P permit
+ * @param {ContractMetaG<CN, SF, CFG>} metaG
+ * @param {P} permitG
+ * @param {MakePrivateArgs<SF, CFG>} makePrivateArgsG
+ * @param {CorePowersG<CN, SF, P> & BootstrapPowers} powers
+ * @param {{ options: LegibleCapData<CFG> }} config
+ */
+export const startOrchContractG = async (
+  metaG,
+  permitG,
+  makePrivateArgsG,
+  {
+    produce,
+    consume,
+    issuer: { produce: produceIssuer },
+    brand: { produce: produceBrand },
+    installation: {
+      consume: { [metaG.name]: installation },
+    },
+    instance: {
+      produce: { [metaG.name]: produceInstance },
+    },
+  },
+  config,
+) => {
+  trace('startOrchContract');
+
+  const issuerKeywordRecord = await permittedIssuers(consume, permitG);
+
+  const { agoricNames, board } = consume;
+  const xVatContext = await E(E(agoricNames).lookup('brand')).entries();
+  const internalConfig = fromExternalConfig(
+    config.options,
+    xVatContext,
+    metaG.deployConfigShape,
+  );
+  const { terms } = internalConfig;
+  trace('using terms', terms);
+
+  const adminRoles = objectMap(metaG?.adminRoles || {}, (_method, role) => {
+    const nameToAddress = internalConfig[role];
+    mustMatch(nameToAddress, M.recordOf(M.string(), M.string()));
+    return makeAdminRole(
+      /** @type {string} */ (role), // XXX tsc gets confused?
+      consume.namesByAddress,
+      nameToAddress,
+    );
+  });
+
+  await Promise.all(values(adminRoles).map(r => r.lookup()));
+
+  /** @type {{ chainStorage: Promise<StorageNode>}} */
+  // @ts-expect-error Promise<null> case is vestigial
+  const { chainStorage } = consume;
+  const { storageNode, marshaller } = await makePublishingStorageKit(
+    meta.name,
+    { board, chainStorage },
+  );
+
+  const {
+    chainTimerService: timerService,
+    localchain,
+    cosmosInterchainService,
+  } = consume;
+  const orchestrationPowers = await deeplyFulfilledObject(
+    harden({
+      localchain,
+      orchestrationService: cosmosInterchainService,
+      storageNode,
+      timerService,
+      agoricNames,
+    }),
+  );
+  const privateArgs = await makePrivateArgsG(
+    orchestrationPowers,
+    marshaller,
+    internalConfig,
+    trace,
+  );
+
+  const { startUpgradable, zoe } = consume;
+  const kit = await E(startUpgradable)({
+    label: metaG.name,
+    installation,
+    issuerKeywordRecord,
+    terms,
+    privateArgs,
+  });
+  const { instance, creatorFacet } = kit;
+  /** @type {UpgradeKit<SF>} */
+  const fullKit = harden({ ...kit, privateArgs });
+  // @ts-expect-error XXX tsc gets confused?
+  produce[`${metaG.name}Kit`].resolve(fullKit);
+
+  const newIssuerNames = keys(permit?.issuer?.produce || {}).filter(
+    n => permit?.brand?.produce?.[n],
+  );
+  if (newIssuerNames.length > 0) {
+    const { issuers, brands } = await E(zoe).getTerms(instance);
+    for (const name of newIssuerNames) {
+      console.log('new well-known Issuer, Brand:', name);
+      produceIssuer[name].reset();
+      produceIssuer[name].resolve(issuers[name]);
+      produceBrand[name].reset();
+      produceBrand[name].resolve(brands[name]);
+      await publishDisplayInfo(brands[name], { board, chainStorage });
+    }
+  }
+
+  for (const [role, method] of entries(meta.adminRoles)) {
+    await adminRoles[role].send(addr => E(creatorFacet)[method](addr));
+  }
+
+  produceInstance.reset();
+  produceInstance.resolve(instance);
+
+  trace('startOrchContract done', instance);
+  return { config: internalConfig, kit };
+};
+harden(startOrchContractG);
 
 /**
  * @throws if admin role smart wallets are not yet provisioned

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -115,7 +115,7 @@ const makeAdminRole = (role, namesByAddress, nameToAddress) => {
  * @param {BootstrapPowers & CorePowers } powers
  * @param {{ options: LegibleCapData<ContractConfig> }} config
  */
-export const startFastUSDC = async (
+export const startOrchContract = async (
   {
     produce,
     consume: {
@@ -140,7 +140,7 @@ export const startFastUSDC = async (
   },
   config,
 ) => {
-  trace('startFastUSDC');
+  trace('startOrchContract');
 
   const xVatContext = await E(E(agoricNames).lookup('brand')).entries();
   const internalConfig = fromExternalConfig(
@@ -230,9 +230,9 @@ export const startFastUSDC = async (
     const addr = await E(creatorFacet).connectToNoble();
     trace('noble intermediate recipient', addr);
   }
-  trace('startFastUSDC done', instance);
+  trace('startOrchContract done', instance);
 };
-harden(startFastUSDC);
+harden(startOrchContract);
 
 /**
  * @param {{
@@ -249,7 +249,7 @@ export const getManifestForFastUSDC = (
 ) => {
   return {
     /** @type {BootstrapManifest} */
-    manifest: { [startFastUSDC.name]: permit },
+    manifest: { [startOrchContract.name]: permit },
     installations: { [contractName]: restoreRef(installKeys[contractName]) },
     options,
   };

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -1,469 +1,82 @@
-import { deeplyFulfilledObject, makeTracer, objectMap } from '@agoric/internal';
-import { Fail } from '@endo/errors';
+/** ContractMeta, Permit for Fast USDC */
 import { E } from '@endo/far';
-import { makeMarshal } from '@endo/marshal';
-import { M, mustMatch } from '@endo/patterns';
-import {
-  finishDeploy,
-  makePrivateArgs,
-  meta,
-  permit,
-} from './fast-usdc.contract.meta.js';
-import { fromExternalConfig } from './utils/config-marshal.js';
+import { makeTracer } from '@agoric/internal/src/debug.js';
+import { meta, permit } from './fast-usdc.contract.meta.js';
+import { makeGetManifest, startOrchContract } from './orch.start.js';
 
 /**
- * @import {CopyRecord} from '@endo/pass-style';
- * @import {TypedPattern} from '@agoric/internal';
+ * @import {Marshaller} from '@agoric/internal/src/lib-chainStorage.js'
  * @import {OrchestrationPowers} from '@agoric/orchestration';
- * @import {ContractStartFunction, Instance, StartParams, StartedInstanceKit} from '@agoric/zoe/src/zoeService/utils'
- * @import {DepositFacet} from '@agoric/ertp/src/types.js'
- * @import {Board} from '@agoric/vats'
- * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
- * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js'
+ *
+ * XXX these 2 could/should be down in the platform somewhere
  * @import {LegibleCapData} from './utils/config-marshal.js'
+ * @import {CorePowersG} from './orch.start.js';
  *
- * TODO: re-export these from .meta with generic names
- * @import {FastUSDCConfig as ContractConfig} from './types.js'
- * @import {FastUsdcSF as TheSF} from './fast-usdc.contract.js';
+ * @import {FastUsdcSF} from './fast-usdc.contract.js';
+ * @import {FastUSDCConfig} from './types.js'
  */
 
-const { entries, fromEntries, keys, values } = Object; // XXX move up
+const POOL_METRICS = 'poolMetrics';
+const FEED_POLICY = 'feedPolicy';
 
-const contractName = meta.name;
-/** @typedef {typeof meta.name} TheContractName */
-
-const trace = makeTracer(`${meta.abbr}-Start`, true);
+const trace = makeTracer(`FUSDC-Start`, true);
 
 /**
- * XXX Shouldn't the bridge or board vat handle this?
  *
- * @param {string} path
- * @param {{
- *   chainStorage: ERef<StorageNode>;
- *   board: ERef<Board>;
- * }} io
+ * @param {OrchestrationPowers} orchestrationPowers
+ * @param {Marshaller} marshaller
+ * @param {FastUSDCConfig} config
+ * @returns {Promise<Parameters<FastUsdcSF>[1]>}
  */
-const makePublishingStorageKit = async (path, { chainStorage, board }) => {
-  const storageNode = await E(chainStorage).makeChildNode(path);
+export const makePrivateArgs = async (
+  orchestrationPowers,
+  marshaller,
+  config,
+) => {
+  const { feeConfig, chainInfo, assetInfo } = config;
+  trace('using fee config', feeConfig);
 
-  const marshaller = await E(board).getPublishingMarshaller();
-  return { storageNode, marshaller };
-};
-
-const BOARD_AUX = 'boardAux';
-const marshalData = makeMarshal(_val => Fail`data only`);
-/**
- * @param {Brand} brand
- * @param {Pick<BootstrapPowers['consume'], 'board' | 'chainStorage'>} powers
- */
-const publishDisplayInfo = async (brand, { board, chainStorage }) => {
-  // chainStorage type includes undefined, which doesn't apply here.
-  // @ts-expect-error UNTIL https://github.com/Agoric/agoric-sdk/issues/8247
-  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
-  const [id, displayInfo, allegedName] = await Promise.all([
-    E(board).getId(brand),
-    E(brand).getDisplayInfo(),
-    E(brand).getAllegedName(),
-  ]);
-  const node = E(boardAux).makeChildNode(id);
-  const aux = marshalData.toCapData(harden({ allegedName, displayInfo }));
-  await E(node).setValue(JSON.stringify(aux));
-};
-
-/**
- * @param {string} role
- * @param {ERef<BootstrapPowers['consume']['namesByAddress']>} namesByAddress
- * @param {Record<string, string>} nameToAddress
- */
-const makeAdminRole = (role, namesByAddress, nameToAddress) => {
-  const lookup = async () => {
-    trace('look up deposit facets for', role);
-    return deeplyFulfilledObject(
-      objectMap(nameToAddress, async address => {
-        /** @type {DepositFacet} */
-        const depositFacet = await E(namesByAddress).lookup(
-          address,
-          'depositFacet',
-        );
-        return depositFacet;
-      }),
-    );
-  };
-  const lookupP = lookup();
+  const { storageNode } = orchestrationPowers;
+  const poolMetricsNode = await E(storageNode).makeChildNode(POOL_METRICS);
 
   return harden({
-    lookup: () => lookupP,
-    /** @param {(addr: string) => Promise<Invitation>} makeInvitation */
-    send: async makeInvitation => {
-      const oracleDepositFacets = await lookupP;
-      await Promise.all(
-        entries(oracleDepositFacets).map(async ([name, depositFacet]) => {
-          const address = nameToAddress[name];
-          trace('making invitation for', role, name, address);
-          const toWatch = await makeInvitation(address);
-
-          const amt = await E(depositFacet).receive(toWatch);
-          trace('sent', amt, 'to', role, name);
-        }),
-      );
-    },
-  });
-};
-
-/**
- * @typedef { typeof permit.issuer.produce } PermittedIssuers
- * @typedef { PromiseSpaceOf<Record<`${TheContractName}Kit`, TheContractKit>> & {
- *   installation: PromiseSpaceOf<Record<TheContractName, Installation<TheSF>>>;
- *   instance: PromiseSpaceOf<Record<TheContractName, Instance<TheSF>>>;
- *   issuer: PromiseSpaceOf<Record<keyof typeof permit.issuer.produce, Issuer>>;
- *   brand: PromiseSpaceOf<Record<keyof typeof permit.brand.produce, Brand>>;
- * }} ExtraCorePowers
- *
- * @typedef {StartedInstanceKit<TheSF> & {
- *   label: string,
- *   privateArgs: StartParams<TheSF>['privateArgs'];
- * }} TheContractKit
- */
-
-/**
- * @template {{}} T
- * @param {T} obj
- * @param {<K extends keyof T>(entry: [k: K, v: T[K]], index: number, es: [PropertyKey, unknown][]) => Partial<T>} pred
- * @returns {Partial<T>}
- */
-const objectFilter = (obj, pred) => {
-  /** @type {Partial<T>} */
-  // @ts-expect-error pred type too narrow
-  const found = harden(fromEntries(entries(obj).filter(pred)));
-  return found;
-};
-
-/**
- * @template {PermitG} P
- * @param {Pick<BootstrapPowers['consume'], 'agoricNames'>} consume
- * @param {P} permitG
- */
-export const permittedIssuers = async ({ agoricNames }, permitG) => {
-  const permittedKeys = keys(permitG?.issuer?.consume || {});
-  const agoricIssuers = await E(E(agoricNames).lookup('issuer')).entries();
-  /** @type {Record<keyof P['issuer']['produce'], Issuer>} */
-  // @ts-expect-error by construction
-  const issuerKeywordRecord = fromEntries(
-    agoricIssuers.filter(([n, _v]) => permittedKeys.includes(n)),
-  );
-  return issuerKeywordRecord;
-};
-
-/**
- * @template {string} CN contract name
- * @template {ContractStartFunction} SF typeof start
- * @template {CopyRecord} CFG
- * @typedef {ContractMeta & {name: CN} & {
- *   adminRoles?: Record<keyof CFG, keyof StartedInstanceKit<SF>['creatorFacet']>,
- *   deployConfigShape?: TypedPattern<CFG>,
- * }} ContractMetaG
- */
-
-/**
- * @template {ContractStartFunction} SF typeof start
- * @typedef {StartedInstanceKit<SF> & {
- *   label: string,
- *   privateArgs: Parameters<SF>[1];
- * }} UpgradeKit
- *
- */
-
-/**
- * @typedef {BootstrapManifest &
- *   { issuer: BootstrapManifest} &
- *   { brand: BootstrapManifest }
- * } PermitG generic permit constraints
- */
-
-/**
- * @template {string} CN contract name
- * @template {ContractStartFn} SF typeof start
- * @template {PermitG} P permit
- * @typedef { PromiseSpaceOf<Record<`${CN}Kit`, UpgradeKit<SF>>> & {
- *   installation: PromiseSpaceOf<Record<CN, Installation<SF>>>;
- *   instance: PromiseSpaceOf<Record<CN, Instance<SF>>>;
- *   issuer: PromiseSpaceOf<Record<keyof P['issuer']['produce'], Issuer>>;
- *   brand: PromiseSpaceOf<Record<keyof P['brand']['produce'], Brand>>;
- * }} CorePowersG
- */
-
-/**
- * @template {ContractStartFn} SF typeof start
- * @template {CopyRecord} CFG
- * @typedef {(op: OrchestrationPowers, m: Marshaller, cfg: CFG, log: typeof trace) => Parameters<SF>[1]} MakePrivateArgs
- */
-
-/**
- * @throws if admin role smart wallets are not yet provisioned
- *
- * @template {string} CN contract name
- * @template {ContractStartFn} SF typeof start
- * @template {CopyRecord} CFG
- * @template {PermitG} P permit
- * @param {ContractMetaG<CN, SF, CFG>} metaG
- * @param {P} permitG
- * @param {MakePrivateArgs<SF, CFG>} makePrivateArgsG
- * @param {CorePowersG<CN, SF, P> & BootstrapPowers} powers
- * @param {{ options: LegibleCapData<CFG> }} config
- */
-export const startOrchContractG = async (
-  metaG,
-  permitG,
-  makePrivateArgsG,
-  {
-    produce,
-    consume,
-    issuer: { produce: produceIssuer },
-    brand: { produce: produceBrand },
-    installation: {
-      consume: { [metaG.name]: installation },
-    },
-    instance: {
-      produce: { [metaG.name]: produceInstance },
-    },
-  },
-  config,
-) => {
-  trace('startOrchContract');
-
-  const issuerKeywordRecord = await permittedIssuers(consume, permitG);
-
-  const { agoricNames, board } = consume;
-  const xVatContext = await E(E(agoricNames).lookup('brand')).entries();
-  const internalConfig = fromExternalConfig(
-    config.options,
-    xVatContext,
-    metaG.deployConfigShape,
-  );
-  const { terms } = internalConfig;
-  trace('using terms', terms);
-
-  const adminRoles = objectMap(metaG?.adminRoles || {}, (_method, role) => {
-    const nameToAddress = internalConfig[role];
-    mustMatch(nameToAddress, M.recordOf(M.string(), M.string()));
-    return makeAdminRole(
-      /** @type {string} */ (role), // XXX tsc gets confused?
-      consume.namesByAddress,
-      nameToAddress,
-    );
-  });
-
-  await Promise.all(values(adminRoles).map(r => r.lookup()));
-
-  /** @type {{ chainStorage: Promise<StorageNode>}} */
-  // @ts-expect-error Promise<null> case is vestigial
-  const { chainStorage } = consume;
-  const { storageNode, marshaller } = await makePublishingStorageKit(
-    meta.name,
-    { board, chainStorage },
-  );
-
-  const {
-    chainTimerService: timerService,
-    localchain,
-    cosmosInterchainService,
-  } = consume;
-  const orchestrationPowers = await deeplyFulfilledObject(
-    harden({
-      localchain,
-      orchestrationService: cosmosInterchainService,
-      storageNode,
-      timerService,
-      agoricNames,
-    }),
-  );
-  const privateArgs = await makePrivateArgsG(
-    orchestrationPowers,
+    ...orchestrationPowers,
+    feeConfig,
+    poolMetricsNode,
     marshaller,
-    internalConfig,
-    trace,
-  );
-
-  const { startUpgradable, zoe } = consume;
-  const kit = await E(startUpgradable)({
-    label: metaG.name,
-    installation,
-    issuerKeywordRecord,
-    terms,
-    privateArgs,
+    chainInfo,
+    assetInfo,
   });
-  const { instance, creatorFacet } = kit;
-  /** @type {UpgradeKit<SF>} */
-  const fullKit = harden({ ...kit, privateArgs });
-  // @ts-expect-error XXX tsc gets confused?
-  produce[`${metaG.name}Kit`].resolve(fullKit);
-
-  const newIssuerNames = keys(permit?.issuer?.produce || {}).filter(
-    n => permit?.brand?.produce?.[n],
-  );
-  if (newIssuerNames.length > 0) {
-    const { issuers, brands } = await E(zoe).getTerms(instance);
-    for (const name of newIssuerNames) {
-      console.log('new well-known Issuer, Brand:', name);
-      produceIssuer[name].reset();
-      produceIssuer[name].resolve(issuers[name]);
-      produceBrand[name].reset();
-      produceBrand[name].resolve(brands[name]);
-      await publishDisplayInfo(brands[name], { board, chainStorage });
-    }
-  }
-
-  for (const [role, method] of entries(meta.adminRoles)) {
-    await adminRoles[role].send(addr => E(creatorFacet)[method](addr));
-  }
-
-  produceInstance.reset();
-  produceInstance.resolve(instance);
-
-  trace('startOrchContract done', instance);
-  return { config: internalConfig, kit };
 };
-harden(startOrchContractG);
+harden(makePrivateArgs);
 
 /**
- * @throws if admin role smart wallets are not yet provisioned
- *
- * @param {BootstrapPowers & ExtraCorePowers } powers
- * @param {{ options: LegibleCapData<ContractConfig> }} config
+ * @param {BootstrapPowers & CorePowersG<'fastUsdc', FastUsdcSF, typeof permit>} permitted
+ * @param {{ options: LegibleCapData<FastUSDCConfig> }} configStruct
  */
-export const startOrchContract = async (
-  {
-    produce,
-    consume: {
-      agoricNames,
-      namesByAddress,
-      board,
-      chainStorage,
-      chainTimerService: timerService,
-      localchain,
-      cosmosInterchainService,
-      startUpgradable,
-      zoe,
-    },
-    issuer: { produce: produceIssuer },
-    brand: { produce: produceBrand },
-    installation: {
-      consume: { [contractName]: installation },
-    },
-    instance: {
-      produce: { [contractName]: produceInstance },
-    },
-  },
-  config,
-) => {
-  trace('startOrchContract');
-
-  const xVatContext = await E(E(agoricNames).lookup('brand')).entries();
-  const internalConfig = fromExternalConfig(
-    config.options,
-    xVatContext,
-    meta.deployConfigShape,
-  );
-  const { terms } = internalConfig;
-  trace('using terms', terms);
-
-  const adminRoles = objectMap(meta?.adminRoles || {}, (_method, role) => {
-    const nameToAddress = internalConfig[role];
-    mustMatch(nameToAddress, M.recordOf(M.string(), M.string()));
-    return makeAdminRole(role, namesByAddress, nameToAddress);
-  });
-
-  await Promise.all(values(adminRoles).map(r => r.lookup()));
-
-  const { storageNode, marshaller } = await makePublishingStorageKit(
-    contractName,
-    {
-      board,
-      // @ts-expect-error Promise<null> case is vestigial
-      chainStorage,
-    },
+export const startFastUSDC = async (permitted, configStruct) => {
+  const { config, kit } = await startOrchContract(
+    meta,
+    permit,
+    makePrivateArgs,
+    permitted,
+    configStruct,
   );
 
-  const orchestrationPowers = await deeplyFulfilledObject(
-    harden({
-      localchain,
-      orchestrationService: cosmosInterchainService,
-      storageNode,
-      timerService,
-      agoricNames,
-    }),
-  );
-  const privateArgs = await makePrivateArgs(
-    orchestrationPowers,
-    marshaller,
-    internalConfig,
-    trace,
-  );
+  const { storageNode } = kit.privateArgs;
+  const { feedPolicy } = config;
+  const policyNode = E(storageNode).makeChildNode(FEED_POLICY);
+  await E(policyNode).setValue(JSON.stringify(feedPolicy));
 
-  const permittedIssuers = keys(permit?.issuer?.consume || {});
-  const agoricIssuers = await E(E(agoricNames).lookup('issuer')).entries();
-  const issuerKeywordRecord = fromEntries(
-    agoricIssuers.filter(([n, _v]) => permittedIssuers.includes(n)),
-  );
-
-  const kit = await E(startUpgradable)({
-    label: contractName,
-    installation,
-    issuerKeywordRecord,
-    terms,
-    privateArgs,
-  });
-  const { instance, creatorFacet } = kit;
-  /** @type {TheContractKit} */
-  const fullKit = harden({ ...kit, privateArgs });
-  produce[`${contractName}Kit`].resolve(fullKit);
-
-  const newIssuerNames = keys(permit?.issuer?.produce || {}).filter(
-    n => permit?.brand?.produce?.[n],
-  );
-  if (newIssuerNames.length > 0) {
-    const { issuers, brands } = await E(zoe).getTerms(instance);
-    for (const name of newIssuerNames) {
-      console.log('new well-known Issuer, Brand:', name);
-      produceIssuer[name].reset();
-      produceIssuer[name].resolve(issuers[name]);
-      produceBrand[name].reset();
-      produceBrand[name].resolve(brands[name]);
-      await publishDisplayInfo(brands[name], { board, chainStorage });
-    }
+  const { creatorFacet } = kit;
+  const addresses = await E(creatorFacet).publishAddresses();
+  trace('contract orch account addresses', addresses);
+  if (!config.noNoble) {
+    const addr = await E(creatorFacet).connectToNoble();
+    trace('noble intermediate recipient', addr);
   }
-
-  for (const [role, method] of entries(meta.adminRoles)) {
-    await adminRoles[role].send(addr => E(creatorFacet)[method](addr));
-  }
-
-  await finishDeploy(internalConfig, fullKit, trace);
-
-  produceInstance.reset();
-  produceInstance.resolve(instance);
-
-  trace('startOrchContract done', instance);
 };
-harden(startOrchContract);
 
-/**
- * @param {{
- *   restoreRef: (b: ERef<ManifestBundleRef>) => Promise<Installation>;
- * }} utils
- * @param {{
- *   installKeys: Record<TheContractName, ERef<ManifestBundleRef>>;
- *   options: LegibleCapData<ContractConfig>;
- * }} param1
- */
-// TODO: rename to getManifestForOrchContract
-export const getManifestForFastUSDC = (
-  { restoreRef },
-  { installKeys, options },
-) => {
-  return {
-    /** @type {BootstrapManifest} */
-    manifest: { [startOrchContract.name]: permit },
-    installations: { [contractName]: restoreRef(installKeys[contractName]) },
-    options,
-  };
-};
+// XXX hm... we need to preserve the function name.
+export const getManifestForFastUSDC = (u, d) =>
+  makeGetManifest(startFastUSDC, permit, meta.name)(u, d);

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -21,7 +21,7 @@ const { entries, fromEntries, keys, values } = Object; // XXX move up
 
 const trace = makeTracer('FUSD-Start', true);
 
-const contractName = 'fastUsdc';
+const contractName = meta.name;
 
 /**
  * XXX Shouldn't the bridge or board vat handle this?

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -19,9 +19,9 @@ import { meta, permit } from './fast-usdc.contract.meta.js';
 
 const { entries, fromEntries, keys, values } = Object; // XXX move up
 
-const trace = makeTracer('FUSD-Start', true);
-
 const contractName = meta.name;
+
+const trace = makeTracer(`${meta.abbr}-Start`, true);
 
 /**
  * XXX Shouldn't the bridge or board vat handle this?

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -256,10 +256,10 @@ export const startFastUSDC = async (
   produceInstance.reset();
   produceInstance.resolve(instance);
 
-  const addresses = await E(kit.creatorFacet).publishAddresses();
+  const addresses = await E(creatorFacet).publishAddresses();
   trace('contract orch account addresses', addresses);
   if (!net.noNoble) {
-    const addr = await E(kit.creatorFacet).connectToNoble();
+    const addr = await E(creatorFacet).connectToNoble();
     trace('noble intermediate recipient', addr);
   }
   trace('startFastUSDC done', instance);

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -1,24 +1,13 @@
 import { deeplyFulfilledObject, makeTracer, objectMap } from '@agoric/internal';
-import {
-  CosmosChainInfoShape,
-  DenomDetailShape,
-  DenomShape,
-} from '@agoric/orchestration';
 import { Fail } from '@endo/errors';
 import { E } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import { M, mustMatch } from '@endo/patterns';
-import {
-  FastUSDCTermsShape,
-  FeeConfigShape,
-  FeedPolicyShape,
-} from './type-guards.js';
 import { fromExternalConfig } from './utils/config-marshal.js';
 import { meta, permit } from './fast-usdc.contract.meta.js';
 
 /**
  * @import {DepositFacet} from '@agoric/ertp/src/types.js'
- * @import {TypedPattern} from '@agoric/internal'
  * @import {Instance, StartParams} from '@agoric/zoe/src/zoeService/utils'
  * @import {Board} from '@agoric/vats'
  * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
@@ -33,16 +22,6 @@ const { entries, fromEntries, keys, values } = Object; // XXX move up
 const trace = makeTracer('FUSD-Start', true);
 
 const contractName = 'fastUsdc';
-
-/** @type {TypedPattern<FastUSDCConfig>} */
-export const FastUSDCConfigShape = M.splitRecord({
-  terms: FastUSDCTermsShape,
-  oracles: M.recordOf(M.string(), M.string()),
-  feeConfig: FeeConfigShape,
-  feedPolicy: FeedPolicyShape,
-  chainInfo: M.recordOf(M.string(), CosmosChainInfoShape),
-  assetInfo: M.arrayOf([DenomShape, DenomDetailShape]),
-});
 
 /**
  * XXX Shouldn't the bridge or board vat handle this?
@@ -184,7 +163,7 @@ export const startFastUSDC = async (
   const internalConfig = fromExternalConfig(
     config.options,
     xVatContext,
-    FastUSDCConfigShape,
+    meta.deployConfigShape,
   );
   const { terms, feeConfig, feedPolicy, ...net } = internalConfig;
   trace('using terms', terms);

--- a/packages/fast-usdc/src/orch.start.js
+++ b/packages/fast-usdc/src/orch.start.js
@@ -60,7 +60,7 @@ const publishDisplayInfo = async (brand, { board, chainStorage }) => {
 
 /**
  * @param {string} role
- * @param {ERef<BootstrapPowers['consume']['namesByAddress']>} namesByAddress
+ * @param {BootstrapPowers['consume']['namesByAddress']} namesByAddress
  * @param {Record<string, string>} nameToAddress
  */
 const makeAdminRole = (role, namesByAddress, nameToAddress) => {

--- a/packages/fast-usdc/src/orch.start.js
+++ b/packages/fast-usdc/src/orch.start.js
@@ -1,0 +1,356 @@
+import { deeplyFulfilledObject, makeTracer, objectMap } from '@agoric/internal';
+import { Fail } from '@endo/errors';
+import { E } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
+import { M, mustMatch } from '@endo/patterns';
+import { fromExternalConfig } from './utils/config-marshal.js';
+
+/**
+ * @import {CopyRecord} from '@endo/pass-style';
+ * @import {TypedPattern} from '@agoric/internal';
+ * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js'
+ * @import {OrchestrationPowers} from '@agoric/orchestration';
+ * @import {ContractStartFunction, Instance, StartedInstanceKit} from '@agoric/zoe/src/zoeService/utils'
+ * @import {DepositFacet} from '@agoric/ertp/src/types.js'
+ * @import {Board} from '@agoric/vats'
+ * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js'
+ * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
+ * @import {LegibleCapData} from './utils/config-marshal.js'
+ */
+
+const { entries, fromEntries, keys, values } = Object; // XXX move up
+
+const trace = makeTracer(`ORCH-Start`, true);
+
+/**
+ * XXX Shouldn't the bridge or board vat handle this?
+ *
+ * @param {string} path
+ * @param {{
+ *   chainStorage: ERef<StorageNode>;
+ *   board: ERef<Board>;
+ * }} io
+ */
+const makePublishingStorageKit = async (path, { chainStorage, board }) => {
+  const storageNode = await E(chainStorage).makeChildNode(path);
+
+  const marshaller = await E(board).getPublishingMarshaller();
+  return { storageNode, marshaller };
+};
+
+const BOARD_AUX = 'boardAux';
+const marshalData = makeMarshal(_val => Fail`data only`);
+/**
+ * @param {Brand} brand
+ * @param {Pick<BootstrapPowers['consume'], 'board' | 'chainStorage'>} powers
+ */
+const publishDisplayInfo = async (brand, { board, chainStorage }) => {
+  // chainStorage type includes undefined, which doesn't apply here.
+  // @ts-expect-error UNTIL https://github.com/Agoric/agoric-sdk/issues/8247
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  const [id, displayInfo, allegedName] = await Promise.all([
+    E(board).getId(brand),
+    E(brand).getDisplayInfo(),
+    E(brand).getAllegedName(),
+  ]);
+  const node = E(boardAux).makeChildNode(id);
+  const aux = marshalData.toCapData(harden({ allegedName, displayInfo }));
+  await E(node).setValue(JSON.stringify(aux));
+};
+
+/**
+ * @param {string} role
+ * @param {ERef<BootstrapPowers['consume']['namesByAddress']>} namesByAddress
+ * @param {Record<string, string>} nameToAddress
+ */
+const makeAdminRole = (role, namesByAddress, nameToAddress) => {
+  const lookup = async () => {
+    trace('look up deposit facets for', role);
+    return deeplyFulfilledObject(
+      objectMap(nameToAddress, async address => {
+        /** @type {DepositFacet} */
+        const depositFacet = await E(namesByAddress).lookup(
+          address,
+          'depositFacet',
+        );
+        return depositFacet;
+      }),
+    );
+  };
+  const lookupP = lookup();
+
+  return harden({
+    lookup: () => lookupP,
+    /** @param {(addr: string) => Promise<Invitation>} makeInvitation */
+    send: async makeInvitation => {
+      const oracleDepositFacets = await lookupP;
+      await Promise.all(
+        entries(oracleDepositFacets).map(async ([name, depositFacet]) => {
+          const address = nameToAddress[name];
+          trace('making invitation for', role, name, address);
+          const toWatch = await makeInvitation(address);
+
+          const amt = await E(depositFacet).receive(toWatch);
+          trace('sent', amt, 'to', role, name);
+        }),
+      );
+    },
+  });
+};
+
+/**
+ * @template {{}} T
+ * @param {T} obj
+ * @param {<K extends keyof T>(entry: [k: K, v: T[K]], index: number, es: [PropertyKey, unknown][]) => Partial<T>} pred
+ * @returns {Partial<T>}
+ */
+const objectFilter = (obj, pred) => {
+  /** @type {Partial<T>} */
+  // @ts-expect-error pred type too narrow
+  const found = harden(fromEntries(entries(obj).filter(pred)));
+  return found;
+};
+
+/**
+ * @template {PermitG} P
+ * @param {BootstrapPowers['consume']['agoricNames']} agoricNames
+ * @param {P} permitG
+ */
+export const permittedIssuers = async (agoricNames, permitG) => {
+  const permittedKeys = keys(permitG?.issuer?.consume || {});
+  const agoricIssuers = await E(E(agoricNames).lookup('issuer')).entries();
+  /** @type {Record<keyof P['issuer']['produce'], Issuer>} */
+  // @ts-expect-error by construction
+  const issuerKeywordRecord = fromEntries(
+    agoricIssuers.filter(([n, _v]) => permittedKeys.includes(n)),
+  );
+  return issuerKeywordRecord;
+};
+
+/**
+ * @template {string} CN contract name
+ * @template {ContractStartFunction} SF typeof start
+ * @template {CopyRecord} CFG
+ * @typedef {ContractMeta & {name: CN} & {
+ *   adminRoles?: Record<keyof CFG, keyof StartedInstanceKit<SF>['creatorFacet']>,
+ *   deployConfigShape?: TypedPattern<CFG>,
+ * }} ContractMetaG
+ */
+
+/**
+ * @template {ContractStartFunction} SF typeof start
+ * @typedef {StartedInstanceKit<SF> & {
+ *   label: string,
+ *   privateArgs: Parameters<SF>[1];
+ * }} UpgradeKit
+ *
+ */
+
+/**
+ * @typedef {BootstrapManifest &
+ *   { issuer: BootstrapManifest} &
+ *   { brand: BootstrapManifest }
+ * } PermitG generic permit constraints
+ */
+
+/**
+ * @template {string} CN contract name
+ * @template {ContractStartFn} SF typeof start
+ * @template {PermitG} P permit
+ * @typedef { PromiseSpaceOf<Record<`${CN}Kit`, UpgradeKit<SF>>> & {
+ *   installation: PromiseSpaceOf<Record<CN, Installation<SF>>>;
+ *   instance: PromiseSpaceOf<Record<CN, Instance<SF>>>;
+ *   issuer: PromiseSpaceOf<Record<keyof P['issuer']['produce'], Issuer>>;
+ *   brand: PromiseSpaceOf<Record<keyof P['brand']['produce'], Brand>>;
+ * }} CorePowersG
+ */
+
+/**
+ * @template {ContractStartFn} SF typeof start
+ * @template {CopyRecord} CFG
+ * @typedef {(op: OrchestrationPowers, m: Marshaller, cfg: CFG) => Parameters<SF>[1]} MakePrivateArgs
+ */
+
+/**
+ * @throws if admin role smart wallets are not yet provisioned
+ *
+ * @template {string} CN contract name
+ * @template {ContractStartFn} SF typeof start
+ * @template {CopyRecord} CFG
+ * @template {PermitG} P permit
+ * @param {ContractMetaG<CN, SF, CFG>} metaG generic metadata
+ * @param {P} permitG
+ * @param {MakePrivateArgs<SF, CFG>} makePrivateArgs
+ * @param {CorePowersG<CN, SF, P> & BootstrapPowers} powers
+ * @param {{ options: LegibleCapData<CFG> }} configStruct
+ */
+export const startOrchContract = async (
+  metaG,
+  permitG,
+  makePrivateArgs,
+  {
+    produce,
+    consume,
+    issuer: { produce: produceIssuer },
+    brand: { produce: produceBrand },
+    installation: {
+      consume: { [metaG.name]: installation },
+    },
+    instance: {
+      produce: { [metaG.name]: produceInstance },
+    },
+  },
+  configStruct,
+) => {
+  trace('startOrchContract');
+
+  const { agoricNames } = consume;
+  const issuerKeywordRecord = await permittedIssuers(agoricNames, permitG);
+
+  const xVatContext = await E(E(agoricNames).lookup('brand')).entries();
+  const config = fromExternalConfig(
+    configStruct.options,
+    xVatContext,
+    metaG.deployConfigShape,
+  );
+  const { terms } = config;
+  trace('using terms', terms);
+
+  const adminRoles = objectMap(metaG?.adminRoles || {}, (_method, role) => {
+    const nameToAddress = config[role];
+    mustMatch(nameToAddress, M.recordOf(M.string(), M.string()));
+    return makeAdminRole(
+      /** @type {string} */ (role), // XXX tsc gets confused?
+      consume.namesByAddress,
+      nameToAddress,
+    );
+  });
+
+  await Promise.all(values(adminRoles).map(r => r.lookup()));
+
+  /** @type {{ chainStorage: Promise<StorageNode>}} */
+  // @ts-expect-error Promise<null> case is vestigial
+  const { chainStorage, board } = consume;
+  const { storageNode, marshaller } = await makePublishingStorageKit(
+    metaG.name,
+    { board, chainStorage },
+  );
+
+  const {
+    chainTimerService: timerService,
+    localchain,
+    cosmosInterchainService,
+  } = consume;
+  const orchestrationPowers = await deeplyFulfilledObject(
+    harden({
+      localchain,
+      orchestrationService: cosmosInterchainService,
+      storageNode,
+      timerService,
+      agoricNames,
+    }),
+  );
+  const privateArgs = await makePrivateArgs(
+    orchestrationPowers,
+    marshaller,
+    config,
+  );
+
+  const { startUpgradable, zoe } = consume;
+  const kit = await E(startUpgradable)({
+    label: metaG.name,
+    installation,
+    issuerKeywordRecord,
+    terms,
+    privateArgs,
+  });
+  const { instance, creatorFacet } = kit;
+  /** @type {UpgradeKit<SF>} */
+  const fullKit = harden({ ...kit, privateArgs });
+  // @ts-expect-error XXX tsc gets confused?
+  produce[`${metaG.name}Kit`].resolve(fullKit);
+
+  const newIssuerNames = keys(permitG?.issuer?.produce || {}).filter(
+    n => permitG?.brand?.produce?.[n],
+  );
+  if (newIssuerNames.length > 0) {
+    const { issuers, brands } = await E(zoe).getTerms(instance);
+    for (const name of newIssuerNames) {
+      console.log('new well-known Issuer, Brand:', name);
+      produceIssuer[name].reset();
+      produceIssuer[name].resolve(issuers[name]);
+      produceBrand[name].reset();
+      produceBrand[name].resolve(brands[name]);
+      await publishDisplayInfo(brands[name], { board, chainStorage });
+    }
+  }
+
+  for (const [role, method] of entries(metaG.adminRoles || {})) {
+    await adminRoles[role].send(addr => E(creatorFacet)[method](addr));
+  }
+
+  produceInstance.reset();
+  produceInstance.resolve(instance);
+
+  trace('startOrchContract done', instance);
+  return { config, kit: fullKit };
+};
+harden(startOrchContract);
+
+/** @satisfies {BootstrapManifestPermit} */
+export const orchPermit = /** @type {const} */ ({
+  localchain: true,
+  cosmosInterchainService: true,
+  chainStorage: true,
+  chainTimerService: true,
+  agoricNames: true,
+
+  // for publishing Brands and other remote object references
+  board: true,
+
+  // limited distribution durin MN2: contract installation
+  startUpgradable: true,
+  zoe: true, // only getTerms() is needed. XXX should be split?
+});
+harden(orchPermit);
+
+/**
+ * to find deposit facets for admin invitations
+ *
+ * @satisfies {BootstrapManifestPermit}
+ */
+export const adminPermit = /** @type {const} */ ({
+  namesByAddress: true,
+});
+harden(adminPermit);
+
+/**
+ * @template {CopyRecord} CFG
+ * @template {PermitG} P permit
+ *
+ * @param {Function} startFn
+ * @param {P} permit
+ * @param {string} contractName
+ */
+export const makeGetManifest = (startFn, permit, contractName) => {
+  /**
+   * @param {{
+   *   restoreRef: (b: ERef<ManifestBundleRef>) => Promise<Installation>;
+   * }} utils
+   * @param {{
+   *   installKeys: { fastUsdc: ERef<ManifestBundleRef> };
+   *   options: LegibleCapData<CFG>;
+   * }} data
+   */
+  const getManifestForFastOrch = ({ restoreRef }, { installKeys, options }) => {
+    return {
+      /** @satisfies {BootstrapManifest} */
+      manifest: { [startFn.name]: permit },
+      installations: { [contractName]: restoreRef(installKeys[contractName]) },
+      options,
+    };
+  };
+  harden(getManifestForFastOrch);
+
+  return getManifestForFastOrch;
+};

--- a/packages/fast-usdc/src/orch.start.js
+++ b/packages/fast-usdc/src/orch.start.js
@@ -99,19 +99,6 @@ const makeAdminRole = (role, namesByAddress, nameToAddress) => {
 };
 
 /**
- * @template {{}} T
- * @param {T} obj
- * @param {<K extends keyof T>(entry: [k: K, v: T[K]], index: number, es: [PropertyKey, unknown][]) => Partial<T>} pred
- * @returns {Partial<T>}
- */
-const objectFilter = (obj, pred) => {
-  /** @type {Partial<T>} */
-  // @ts-expect-error pred type too narrow
-  const found = harden(fromEntries(entries(obj).filter(pred)));
-  return found;
-};
-
-/**
  * @template {PermitG} P
  * @param {BootstrapPowers['consume']['agoricNames']} agoricNames
  * @param {P} permitG


### PR DESCRIPTION
refs:
 - https://github.com/Agoric/agoric-sdk/discussions/9717
 - https://github.com/Agoric/dapp-agoric-basics/pull/48
 - https://github.com/agoric-labs/ag-power-tools/issues/14
 - https://github.com/Agoric/agoric-sdk/issues/8594
 - https://github.com/Agoric/agoric-sdk/issues/8378

## Description

Drive most of the core-eval code from `ContractMeta` and `permit`.

 - generic Issuer / Brand handling
   - issuerKeywordRecord: derive from `permit.issuer.consume`
   - issuer / brand publishing: drive from `permit.issuer.produce`
   - extra BootstrapPowers: derive from `meta.name`, `permit.issuer.produce`, `permit.brand.produce`
 - `meta.adminRoles` generalizes sending oracle invitations
 - ContractMeta: move to a new .meta file so both contract and core-eval can get it without swallowing the other whole
   - likewise: FastUSDCConfigShape -> meta.deployConfigShape
   - contractName = meta.name
 - permit: move to fast-usdc.meta file to separate it from orch.start code
   - factor out typical permit stuff: `orchPermit`, 
 - `makePrivateArgs()` remains custom code, though only for stuff beyond `orchestrationPowers`
 - `finishDeploy()` remains custom code: for `publishFeedPolicy` and calling `creatorFacet` methods

permit is down to ~15 LOC:
https://github.com/Agoric/agoric-sdk/blob/151c868b83c653e2db9d1eae7beb5aa896d7def8/packages/fast-usdc/src/fast-usdc.contract.meta.js#L84-L98

In order to keep it type-safe, `meta` and `permit` are imported. Maybe there's a way to parameterize the types or something so that the custom code can call the boilerplate. hm.

DRAFT until:
 - [ ] rebase on master (I started this while reviewing #10692)
 - [ ] rename `fast-usdc.start.js` to `orch.start.js` and update builders, boot tests

### Security Considerations

This contributes somewhat to...

 - https://github.com/Agoric/agoric-sdk/issues/8594
 - https://github.com/Agoric/agoric-sdk/issues/8378

### Scaling Considerations

n/a

### Documentation Considerations

should simplify [Writing a Core Eval Script to Deploy a Contract](https://docs.agoric.com/guides/coreeval/proposal.html#writing-a-core-eval-script-to-deploy-a-contract)

### Testing Considerations

For Fast USDC, existing tests should do it. It's essentially a pure refactor, but some of the filenames have runtime impact in builders and such, so it's possible that the changes are visible from tests.

### Upgrade Considerations

This could / should make it less likely to mess up saving admin facets.
