### PR TITLE
clean up liveslots tests

### DIFF
--- a/packages/swingset-liveslots/test/vo-test-harness.test.js
+++ b/packages/swingset-liveslots/test/vo-test-harness.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { runVOTest } from '../tools/vo-test-harness.js';
+import { makeSpy, runVOTest } from '../tools/vo-test-harness.js';
 
 async function voTestTest(t, mode) {
   let makeThing;
@@ -36,8 +36,6 @@ async function voTestTest(t, mode) {
   await runVOTest(t, prepare, makeTestThing, testTestThing);
 }
 
-// Note: these first two are not marked "test.failing" because
-// something is wrong and we need to fix it. Rather, they are
 // confirming that the voTestTest harness would catch problems during
 // downstream tests that use the harness, if those problems arose in
 // the "before" or "after" phases, and reported by the downstream test
@@ -47,20 +45,26 @@ async function voTestTest(t, mode) {
 // fails, otherwise the harness is not doing its job, and is hiding
 // real test failures in some downstream client package.
 
-test.failing('fail during "before" phase', async t => {
-  await voTestTest(t, 'before');
+test('fail during "before" phase', async t => {
+  const tSpy = makeSpy(t);
+  await voTestTest(tSpy, 'before');
+  t.is(tSpy.failureMessage, 'deliberate failure in before phase');
 });
 
-test.failing('fail during "after" phase', async t => {
-  await voTestTest(t, 'after');
+test('fail during "after" phase', async t => {
+  const tSpy = makeSpy(t);
+  await voTestTest(tSpy, 'after');
+  t.is(tSpy.failureMessage, 'deliberate failure in after phase');
 });
 
 // Similarly, this test makes sure that our harness can detect when
 // the downstream test misbehaves and holds on to the object they were
 // supposed to drop.
 
-test.failing('fail due to held object', async t => {
-  await voTestTest(t, 'hold');
+test('fail due to held object', async t => {
+  const tSpy = makeSpy(t);
+  await voTestTest(tSpy, 'hold');
+  t.is(tSpy.falsyMessage, 'somebody continues to hold test object');
 });
 
 test.serial('succeed', async t => {

--- a/packages/swingset-liveslots/tools/vo-test-harness.js
+++ b/packages/swingset-liveslots/tools/vo-test-harness.js
@@ -5,6 +5,27 @@ import { setupTestLiveslots } from '../test/liveslots-helpers.js';
 // is to to help verify that a VO can be garbage collected and then
 // reloaded from persistent storage while maintaining functionality.
 
+/**
+ * A spy wrapping Ava's t for tests that are testing the harness itself.
+ * @param {import('ava').ExecutionContext} t
+ */
+export const makeSpy = t => {
+  const tSpy = {
+    ...t,
+    fail: msg => {
+      tSpy.failureMessage = msg;
+    },
+    // In Ava 6, assertions throw?
+    falsy: (check, msg) => {
+      if (!check) return;
+      tSpy.falsyMessage = msg;
+    },
+    failureMessage: '',
+    falsyMessage: '',
+  };
+  return tSpy;
+};
+
 // Testing VO swapping with runVOTest:
 //
 // Step 1: import the necessary harness paraphernalia


### PR DESCRIPTION
refs: #5575

## Description

As needed for Ava 6,
- https://github.com/Agoric/agoric-sdk/issues/9083

It has different exception behavior that breaks the intentional `.failing` hack. This changes the four`test.failing` to use `test` that are confirmed to be the correct behavior. Since the test is of test failures, it uses a new spy instead.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations

~This is one package of the monorepo on Ava 6. I [tried bumping them all before](https://github.com/Agoric/agoric-sdk/pull/9081) but ran into problems. We should tackle them all eventually,~ (DEFERRED)


### Testing Considerations
per se
### Upgrade Considerations
none