### PR TITLE
Operator attestation policy

### DIFF
--- a/packages/fast-usdc/src/exos/operator-kit.js
+++ b/packages/fast-usdc/src/exos/operator-kit.js
@@ -12,7 +12,7 @@ const trace = makeTracer('TxOperator');
 
 /**
  * @typedef {object} OperatorPowers
- * @property {(evidence: CctpTxEvidence, operatorKit: OperatorKit) => void} attest
+ * @property {(evidence: CctpTxEvidence, operatorId: string) => void} attest
  */
 
 /**
@@ -103,7 +103,7 @@ export const prepareOperatorKit = (zone, staticPowers) =>
         submitEvidence(evidence) {
           const { state } = this;
           !state.disabled || Fail`submitEvidence for disabled operator`;
-          state.powers.attest(evidence, this.facets);
+          state.powers.attest(evidence, state.operatorId);
         },
         /** @returns {OperatorStatus} */
         getStatus() {

--- a/packages/fast-usdc/src/exos/operator-kit.js
+++ b/packages/fast-usdc/src/exos/operator-kit.js
@@ -35,7 +35,7 @@ const OperatorKitI = {
   }),
 
   operator: M.interface('Operator', {
-    submitEvidence: M.call(CctpTxEvidenceShape).returns(M.promise()),
+    submitEvidence: M.call(CctpTxEvidenceShape).returns(),
     getStatus: M.call().returns(M.record()),
   }),
 };
@@ -87,7 +87,7 @@ export const prepareOperatorKit = (zone, staticPowers) =>
           const { operator } = this.facets;
           // TODO(bootstrap integration): cause this call to throw and confirm that it
           // shows up in the the smart-wallet UpdateRecord `error` property
-          await operator.submitEvidence(evidence);
+          operator.submitEvidence(evidence);
           return staticPowers.makeInertInvitation(
             'evidence was pushed in the invitation maker call',
           );
@@ -98,12 +98,12 @@ export const prepareOperatorKit = (zone, staticPowers) =>
          * submit evidence from this operator
          *
          * @param {CctpTxEvidence} evidence
+         * @returns {void}
          */
-        async submitEvidence(evidence) {
+        submitEvidence(evidence) {
           const { state } = this;
           !state.disabled || Fail`submitEvidence for disabled operator`;
-          const result = state.powers.attest(evidence, this.facets);
-          return result;
+          state.powers.attest(evidence, this.facets);
         },
         /** @returns {OperatorStatus} */
         getStatus() {

--- a/packages/fast-usdc/src/exos/operator-kit.js
+++ b/packages/fast-usdc/src/exos/operator-kit.js
@@ -12,7 +12,7 @@ const trace = makeTracer('TxOperator');
 
 /**
  * @typedef {object} OperatorPowers
- * @property {(evidence: CctpTxEvidence, operatorKit: OperatorKit) => void} submitEvidence
+ * @property {(evidence: CctpTxEvidence, operatorKit: OperatorKit) => void} attest
  */
 
 /**
@@ -102,7 +102,7 @@ export const prepareOperatorKit = (zone, staticPowers) =>
         async submitEvidence(evidence) {
           const { state } = this;
           !state.disabled || Fail`submitEvidence for disabled operator`;
-          const result = state.powers.submitEvidence(evidence, this.facets);
+          const result = state.powers.attest(evidence, this.facets);
           return result;
         },
         /** @returns {OperatorStatus} */

--- a/packages/fast-usdc/src/exos/transaction-feed.js
+++ b/packages/fast-usdc/src/exos/transaction-feed.js
@@ -18,7 +18,7 @@ export const INVITATION_MAKERS_DESC = 'oracle operator invitation';
 
 const TransactionFeedKitI = harden({
   operatorPowers: M.interface('Transaction Feed Admin', {
-    submitEvidence: M.call(CctpTxEvidenceShape, M.any()).returns(),
+    attest: M.call(CctpTxEvidenceShape, M.any()).returns(),
   }),
   creator: M.interface('Transaction Feed Creator', {
     // TODO narrow the return shape to OperatorKit
@@ -118,10 +118,12 @@ export const prepareTransactionFeedKit = (zone, zcf) => {
         /**
          * Add evidence from an operator.
          *
+         * NB: the operatorKit is responsible for
+         *
          * @param {CctpTxEvidence} evidence
          * @param {OperatorKit} operatorKit
          */
-        submitEvidence(evidence, operatorKit) {
+        attest(evidence, operatorKit) {
           const { pending } = this.state;
           trace(
             'submitEvidence',

--- a/packages/fast-usdc/src/exos/transaction-feed.js
+++ b/packages/fast-usdc/src/exos/transaction-feed.js
@@ -18,7 +18,7 @@ export const INVITATION_MAKERS_DESC = 'oracle operator invitation';
 
 const TransactionFeedKitI = harden({
   operatorPowers: M.interface('Transaction Feed Admin', {
-    attest: M.call(CctpTxEvidenceShape, M.any()).returns(),
+    attest: M.call(CctpTxEvidenceShape, M.string()).returns(),
   }),
   creator: M.interface('Transaction Feed Creator', {
     // TODO narrow the return shape to OperatorKit
@@ -121,21 +121,11 @@ export const prepareTransactionFeedKit = (zone, zcf) => {
          * NB: the operatorKit is responsible for
          *
          * @param {CctpTxEvidence} evidence
-         * @param {OperatorKit} operatorKit
+         * @param {string} operatorId
          */
-        attest(evidence, operatorKit) {
+        attest(evidence, operatorId) {
           const { pending } = this.state;
-          trace(
-            'submitEvidence',
-            operatorKit.operator.getStatus().operatorId,
-            evidence,
-          );
-          const { operatorId } = operatorKit.operator.getStatus();
-
-          // TODO should this verify that the operator is one made by this exo?
-          // This doesn't work...
-          // operatorKit === operators.get(operatorId) ||
-          //   Fail`operatorKit mismatch`;
+          trace('submitEvidence', operatorId, evidence);
 
           // TODO validate that it's a valid for Fast USDC before accepting
           // E.g. that the `recipientAddress` is the FU settlement account and that

--- a/packages/fast-usdc/src/exos/transaction-feed.js
+++ b/packages/fast-usdc/src/exos/transaction-feed.js
@@ -1,6 +1,7 @@
 import { makeTracer } from '@agoric/internal';
 import { prepareDurablePublishKit } from '@agoric/notifier';
-import { M } from '@endo/patterns';
+import { keyEQ, M } from '@endo/patterns';
+import { Fail } from '@endo/errors';
 import { CctpTxEvidenceShape } from '../type-guards.js';
 import { defineInertInvitation } from '../utils/zoe.js';
 import { prepareOperatorKit } from './operator-kit.js';
@@ -127,6 +128,7 @@ export const prepareTransactionFeedKit = (zone, zcf) => {
           const { operators, pending } = this.state;
           trace('submitEvidence', operatorId, evidence);
 
+          // TODO https://github.com/Agoric/agoric-sdk/pull/10720
           // TODO validate that it's a valid for Fast USDC before accepting
           // E.g. that the `recipientAddress` is the FU settlement account and that
           // the EUD is a chain supported by FU.
@@ -160,7 +162,26 @@ export const prepareTransactionFeedKit = (zone, zcf) => {
             return;
           }
 
-          // TODO verify that all found deep equal
+          let lastEvidence;
+          for (const store of found) {
+            const next = store.get(txHash);
+            if (lastEvidence) {
+              if (keyEQ(lastEvidence, next)) {
+                lastEvidence = next;
+              } else {
+                trace(
+                  '🚨 conflicting evidence for',
+                  txHash,
+                  ':',
+                  lastEvidence,
+                  '!=',
+                  next,
+                );
+                Fail`conflicting evidence for ${txHash}`;
+              }
+            }
+            lastEvidence = next;
+          }
 
           // sufficient agreement, so remove from pending and publish
           for (const store of found) {

--- a/packages/fast-usdc/src/utils/deploy-config.js
+++ b/packages/fast-usdc/src/utils/deploy-config.js
@@ -156,3 +156,11 @@ export const configurations = {
   },
 };
 harden(configurations);
+
+// Constraints on the configurations
+const MAINNET_EXPECTED_ORACLES = 3;
+assert(
+  new Set(Object.values(configurations.MAINNET.oracles)).size ===
+    MAINNET_EXPECTED_ORACLES,
+  `Mainnet must have exactly ${MAINNET_EXPECTED_ORACLES} oracles`,
+);

--- a/packages/fast-usdc/test/exos/transaction-feed.test.ts
+++ b/packages/fast-usdc/test/exos/transaction-feed.test.ts
@@ -89,19 +89,3 @@ test('disabled operator', async t => {
     message: 'submitEvidence for disabled operator',
   });
 });
-
-// TODO: find a way to get this working
-test.skip('forged source', async t => {
-  const feedKit = makeFeedKit();
-  const { op1 } = await makeOperators(feedKit);
-  const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO();
-
-  // op1 is different than the facets object the evidence must come from
-  t.throws(() =>
-    feedKit.operatorPowers.attest(
-      evidence,
-      // @ts-expect-error XXX Types of property '[GET_INTERFACE_GUARD]' are incompatible.
-      op1,
-    ),
-  );
-});

--- a/packages/fast-usdc/test/exos/transaction-feed.test.ts
+++ b/packages/fast-usdc/test/exos/transaction-feed.test.ts
@@ -102,7 +102,7 @@ test.skip('forged source', async t => {
 
   // op1 is different than the facets object the evidence must come from
   t.throws(() =>
-    feedKit.operatorPowers.submitEvidence(
+    feedKit.operatorPowers.attest(
       evidence,
       // @ts-expect-error XXX Types of property '[GET_INTERFACE_GUARD]' are incompatible.
       op1,

--- a/packages/fast-usdc/test/exos/transaction-feed.test.ts
+++ b/packages/fast-usdc/test/exos/transaction-feed.test.ts
@@ -79,6 +79,21 @@ test('happy aggregation', async t => {
   });
 });
 
+test('disabled operator', async t => {
+  const feedKit = makeFeedKit();
+  const { op1 } = await makeOperators(feedKit);
+  const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO();
+
+  // works before disabling
+  await op1.operator.submitEvidence(evidence);
+
+  op1.admin.disable();
+
+  await t.throwsAsync(() => op1.operator.submitEvidence(evidence), {
+    message: 'submitEvidence for disabled operator',
+  });
+});
+
 // TODO: find a way to get this working
 test.skip('forged source', async t => {
   const feedKit = makeFeedKit();

--- a/packages/fast-usdc/test/exos/transaction-feed.test.ts
+++ b/packages/fast-usdc/test/exos/transaction-feed.test.ts
@@ -48,12 +48,9 @@ test('happy aggregation', async t => {
 
   const { op1, op2, op3 } = await makeOperators(feedKit);
   const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO();
-  const results = await Promise.all([
-    op1.operator.submitEvidence(evidence),
-    op2.operator.submitEvidence(evidence),
-    op3.operator.submitEvidence(evidence),
-  ]);
-  t.deepEqual(results, [undefined, undefined, undefined]);
+  op1.operator.submitEvidence(evidence);
+  op2.operator.submitEvidence(evidence);
+  op3.operator.submitEvidence(evidence);
 
   const accepted = await evidenceSubscriber.getUpdateSince(0);
   t.deepEqual(accepted, {
@@ -62,18 +59,17 @@ test('happy aggregation', async t => {
   });
 
   // verify that it doesn't publish until three match
-  await Promise.all([
-    // once it publishes, it doesn't remember that it already saw these
-    op1.operator.submitEvidence(evidence),
-    op2.operator.submitEvidence(evidence),
-    // but this time the third is different
-    op3.operator.submitEvidence(MockCctpTxEvidences.AGORIC_PLUS_DYDX()),
-  ]);
+  // once it publishes, it doesn't remember that it already saw these
+  op1.operator.submitEvidence(evidence);
+  op2.operator.submitEvidence(evidence);
+  // but this time the third is different
+  op3.operator.submitEvidence(MockCctpTxEvidences.AGORIC_PLUS_DYDX());
+
   t.like(await evidenceSubscriber.getUpdateSince(0), {
     // Update count is still 1
     updateCount: 1n,
   });
-  await op3.operator.submitEvidence(evidence);
+  op3.operator.submitEvidence(evidence);
   t.like(await evidenceSubscriber.getUpdateSince(0), {
     updateCount: 2n,
   });
@@ -85,11 +81,11 @@ test('disabled operator', async t => {
   const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO();
 
   // works before disabling
-  await op1.operator.submitEvidence(evidence);
+  op1.operator.submitEvidence(evidence);
 
   op1.admin.disable();
 
-  await t.throwsAsync(() => op1.operator.submitEvidence(evidence), {
+  t.throws(() => op1.operator.submitEvidence(evidence), {
     message: 'submitEvidence for disabled operator',
   });
 });


### PR DESCRIPTION
TODO in code

## Description
Update `TransactionFeed` to publish when a majority of operators to attest (previous required unanimous). Conflicts log a loud error and don't publish.

Also updates the contract test to have 3 operators (per Mainnet policy) and rely on unit tests for the other values.

### Security Considerations

Adds assertions to the deploy-config to help ensure that Mainnet has three unique operators, per security policy.

### Scaling Considerations
Each new attestation iterates over three stores for matching values.

### Documentation Considerations
Nothing end-user. OCW is documented elsewhere.

### Testing Considerations
CI

### Upgrade Considerations
not yet deployed.

contract is upgradable but changing the settlementAccountAddress will require creating a new TransactionFeed (as is the case for the Settler object.