### PR TITLE
Turn on test of priceAuthority registry

### DIFF
--- a/a3p-integration/proposals/p:upgrade-19/test.sh
+++ b/a3p-integration/proposals/p:upgrade-19/test.sh
@@ -8,3 +8,5 @@ yarn ava provisionPool.test.js
 yarn ava agoricNames.test.js
 
 yarn ava assetReserve.test.js
+
+yarn ava registry.test.js


### PR DESCRIPTION
closes: #10727

## Description

Add the existing test `registry-test.js` to `test.sh` so it actually runs. The test already passes.

### Security Considerations

Overlooking stuff like this leaves gaping holes.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

I don't understand why we have `test.sh` rather than the default, which runs all `*.test.js` files.

### Upgrade Considerations

The upgrade succeeds.
