### PR TITLE
Cherry-pick u18 branch a3p test change

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/prepare.sh
+++ b/a3p-integration/proposals/n:upgrade-next/prepare.sh
@@ -7,3 +7,6 @@ set -uxeo pipefail
 # actions are executed in the previous chain software, and the effects are
 # persisted so they can be used in the steps after the upgrade is complete,
 # such as in the "use" or "test" steps, or further proposal layers.
+
+yarn
+node ./addGov4

--- a/a3p-integration/proposals/n:upgrade-next/use.sh
+++ b/a3p-integration/proposals/n:upgrade-next/use.sh
@@ -3,8 +3,6 @@
 # Exit when any command fails
 set -uxeo pipefail
 
-node ./addGov4
-
 # Econ Committee accept invitations for Committee and Charter
 ./acceptInvites.js
 


### PR DESCRIPTION
refs: #10460

## Description
Cherry picks https://github.com/Agoric/agoric-sdk/pull/10460/commits/f0dca14997cf496c13390e4e229fe303642a795d back into master as that is the more correct test (address provisioned before upgrade)

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
More accurate a3p test

### Upgrade Considerations
None
