### PR TITLE
fix(liveslots): avoid slotToVal memory leak for watched promises

### DIFF
--- a/packages/swingset-liveslots/test/watch-promise.test.js
+++ b/packages/swingset-liveslots/test/watch-promise.test.js
@@ -26,7 +26,7 @@ const build = vatPowers => {
   });
 };
 
-test.failing('watched local promises should not leak slotToVal entries', async t => {
+test('watched local promises should not leak slotToVal entries', async t => {
   const { dispatchMessage, testHooks } = await setupTestLiveslots(
     t,
     build,

--- a/packages/swingset-liveslots/test/watch-promise.test.js
+++ b/packages/swingset-liveslots/test/watch-promise.test.js
@@ -1,0 +1,42 @@
+import test from 'ava';
+
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+import { setupTestLiveslots } from './liveslots-helpers.js';
+
+const build = vatPowers => {
+  const { VatData } = vatPowers;
+  const { makeKindHandle, defineDurableKind, watchPromise } = VatData;
+
+  const kh = makeKindHandle('handler');
+  const init = () => ({});
+  const behavior = {
+    onFulfilled: _value => 0,
+    onRejected: _reason => 0,
+  };
+  const makeHandler = defineDurableKind(kh, init, behavior);
+
+  return Far('root', {
+    async run() {
+      const pr = makePromiseKit();
+      const handler = makeHandler();
+      watchPromise(pr.promise, handler);
+      pr.resolve('ignored');
+    },
+  });
+};
+
+test.failing('watched local promises should not leak slotToVal entries', async t => {
+  const { dispatchMessage, testHooks } = await setupTestLiveslots(
+    t,
+    build,
+    'vatA',
+  );
+  const { slotToVal } = testHooks;
+  const initial = slotToVal.size;
+
+  await dispatchMessage('run');
+  t.is(slotToVal.size, initial);
+  await dispatchMessage('run');
+  t.is(slotToVal.size, initial);
+});


### PR DESCRIPTION
Liveslots has a bug (#10757) which leaks slotToVal entries when a tracked Promise is still being held in virtual data (e.g. a merely-virtual MapStore) at the time it becomes settled. This is triggered by `watchPromise` because of the order in which we attach two handlers: one which notices the resolution and is inhibited from deleting the slotToVal entry, and a second which removes the Promise from the (virtual) `promiseRegistrations` collection (thus enabling the deletion). For any watched Promise that is resolved, we leave a `slotToVal` entry (with an empty WeakRef) in RAM until the end of the incarnation.

This PR does not fix the underlying bug, but it rearranges the handler order to avoid triggering it.

The attached unit test fails with the original handler order (`slotToVal.size` grows), and passes with the swapped order (`slotToVal.size` remains constant).

closes #10756
refs #10706
