### PR TITLE
feat: save the outgoing EC Charter instance and kit

### DIFF
--- a/packages/builders/scripts/testing/recorded-retired-instances.js
+++ b/packages/builders/scripts/testing/recorded-retired-instances.js
@@ -33,14 +33,17 @@ export const testRecordedRetiredInstances = async ({
   );
   assert(committeeIDs);
   assert(committeeIDs.length === 1);
+  trace('found committeeIDs', committeeIDs);
+
   const committeeInstance = retiredContractInstances.get(committeeIDs[0]);
   assert(await E(contractKits).get(committeeInstance));
 
-  const charterIDs = Array.from(retiredContractInstances.keys()).filter(k =>
+  const charterIDs = [...retiredContractInstances.keys()].filter(k =>
     k.startsWith('econCommitteeCharter'),
   );
   assert(charterIDs);
   assert(charterIDs.length === 1);
+  trace('found charterID', charterIDs);
 
   trace('done');
 };

--- a/packages/builders/scripts/testing/recorded-retired-instances.js
+++ b/packages/builders/scripts/testing/recorded-retired-instances.js
@@ -36,6 +36,12 @@ export const testRecordedRetiredInstances = async ({
   const committeeInstance = retiredContractInstances.get(committeeIDs[0]);
   assert(await E(contractKits).get(committeeInstance));
 
+  const charterIDs = Array.from(retiredContractInstances.keys()).filter(k =>
+    k.startsWith('econCommitteeCharter'),
+  );
+  assert(charterIDs);
+  assert(charterIDs.length === 1);
+
   trace('done');
 };
 harden(testRecordedRetiredInstances);

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -333,7 +333,7 @@ const startNewEconCharter = async ({
   ]);
 
   const label = 'econCommitteeCharter';
-  const previousCharterKit = { label, ...econCharterKit };
+  const previousCharterKit = { ...econCharterKit, label };
 
   const boardID = await E(board).getId(previousCharterKit.instance);
   const identifier = `${label}-${boardID}`;
@@ -365,7 +365,7 @@ const startNewEconCharter = async ({
 
   trace('Starting new EC Charter Instance');
 
-  const terms = await harden({
+  const terms = harden({
     binaryVoteCounterInstallation: counterInstall,
   });
   const startResult = await E(startUpgradable)({

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -289,33 +289,87 @@ const startNewEconomicCommittee = async (
  * Starts a new Economic Committee Charter by creating an instance with the
  * provided committee specifications.
  *
- * @param {EconomyBootstrapPowers} powers - The resources and capabilities
- *   required to start the committee.
+ * @param {EconomyBootstrapPowers &
+ *   PromiseSpaceOf<{ retiredContractInstances: MapStore<string, Instance> }>} powers
+ *   - The resources and capabilities required to start the committee.
+ *
  * @returns {Promise<EconCharterStartResult>} A promise that resolves to the
  *   charter kit result.
  */
 const startNewEconCharter = async ({
-  consume: { startUpgradable },
-  produce: { econCharterKit },
+  consume: {
+    board,
+    startUpgradable,
+    contractKits: contractKitsP,
+    econCharterKit: econCharterKitP,
+    retiredContractInstances: retiredContractInstancesP,
+  },
+  produce: {
+    econCharterKit: produceEconCharterKit,
+    retiredContractInstances: produceRetiredInstances,
+  },
   installation: {
     consume: { binaryVoteCounter: counterP, econCommitteeCharter: installP },
   },
   instance: {
     produce: { econCommitteeCharter },
+    consume: { econCommitteeCharter: previousInstanceP },
   },
 }) => {
-  const [charterInstall, counterInstall] = await Promise.all([
+  const [
+    charterInstall,
+    counterInstall,
+    previousInstance,
+    contractKits,
+    econCharterKit,
+    retiredInstances,
+  ] = await Promise.all([
     installP,
     counterP,
+    previousInstanceP,
+    contractKitsP,
+    econCharterKitP,
+    provideRetiredInstances(retiredContractInstancesP, produceRetiredInstances),
   ]);
-  const terms = await harden({
-    binaryVoteCounterInstallation: counterInstall,
-  });
+
+  const label = 'econCommitteeCharter';
+  const previousCharterKit = { label, ...econCharterKit };
+
+  const boardID = await E(board).getId(previousCharterKit.instance);
+  const identifier = `${label}-${boardID}`;
+  trace('Saving previous EC Charter Instance', label);
+
+  // save the old charter instance kit so we can manage it later
+  if (retiredInstances.has(identifier)) {
+    // bootstrap tests start having already run this upgrade. Actual upgrades on
+    // mainNet or testnets should start with the promiseSpace post upgrade-17,
+    // which doesn't have this entry in the map.
+    trace(
+      '⚠️ WARNING: collision on storing Charter in retireInstances not' +
+        ' expected during chain upgrade.   It IS normal during bootstrap tests',
+    );
+  } else {
+    retiredInstances.init(identifier, previousCharterKit.instance);
+  }
+  if (contractKits.has(previousInstance)) {
+    // bootstrap tests start having already run this upgrade. Actual upgrades on
+    // mainNet or testnets should start with the promiseSpace post upgrade-17,
+    // which doesn't have this entry in the map.
+    trace(
+      '⚠️ WARNING: collision on storing Charter in contractKits not' +
+        ' expected during chain upgrade.   It IS normal during bootstrap tests',
+    );
+  } else {
+    contractKits.init(previousInstance, previousCharterKit);
+  }
 
   trace('Starting new EC Charter Instance');
 
+  const terms = await harden({
+    binaryVoteCounterInstallation: counterInstall,
+  });
   const startResult = await E(startUpgradable)({
-    label: 'econCommitteeCharter',
+    label,
     installation: charterInstall,
     terms,
   });
@@ -325,8 +379,8 @@ const startNewEconCharter = async ({
   econCommitteeCharter.reset();
   econCommitteeCharter.resolve(E.get(startResult).instance);
 
-  econCharterKit.reset();
-  econCharterKit.resolve(startResult);
+  produceEconCharterKit.reset();
+  produceEconCharterKit.resolve(startResult);
   return startResult;
 };
 
@@ -515,6 +569,8 @@ export const getManifestForReplaceAllElectorates = async (
         auctionUpgradeNewGovCreator: true,
         auctionUpgradeNewInstance: true,
         psmKit: true,
+        contractKits: true,
+        econCharterKit: true,
         governedContractKits: true,
         chainStorage: true,
         highPrioritySendersManager: true,
@@ -543,7 +599,10 @@ export const getManifestForReplaceAllElectorates = async (
           economicCommittee: true,
           econCommitteeCharter: true,
         },
-        consume: { economicCommittee: true },
+        consume: {
+          economicCommittee: true,
+          econCommitteeCharter: true,
+        },
       },
     },
   },


### PR DESCRIPTION
refs: #10680

## Description

Add the EconomicCommittee Charter to the instances and kits being saved.

### Security Considerations

Don't throw away stuff you might need.

### Scaling Considerations

Negligible

### Documentation Considerations

None

### Testing Considerations

Added a test to see that the charterID was saved.

### Upgrade Considerations

If U18 and U19 get combined, this will impact the contracts being updated in U18. If we only pull some changes from U19 into U18, this should be inclduded.
