### PR TITLE
feat: add an accessor for the vaultDirector's parameters

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -325,6 +325,7 @@ const prepareVaultDirector = (
         getGovernedParams: M.callWhen({ collateralBrand: BrandShape }).returns(
           M.record(),
         ),
+        getDirectorGovernedParams: M.call().returns(M.promise()),
         getInvitationAmount: M.call(M.string()).returns(AmountShape),
         getPublicTopics: M.call().returns(TopicsRecordShape),
       }),
@@ -492,13 +493,16 @@ const prepareVaultDirector = (
         },
         /**
          * Note this works only for a collateral manager. For the director use,
-         * `getElectorateSubscription`
+         * `getDirectorGovernedParams`
          *
          * @param {{ collateralBrand: Brand }} selector
          */
         getGovernedParams({ collateralBrand }) {
           // TODO use named getters of TypedParamManager
           return vaultParamManagers.get(collateralBrand).getParams();
+        },
+        getDirectorGovernedParams() {
+          return directorParamManager.getParams();
         },
         /** @param {string} name */
         getInvitationAmount(name) {

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -2049,4 +2049,39 @@ test('governance publisher', async t => {
     LiquidationPenalty: { type: 'ratio' },
     MintFee: { type: 'ratio' },
   });
+
+  const params = await E(vfPublic).getDirectorGovernedParams();
+  t.like(params, {
+    ChargingPeriod: { type: 'nat', value: 2n },
+    Electorate: { type: 'invitation' },
+    MinInitialDebt: { type: 'amount' },
+    RecordingPeriod: { type: 'nat' },
+    ReferencedUI: { value: 'abracadabra' },
+    ShortfallInvitation: { type: 'invitation' },
+  });
+});
+
+test('access to director params', async t => {
+  const { aeth } = t.context;
+
+  t.context.referencedUi = 'hocus pocus';
+  const services = await setupServices(
+    t,
+    [500n, 15n],
+    aeth.make(900n),
+    undefined,
+    undefined,
+    500n,
+  );
+  const { vfPublic } = services.vaultFactory;
+
+  const params = await E(vfPublic).getDirectorGovernedParams();
+  t.like(params, {
+    ChargingPeriod: { type: 'nat', value: 2n },
+    Electorate: { type: 'invitation' },
+    MinInitialDebt: { type: 'amount' },
+    RecordingPeriod: { type: 'nat' },
+    ReferencedUI: { value: 'hocus pocus' },
+    ShortfallInvitation: { type: 'invitation' },
+  });
 });


### PR DESCRIPTION
closes: #10094

## Description

Add a direct way to retrieve the governed parameters from the vaultDirector

### Security Considerations

This was already accessible (and intended to be public) via vstorage. It just adds a direct way to request the values when you have the vaultFactory publicFacet.

### Scaling Considerations

No effect.

### Documentation Considerations
No change

### Testing Considerations

Added a Unit test.

### Upgrade Considerations
The purpose was to simplify retrieving the previous values for upgrade.