### PR TITLE
tighten typescript-eslint rules

### DIFF
--- a/.aiderignore
+++ b/.aiderignore
@@ -1,0 +1,7 @@
+# circular symlink
+a3p-integration/agoric-sdk
+
+# git subrepos
+moddable
+xsnap-native
+

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -81,6 +81,11 @@ module.exports = {
   reportUnusedDisableDirectives: true,
 
   rules: {
+    '@typescript-eslint/no-unused-expressions': 'off', // we use `cond || Fail`
+    '@typescript-eslint/no-empty-object-type': 'warn',
+    '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
+    '@typescript-eslint/no-unsafe-function-type': 'warn',
+    '@typescript-eslint/no-wrapper-object-types': 'warn',
     '@typescript-eslint/ban-ts-comment': [
       'error',
       {

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ _testoutput.txt
 junit.xml
 endo-sha.txt
 .aider*
+!.aiderignore
+

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
     "typescript": "~5.7.1",
-    "typescript-eslint": "^8.17.0"
+    "typescript-eslint": "^8.18.2"
   },
   "resolutions": {
     "**/protobufjs": "^7.2.6",
     "**/@types/estree": "^1.0.0",
-    "@endo/eslint-plugin/typescript-eslint": "^8.17.0"
+    "@endo/eslint-plugin/typescript-eslint": "^8.18.2"
   },
   "engines": {
     "node": "^18.12 || ^20.9"

--- a/packages/async-flow/src/types.ts
+++ b/packages/async-flow/src/types.ts
@@ -18,7 +18,7 @@ export type FlowState =
  * but since they still could not be made durable, in this context
  * it'd be pointless.)
  */
-export type Guest<T extends unknown = any> = T;
+export type Guest<T = any> = T;
 export type Host<T extends Passable = Passable> = T;
 
 /**
@@ -109,7 +109,7 @@ export type Outcome =
       problem: any;
     };
 
-export type Ephemera<S extends WeakKey = WeakKey, V extends unknown = any> = {
+export type Ephemera<S extends WeakKey = WeakKey, V = any> = {
   for: (self: S) => V;
   resetFor: (self: S) => void;
 };

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -185,7 +185,7 @@ test.serial('upgrade at many points in network API flow', async t => {
   // continuation after upgrade.
   const pausedFlows = [] as Array<{
     result: any;
-    remainingSteps: [string, Function][];
+    remainingSteps: [string, (lastResult: any) => unknown][];
   }>;
   for (let i = 0; i < flow.length; i += 1) {
     const [beforeStepName] = flow[i];

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -399,7 +399,7 @@ export const makeGovernanceDriver = async (
     proposeApiCall,
     enactLatestProposal,
     getLatestOutcome,
-    async changeParams(instance: Instance, params: Object, path?: object) {
+    async changeParams(instance: Instance, params: object, path?: object) {
       instance || Fail`missing instance`;
       await ensureInvitationsAccepted();
       await proposeParams(instance, params, path);

--- a/packages/casting/test/types.test-d.ts
+++ b/packages/casting/test/types.test-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { E } from '@endo/far';
 import { expectType } from 'tsd';
 import type { ValueFollower } from '../src/follower-cosmjs.js';

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -353,10 +353,10 @@ export interface IBCMsgTransferOptions {
 export type CosmosChainAccountMethods<CCI extends CosmosChainInfo> =
   IcaAccountMethods &
     (CCI extends {
-      stakingTokens: {};
+      stakingTokens: object;
     }
       ? StakingAccountActions & StakingAccountQueries
-      : {});
+      : object);
 
 export type ICQQueryFunction = (
   msgs: JsonSafe<RequestQuery>[],

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -75,7 +75,7 @@ export type OrchestrationAccount<CI extends ChainInfo> =
       ? CI['chainId'] extends `agoric${string}`
         ? LocalAccountMethods
         : CosmosChainAccountMethods<CI>
-      : {});
+      : object);
 
 /**
  * An object for access the core functions of a remote chain.
@@ -133,7 +133,7 @@ export interface Orchestrator {
     chainName: C,
   ) => Promise<
     Chain<C extends keyof KnownChains ? KnownChains[C] : any> &
-      (C extends 'agoric' ? AgoricChainMethods : {})
+      (C extends 'agoric' ? AgoricChainMethods : object)
   >;
 
   /**

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/safe-await-separator */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import type { VowTools } from '@agoric/vow';

--- a/packages/swingset-liveslots/src/vatDataTypes.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.ts
@@ -37,7 +37,7 @@ type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R
 
 // The type of a passable local object with methods.
 // An internal helper to avoid having to repeat `O`.
-type PrimaryRemotable<O> = O & RemotableObject & RemotableBrand<{}, O>;
+type PrimaryRemotable<O> = O & RemotableObject & RemotableBrand<object, O>;
 
 export type KindFacet<O> = PrimaryRemotable<{
   [K in keyof O]: OmitFirstArg<O[K]>; // omit the 'context' parameter

--- a/packages/time/src/types.ts
+++ b/packages/time/src/types.ts
@@ -182,7 +182,7 @@ export interface TimerServiceCommon {
 // XXX copied from Remotable helper return type
 export type TimerService = TimerServiceCommon &
   RemotableObject<'TimerService'> &
-  RemotableBrand<{}, TimerServiceCommon>;
+  RemotableBrand<object, TimerServiceCommon>;
 
 /**
  * Read-only access to a TimeService's current time. This allows reading the

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -128,7 +128,7 @@ type ClientManager = {
  * @template C - Consume only
  * @template P - Produce only
  */
-type PromiseSpaceOf<B, C = {}, P = {}> = {
+type PromiseSpaceOf<B, C = object, P = object> = {
   consume: { [K in keyof (B & C)]: Promise<(B & C)[K]> };
   produce: { [K in keyof (B & P)]: Producer<(B & P)[K]> };
 };
@@ -449,7 +449,7 @@ type BootstrapSpace = WellKnownSpaces &
       loadVat: VatLoader;
       loadCriticalVat: VatLoader;
     },
-    {}
+    object
   >;
 
 type LocalChainVat = ERef<

--- a/packages/vats/src/types.ts
+++ b/packages/vats/src/types.ts
@@ -221,11 +221,18 @@ export type IBCDowncallMethod =
 type IBCMethodEvents = {
   sendPacket: SendPacketDownCall;
   tryOpenExecuted: ChannelOpenAckDowncall;
-  receiveExecuted: {}; // TODO update
+  receiveExecuted: {
+    packet: IBCPacket;
+    ack: Bytes;
+  };
   startChannelOpenInit: ChannelOpenInitDowncall;
-  startChannelCloseInit: {}; // TODO update
+  startChannelCloseInit: {
+    packet: Pick<IBCPacket, 'source_port' | 'source_channel'>;
+  };
   bindPort: { packet: { source_port: IBCPortID } };
-  timeoutExecuted: {}; // TODO update
+  timeoutExecuted: {
+    packet: IBCPacket;
+  };
   // XXX why isn't this in receiver.go?
   initOpenExecuted: ChannelOpenAckDowncall;
 };

--- a/packages/vats/test/types-ambient.test-d.ts
+++ b/packages/vats/test/types-ambient.test-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/safe-await-separator */
 /**
  * @file uses .ts syntax to be able to declare types (e.g. of kit.creatorFacet
  *   as {}) because "there is no JavaScript syntax for passing a a type

--- a/packages/vow/src/types.ts
+++ b/packages/vow/src/types.ts
@@ -158,7 +158,7 @@ export type VowTools = {
    * coerces the result of a function to a Vow. Helpful for scenarios like a
    * synchronously thrown error.
    */
-  asVow: <T extends unknown>(
+  asVow: <T>(
     fn: (...args: any[]) => Vow<Awaited<T>> | Awaited<T> | PromiseVow<T>,
   ) => Vow<Awaited<T>>;
   makeVowKit: <T>() => VowKit<T>;

--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -19,7 +19,7 @@ type InvitationAmount = Amount<'set', InvitationDetails>;
  * synchronously from within the contract, and usually is referred to
  * in code as zcf.
  */
-type ZCF<CT extends unknown = Record<string, unknown>> = {
+type ZCF<CT = Record<string, unknown>> = {
   /**
    * - atomically reallocate amounts among seats.
    */
@@ -214,8 +214,8 @@ type ZcfSeatKit = {
   zcfSeat: ZCFSeat;
   userSeat: Promise<UserSeat>;
 };
-type HandleOffer<OR extends unknown, OA> = (seat: ZCFSeat, offerArgs: OA) => OR;
-type OfferHandler<OR extends unknown = unknown, OA = never> =
+type HandleOffer<OR, OA> = (seat: ZCFSeat, offerArgs: OA) => OR;
+type OfferHandler<OR = unknown, OA = never> =
   | HandleOffer<OR, OA>
   | {
       handle: HandleOffer<OR, OA>;
@@ -241,12 +241,7 @@ type ContractMeta<
  *
  * CAVEAT: assumes synchronous
  */
-type ContractStartFn<
-  PF extends unknown = any,
-  CF extends unknown = any,
-  CT extends unknown = any,
-  PA extends unknown = any,
-> = (
+type ContractStartFn<PF = any, CF = any, CT = any, PA = any> = (
   zcf: ZCF<CT>,
   privateArgs: PA,
   baggage: import('@agoric/vat-data').Baggage,

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -30,9 +30,9 @@ export type InstallationStart<I> =
 
 export type ContractStartFunction = (
   zcf?: ZCF,
-  privateArgs?: {},
+  privateArgs?: object,
   baggage?: Baggage,
-) => ERef<{ creatorFacet?: {}; publicFacet?: {} }>;
+) => ERef<{ creatorFacet?: object; publicFacet?: object }>;
 
 export type AdminFacet<SF extends ContractStartFunction> = FarRef<{
   // Completion, which is currently any
@@ -76,8 +76,8 @@ export type StartedInstanceKit<SF extends ContractStartFunction> = {
   instance: Instance<SF>;
   adminFacet: AdminFacet<SF>;
   // theses are empty by default. the return type will override
-  creatorFacet: {};
-  publicFacet: {};
+  creatorFacet: object;
+  publicFacet: object;
 } & (SF extends ContractStartFunction
   ? // override if the start function specfies the types
     Awaited<ReturnType<SF>>
@@ -120,7 +120,7 @@ export type GetPublicFacet = <SF>(
 
 export type GetTerms = <SF>(instance: Instance<SF>) => Promise<
   // only type if 'terms' info is available
-  StartParams<SF>['terms'] extends {}
+  StartParams<SF>['terms'] extends object
     ? StartParams<SF>['terms']
     : // XXX returning `any` in this case
       any

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -24,7 +24,7 @@ const mock = null as any;
   kit.notInKit;
   void E(kit.publicFacet).getPriceAuthority();
 
-  expectType<{}>(kit.creatorFacet);
+  expectType<object>(kit.creatorFacet);
 
   const validIssuers = {};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,67 +3908,67 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@8.17.0", "@typescript-eslint/eslint-plugin@^8.0.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.17.0.tgz#2ee073c421f4e81e02d10e731241664b6253b23c"
-  integrity sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==
+"@typescript-eslint/eslint-plugin@8.18.2", "@typescript-eslint/eslint-plugin@^8.0.0":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.2.tgz#c78e363ab5fe3b21dd1c90d8be9581534417f78e"
+  integrity sha512-adig4SzPLjeQ0Tm+jvsozSGiCliI2ajeURDGHjZ2llnA+A67HihCQ+a3amtPhUakd1GlwHxSRvzOZktbEvhPPg==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.17.0"
-    "@typescript-eslint/type-utils" "8.17.0"
-    "@typescript-eslint/utils" "8.17.0"
-    "@typescript-eslint/visitor-keys" "8.17.0"
+    "@typescript-eslint/scope-manager" "8.18.2"
+    "@typescript-eslint/type-utils" "8.18.2"
+    "@typescript-eslint/utils" "8.18.2"
+    "@typescript-eslint/visitor-keys" "8.18.2"
     graphemer "^1.4.0"
     ignore "^5.3.1"
     natural-compare "^1.4.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/parser@8.17.0", "@typescript-eslint/parser@^8.0.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.17.0.tgz#2ee972bb12fa69ac625b85813dc8d9a5a053ff52"
-  integrity sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==
+"@typescript-eslint/parser@8.18.2", "@typescript-eslint/parser@^8.0.0":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.18.2.tgz#0379a2e881d51d8fcf7ebdfa0dd18eee79182ce2"
+  integrity sha512-y7tcq4StgxQD4mDr9+Jb26dZ+HTZ/SkfqpXSiqeUXZHxOUyjWDKsmwKhJ0/tApR08DgOhrFAoAhyB80/p3ViuA==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.17.0"
-    "@typescript-eslint/types" "8.17.0"
-    "@typescript-eslint/typescript-estree" "8.17.0"
-    "@typescript-eslint/visitor-keys" "8.17.0"
+    "@typescript-eslint/scope-manager" "8.18.2"
+    "@typescript-eslint/types" "8.18.2"
+    "@typescript-eslint/typescript-estree" "8.18.2"
+    "@typescript-eslint/visitor-keys" "8.18.2"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@8.17.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz#a3f49bf3d4d27ff8d6b2ea099ba465ef4dbcaa3a"
-  integrity sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==
+"@typescript-eslint/scope-manager@8.18.2":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.18.2.tgz#d193c200d61eb0ddec5987c8e48c9d4e1c0510bd"
+  integrity sha512-YJFSfbd0CJjy14r/EvWapYgV4R5CHzptssoag2M7y3Ra7XNta6GPAJPPP5KGB9j14viYXyrzRO5GkX7CRfo8/g==
   dependencies:
-    "@typescript-eslint/types" "8.17.0"
-    "@typescript-eslint/visitor-keys" "8.17.0"
+    "@typescript-eslint/types" "8.18.2"
+    "@typescript-eslint/visitor-keys" "8.18.2"
 
-"@typescript-eslint/type-utils@8.17.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.17.0.tgz#d326569f498cdd0edf58d5bb6030b4ad914e63d3"
-  integrity sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==
+"@typescript-eslint/type-utils@8.18.2":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.18.2.tgz#5ad07e09002eee237591881df674c1c0c91ca52f"
+  integrity sha512-AB/Wr1Lz31bzHfGm/jgbFR0VB0SML/hd2P1yxzKDM48YmP7vbyJNHRExUE/wZsQj2wUCvbWH8poNHFuxLqCTnA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "8.17.0"
-    "@typescript-eslint/utils" "8.17.0"
+    "@typescript-eslint/typescript-estree" "8.18.2"
+    "@typescript-eslint/utils" "8.18.2"
     debug "^4.3.4"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/types@8.17.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.17.0.tgz#ef84c709ef8324e766878834970bea9a7e3b72cf"
-  integrity sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==
+"@typescript-eslint/types@8.18.2":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.18.2.tgz#5ebad5b384c8aa1c0f86cee1c61bcdbe7511f547"
+  integrity sha512-Z/zblEPp8cIvmEn6+tPDIHUbRu/0z5lqZ+NvolL5SvXWT5rQy7+Nch83M0++XzO0XrWRFWECgOAyE8bsJTl1GQ==
 
 "@typescript-eslint/types@^7.2.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.18.0.tgz#b90a57ccdea71797ffffa0321e744f379ec838c9"
   integrity sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==
 
-"@typescript-eslint/typescript-estree@8.17.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz#40b5903bc929b1e8dd9c77db3cb52cfb199a2a34"
-  integrity sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==
+"@typescript-eslint/typescript-estree@8.18.2":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.2.tgz#fffb85527f8304e29bfbbdc712f4515da9f8b47c"
+  integrity sha512-WXAVt595HjpmlfH4crSdM/1bcsqh+1weFRWIa9XMTx/XHZ9TCKMcr725tLYqWOgzKdeDrqVHxFotrvWcEsk2Tg==
   dependencies:
-    "@typescript-eslint/types" "8.17.0"
-    "@typescript-eslint/visitor-keys" "8.17.0"
+    "@typescript-eslint/types" "8.18.2"
+    "@typescript-eslint/visitor-keys" "8.18.2"
     debug "^4.3.4"
     fast-glob "^3.3.2"
     is-glob "^4.0.3"
@@ -3976,22 +3976,22 @@
     semver "^7.6.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/utils@8.17.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.17.0.tgz#41c05105a2b6ab7592f513d2eeb2c2c0236d8908"
-  integrity sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==
+"@typescript-eslint/utils@8.18.2":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.18.2.tgz#a2635f71904a84f9e47fe1b6f65a6d944ff1adf9"
+  integrity sha512-Cr4A0H7DtVIPkauj4sTSXVl+VBWewE9/o40KcF3TV9aqDEOWoXF3/+oRXNby3DYzZeCATvbdksYsGZzplwnK/Q==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "8.17.0"
-    "@typescript-eslint/types" "8.17.0"
-    "@typescript-eslint/typescript-estree" "8.17.0"
+    "@typescript-eslint/scope-manager" "8.18.2"
+    "@typescript-eslint/types" "8.18.2"
+    "@typescript-eslint/typescript-estree" "8.18.2"
 
-"@typescript-eslint/visitor-keys@8.17.0":
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz#4dbcd0e28b9bf951f4293805bf34f98df45e1aa8"
-  integrity sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==
+"@typescript-eslint/visitor-keys@8.18.2":
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.2.tgz#b3e434b701f086b10a7c82416ebc56899d27ef2f"
+  integrity sha512-zORcwn4C3trOWiCqFQP1x6G3xTRyZ1LYydnj51cRnJ6hxBlr/cKPckk+PKPUw/fXmvfKTcw7bwY3w9izgx5jZw==
   dependencies:
-    "@typescript-eslint/types" "8.17.0"
+    "@typescript-eslint/types" "8.18.2"
     eslint-visitor-keys "^4.2.0"
 
 "@ungap/structured-clone@^1.2.0":
@@ -12327,14 +12327,14 @@ typedoc@^0.26.7:
     shiki "^1.16.2"
     yaml "^2.5.1"
 
-typescript-eslint@^7.3.1, typescript-eslint@^8.14.0, typescript-eslint@^8.17.0:
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.17.0.tgz#fa4033c26b3b40f778287bc12918d985481b220b"
-  integrity sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==
+typescript-eslint@^7.3.1, typescript-eslint@^8.14.0, typescript-eslint@^8.18.2:
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.18.2.tgz#71334dcf843adc3fbb771dce5ade7876aa0d62b7"
+  integrity sha512-KuXezG6jHkvC3MvizeXgupZzaG5wjhU3yE8E7e6viOvAvD9xAWYp8/vy0WULTGe9DYDWcQu7aW03YIV3mSitrQ==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "8.17.0"
-    "@typescript-eslint/parser" "8.17.0"
-    "@typescript-eslint/utils" "8.17.0"
+    "@typescript-eslint/eslint-plugin" "8.18.2"
+    "@typescript-eslint/parser" "8.18.2"
+    "@typescript-eslint/utils" "8.18.2"
 
 "typescript@5.1.6 - 5.7.x", typescript@^5.4.5, typescript@~5.7.1:
   version "5.7.2"


### PR DESCRIPTION
unplanned

## Description
Primarily adds these lint rules:
```
    '@typescript-eslint/no-empty-object-type': 'warn',
    '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
    '@typescript-eslint/no-unsafe-function-type': 'warn',
    '@typescript-eslint/no-wrapper-object-types': 'warn',
```

Also,
- bumps the linter dependency to latest
- fixes violations
- finishes the IBCMethodEvents type
- defines an aiderignore for https://aider.chat/


### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none