### PR TITLE
fix(acceptance): fix flakey psm test

### DIFF
--- a/a3p-integration/proposals/z:acceptance/psm.test.js
+++ b/a3p-integration/proposals/z:acceptance/psm.test.js
@@ -34,7 +34,6 @@ import {
   logRecord,
   maxMintBelowLimit,
   psmSwap,
-  sendOfferAgd,
 } from './test-lib/psm-lib.js';
 import { getBalances } from './test-lib/utils.js';
 
@@ -163,7 +162,7 @@ test.serial('swap into IST using agd with default gas', async t => {
       '--feePct',
       wantMintedFeeVal,
     ],
-    { ...psmSwapIo, sendOffer: sendOfferAgd },
+    psmSwapIo,
   );
 
   await checkSwapSucceeded(t, metricsBefore, balancesBefore, {

--- a/a3p-integration/proposals/z:acceptance/test-lib/psm-lib.js
+++ b/a3p-integration/proposals/z:acceptance/test-lib/psm-lib.js
@@ -434,6 +434,8 @@ export const initializeNewUser = async (name, fund, io) => {
 };
 
 /**
+ * UNTIL https://github.com/Agoric/agoric-sdk/issues/10746 better to use {@link sendOfferAgd}
+ *
  * Similar to
  * https://github.com/Agoric/agoric-3-proposals/blob/422b163fecfcf025d53431caebf6d476778b5db3/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts#L123-L139
  * However, for an address that is not provisioned, `agoric wallet send` is
@@ -478,7 +480,6 @@ export const sendOfferAgd = async (address, offerPromise) => {
       [`--keyring-backend=test`, `--from=${address}`],
       ['tx', 'swingset', 'wallet-action', '--allow-spend', offer],
       '--yes',
-      '-bblock',
       '-ojson',
     )
   );
@@ -522,7 +523,7 @@ export const sendOfferAgd = async (address, offerPromise) => {
  * }} io
  */
 export const psmSwap = async (address, params, io) => {
-  const { now, sendOffer = sendOfferAgoric, ...waitIO } = io;
+  const { now, sendOffer = sendOfferAgd, ...waitIO } = io;
   const offerId = `${address}-psm-swap-${now()}`;
   const newParams = ['psm', ...params, '--offerId', offerId];
   const offerPromise = executeCommand(agopsLocation, newParams);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10728 

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Using `-bblock` caused inconsistent timeout behavior due to txs not getting into a block on time. `psm.test.js` is observed to be the only test that sends transactions with `-bblock` set. In this PR we switch to the default option which is `sync`.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Removing flakiness will help landing code faster.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Should force integration tests.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
`z:acceptance` runs after every upgrade.

