### PR TITLE
ability to replace oracle operators in fast-usdc

### DIFF
--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -51,8 +51,8 @@ test.before('bootstrap', async t => {
 test.after.always(t => t.context.shutdown?.());
 
 test.serial('oracles provision before contract deployment', async t => {
-  const { walletFactoryDriver: wd } = t.context;
-  const watcherWallet = await wd.provideSmartWallet('agoric1watcher1');
+  const { walletFactoryDriver: wfd } = t.context;
+  const watcherWallet = await wfd.provideSmartWallet('agoric1watcher1');
   t.truthy(watcherWallet);
 });
 
@@ -66,12 +66,12 @@ test.serial(
       evalProposal,
       refreshAgoricNamesRemotes,
       storage,
-      walletFactoryDriver: wd,
+      walletFactoryDriver: wfd,
     } = t.context;
 
     const { oracles } = configurations.MAINNET;
     const [watcherWallet] = await Promise.all(
-      Object.values(oracles).map(addr => wd.provideSmartWallet(addr)),
+      Object.values(oracles).map(addr => wfd.provideSmartWallet(addr)),
     );
 
     // inbound `startChannelOpenInit` responses immediately.
@@ -201,8 +201,8 @@ test.serial('writes account addresses to vstorage', async t => {
 });
 
 test.serial('LP deposits', async t => {
-  const { walletFactoryDriver: wd, agoricNamesRemotes } = t.context;
-  const lp = await wd.provideSmartWallet(
+  const { walletFactoryDriver: wfd, agoricNamesRemotes } = t.context;
+  const lp = await wfd.provideSmartWallet(
     'agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8',
   );
 
@@ -270,15 +270,15 @@ test.serial('LP deposits', async t => {
 
 test.serial('makes usdc advance', async t => {
   const {
-    walletFactoryDriver: wd,
+    walletFactoryDriver: wfd,
     storage,
     agoricNamesRemotes,
     harness,
   } = t.context;
   const oracles = await Promise.all([
-    wd.provideSmartWallet('agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8'),
-    wd.provideSmartWallet('agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr'),
-    wd.provideSmartWallet('agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj'),
+    wfd.provideSmartWallet('agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8'),
+    wfd.provideSmartWallet('agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr'),
+    wfd.provideSmartWallet('agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj'),
   ]);
   await Promise.all(
     oracles.map(wallet =>
@@ -298,7 +298,7 @@ test.serial('makes usdc advance', async t => {
   const lastNodeValue = storage.getValues('published.fastUsdc').at(-1);
   const { settlementAccount } = JSON.parse(NonNullish(lastNodeValue));
   const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO(
-    // mock with the read settlementAccount address
+    // mock with the real settlementAccount address
     encodeAddressHook(settlementAccount, { EUD }),
   );
 
@@ -344,18 +344,18 @@ test.serial('makes usdc advance', async t => {
 });
 
 test.serial('skips usdc advance when risks identified', async t => {
-  const { walletFactoryDriver: wd, storage } = t.context;
+  const { walletFactoryDriver: wfd, storage } = t.context;
   const oracles = await Promise.all([
-    wd.provideSmartWallet('agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8'),
-    wd.provideSmartWallet('agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr'),
-    wd.provideSmartWallet('agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj'),
+    wfd.provideSmartWallet('agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8'),
+    wfd.provideSmartWallet('agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr'),
+    wfd.provideSmartWallet('agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj'),
   ]);
 
   const EUD = 'dydx1riskyeud';
   const lastNodeValue = storage.getValues('published.fastUsdc').at(-1);
   const { settlementAccount } = JSON.parse(NonNullish(lastNodeValue));
   const evidence = MockCctpTxEvidences.AGORIC_PLUS_DYDX(
-    // mock with the read settlementAccount address
+    // mock with the real settlementAccount address
     encodeAddressHook(settlementAccount, { EUD }),
   );
 
@@ -394,8 +394,8 @@ test.serial('skips usdc advance when risks identified', async t => {
 });
 
 test.serial('LP withdraws', async t => {
-  const { walletFactoryDriver: wd, agoricNamesRemotes } = t.context;
-  const lp = await wd.provideSmartWallet(
+  const { walletFactoryDriver: wfd, agoricNamesRemotes } = t.context;
+  const lp = await wfd.provideSmartWallet(
     'agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8',
   );
 

--- a/packages/fast-usdc/src/exos/transaction-feed.js
+++ b/packages/fast-usdc/src/exos/transaction-feed.js
@@ -141,7 +141,7 @@ export const prepareTransactionFeedKit = (zone, zcf) => {
         },
 
         /** @param {string} operatorId */
-        async removeOperator(operatorId) {
+        removeOperator(operatorId) {
           const { operators } = this.state;
           trace('removeOperator', operatorId);
           const operatorKit = operators.get(operatorId);

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -37,7 +37,7 @@ const ADDRESSES_BAGGAGE_KEY = 'addresses';
  * @import {Remote} from '@agoric/internal';
  * @import {Marshaller, StorageNode} from '@agoric/internal/src/lib-chainStorage.js'
  * @import {Zone} from '@agoric/zone';
- * @import {OperatorKit} from './exos/operator-kit.js';
+ * @import {OperatorOfferResult} from './exos/transaction-feed.js';
  * @import {CctpTxEvidence, FeeConfig, RiskAssessment} from './types.js';
  */
 
@@ -159,7 +159,7 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
   const { makeLocalAccount, makeNobleAccount } = orchestrateAll(flows, {});
 
   const creatorFacet = zone.exo('Fast USDC Creator', undefined, {
-    /** @type {(operatorId: string) => Promise<Invitation<OperatorKit>>} */
+    /** @type {(operatorId: string) => Promise<Invitation<OperatorOfferResult>>} */
     async makeOperatorInvitation(operatorId) {
       return feedKit.creator.makeOperatorInvitation(operatorId);
     },

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -22,7 +22,6 @@ import { prepareStatusManager } from './exos/status-manager.js';
 import { prepareTransactionFeedKit } from './exos/transaction-feed.js';
 import * as flows from './fast-usdc.flows.js';
 import { FastUSDCTermsShape, FeeConfigShape } from './type-guards.js';
-import { defineInertInvitation } from './utils/zoe.js';
 
 const trace = makeTracer('FastUsdc');
 
@@ -151,11 +150,6 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     { makeRecorderKit },
   );
 
-  const makeTestInvitation = defineInertInvitation(
-    zcf,
-    'test of forcing evidence',
-  );
-
   const { makeLocalAccount, makeNobleAccount } = orchestrateAll(flows, {});
 
   const creatorFacet = zone.exo('Fast USDC Creator', undefined, {
@@ -193,21 +187,6 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
   });
 
   const publicFacet = zone.exo('Fast USDC Public', undefined, {
-    // XXX to be removed before production
-    /**
-     * NB: Any caller with access to this invitation maker has the ability to
-     * force handling of evidence.
-     *
-     * Provide an API call in the form of an invitation maker, so that the
-     * capability is available in the smart-wallet bridge during UI testing.
-     *
-     * @param {CctpTxEvidence} evidence
-     * @param {RiskAssessment} [risk]
-     */
-    makeTestPushInvitation(evidence, risk = {}) {
-      void advancer.handleTransactionEvent({ evidence, risk });
-      return makeTestInvitation();
-    },
     makeDepositInvitation() {
       return poolKit.public.makeDepositInvitation();
     },

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -157,6 +157,10 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     async makeOperatorInvitation(operatorId) {
       return feedKit.creator.makeOperatorInvitation(operatorId);
     },
+    /** @type {(operatorId: string) => void} */
+    removeOperator(operatorId) {
+      return feedKit.creator.removeOperator(operatorId);
+    },
     async connectToNoble() {
       return vowTools.when(nobleAccountV, nobleAccount => {
         trace('nobleAccount', nobleAccount);

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -109,6 +109,7 @@ const publishFeedPolicy = async (node, policy) => {
  * }} FastUSDCCorePowers
  *
  * @typedef {StartedInstanceKitWithLabel & {
+ *   creatorFacet: Awaited<ReturnType<FastUsdcSF>>['creatorFacet'];
  *   privateArgs: StartParams<FastUsdcSF>['privateArgs'];
  * }} FastUSDCKit
  */

--- a/packages/fast-usdc/test/exos/transaction-feed.test.ts
+++ b/packages/fast-usdc/test/exos/transaction-feed.test.ts
@@ -189,7 +189,7 @@ test('disagreement after publishing', async t => {
   });
 });
 
-test('disabled operator', async t => {
+test('remove operator', async t => {
   const feedKit = makeFeedKit();
   const { op1 } = await makeOperators(feedKit);
   const evidence = MockCctpTxEvidences.AGORIC_PLUS_OSMO();
@@ -197,7 +197,7 @@ test('disabled operator', async t => {
   // works before disabling
   op1.operator.submitEvidence(evidence);
 
-  op1.admin.disable();
+  await feedKit.creator.removeOperator('op1');
 
   t.throws(() => op1.operator.submitEvidence(evidence), {
     message: 'submitEvidence for disabled operator',

--- a/packages/fast-usdc/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc/test/fast-usdc.contract.test.ts
@@ -39,6 +39,7 @@ import type { CctpTxEvidence, FeeConfig, PoolMetrics } from '../src/types.js';
 import { makeFeeTools } from '../src/utils/fees.js';
 import { MockCctpTxEvidences } from './fixtures.js';
 import { commonSetup, uusdcOnAgoric } from './supports.js';
+import type { OperatorOfferResult } from '../src/exos/transaction-feed.js';
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
@@ -223,7 +224,7 @@ const purseOf =
   };
 
 const makeOracleOperator = async (
-  opInv: Invitation<OperatorKit>,
+  opInv: Invitation<OperatorOfferResult>,
   txSubscriber: Subscriber<TxWithRisk>,
   zoe: ZoeService,
   t: ExecutionContext,
@@ -234,15 +235,9 @@ const makeOracleOperator = async (
     description: 'oracle operator invitation',
   });
 
-  // operator only gets `.invitationMakers`
-  // but for testing, we need `.admin` too. UNTIL #?????
-  const operatorKit = await E(E(zoe).offer(opInv)).getOfferResult();
-  t.deepEqual(Object.keys(operatorKit), [
-    'admin',
-    'invitationMakers',
-    'operator',
-  ]);
-  const { invitationMakers } = operatorKit;
+  const offerResult = await E(E(zoe).offer(opInv)).getOfferResult();
+  t.deepEqual(Object.keys(offerResult), ['invitationMakers', 'operator']);
+  const { invitationMakers } = offerResult;
 
   let active = true;
 
@@ -274,7 +269,7 @@ const makeOracleOperator = async (
     getDone: () => done,
     getFailures: () => harden([...failures]),
     // operator only gets .invitationMakers
-    getKit: () => operatorKit,
+    getKit: () => offerResult,
     setActive: flag => {
       active = flag;
     },


### PR DESCRIPTION
refs: #10754

## Description

Add and test the ability to replace operators

Before closing: test coverage of adding new ones

### Security Considerations
removes `.admin` from operator offer result kit. (wasn't exploitable but this is better)

### Scaling Considerations
no changes


### Documentation Considerations
no changes

### Testing Considerations
new coverage suffices

### Upgrade Considerations
not yet deployed