### PR TITLE
fix(fast-usdc): recover from bad lp proposal

### DIFF
--- a/packages/fast-usdc/src/pool-share-math.js
+++ b/packages/fast-usdc/src/pool-share-math.js
@@ -38,7 +38,7 @@ export const makeParity = (numerator, denominatorBrand) => {
  * @typedef {{
  *   deposit: {
  *     give: { USDC: Amount<'nat'> },
- *     want?: { PoolShare: Amount<'nat'> }
+ *     want: { PoolShare: Amount<'nat'> }
  *   },
  *   withdraw: {
  *     give: { PoolShare: Amount<'nat'> }

--- a/packages/fast-usdc/src/type-guards.js
+++ b/packages/fast-usdc/src/type-guards.js
@@ -19,10 +19,10 @@ export const makeNatAmountShape = (brand, min) =>
 /** @param {Record<'PoolShares' | 'USDC', Brand<'nat'>>} brands */
 export const makeProposalShapes = ({ PoolShares, USDC }) => {
   /** @type {TypedPattern<USDCProposalShapes['deposit']>} */
-  const deposit = M.splitRecord(
-    { give: { USDC: makeNatAmountShape(USDC, 1n) } },
-    { want: M.splitRecord({}, { PoolShare: makeNatAmountShape(PoolShares) }) },
-  );
+  const deposit = M.splitRecord({
+    give: { USDC: makeNatAmountShape(USDC, 1n) },
+    want: { PoolShare: makeNatAmountShape(PoolShares) },
+  });
   /** @type {TypedPattern<USDCProposalShapes['withdraw']>} */
   const withdraw = M.splitRecord({
     give: { PoolShare: makeNatAmountShape(PoolShares, 1n) },

--- a/packages/fast-usdc/test/cli/lp-commands.test.ts
+++ b/packages/fast-usdc/test/cli/lp-commands.test.ts
@@ -58,7 +58,7 @@ const test = anyTest as TestFn<Awaited<ReturnType<typeof makeTestContext>>>;
 test.beforeEach(async t => (t.context = await makeTestContext()));
 
 test('fast-usdc deposit command', async t => {
-  const { program, marshaller, out, err, USDC } = t.context;
+  const { program, marshaller, out, err, USDC, FastLP } = t.context;
   const amount = 100.05;
   const argv = [...`node fast-usdc deposit`.split(' '), ...flags({ amount })];
   t.log(...argv);
@@ -77,6 +77,9 @@ test('fast-usdc deposit command', async t => {
       proposal: {
         give: {
           USDC: { brand: USDC, value: 100_050_000n },
+        },
+        want: {
+          PoolShare: { brand: FastLP, value: 90_954_545n },
         },
       },
     },

--- a/packages/fast-usdc/test/pool-share-math.test.ts
+++ b/packages/fast-usdc/test/pool-share-math.test.ts
@@ -58,8 +58,12 @@ test('initial withdrawal fails', t => {
 test('withdrawal after deposit OK', t => {
   const { PoolShares, USDC } = brands;
   const state0 = makeParity(make(USDC, 1n), PoolShares);
+  const emptyShares = makeEmpty(PoolShares);
 
-  const pDep = { give: { USDC: make(USDC, 100n) } };
+  const pDep = {
+    give: { USDC: make(USDC, 100n) },
+    want: { PoolShare: emptyShares },
+  };
   const { shareWorth: state1 } = depositCalc(state0, pDep);
 
   const proposal = harden({
@@ -81,8 +85,12 @@ test('withdrawal after deposit OK', t => {
 
 test('deposit offer underestimates value of share', t => {
   const { PoolShares, USDC } = brands;
+  const emptyShares = makeEmpty(PoolShares);
 
-  const pDep = { give: { USDC: make(USDC, 100n) } };
+  const pDep = {
+    give: { USDC: make(USDC, 100n) },
+    want: { PoolShare: emptyShares },
+  };
   const { shareWorth: state1 } = depositCalc(parity, pDep);
   const state2 = withFees(state1, make(USDC, 20n));
 
@@ -119,9 +127,13 @@ test('deposit offer overestimates value of share', t => {
 
 test('withdrawal offer underestimates value of share', t => {
   const { PoolShares, USDC } = brands;
+  const emptyShares = makeEmpty(PoolShares);
   const state0 = makeParity(make(USDC, 1n), PoolShares);
 
-  const proposal1 = harden({ give: { USDC: make(USDC, 100n) } });
+  const proposal1 = harden({
+    give: { USDC: make(USDC, 100n) },
+    want: { PoolShare: emptyShares },
+  });
   const { shareWorth: state1 } = depositCalc(state0, proposal1);
 
   const proposal = harden({
@@ -143,9 +155,13 @@ test('withdrawal offer underestimates value of share', t => {
 
 test('withdrawal offer overestimates value of share', t => {
   const { PoolShares, USDC } = brands;
+  const emptyShares = makeEmpty(PoolShares);
   const state0 = makeParity(make(USDC, 1n), PoolShares);
 
-  const d100 = { give: { USDC: make(USDC, 100n) } };
+  const d100 = {
+    give: { USDC: make(USDC, 100n) },
+    want: { PoolShare: emptyShares },
+  };
   const { shareWorth: state1 } = depositCalc(state0, d100);
 
   const proposal = harden({
@@ -196,7 +212,12 @@ testProp(
   'deposit properties',
   [arbShareWorth, arbUSDC],
   (t, shareWorth, In) => {
-    const actual = depositCalc(shareWorth, { give: { USDC: In } });
+    const { PoolShares } = brands;
+    const emptyShares = makeEmpty(PoolShares);
+    const actual = depositCalc(shareWorth, {
+      give: { USDC: In },
+      want: { PoolShare: emptyShares },
+    });
     const {
       payouts: { PoolShare },
       shareWorth: post,
@@ -234,7 +255,10 @@ testProp(
 
     for (const { party, action } of actions) {
       if ('In' in action) {
-        const d = depositCalc(shareWorth, { give: { USDC: action.In } });
+        const d = depositCalc(shareWorth, {
+          give: { USDC: action.In },
+          want: { PoolShare: emptyShares },
+        });
         myShares[party] = add(
           myShares[party] || emptyShares,
           d.payouts.PoolShare,


### PR DESCRIPTION
closes https://github.com/Agoric/agoric-private/issues/234

## Description

See issue for context. It also seems related to https://github.com/Agoric/agoric-sdk/issues/10684 because the code path that was triggering the bad state was this:

https://github.com/Agoric/agoric-sdk/blob/ca25dd59f43f27451fad685207086a9be87860c7/packages/fast-usdc/src/exos/liquidity-pool.js#L272-L285

As you can see, we were updating the pool state, but then the `atomicRearrange` failed, so the pool state was left invalid. This PR makes it so that the bad proposal shape is caught by the type guard earlier, so this code path never happens.

The withdraw path was already being handled correctly because the typeguard was specific enough.

If the proposal shape is correct, but the amounts are incorrect, the contract already handles that fine by failing before the state update.

### Security Considerations
The bug would allow anyone to send an offer that breaks the liquidity pool.

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Added a bootstrap test that fails accordingly without the fix.

### Upgrade Considerations
None
