### PR TITLE
refactor: prepare for use of non-trapping integrity trait

### DIFF
--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -8,6 +8,17 @@ import {
 } from '../lib/parseVatSlots.js';
 import { insistCapData } from '../lib/capdata.js';
 
+const { freeze } = Object;
+
+/**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * Although a frozen-only object will not be defensive, since it could still
+ * be made non-trapping, these are encapsulated only within proxies that
+ * will refuse to be made non-trapping, and so can safely be shared.
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const target = freeze({});
+
 // 'makeDeviceSlots' is a subset of makeLiveSlots, for device code
 
 export function makeDeviceSlots(
@@ -142,7 +153,7 @@ export function makeDeviceSlots(
     (slot && parseVatSlot(slot).type === 'object') ||
       Fail`SO(x) must be called on a Presence, not ${x}`;
     const handler = PresenceHandler(slot);
-    const p = harden(new Proxy({}, handler));
+    const p = new Proxy(target, handler);
     outstandingProxies.add(p);
     return p;
   }

--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -7,6 +7,8 @@ import { makeQueue } from '@endo/stream';
  * @import { RunPolicy } from '../src/types-external.js'
  */
 
+const { freeze } = Object;
+
 /** @typedef {{ provideRunPolicy: () => RunPolicy | undefined }} RunHarness */
 
 /**
@@ -103,11 +105,29 @@ export const makeRunUtils = (controller, harness) => {
   // promise that can remain pending indefinitely, possibly to be settled by a
   // future message delivery.
 
+  /**
+   * `freeze` but not `harden` the proxy target so it remains trapping.
+   * Although a frozen-only object will not be defensive, since it could still
+   * be made non-trapping, these are encapsulated only within proxies that
+   * will refuse to be made non-trapping, and so can safely be shared.
+   * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+   */
+  const objTarget = freeze({});
+
+  /**
+   * `freeze` but not `harden` the proxy target so it remains trapping.
+   * Although a frozen-only object will not be defensive, since it could still
+   * be made non-trapping, these are encapsulated only within proxies that
+   * will refuse to be made non-trapping, and so can safely be shared.
+   * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+   */
+  const funcTarget = freeze(() => {});
+
   /** @type {EVProxy} */
   // @ts-expect-error cast, approximate
   const EV = Object.assign(
     presence =>
-      new Proxy(harden({}), {
+      new Proxy(funcTarget, {
         get: (_t, method, _rx) => {
           const boundMethod = (...args) =>
             queueAndRun(() =>
@@ -118,7 +138,7 @@ export const makeRunUtils = (controller, harness) => {
       }),
     {
       vat: vatName =>
-        new Proxy(harden({}), {
+        new Proxy(funcTarget, {
           get: (_t, method, _rx) => {
             const boundMethod = (...args) =>
               queueAndRun(() =>
@@ -128,7 +148,7 @@ export const makeRunUtils = (controller, harness) => {
           },
         }),
       sendOnly: presence =>
-        new Proxy(harden({}), {
+        new Proxy(funcTarget, {
           get: (_t, method, _rx) => {
             const boundMethod = (...args) =>
               queueAndRun(
@@ -139,7 +159,7 @@ export const makeRunUtils = (controller, harness) => {
           },
         }),
       get: presence =>
-        new Proxy(harden({}), {
+        new Proxy(objTarget, {
           get: (_t, pathElement, _rx) =>
             queueAndRun(() =>
               controller.queueToVatRoot('bootstrap', 'awaitVatObject', [

--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -114,20 +114,11 @@ export const makeRunUtils = (controller, harness) => {
    */
   const objTarget = freeze({});
 
-  /**
-   * `freeze` but not `harden` the proxy target so it remains trapping.
-   * Although a frozen-only object will not be defensive, since it could still
-   * be made non-trapping, these are encapsulated only within proxies that
-   * will refuse to be made non-trapping, and so can safely be shared.
-   * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
-   */
-  const funcTarget = freeze(() => {});
-
   /** @type {EVProxy} */
   // @ts-expect-error cast, approximate
   const EV = Object.assign(
     presence =>
-      new Proxy(funcTarget, {
+      new Proxy(objTarget, {
         get: (_t, method, _rx) => {
           const boundMethod = (...args) =>
             queueAndRun(() =>
@@ -138,7 +129,7 @@ export const makeRunUtils = (controller, harness) => {
       }),
     {
       vat: vatName =>
-        new Proxy(funcTarget, {
+        new Proxy(objTarget, {
           get: (_t, method, _rx) => {
             const boundMethod = (...args) =>
               queueAndRun(() =>
@@ -148,7 +139,7 @@ export const makeRunUtils = (controller, harness) => {
           },
         }),
       sendOnly: presence =>
-        new Proxy(funcTarget, {
+        new Proxy(objTarget, {
           get: (_t, method, _rx) => {
             const boundMethod = (...args) =>
               queueAndRun(

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -14,6 +14,8 @@ import { makeCollectionManager } from './collectionManager.js';
 import { makeWatchedPromiseManager } from './watchedPromises.js';
 import { makeBOYDKit } from './boyd-gc.js';
 
+const { freeze } = Object;
+
 const SYSCALL_CAPDATA_BODY_SIZE_LIMIT = 10_000_000;
 const SYSCALL_CAPDATA_SLOTS_LENGTH_LIMIT = 10_000;
 
@@ -864,8 +866,13 @@ function build(
     if (!slot || parseVatSlot(slot).type !== 'device') {
       throw Error('D() must be given a device node');
     }
+    /**
+     * `freeze` but not `harden` the proxy target so it remains trapping.
+     * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+     */
+    const target = freeze({});
     const handler = DeviceHandler(slot);
-    const pr = harden(new Proxy({}, handler));
+    const pr = new Proxy(target, handler);
     outstandingProxies.add(pr);
     return pr;
   }

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -10,7 +10,7 @@ import { makeLogHooks, makePromiseSpace } from './promise-space.js';
 
 import './types-ambient.js';
 
-const { entries, fromEntries, keys } = Object;
+const { entries, fromEntries, keys, freeze } = Object;
 
 /**
  * Used in bootstrap to reserve names in the agoricNames namespace before any
@@ -130,7 +130,12 @@ export const extract = (template, specimen, path = []) => {
         specimen,
       )}`;
     }
-    const target = harden(
+    /**
+     * `freeze` but not `harden` the proxy target so it remains trapping.
+     *
+     * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+     */
+    const target = freeze(
       fromEntries(
         entries(template).map(([propName, subTemplate]) => [
           propName,


### PR DESCRIPTION
#endo-branch: master

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2679

## Description

Does for agoric-sdk what https://github.com/endojs/endo/pull/2679 does for endo

Prepare for anticipated introduction and use of the non-trapping integrity trait as explained at https://github.com/endojs/endo/blob/b12eb434b6672f0ceae41be55aac7f24c4562b7b/packages/ses/docs/preparing-for-stabilize.md

These preparations must work now, before these traits are introduced, and should continue to work after these traits are introduced and used.

### Security Considerations

Some things that had been deeply frozen automatically by `harden` are now manually frozen by explicit calls to `freeze`. We need to review these carefully to ensure that nothing has inadvertently be left unfrozen as a result of the changes in this PR.

Some proxies will become unhardenable, but they will still be hardenable as of now, so mistaken hardenings will not be detected.

### Scaling Considerations

For this PR by itself, none. Using the shim-based implementation of the non-trapping trait will have scaling consequences: https://github.com/endojs/endo/pull/2675

### Documentation Considerations

https://github.com/endojs/endo/blob/b12eb434b6672f0ceae41be55aac7f24c4562b7b/packages/ses/docs/preparing-for-stabilize.md will need to be reflected in developer docs.

### Testing Considerations

Since this PR by itself should be a pure refactor with no observable changes, there is nothing to test at this stage. The testing burden will come with https://github.com/Agoric/agoric-sdk/pull/10796 to see how adequate these preparations were.

### Compatibility Considerations

The point. This changes to coding patterns that should be compat both with the current status quo and with https://github.com/Agoric/agoric-sdk/pull/10796

### Upgrade Considerations

As a pure refactor, none.
