### PR TITLE
record transaction fees

### DIFF
--- a/packages/fast-usdc/src/exos/settler.js
+++ b/packages/fast-usdc/src/exos/settler.js
@@ -260,7 +260,7 @@ export const prepareSettler = (
           repayer.repay(settlingSeat, split);
 
           // update status manager, marking tx `SETTLED`
-          statusManager.disbursed(txHash);
+          statusManager.disbursed(txHash, split);
         },
         /**
          * @param {EvmHash} txHash

--- a/packages/fast-usdc/src/exos/status-manager.js
+++ b/packages/fast-usdc/src/exos/status-manager.js
@@ -1,5 +1,6 @@
 import { makeTracer } from '@agoric/internal';
 import { appendToStoredArray } from '@agoric/store/src/stores/store-utils.js';
+import { AmountKeywordRecordShape } from '@agoric/zoe/src/typeGuards.js';
 import { Fail, makeError, q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { M } from '@endo/patterns';
@@ -209,7 +210,9 @@ export const prepareStatusManager = (
           M.undefined(),
         ),
       ),
-      disbursed: M.call(EvmHashShape).returns(M.undefined()),
+      disbursed: M.call(EvmHashShape, AmountKeywordRecordShape).returns(
+        M.undefined(),
+      ),
       forwarded: M.call(M.opt(EvmHashShape), M.string(), M.nat()).returns(
         M.undefined(),
       ),
@@ -310,9 +313,13 @@ export const prepareStatusManager = (
        * Mark a transaction as `DISBURSED`
        *
        * @param {EvmHash} txHash
+       * @param {import('./liquidity-pool.js').RepayAmountKWR} split
        */
-      disbursed(txHash) {
-        void publishTxnRecord(txHash, harden({ status: TxStatus.Disbursed }));
+      disbursed(txHash, split) {
+        void publishTxnRecord(
+          txHash,
+          harden({ split, status: TxStatus.Disbursed }),
+        );
       },
 
       /**

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -112,6 +112,7 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
   const statusManager = prepareStatusManager(
     zone,
     E(storageNode).makeChildNode(TXNS_NODE),
+    { marshaller },
   );
 
   const { USDC } = terms.brands;

--- a/packages/fast-usdc/src/types.ts
+++ b/packages/fast-usdc/src/types.ts
@@ -9,6 +9,7 @@ import type { Amount } from '@agoric/ertp';
 import type { CopyRecord, Passable } from '@endo/pass-style';
 import type { PendingTxStatus, TxStatus } from './constants.js';
 import type { FastUsdcTerms } from './fast-usdc.contract.js';
+import type { RepayAmountKWR } from './exos/liquidity-pool.js';
 
 export type EvmHash = `0x${string}`;
 export type EvmAddress = `0x${string & { length: 40 }}`;
@@ -40,6 +41,7 @@ export interface CctpTxEvidence {
  */
 export interface TransactionRecord extends CopyRecord {
   evidence?: CctpTxEvidence;
+  split?: RepayAmountKWR;
   status: TxStatus;
 }
 

--- a/packages/fast-usdc/test/exos/advancer.test.ts
+++ b/packages/fast-usdc/test/exos/advancer.test.ts
@@ -12,6 +12,7 @@ import { type ZoeTools } from '@agoric/orchestration/src/utils/zoe-tools.js';
 import { q } from '@endo/errors';
 import { Far } from '@endo/pass-style';
 import type { TestFn } from 'ava';
+import { makeTracer } from '@agoric/internal';
 import { PendingTxStatus } from '../../src/constants.js';
 import { prepareAdvancer } from '../../src/exos/advancer.js';
 import type { SettlerKit } from '../../src/exos/settler.js';
@@ -25,6 +26,8 @@ import {
   prepareMockOrchAccounts,
 } from '../mocks.js';
 import { commonSetup } from '../supports.js';
+
+const trace = makeTracer('AdvancerTest', false);
 
 const LOCAL_DENOM = `ibc/${denomHash({
   denom: 'uusdc',
@@ -74,7 +77,7 @@ const createTestExtensions = (t, common: CommonSetup) => {
   };
   const mockZoeTools = Far('MockZoeTools', {
     localTransfer(...args: Parameters<ZoeTools['localTransfer']>) {
-      console.log('ZoeTools.localTransfer called with', args);
+      trace('ZoeTools.localTransfer called with', args);
       return localTransferVK.vow;
     },
   });
@@ -99,7 +102,7 @@ const createTestExtensions = (t, common: CommonSetup) => {
   const notifyAdvancingResultCalls: NotifyArgs[] = [];
   const mockNotifyF = Far('Settler Notify Facet', {
     notifyAdvancingResult: (...args: NotifyArgs) => {
-      console.log('Settler.notifyAdvancingResult called with', args);
+      trace('Settler.notifyAdvancingResult called with', args);
       notifyAdvancingResultCalls.push(args);
     },
   });

--- a/packages/fast-usdc/test/exos/advancer.test.ts
+++ b/packages/fast-usdc/test/exos/advancer.test.ts
@@ -53,6 +53,7 @@ const createTestExtensions = (t, common: CommonSetup) => {
   const statusManager = prepareStatusManager(
     rootZone.subZone('status-manager'),
     storageNode.makeChildNode('txns'),
+    { marshaller: common.commonPrivateArgs.marshaller },
   );
 
   const mockAccounts = prepareMockOrchAccounts(rootZone.subZone('accounts'), {
@@ -170,7 +171,7 @@ test.beforeEach(async t => {
 test('updates status to ADVANCING in happy path', async t => {
   const {
     extensions: {
-      services: { advancer, feeTools, statusManager },
+      services: { advancer, feeTools },
       helpers: { inspectLogs, inspectNotifyCalls },
       mocks: { mockPoolAccount, resolveLocalTransferV },
     },
@@ -238,7 +239,7 @@ test('updates status to OBSERVED on insufficient pool funds', async t => {
     brands: { usdc },
     bootstrap: { storage },
     extensions: {
-      services: { makeAdvancer, statusManager },
+      services: { makeAdvancer },
       helpers: { inspectLogs },
       mocks: { mockPoolAccount, mockNotifyF },
     },
@@ -286,13 +287,14 @@ test('updates status to OBSERVED if makeChainAddress fails', async t => {
   const {
     bootstrap: { storage },
     extensions: {
-      services: { advancer, statusManager },
+      services: { advancer },
       helpers: { inspectLogs },
     },
   } = t.context;
 
   const evidence = MockCctpTxEvidences.AGORIC_UNKNOWN_EUD();
   await advancer.handleTransactionEvent(evidence);
+  await eventLoopIteration();
 
   t.deepEqual(
     storage.getDeserialized(`fun.txns.${evidence.txHash}`),
@@ -313,7 +315,7 @@ test('calls notifyAdvancingResult (AdvancedFailed) on failed transfer', async t 
   const {
     bootstrap: { storage },
     extensions: {
-      services: { advancer, feeTools, statusManager },
+      services: { advancer, feeTools },
       helpers: { inspectLogs, inspectNotifyCalls },
       mocks: { mockPoolAccount, resolveLocalTransferV },
     },
@@ -366,7 +368,7 @@ test('updates status to OBSERVED if pre-condition checks fail', async t => {
   const {
     bootstrap: { storage },
     extensions: {
-      services: { advancer, statusManager },
+      services: { advancer },
       helpers: { inspectLogs },
     },
   } = t.context;
@@ -374,6 +376,7 @@ test('updates status to OBSERVED if pre-condition checks fail', async t => {
   const evidence = MockCctpTxEvidences.AGORIC_NO_PARAMS();
 
   await advancer.handleTransactionEvent(evidence);
+  await eventLoopIteration();
 
   t.deepEqual(
     storage.getDeserialized(`fun.txns.${evidence.txHash}`),

--- a/packages/fast-usdc/test/exos/settler.test.ts
+++ b/packages/fast-usdc/test/exos/settler.test.ts
@@ -4,6 +4,7 @@ import type { TestFn } from 'ava';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import type { Zone } from '@agoric/zone';
+import { defaultMarshaller } from '@agoric/internal/src/storage-test-utils.js';
 import { PendingTxStatus } from '../../src/constants.js';
 import { prepareSettler } from '../../src/exos/settler.js';
 import { prepareStatusManager } from '../../src/exos/status-manager.js';
@@ -48,7 +49,7 @@ const makeTestContext = async t => {
   const statusManager = prepareStatusManager(
     zone.subZone('status-manager'),
     common.commonPrivateArgs.storageNode.makeChildNode('txns'),
-    { log },
+    { marshaller: defaultMarshaller, log },
   );
   const { zcf, callLog } = mockZcf(zone.subZone('Mock ZCF'));
 
@@ -239,7 +240,7 @@ test('happy path: disburse to LPs; StatusManager removes tx', async t => {
     { evidence: cctpTxEvidence, status: 'OBSERVED' },
     { status: 'ADVANCING' },
     { status: 'ADVANCED' },
-    { status: 'DISBURSED' },
+    { split: expectedSplit, status: 'DISBURSED' },
   ]);
 
   // Check deletion of DISBURSED transactions

--- a/packages/fast-usdc/test/supports.ts
+++ b/packages/fast-usdc/test/supports.ts
@@ -1,7 +1,6 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import {
-  defaultMarshaller,
   defaultSerializer,
   makeFakeStorageKit,
 } from '@agoric/internal/src/storage-test-utils.js';
@@ -28,10 +27,7 @@ import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
 import { prepareLocalChainTools } from '@agoric/vats/src/localchain.js';
 import { prepareTransferTools } from '@agoric/vats/src/transfer.js';
 import { makeFakeBankManagerKit } from '@agoric/vats/tools/bank-utils.js';
-import {
-  makeFakeBoard,
-  pureDataMarshaller,
-} from '@agoric/vats/tools/board-utils.js';
+import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import {
   makeFakeLocalchainBridge,
   makeFakeTransferBridge,
@@ -44,7 +40,6 @@ import { makeHeapZone, type Zone } from '@agoric/zone';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { E } from '@endo/far';
 import type { ExecutionContext } from 'ava';
-import type { PureData } from '@endo/pass-style';
 import { makeTestFeeConfig } from './mocks.js';
 
 export {
@@ -156,7 +151,7 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
     transfer: transferMiddleware,
   });
   const timer = buildZoeManualTimer(t.log);
-  const marshaller = makeFakeBoard().getReadonlyMarshaller();
+  const marshaller = makeFakeBoard().getPublishingMarshaller();
   const storage = makeFakeStorageKit(
     'fun', // Fast USDC Node
   );

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -209,7 +209,9 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
    */
   const getValues = path => {
     assert(resolvedOptions.sequence);
-    const wrapper = JSON.parse(data.get(path));
+    const nodeData = data.get(path);
+    assert(nodeData, `no data at path ${path}`);
+    const wrapper = JSON.parse(nodeData);
     return wrapper.values;
   };
 


### PR DESCRIPTION
closes: #10578

## Description

Adds the fee `split` to the Disbursed status of TransactionRecord.

Also updates tests to have a marshaller that is capable of marshaling brands in the split.


### Security Considerations
Gives a read-only marshaller to StatusManager.

### Scaling Considerations
a little more data recorded on disbursement. Since that's a terminal state it will be retained until the GC action is run in a core-eval (or we are able to delete upon completion)

### Documentation Considerations
updated types

### Testing Considerations
CI

### Upgrade Considerations
not deployed