### PR TITLE
chore(cosmic-swingset): Add `phase` to cosmic-swingset-run-{start,finish} slog entries

### DIFF
--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -479,6 +479,7 @@ export async function launch({
         type: 'cosmic-swingset-run-start',
         blockHeight,
         runNum,
+        phase,
         startBeans,
         remainingBeans: runPolicy.remainingBeans(),
       });
@@ -495,6 +496,7 @@ export async function launch({
         type: 'cosmic-swingset-run-finish',
         blockHeight,
         runNum,
+        phase,
         startBeans,
         finishBeans,
         usedBeans: finishBeans - startBeans,


### PR DESCRIPTION
## Description
Extracted from #10752.

Add `phase: "{leftover,forced,high-priority,timer,queued,cleanup}"` to cosmic-swingset-run{start,finish} slogfile entries (see [launch-chain.js](https://github.com/Agoric/agoric-sdk/blob/master/packages/cosmic-swingset/src/launch-chain.js), particularly [`processBlockActions`](https://github.com/Agoric/agoric-sdk/blob/837776e6eb693603bce4ed3f9af5c659c9a19d2d/packages/cosmic-swingset/src/launch-chain.js#L737-L781)).

### Security Considerations
None known.

### Scaling Considerations
The size increase should be modest, and I believe pays for itself in increased transparency.

### Documentation Considerations
n/a

### Testing Considerations
Already seen working in #10752.

### Upgrade Considerations
None known, although we will probably want slog-to-otel consumption of the new data.
