### PR TITLE
fix(scripts): Support jq version 1.6

### DIFF
--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -85,7 +85,7 @@ CMD="${1-"--help"}"
 # Read current-directory package.json fields "name"/"version"/"private" into shell variables
 # by evaluating single-quoted assignments like `<name>='...'`.
 eval "$(jq < package.json -r --arg Q "'" '
-  pick(.name, .version, .private)
+  { name: .name, version: .version, private: .private }
   | to_entries
   | .[]
   # Replace a null/false value with empty string.


### PR DESCRIPTION
https://github.com/Agoric/agoric-sdk/pull/10590#issuecomment-2565413147
> I also noticed we need `jq 1.7` minimum when running `scripts/npm-dist-tag.sh` and my machine had jq 1.6 out of the box.

## Description
Replace [`pick(...)`](https://jqlang.github.io/jq/manual/v1.7/#pick) with an equivalent expression that doesn't require version 1.7 (cf. [jq/NEWS.md](https://github.com/jqlang/jq/blob/jq-1.7/NEWS.md#language-changes:~:text=Adds%20new%20builtin%20pick(stream)) and https://github.com/jqlang/jq/pull/2656 ).

### Security Considerations
None.

### Scaling Considerations
n/a

### Documentation Considerations
Deferred.

### Testing Considerations
Not covered.

### Upgrade Considerations
n/a