### PR TITLE
lint promise-function-async

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -85,7 +85,7 @@ module.exports = {
     '@typescript-eslint/promise-function-async': [
       // so throw in promise-returning function still returns a promise
       'warn',
-      { checkArrowFunctions: false, checkFunctionExpressions: false },
+      { checkFunctionExpressions: false },
     ],
     '@typescript-eslint/no-empty-object-type': 'warn',
     '@typescript-eslint/no-unnecessary-type-constraint': 'warn',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -82,6 +82,11 @@ module.exports = {
 
   rules: {
     '@typescript-eslint/no-unused-expressions': 'off', // we use `cond || Fail`
+    '@typescript-eslint/promise-function-async': [
+      // so throw in promise-returning function still returns a promise
+      'warn',
+      { checkArrowFunctions: false, checkFunctionExpressions: false },
+    ],
     '@typescript-eslint/no-empty-object-type': 'warn',
     '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
     '@typescript-eslint/no-unsafe-function-type': 'warn',

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -38,8 +38,9 @@ export const claim = async (
 ) => {
   const srcPayment = await srcPaymentP;
   // @ts-expect-error XXX could be instantiated with a different subtype
-  return E.when(E(recoveryPurse).deposit(srcPayment, optAmountShape), amount =>
-    E(recoveryPurse).withdraw(amount),
+  return E.when(
+    E(recoveryPurse).deposit(srcPayment, optAmountShape),
+    async amount => E(recoveryPurse).withdraw(amount),
   );
 };
 harden(claim);
@@ -70,7 +71,7 @@ export const combine = async (
     ...srcPaymentsPs,
   ]);
   const emptyAmount = AmountMath.makeEmpty(brand, displayInfo.assetKind);
-  const amountPs = srcPayments.map(srcPayment =>
+  const amountPs = srcPayments.map(async srcPayment =>
     E(recoveryPurse).deposit(srcPayment),
   );
   const amounts = await Promise.all(amountPs);
@@ -141,6 +142,8 @@ export const splitMany = async (recoveryPurse, srcPaymentP, amounts) => {
   AmountMath.isEqual(srcAmount, total) ||
     Fail`rights were not conserved: ${total} vs ${srcAmount}`;
 
-  return Promise.all(amounts.map(amount => E(recoveryPurse).withdraw(amount)));
+  return Promise.all(
+    amounts.map(async amount => E(recoveryPurse).withdraw(amount)),
+  );
 };
 harden(splitMany);

--- a/packages/ERTP/test/unitTests/inputValidation.test.js
+++ b/packages/ERTP/test/unitTests/inputValidation.test.js
@@ -140,7 +140,7 @@ test('makeIssuerKit bad optShutdownWithFailure', async t => {
 test('brand.isMyIssuer bad issuer', async t => {
   const { brand } = makeIssuerKit('myTokens');
   // @ts-expect-error Intentional wrong type for testing
-  await t.throwsAsync(() => brand.isMyIssuer('not an issuer'), {
+  await t.throwsAsync(async () => brand.isMyIssuer('not an issuer'), {
     message:
       /In "isMyIssuer" method of \(myTokens brand\): arg 0: .*"not an issuer" - Must be a remotable/,
   });
@@ -160,7 +160,7 @@ test('assertLivePayment', async t => {
   const paymentB = E(mintB).mintPayment(AmountMath.make(brandB, 837n));
 
   // payment is of the wrong brand
-  await t.throwsAsync(() => claim(E(issuer).makeEmptyPurse(), paymentB), {
+  await t.throwsAsync(async () => claim(E(issuer).makeEmptyPurse(), paymentB), {
     message:
       '"[Alleged: fungibleB payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   });
@@ -170,7 +170,7 @@ test('assertLivePayment', async t => {
   // use up payment
   await claim(E(issuer).makeEmptyPurse(), payment);
 
-  await t.throwsAsync(() => claim(E(issuer).makeEmptyPurse(), payment), {
+  await t.throwsAsync(async () => claim(E(issuer).makeEmptyPurse(), payment), {
     message:
       '"[Alleged: fungible payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   });
@@ -184,18 +184,24 @@ test('issuer.combine bad payments array', async t => {
   };
   // @ts-expect-error Intentional wrong type for testing
 
-  await t.throwsAsync(() => combine(E(issuer).makeEmptyPurse(), notAnArray), {
-    message: 'srcPaymentsPs is not iterable',
-  });
+  await t.throwsAsync(
+    async () => combine(E(issuer).makeEmptyPurse(), notAnArray),
+    {
+      message: 'srcPaymentsPs is not iterable',
+    },
+  );
 
   const notAnArray2 = Far('notAnArray2', {
     length: () => 2,
     split: () => {},
   });
   // @ts-expect-error Intentional wrong type for testing
-  await t.throwsAsync(() => combine(E(issuer).makeEmptyPurse(), notAnArray2), {
-    message: 'srcPaymentsPs is not iterable',
-  });
+  await t.throwsAsync(
+    async () => combine(E(issuer).makeEmptyPurse(), notAnArray2),
+    {
+      message: 'srcPaymentsPs is not iterable',
+    },
+  );
 });
 
 test('amount with accessor properties', async t => {

--- a/packages/ERTP/test/unitTests/legacy-payment-helpers.test.js
+++ b/packages/ERTP/test/unitTests/legacy-payment-helpers.test.js
@@ -13,10 +13,13 @@ test('no lost assets on non-atomic combine failure', async t => {
   const precious = num => AmountMath.make(brand, num);
   const payment1 = mint.mintPayment(precious(39n));
   const payment2 = payment1; // "accidental" aliasing
-  await t.throwsAsync(() => combine(recoveryPurse, [payment1, payment2]), {
-    message:
-      /^".*" was not a live payment for brand ".*". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.$/,
-  });
+  await t.throwsAsync(
+    async () => combine(recoveryPurse, [payment1, payment2]),
+    {
+      message:
+        /^".*" was not a live payment for brand ".*". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.$/,
+    },
+  );
 
   const live = await issuer.isLive(payment1);
   t.assert(!live); // demonstrates non-failure atomicity
@@ -30,9 +33,12 @@ test('no lost assets on non-atomic split failure', async t => {
   /** @param {bigint} num */
   const precious = num => AmountMath.make(brand, num);
   const srcPayment = mint.mintPayment(precious(78n));
-  await t.throwsAsync(() => split(recoveryPurse, srcPayment, precious(100n)), {
-    message: '-22 is negative',
-  });
+  await t.throwsAsync(
+    async () => split(recoveryPurse, srcPayment, precious(100n)),
+    {
+      message: '-22 is negative',
+    },
+  );
 
   const live = await issuer.isLive(srcPayment);
   t.assert(!live); // demonstrates non-failure atomicity

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -367,7 +367,7 @@ async function replay(transcriptFile) {
 
   const updateWorkersSynced = () => {
     const stepsCompleted = Promise.all(
-      workers.map(({ stepCompleted }) => stepCompleted),
+      workers.map(async ({ stepCompleted }) => stepCompleted),
     );
     const newWorkersSynced = stepsCompleted.then(() => {
       if (workersSynced === newWorkersSynced) {

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -39,7 +39,7 @@ const allValues = async obj => {
   return fromEntries(zip(keys(obj), vs));
 };
 
-const bundleRelative = rel =>
+const bundleRelative = async rel =>
   bundleSource(new URL(rel, import.meta.url).pathname);
 
 /**
@@ -434,7 +434,7 @@ export async function initializeSwingset(
     ? provideBundleCache(
         config.bundleCachePath,
         { dev: config.includeDevDependencies, format: config.bundleFormat },
-        s => import(s),
+        async s => import(s),
       )
     : null);
 
@@ -543,7 +543,7 @@ export async function initializeSwingset(
   async function processGroup(groupName, nameToBundle) {
     const group = config[groupName] || {};
     const names = Object.keys(group).sort();
-    const processP = names.map(name =>
+    const processP = names.map(async name =>
       processDesc(group[name], nameToBundle).catch(err => {
         throw Error(`config.${groupName}.${name}: ${err.message}`);
       }),

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -71,7 +71,7 @@ export function makeStartXSnap(options) {
       serial += 1;
       return workerTrace;
     };
-    doXSnap = opts => {
+    doXSnap = async opts => {
       const workerTraceDir = makeNextTraceDir();
       console.log('SwingSet xsnap worker tracing:', { workerTraceDir });
       fs.mkdirSync(workerTraceDir, { recursive: true });
@@ -174,7 +174,7 @@ export function makeStartXSnap(options) {
     if (overrideBundles) {
       bundles = overrideBundles; // ignore the usual bundles
     } else {
-      const bundlePs = bundleIDs.map(id => bundleHandler.getBundle(id));
+      const bundlePs = bundleIDs.map(async id => bundleHandler.getBundle(id));
       bundles = await Promise.all(bundlePs);
     }
 

--- a/packages/SwingSet/src/devices/command/command.js
+++ b/packages/SwingSet/src/devices/command/command.js
@@ -9,7 +9,7 @@ export default function buildCommand(broadcastCallback) {
   let nextCount = 0n;
   const responses = new Map();
 
-  function inboundCommand(obj) {
+  async function inboundCommand(obj) {
     // deliver the JSON-serializable object to the registered handler, and
     // return a promise that fires with a JSON-serializable object in
     // response

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -2043,7 +2043,7 @@ export default function buildKernel(
   }
 
   // mostly used by tests, only needed with thread/process-based workers
-  function shutdown() {
+  async function shutdown() {
     return vatWarehouse.shutdown();
   }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -16,7 +16,12 @@ function parentLog(first, ...args) {
 export function makeNodeSubprocessFactory(tools) {
   const { startSubprocessWorker, testLog } = tools;
 
-  function createFromBundle(vatID, bundle, managerOptions, liveSlotsOptions) {
+  async function createFromBundle(
+    vatID,
+    bundle,
+    managerOptions,
+    liveSlotsOptions,
+  ) {
     assert(!managerOptions.enableSetup, 'not supported at all');
     assert(
       managerOptions.useTranscript,
@@ -62,7 +67,7 @@ export function makeNodeSubprocessFactory(tools) {
      * @param {import('@agoric/swingset-liveslots').VatDeliveryObject} delivery
      * @returns {Promise<import('@agoric/swingset-liveslots').VatDeliveryResult>}
      */
-    function deliverToWorker(delivery) {
+    async function deliverToWorker(delivery) {
       parentLog(`sending delivery`, delivery);
       !waiting || Fail`already waiting for delivery`;
       const pr = makePromiseKit();
@@ -107,7 +112,7 @@ export function makeNodeSubprocessFactory(tools) {
     parentLog(`instructing worker to load bundle..`);
     sendToWorker(['setBundle', vatID, bundle, liveSlotsOptions]);
 
-    function shutdown() {
+    async function shutdown() {
       // terminate(); // XXX currently disabled since it breaks profiling; we should revisit if we develop a problem with worker vat processes refusing to exit when requested to do so
       sendToWorker(['exit']);
       return E.when(done, _ => undefined);

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -226,7 +226,7 @@ export function makeXsSubprocessFactory({
     }
     mk.setDeliverToWorker(deliverToWorker);
 
-    function shutdown() {
+    async function shutdown() {
       handleCommandKit?.revoke();
       handleCommandKit = undefined;
       return worker.close().then(_ => undefined);

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -687,7 +687,7 @@ export function makeVatWarehouse({
 
   // mostly used by tests, only needed with thread/process-based workers
   async function shutdown() {
-    const work = Array.from(ephemeral.vats.values(), ({ manager }) =>
+    const work = Array.from(ephemeral.vats.values(), async ({ manager }) =>
       manager.shutdown(),
     );
     return Promise.all(work).then(() => {});

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -686,7 +686,7 @@ export function makeVatWarehouse({
   }
 
   // mostly used by tests, only needed with thread/process-based workers
-  function shutdown() {
+  async function shutdown() {
     const work = Array.from(ephemeral.vats.values(), ({ manager }) =>
       manager.shutdown(),
     );

--- a/packages/SwingSet/src/lib/recordVatOptions.js
+++ b/packages/SwingSet/src/lib/recordVatOptions.js
@@ -66,7 +66,7 @@ export const makeVatOptionRecorder = (kernelKeeper, bundleHandler) => {
    * @param {import('../types-external.js').StaticVatOptions} staticOptions
    * @returns {Promise<void>}
    */
-  const recordStatic = (vatID, source, staticOptions) => {
+  const recordStatic = async (vatID, source, staticOptions) => {
     const options = { ...staticOptions, meterID: undefined };
     return record(vatID, source, options);
   };
@@ -81,7 +81,7 @@ export const makeVatOptionRecorder = (kernelKeeper, bundleHandler) => {
    * @param {import('../types-internal.js').InternalDynamicVatOptions} dynamicOptions
    * @returns {Promise<void>}
    */
-  const recordDynamic = (vatID, source, dynamicOptions) => {
+  const recordDynamic = async (vatID, source, dynamicOptions) => {
     const options = { ...dynamicOptions, enableDisavow: false };
     return record(vatID, source, options);
   };

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -469,7 +469,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
    * @param {CancelToken} cancelToken
    * @returns {Promise<Timestamp>}
    */
-  const wakeAtInternal = (when, now, cancelToken) => {
+  const wakeAtInternal = async (when, now, cancelToken) => {
     if (when <= now) {
       return Promise.resolve(toTimestamp(now));
     }
@@ -612,7 +612,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
    * @param {CancelToken} [cancelToken]
    * @returns { Promise<Timestamp> }
    */
-  const wakeAt = (whenTS, cancelToken = undefined) => {
+  const wakeAt = async (whenTS, cancelToken = undefined) => {
     const when = fromTimestamp(whenTS);
     const now = getNow();
     return wakeAtInternal(when, now, cancelToken);
@@ -626,7 +626,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
    * @param {CancelToken} [cancelToken]
    * @returns { Promise<Timestamp> }
    */
-  const addDelay = (delayRT, cancelToken = undefined) => {
+  const addDelay = async (delayRT, cancelToken = undefined) => {
     const delay = fromRelativeTime(delayRT);
     assert(delay >= 0n, 'delay must not be negative');
     const now = getNow();

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -322,7 +322,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
     },
   );
 
-  function finishVatCreation(vatID) {
+  async function finishVatCreation(vatID) {
     const [pendingP, pendingRR] = producePRR();
     pendingVatCreations.set(vatID, pendingRR);
 

--- a/packages/SwingSet/test/bundling/bundles-controller.test.js
+++ b/packages/SwingSet/test/bundling/bundles-controller.test.js
@@ -52,7 +52,7 @@ test('install invalid bundle fails', async t => {
   const wrong =
     'b1-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
   await t.throwsAsync(
-    () => controller.validateAndInstallBundle(bundle, wrong),
+    async () => controller.validateAndInstallBundle(bundle, wrong),
     {
       message:
         /alleged bundleID "b1-[0-9a-f]{128}" does not match actual "b1-[0-9a-f]{128}"/,
@@ -78,7 +78,7 @@ test('install corrupt bundle fails', async t => {
     endoZipBase64Sha512: wrong,
   });
   await t.throwsAsync(
-    () => controller.validateAndInstallBundle(corruptBundle),
+    async () => controller.validateAndInstallBundle(corruptBundle),
     {
       message: /expected [0-9a-f]{128}, got [0-9a-f]{128}/,
     },

--- a/packages/SwingSet/test/bundling/bundles-kernel.test.js
+++ b/packages/SwingSet/test/bundling/bundles-kernel.test.js
@@ -39,12 +39,12 @@ test('install bundle', async t => {
 
   const badVersion =
     'b2-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
-  await t.throwsAsync(() => kernel.installBundle(badVersion, bundle), {
+  await t.throwsAsync(async () => kernel.installBundle(badVersion, bundle), {
     message: /unsupported BundleID/,
   });
 
   const tooShort = 'b1-000';
-  await t.throwsAsync(() => kernel.installBundle(tooShort, bundle), {
+  await t.throwsAsync(async () => kernel.installBundle(tooShort, bundle), {
     message: /does not match bundle/,
   });
 

--- a/packages/SwingSet/test/device-plugin/device.test.js
+++ b/packages/SwingSet/test/device-plugin/device.test.js
@@ -22,7 +22,7 @@ async function setupVatController(t) {
     inputQueue.push(thunk);
   };
 
-  const importPlugin = mod => {
+  const importPlugin = async mod => {
     t.is(mod, 'pingpong');
     return import('./pingpong.js');
   };

--- a/packages/SwingSet/test/gc/gc-vat.test.js
+++ b/packages/SwingSet/test/gc/gc-vat.test.js
@@ -95,8 +95,10 @@ async function dropPresence(t, dropExport) {
   }
 }
 
-test.serial('drop presence (export retains)', t => dropPresence(t, false));
-test.serial('drop presence (export drops)', t => dropPresence(t, true));
+test.serial('drop presence (export retains)', async t =>
+  dropPresence(t, false),
+);
+test.serial('drop presence (export drops)', async t => dropPresence(t, true));
 
 test('forward to fake zoe', async t => {
   const config = {

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -449,7 +449,7 @@ export function buildPatterns(log) {
       log(a.alice === alice2);
       log(alice2 === alice3);
     };
-    objB.b64_one = () => {
+    objB.b64_one = async () => {
       return pX.promise; // resolves to amy
     };
     objB.b64_two = (resPX, argPY) => {
@@ -510,7 +510,7 @@ export function buildPatterns(log) {
       await p3;
     };
     const pk = makePromiseKit();
-    objB.b66_wait = () => pk.promise;
+    objB.b66_wait = async () => pk.promise;
     objB.b66_msg1 = p2 => {
       log('one');
       p2.then(() => log('p2 resolved'));
@@ -840,7 +840,7 @@ export function buildPatterns(log) {
       E(aliceP).a84_three('calling alice'); // 1: promise second appears as target
     };
     const p1 = makePromiseKit();
-    objB.b84_one = () => {
+    objB.b84_one = async () => {
       const aliceP = p1.promise;
       return aliceP;
     };
@@ -860,7 +860,7 @@ export function buildPatterns(log) {
       E(b.bob).b85_three(a.alice, aliceP); // 2: promise second appears as argument
     };
     const p1 = makePromiseKit();
-    objB.b85_one = () => {
+    objB.b85_one = async () => {
       const aliceP = p1.promise;
       return harden(aliceP);
     };
@@ -886,7 +886,7 @@ export function buildPatterns(log) {
       E(billP).log_bill('three'); // 1: promise second appears as a target
     };
     const p1 = makePromiseKit();
-    objB.b86_one = () => {
+    objB.b86_one = async () => {
       const billP = p1.promise;
       return harden(billP);
     };
@@ -905,7 +905,7 @@ export function buildPatterns(log) {
       E(b.bob).b87_three(billP); // 2: promise second appears as argument
     };
     const p1 = makePromiseKit();
-    objB.b87_one = () => {
+    objB.b87_one = async () => {
       const billP = p1.promise;
       return harden(billP);
     };

--- a/packages/SwingSet/test/metering/dynamic-vat-metered.test.js
+++ b/packages/SwingSet/test/metering/dynamic-vat-metered.test.js
@@ -245,15 +245,15 @@ async function overflowCrank(t, explosion) {
   kpidRejected(t, c, kp5, 'vat terminated');
 }
 
-test('exceed allocate', t => {
+test('exceed allocate', async t => {
   return overflowCrank(t, 'allocate');
 });
 
-test('exceed per-crank compute', t => {
+test('exceed per-crank compute', async t => {
   return overflowCrank(t, 'compute');
 });
 
-test('exceed stack', t => {
+test('exceed stack', async t => {
   return overflowCrank(t, 'stack');
 });
 

--- a/packages/SwingSet/test/run-policy/run-policy.test.js
+++ b/packages/SwingSet/test/run-policy/run-policy.test.js
@@ -110,7 +110,8 @@ async function testCranks(t, mode) {
   }
 }
 
-test('run policy - cranks - messages', t => testCranks(t, 'messages'));
-test('run policy - cranks - resolutions', t => testCranks(t, 'resolutions'));
-test('run policy - computrons', t => testCranks(t, 'computrons'));
-test('run policy - wallclock', t => testCranks(t, 'wallclock'));
+test('run policy - cranks - messages', async t => testCranks(t, 'messages'));
+test('run policy - cranks - resolutions', async t =>
+  testCranks(t, 'resolutions'));
+test('run policy - computrons', async t => testCranks(t, 'computrons'));
+test('run policy - wallclock', async t => testCranks(t, 'wallclock'));

--- a/packages/SwingSet/test/transcript/state-sync-reload.test.js
+++ b/packages/SwingSet/test/transcript/state-sync-reload.test.js
@@ -16,7 +16,7 @@ import { buildKernelBundle } from '../../src/controller/initializeSwingset.js';
  * @param {string} [prefix]
  * @returns {Promise<[string, () => void]>}
  */
-const tmpDir = prefix =>
+const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
       if (err) {

--- a/packages/SwingSet/test/upgrade-swingset.test.js
+++ b/packages/SwingSet/test/upgrade-swingset.test.js
@@ -36,7 +36,7 @@ test('kernel refuses to run with out-of-date DB - v0', async t => {
   await commit();
 
   // Now build a controller around this modified state, which should fail.
-  await t.throwsAsync(() => makeSwingsetController(kernelStorage), {
+  await t.throwsAsync(async () => makeSwingsetController(kernelStorage), {
     message: /kernel DB is too old/,
   });
 });
@@ -59,7 +59,7 @@ test('kernel refuses to run with out-of-date DB - v1', async t => {
   await commit();
 
   // Now build a controller around this modified state, which should fail.
-  await t.throwsAsync(() => makeSwingsetController(kernelStorage), {
+  await t.throwsAsync(async () => makeSwingsetController(kernelStorage), {
     message: /kernel DB is too old/,
   });
 });
@@ -81,7 +81,7 @@ test('kernel refuses to run with out-of-date DB - v2', async t => {
   await commit();
 
   // Now build a controller around this modified state, which should fail.
-  await t.throwsAsync(() => makeSwingsetController(kernelStorage), {
+  await t.throwsAsync(async () => makeSwingsetController(kernelStorage), {
     message: /kernel DB is too old/,
   });
 });
@@ -153,7 +153,7 @@ test('upgrade kernel state', async t => {
   await commit();
 
   // confirm that this state is too old for the kernel to use
-  await t.throwsAsync(() => makeSwingsetController(kernelStorage), {
+  await t.throwsAsync(async () => makeSwingsetController(kernelStorage), {
     message: /kernel DB is too old/,
   });
 
@@ -237,7 +237,7 @@ test('upgrade non-reaping kernel state', async t => {
   await commit();
 
   // confirm that this state is too old for the kernel to use
-  await t.throwsAsync(() => makeSwingsetController(kernelStorage), {
+  await t.throwsAsync(async () => makeSwingsetController(kernelStorage), {
     message: /kernel DB is too old/,
   });
 
@@ -389,7 +389,7 @@ test('v3 upgrade', async t => {
   const data = { ...debug.dump().kvEntries };
 
   // confirm that this state is too old for the kernel to use
-  await t.throwsAsync(() => makeSwingsetController(kernelStorage), {
+  await t.throwsAsync(async () => makeSwingsetController(kernelStorage), {
     message: /kernel DB is too old/,
   });
 

--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -568,7 +568,7 @@ test('non-durable exports are abandoned by upgrade of liveslots vat', async t =>
   };
   /** @type {Record<string, { presence: unknown, kref: string }>} */
   const counters = {};
-  const runIncrement = presence => messageToObject(presence, 'increment');
+  const runIncrement = async presence => messageToObject(presence, 'increment');
   for (const [name, methodName] of Object.entries(counterGetters)) {
     const counter = await messageToObject(exporterRoot, methodName);
     const val = await runIncrement(counter);
@@ -644,12 +644,12 @@ test('non-durable exports are abandoned by upgrade of liveslots vat', async t =>
   // Verify post-upgrade behavior.
   t.is(await messageToObject(exporterRoot, 'getVersion'), 'v2');
   await t.throwsAsync(
-    () => runIncrement(counters.ephCounter.presence),
+    async () => runIncrement(counters.ephCounter.presence),
     { message: 'vat terminated' },
     'message to ephemeral object from previous incarnation must go splat',
   );
   await t.throwsAsync(
-    () => runIncrement(counters.virCounter.presence),
+    async () => runIncrement(counters.virCounter.presence),
     { message: 'vat terminated' },
     'message to non-durable virtual object from previous incarnation must go splat',
   );

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -185,8 +185,8 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
       heldPromise.catch(() => 'hush');
     },
     getEternalPromiseInArray: () => [p1],
-    getEternalPromise: () => p2,
-    getWatchedDecidedPromise: () => p3,
+    getEternalPromise: async () => p2,
+    getWatchedDecidedPromise: async () => p3,
 
     makeLostKind: () => {
       makeKindHandle('unhandled');

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -15,7 +15,7 @@ const behavior = {
   },
 };
 
-export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
+export const buildRootObject = async (_vatPowers, vatParameters, baggage) => {
   const durandalHandle = baggage.get('durandalHandle');
   const makeDurandal = defineDurableKind(durandalHandle, initialize, behavior);
   // note: to test #5725, newDur must be the first new Durandal

--- a/packages/SwingSet/test/vat-admin/broken-hang-vat.js
+++ b/packages/SwingSet/test/vat-admin/broken-hang-vat.js
@@ -1,6 +1,6 @@
 import { makePromiseKit } from '@endo/promise-kit';
 
-export function buildRootObject() {
+export async function buildRootObject() {
   const pk = makePromiseKit();
   return pk.promise; // never resolves
 }

--- a/packages/SwingSet/test/vat-admin/new-vat-13.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-13.js
@@ -1,6 +1,6 @@
 import { Far, E } from '@endo/far';
 
-export function buildRootObject(_vatPowers, vatParameters) {
+export async function buildRootObject(_vatPowers, vatParameters) {
   const { adder } = vatParameters;
   function rcvrMaker(seed) {
     let count = 0;

--- a/packages/SwingSet/test/vat-admin/slow-termination/slow-termination.test.js
+++ b/packages/SwingSet/test/vat-admin/slow-termination/slow-termination.test.js
@@ -16,7 +16,7 @@ import { enumeratePrefixedKeys } from '../../../src/kernel/state/storageHelper.j
  * @param {string} [prefix]
  * @returns {Promise<[string, () => void]>}
  */
-export const tmpDir = prefix =>
+export const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
       if (err) {

--- a/packages/SwingSet/test/vat-admin/slow-termination/vat-slow-terminate.js
+++ b/packages/SwingSet/test/vat-admin/slow-termination/vat-slow-terminate.js
@@ -8,7 +8,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
     dieHappy: completion => vatPowers.exitVat(completion),
     sendExport: () => Far('dude export', {}),
     acceptImports: imports => hold.push(imports),
-    forever: () => makePromiseKit().promise,
+    forever: async () => makePromiseKit().promise,
     makeVatstore: count => {
       for (let i = 0; i < count; i += 1) {
         baggage.init(`key-${i}`, i);

--- a/packages/SwingSet/test/vat-admin/terminate/terminate.test.js
+++ b/packages/SwingSet/test/vat-admin/terminate/terminate.test.js
@@ -142,7 +142,7 @@ async function doTerminateCritical(
   }
 
   const kpid = controller.queueToVatRoot('bootstrap', 'performTest', [mode]);
-  const err = await t.throwsAsync(() => controller.run());
+  const err = await t.throwsAsync(async () => controller.run());
   const thrown = kunser({ body: err.message, slots: [] });
   if (typeof thrown === 'string') {
     t.is(thrown, mode);
@@ -444,7 +444,7 @@ test.serial('invalid criticalVatKey causes vat creation to fail', async t => {
   config.defaultReapInterval = 'never';
   const controller = await buildVatController(config, [], t.context.data);
   t.teardown(controller.shutdown);
-  await t.throwsAsync(() => controller.run(), {
+  await t.throwsAsync(async () => controller.run(), {
     message: /invalid criticalVatKey/,
   });
 });

--- a/packages/SwingSet/test/vat-timer.test.js
+++ b/packages/SwingSet/test/vat-timer.test.js
@@ -244,8 +244,8 @@ test('brand', async t => {
   const delay = TimeMath.coerceRelativeTimeRecord(1000n, wrong);
   const exp = { message: /TimerBrands must match/ };
   t.throws(() => ts.setWakeup(when, handler), exp);
-  t.throws(() => ts.wakeAt(when), exp);
-  t.throws(() => ts.delay(delay), exp);
+  t.throws(async () => ts.wakeAt(when), exp);
+  t.throws(async () => ts.delay(delay), exp);
   t.throws(() => ts.makeRepeater(delay, delay), exp);
   t.throws(() => ts.repeatAfter(delay, delay, handler), exp);
   t.throws(() => ts.makeNotifier(delay, delay), exp);
@@ -443,7 +443,9 @@ test('delay', async t => {
   t.deepEqual(fired['0'], ['fulfill', toTS(110n)]);
 
   // delay must be non-negative
-  t.throws(() => ts.delay(toRT(-1n)), { message: /Must be non-negative/ });
+  t.throws(async () => ts.delay(toRT(-1n)), {
+    message: /Must be non-negative/,
+  });
 
   // cancelling a delay causes the promise to reject
   ts.cancel(cancel20);
@@ -1086,7 +1088,7 @@ test('iterator', async t => {
   t.deepEqual(done1, undefined);
 
   // concurrent next() is rejected
-  t.throws(() => iter.next(), {
+  t.throws(async () => iter.next(), {
     message: 'timer iterator dislikes overlapping next()',
   });
 

--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -46,7 +46,7 @@ export function buildRootObject() {
     return three === 3 ? 'three good' : `not three, got ${three}`;
   }
 
-  function checkA([pB, pC, pF, three, evt, evwft]) {
+  async function checkA([pB, pC, pF, three, evt, evwft]) {
     return Promise.all([
       pB.then(checkResB),
       pC.then(checkResC, checkErrC),

--- a/packages/SwingSet/test/workers/worker.test.js
+++ b/packages/SwingSet/test/workers/worker.test.js
@@ -81,7 +81,7 @@ test('accept node command-line args for node worker', async t => {
 
 test('reject node command-line args for non-node worker', async t => {
   const config = nodeVatConfig('xsnap');
-  await t.throwsAsync(() => buildVatController(config, []), {
+  await t.throwsAsync(async () => buildVatController(config, []), {
     message: "nodeOptions requires managerType 'node-subprocess'",
   });
 });

--- a/packages/SwingSet/test/xsnap-metering.test.js
+++ b/packages/SwingSet/test/xsnap-metering.test.js
@@ -61,7 +61,7 @@ async function doTest(t, metered) {
   const spawnArgs1 = await p1;
   checkMetered(t, spawnArgs1, metered);
   await worker1.evaluate('1+2');
-  t.teardown(() => worker1.close());
+  t.teardown(async () => worker1.close());
 
   // now extract a snapshot
   await store.saveSnapshot('vat', 1, worker1.makeSnapshotStream());
@@ -77,7 +77,7 @@ async function doTest(t, metered) {
   const spawnArgs2 = await p2;
   checkMetered(t, spawnArgs2, metered);
   await worker2.evaluate('1+2');
-  t.teardown(() => worker2.close());
+  t.teardown(async () => worker2.close());
 }
 
 test('no metering', async t => {

--- a/packages/SwingSet/test/xsnap-store.test.js
+++ b/packages/SwingSet/test/xsnap-store.test.js
@@ -17,7 +17,7 @@ const makeMockSnapStoreIO = () => ({
   measureSeconds: makeMeasureSeconds(() => 0),
 });
 
-const getBootScript = () =>
+const getBootScript = async () =>
   getLockdownBundle().then(bundle => `(${bundle.source}\n)()`.trim());
 
 /** @type {(compressedSize: number, fullSize: number) => number} */
@@ -61,7 +61,7 @@ async function bootSESWorker(name, handleCommand) {
 
 test(`create XS Machine, snapshot (${snapSize.raw} Kb), compress to smaller`, async t => {
   const vat = await bootWorker('xs1', async m => m, '1 + 1');
-  t.teardown(() => vat.close());
+  t.teardown(async () => vat.close());
 
   const db = sqlite3(':memory:');
   const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
@@ -80,7 +80,7 @@ test(`create XS Machine, snapshot (${snapSize.raw} Kb), compress to smaller`, as
 
 test('SES bootstrap, save, compress', async t => {
   const vat = await bootSESWorker('ses-boot1', async m => m);
-  t.teardown(() => vat.close());
+  t.teardown(async () => vat.close());
 
   const db = sqlite3(':memory:');
   const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
@@ -104,7 +104,7 @@ test('create SES worker, save, restore, resume', async t => {
   const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 
   const vat0 = await bootSESWorker('ses-boot2', async m => m);
-  t.teardown(() => vat0.close());
+  t.teardown(async () => vat0.close());
   await vat0.evaluate('globalThis.x = harden({a: 1})');
   await store.saveSnapshot('vat0', 1, vat0.makeSnapshotStream());
 
@@ -118,7 +118,7 @@ test('create SES worker, save, restore, resume', async t => {
     fs: { ...fs, ...fs.promises, tmpName },
   });
   await worker.isReady();
-  t.teardown(() => worker.close());
+  t.teardown(async () => worker.close());
   await worker.evaluate('x.a');
   t.pass();
 });
@@ -142,7 +142,7 @@ test('XS + SES snapshots are long-term deterministic', async t => {
   const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 
   const vat = await bootWorker('xs1', async m => m, '1 + 1');
-  t.teardown(() => vat.close());
+  t.teardown(async () => vat.close());
 
   const {
     filePath: _path1,

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -32,7 +32,7 @@ const providedCaches = new Map();
  * @param {number} [pid]
  * @returns {Promise<BundleCache>}
  */
-export const provideBundleCache = (dest, options, loadModule, pid) => {
+export const provideBundleCache = async (dest, options, loadModule, pid) => {
   const uniqueDest = [dest, options.format, options.dev].join('-');
   // store the promise instead of awaiting to prevent a race
   let bundleCache = providedCaches.get(uniqueDest);
@@ -48,5 +48,5 @@ harden(provideBundleCache);
  * @param {string} dest
  * @returns {Promise<BundleCache>}
  */
-export const unsafeMakeBundleCache = dest =>
-  makeNodeBundleCache(dest, {}, s => import(s));
+export const unsafeMakeBundleCache = async dest =>
+  makeNodeBundleCache(dest, {}, async s => import(s));

--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -109,7 +109,7 @@ export const makeRunUtils = (controller, harness) => {
     presence =>
       new Proxy(harden({}), {
         get: (_t, method, _rx) => {
-          const boundMethod = (...args) =>
+          const boundMethod = async (...args) =>
             queueAndRun(() =>
               controller.queueToVatObject(presence, method, args),
             );
@@ -120,7 +120,7 @@ export const makeRunUtils = (controller, harness) => {
       vat: vatName =>
         new Proxy(harden({}), {
           get: (_t, method, _rx) => {
-            const boundMethod = (...args) =>
+            const boundMethod = async (...args) =>
               queueAndRun(() =>
                 controller.queueToVatRoot(vatName, method, args),
               );
@@ -130,7 +130,7 @@ export const makeRunUtils = (controller, harness) => {
       sendOnly: presence =>
         new Proxy(harden({}), {
           get: (_t, method, _rx) => {
-            const boundMethod = (...args) =>
+            const boundMethod = async (...args) =>
               queueAndRun(
                 () => controller.queueToVatObject(presence, method, args),
                 true,
@@ -140,7 +140,7 @@ export const makeRunUtils = (controller, harness) => {
         }),
       get: presence =>
         new Proxy(harden({}), {
-          get: (_t, pathElement, _rx) =>
+          get: async (_t, pathElement, _rx) =>
             queueAndRun(() =>
               controller.queueToVatRoot('bootstrap', 'awaitVatObject', [
                 presence,

--- a/packages/SwingSet/tools/vat.js
+++ b/packages/SwingSet/tools/vat.js
@@ -51,11 +51,11 @@ async function main() {
       deepLog(d.acceptanceQueue);
     };
     r.context.dump2 = () => controller.dump();
-    r.context.run = () => {
+    r.context.run = async () => {
       console.log('run!');
       return controller.run();
     };
-    r.context.step = () => {
+    r.context.step = async () => {
       console.log('step!');
       return controller.step();
     };

--- a/packages/access-token/src/access-token.js
+++ b/packages/access-token/src/access-token.js
@@ -11,7 +11,7 @@ import { openJSONStore } from './json-store.js';
  * @param {BufferEncoding} [opts.stringBase]
  * @param {number} [opts.byteLength]
  */
-export function generateAccessToken({
+export async function generateAccessToken({
   stringBase = 'base64url',
   byteLength = 48,
 } = {}) {

--- a/packages/access-token/src/json-store.js
+++ b/packages/access-token/src/json-store.js
@@ -270,7 +270,7 @@ async function makeJSONStore(
  *            // changes
  * }
  */
-export function initJSONStore(dirPath) {
+export async function initJSONStore(dirPath) {
   if (dirPath !== null && dirPath !== undefined && `${dirPath}` !== dirPath) {
     throw Error('dirPath must be a string or nullish');
   }
@@ -294,7 +294,7 @@ export function initJSONStore(dirPath) {
  *            // changes
  * }
  */
-export function openJSONStore(dirPath) {
+export async function openJSONStore(dirPath) {
   if (`${dirPath}` !== dirPath) {
     throw Error('dirPath must be a string');
   }

--- a/packages/access-token/test/tmp.js
+++ b/packages/access-token/test/tmp.js
@@ -4,7 +4,7 @@ import tmp from 'tmp';
  * @param {string} [prefix]
  * @returns {Promise<[string, () => void]>}
  */
-export const tmpDir = prefix =>
+export const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     // We use `unsafeCleanup` because we want to remove the directory even if it
     // still contains files.

--- a/packages/agoric-cli/integration-tests/workflow.test.js
+++ b/packages/agoric-cli/integration-tests/workflow.test.js
@@ -2,4 +2,4 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { gettingStartedWorkflowTest } from '../tools/getting-started.js';
 
-test('"getting started" workflow', t => gettingStartedWorkflowTest(t));
+test('"getting started" workflow', async t => gettingStartedWorkflowTest(t));

--- a/packages/agoric-cli/src/commands/gov.js
+++ b/packages/agoric-cli/src/commands/gov.js
@@ -52,7 +52,7 @@ export const makeGovCommand = (_logger, io = {}) => {
     stderr = process.stderr,
     fetch = global.fetch,
     execFileSync = execFileSyncAmbient,
-    delay = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    delay = async ms => new Promise(resolve => setTimeout(resolve, ms)),
   } = io;
 
   const cmd = new Command('gov').description('Electoral governance commands');

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -220,7 +220,7 @@ export const makeInterCommand = (
   };
 
   /** @param {number} ms */
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const delay = async ms => new Promise(resolve => setTimeout(resolve, ms));
   const show = (info, indent = false) =>
     stdout.write(
       `${JSON.stringify(info, bigintReplacer, indent ? 2 : undefined)}\n`,

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -43,7 +43,7 @@ const scaleDecimals = num => BigInt(num * Number(COSMOS_UNIT));
  */
 export const makeOracleCommand = (logger, io = {}) => {
   const {
-    delay = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    delay = async ms => new Promise(resolve => setTimeout(resolve, ms)),
     execFileSync = cp.execFileSync,
     env = process.env,
     stdout = process.stdout,
@@ -284,7 +284,7 @@ export const makeOracleCommand = (logger, io = {}) => {
 
         const feedPath = `published.priceFeed.${pair[0]}-${pair[1]}_price_feed`;
 
-        const readPrice = () =>
+        const readPrice = async () =>
           /** @type {Promise<PriceDescription>} */ (
             readLatestHead(feedPath).catch(() => {
               const viewer = `https://vstorage.agoric.net/#${networkConfig.rpcAddrs[0]}|published,published.priceFeed|${feedPath}`;

--- a/packages/agoric-cli/src/commands/test-upgrade.js
+++ b/packages/agoric-cli/src/commands/test-upgrade.js
@@ -27,7 +27,7 @@ export const makeTestCommand = (
   { fetch },
 ) => {
   /** @param {number} ms */
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const delay = async ms => new Promise(resolve => setTimeout(resolve, ms));
   const show = (info, indent = false) =>
     stdout.write(
       `${JSON.stringify(info, bigintReplacer, indent ? 2 : undefined)}\n`,

--- a/packages/agoric-cli/src/cosmos.js
+++ b/packages/agoric-cli/src/cosmos.js
@@ -37,7 +37,7 @@ export default async function cosmosMain(progname, rawArgs, powers, opts) {
         .stat(cosmosHelper)
         .then(
           () => 0,
-          e => {
+          async e => {
             if (e.code === 'ENOENT') {
               // Build the client helper.
               log.warn('Building the Cosmos client helper...');
@@ -56,7 +56,7 @@ export default async function cosmosMain(progname, rawArgs, powers, opts) {
             throw e;
           },
         )
-        .then(code => {
+        .then(async code => {
           if (code !== 0) {
             throw Error(`Cosmos client helper build failed with code ${code}`);
           }

--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -180,14 +180,17 @@ const connectAndRun = async (
     ws.on('error', e => {
       if (e.code === 'ECONNREFUSED' && !connected) {
         // Retry in a little bit.
-        setTimeout(() => retryWebsocket().catch(exit.reject), RETRY_DELAY_MS);
+        setTimeout(
+          async () => retryWebsocket().catch(exit.reject),
+          RETRY_DELAY_MS,
+        );
         return;
       }
       exit.reject(e);
     });
   };
   // Start the retry process.
-  return retryWebsocket().then(() => exit.promise);
+  return retryWebsocket().then(async () => exit.promise);
 };
 
 export default async function deployMain(progname, rawArgs, powers, opts) {

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -27,7 +27,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
 
   const pspawn = makePspawn({ log, spawn, chalk });
 
-  const rimraf = file => pspawn('rm', ['-rf', file]);
+  const rimraf = async file => pspawn('rm', ['-rf', file]);
 
   async function getWorktreePackagePaths(cwd = '.', map = new Map()) {
     // run `yarn workspaces info` to get the list of directories to
@@ -188,7 +188,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
 
     // Ensure we do all the package.json+yarn.lock additions after any necessary
     // pruning, even if there are failures.
-    await prunedP.finally(() =>
+    await prunedP.finally(async () =>
       // Ensure the package.jsons are installed with the fresh version information.
       Promise.allSettled(addPackagesTodo.map(async update => update())),
     );

--- a/packages/agoric-cli/src/lib/casting.js
+++ b/packages/agoric-cli/src/lib/casting.js
@@ -9,7 +9,7 @@ import { delay, exponentialBackoff, randomBackoff } from '@agoric/casting';
  */
 export const makeLeaderOptions = ({ log, sleep, jitter }) => {
   return {
-    retryCallback: (where, e, attempt) => {
+    retryCallback: async (where, e, attempt) => {
       const backoff = Math.ceil(exponentialBackoff(attempt));
       log(
         `Retrying ${where} in ${backoff}ms due to:`,

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -63,7 +63,7 @@ export const getCurrent = async (addr, { readPublished }) => {
  * @param {Pick<VstorageKit, 'readPublished'>} io
  * @returns {Promise<import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord>}
  */
-export const getLastUpdate = (addr, { readPublished }) => {
+export const getLastUpdate = async (addr, { readPublished }) => {
   return readPublished(`wallet.${addr}`);
 };
 

--- a/packages/agoric-cli/src/scripts.js
+++ b/packages/agoric-cli/src/scripts.js
@@ -29,7 +29,7 @@ export const makeLookup =
    * @param  {string[]} args
    * @returns {Promise<any>}
    */
-  (...args) => {
+  async (...args) => {
     /** @type {string[]} */
     let namePath;
     if (args.length === 1 && Array.isArray(args[0])) {
@@ -102,7 +102,7 @@ export const makeScriptLoader =
           );
         };
       } else {
-        installUnsafePlugin = (plugin, pluginOpts = undefined) => {
+        installUnsafePlugin = async (plugin, pluginOpts = undefined) => {
           const tryInstallUnsafePlugin = async () => {
             const absPath = pathResolve(plugin);
             const pluginName = absPath.replace(PATH_SEP_RE, '_');
@@ -167,7 +167,7 @@ export { bootPlugin } from ${JSON.stringify(absPath)};
          * @param {import('@endo/bundle-source').BundleOptions<ModuleFormat>} options
          * @returns {Promise<import('@endo/bundle-source').BundleSourceResult<ModuleFormat>>}
          */
-        bundleSource: (file, options = {}) =>
+        bundleSource: async (file, options = {}) =>
           bundleSource(pathResolve(file), {
             elideComments: true,
             ...options,

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -58,7 +58,8 @@ const GAS_ADJUSTMENT = '1.2';
  * @param {number} ms
  * @returns {Promise<void>}
  */
-const delay = ms => new Promise(resolve => setTimeout(() => resolve(), ms));
+const delay = async ms =>
+  new Promise(resolve => setTimeout(() => resolve(), ms));
 
 export default async function startMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs, spawn, now, process } = powers;
@@ -95,10 +96,10 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   let keysSpawn;
   if (!opts.dockerTag) {
     const { cosmosHelper } = getSDKBinaries(sdkPrefixes);
-    keysSpawn = (args, ...rest) =>
+    keysSpawn = async (args, ...rest) =>
       pspawn(cosmosHelper, [`--home=_agstate/keys`, ...args], ...rest);
   } else {
-    keysSpawn = (args, ...rest) =>
+    keysSpawn = async (args, ...rest) =>
       pspawn(
         'docker',
         [
@@ -279,10 +280,10 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     /** @type {(args: string[], spawnOpts?: Parameters<typeof pspawn>[2], dockerArgs?: string[]) => ReturnType<pspawn>} */
     let chainSpawn;
     if (!popts.dockerTag) {
-      chainSpawn = (args, spawnOpts) =>
+      chainSpawn = async (args, spawnOpts) =>
         pspawn(cosmosChain, [...args, `--home=${serverDir}`], spawnOpts);
     } else {
-      chainSpawn = (args, spawnOpts, dockerArgs = []) =>
+      chainSpawn = async (args, spawnOpts, dockerArgs = []) =>
         pspawn(
           'docker',
           [
@@ -485,9 +486,9 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     /** @type {(args: string[], spawnOpts?: Parameters<typeof pspawn>[2], dockerArgs?: string[]) => ReturnType<pspawn>} */
     let soloSpawn;
     if (!popts.dockerTag) {
-      soloSpawn = (args, spawnOpts) => pspawn(agSolo, args, spawnOpts);
+      soloSpawn = async (args, spawnOpts) => pspawn(agSolo, args, spawnOpts);
     } else {
-      soloSpawn = (args, spawnOpts, dockerArgs = []) =>
+      soloSpawn = async (args, spawnOpts, dockerArgs = []) =>
         pspawn(
           'docker',
           [
@@ -705,7 +706,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       await rmVerbose(serverDir);
     }
 
-    const setupRun = (...bonusArgs) =>
+    const setupRun = async (...bonusArgs) =>
       pspawn('docker', [
         'run',
         `-p127.0.0.1:${HOST_PORT}:${port}`,
@@ -732,7 +733,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       await rmVerbose(serverDir);
     }
 
-    const setupRun = (...bonusArgs) =>
+    const setupRun = async (...bonusArgs) =>
       pspawn(agSolo, [`--webport=${port}`, ...bonusArgs], {
         env: { ...pspawnEnv, AG_SOLO_BASEDIR: serverDir },
       });

--- a/packages/agoric-cli/test/inter-cli.test.js
+++ b/packages/agoric-cli/test/inter-cli.test.js
@@ -176,7 +176,7 @@ const makeProcess = (t, keyring, out) => {
 
   /** @type {typeof setTimeout} */
   // @ts-expect-error mock
-  const setTimeout = (f, _ms) => Promise.resolve().then(_ => f());
+  const setTimeout = async (f, _ms) => Promise.resolve().then(_ => f());
 
   return {
     env: {},

--- a/packages/agoric-cli/test/main.test.js
+++ b/packages/agoric-cli/test/main.test.js
@@ -16,7 +16,7 @@ test('sanity', async t => {
     }
     return l;
   };
-  const myMain = args => {
+  const myMain = async args => {
     const oldConsole = console;
     try {
       // @ts-expect-error

--- a/packages/agoric-cli/test/publish-bundle.test.js
+++ b/packages/agoric-cli/test/publish-bundle.test.js
@@ -168,7 +168,7 @@ test('publish bundle with fake HTTP server ok', async t => {
     });
   });
   t.teardown(
-    () =>
+    async () =>
       new Promise((resolve, reject) =>
         server.close(err => {
           if (err) {

--- a/packages/agoric-cli/test/upgrade-contract/buggy-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/buggy-contract.js
@@ -25,7 +25,7 @@ export const start = async (zcf, _privateArgs, baggage) => {
 
   return harden({
     publicFacet: zone.exo('PublicFacet', undefined, {
-      makeInvitation: () => {
+      makeInvitation: async () => {
         return zcf.makeInvitation(offerHandler, 'free tokens');
       },
     }),

--- a/packages/agoric-cli/test/upgrade-contract/fixed-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/fixed-contract.js
@@ -29,7 +29,7 @@ export const start = async (zcf, _privateArgs, baggage) => {
 
   return harden({
     publicFacet: zone.exo('PublicFacet', undefined, {
-      makeInvitation: () => {
+      makeInvitation: async () => {
         return zcf.makeInvitation(offerHandler, 'free tokens fur realz');
       },
     }),

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -77,7 +77,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
   const pkill = (cp, signal = 'SIGINT') => process.kill(-cp.pid, signal);
 
   /** @param {Parameters<typeof pspawn>} args */
-  function pspawnStdout(...args) {
+  async function pspawnStdout(...args) {
     const ps = pspawn(...args);
     const { stdout } = ps.childProcess;
     if (stdout) {
@@ -99,7 +99,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
   };
   const { AGORIC_CMD = JSON.stringify(defaultAgoricCmd()) } = process.env;
   const agoricCmd = JSON.parse(AGORIC_CMD);
-  function myMain(args, opts = {}) {
+  async function myMain(args, opts = {}) {
     return pspawnStdout(agoricCmd[0], [...agoricCmd.slice(1), ...args], {
       stdio: ['ignore', 'pipe', 'inherit'],
       env: { ...process.env, DEBUG: 'agoric:debug' },
@@ -108,7 +108,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
     });
   }
 
-  function yarn(args) {
+  async function yarn(args) {
     return pspawnStdout('yarn', args, {
       stdio: ['ignore', 'pipe', 'inherit'],
       env: { ...process.env },

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -34,7 +34,7 @@ const dirname = new URL('./', import.meta.url).pathname;
  * @param {string} url
  * @returns {Promise<bigint>}
  */
-const getLatestBlockHeight = url =>
+const getLatestBlockHeight = async url =>
   new Promise((resolve, reject) => {
     const req = request(url, res => {
       if (!res) {

--- a/packages/async-flow/src/bijection.js
+++ b/packages/async-flow/src/bijection.js
@@ -111,7 +111,7 @@ const makeVowishStore = name => {
  */
 export const prepareBijection = (
   zone,
-  unwrap = (_hostWrapper, guestWrapper) => guestWrapper,
+  unwrap = async (_hostWrapper, guestWrapper) => guestWrapper,
 ) => {
   /** @type {Ephemera<Bijection, VowishStore>} */
   const g2h = makeEphemera(() => makeVowishStore('guestToHost'));

--- a/packages/async-flow/src/replay-membrane.js
+++ b/packages/async-flow/src/replay-membrane.js
@@ -539,7 +539,7 @@ export const makeReplayMembraneForTesting = ({
    *   paired with hVow.
    * @returns {Promise}
    */
-  const makeGuestForHostVow = (hVow, promiseKey = undefined) => {
+  const makeGuestForHostVow = async (hVow, promiseKey = undefined) => {
     isVow(hVow) || Fail`vow expected ${hVow}`;
     const { promise, resolve, reject } = makeGuestPromiseKit();
     promiseKey ??= promise;

--- a/packages/async-flow/test/async-flow-crank.test.js
+++ b/packages/async-flow/test/async-flow-crank.test.js
@@ -70,7 +70,7 @@ const testPlay3 = async (t, zone) => {
   const guestFunc = async () => neverSettlesP;
   t.notThrows(() => asyncFlow(zone, 'guestFunc', guestFunc));
   t.notThrowsAsync(
-    () => allWokenP,
+    async () => allWokenP,
     'will actually throw due to crank bug #9377',
   );
 };

--- a/packages/async-flow/test/convert.test.js
+++ b/packages/async-flow/test/convert.test.js
@@ -38,7 +38,7 @@ const testConvert = (t, zone, showOnConsole = false) => {
     return Far(`${iface} guest wrapper`, {});
   };
 
-  const makeGuestForHostVow = _hVow => Promise.resolve('guest P');
+  const makeGuestForHostVow = async _hVow => Promise.resolve('guest P');
 
   const { guestToHost, hostToGuest } = makeConvertKit(
     bij,

--- a/packages/async-flow/test/endowments.test.js
+++ b/packages/async-flow/test/endowments.test.js
@@ -102,7 +102,7 @@ const testEndowmentPlay = async (t, zone, gen, isDurable) => {
     return Far(`${iface} guest wrapper`, forwardingMethods(hRem));
   };
 
-  const makeGuestForHostVow = hVow => {
+  const makeGuestForHostVow = async hVow => {
     return when(hVow);
   };
 

--- a/packages/async-flow/test/replay-membrane-eventual.test.js
+++ b/packages/async-flow/test/replay-membrane-eventual.test.js
@@ -248,10 +248,13 @@ test.serial('test durable toggle eventual send', async t => {
 
   nextLife();
   const zone1 = makeDurableZone(getBaggage(), 'durableRoot');
-  await t.throwsAsync(() => testFirstPlay(t, zone1, testMode.noEventualSend), {
-    message:
-      /^panic over "\[Error: guest eventual applyMethod not yet supported:/,
-  });
+  await t.throwsAsync(
+    async () => testFirstPlay(t, zone1, testMode.noEventualSend),
+    {
+      message:
+        /^panic over "\[Error: guest eventual applyMethod not yet supported:/,
+    },
+  );
 
   await eventLoopIteration();
   nextLife();
@@ -261,10 +264,13 @@ test.serial('test durable toggle eventual send', async t => {
   await eventLoopIteration();
   nextLife();
   const zone2 = makeDurableZone(getBaggage(), 'durableRoot');
-  await t.throwsAsync(() => testReplay(t, zone2, testMode.noEventualSend), {
-    message:
-      /^panic over "\[Error: guest eventual applyMethod not yet supported:/,
-  });
+  await t.throwsAsync(
+    async () => testReplay(t, zone2, testMode.noEventualSend),
+    {
+      message:
+        /^panic over "\[Error: guest eventual applyMethod not yet supported:/,
+    },
+  );
 
   await eventLoopIteration();
   nextLife();

--- a/packages/benchmark/benchmark/benchmark-vault-adjust.js
+++ b/packages/benchmark/benchmark/benchmark-vault-adjust.js
@@ -59,7 +59,7 @@ bench.addBenchmark('adjust vault balance', {
 
     const adjustN = async n => {
       const range = [...Array(n)].map((_, i) => i + 1);
-      await Promise.all(range.map(i => adjustVault(i, n, round)));
+      await Promise.all(range.map(async i => adjustVault(i, n, round)));
     };
 
     const roundSize = context.options.size ? Number(context.options.size) : 1;

--- a/packages/benchmark/benchmark/benchmark-vault-open.js
+++ b/packages/benchmark/benchmark/benchmark-vault-open.js
@@ -28,7 +28,7 @@ bench.addBenchmark('open vault', {
 
     const openN = async n => {
       const range = [...Array(n)].map((_, i) => i + 1);
-      await Promise.all(range.map(i => openVault(i, n, round)));
+      await Promise.all(range.map(async i => openVault(i, n, round)));
     };
 
     const roundSize = context.options.size ? Number(context.options.size) : 1;

--- a/packages/boot/test/bootstrapTests/addAssets.test.ts
+++ b/packages/boot/test/bootstrapTests/addAssets.test.ts
@@ -52,7 +52,7 @@ test.before(async t => {
   };
 });
 
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/demo-config.test.ts
+++ b/packages/boot/test/bootstrapTests/demo-config.test.ts
@@ -19,7 +19,7 @@ type DefaultTestContext = Awaited<ReturnType<typeof makeDefaultTestContext>>;
 const test: TestFn<DefaultTestContext> = anyTest;
 
 test.before(async t => (t.context = await makeDefaultTestContext(t)));
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 // Goal: test that prod config does not expose mailbox access.
 // But on the JS side, aside from vattp, prod config exposes mailbox access

--- a/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
+++ b/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
@@ -348,7 +348,7 @@ test.serial('unsuccessful vote by 2 outgoing members', async t => {
   t.log('voting is done by invitations already present and should fail');
   const votePromises = outgoingCommittee
     .slice(0, 2)
-    .map(member =>
+    .map(async member =>
       member.voteOnLatestProposal(getVoteId(3), offerIds.vote.outgoing),
     );
 
@@ -399,7 +399,7 @@ test.serial(
 
     t.log('Voting on question using first all wallets');
     t.log('first 2 should pass, last should fail');
-    const votePromises = committee.map((member, index) =>
+    const votePromises = committee.map(async (member, index) =>
       member.voteOnLatestProposal(
         getVoteId(4),
         index === 2 ? offerIds.vote.outgoing : offerIds.vote.incoming,
@@ -455,7 +455,7 @@ test.serial(
 
     t.log('Voting on question using first all wallets');
     t.log('first 2 should fail, last should pass');
-    const votePromises = committee.map((member, index) =>
+    const votePromises = committee.map(async (member, index) =>
       member.voteOnLatestProposal(
         getVoteId(5),
         index === 0 ? offerIds.vote.incoming : offerIds.vote.outgoing,

--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -47,8 +47,8 @@ export const start = async (zcf, privateArgs, _baggage) => {
       assert(connP, 'must connect first');
       ackP = E(connP).send(data);
     },
-    getAck: () => E.when(ackP),
-    close: () => E(connP).close(),
+    getAck: async () => E.when(ackP),
+    close: async () => E(connP).close(),
     getLocalAddress: async () => {
       return E(myPort).getLocalAddress();
     },

--- a/packages/boot/test/bootstrapTests/lca.test.ts
+++ b/packages/boot/test/bootstrapTests/lca.test.ts
@@ -19,7 +19,7 @@ test.before(async t => {
     '@agoric/vm-config/decentral-itest-orchestration-config.json',
   );
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test.serial('stakeBld', async t => {
   const {

--- a/packages/boot/test/bootstrapTests/liquidation-1.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-1.test.ts
@@ -122,7 +122,7 @@ const outcome = {
 test.before(async t => {
   t.context = await makeLiquidationTestContext(t);
 });
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/liquidation-2b.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-2b.test.ts
@@ -120,7 +120,7 @@ const outcome = {
 test.before(async t => {
   t.context = await makeLiquidationTestContext(t);
 });
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/liquidation-concurrent-1.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-concurrent-1.test.ts
@@ -228,7 +228,7 @@ test.before(async t => {
   t.context = await makeLiquidationTestContext(t);
 });
 
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 
@@ -257,7 +257,7 @@ test('concurrent flow 1', async t => {
   ];
 
   await Promise.all(
-    cases.map(({ collateralBrandKey }) =>
+    cases.map(async ({ collateralBrandKey }) =>
       ensureVaultCollateral(collateralBrandKey, t),
     ),
   );
@@ -290,7 +290,7 @@ test('concurrent flow 1', async t => {
   );
 
   await Promise.all(
-    cases.map(({ collateralBrandKey }) =>
+    cases.map(async ({ collateralBrandKey }) =>
       placeBids(collateralBrandKey, 'agoric1buyer', setups[collateralBrandKey]),
     ),
   );

--- a/packages/boot/test/bootstrapTests/liquidation-concurrent-2b.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-concurrent-2b.test.ts
@@ -192,7 +192,7 @@ const outcomes = {
 test.before(async t => {
   t.context = await makeLiquidationTestContext(t);
 });
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 
@@ -216,7 +216,7 @@ test.serial(
     ];
 
     await Promise.all(
-      cases.map(({ collateralBrandKey }) =>
+      cases.map(async ({ collateralBrandKey }) =>
         ensureVaultCollateral(collateralBrandKey, t),
       ),
     );
@@ -247,7 +247,7 @@ test.serial(
     );
 
     await Promise.all(
-      cases.map(({ collateralBrandKey }) =>
+      cases.map(async ({ collateralBrandKey }) =>
         placeBids(
           collateralBrandKey,
           'agoric1buyer',

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -32,7 +32,7 @@ export const makeTestContext = async t => {
   const bundleCache = await makeNodeBundleCache(
     bundleDir,
     { cacheSourceMaps: false },
-    s => import(s),
+    async s => import(s),
   );
   const swingsetTestKit = await makeSwingsetTestKit(t.log, bundleDir, {
     configSpecifier: PLATFORM_CONFIG,
@@ -48,7 +48,7 @@ const test = anyTest as TestFn<Awaited<ReturnType<typeof makeTestContext>>>;
 test.before(async t => {
   t.context = await makeTestContext(t);
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test.serial('bootstrap produces provisioning vat', async t => {
   const { EV } = t.context.runUtils;

--- a/packages/boot/test/bootstrapTests/orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/orchestration.test.ts
@@ -56,7 +56,7 @@ test.before(async t => {
   );
   t.context = { ...ctx, harness };
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 /**
  * Test the config itself. Part of this suite so we don't have to start up another swingset.

--- a/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
+++ b/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
@@ -32,7 +32,7 @@ test.before(
   async t =>
     (t.context = await makeLiquidationTestContext(t, { env: process.env })),
 );
-test.after.always(t => t.context.shutdown());
+test.after.always(async t => t.context.shutdown());
 
 const collateralBrandKey = 'ATOM';
 const managerIndex = 0;

--- a/packages/boot/test/bootstrapTests/updateGovernedParams.test.ts
+++ b/packages/boot/test/bootstrapTests/updateGovernedParams.test.ts
@@ -72,7 +72,7 @@ const test = anyTest as TestFn<
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
+++ b/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
@@ -67,7 +67,7 @@ const test = anyTest as TestFn<
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/vat-orchestration.test.ts
+++ b/packages/boot/test/bootstrapTests/vat-orchestration.test.ts
@@ -70,7 +70,7 @@ test.before(async t => {
   await setupDeps();
 });
 
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 // skipping until EV supports Vows, or this functionality is tested elsewhere #9572
 test.skip('makeAccount returns an ICA connection', async t => {

--- a/packages/boot/test/bootstrapTests/vats-restart.test.ts
+++ b/packages/boot/test/bootstrapTests/vats-restart.test.ts
@@ -63,7 +63,7 @@ const collateralBrandKey = 'ATOM';
 test.before(async t => {
   t.context = await makeTestContext(t);
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 const walletAddr = 'agoric1a';
 

--- a/packages/boot/test/bootstrapTests/vaults-integration.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-integration.test.ts
@@ -67,7 +67,7 @@ const test = anyTest as TestFn<
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
@@ -84,7 +84,7 @@ test.before(async t => {
   const shared = await makeDefaultTestContext(t);
   t.context = { shared };
 });
-test.after.always(t => t.context.shared.shutdown());
+test.after.always(async t => t.context.shared.shutdown());
 
 test.serial('re-bootstrap', async t => {
   const oldContext = { ...t.context.shared };
@@ -205,7 +205,7 @@ test.serial('audit bootstrap exports', async t => {
   const toIface = new Map();
   const anObj = Far('obj', {});
   const aPromise = harden(new Promise(() => {}));
-  const saveBootstrapIface = (slot, iface) => {
+  const saveBootstrapIface = async (slot, iface) => {
     if (slot.startsWith('p')) return aPromise;
     if (oids.has(slot)) {
       toIface.set(slot, iface);

--- a/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
+++ b/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
@@ -15,7 +15,7 @@ test.before(async t => {
     '@agoric/vm-config/decentral-itest-orchestration-config.json',
   );
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test('resolves', async t => {
   const { walletFactoryDriver, buildProposal, evalProposal } = t.context;

--- a/packages/boot/test/bootstrapTests/vtransfer.test.ts
+++ b/packages/boot/test/bootstrapTests/vtransfer.test.ts
@@ -20,7 +20,7 @@ type DefaultTestContext = Awaited<ReturnType<typeof makeDefaultTestContext>>;
 const test: TestFn<DefaultTestContext> = anyTest;
 
 test.before(async t => (t.context = await makeDefaultTestContext(t)));
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test('vtransfer', async t => {
   const {
@@ -108,7 +108,7 @@ test('vtransfer', async t => {
   ]);
 
   // test adding an interceptor for the same target, which should fail
-  await t.throwsAsync(() => evalProposal(testVtransferProposal), {
+  await t.throwsAsync(async () => evalProposal(testVtransferProposal), {
     message: /Target.*already registered/,
   });
 });

--- a/packages/boot/test/bootstrapTests/walletSurvivesZoeRestart.test.ts
+++ b/packages/boot/test/bootstrapTests/walletSurvivesZoeRestart.test.ts
@@ -47,7 +47,7 @@ test.before(async t => {
   t.context = await makeLiquidationTestContext(t);
 });
 
-test.after.always(t => {
+test.after.always(async t => {
   return t.context.shutdown && t.context.shutdown();
 });
 

--- a/packages/boot/test/bootstrapTests/zcf-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/zcf-upgrade.test.ts
@@ -74,7 +74,7 @@ test.before(async t => {
   t.context = await makeZoeTestContext(t);
 });
 
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test('run restart-vats proposal', async t => {
   const { controller, buildProposal, evalProposal, zoeDriver } = t.context;

--- a/packages/boot/test/bootstrapTests/zcfProbe.contract.js
+++ b/packages/boot/test/bootstrapTests/zcfProbe.contract.js
@@ -28,7 +28,7 @@ const ZcfProbeI = M.interface('ZCF Probe', {
  */
 export const start = async (zcf, privateArgs, baggage) => {
   const { probeMint } = await provideAll(baggage, {
-    probeMint: () => zcf.makeZCFMint('Ducats'),
+    probeMint: async () => zcf.makeZCFMint('Ducats'),
   });
 
   const storageNode = privateArgs?.storageNode;

--- a/packages/boot/test/configs.test.js
+++ b/packages/boot/test/configs.test.js
@@ -12,7 +12,7 @@ import { mustMatch } from '@agoric/store';
 import { loadSwingsetConfigFile, shape as ssShape } from '@agoric/swingset-vat';
 import { provideBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 
-const importConfig = configName =>
+const importConfig = async configName =>
   importMetaResolve(`@agoric/vm-config/${configName}`, import.meta.url).then(
     u => new URL(u).pathname,
   );
@@ -66,7 +66,11 @@ const makeTestContext = async () => {
   const pathResolve = (...ps) => path.join(dirname, ...ps);
 
   const cacheDir = pathResolve('..', 'bundles');
-  const bundleCache = await provideBundleCache(cacheDir, {}, s => import(s));
+  const bundleCache = await provideBundleCache(
+    cacheDir,
+    {},
+    async s => import(s),
+  );
 
   const vizTool = pathResolve('..', 'tools', 'authorityViz.js');
   const runViz = pspawn(vizTool, { spawn: ambientSpawn });

--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -48,7 +48,7 @@ test.before('bootstrap', async t => {
   });
   t.context = { ...ctx, harness };
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test.serial('oracles provision before contract deployment', async t => {
   const { walletFactoryDriver: wd } = t.context;
@@ -71,7 +71,7 @@ test.serial(
 
     const { oracles } = configurations.MAINNET;
     const [watcherWallet] = await Promise.all(
-      Object.values(oracles).map(addr => wd.provideSmartWallet(addr)),
+      Object.values(oracles).map(async addr => wd.provideSmartWallet(addr)),
     );
 
     // inbound `startChannelOpenInit` responses immediately.
@@ -281,7 +281,7 @@ test.serial('makes usdc advance', async t => {
     wd.provideSmartWallet('agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj'),
   ]);
   await Promise.all(
-    oracles.map(wallet =>
+    oracles.map(async wallet =>
       wallet.sendOffer({
         id: 'claim-oracle-invitation',
         invitationSpec: {
@@ -304,7 +304,7 @@ test.serial('makes usdc advance', async t => {
 
   harness?.useRunPolicy(true);
   await Promise.all(
-    oracles.map(wallet =>
+    oracles.map(async wallet =>
       wallet.sendOffer({
         id: 'submit-mock-evidence-osmo',
         invitationSpec: {
@@ -360,7 +360,7 @@ test.serial('skips usdc advance when risks identified', async t => {
   );
 
   await Promise.all(
-    oracles.map(wallet =>
+    oracles.map(async wallet =>
       wallet.sendOffer({
         id: 'submit-mock-evidence-dydx-risky',
         invitationSpec: {

--- a/packages/boot/test/orchestration/contract-upgrade.test.ts
+++ b/packages/boot/test/orchestration/contract-upgrade.test.ts
@@ -19,7 +19,7 @@ test.before(async t => {
     '@agoric/vm-config/decentral-itest-orchestration-config.json',
   );
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 /**
  * This test core-evals an installation of the sendAnywhere contract that

--- a/packages/boot/test/orchestration/restart-contracts.test.ts
+++ b/packages/boot/test/orchestration/restart-contracts.test.ts
@@ -23,7 +23,7 @@ test.before(async t => {
     '@agoric/vm-config/decentral-itest-orchestration-config.json',
   );
 });
-test.after.always(t => t.context.shutdown?.());
+test.after.always(async t => t.context.shutdown?.());
 
 test.serial('send-anywhere', async t => {
   const {

--- a/packages/boot/test/upgrading/upgrade-contracts.test.js
+++ b/packages/boot/test/upgrading/upgrade-contracts.test.js
@@ -12,7 +12,7 @@ import { buildVatController } from '@agoric/swingset-vat';
 const test = anyTest;
 
 const bfile = name => new URL(name, import.meta.url).pathname;
-const importSpec = spec =>
+const importSpec = async spec =>
   importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
 test('upgrade mintHolder', async t => {

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -12,7 +12,7 @@ import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
 import type { buildRootObject as buildTestMintVat } from './vat-mint.js';
 
 const bfile = name => new URL(name, import.meta.url).pathname;
-const importSpec = spec =>
+const importSpec = async spec =>
   importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
 const makeCallOutbound = t => (srcID, obj) => {
@@ -341,10 +341,10 @@ test('upgrade vat-bank', async t => {
 
   t.is(incarnationNumber, 1, 'Bank vat must be upgraded');
 
-  await t.throwsAsync(() => EV(noBridgeIterator).next(), {
+  await t.throwsAsync(async () => EV(noBridgeIterator).next(), {
     message: 'vat terminated',
   });
-  await t.throwsAsync(() => EV(bridgedIterator).next(), {
+  await t.throwsAsync(async () => EV(bridgedIterator).next(), {
     message: 'vat terminated',
   });
 

--- a/packages/boot/tools/authorityViz.js
+++ b/packages/boot/tools/authorityViz.js
@@ -243,7 +243,7 @@ const main = async (args, { stdout, fsp, meta }) => {
 
   const { MANIFEST } = await meta
     .resolve(bootstrap.sourceSpec, meta.url)
-    .then(p => meta.load(p));
+    .then(async p => meta.load(p));
   // console.log('manifest keys:', Object.keys(MANIFEST));
 
   const [gov] = ['--gov'].map(opt => opts.includes(opt));
@@ -276,7 +276,7 @@ const run = async () => {
     meta: {
       resolve: metaResolve.resolve,
       url: import.meta.url,
-      load: specifier => import(specifier),
+      load: async specifier => import(specifier),
     },
   });
 };

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -154,7 +154,9 @@ export const makePriceFeedDriver = async (
   const priceFeedName = oracleBrandFeedName(collateralBrandKey, 'USD');
 
   const oracleWallets = await Promise.all(
-    oracleAddresses.map(addr => walletFactoryDriver.provideSmartWallet(addr)),
+    oracleAddresses.map(async addr =>
+      walletFactoryDriver.provideSmartWallet(addr),
+    ),
   );
 
   let nonce = 0;
@@ -165,7 +167,7 @@ export const makePriceFeedDriver = async (
     nonce += 1;
     adminOfferId = `accept-${collateralBrandKey}-oracleInvitation${nonce}`;
     return Promise.all(
-      oracleWallets.map(w =>
+      oracleWallets.map(async w =>
         w.executeOffer({
           id: adminOfferId,
           invitationSpec: {
@@ -185,7 +187,7 @@ export const makePriceFeedDriver = async (
   return {
     async setPrice(price: number) {
       await Promise.all(
-        oracleWallets.map(w =>
+        oracleWallets.map(async w =>
           w.executeOfferMaker(
             Offers.fluxAggregator.PushPrice,
             {
@@ -229,7 +231,7 @@ export const makeGovernanceDriver = async (
   let invitationsAccepted = false;
 
   const smartWallets = await Promise.all(
-    committeeAddresses.map(address =>
+    committeeAddresses.map(async address =>
       walletFactoryDriver.provideSmartWallet(address),
     ),
   );
@@ -385,7 +387,7 @@ export const makeGovernanceDriver = async (
     voteId = 'voteInNewLimit',
     committeeId = committeeMembershipId,
   ) => {
-    const promises = members.map(member =>
+    const promises = members.map(async member =>
       member.voteOnLatestProposal(voteId, committeeId),
     );
     await Promise.all(promises);

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -167,7 +167,7 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
   const getPkgPath = (pkg, fileName = '') =>
     new URL(`../../${pkg}/${fileName}`, import.meta.url).pathname;
 
-  const importSpec = spec =>
+  const importSpec = async spec =>
     importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
   const runPackageScript = (
@@ -228,7 +228,8 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
       ).toString(),
     );
 
-    const loadPkgFile = fileName => fs.readFile(join(tmpDir, fileName), 'utf8');
+    const loadPkgFile = async fileName =>
+      fs.readFile(join(tmpDir, fileName), 'utf8');
 
     const evalsP = Promise.all(
       built.evals.map(async ({ permit, script }) => {
@@ -625,13 +626,13 @@ export const makeSwingsetTestKit = async (
   const updateTimer = async time => {
     await timer.poll(time);
   };
-  const jumpTimeTo = (targetTime: Timestamp) => {
+  const jumpTimeTo = async (targetTime: Timestamp) => {
     targetTime = TimeMath.absValue(targetTime);
     targetTime >= currentTime ||
       Fail`cannot reverse time :-(  (${targetTime} < ${currentTime})`;
     currentTime = targetTime;
     trace('jumpTimeTo', currentTime);
-    return runUtils.queueAndRun(() => updateTimer(currentTime), true);
+    return runUtils.queueAndRun(async () => updateTimer(currentTime), true);
   };
   const advanceTimeTo = async (targetTime: Timestamp) => {
     targetTime = TimeMath.absValue(targetTime);
@@ -640,10 +641,10 @@ export const makeSwingsetTestKit = async (
     while (currentTime < targetTime) {
       trace('stepping time from', currentTime, 'towards', targetTime);
       currentTime += 1n;
-      await runUtils.queueAndRun(() => updateTimer(currentTime), true);
+      await runUtils.queueAndRun(async () => updateTimer(currentTime), true);
     }
   };
-  const advanceTimeBy = (
+  const advanceTimeBy = async (
     n: number,
     unit: 'seconds' | 'minutes' | 'hours' | 'days',
   ) => {

--- a/packages/builders/scripts/fast-usdc/fast-usdc-update.build.js
+++ b/packages/builders/scripts/fast-usdc/fast-usdc-update.build.js
@@ -55,7 +55,7 @@ export default async (homeP, endowments) => {
     return JSON.parse(feedPolicy);
   };
   const config = harden({ feedPolicy: parseFeedPolicy() });
-  await writeCoreEval('eval-fast-usdc-policy-update', utils =>
+  await writeCoreEval('eval-fast-usdc-policy-update', async utils =>
     updateProposalBuilder(utils, config),
   );
 };

--- a/packages/builders/scripts/fast-usdc/init-fast-usdc.js
+++ b/packages/builders/scripts/fast-usdc/init-fast-usdc.js
@@ -191,7 +191,7 @@ export default async (homeP, endowments) => {
     noNoble,
   });
 
-  await writeCoreEval('start-fast-usdc', utils =>
+  await writeCoreEval('start-fast-usdc', async utils =>
     defaultProposalBuilder(utils, config),
   );
 };

--- a/packages/builders/scripts/inter-protocol/add-collateral-core.js
+++ b/packages/builders/scripts/inter-protocol/add-collateral-core.js
@@ -108,11 +108,11 @@ export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
   const tool = await makeInstallCache(homeP, {
-    loadBundle: spec => import(spec),
+    loadBundle: async spec => import(spec),
   });
 
   await writeCoreEval('gov-add-collateral', defaultProposalBuilder);
-  await writeCoreEval('gov-start-psm', opts =>
+  await writeCoreEval('gov-start-psm', async opts =>
     psmProposalBuilder({
       ...opts,
       // @ts-expect-error XXX makeInstallCache types

--- a/packages/builders/scripts/inter-protocol/init-core.js
+++ b/packages/builders/scripts/inter-protocol/init-core.js
@@ -151,7 +151,7 @@ export const defaultProposalBuilder = async (
 
   /** @param {Record<string, [string, string]>} group */
   const publishGroup = group =>
-    objectMap(group, ([mod, bundle]) => publishRef(install(mod, bundle)));
+    objectMap(group, async ([mod, bundle]) => publishRef(install(mod, bundle)));
 
   const anchorOptions = anchorDenom && {
     denom: anchorDenom,
@@ -189,14 +189,14 @@ export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
   const tool = await makeInstallCache(homeP, {
-    loadBundle: spec => import(spec),
+    loadBundle: async spec => import(spec),
   });
   await Promise.all([
-    writeCoreEval('gov-econ-committee', opts =>
+    writeCoreEval('gov-econ-committee', async opts =>
       // @ts-expect-error XXX makeInstallCache types
       committeeProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
     ),
-    writeCoreEval('gov-amm-vaults-etc', opts =>
+    writeCoreEval('gov-amm-vaults-etc', async opts =>
       // @ts-expect-error XXX makeInstallCache types
       mainProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
     ),

--- a/packages/builders/scripts/inter-protocol/price-feed-core.js
+++ b/packages/builders/scripts/inter-protocol/price-feed-core.js
@@ -89,7 +89,7 @@ export const createGov = async (homeP, endowments) => {
   const inLookup = JSON.parse(IN_BRAND_LOOKUP);
   const outLookup = JSON.parse(OUT_BRAND_LOOKUP);
 
-  const proposalBuilder = powers =>
+  const proposalBuilder = async powers =>
     defaultProposalBuilder(powers, {
       AGORIC_INSTANCE_NAME,
       IN_BRAND_DECIMALS: parseInt(IN_BRAND_DECIMALS, 10),

--- a/packages/builders/scripts/inter-protocol/replace-electorate-core.js
+++ b/packages/builders/scripts/inter-protocol/replace-electorate-core.js
@@ -158,6 +158,6 @@ export default async (homeP, endowments) => {
 
   await writeCoreEval(
     `replace-committee-${opts.variant || 'from-config'}`,
-    utils => defaultProposalBuilder(utils, opts),
+    async utils => defaultProposalBuilder(utils, opts),
   );
 };

--- a/packages/builders/scripts/inter-protocol/replace-feeDistributor.js
+++ b/packages/builders/scripts/inter-protocol/replace-feeDistributor.js
@@ -16,7 +16,7 @@ export const defaultProposalBuilder = async (_, opts) => {
 export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval('replace-feeDistributor', utils =>
+  await writeCoreEval('replace-feeDistributor', async utils =>
     defaultProposalBuilder(utils, {
       collectionInterval: 1n * SECONDS_PER_HOUR,
       keywordShares: {

--- a/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
+++ b/packages/builders/scripts/inter-protocol/updatePriceFeeds.js
@@ -123,6 +123,6 @@ export default async (homeP, endowments) => {
 
   await writeCoreEval(
     `gov-price-feeds-${opts.variant || 'from-config'}`,
-    utils => defaultProposalBuilder(utils, opts),
+    async utils => defaultProposalBuilder(utils, opts),
   );
 };

--- a/packages/builders/scripts/orchestration/init-basic-flows.js
+++ b/packages/builders/scripts/orchestration/init-basic-flows.js
@@ -61,7 +61,7 @@ export default async (homeP, endowments) => {
 
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval(startBasicFlows.name, utils =>
+  await writeCoreEval(startBasicFlows.name, async utils =>
     defaultProposalBuilder(utils, opts),
   );
 };

--- a/packages/builders/scripts/testing/init-auto-stake-it.js
+++ b/packages/builders/scripts/testing/init-auto-stake-it.js
@@ -67,7 +67,7 @@ export default async (homeP, endowments) => {
 
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval(startAutoStakeIt.name, utils =>
+  await writeCoreEval(startAutoStakeIt.name, async utils =>
     defaultProposalBuilder(utils, opts),
   );
 };

--- a/packages/builders/scripts/testing/init-send-anywhere.js
+++ b/packages/builders/scripts/testing/init-send-anywhere.js
@@ -61,7 +61,7 @@ export default async (homeP, endowments) => {
 
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval(startSendAnywhere.name, utils =>
+  await writeCoreEval(startSendAnywhere.name, async utils =>
     defaultProposalBuilder(utils, opts),
   );
 };

--- a/packages/builders/scripts/testing/replace-feeDistributor-short.js
+++ b/packages/builders/scripts/testing/replace-feeDistributor-short.js
@@ -21,7 +21,7 @@ export const defaultProposalBuilder = async (_, opts) => {
 export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
 
-  await writeCoreEval('replace-feeDistributor-testing', utils =>
+  await writeCoreEval('replace-feeDistributor-testing', async utils =>
     defaultProposalBuilder(utils, {
       collectionInterval: 30n,
       keywordShares: {

--- a/packages/builders/scripts/vats/terminate-governor-instance.js
+++ b/packages/builders/scripts/vats/terminate-governor-instance.js
@@ -128,7 +128,7 @@ export default async (homeP, endowments) => {
   const dspModule = await import('@agoric/deploy-script-support');
   const { makeHelpers } = dspModule;
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
-  await writeCoreEval(terminateGovernors.name, utils =>
+  await writeCoreEval(terminateGovernors.name, async utils =>
     defaultProposalBuilder(utils, scriptArgs),
   );
 };

--- a/packages/builders/scripts/vats/upgrade-mintHolder.js
+++ b/packages/builders/scripts/vats/upgrade-mintHolder.js
@@ -120,7 +120,7 @@ export default async (homeP, endowments) => {
   }
 
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
-  await writeCoreEval(`upgrade-mintHolder`, utils =>
+  await writeCoreEval(`upgrade-mintHolder`, async utils =>
     defaultProposalBuilder(utils, opts),
   );
 };

--- a/packages/cache/src/cache.js
+++ b/packages/cache/src/cache.js
@@ -26,7 +26,7 @@ export const makeCache = (coordinator = makeScalarStoreCoordinator()) => {
    * @param {Passable} key the cache key (any key type acceptable to the cache)
    * @param {[] | [Update] | [Update, Pattern]} optUpdateGuardPattern an optional
    */
-  const cache = (key, ...optUpdateGuardPattern) => {
+  const cache = async (key, ...optUpdateGuardPattern) => {
     if (optUpdateGuardPattern.length === 0) {
       return E(coordinator).getRecentValue(key);
     }

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -10,7 +10,7 @@ import { withGroundState, makeState } from './state.js';
  * @param {(obj: Passable) => Passable} [sanitize]
  * @returns {(key: Passable) => Promise<string>}
  */
-const makeKeyToString = (sanitize = obj => obj) => {
+const makeKeyToString = (sanitize = async obj => obj) => {
   let lastNonce = 0;
   const valToNonce = new WeakMap();
   const valToSlot = val => {
@@ -148,7 +148,7 @@ export const makeScalarStoreCoordinator = (
       const keyStr = await serializePassable(key);
       return applyCacheTransaction(
         keyStr,
-        () => newValue,
+        async () => newValue,
         guardPattern,
         sanitize,
         defaultStateStore,
@@ -158,7 +158,7 @@ export const makeScalarStoreCoordinator = (
       const keyStr = await serializePassable(key);
       return applyCacheTransaction(
         keyStr,
-        oldValue => E(updater).update(oldValue),
+        async oldValue => E(updater).update(oldValue),
         guardPattern,
         sanitize,
         defaultStateStore,
@@ -228,7 +228,7 @@ export const makeChainStorageCoordinator = (storageNode, marshaller) => {
       const keyStr = await serializePassable(key);
       const storedValue = await applyCacheTransaction(
         keyStr,
-        () => newValue,
+        async () => newValue,
         guardPattern,
         sanitize,
         defaultStateStore,
@@ -239,7 +239,7 @@ export const makeChainStorageCoordinator = (storageNode, marshaller) => {
       const keyStr = await serializePassable(key);
       const storedValue = await applyCacheTransaction(
         keyStr,
-        oldValue => E(updater).update(oldValue),
+        async oldValue => E(updater).update(oldValue),
         guardPattern,
         sanitize,
         defaultStateStore,

--- a/packages/cache/test/storage.test.js
+++ b/packages/cache/test/storage.test.js
@@ -110,7 +110,7 @@ test('makeChainStorageCoordinator with remote values', async t => {
 test('makeChainStorageCoordinator with updater', async t => {
   const { cache, storageNodeState } = setup();
 
-  const increment = (counter = 0) => Promise.resolve(counter + 1);
+  const increment = async (counter = 0) => Promise.resolve(counter + 1);
 
   // Initial
   t.is(await cache('counter', increment), 1);

--- a/packages/casting/src/change-follower.js
+++ b/packages/casting/src/change-follower.js
@@ -18,7 +18,7 @@ export const makePollingChangeFollower = async leader => {
         next: async () => {
           if (!nextPollPromise) {
             nextPollPromise = keepPolling('polling change follower').then(
-              cont => {
+              async cont => {
                 if (cont) {
                   return E(leader)
                     .jitter('polling change follower')

--- a/packages/casting/src/defaults.js
+++ b/packages/casting/src/defaults.js
@@ -21,7 +21,8 @@ export const DEFAULT_KEEP_POLLING_SECONDS = 5;
  * @param {number} ms
  * @returns {Promise<void>}
  */
-export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+export const delay = async ms =>
+  new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * @param {number} range
@@ -46,7 +47,7 @@ export const exponentialBackoff = (attempt = 0, base = 1_000, cap = 30_000) => {
  * @param {string} where
  * @returns {Promise<void>}
  */
-export const DEFAULT_JITTER = where => {
+export const DEFAULT_JITTER = async where => {
   const jitter = randomBackoff(DEFAULT_JITTER_SECONDS * 1_000);
   console.debug(`jittering ${where} by ${Math.ceil(jitter)}ms`);
   return delay(jitter);
@@ -60,7 +61,7 @@ export const DEFAULT_JITTER = where => {
  * @param {number} [attempt]
  * @returns {Promise<void>}
  */
-export const DEFAULT_RETRY_CALLBACK = (where, err, attempt = 0) => {
+export const DEFAULT_RETRY_CALLBACK = async (where, err, attempt = 0) => {
   const backoff = exponentialBackoff(attempt);
   console.log(
     `retrying ${where} in ${Math.ceil(backoff)}ms after attempt #${attempt}`,
@@ -74,7 +75,7 @@ export const DEFAULT_RETRY_CALLBACK = (where, err, attempt = 0) => {
  *
  * @returns {Promise<boolean>}
  */
-export const DEFAULT_KEEP_POLLING = () =>
+export const DEFAULT_KEEP_POLLING = async () =>
   delay(randomBackoff(DEFAULT_KEEP_POLLING_SECONDS * 1_000)).then(() => true);
 
 export const MAKE_DEFAULT_DECODER = () => {

--- a/packages/casting/src/iterable.js
+++ b/packages/casting/src/iterable.js
@@ -33,7 +33,7 @@ export const iterateLatest = follower =>
       const latestIterable = E(follower).getLatestIterable();
       const iterator = E(latestIterable)[Symbol.asyncIterator]();
       return Far('iterateLatest iterator', {
-        next: () => E(iterator).next(),
+        next: async () => E(iterator).next(),
       });
     },
   });
@@ -53,7 +53,7 @@ export const iterateEach = (follower, options) =>
       const eachIterable = E(follower).getEachIterable(options);
       const iterator = E(eachIterable)[Symbol.asyncIterator]();
       return Far('iterateEach iterator', {
-        next: () => E(iterator).next(),
+        next: async () => E(iterator).next(),
       });
     },
   });
@@ -71,7 +71,7 @@ export const iterateReverse = (follower, options) =>
       const eachIterable = E(follower).getReverseIterable(options);
       const iterator = E(eachIterable)[Symbol.asyncIterator]();
       return Far('iterateEach iterator', {
-        next: () => E(iterator).next(),
+        next: async () => E(iterator).next(),
       });
     },
   });

--- a/packages/casting/src/leader-netconfig.js
+++ b/packages/casting/src/leader-netconfig.js
@@ -32,7 +32,10 @@ export const makeLeaderFromRpcAddresses = (rpcAddrs, leaderOptions) => {
  * @param {string} netconfigURL
  * @param {import('./types.js').LeaderOptions} [options]
  */
-export const makeLeaderFromNetworkConfig = (netconfigURL, options = {}) => {
+export const makeLeaderFromNetworkConfig = async (
+  netconfigURL,
+  options = {},
+) => {
   const { retryCallback = DEFAULT_RETRY_CALLBACK, jitter = DEFAULT_JITTER } =
     options;
   /** @type {import('./types.js').LeaderOptions['retryCallback']} */
@@ -58,8 +61,8 @@ export const makeLeaderFromNetworkConfig = (netconfigURL, options = {}) => {
     };
     const retryLeader = async err => {
       retry(where, err, attempt)
-        .then(() => jitter(where))
-        .then(() => makeLeader().then(resolve, retryLeader))
+        .then(async () => jitter(where))
+        .then(async () => makeLeader().then(resolve, retryLeader))
         .catch(reject);
       attempt += 1;
     };

--- a/packages/casting/src/leader.js
+++ b/packages/casting/src/leader.js
@@ -31,7 +31,7 @@ export const makeRoundRobinLeader = (endpoints, leaderOptions = {}) => {
       }
       throw err;
     },
-    watchCasting: _castingSpecP => pollingChangeFollower,
+    watchCasting: async _castingSpecP => pollingChangeFollower,
     /**
      * @template T
      * @param {string} where
@@ -54,13 +54,15 @@ export const makeRoundRobinLeader = (endpoints, leaderOptions = {}) => {
               });
           }
 
-          retrying.then(() => jitter && jitter(where)).then(applyOne, reject);
+          retrying
+            .then(async () => jitter && jitter(where))
+            .then(applyOne, reject);
           thisAttempt += 1;
         };
 
         const applyOne = () => {
           Promise.resolve()
-            .then(() => callback(endpoints[endpointIndex]))
+            .then(async () => callback(endpoints[endpointIndex]))
             .then(res => {
               resolve(harden([res]));
               lastRespondingEndpointIndex = endpointIndex;

--- a/packages/casting/test/fake-rpc-server.js
+++ b/packages/casting/test/fake-rpc-server.js
@@ -80,7 +80,7 @@ const fakeStatusResult = {
  * @param {Marshaller} [options.marshaller]
  * @param {number} [options.batchSize] count of stream-cell results per response, or 0/absent to return lone naked values
  */
-export const startFakeServer = (t, fakeValues, options = {}) => {
+export const startFakeServer = async (t, fakeValues, options = {}) => {
   const { log = console.log } = t;
   lastPort += 1;
   const PORT = lastPort;

--- a/packages/casting/test/mvp.test.js
+++ b/packages/casting/test/mvp.test.js
@@ -34,7 +34,7 @@ const testHappyPath = (label, ...input) => {
       /** @type {import('../src/types.js').LeaderOptions} */
       const lo = {
         retryCallback: null, // fail fast, no retries
-        keepPolling: () => delay(1000).then(() => true), // poll really quickly
+        keepPolling: async () => delay(1000).then(() => true), // poll really quickly
         jitter: null, // no jitter
       };
       /** @type {import('../src/types.js').FollowerOptions} */
@@ -162,7 +162,7 @@ test('missing rpc server', async t => {
 
 test('unrecognized proof', async t => {
   await t.throwsAsync(
-    () =>
+    async () =>
       makeFollower(makeCastingSpec(':activityhash'), {}, { proof: 'bother' }),
     {
       message: /unrecognized follower proof mode.*/,
@@ -189,7 +189,7 @@ test('yields error on bad capdata without terminating', async t => {
   /** @type {import('../src/types.js').LeaderOptions} */
   const lo = {
     retryCallback: null, // fail fast, no retries
-    keepPolling: () => delay(1000).then(() => true), // poll really quickly
+    keepPolling: async () => delay(1000).then(() => true), // poll really quickly
     jitter: null, // no jitter
   };
   /** @type {import('../src/types.js').FollowerOptions} */

--- a/packages/client-utils/src/network-config.js
+++ b/packages/client-utils/src/network-config.js
@@ -35,7 +35,7 @@ export const fetchNetworkConfig = async (spec, { fetch }) => {
   }
 
   return fetch(toNetworkConfigUrl(netName))
-    .then(res => res.json())
+    .then(async res => res.json())
     .catch(err => {
       throw Error(`cannot get network config (${spec}): ${err.message}`);
     });

--- a/packages/client-utils/src/rpc.js
+++ b/packages/client-utils/src/rpc.js
@@ -14,7 +14,7 @@ export const pickEndpoint = ({ rpcAddrs }) => rpcAddrs[0];
  * @param {{ fetch: typeof window.fetch }} io
  * @returns {Promise<Tendermint34Client>}
  */
-export const makeTendermint34Client = (endpoint, { fetch }) => {
+export const makeTendermint34Client = async (endpoint, { fetch }) => {
   const rpcClient = makeTendermintRpcClient(endpoint, fetch);
   return Tendermint34Client.create(rpcClient);
 };

--- a/packages/client-utils/src/smart-wallet-kit.js
+++ b/packages/client-utils/src/smart-wallet-kit.js
@@ -87,7 +87,7 @@ export const makeSmartWalletKit = async ({ fetch, delay }, networkConfig) => {
    * @param {string} addr
    * @returns {Promise<UpdateRecord>}
    */
-  const getLastUpdate = addr => {
+  const getLastUpdate = async addr => {
     return vsk.readPublished(`wallet.${addr}`);
   };
 
@@ -95,7 +95,7 @@ export const makeSmartWalletKit = async ({ fetch, delay }, networkConfig) => {
    * @param {string} addr
    * @returns {Promise<CurrentWalletRecord>}
    */
-  const getCurrentWalletRecord = addr => {
+  const getCurrentWalletRecord = async addr => {
     return vsk.readPublished(`wallet.${addr}.current`);
   };
 

--- a/packages/client-utils/src/sync-tools.js
+++ b/packages/client-utils/src/sync-tools.js
@@ -33,7 +33,7 @@
  * @param {number} ms
  * @param {{log: (message: string) => void, setTimeout: typeof global.setTimeout}} io
  */
-export const sleep = (ms, { log = () => {}, setTimeout }) =>
+export const sleep = async (ms, { log = () => {}, setTimeout }) =>
   new Promise(resolve => {
     log(`Sleeping for ${ms}ms...`);
     setTimeout(resolve, ms);
@@ -150,7 +150,7 @@ const makeGetInstances = follow => async () => {
  * @param {{ log: (message: string) => void, follow: () => object, setTimeout: typeof global.setTimeout }} ambientAuthority
  * @param {WaitUntilOptions} options
  */
-export const waitUntilContractDeployed = (
+export const waitUntilContractDeployed = async (
   contractName,
   ambientAuthority,
   options,
@@ -191,7 +191,12 @@ const checkCosmosBalance = (balances, threshold) => {
  * @param {{denom: string, value: number}} threshold
  * @param {WaitUntilOptions} options
  */
-export const waitUntilAccountFunded = (destAcct, io, threshold, options) => {
+export const waitUntilAccountFunded = async (
+  destAcct,
+  io,
+  threshold,
+  options,
+) => {
   const { query, setTimeout } = io;
   const queryCosmosBalance = makeQueryCosmosBalance(query);
   const { errorMessage, ...resolvedOptions } = overrideDefaultOptions(options);
@@ -239,7 +244,7 @@ const checkOfferState = (offerStatus, waitForPayouts, offerId) => {
  * @param {{ log?: typeof console.log, follow: () => object, setTimeout: typeof global.setTimeout }} io
  * @param {WaitUntilOptions} options
  */
-export const waitUntilOfferResult = (
+export const waitUntilOfferResult = async (
   addr,
   offerId,
   waitForPayouts,
@@ -280,7 +285,7 @@ const checkForInvitation = update => {
  * @param {{ follow: () => object, log: typeof console.log, setTimeout: typeof global.setTimeout}} io
  * @param {WaitUntilOptions} options
  */
-export const waitUntilInvitationReceived = (addr, io, options) => {
+export const waitUntilInvitationReceived = async (addr, io, options) => {
   const { follow, setTimeout } = io;
   const queryWallet = makeQueryWallet(follow);
   const { errorMessage, ...resolvedOptions } = overrideDefaultOptions(options);
@@ -407,7 +412,7 @@ const checkCommitteeElectionResult = (electionResult, expectedResult) => {
  * }} io
  * @param {WaitUntilOptions} options
  */
-export const waitUntilElectionResult = (
+export const waitUntilElectionResult = async (
   committeePathBase,
   expectedResult,
   io,
@@ -419,7 +424,7 @@ export const waitUntilElectionResult = (
     overrideDefaultOptions(options);
 
   return retryUntilCondition(
-    () => fetchLatestEcQuestion(committeePathBase, vstorage),
+    async () => fetchLatestEcQuestion(committeePathBase, vstorage),
     electionResult =>
       checkCommitteeElectionResult(electionResult, expectedResult),
     errorMessage,

--- a/packages/client-utils/src/vstorage-kit.js
+++ b/packages/client-utils/src/vstorage-kit.js
@@ -113,7 +113,7 @@ export const makeVstorageKit = ({ fetch }, config) => {
      * Read latest at path and unmarshal it
      * @type {(path: string) => Promise<unknown>}
      */
-    const readLatestHead = path =>
+    const readLatestHead = async path =>
       vstorage.readLatest(path).then(unserializeHead);
 
     /**
@@ -126,7 +126,7 @@ export const makeVstorageKit = ({ fetch }, config) => {
      *
      * @type {<T extends string>(subpath: T) => Promise<TypedPublished<T>>}
      */
-    const readPublished = subpath =>
+    const readPublished = async subpath =>
       // @ts-expect-error cast
       readLatestHead(`published.${subpath}`);
 

--- a/packages/client-utils/src/vstorage.js
+++ b/packages/client-utils/src/vstorage.js
@@ -11,16 +11,19 @@
  */
 export const makeVStorage = ({ fetch }, config) => {
   /** @param {string} path */
-  const getJSON = path => {
+  const getJSON = async path => {
     const url = config.rpcAddrs[0] + path;
     // console.warn('fetching', url);
-    return fetch(url, { keepalive: true }).then(res => res.json());
+    return fetch(url, { keepalive: true }).then(async res => res.json());
   };
   // height=0 is the same as omitting height and implies the highest block
   const url = (path = 'published', { kind = 'children', height = 0 } = {}) =>
     `/abci_query?path=%22/custom/vstorage/${kind}/${path}%22&height=${height}`;
 
-  const readStorage = (path = 'published', { kind = 'children', height = 0 }) =>
+  const readStorage = async (
+    path = 'published',
+    { kind = 'children', height = 0 },
+  ) =>
     getJSON(url(path, { kind, height }))
       .catch(err => {
         throw Error(`cannot read ${kind} of ${path}: ${err.message}`);

--- a/packages/client-utils/test/sync-tools.test.js
+++ b/packages/client-utils/test/sync-tools.test.js
@@ -20,12 +20,12 @@ const makeFakeVstorageKit = () => {
 
   const setValue = newValue => (value = newValue);
   // TODO remove this when we switch all sync-tools to use client-utils's vstorageKit
-  const follow = () => Promise.resolve(value);
+  const follow = async () => Promise.resolve(value);
   /**
    * @param {string} path Assumes the path will be something like 'published.auction.book0'
    * where value = { book0: {...} }
    */
-  const readLatestHead = path => {
+  const readLatestHead = async path => {
     const key = path.split('.').at(-1);
     // @ts-expect-error path will be a string joined by "."
     return Promise.resolve(value[key]);
@@ -53,7 +53,7 @@ const makeFakeBalanceQuery = () => {
   };
 
   const setResult = newValue => (result = newValue);
-  const query = () => Promise.resolve(result);
+  const query = async () => Promise.resolve(result);
 
   return { setResult, query };
 };

--- a/packages/client-utils/test/vstorage-kit.test.js
+++ b/packages/client-utils/test/vstorage-kit.test.js
@@ -14,7 +14,7 @@ const makeMockFetch = (responses = {}) => {
         },
       },
     };
-    return { json: () => Promise.resolve(response) };
+    return { json: async () => Promise.resolve(response) };
   };
 };
 

--- a/packages/client-utils/test/vstorage.test.js
+++ b/packages/client-utils/test/vstorage.test.js
@@ -4,7 +4,7 @@ import test from 'ava';
 import { makeVStorage } from '../src/vstorage.js';
 
 /** @type {any} */
-const fetch = () => Promise.resolve({});
+const fetch = async () => Promise.resolve({});
 
 test('readFully can be used without instance binding', async t => {
   const vstorage = makeVStorage({ fetch }, { chainName: '', rpcAddrs: [''] });
@@ -14,5 +14,5 @@ test('readFully can be used without instance binding', async t => {
   vstorage.readAt = async () => ({ blockHeight: 0, values: ['test'] });
 
   // This would throw if readFully required 'this' binding
-  await t.notThrowsAsync(() => readFully('some/path'));
+  await t.notThrowsAsync(async () => readFully('some/path'));
 });

--- a/packages/cosmic-swingset/scripts/clean-core-eval.js
+++ b/packages/cosmic-swingset/scripts/clean-core-eval.js
@@ -63,7 +63,7 @@ export const main = async (argv, { readFile, stdout }) => {
 };
 
 if (isEntrypoint(import.meta.url)) {
-  void farExports.E.when(import('fs/promises'), fsp =>
+  void farExports.E.when(import('fs/promises'), async fsp =>
     main([...process.argv], {
       readFile: fsp.readFile,
       stdout: process.stdout,

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -683,7 +683,7 @@ export default async function main(
           },
         );
 
-        exportData.exporter.onDone().catch(() => {
+        exportData.exporter.onDone().catch(async () => {
           if (exportData === stateSyncExport) {
             stateSyncExport = undefined;
           }

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -350,7 +350,7 @@ export const main = async (
     },
   );
 
-  registerShutdown(() => exporter.stop());
+  registerShutdown(async () => exporter.stop());
 
   exporter.onStarted().then(
     () =>

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -816,7 +816,7 @@ export async function launch({
    * @param {() => Promise<T>} fn
    * @param {() => void} onSettled
    */
-  function withErrorLogging(label, fn, onSettled) {
+  async function withErrorLogging(label, fn, onSettled) {
     const p = fn();
     void E.when(p, onSettled, err => {
       blockManagerConsole.error(label, 'error:', err);

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -895,7 +895,8 @@ export async function launch({
       const start = Date.now();
       await withErrorLogging(
         action.type,
-        () => bootstrapBlock(blockHeight, blockTime, bootstrapBlockParams),
+        async () =>
+          bootstrapBlock(blockHeight, blockTime, bootstrapBlockParams),
         () => {
           runTime += Date.now() - start;
         },
@@ -1159,7 +1160,7 @@ export async function launch({
           const start = Date.now();
           await withErrorLogging(
             action.type,
-            () => endBlock(blockHeight, blockTime, blockParams),
+            async () => endBlock(blockHeight, blockTime, blockParams),
             () => {
               runTime += Date.now() - start;
             },
@@ -1197,7 +1198,7 @@ export async function launch({
 
     await afterCommitWorkDone;
 
-    return doBlockingSend(action).finally(() => pendingSwingStoreExport);
+    return doBlockingSend(action).finally(async () => pendingSwingStoreExport);
   }
 
   async function shutdown() {

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -198,7 +198,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     },
   );
 
-  const simulateBlock = () =>
+  const simulateBlock = async () =>
     unhandledSimulateBlock().catch(e => {
       console.error(e);
       process.exit(1);

--- a/packages/cosmic-swingset/test/provision-smartwallet.test.js
+++ b/packages/cosmic-swingset/test/provision-smartwallet.test.js
@@ -35,7 +35,7 @@ test.before(async t => {
   const dirname = ambientPath.dirname(filename);
   const makefileDir = ambientPath.join(dirname, '..');
 
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const delay = async ms => new Promise(resolve => setTimeout(resolve, ms));
 
   const io = { spawn: ambientSpawn, cwd: makefileDir };
   const pspawnMake = pspawn('make', io);
@@ -50,7 +50,7 @@ test.before(async t => {
   await scenario2.setup();
 
   const { readFile } = ambientFs.promises;
-  const readItem = f => readFile(f, 'utf-8').then(line => line.trim());
+  const readItem = async f => readFile(f, 'utf-8').then(line => line.trim());
   const soloAddr = await readItem('./t1/8000/ag-cosmos-helper-address');
   const bootstrapAddr = await readItem('./t1/bootstrap-address');
   // console.debug('scenario2 addresses', { soloAddr, bootstrapAddr });

--- a/packages/cosmic-swingset/test/scenario2.js
+++ b/packages/cosmic-swingset/test/scenario2.js
@@ -139,7 +139,7 @@ export const makeWalletTool = ({ runMake, pspawnAgd, delay, log }) => {
     return JSON.parse(txt);
   };
 
-  const queryBalance = addr =>
+  const queryBalance = async addr =>
     query(['bank', 'balances', addr, '--output', 'json']).then(b => {
       console.log(addr, b);
       return b;
@@ -195,7 +195,7 @@ export const makeWalletTool = ({ runMake, pspawnAgd, delay, log }) => {
       await waitForBlock(`${a4}'s funds to appear`, 2, true);
       return queryBalance(ACCT_ADDR);
     },
-    provisionMine: ACCT_ADDR =>
+    provisionMine: async ACCT_ADDR =>
       waitMyTurn('provision', ACCT_ADDR).then(() =>
         runMake([...bind({ ACCT_ADDR }), 'provision-my-acct']),
       ),

--- a/packages/deploy-script-support/src/endo-pieces-contract.js
+++ b/packages/deploy-script-support/src/endo-pieces-contract.js
@@ -59,7 +59,7 @@ export const start = () => {
         }
       },
       /** @param {{ moduleFormat: string}} bundleShell */
-      install: bundleShell => {
+      install: async bundleShell => {
         const writer = new ZipWriter();
         for (const [name, [_hash, content]] of nameToContent.entries()) {
           writer.write(name, content);

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -120,7 +120,7 @@ export const extractCoreProposalBundles = async (
     'steps' in coreProposals ? coreProposals.steps : [coreProposals];
   const bundleToSource = new Map();
   const extractedSteps = await Promise.all(
-    proposalSteps.map((proposalStep, i) =>
+    proposalSteps.map(async (proposalStep, i) =>
       Promise.all(
         proposalStep.map(async (coreProposal, j) => {
           const key = `${i}.${j}`;

--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -79,7 +79,7 @@ export const makeOfferAndFindInvitationAmount = (
     return withdrawInvitation(invitationDetails);
   };
 
-  const depositPayouts = (seat, payoutPursePetnames) => {
+  const depositPayouts = async (seat, payoutPursePetnames) => {
     const makeDepositInPurse = keyword => {
       const deposit = payment => {
         const pursePetname = payoutPursePetnames[keyword];
@@ -88,9 +88,9 @@ export const makeOfferAndFindInvitationAmount = (
       };
       return deposit;
     };
-    const handlePayments = paymentsP => {
+    const handlePayments = async paymentsP => {
       const allDepositedP = Promise.all(
-        Object.entries(paymentsP).map(([keyword, paymentP]) => {
+        Object.entries(paymentsP).map(async ([keyword, paymentP]) => {
           const depositInPurse = makeDepositInPurse(keyword);
           return E.when(paymentP, depositInPurse);
         }),

--- a/packages/deploy-script-support/test/unitTests/assertOfferResult.test.js
+++ b/packages/deploy-script-support/test/unitTests/assertOfferResult.test.js
@@ -9,8 +9,8 @@ test('assertOfferResult', async t => {
     // @ts-expect-error mock
     getOfferResult: () => 'result',
   };
-  await t.notThrowsAsync(() => assertOfferResult(mockSeat, 'result'));
-  await t.throwsAsync(() => assertOfferResult(mockSeat, 'not result'), {
+  await t.notThrowsAsync(async () => assertOfferResult(mockSeat, 'result'));
+  await t.throwsAsync(async () => assertOfferResult(mockSeat, 'not result'), {
     message: /offerResult (.*) did not equal expected: .*/,
   });
 });

--- a/packages/deploy-script-support/test/unitTests/install.test.js
+++ b/packages/deploy-script-support/test/unitTests/install.test.js
@@ -16,7 +16,7 @@ test('install', async t => {
   /** @type {import('../../src/startInstance.js').InstallationManager} */
   // @ts-expect-error mock
   const installationManager = {
-    add: (_petname, installation) => {
+    add: async (_petname, installation) => {
       addedInstallation = installation;
       return Promise.resolve();
     },

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -229,7 +229,7 @@ show-config      display the client connection parameters
       });
 
       // Prepare all the machines.
-      await guardFile(`${PROVISION_DIR}/prepare.stamp`, () =>
+      await guardFile(`${PROVISION_DIR}/prepare.stamp`, async () =>
         needReMain(['play', 'prepare-machine']),
       );
 
@@ -370,7 +370,7 @@ show-config      display the client connection parameters
       });
 
       // Bootstrap the chain nodes.
-      await guardFile(`${COSMOS_DIR}/prepare.stamp`, () =>
+      await guardFile(`${COSMOS_DIR}/prepare.stamp`, async () =>
         needReMain(['play', 'prepare-cosmos']),
       );
 
@@ -445,7 +445,7 @@ show-config      display the client connection parameters
         await makeFile(peers);
       });
 
-      await guardFile(`${COSMOS_DIR}/install.stamp`, () =>
+      await guardFile(`${COSMOS_DIR}/install.stamp`, async () =>
         needReMain(['play', 'install-cosmos']),
       );
 
@@ -483,7 +483,7 @@ show-config      display the client connection parameters
       const agChainCosmosEnvironment = [
         `-eserviceLines=${shellEscape(serviceLines.join('\n'))}`,
       ];
-      await guardFile(`${COSMOS_DIR}/service.stamp`, () =>
+      await guardFile(`${COSMOS_DIR}/service.stamp`, async () =>
         needReMain([
           'play',
           'install',
@@ -496,7 +496,7 @@ show-config      display the client connection parameters
         ]),
       );
 
-      await guardFile(`${COSMOS_DIR}/start.stamp`, () =>
+      await guardFile(`${COSMOS_DIR}/start.stamp`, async () =>
         needReMain(['play', 'start']),
       );
 
@@ -504,7 +504,7 @@ show-config      display the client connection parameters
 
       // Add the bootstrap validators.
       if (!importFrom) {
-        await guardFile(`${COSMOS_DIR}/validators.stamp`, () =>
+        await guardFile(`${COSMOS_DIR}/validators.stamp`, async () =>
           needReMain(['play', 'cosmos-validators']),
         );
       }

--- a/packages/deployment/src/run.js
+++ b/packages/deployment/src/run.js
@@ -14,7 +14,7 @@ export const running = (process, { exec, spawn }) => {
     setSilent: val => {
       SETUP_SILENT = val;
     },
-    exec: cmd => {
+    exec: async cmd => {
       const cp = exec(cmd);
       const promise = new Promise((resolve, reject) => {
         cp.addListener('error', reject);
@@ -55,7 +55,7 @@ export const running = (process, { exec, spawn }) => {
       return ret.stdout;
     },
     cwd: () => process.cwd(),
-    chdir: path => {
+    chdir: async path => {
       if (!SETUP_SILENT) {
         console.error('$ cd', shellEscape(path));
       }
@@ -66,7 +66,7 @@ export const running = (process, { exec, spawn }) => {
     },
 
     // Dah-doo-run-run-run, dah-doo-run-run.
-    doRun: (cmd, readable, writeCb) => {
+    doRun: async (cmd, readable, writeCb) => {
       if (!SETUP_SILENT) {
         console.error('$', ...cmd.map(shellEscape));
       }

--- a/packages/deployment/src/setup.js
+++ b/packages/deployment/src/setup.js
@@ -18,7 +18,7 @@ export const setup = ({ resolve, env, setInterval }) => {
       const fullPath = `${it.SETUP_DIR}/ansible/${name}.yml`;
       return [PLAYBOOK_WRAPPER, fullPath, ...args];
     },
-    sleep: (seconds, why) => {
+    sleep: async (seconds, why) => {
       console.error(chalk.yellow(`Waiting ${seconds} seconds`, why || ''));
       return new Promise(res => setInterval(res, 1000 * seconds));
     },

--- a/packages/fast-usdc/src/cli/lp-commands.js
+++ b/packages/fast-usdc/src/cli/lp-commands.js
@@ -21,7 +21,8 @@ import {
 import { InvalidArgumentError } from 'commander';
 import { outputActionAndHint } from './bridge-action.js';
 
-export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+export const delay = async ms =>
+  new Promise(resolve => setTimeout(resolve, ms));
 
 /** @param {string} arg */
 const parseDecimal = arg => {

--- a/packages/fast-usdc/src/cli/operator-commands.js
+++ b/packages/fast-usdc/src/cli/operator-commands.js
@@ -17,7 +17,8 @@ import { INVITATION_MAKERS_DESC } from '../exos/transaction-feed.js';
 import { CctpTxEvidenceShape } from '../type-guards.js';
 import { outputActionAndHint } from './bridge-action.js';
 
-export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+export const delay = async ms =>
+  new Promise(resolve => setTimeout(resolve, ms));
 
 /** @param {string} arg */
 const parseNat = arg => {

--- a/packages/fast-usdc/src/cli/transfer.js
+++ b/packages/fast-usdc/src/cli/transfer.js
@@ -110,7 +110,10 @@ const transfer = async (
           if (currentBalance !== startingBalance) {
             res();
           } else {
-            setTimeout(() => refreshUSDCBalance().catch(rej), refreshDelayMS);
+            setTimeout(
+              async () => refreshUSDCBalance().catch(rej),
+              refreshDelayMS,
+            );
           }
         };
         refreshUSDCBalance().catch(rej);

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -81,7 +81,7 @@ const publishFeeConfig = async (node, marshaller, feeConfig) => {
  *  settlementAccount: ChainAddress['value'];
  * }} addresses
  */
-const publishAddresses = (contractNode, addresses) => {
+const publishAddresses = async (contractNode, addresses) => {
   return E(contractNode).setValue(JSON.stringify(addresses));
 };
 
@@ -164,7 +164,7 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
       return feedKit.creator.makeOperatorInvitation(operatorId);
     },
     async connectToNoble() {
-      return vowTools.when(nobleAccountV, nobleAccount => {
+      return vowTools.when(nobleAccountV, async nobleAccount => {
         trace('nobleAccount', nobleAccount);
         return vowTools.when(
           E(nobleAccount).getAddress(),
@@ -244,7 +244,7 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
   const shareMint = await provideSingleton(
     zone.mapStore('mint'),
     'PoolShare',
-    () =>
+    async () =>
       zcf.makeZCFMint('PoolShares', AssetKind.NAT, {
         decimalPlaces: 6,
       }),

--- a/packages/fast-usdc/src/util/bank.js
+++ b/packages/fast-usdc/src/util/bank.js
@@ -5,7 +5,7 @@ export const queryUSDCBalance = async (
   /** @type {typeof globalThis.fetch} */ fetch,
 ) => {
   const query = `${api}/cosmos/bank/v1beta1/balances/${address}`;
-  const json = await fetch(query).then(res => res.json());
+  const json = await fetch(query).then(async res => res.json());
   const amount = json.balances?.find(b => b.denom === denom)?.amount ?? '0';
 
   return BigInt(amount);

--- a/packages/fast-usdc/src/util/file.js
+++ b/packages/fast-usdc/src/util/file.js
@@ -12,7 +12,7 @@ export const makeFile = (
   /** @type {mkdirSync} */ mkdir,
   /** @type {existsSync} */ pathExists,
 ) => {
-  const read = () => readFile(path, 'utf-8');
+  const read = async () => readFile(path, 'utf-8');
 
   const write = async (/** @type {string} */ data) => {
     const dir = dirname(path);

--- a/packages/fast-usdc/src/util/noble.js
+++ b/packages/fast-usdc/src/util/noble.js
@@ -96,7 +96,7 @@ export const queryForwardingAccount = async (
   let forwardingAddressRes;
   await null;
   try {
-    forwardingAddressRes = await fetch(query).then(res => res.json());
+    forwardingAddressRes = await fetch(query).then(async res => res.json());
   } catch (e) {
     out.error(`Error querying forwarding address from ${query}`);
     throw e;

--- a/packages/fast-usdc/src/utils/config-marshal.js
+++ b/packages/fast-usdc/src/utils/config-marshal.js
@@ -31,7 +31,7 @@ const { entries } = Object;
  * @returns {Marshal<string>}
  */
 export const makeMarshalFromRecord = slotToVal => {
-  const convertSlotToVal = slot => {
+  const convertSlotToVal = async slot => {
     slot in slotToVal || Fail`unknown slot ${slot}`;
     return slotToVal[slot];
   };

--- a/packages/fast-usdc/src/utils/zoe.js
+++ b/packages/fast-usdc/src/utils/zoe.js
@@ -19,7 +19,7 @@ const trace = makeTracer('ZoeUtils');
  * @returns {() => Promise<Invitation>} an arg-less invitation maker
  */
 export const defineInertInvitation = (zcf, description) => {
-  return () =>
+  return async () =>
     zcf.makeInvitation(seat => {
       trace(`ℹ️ An offer was made on an inert invitation for ${description}`);
       seat.exit();

--- a/packages/fast-usdc/test/exos/transaction-feed.test.ts
+++ b/packages/fast-usdc/test/exos/transaction-feed.test.ts
@@ -17,7 +17,7 @@ const makeFeedKit = () => {
   return makeKit();
 };
 
-const makeOperators = (feedKit: TransactionFeedKit) => {
+const makeOperators = async (feedKit: TransactionFeedKit) => {
   const operators = Object.fromEntries(
     ['op1', 'op2', 'op3'].map(name => [
       name,

--- a/packages/fast-usdc/test/supports.ts
+++ b/packages/fast-usdc/test/supports.ts
@@ -263,7 +263,7 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
     utils: {
       pourPayment,
       inspectLocalBridge: () => harden([...localBridgeMessages]),
-      inspectDibcBridge: () => E(ibcBridge).inspectDibcBridge(),
+      inspectDibcBridge: async () => E(ibcBridge).inspectDibcBridge(),
       inspectBankBridge: () => harden([...bankBridgeMessages]),
       transmitTransferAck,
     },

--- a/packages/fast-usdc/testing/mocks.ts
+++ b/packages/fast-usdc/testing/mocks.ts
@@ -11,7 +11,7 @@ export const mockOut = () => {
 
 export const mockrl = (answer: string) => {
   return {
-    question: () => Promise.resolve(answer),
+    question: async () => Promise.resolve(answer),
     close: () => {},
   };
 };

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -125,7 +125,7 @@ const makeBinaryVoteCounter = (
     }
 
     // XXX if we should distinguish ties, publish should be called in if above
-    void E.when(outcomePromise.promise, position => {
+    void E.when(outcomePromise.promise, async position => {
       /** @type {OutcomeRecord} */
       const voteOutcome = {
         question: details.questionHandle,

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -76,7 +76,7 @@ export const start = (zcf, privateArgs, baggage) => {
   const { subscriber: questionsSubscriber, publisher: questionsPublisher } =
     makeStoredPublishKit(questionNode, privateArgs.marshaller);
 
-  const makeCommitteeVoterInvitation = index => {
+  const makeCommitteeVoterInvitation = async index => {
     // https://github.com/Agoric/agoric-sdk/pull/3448/files#r704003612
     // This will produce unique descriptions because
     // makeCommitteeVoterInvitation() is only called within the following loop,

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -130,8 +130,11 @@ export const prepareContractGovernorKit = (baggage, powers) => {
             trace('setupApiGovernance');
             apiGovernance = governedNames.length
               ? // @ts-expect-error FIXME
-                setupApiGovernance(governedApis, governedNames, timer, () =>
-                  this.facets.helper.getUpdatedPoserFacet(),
+                setupApiGovernance(
+                  governedApis,
+                  governedNames,
+                  timer,
+                  async () => this.facets.helper.getUpdatedPoserFacet(),
                 )
               : {
                   // if we aren't governing APIs, voteOnApiInvocation shouldn't be called
@@ -149,7 +152,7 @@ export const prepareContractGovernorKit = (baggage, powers) => {
             const { creatorFacet } = this.state;
             filterGovernance = setupFilterGovernance(
               timer,
-              () => this.facets.helper.getUpdatedPoserFacet(),
+              async () => this.facets.helper.getUpdatedPoserFacet(),
               creatorFacet,
             );
           }
@@ -160,10 +163,10 @@ export const prepareContractGovernorKit = (baggage, powers) => {
             const { timer } = powers;
             const { creatorFacet, instance } = this.state;
             paramGovernance = setupParamGovernance(
-              () => E(creatorFacet).getParamMgrRetriever(),
+              async () => E(creatorFacet).getParamMgrRetriever(),
               instance,
               timer,
-              () => this.facets.helper.getUpdatedPoserFacet(),
+              async () => this.facets.helper.getUpdatedPoserFacet(),
             );
           }
           return paramGovernance;
@@ -247,7 +250,9 @@ export const prepareContractGovernorKit = (baggage, powers) => {
             helper.provideParamGovernance(),
           ];
           const checks = await Promise.all(
-            validators.map(validate => E(validate.createdQuestion)(counter)),
+            validators.map(async validate =>
+              E(validate.createdQuestion)(counter),
+            ),
           );
 
           checks.some(Boolean) ||

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -39,7 +39,7 @@ const publicMixinAPI = harden({
  * @param {ZCF<GovernanceTerms<{}> & {}>} zcf
  * @param {import('./contractGovernance/typedParamManager.js').TypedParamManager<any>} paramManager
  */
-export const validateElectorate = (zcf, paramManager) => {
+export const validateElectorate = async (zcf, paramManager) => {
   const invitation = paramManager.getInternalParamValue(CONTRACT_ELECTORATE);
   return E.when(
     E(zcf.getInvitationIssuer()).isLive(invitation),
@@ -118,7 +118,7 @@ const facetHelpers = (zcf, paramManager) => {
     const governorFacet = Far('governorFacet', {
       getParamMgrRetriever: () =>
         Far('paramRetriever', { get: () => paramManager }),
-      getInvitation: name => paramManager.getInternalParamValue(name),
+      getInvitation: async name => paramManager.getInternalParamValue(name),
       getLimitedCreatorFacet: () => limitedCreatorFacet,
       // The contract provides a facet with the APIs that can be invoked by
       // governance
@@ -128,7 +128,7 @@ const facetHelpers = (zcf, paramManager) => {
       // methods it has. There's no clean way to have contracts specify the APIs
       // without also separately providing their names.
       getGovernedApiNames: () => Object.keys(governedApis),
-      setOfferFilter: strings => zcf.setOfferFilter(strings),
+      setOfferFilter: async strings => zcf.setOfferFilter(strings),
     });
 
     // exclusively for contractGovernor, which only reveals limitedCreatorFacet
@@ -158,7 +158,7 @@ const facetHelpers = (zcf, paramManager) => {
     const governorFacet = harden({
       getParamMgrRetriever: () =>
         Far('paramRetriever', { get: () => paramManager }),
-      getInvitation: (_context, /** @type {string} */ name) =>
+      getInvitation: async (_context, /** @type {string} */ name) =>
         paramManager.getInternalParamValue(name),
       getLimitedCreatorFacet: ({ facets }) => facets.limitedCreatorFacet,
       // The contract provides a facet with the APIs that can be invoked by
@@ -169,7 +169,7 @@ const facetHelpers = (zcf, paramManager) => {
       // without also separately providing their names.
       getGovernedApiNames: ({ facets }) =>
         getMethodNames(facets.governedApis || {}),
-      setOfferFilter: (_context, strings) => zcf.setOfferFilter(strings),
+      setOfferFilter: async (_context, strings) => zcf.setOfferFilter(strings),
     });
 
     return { governorFacet, limitedCreatorFacet };
@@ -197,7 +197,7 @@ const facetHelpers = (zcf, paramManager) => {
       {
         getParamMgrRetriever: () =>
           Far('paramRetriever', { get: () => paramManager }),
-        getInvitation: name => paramManager.getInternalParamValue(name),
+        getInvitation: async name => paramManager.getInternalParamValue(name),
         getLimitedCreatorFacet: () => limitedCreatorFacet,
         // The contract provides a facet with the APIs that can be invoked by
         // governance
@@ -207,7 +207,7 @@ const facetHelpers = (zcf, paramManager) => {
         // methods it has. There's no clean way to have contracts specify the APIs
         // without also separately providing their names.
         getGovernedApiNames: () => Object.keys(governedApis || {}),
-        setOfferFilter: strings => zcf.setOfferFilter(strings),
+        setOfferFilter: async strings => zcf.setOfferFilter(strings),
       },
     );
 

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -83,8 +83,8 @@ const getOpenQuestions = async questionStore => {
  * @param {ERef<Handle<'Question'>>} questionHandleP
  * @param {MapStore<Handle<'Question'>, QuestionRecord>} questionStore
  */
-const getQuestion = (questionHandleP, questionStore) =>
-  E.when(questionHandleP, questionHandle =>
+const getQuestion = async (questionHandleP, questionStore) =>
+  E.when(questionHandleP, async questionHandle =>
     E(questionStore.get(questionHandle).publicFacet).getQuestion(),
   );
 
@@ -92,7 +92,7 @@ const getQuestion = (questionHandleP, questionStore) =>
  * @param {ZCF} zcf
  * @param {AddQuestion} addQuestion
  */
-const getPoserInvitation = (zcf, addQuestion) => {
+const getPoserInvitation = async (zcf, addQuestion) => {
   const questionPoserHandler = seat => {
     seat.exit();
     return Far(`questionPoser`, { addQuestion });

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -142,7 +142,7 @@ const makeMultiCandidateVoteCounter = (
       outcomePromise.resolve(untiedPositions.concat(tieWinners));
     }
 
-    void E.when(outcomePromise.promise, winPositions => {
+    void E.when(outcomePromise.promise, async winPositions => {
       /** @type { MultiOutcomeRecord } */
       const voteOutcome = {
         question: details.questionHandle,

--- a/packages/governance/src/voterKit.js
+++ b/packages/governance/src/voterKit.js
@@ -48,7 +48,7 @@ export const prepareVoterKit = (baggage, { submitVote, zcf }) => {
       invitationMakers: {
         makeVoteInvitation(positions, questionHandle) {
           const { voter } = this.facets;
-          const continuingVoteHandler = cSeat => {
+          const continuingVoteHandler = async cSeat => {
             cSeat.exit();
             return voter.castBallotFor(questionHandle, positions);
           };

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -17,7 +17,7 @@ import { keyEQ } from '@agoric/store';
  */
 const verify = async (log, issue, electoratePublicFacet, instances) => {
   const questionHandles = await E(electoratePublicFacet).getOpenQuestions();
-  const detailsP = questionHandles.map(h => {
+  const detailsP = questionHandles.map(async h => {
     const question = E(electoratePublicFacet).getQuestion(h);
     return E(question).getDetails();
   });
@@ -68,7 +68,7 @@ const build = async (log, zoe) => {
       );
 
       return Far(`Voter ${name}`, {
-        verifyBallot: (question, instances) =>
+        verifyBallot: async (question, instances) =>
           verify(log, question, electoratePublicFacet, instances),
       });
     },
@@ -97,7 +97,7 @@ const build = async (log, zoe) => {
       );
 
       return Far(`Voter ${name}`, {
-        verifyBallot: (question, instances) =>
+        verifyBallot: async (question, instances) =>
           verify(log, question, electoratePublicFacet, instances),
       });
     },
@@ -108,5 +108,5 @@ const build = async (log, zoe) => {
 export const buildRootObject = vatPowers =>
   Far('root', {
     /** @param {ZoeService} zoe */
-    build: zoe => build(vatPowers.testLog, zoe),
+    build: async zoe => build(vatPowers.testLog, zoe),
   });

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
@@ -111,5 +111,5 @@ const build = async (log, zoe) => {
 /** @type {import('@agoric/swingset-vat/src/kernel/vat-loader/types.js').BuildRootObjectForTestVat} */
 export const buildRootObject = vatPowers =>
   Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });

--- a/packages/governance/test/unitTests/binaryballotCount.test.js
+++ b/packages/governance/test/unitTests/binaryballotCount.test.js
@@ -117,7 +117,7 @@ test('binary spoiled', async t => {
   t.deepEqual(alicePositions[0], FISH);
 
   await t.throwsAsync(
-    () => E(creatorFacet).submitVote(aliceSeat, [harden({ text: 'no' })]),
+    async () => E(creatorFacet).submitVote(aliceSeat, [harden({ text: 'no' })]),
     {
       message: `The specified choice is not a legal position: {"text":"no"}.`,
     },
@@ -183,9 +183,12 @@ test('binary bad vote', async t => {
   );
   const aliceSeat = makeHandle('Voter');
 
-  await t.throwsAsync(() => E(creatorFacet).submitVote(aliceSeat, [BAIT]), {
-    message: `The specified choice is not a legal position: {"text":"Cut Bait"}.`,
-  });
+  await t.throwsAsync(
+    async () => E(creatorFacet).submitVote(aliceSeat, [BAIT]),
+    {
+      message: `The specified choice is not a legal position: {"text":"Cut Bait"}.`,
+    },
+  );
 
   closeFacet.closeVoting();
   const outcome = await E(publicFacet)
@@ -376,7 +379,7 @@ test('binary question too many positions', async t => {
 
   const alicePositions = aliceTemplate.getDetails().positions;
   await t.throwsAsync(
-    () => E(creatorFacet).submitVote(aliceSeat, alicePositions),
+    async () => E(creatorFacet).submitVote(aliceSeat, alicePositions),
     {
       message: 'only 1 position allowed',
     },

--- a/packages/governance/test/unitTests/buildParamManager.test.js
+++ b/packages/governance/test/unitTests/buildParamManager.test.js
@@ -87,7 +87,7 @@ test('Amount', async t => {
   );
 
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         Shimmer: AmountMath.make(dessertBrand, 20n),
       }),
@@ -98,7 +98,7 @@ test('Amount', async t => {
   );
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ Shimmer: 'fear,loathing' }),
+    async () => paramManager.updateParams({ Shimmer: 'fear,loathing' }),
     {
       message: 'Expected an Amount for "Shimmer", got: "fear,loathing"',
     },
@@ -124,7 +124,7 @@ test('params one installation', async t => {
 
   t.deepEqual(paramManager.getInstallation('PName'), installationHandle);
   await t.throwsAsync(
-    () => paramManager.updateParams({ PName: 18.1 }),
+    async () => paramManager.updateParams({ PName: 18.1 }),
     {
       message: 'value for "PName" must be an Installation, was 18.1',
     },
@@ -165,7 +165,7 @@ test('params one instance', async t => {
 
   t.deepEqual(paramManager.getInstance('PName'), instanceHandle);
   await t.throwsAsync(
-    () => paramManager.updateParams({ PName: 18.1 }),
+    async () => paramManager.updateParams({ PName: 18.1 }),
     {
       message: 'value for "PName" must be an Instance, was 18.1',
     },
@@ -257,15 +257,18 @@ test('two Nats', async t => {
   t.is(paramManager.getNat('SpeedLimit'), 299_792_458n);
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ SpeedLimit: 300000000 }),
+    async () => paramManager.updateParams({ SpeedLimit: 300000000 }),
     {
       message: '300000000 must be a bigint',
     },
   );
 
-  await t.throwsAsync(() => paramManager.updateParams({ SpeedLimit: -37n }), {
-    message: '-37 is negative',
-  });
+  await t.throwsAsync(
+    async () => paramManager.updateParams({ SpeedLimit: -37n }),
+    {
+      message: '-37 is negative',
+    },
+  );
 });
 
 test('Ratio', async t => {
@@ -284,14 +287,14 @@ test('Ratio', async t => {
   const anotherBrand = makeIssuerKit('arbitrary').brand;
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ GoldenRatio: 300000000 }),
+    async () => paramManager.updateParams({ GoldenRatio: 300000000 }),
     {
       message: '"ratio" 300000000 must be a pass-by-copy record, not "number"',
     },
   );
 
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         GoldenRatio: makeRatio(16180n, anotherBrand, 10_000n),
       }),
@@ -332,7 +335,7 @@ test('Record', async t => {
     B2: 'Matchbox',
   };
   await t.throwsAsync(
-    () => paramManager.updateParams({ BestEP: brokenRecord }),
+    async () => paramManager.updateParams({ BestEP: brokenRecord }),
     {
       message:
         'Cannot pass non-frozen objects like {"A1":"Long Tall Sally","A2":"I Call Your Name","B1":"Slow Down","B2":"Matchbox"}. Use harden()',
@@ -340,7 +343,7 @@ test('Record', async t => {
   );
 
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         duration: '2:37',
       }),
@@ -350,7 +353,7 @@ test('Record', async t => {
   );
 
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         BestEP: '2:37',
       }),
@@ -370,7 +373,7 @@ test('Strings', async t => {
   await paramManager.updateParams({ OurWeapons: 'fear,surprise' });
   t.is(paramManager.getString('OurWeapons'), 'fear,surprise');
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         OurWeapons: 300000000,
       }),

--- a/packages/governance/test/unitTests/multiCandidateBallotCount.test.js
+++ b/packages/governance/test/unitTests/multiCandidateBallotCount.test.js
@@ -235,7 +235,7 @@ test('multi candidate spoiled', async t => {
   t.deepEqual(alicePositions[0], FISH);
 
   await t.throwsAsync(
-    () => E(creatorFacet).submitVote(aliceSeat, [harden({ text: 'no' })]),
+    async () => E(creatorFacet).submitVote(aliceSeat, [harden({ text: 'no' })]),
     {
       message: `The specified choice is not a legal position: {"text":"no"}.`,
     },
@@ -609,7 +609,8 @@ test('multi candidate exceeds max choices', async t => {
   t.deepEqual(positions[0], FISH);
 
   await t.throwsAsync(
-    () => E(creatorFacet).submitVote(aliceSeat, [positions[0], positions[1]]),
+    async () =>
+      E(creatorFacet).submitVote(aliceSeat, [positions[0], positions[1]]),
     {
       message: `The number of choices exceeds the max choices.`,
     },

--- a/packages/governance/test/unitTests/puppetContractGovernor.test.js
+++ b/packages/governance/test/unitTests/puppetContractGovernor.test.js
@@ -55,7 +55,7 @@ test('multiple params bad change', async t => {
   });
 
   await t.throwsAsync(
-    () => E(governorFacets.creatorFacet).changeParams(paramChangesSpec),
+    async () => E(governorFacets.creatorFacet).changeParams(paramChangesSpec),
     {
       message:
         'In "getAmountOf" method of (Zoe Invitation issuer): arg 0: "[13n]" - Must be a remotable Payment, not bigint',

--- a/packages/governance/test/unitTests/typedParamManager.test.js
+++ b/packages/governance/test/unitTests/typedParamManager.test.js
@@ -35,7 +35,9 @@ test('types', async t => {
     Working: [ParamTypes.NAT, 0n],
   });
   mgr.getWorking().valueOf();
-  await t.throwsAsync(() => mgr.updateParams({ Working: 'not a bigint' }));
+  await t.throwsAsync(async () =>
+    mgr.updateParams({ Working: 'not a bigint' }),
+  );
 });
 
 test('makeParamManagerFromTerms', async t => {
@@ -109,14 +111,14 @@ test('Amount', async t => {
   t.deepEqual(paramManager.getShimmer(), AmountMath.make(floorBrand, 5n));
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ Shimmer: 'fear,loathing' }),
+    async () => paramManager.updateParams({ Shimmer: 'fear,loathing' }),
     {
       message: 'Expected an Amount for "Shimmer", got: "fear,loathing"',
     },
   );
 
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         Shimmer: AmountMath.make(dessertBrand, 20n),
       }),
@@ -127,7 +129,7 @@ test('Amount', async t => {
   );
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ Shimmer: 'fear,loathing' }),
+    async () => paramManager.updateParams({ Shimmer: 'fear,loathing' }),
     {
       message: 'Expected an Amount for "Shimmer", got: "fear,loathing"',
     },
@@ -159,7 +161,7 @@ test('params one installation', async t => {
 
   t.deepEqual(paramManager.getPName(), installationHandle);
   await t.throwsAsync(
-    () => paramManager.updateParams({ PName: 18.1 }),
+    async () => paramManager.updateParams({ PName: 18.1 }),
     {
       message: 'value for "PName" must be an Installation, was 18.1',
     },
@@ -196,7 +198,7 @@ test('params one instance', async t => {
 
   t.deepEqual(paramManager.getPName(), instanceHandle);
   await t.throwsAsync(
-    () => paramManager.updateParams({ PName: 18.1 }),
+    async () => paramManager.updateParams({ PName: 18.1 }),
     {
       message: 'value for "PName" must be an Instance, was 18.1',
     },
@@ -286,15 +288,18 @@ test('two Nats', async t => {
   t.is(paramManager.getSpeedLimit(), 299_792_458n);
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ SpeedLimit: 300000000 }),
+    async () => paramManager.updateParams({ SpeedLimit: 300000000 }),
     {
       message: '300000000 must be a bigint',
     },
   );
 
-  await t.throwsAsync(() => paramManager.updateParams({ SpeedLimit: -37n }), {
-    message: '-37 is negative',
-  });
+  await t.throwsAsync(
+    async () => paramManager.updateParams({ SpeedLimit: -37n }),
+    {
+      message: '-37 is negative',
+    },
+  );
 });
 
 test('Ratio', async t => {
@@ -312,7 +317,7 @@ test('Ratio', async t => {
   t.is(paramManager.getGoldenRatio(), morePrecise);
 
   await t.throwsAsync(
-    () => paramManager.updateParams({ GoldenRatio: 300000000 }),
+    async () => paramManager.updateParams({ GoldenRatio: 300000000 }),
     {
       message: '"ratio" 300000000 must be a pass-by-copy record, not "number"',
     },
@@ -321,7 +326,7 @@ test('Ratio', async t => {
   const anotherBrand = makeIssuerKit('arbitrary').brand;
 
   await t.throwsAsync(
-    () =>
+    async () =>
       paramManager.updateParams({
         GoldenRatio: makeRatio(16180n, anotherBrand, 10_000n),
       }),
@@ -342,7 +347,7 @@ test('Strings', async t => {
   await paramManager.updateParams({ OurWeapons: 'fear,surprise' });
   t.is(paramManager.getOurWeapons(), 'fear,surprise');
   await t.throwsAsync(
-    () => paramManager.updateParams({ OurWeapons: 300000000 }),
+    async () => paramManager.updateParams({ OurWeapons: 300000000 }),
     {
       message: '300000000 must be a string',
     },

--- a/packages/governance/tools/puppetContractGovernor.js
+++ b/packages/governance/tools/puppetContractGovernor.js
@@ -63,13 +63,13 @@ export const start = async (zcf, privateArgs) => {
   const limitedCreatorFacet = E(governedCF).getLimitedCreatorFacet();
 
   /** @param {ParamChangesSpec<any>} paramSpec */
-  const changeParams = paramSpec => {
+  const changeParams = async paramSpec => {
     const paramMgr = E(paramMgrRetriever).get(paramSpec.paramPath);
     return E(paramMgr).updateParams(paramSpec.changes);
   };
 
   /** @param {Array<string>} strings */
-  const setFilters = strings => E(governedCF).setOfferFilter(strings);
+  const setFilters = async strings => E(governedCF).setOfferFilter(strings);
 
   /**
    * @param {string} apiMethodName
@@ -92,7 +92,7 @@ export const start = async (zcf, privateArgs) => {
     changeParams,
     invokeAPI,
     setFilters,
-    getCreatorFacet: () => limitedCreatorFacet,
+    getCreatorFacet: async () => limitedCreatorFacet,
     getAdminFacet: () => adminFacet,
     getInstance: () => governedInstance,
     /** @returns {Awaited<ReturnType<SF>>['publicFacet']} */

--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -476,7 +476,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
 
           void E.when(
             quoteNotifierP,
-            quoteNotifier =>
+            async quoteNotifier =>
               observeNotifier(quoteNotifier, {
                 updateState: quote => {
                   trace(

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -604,7 +604,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     return 'deposited';
   };
 
-  const makeDepositInvitation = () =>
+  const makeDepositInvitation = async () =>
     zcf.makeInvitation(
       depositOfferHandler,
       'deposit Collateral',
@@ -674,16 +674,18 @@ export const start = async (zcf, privateArgs, baggage) => {
     }),
   );
 
-  const scheduler = await E.when(scheduleKit.recorderP, scheduleRecorder =>
-    makeScheduler(
-      driver,
-      timer,
-      // @ts-expect-error types are correct. How to convince TS?
-      params,
-      timerBrand,
-      scheduleRecorder,
-      publicFacet.getSubscription(),
-    ),
+  const scheduler = await E.when(
+    scheduleKit.recorderP,
+    async scheduleRecorder =>
+      makeScheduler(
+        driver,
+        timer,
+        // @ts-expect-error types are correct. How to convince TS?
+        params,
+        timerBrand,
+        scheduleRecorder,
+        publicFacet.getSubscription(),
+      ),
   );
 
   const creatorFacet = makeFarGovernorFacet(

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -120,7 +120,7 @@ export const makeScheduler = async (
    * Publish the schedule. To be called after clockTick() (which processes a
    * descending step) or when the next round is scheduled.
    */
-  const publishSchedule = () => {
+  const publishSchedule = async () => {
     const sched = harden({
       activeStartTime: liveSchedule?.startTime || null,
       nextStartTime: nextSchedule?.startTime || null,

--- a/packages/inter-protocol/src/collectFees.js
+++ b/packages/inter-protocol/src/collectFees.js
@@ -11,7 +11,12 @@ import { atomicTransfer } from '@agoric/zoe/src/contractSupport/index.js';
  * @param {string} keyword
  * @returns {Promise<Invitation<string>>}
  */
-export const makeCollectFeesInvitation = (zcf, feeSeat, feeBrand, keyword) => {
+export const makeCollectFeesInvitation = async (
+  zcf,
+  feeSeat,
+  feeBrand,
+  keyword,
+) => {
   const collectFees = seat => {
     const amount = feeSeat.getAmountAllocated(keyword, feeBrand);
     atomicTransfer(zcf, feeSeat, seat, { [keyword]: amount }, { Fee: amount });

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -60,12 +60,12 @@ export const start = async (zcf, privateArgs, baggage) => {
     'instanceToGovernor',
   );
 
-  const makeParamInvitation = () => {
+  const makeParamInvitation = async () => {
     /**
      * @param {ZCFSeat} seat
      * @param {ParamChangesOfferArgs} args
      */
-    const voteOnParamChanges = (seat, args) => {
+    const voteOnParamChanges = async (seat, args) => {
       mustMatch(args, ParamChangesOfferArgsShape);
       seat.exit();
 
@@ -86,8 +86,8 @@ export const start = async (zcf, privateArgs, baggage) => {
     return zcf.makeInvitation(voteOnParamChanges, 'vote on param changes');
   };
 
-  const makeOfferFilterInvitation = (instance, strings, deadline) => {
-    const voteOnOfferFilterHandler = seat => {
+  const makeOfferFilterInvitation = async (instance, strings, deadline) => {
+    const voteOnOfferFilterHandler = async seat => {
       seat.exit();
 
       const governor = instanceToGovernor.get(instance);
@@ -103,13 +103,13 @@ export const start = async (zcf, privateArgs, baggage) => {
    * @param {string[]} methodArgs
    * @param {import('@agoric/time').TimestampValue} deadline
    */
-  const makeApiInvocationInvitation = (
+  const makeApiInvocationInvitation = async (
     instance,
     methodName,
     methodArgs,
     deadline,
   ) => {
-    const handler = seat => {
+    const handler = async seat => {
       seat.exit();
 
       const governor = instanceToGovernor.get(instance);
@@ -177,7 +177,7 @@ export const start = async (zcf, privateArgs, baggage) => {
         console.log('charter: adding instance', label);
         instanceToGovernor.init(governedInstance, governorFacet);
       },
-      makeCharterMemberInvitation: () =>
+      makeCharterMemberInvitation: async () =>
         zcf.makeInvitation(charterMemberHandler, INVITATION_MAKERS_DESC),
     },
   );

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -51,7 +51,7 @@ harden(meta);
 export const makeContractFeeCollector = (zoe, creatorFacet) => {
   /** @type {FeeCollector} */
   return Far('feeCollector', {
-    collectFees: () => {
+    collectFees: async () => {
       const invitation = E(creatorFacet).makeCollectFeesInvitation();
       const collectFeesSeat = E(zoe).offer(invitation, undefined, undefined);
       return E(collectFeesSeat).getPayout('Fee');
@@ -78,7 +78,7 @@ export const startDistributing = (
   collectionInterval = 1n,
 ) => {
   const timeObserver = {
-    updateState: _ =>
+    updateState: async _ =>
       schedulePayments().catch(e => {
         console.error('failed with', e);
         throw e;
@@ -187,7 +187,7 @@ export const sharePayment = async (
 
   // Send each nonempty payment to the corresponding destination.
   await Promise.all(
-    destinedAmountEntries.map(([destination], i) =>
+    destinedAmountEntries.map(async ([destination], i) =>
       E(destination).pushPayment(sharedPayment[i], issuer),
     ),
   );
@@ -213,7 +213,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
   const collectors = makeScalarSetStore();
 
   /** @param {Payment<'nat'>} payment */
-  const distributeFees = payment =>
+  const distributeFees = async payment =>
     sharePayment(payment, feeIssuer, shareConfig);
 
   const schedulePayments = async () => {
@@ -221,7 +221,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
       return;
     }
     await Promise.all(
-      [...collectors.values()].map(collector =>
+      [...collectors.values()].map(async collector =>
         E(collector).collectFees().then(distributeFees),
       ),
     );

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -166,7 +166,7 @@ export const start = async (zcf, privateArgs, baggage) => {
      * @param {string[]} addrs
      * @returns {Promise<PromiseSettledResult<string>[]>}
      */
-    addOracles: addrs => {
+    addOracles: async addrs => {
       return Promise.allSettled(addrs.map(addOracle));
     },
     /**
@@ -177,7 +177,7 @@ export const start = async (zcf, privateArgs, baggage) => {
      * @param {string[]} addrs
      * @returns {Promise<PromiseSettledResult<string>[]>}
      */
-    removeOracles: addrs => {
+    removeOracles: async addrs => {
       return Promise.allSettled(addrs.map(removeOracle));
     },
   };

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -149,7 +149,7 @@ export const prepareFluxAggregatorKit = async (
         storageNode,
         /** @type {TypedPattern<PriceDescription>} */ (M.any()),
       ),
-    latestRoundKit: () =>
+    latestRoundKit: async () =>
       E.when(E(storageNode).makeChildNode('latestRound'), node =>
         makeRecorderKit(
           node,
@@ -285,7 +285,7 @@ export const prepareFluxAggregatorKit = async (
           oracles.delete(oracleId);
         },
 
-        getRoundData: roundIdRaw => {
+        getRoundData: async roundIdRaw => {
           return roundsManagerKit.contract.getRoundData(roundIdRaw);
         },
 

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -477,7 +477,7 @@ export const prepareRoundsManagerKit = baggage =>
           const { contract } = this.facets;
 
           /** @param {PriceQuery} priceQuery */
-          return Far('createQuote', priceQuery => {
+          return Far('createQuote', async priceQuery => {
             const { lastValueOutForUnitIn, unitIn } = state;
 
             // Sniff the current baseValueOut.
@@ -533,7 +533,7 @@ export const prepareRoundsManagerKit = baggage =>
             }
             return E(timerPresence)
               .getCurrentTimestamp()
-              .then(now =>
+              .then(async now =>
                 contract.authenticateQuote([
                   { amountIn, amountOut, timer: timerPresence, timestamp: now },
                 ]),

--- a/packages/inter-protocol/src/proposals/add-auction.js
+++ b/packages/inter-protocol/src/proposals/add-auction.js
@@ -189,7 +189,7 @@ export const addAuction = async (
   const allIssuers = await E(zoe).getIssuers(legacyKit.instance);
   const { Bid: _istIssuer, ...auctionIssuers } = allIssuers;
   await Promise.all(
-    Object.keys(auctionIssuers).map(kwd =>
+    Object.keys(auctionIssuers).map(async kwd =>
       E(governedCreatorFacet).addBrand(
         /** @type {Issuer<'nat'>} */ (auctionIssuers[kwd]),
         kwd,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -140,7 +140,7 @@ export const createPriceFeed = async (
       installationP = E(zoe).installBundleID(bundleID);
       await E.when(
         installationP,
-        installation =>
+        async installation =>
           E(E(agoricNamesAdmin).lookupAdmin('installation')).update(
             'priceAggregator',
             installation,

--- a/packages/inter-protocol/src/proposals/replace-scaledPriceAuthorities.js
+++ b/packages/inter-protocol/src/proposals/replace-scaledPriceAuthorities.js
@@ -58,7 +58,7 @@ export const replaceScaledPriceAuthorities = async (powers, { options }) => {
   if (scaledPARef && bundleID) {
     await E.when(
       E(zoe).installBundleID(bundleID),
-      installation =>
+      async installation =>
         E(installationsAdmin).update('scaledPriceAuthority', installation),
       err =>
         console.error(

--- a/packages/inter-protocol/src/proposals/replaceElectorate.js
+++ b/packages/inter-protocol/src/proposals/replaceElectorate.js
@@ -70,7 +70,7 @@ const handlehighPrioritySendersList = async (
   const { addressesToAdd, addressesToRemove } = highPrioritySendersConfig;
 
   await Promise.all(
-    addressesToAdd.map(addr =>
+    addressesToAdd.map(async addr =>
       E(highPrioritySendersManager).add(
         HIGH_PRIORITY_SENDERS_NAMESPACE,
         traced('High Priority Senders: adding', addr),
@@ -79,7 +79,7 @@ const handlehighPrioritySendersList = async (
   );
 
   await Promise.all(
-    addressesToRemove.map(addr =>
+    addressesToRemove.map(async addr =>
       E(highPrioritySendersManager).remove(
         HIGH_PRIORITY_SENDERS_NAMESPACE,
         traced('High Priority Senders: removing', addr),

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -145,7 +145,7 @@ export const startPSM = async (
     ]);
 
   const [anchorInfo, mintedInfo] = await Promise.all(
-    [anchorBrand, minted].map(b => E(b).getDisplayInfo()),
+    [anchorBrand, minted].map(async b => E(b).getDisplayInfo()),
   );
 
   const mintLimit = AmountMath.make(minted, MINT_LIMIT);

--- a/packages/inter-protocol/src/proposals/upgrade-scaledPriceAuthorities.js
+++ b/packages/inter-protocol/src/proposals/upgrade-scaledPriceAuthorities.js
@@ -26,7 +26,7 @@ export const upgradeScaledPriceAuthorities = async (
   if (scaledPARef && bundleID) {
     await E.when(
       E(zoe).installBundleID(bundleID),
-      installation =>
+      async installation =>
         E(E(agoricNamesAdmin).lookupAdmin('installation')).update(
           'scaledPriceAuthority',
           installation,

--- a/packages/inter-protocol/src/provisionPool.js
+++ b/packages/inter-protocol/src/provisionPool.js
@@ -92,7 +92,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const provisionPoolKit = await provideSingleton(
     baggage,
     'provisionPoolKit',
-    () =>
+    async () =>
       makeProvisionPoolKit({
         // XXX governance can change the brand of the amount but should only be able to change the value
         // NB: changing the brand will break this pool

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -129,7 +129,8 @@ export const start = async (zcf, privateArgs, baggage) => {
   );
 
   const { stableMint } = await provideAll(baggage, {
-    stableMint: () => zcf.registerFeeMint('Minted', privateArgs.feeMintAccess),
+    stableMint: async () =>
+      zcf.registerFeeMint('Minted', privateArgs.feeMintAccess),
   });
   const { brand: stableBrand } = stableMint.getIssuerRecord();
   (anchorPerMinted.numerator.brand === anchorBrand &&
@@ -172,7 +173,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   );
 
   const { metricsKit } = await provideAll(baggage, {
-    metricsKit: () =>
+    metricsKit: async () =>
       E.when(E(privateArgs.storageNode).makeChildNode('metrics'), node =>
         makeRecorderKit(
           node,
@@ -346,8 +347,8 @@ export const start = async (zcf, privateArgs, baggage) => {
   };
 
   const { anchorAmountShape, stableAmountShape } = await provideAll(baggage, {
-    anchorAmountShape: () => E(anchorBrand).getAmountShape(),
-    stableAmountShape: () => E(stableBrand).getAmountShape(),
+    anchorAmountShape: async () => E(anchorBrand).getAmountShape(),
+    stableAmountShape: async () => E(stableBrand).getAmountShape(),
   });
 
   const publicFacet = prepareExo(

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -61,7 +61,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   trace('awaiting feeMint');
   const { feeMint } = await provideAll(baggage, {
-    feeMint: () => zcf.registerFeeMint('Fee', privateArgs.feeMintAccess),
+    feeMint: async () => zcf.registerFeeMint('Fee', privateArgs.feeMintAccess),
   });
 
   const makeAssetReserveKit = await prepareAssetReserveKit(baggage, {

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -215,7 +215,7 @@ export const watchForGovernanceChange = (
   timer,
   reschedulerWaker,
 ) => {
-  void E.when(E(timer).getCurrentTimestamp(), now =>
+  void E.when(E(timer).getCurrentTimestamp(), async now =>
     // make one observer that will usually ignore the update.
     observeIteration(
       subscribeEach(E(auctioneerPublicFacet).getSubscription()),

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -762,7 +762,7 @@ export const prepareVault = (baggage, makeRecorderKit, zcf) => {
           const { helper } = facets;
           helper.assertCloseable();
           return zcf.makeInvitation(
-            seat => helper.closeHook(seat),
+            async seat => helper.closeHook(seat),
             state.manager.scopeDescription('CloseVault'),
             undefined,
             M.splitRecord({

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -161,7 +161,8 @@ const prepareVaultDirector = (
       rewardPoolAllocation: rewardPoolSeat.getCurrentAllocation(),
     });
   };
-  const writeMetrics = () => E(metricsKit.recorderP).write(sampleMetrics());
+  const writeMetrics = async () =>
+    E(metricsKit.recorderP).write(sampleMetrics());
 
   const updateShortfallReporter = async () => {
     const oldInvitation = baggage.has(shortfallInvitationKey)
@@ -367,7 +368,7 @@ const prepareVaultDirector = (
         getGovernedApiNames() {
           return harden([]);
         },
-        setOfferFilter: strings => zcf.setOfferFilter(strings),
+        setOfferFilter: async strings => zcf.setOfferFilter(strings),
       },
       machine: {
         // TODO move this under governance #3924
@@ -444,7 +445,7 @@ const prepareVaultDirector = (
         makeLiquidationWaker() {
           return makeWaker('liquidationWaker', _timestamp => {
             // XXX floating promise
-            allManagersDo(vm => vm.liquidateVaults(auctioneer));
+            allManagersDo(async vm => vm.liquidateVaults(auctioneer));
           });
         },
         makeReschedulerWaker() {

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -92,7 +92,8 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   trace('awaiting debtMint');
   const { debtMint } = await provideAll(baggage, {
-    debtMint: () => zcf.registerFeeMint('Minted', privateArgs.feeMintAccess),
+    debtMint: async () =>
+      zcf.registerFeeMint('Minted', privateArgs.feeMintAccess),
   });
 
   zcf.setTestJig(() => ({

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -351,7 +351,7 @@ export const prepareVaultManagerKit = (
           const { facets } = this;
           const { collateralBrand, debtBrand } = this.state;
           return zcf.makeInvitation(
-            seat => this.facets.self.makeVaultKit(seat),
+            async seat => this.facets.self.makeVaultKit(seat),
             facets.manager.scopeDescription('MakeVault'),
             undefined,
             M.splitRecord({
@@ -407,7 +407,7 @@ export const prepareVaultManagerKit = (
 
           trace('helper.start() starting observe periodNotifier');
           void observeNotifier(periodNotifier, {
-            updateState: updateTime =>
+            updateState: async updateTime =>
               facets.helper
                 .chargeAllVaults(updateTime)
                 .catch(e =>
@@ -569,7 +569,7 @@ export const prepareVaultManagerKit = (
           trace('Sending to reserve: ', penalty);
 
           // don't wait for response
-          void E.when(invitation, invite => {
+          void E.when(invitation, async invite => {
             const proposal = { give: { Collateral: penalty } };
             return offerTo(
               zcf,
@@ -627,7 +627,8 @@ export const prepareVaultManagerKit = (
 
           E.when(
             factoryPowers.getShortfallReporter(),
-            reporter => E(reporter).increaseLiquidationShortfall(shortfall),
+            async reporter =>
+              E(reporter).increaseLiquidationShortfall(shortfall),
             err =>
               console.error(
                 '🛠️ getShortfallReporter() failed during liquidation; repair by updating governance',
@@ -1211,7 +1212,7 @@ export const prepareVaultManagerKit = (
 
           const { userSeatPromise, deposited } = await E.when(
             E(auctionPF).makeDepositInvitation(),
-            depositInvitation =>
+            async depositInvitation =>
               offerTo(
                 zcf,
                 depositInvitation,

--- a/packages/inter-protocol/test/auction/auctionContract.test.js
+++ b/packages/inter-protocol/test/auction/auctionContract.test.js
@@ -248,7 +248,7 @@ const makeAuctionDriver = async (t, params = defaultParams) => {
     /** @type {Promise<BookDataTracker>} */
     const tracker = E.when(
       E(publicFacet).getBookDataUpdates(brand),
-      subscription => subscriptionTracker(t, subscribeEach(subscription)),
+      async subscription => subscriptionTracker(t, subscribeEach(subscription)),
     );
     // @ts-expect-error I don't know what it wants.
     bookDataTrackers.init(brand, tracker);
@@ -345,7 +345,7 @@ const makeAuctionDriver = async (t, params = defaultParams) => {
       return timer;
     },
     getScheduleTracker() {
-      return E.when(E(publicFacet).getScheduleUpdates(), subscription =>
+      return E.when(E(publicFacet).getScheduleUpdates(), async subscription =>
         subscriptionTracker(t, subscribeEach(subscription)),
       );
     },
@@ -506,7 +506,7 @@ test.serial('Excessive want in proposal', async t => {
     undefined,
     collateral.make(5000n),
   );
-  await t.throwsAsync(() => E(seat).getOfferResult(), {
+  await t.throwsAsync(async () => E(seat).getOfferResult(), {
     message: 'seat has been exited',
   });
 
@@ -1365,10 +1365,13 @@ test('deposit unregistered collateral', async t => {
   const asset = withAmountUtils(makeIssuerKit('Asset'));
   const driver = await makeAuctionDriver(t);
 
-  await t.throwsAsync(() => driver.depositCollateral(asset.make(500n), asset), {
-    message:
-      /key "\[Alleged: Asset brand\]" not found in collection "brandToIssuerRecord"/,
-  });
+  await t.throwsAsync(
+    async () => driver.depositCollateral(asset.make(500n), asset),
+    {
+      message:
+        /key "\[Alleged: Asset brand\]" not found in collection "brandToIssuerRecord"/,
+    },
+  );
 });
 
 test('bid on unregistered collateral', async t => {

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -39,7 +39,9 @@ export const setUpInstallations = async zoe => {
   });
   /** @type {AuctionTestInstallations} */
   // @ts-expect-error cast
-  const installations = objectMap(bundles, bundle => E(zoe).install(bundle));
+  const installations = objectMap(bundles, async bundle =>
+    E(zoe).install(bundle),
+  );
   return installations;
 };
 

--- a/packages/inter-protocol/test/feeDistributor.test.js
+++ b/packages/inter-protocol/test/feeDistributor.test.js
@@ -21,7 +21,7 @@ const makeFakeFeeDepositFacetKit = feeIssuer => {
     },
   };
 
-  const getPayments = () =>
+  const getPayments = async () =>
     // await event loop so the receive() can run
     Promise.resolve(eventLoopIteration()).then(_ => depositPayments);
 

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -146,7 +146,7 @@ const tools = context => {
   // Each driver needs its own to avoid state pollution between tests
   context.mockChainStorage = makeMockChainStorageRoot();
   const { feeMintAccess, initialPoserInvitation } = context;
-  const startPSM = name => {
+  const startPSM = async name => {
     return E(zoe).startInstance(
       installs.psmInstall,
       harden({ AUSD: anchor.issuer }),
@@ -308,7 +308,7 @@ const makeWalletFactoryKitForAddresses = async addresses => {
       const mockWallet = Far('mock wallet', {
         getDepositFacet: () =>
           Far('mock depositFacet', {
-            receive: payment => E(purse).deposit(payment),
+            receive: async payment => E(purse).deposit(payment),
           }),
       });
       return [addr, mockWallet];

--- a/packages/inter-protocol/test/psm/governedPsm.test.js
+++ b/packages/inter-protocol/test/psm/governedPsm.test.js
@@ -47,7 +47,7 @@ test('psm block offers w/Governance', async t => {
   const giveCentral = knut.make(1_000_000n);
 
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).offer(
         E(psm.psmPublicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveCentral } }),
@@ -102,7 +102,7 @@ test('psm block offers w/charter', async t => {
 
   const giveCentral = knut.make(1_000_000n);
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).offer(
         E(psm.psmPublicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveCentral } }),
@@ -156,7 +156,7 @@ test('psm block offers w/charter via invitationMakers', async t => {
 
   const giveCentral = knut.make(1_000_000n);
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).offer(
         E(psm.psmPublicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveCentral } }),

--- a/packages/inter-protocol/test/psm/psm.test.js
+++ b/packages/inter-protocol/test/psm/psm.test.js
@@ -379,7 +379,7 @@ test('limit is for minted', async t => {
   const giveTooMuch = anchor.make(MINT_LIMIT);
   const seat1 = await driver.swapAnchorForMintedSeat(giveTooMuch);
   await t.throwsAsync(
-    () => E(seat1).getOfferResult(),
+    async () => E(seat1).getOfferResult(),
     {
       message: 'Request would exceed mint limit',
     },
@@ -662,7 +662,7 @@ test('wrong give giveMintedInvitation', async t => {
   const { publicFacet } = await makePsmDriver(t);
   const giveAnchor = anchor.units(200);
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).offer(
         E(publicFacet).makeGiveMintedInvitation(),
         harden({ give: { In: giveAnchor } }),
@@ -691,7 +691,7 @@ test('wrong give wantMintedInvitation', async t => {
     zoe,
   });
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).offer(
         E(publicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveIST } }),
@@ -710,7 +710,7 @@ test('extra give wantMintedInvitation', async t => {
   const giveAnchor = anchor.units(200);
   const mint = NonNullish(anchor.mint);
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).offer(
         E(publicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveAnchor, Extra: giveAnchor } }),
@@ -814,12 +814,12 @@ test('restore PSM: startPSM with previous metrics, params', async t => {
 
   // Run code under test
   await Promise.all([
-    ...anchorAssets.map(anchorOptions =>
+    ...anchorAssets.map(async anchorOptions =>
       makeAnchorAsset(powers, {
         options: { anchorOptions },
       }),
     ),
-    ...anchorAssets.map(anchorOptions =>
+    ...anchorAssets.map(async anchorOptions =>
       startPSM(powers, {
         options: { anchorOptions },
       }),

--- a/packages/inter-protocol/test/smartWallet/boot-psm.js
+++ b/packages/inter-protocol/test/smartWallet/boot-psm.js
@@ -291,12 +291,12 @@ export const buildRootObject = async (vatPowers, vatParameters) => {
       inviteToEconCharter(powersFor('inviteToEconCharter'), {
         options: { voterAddresses: economicCommitteeAddresses },
       }),
-      ...anchorAssets.map(anchorOptions =>
+      ...anchorAssets.map(async anchorOptions =>
         makeAnchorAsset(powersFor('makeAnchorAsset'), {
           options: { anchorOptions },
         }),
       ),
-      ...anchorAssets.map(anchorOptions =>
+      ...anchorAssets.map(async anchorOptions =>
         startPSM(powersFor(startPSM.name), {
           options: { anchorOptions },
         }),
@@ -311,7 +311,7 @@ export const buildRootObject = async (vatPowers, vatParameters) => {
   };
 
   return Far('bootstrap', {
-    bootstrap: (vats, devices) => {
+    bootstrap: async (vats, devices) => {
       const { D } = vatPowers;
       D(devices.mailbox).registerInboundHandler(
         Far('dummyInboundHandler', { deliverInboundMessages: () => {} }),
@@ -338,7 +338,7 @@ export const buildRootObject = async (vatPowers, vatParameters) => {
       produce[name].reset();
     },
     // expose consume mostly for testing
-    consumeItem: name => {
+    consumeItem: async name => {
       assert.typeof(name, 'string');
       return consume[name];
     },

--- a/packages/inter-protocol/test/smartWallet/boot-test-utils.js
+++ b/packages/inter-protocol/test/smartWallet/boot-test-utils.js
@@ -89,7 +89,7 @@ export const makePopulatedFakeVatAdmin = () => {
     fakeNameToCap.set(name, cap);
   }
 
-  const createVat = (bundleCap, options) => {
+  const createVat = async (bundleCap, options) => {
     assert(bundleCap);
     if (bundleCap === zcfBundleCap) {
       return fakeVatAdmin.createVat(zcfBundleCap, options);

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -145,12 +145,12 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
      *
      * @param {Brand<'nat'>} brand
      */
-    const getBalanceFor = brand =>
+    const getBalanceFor = async brand =>
       E(E(bank).getPurse(brand)).getCurrentAmount();
     return { getBalanceFor, wallet };
   };
 
-  const simpleProvideWallet = address =>
+  const simpleProvideWallet = async address =>
     provideWalletAndBalances(address).then(({ wallet }) => wallet);
 
   /**
@@ -225,7 +225,8 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     anchor,
     invitationBrand: await E(E(zoe).getInvitationIssuer()).getBrand(),
     sendToBridge:
-      walletBridgeManager && (obj => E(walletBridgeManager).toBridge(obj)),
+      walletBridgeManager &&
+      (async obj => E(walletBridgeManager).toBridge(obj)),
     consume,
     provideWalletAndBalances,
     simpleProvideWallet,

--- a/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
@@ -111,7 +111,7 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
   const { agoricNames } = t.context.consume;
 
   const wallets = await Promise.all(
-    oracleAddresses.map(addr => t.context.simpleProvideWallet(addr)),
+    oracleAddresses.map(async addr => t.context.simpleProvideWallet(addr)),
   );
 
   const oracleWallets = Object.fromEntries(zip(oracleAddresses, wallets));

--- a/packages/inter-protocol/test/smartWallet/psm-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/psm-integration.test.js
@@ -394,14 +394,14 @@ test('recover when some withdrawals succeed and others fail', async t => {
   const { make } = AmountMath;
   const { anchor } = t.context;
   const { agoricNames, bankManager } = t.context.consume;
-  const getBalance = (addr, brand) => {
+  const getBalance = async (addr, brand) => {
     const bank = E(bankManager).getBankForAddress(addr);
     const purse = E(bank).getPurse(brand);
     return E(purse).getCurrentAmount();
   };
-  const namedBrands = kws =>
+  const namedBrands = async kws =>
     Promise.all(
-      kws.map(kw =>
+      kws.map(async kw =>
         E(agoricNames)
           .lookup('brand', kw)
           .then(b => [kw, b]),

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -31,7 +31,7 @@ export const DENOM_UNIT = 1_000_000n;
  * @param {string} bundleName
  * @returns {Promise<SourceBundle>}
  */
-export const provideBundle = (t, sourceRoot, bundleName) => {
+export const provideBundle = async (t, sourceRoot, bundleName) => {
   assert(
     t.context && t.context.bundleCache,
     'must set t.context.bundleCache in test.before()',
@@ -150,7 +150,7 @@ export const scale6 = x => BigInt(Math.round(x * 1_000_000));
 export { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 
 /** @param {ERef<StoredSubscription<unknown> | StoredSubscriber<unknown>>} subscription */
-export const subscriptionKey = subscription => {
+export const subscriptionKey = async subscription => {
   return E(subscription)
     .getStoreKey()
     .then(storeKey => {
@@ -169,7 +169,7 @@ export const subscriptionKey = subscription => {
  * }>} hasTopics
  * @param {string} subscriberName
  */
-export const topicPath = (hasTopics, subscriberName) => {
+export const topicPath = async (hasTopics, subscriberName) => {
   return E(hasTopics)
     .getPublicTopics()
     .then(topics => topics[subscriberName])

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -128,7 +128,9 @@ export const makeDriverContext = async ({
     auctioneer: bundleCache.load(contractRoots.auctioneer, 'auction'),
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
   });
-  const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+  const installation = objectMap(bundles, async bundle =>
+    E(zoe).install(bundle),
+  );
 
   const feeMintAccess = await feeMintAccessP;
   const contextPs = {
@@ -528,7 +530,7 @@ export const makeManagerDriver = async (
      * @param {VaultFactoryParamPath} [paramPath] defaults to root path for the
      *   factory
      */
-    setGovernedParam: (
+    setGovernedParam: async (
       name,
       newValue,
       paramPath = { key: 'governedParams' },
@@ -543,7 +545,7 @@ export const makeManagerDriver = async (
       );
     },
     /** @param {string[]} filters */
-    setGovernedFilters: filters => {
+    setGovernedFilters: async filters => {
       trace(t, 'setGovernedFilters', filters);
       const vfGov = NonNullish(t.context.puppetGovernors.vaultFactory);
       return E(vfGov).setFilters(harden(filters));

--- a/packages/inter-protocol/test/vaultFactory/faucet.js
+++ b/packages/inter-protocol/test/vaultFactory/faucet.js
@@ -11,7 +11,7 @@ import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 export async function start(zcf, { feeMintAccess }) {
   const stableMint = await zcf.registerFeeMint('RUN', feeMintAccess);
 
-  function makeFaucetInvitation() {
+  async function makeFaucetInvitation() {
     /** @param {ZCFSeat} seat */
     async function faucetHook(seat) {
       assertProposalShape(seat, { want: { RUN: null } });

--- a/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
+++ b/packages/inter-protocol/test/vaultFactory/replacePriceAuthority.test.js
@@ -95,7 +95,9 @@ test.before(async t => {
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
     auctioneer: bundleCache.load(contractRoots.auctioneer, 'auction'),
   });
-  const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+  const installation = objectMap(bundles, async bundle =>
+    E(zoe).install(bundle),
+  );
 
   const feeMintAccess = await feeMintAccessP;
   const contextPs = {

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -102,7 +102,9 @@ test.before(async t => {
     auctioneer: bundleCache.load(contractRoots.auctioneer, 'auction'),
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
   });
-  const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+  const installation = objectMap(bundles, async bundle =>
+    E(zoe).install(bundle),
+  );
 
   const feeMintAccess = await feeMintAccessP;
   const contextPs = {
@@ -819,9 +821,12 @@ test('adjust balances', async t => {
     }),
   );
 
-  await t.throwsAsync(() => E(aliceReduceCollateralSeat2).getOfferResult(), {
-    message: /Proposed debt.*exceeds max/,
-  });
+  await t.throwsAsync(
+    async () => E(aliceReduceCollateralSeat2).getOfferResult(),
+    {
+      message: /Proposed debt.*exceeds max/,
+    },
+  );
 
   // try to trade zero for zero
   const aliceReduceCollateralSeat3 = await E(zoe).offer(
@@ -1025,7 +1030,7 @@ test('transfer vault', async t => {
     vault: transferVault,
     publicNotifiers: { vault: transferNotifier },
   } = await legacyOfferResult(transferSeat);
-  await t.throwsAsync(() => E(aliceVault).getCurrentDebt());
+  await t.throwsAsync(async () => E(aliceVault).getCurrentDebt());
   const debtAfter = await E(transferVault).getCurrentDebt();
   t.deepEqual(debtAfter, debtAmount, 'vault lent 5000 Minted + fees');
   const collateralAfter = await E(transferVault).getCollateralAmount();
@@ -1082,7 +1087,7 @@ test('transfer vault', async t => {
     vault: t2Vault,
     publicNotifiers: { vault: t2Notifier },
   } = await legacyOfferResult(t2Seat);
-  await t.throwsAsync(() => E(transferVault).getCurrentDebt());
+  await t.throwsAsync(async () => E(transferVault).getCurrentDebt());
   const debtAfter2 = await E(t2Vault).getCurrentDebt();
   t.deepEqual(debtAmount, debtAfter2, 'vault lent 5000 Minted + fees');
 
@@ -1527,7 +1532,7 @@ test('debt too small - MinInitialDebt', async t => {
       Collateral: aeth.mint.mintPayment(collateralAmount),
     }),
   );
-  await t.throwsAsync(() => E(aliceVaultSeat).getOfferResult(), {
+  await t.throwsAsync(async () => E(aliceVaultSeat).getOfferResult(), {
     message:
       'Vault creation requires a minInitialDebt of {"brand":"[Alleged: IST brand]","value":"[50000n]"}',
   });
@@ -1565,7 +1570,7 @@ test('excessive debt on collateral type - debtLimit', async t => {
       Collateral: aeth.mint.mintPayment(collateralAmount),
     }),
   );
-  await t.throwsAsync(() => E(vaultSeat).getOfferResult(), {
+  await t.throwsAsync(async () => E(vaultSeat).getOfferResult(), {
     message:
       'Minting {"brand":"[Alleged: IST brand]","value":"[1050000n]"} past {"brand":"[Alleged: IST brand]","value":"[0n]"} would hit total debt limit {"brand":"[Alleged: IST brand]","value":"[1000000n]"}',
   });
@@ -1592,7 +1597,7 @@ test('addVaultType: invalid args do not modify state', async t => {
   const failsForSameReason = async p =>
     p
       .then(oops => t.fail(`${oops}`))
-      .catch(reason1 => t.throwsAsync(p, { message: reason1.message }));
+      .catch(async reason1 => t.throwsAsync(p, { message: reason1.message }));
   await failsForSameReason(
     E(vaultFactory)
       // @ts-expect-error bad args on purpose for test

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -189,7 +189,7 @@ export const getRunFromFaucet = async (t, amount) => {
  *
  * @param {UserSeat<VaultKit>} vaultSeat
  */
-export const legacyOfferResult = vaultSeat => {
+export const legacyOfferResult = async vaultSeat => {
   return E(vaultSeat)
     .getOfferResult()
     .then(result => {

--- a/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultLiquidation.test.js
@@ -100,7 +100,9 @@ test.before(async t => {
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
     auctioneer: bundleCache.load(contractRoots.auctioneer, 'auction'),
   });
-  const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+  const installation = objectMap(bundles, async bundle =>
+    E(zoe).install(bundle),
+  );
 
   const feeMintAccess = await feeMintAccessP;
   const contextPs = {
@@ -2141,7 +2143,7 @@ test('Bug 7422 vault reinstated with no assets', async t => {
     lockedQuote: null,
   });
 
-  const openVault = (collateral, want) =>
+  const openVault = async (collateral, want) =>
     E(zoe).offer(
       E(aethCollateralManager).makeVaultInvitation(),
       harden({
@@ -2377,7 +2379,7 @@ test('Bug 7346 excess collateral to holder', async t => {
     lockedQuote: null,
   });
 
-  const openVault = (collateral, want) =>
+  const openVault = async (collateral, want) =>
     E(zoe).offer(
       E(aethCollateralManager).makeVaultInvitation(),
       harden({
@@ -2831,7 +2833,7 @@ test('Bug 7784 reconstitute both', async t => {
     lockedQuote: null,
   });
 
-  const openVault = (collateral, want) =>
+  const openVault = async (collateral, want) =>
     E(zoe).offer(
       E(aethCollateralManager).makeVaultInvitation(),
       harden({
@@ -3050,7 +3052,7 @@ test('Bug 7796 missing lockedPrice', async t => {
     lockedQuote: null,
   });
 
-  const openVault = (collateral, want) =>
+  const openVault = async (collateral, want) =>
     E(zoe).offer(
       E(aethCollateralManager).makeVaultInvitation(),
       harden({
@@ -3328,7 +3330,7 @@ test('Bug 7851 & no bidders', async t => {
     lockedQuote: null,
   });
 
-  const openVault = (collateral, want) =>
+  const openVault = async (collateral, want) =>
     E(zoe).offer(
       E(aethCollateralManager).makeVaultInvitation(),
       harden({

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -63,7 +63,7 @@ harden(callSync);
  * @param {Parameters<I>} args
  * @returns {Promise<Awaited<ReturnType<I>>>}
  */
-export const callE = (callback, ...args) => {
+export const callE = async (callback, ...args) => {
   const { target, methodName, bound } = callback;
   if (methodName === undefined) {
     return E(target)(...bound, ...args);

--- a/packages/internal/src/lib-nodejs/waitUntilQuiescent.js
+++ b/packages/internal/src/lib-nodejs/waitUntilQuiescent.js
@@ -4,7 +4,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 // This can only be imported from the Start Compartment, where 'setImmediate'
 // is available.
 
-export function waitUntilQuiescent() {
+export async function waitUntilQuiescent() {
   // the delivery might cause some number of (native) Promises to be
   // created and resolved, so we use the IO queue to detect when the
   // Promise queue is empty. The IO queue (setImmediate and setTimeout) is

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -8,7 +8,7 @@ import { open } from 'node:fs/promises';
  *   | import('net').Socket} stream
  * @returns {Promise<void>}
  */
-export const fsStreamReady = stream =>
+export const fsStreamReady = async stream =>
   new Promise((resolve, reject) => {
     if (stream.destroyed) {
       reject(Error('Stream already destroyed'));
@@ -66,8 +66,8 @@ export const makeFsStreamWriter = async filePath => {
       () => p,
       err =>
         p.then(
-          () => Promise.reject(err),
-          pError =>
+          async () => Promise.reject(err),
+          async pError =>
             Promise.reject(
               pError !== err ? AggregateError([err, pError]) : err,
             ),

--- a/packages/internal/src/node/shutdown.js
+++ b/packages/internal/src/node/shutdown.js
@@ -27,7 +27,7 @@ export const makeFreshShutdown = (verbose = true) => {
     const shutdowners = [...shutdownThunks.keys()];
     shutdownThunks.clear();
     Promise.allSettled(
-      [...shutdowners].map(t => Promise.resolve(isSigInt).then(t)),
+      [...shutdowners].map(async t => Promise.resolve(isSigInt).then(t)),
     )
       .then(statuses => {
         for (const status of statuses) {

--- a/packages/internal/src/priority-senders.js
+++ b/packages/internal/src/priority-senders.js
@@ -35,7 +35,7 @@ export const makePrioritySendersManager = sendersNode => {
    * @param {import('./lib-chainStorage.js').StorageNode} node
    * @param {Set<string>} namespaces
    */
-  const refreshVstorage = (node, namespaces) => {
+  const refreshVstorage = async (node, namespaces) => {
     return E(node).setValue(
       // if the list set is empty, the string will be '' and thus deleted from IAVL
       [...namespaces.keys()].sort().join(','),
@@ -80,7 +80,7 @@ export const makePrioritySendersManager = sendersNode => {
      * @param {string} address
      * @returns {Promise<void>}
      */
-    remove: (rawNamespace, address) => {
+    remove: async (rawNamespace, address) => {
       const namespace = normalizeSenderNamespace(rawNamespace);
       const record = addressRecords.get(address);
       if (!record) {

--- a/packages/internal/test/callback.test.js
+++ b/packages/internal/test/callback.test.js
@@ -161,7 +161,7 @@ test('far method callbacks', async t => {
   t.is(await p3r, '19go');
 
   // @ts-expect-error deliberate: is not assignable to SyncCallback
-  const thunk = () => cb.callSync(cbp2, 'go');
+  const thunk = async () => cb.callSync(cbp2, 'go');
   t.throws(thunk, { message: /not a function/ });
 });
 
@@ -179,7 +179,7 @@ test('far function callbacks', async t => {
   t.like(cbp2, { bound: [9, 10] });
   t.assert(cbp2.target instanceof Promise);
   // @ts-expect-error deliberate: is not assignable to SyncCallback
-  const thunk = () => cb.callSync(cbp2, 'go');
+  const thunk = async () => cb.callSync(cbp2, 'go');
   t.throws(thunk, { message: /not a function/ });
   const p2r = cb.callE(cbp2, 'go');
   t.assert(p2r instanceof Promise);

--- a/packages/internal/test/priority-senders.test.js
+++ b/packages/internal/test/priority-senders.test.js
@@ -45,12 +45,12 @@ test('errors', async t => {
   });
   const manager = makePrioritySendersManager(storage.rootNode);
 
-  t.throws(() => manager.remove('oracles', 'agoric1a'), {
+  t.throws(async () => manager.remove('oracles', 'agoric1a'), {
     message: 'address not registered: "agoric1a"',
   });
 
   await manager.add('oracles', 'agoric1a');
-  t.throws(() => manager.remove('unknown', 'agoric1a'), {
+  t.throws(async () => manager.remove('unknown', 'agoric1a'), {
     message: 'namespace "unknown" does not have address "agoric1a"',
   });
 

--- a/packages/internal/test/storage-test-utils.test.js
+++ b/packages/internal/test/storage-test-utils.test.js
@@ -41,7 +41,7 @@ test('makeFakeStorageKit', async t => {
   for (const [label, val] of nonStrings) {
     await t.throwsAsync(
       // @ts-expect-error invalid value
-      () => rootNode.setValue(val),
+      async () => rootNode.setValue(val),
       undefined,
       `${label} value for root node is rejected`,
     );
@@ -138,7 +138,7 @@ test('makeFakeStorageKit', async t => {
   for await (const [label, val] of nonStrings) {
     await t.throwsAsync(
       // @ts-expect-error invalid value
-      () => deepNode.setValue(val),
+      async () => deepNode.setValue(val),
       undefined,
       `${label} value for non-root node is rejected`,
     );
@@ -198,7 +198,7 @@ test('makeFakeStorageKit sequence data', async t => {
 
   await t.throwsAsync(
     // @ts-expect-error
-    () => rootNode.setValue([]),
+    async () => rootNode.setValue([]),
     undefined,
     'array value is rejected',
   );

--- a/packages/internal/test/utils.test.js
+++ b/packages/internal/test/utils.test.js
@@ -13,7 +13,9 @@ import {
 } from '../src/ses-utils.js';
 
 test('deeplyFulfilledObject', async t => {
-  const someFar = Far('somefar', { getAsync: () => Promise.resolve('async') });
+  const someFar = Far('somefar', {
+    getAsync: async () => Promise.resolve('async'),
+  });
   const unfulfilled = harden({
     obj1: {
       obj2a: {

--- a/packages/kmarshal/src/kmarshal.js
+++ b/packages/kmarshal/src/kmarshal.js
@@ -18,7 +18,7 @@ import { makeMarshal } from '@endo/marshal';
 
 const { toStringTag } = Symbol;
 
-const makeStandinPromise = kref => {
+const makeStandinPromise = async kref => {
   const p = Promise.resolve(`${kref} stand in`);
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   Object.defineProperty(p, toStringTag, {

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -52,7 +52,7 @@ export const makeAsyncIterableFromNotifier = subscribeLatest;
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @returns {Promise<undefined>}
  */
-export const observeIterator = (asyncIteratorP, iterationObserver) => {
+export const observeIterator = async (asyncIteratorP, iterationObserver) => {
   return new Promise((ack, observerError) => {
     const recur = () => {
       E.when(
@@ -88,7 +88,7 @@ export const observeIterator = (asyncIteratorP, iterationObserver) => {
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @returns {Promise<undefined>}
  */
-export const observeIteration = (asyncIterableP, iterationObserver) => {
+export const observeIteration = async (asyncIterableP, iterationObserver) => {
   const iteratorP = E(asyncIterableP)[Symbol.asyncIterator]();
   return observeIterator(iteratorP, iterationObserver);
 };
@@ -104,5 +104,5 @@ export const observeIteration = (asyncIterableP, iterationObserver) => {
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @returns {Promise<undefined>}
  */
-export const observeNotifier = (notifierP, iterationObserver) =>
+export const observeNotifier = async (notifierP, iterationObserver) =>
   observeIteration(subscribeLatest(notifierP), iterationObserver);

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -50,7 +50,7 @@ export const makeNotifierFromSubscriber = subscriber => {
    * @type {LatestTopic<T>}
    */
   const baseNotifier = harden({
-    getUpdateSince: (updateCount = undefined) =>
+    getUpdateSince: async (updateCount = undefined) =>
       E(subscriber).getUpdateSince(updateCount),
   });
 

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -12,7 +12,7 @@ import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
  */
 
 const sink = () => {};
-const makeQuietRejection = reason => {
+const makeQuietRejection = async reason => {
   const rejection = harden(Promise.reject(reason));
   void E.when(rejection, sink, sink);
   return rejection;
@@ -155,7 +155,7 @@ export const makePublishKit = () => {
    * @type {Subscriber<T>}
    */
   const subscriber = Far('Subscriber', {
-    subscribeAfter: (publishCount = -1n) => {
+    subscribeAfter: async (publishCount = -1n) => {
       assert.typeof(publishCount, 'bigint');
       if (publishCount === currentPublishCount) {
         return tailP;
@@ -167,7 +167,7 @@ export const makePublishKit = () => {
         );
       }
     },
-    getUpdateSince: updateCount => {
+    getUpdateSince: async updateCount => {
       if (updateCount === undefined) {
         return subscriber.subscribeAfter().then(makeMemoizedUpdateRecord);
       }
@@ -180,7 +180,7 @@ export const makePublishKit = () => {
           .subscribeAfter(updateCount)
           // ... so we poll the latest published update, without waiting for any
           // further ones.
-          .then(() => subscriber.getUpdateSince())
+          .then(async () => subscriber.getUpdateSince())
       );
     },
   });
@@ -266,7 +266,7 @@ const durablePublishKitEphemeralData = new WeakMap();
  * @param {Promise<*>} tail
  * @returns {Promise<*>}
  */
-const provideCurrentP = (state, facets, tail) => {
+const provideCurrentP = async (state, facets, tail) => {
   const ephemeralKey = getEphemeralKey(facets);
   const foundData = durablePublishKitEphemeralData.get(ephemeralKey);
   const currentP = foundData && foundData.currentP;

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -58,8 +58,9 @@ export const makeStoredNotifier = (notifier, storageNode, marshaller) => {
 
   /** @type {StoredNotifier<T>} */
   const storedNotifier = Far('StoredNotifier', {
-    getUpdateSince: updateCount => E(notifier).getUpdateSince(updateCount),
-    getPath: () => E(storageNode).getPath(),
+    getUpdateSince: async updateCount =>
+      E(notifier).getUpdateSince(updateCount),
+    getPath: async () => E(storageNode).getPath(),
     getUnserializer: () => unserializer,
   });
   return storedNotifier;

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -70,10 +70,11 @@ export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
 
   /** @type {StoredSubscriber<T>} */
   const storesub = Far('StoredSubscriber', {
-    subscribeAfter: publishCount => subscriber.subscribeAfter(publishCount),
-    getUpdateSince: updateCount => subscriber.getUpdateSince(updateCount),
-    getPath: () => E(storageNode).getPath(),
-    getStoreKey: () => E(storageNode).getStoreKey(),
+    subscribeAfter: async publishCount =>
+      subscriber.subscribeAfter(publishCount),
+    getUpdateSince: async updateCount => subscriber.getUpdateSince(updateCount),
+    getPath: async () => E(storageNode).getPath(),
+    getStoreKey: async () => E(storageNode).getStoreKey(),
     getUnserializer: () => unserializer,
   });
   return storesub;
@@ -130,7 +131,7 @@ export const makeStoredSubscription = (
     // Publish the value, capturing any error.
     E(marshaller)
       .toCapData(obj)
-      .then(serialized => {
+      .then(async serialized => {
         const encoded = JSON.stringify(serialized);
         return E(storageNode).setValue(encoded);
       })
@@ -156,10 +157,11 @@ export const makeStoredSubscription = (
       return harden({ ...storeKey, subscription });
     },
     getUnserializer: () => unserializer,
-    getSharableSubscriptionInternals: () =>
+    getSharableSubscriptionInternals: async () =>
       subscription.getSharableSubscriptionInternals(),
     [Symbol.asyncIterator]: () => subscription[Symbol.asyncIterator](),
-    subscribeAfter: publishCount => subscription.subscribeAfter(publishCount),
+    subscribeAfter: async publishCount =>
+      subscription.subscribeAfter(publishCount),
   });
   return storesub;
 };

--- a/packages/notifier/src/subscribe.js
+++ b/packages/notifier/src/subscribe.js
@@ -95,7 +95,7 @@ const makeEachIterator = (topic, nextCellP) => {
   // https://web.archive.org/web/20160404122250/http://wiki.ecmascript.org/doku.php?id=strawman:concurrency#infinite_queue
   const self = Far('EachIterator', {
     [Symbol.asyncIterator]: () => self,
-    next: () => {
+    next: async () => {
       const {
         head: resultP,
         publishCount: publishCountP,
@@ -151,7 +151,9 @@ const makeEachIterator = (topic, nextCellP) => {
 export const subscribeEach = topic => {
   const iterable = Far('EachIterable', {
     [Symbol.asyncIterator]: () => {
-      const firstCellP = reconnectAsNeeded(() => E(topic).subscribeAfter());
+      const firstCellP = reconnectAsNeeded(async () =>
+        E(topic).subscribeAfter(),
+      );
       return makeEachIterator(topic, firstCellP);
     },
   });
@@ -184,7 +186,7 @@ const cloneLatestIterator = (topic, localUpdateCount, terminalResult) => {
 
     // Send the next request now, skipping past intermediate updates
     // and upgrade disconnections.
-    const { value, updateCount } = await reconnectAsNeeded(() =>
+    const { value, updateCount } = await reconnectAsNeeded(async () =>
       E(topic).getUpdateSince(localUpdateCount),
     );
     // Make sure the next request is for a fresher value.

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -101,7 +101,7 @@ export const explodingStream = makeTestIterable(true);
  * @param {ERef<Passable>} p
  * @param {boolean} fails
  */
-export const testEnding = (t, p, fails) => {
+export const testEnding = async (t, p, fails) => {
   return E.when(
     p,
     result => {
@@ -148,7 +148,7 @@ const skip = (i, value, lossy) => {
  * @param {boolean} lossy
  * @returns {Promise<Passable>}
  */
-export const testManualConsumer = (t, iterable, lossy = false) => {
+export const testManualConsumer = async (t, iterable, lossy = false) => {
   const iterator = iterable[Symbol.asyncIterator]();
   const testLoop = i => {
     return iterator.next().then(

--- a/packages/notifier/test/makeNotifierFromSubscriber.test.js
+++ b/packages/notifier/test/makeNotifierFromSubscriber.test.js
@@ -156,7 +156,7 @@ test('makeNotifierFromSubscriber(fails) - getUpdateSince', async t => {
     [1, 2, 4, 8, 16, 32],
     'only the last of values published between iteration steps should be observed',
   );
-  await t.throwsAsync(() => notifier.getUpdateSince(), { is: failure });
+  await t.throwsAsync(async () => notifier.getUpdateSince(), { is: failure });
 });
 
 test('makeNotifierKit - getUpdateSince timing', async t => {
@@ -247,7 +247,7 @@ test('makeNotifierFromSubscriber - updateCount validation', async t => {
     conclusionValue: 'done',
   });
   const notifier = makeNotifierFromSubscriber(subscriber);
-  await t.throwsAsync(() => notifier.getUpdateSince(1n));
+  await t.throwsAsync(async () => notifier.getUpdateSince(1n));
 });
 
 test('makeNotifierFromSubscriber - getUpdateSince() result identity', async t => {

--- a/packages/notifier/test/notifier-adaptor.test.js
+++ b/packages/notifier/test/notifier-adaptor.test.js
@@ -37,12 +37,12 @@ test('async iterator - for await fails', async t => {
   return testEnding(t, p, true);
 });
 
-test('observeIteration - update from iterator finishes', t => {
+test('observeIteration - update from iterator finishes', async t => {
   const u = makeTestIterationObserver(t, false, false);
   return observeIteration(finiteStream, u);
 });
 
-test('observeIteration - update from iterator fails', t => {
+test('observeIteration - update from iterator fails', async t => {
   const u = makeTestIterationObserver(t, false, true);
   return observeIteration(explodingStream, u);
 });
@@ -50,7 +50,7 @@ test('observeIteration - update from iterator fails', t => {
 test('observeIteration - synchronous throw from observer stops hard', async t => {
   t.plan(2);
   await t.throwsAsync(
-    () =>
+    async () =>
       observeIteration(finiteStream, {
         updateState: state => {
           t.is(state, 1);
@@ -70,24 +70,24 @@ test('observeIteration - synchronous throw from observer stops hard', async t =>
 
 test('observeIteration - rejection from observer does nothing', async t => {
   const u = makeTestIterationObserver(t, true, false);
-  const handledRejection = reason => {
+  const handledRejection = async reason => {
     const r = Promise.reject(reason);
     r.catch(() => {});
     return r;
   };
   await observeIteration(finiteStream, {
     ...u,
-    updateState: state => {
+    updateState: async state => {
       u.updateState(state);
       return handledRejection(
         Error('updateState rejection does not propagate'),
       );
     },
-    finish: state => {
+    finish: async state => {
       u.finish(state);
       return handledRejection(Error('finish rejection does not propagate'));
     },
-    fail: reason => {
+    fail: async reason => {
       u.fail(reason);
       return handledRejection(Error('fail rejection does not propagate'));
     },
@@ -124,13 +124,13 @@ test('notifier adaptor - for await fails', async t => {
   return testEnding(t, p, true);
 });
 
-test('notifier adaptor - update from notifier finishes', t => {
+test('notifier adaptor - update from notifier finishes', async t => {
   const u = makeTestIterationObserver(t, true, false);
   const n = makeNotifierFromAsyncIterable(finiteStream);
   return observeNotifier(n, u);
 });
 
-test('notifier adaptor - update from notifier fails', t => {
+test('notifier adaptor - update from notifier fails', async t => {
   const u = makeTestIterationObserver(t, true, true);
   const n = makeNotifierFromAsyncIterable(explodingStream);
   return observeNotifier(n, u);

--- a/packages/notifier/test/notifier.test.js
+++ b/packages/notifier/test/notifier.test.js
@@ -74,7 +74,7 @@ test('notifier - update after state change', async t => {
 
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   t.is(updateDeNovo.value, 1, 'first state check (1)');
-  const all = Promise.all([updateInWaiting]).then(([update1]) => {
+  const all = Promise.all([updateInWaiting]).then(async ([update1]) => {
     t.is(update1.value, 3, '4th check (delayed) 3');
     const thirdStatePromise = notifier.getUpdateSince(update1.updateCount);
     return Promise.all([thirdStatePromise]).then(([update2]) => {
@@ -98,7 +98,7 @@ test('notifier - final state', async t => {
   const updateDeNovo = await notifier.getUpdateSince();
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   t.is(updateDeNovo.value, 1, 'initial state is one');
-  const all = Promise.all([updateInWaiting]).then(([update]) => {
+  const all = Promise.all([updateInWaiting]).then(async ([update]) => {
     t.is(update.value, 'final', 'state is "final"');
     t.falsy(update.updateCount, 'no handle after close');
     const postFinalUpdate = notifier.getUpdateSince(update.updateCount);

--- a/packages/notifier/test/publish-kit.test.js
+++ b/packages/notifier/test/publish-kit.test.js
@@ -150,7 +150,7 @@ const verifyPublishKit = test.macro(async (t, makePublishKit) => {
 
   t.throws(
     // @ts-expect-error deliberate testing of invalid invocation
-    () => subscriber.subscribeAfter(Number(secondPublishCount)),
+    async () => subscriber.subscribeAfter(Number(secondPublishCount)),
     { message: /bigint/ },
   );
 
@@ -195,7 +195,7 @@ const verifySubscribeAfter = test.macro(async (t, makePublishKit) => {
   for (const badCount of [1n, 0, '', false, Symbol('symbol'), {}]) {
     t.throws(
       // @ts-expect-error deliberate invalid arguments for testing
-      () => subscriber.subscribeAfter(badCount),
+      async () => subscriber.subscribeAfter(badCount),
       undefined,
       `subscribeAfter must reject invalid publish count: ${typeof badCount} ${q(
         badCount,

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -56,8 +56,12 @@ export const makePortfolioAccount = async (
   trace('makePortfolioAccount', chainNames);
   seat.exit(); // no funds exchanged
   mustMatch(chainNames, M.arrayOf(M.string()));
-  const allChains = await Promise.all(chainNames.map(n => orch.getChain(n)));
-  const allAccounts = await Promise.all(allChains.map(c => c.makeAccount()));
+  const allChains = await Promise.all(
+    chainNames.map(async n => orch.getChain(n)),
+  );
+  const allAccounts = await Promise.all(
+    allChains.map(async c => c.makeAccount()),
+  );
 
   const accountEntries = harden(
     /** @type {[string, OrchestrationAccount<any>][]} */ (

--- a/packages/orchestration/src/examples/stake-ica.contract.js
+++ b/packages/orchestration/src/examples/stake-ica.contract.js
@@ -77,7 +77,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const zone = makeDurableZone(baggage);
 
   const { accountsStorageNode } = await provideAll(baggage, {
-    accountsStorageNode: () => E(storageNode).makeChildNode('accounts'),
+    accountsStorageNode: async () => E(storageNode).makeChildNode('accounts'),
   });
 
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);

--- a/packages/orchestration/src/exos/ica-account-kit.js
+++ b/packages/orchestration/src/exos/ica-account-kit.js
@@ -150,7 +150,7 @@ export const prepareIcaAccountKit = (zone, { watch, asVow }) =>
         },
         /** @type {HostOf<IcaAccount['deactivate']>} */
         deactivate() {
-          return asVow(() => {
+          return asVow(async () => {
             const { connection } = this.state;
             if (!connection) throw Fail`Account not available or deactivated.`;
             this.state.isInitiatingClose = true;

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -698,7 +698,9 @@ export const prepareLocalOrchestrationAccountKit = (
               opts?.timeoutTimestamp ??
               (opts?.timeoutHeight
                 ? 0n
-                : asVow(() => E(timestampHelper).getTimeoutTimestampNS()));
+                : asVow(async () =>
+                    E(timestampHelper).getTimeoutTimestampNS(),
+                  ));
 
             // don't resolve the vow until the transfer is confirmed on remote
             // and reject vow if the transfer fails for any reason

--- a/packages/orchestration/src/exos/portfolio-holder-kit.js
+++ b/packages/orchestration/src/exos/portfolio-holder-kit.js
@@ -98,8 +98,10 @@ const preparePortfolioHolderKit = (zone, { asVow, when }) => {
           accounts.has(chainName) || Fail`no account found for ${chainName}`;
           const account = accounts.get(chainName);
           // @ts-expect-error XXX invitationMakers
-          return when(E(account).asContinuingOffer(), ({ invitationMakers }) =>
-            E(invitationMakers)[action](...(invitationArgs || [])),
+          return when(
+            E(account).asContinuingOffer(),
+            async ({ invitationMakers }) =>
+              E(invitationMakers)[action](...(invitationArgs || [])),
           );
         },
       },

--- a/packages/orchestration/src/proposals/start-send-anywhere.js
+++ b/packages/orchestration/src/proposals/start-send-anywhere.js
@@ -91,10 +91,10 @@ export const startSendAnywhere = async (
       () => undefined,
     );
 
-  const atomIssuer = await safeFulfill(() =>
+  const atomIssuer = await safeFulfill(async () =>
     E(agoricNames).lookup('issuer', 'ATOM'),
   );
-  const osmoIssuer = await safeFulfill(() =>
+  const osmoIssuer = await safeFulfill(async () =>
     E(agoricNames).lookup('issuer', 'OSMO'),
   );
 

--- a/packages/orchestration/src/utils/zoe-tools.js
+++ b/packages/orchestration/src/utils/zoe-tools.js
@@ -89,17 +89,17 @@ export const makeZoeTools = (zcf, { when, allVows, allSettled, asVow }) => {
 
       // Now all the `amounts` are accessible, so we can move them to the localAccount
       const payments = await Promise.all(
-        keys(amounts).map(kw => E(userSeat).getPayout(kw)),
+        keys(amounts).map(async kw => E(userSeat).getPayout(kw)),
       );
       const settleDeposits = await when(
-        allSettled(payments.map(pmt => E(localAccount).deposit(pmt))),
+        allSettled(payments.map(async pmt => E(localAccount).deposit(pmt))),
       );
       // if any of the deposits to localAccount failed, unwind all of the allocations
       if (settleDeposits.find(x => x.status === 'rejected')) {
         const amts = values(amounts);
         const errors = [];
         // withdraw the successfully deposited payments
-        const paymentsOrWithdrawVs = settleDeposits.map((x, i) => {
+        const paymentsOrWithdrawVs = settleDeposits.map(async (x, i) => {
           if (x.status === 'rejected') {
             errors.push(x.reason);
             return payments[i];
@@ -140,7 +140,9 @@ export const makeZoeTools = (zcf, { when, allVows, allSettled, asVow }) => {
       !destSeat.hasExited() || Fail`The seat cannot have exited.`;
 
       const settledWithdrawals = await when(
-        allSettled(values(amounts).map(amt => E(localAccount).withdraw(amt))),
+        allSettled(
+          values(amounts).map(async amt => E(localAccount).withdraw(amt)),
+        ),
       );
 
       // if any of the withdrawals were rejected, unwind the successful ones

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -76,7 +76,7 @@ test('makeAccount, deposit, withdraw', async t => {
   t.true(AmountMath.isEqual(withdrawAmt, bld.units(100)), 'withdraw');
 
   await t.throwsAsync(
-    () => E(account).withdraw(bld.units(100)),
+    async () => E(account).withdraw(bld.units(100)),
     undefined, // fake bank error messages don't match production
     'cannot withdraw more than balance',
   );
@@ -140,7 +140,7 @@ test('makeStakeBldInvitation', async t => {
     });
   }
 
-  await t.throwsAsync(() => E(invitationMakers).CloseAccount(), {
+  await t.throwsAsync(async () => E(invitationMakers).CloseAccount(), {
     message: 'not yet implemented',
   });
 });

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -134,7 +134,7 @@ test('send (to addr on same chain)', async t => {
   );
 
   await t.throwsAsync(
-    () => E(account).send(toAddress, ist.make(10n) as AmountArg),
+    async () => E(account).send(toAddress, ist.make(10n) as AmountArg),
     {
       message:
         "'amountToCoin' not working for \"[Alleged: IST brand]\" until #10449; use 'DenomAmount' for now",

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -336,7 +336,7 @@ test('monitor transfers', async t => {
   let upcallCount = 0;
   const zone = rootZone.subZone('tap');
   const tap: TargetApp = zone.exo('tap', undefined, {
-    receiveUpcall: (obj: unknown) => {
+    receiveUpcall: async (obj: unknown) => {
       upcallCount += 1;
       t.log('receiveUpcall', obj);
       return Promise.resolve();

--- a/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
+++ b/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
@@ -17,7 +17,7 @@ test('portfolio holder kit behaviors', async t => {
    */
   const mockZcf = Far('MockZCF', {
     /** @type {ZCF['makeInvitation']} */
-    makeInvitation: (offerHandler, description, ..._rest) => {
+    makeInvitation: async (offerHandler, description, ..._rest) => {
       t.is(typeof offerHandler, 'function');
       const p = new Promise(resolve => resolve(description));
       return p;

--- a/packages/orchestration/test/fixtures/zcfTester.contract.js
+++ b/packages/orchestration/test/fixtures/zcfTester.contract.js
@@ -11,7 +11,7 @@ export const start = async zcf => {
   zcf.setTestJig(() => harden({ instance }));
 
   const publicFacet = Far('public facet', {
-    makeInvitation: () => zcf.makeInvitation(() => 17, 'simple'),
+    makeInvitation: async () => zcf.makeInvitation(() => 17, 'simple'),
   });
 
   return { publicFacet };

--- a/packages/orchestration/test/network-fakes.test.ts
+++ b/packages/orchestration/test/network-fakes.test.ts
@@ -64,7 +64,10 @@ test('ibc connection', async t => {
 
   // closed connections cannot send packets
   await E(icaConnection).close();
-  await t.throwsAsync(() => E(icaConnection).send('fake packet bytes string'), {
-    message: 'Connection closed',
-  });
+  await t.throwsAsync(
+    async () => E(icaConnection).send('fake packet bytes string'),
+    {
+      message: 'Connection closed',
+    },
+  );
 });

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -201,7 +201,7 @@ const makeScenario = () => {
         });
         const result = Promise.resolve(null).then(() => handler(zcfSeat));
         const userSeat = harden({
-          getOfferResult: () => result,
+          getOfferResult: async () => result,
         });
         return userSeat;
       },
@@ -524,14 +524,14 @@ test(`undelegate waits for unbonding period`, async t => {
     validator,
   };
   const toUndelegate = await E(invitationMakers).Undelegate([delegation]);
-  const current = () => E(timer).getCurrentTimestamp().then(time.format);
+  const current = async () => E(timer).getCurrentTimestamp().then(time.format);
   t.log(await current(), 'undelegate', delegation.amount.value);
   const seat = E(zoe).offer(toUndelegate);
 
   const beforeDone = E(timer)
     .tickN(15 * DAYf)
     .then(() => 15);
-  const afterDone = beforeDone.then(() =>
+  const afterDone = beforeDone.then(async () =>
     E(timer)
       .tickN(10 * DAYf)
       .then(() => 25),

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -241,7 +241,7 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
     utils: {
       pourPayment,
       inspectLocalBridge: () => harden([...localBridgeMessages]),
-      inspectDibcBridge: () => E(ibcBridge).inspectDibcBridge(),
+      inspectDibcBridge: async () => E(ibcBridge).inspectDibcBridge(),
       inspectBankBridge: () => harden([...bankBridgeMessages]),
       populateChainHub,
       transmitTransferAck,

--- a/packages/orchestration/test/utils/zcf-tools.test.ts
+++ b/packages/orchestration/test/utils/zcf-tools.test.ts
@@ -22,7 +22,11 @@ const makeTestContext = async () => {
     fakeVatAdmin.admin,
   );
 
-  const bundleCache = await makeNodeBundleCache('bundles', {}, s => import(s));
+  const bundleCache = await makeNodeBundleCache(
+    'bundles',
+    {},
+    async s => import(s),
+  );
   const contractBundle = await bundleCache.load(contractEntry);
 
   fakeVatAdmin.vatAdminState.installBundle('b1-contract', contractBundle);

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -80,7 +80,7 @@ export const makeCourierMaker =
 
         // The payment is already escrowed, and proposed to retain, so try sending.
         return when(E(connection).send(transferPacket))
-          .then(ack => E(transferProtocol).assertTransferPacketAck(ack))
+          .then(async ack => E(transferProtocol).assertTransferPacketAck(ack))
           .then(
             _ => zcfSeat.exit(),
             reason => {
@@ -105,7 +105,7 @@ export const makeCourierMaker =
       /** @type {DepositFacet} */
       const depositFacet = await E(board)
         .getValue(depositAddress)
-        .catch(_ =>
+        .catch(async _ =>
           E(namesByAddress).lookup(depositAddress, WalletName.depositFacet),
         );
 

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -411,7 +411,7 @@ export const makePegasus = ({ zcf, board, namesByAddress, when }) => {
             return receive(parts);
           };
 
-          return doReceive().catch(error =>
+          return doReceive().catch(async error =>
             E(transferProtocol).makeTransferPacketAck(false, error),
           );
         },

--- a/packages/pegasus/test/fakeVatAdmin.js
+++ b/packages/pegasus/test/fakeVatAdmin.js
@@ -6,13 +6,13 @@ import { evalContractBundle } from '@agoric/zoe/src/contractFacet/evalContractCo
 export default harden({
   createMeter: () => {},
   createUnlimitedMeter: () => {},
-  createVat: bundle => {
+  createVat: async bundle => {
     const rootP = E(evalContractBundle(bundle)).buildRootObject();
     return E.when(rootP, root =>
       harden({
         root,
         adminNode: {
-          done: () => {
+          done: async () => {
             return makePromiseKit().promise;
           },
           terminate: () => {},

--- a/packages/pegasus/test/peg.test.js
+++ b/packages/pegasus/test/peg.test.js
@@ -322,9 +322,9 @@ async function testRemotePeg(t) {
   t.assert(!stillIsLive2, 'payment is consumed');
 
   await E(connP).close();
-  await t.throwsAsync(() => remoteDenomAit.next(), {
+  await t.throwsAsync(async () => remoteDenomAit.next(), {
     message: 'pegasusConnectionHandler closed',
   });
 }
 
-test('remote peg', t => testRemotePeg(t));
+test('remote peg', async t => testRemotePeg(t));

--- a/packages/smart-wallet/src/marshal-contexts.js
+++ b/packages/smart-wallet/src/marshal-contexts.js
@@ -274,7 +274,7 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
    * @param {Slot} slot
    * @param {string} iface
    */
-  const provideVal = (table, slot, iface) => {
+  const provideVal = async (table, slot, iface) => {
     if (table.bySlot.has(slot)) {
       return table.bySlot.get(slot);
     }
@@ -288,7 +288,7 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
      * @param {string} slot
      * @param {string} iface
      */
-    fromBoard: (slot, iface) => {
+    fromBoard: async (slot, iface) => {
       isDefaultBoardId(slot) || Fail`bad board slot ${q(slot)}`;
       return provideVal(boardObjects, slot, iface);
     },
@@ -297,7 +297,7 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
      * @param {string} slot
      * @param {string} iface
      */
-    fromMyWallet: (slot, iface) => {
+    fromMyWallet: async (slot, iface) => {
       if (!slot) {
         // Empty or null slots are neither in the wallet nor the board.
         return makePresence(`${slot}`);

--- a/packages/smart-wallet/src/offerWatcher.js
+++ b/packages/smart-wallet/src/offerWatcher.js
@@ -53,7 +53,7 @@ const makeWatchForOfferResult = ({ watch }) => {
  * @param {OutcomeWatchers} watchers
  * @param {UserSeat} seat
  */
-const watchForNumWants = ({ numWantsWatcher }, seat) => {
+const watchForNumWants = async ({ numWantsWatcher }, seat) => {
   const p = E(seat).numWantsSatisfied();
   watchPromise(p, numWantsWatcher, seat);
   return p;
@@ -63,7 +63,7 @@ const watchForNumWants = ({ numWantsWatcher }, seat) => {
  * @param {OutcomeWatchers} watchers
  * @param {UserSeat} seat
  */
-const watchForPayout = ({ paymentWatcher }, seat) => {
+const watchForPayout = async ({ paymentWatcher }, seat) => {
   const p = E(seat).getPayouts();
   watchPromise(p, paymentWatcher, seat);
   return p;
@@ -77,7 +77,7 @@ export const makeWatchOfferOutcomes = vowTools => {
    * @param {OutcomeWatchers} watchers
    * @param {UserSeat} seat
    */
-  const watchOfferOutcomes = (watchers, seat) => {
+  const watchOfferOutcomes = async (watchers, seat) => {
     // Use `when` to get a promise from the vow.
     // Unlike `asPromise` this doesn't warn in case of disconnections, which is
     // fine since we actually handle the outcome durably through the watchers.
@@ -245,8 +245,8 @@ export const prepareOfferWatcher = (baggage, vowTools) => {
 
           // This will block until all payouts succeed, but user will be updated
           // since each payout will trigger its corresponding purse notifier.
-          const amountPKeywordRecord = objectMap(payouts, paymentRef =>
-            E.when(paymentRef, payment => state.deposit.receive(payment)),
+          const amountPKeywordRecord = objectMap(payouts, async paymentRef =>
+            E.when(paymentRef, async payment => state.deposit.receive(payment)),
           );
           const amounts = await deeplyFulfilledObject(amountPKeywordRecord);
           facets.helper.updateStatus({ payouts: amounts });

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -242,7 +242,7 @@ const namesOf = async (target, nameHub) => {
  * @param {Brand} brand
  * @returns {Promise<boolean>} true iff the the brand and issuer match
  */
-const checkMutual = (issuer, brand) =>
+const checkMutual = async (issuer, brand) =>
   Promise.all([
     E(issuer)
       .getBrand()
@@ -815,7 +815,7 @@ export const prepareSmartWallet = (baggage, shared) => {
 
           // Add each payment amount to brandPaymentRecord as it is withdrawn. If
           // there's an error later, we can use it to redeposit the correct amount.
-          return objectMap(give, amount => {
+          return objectMap(give, async amount => {
             /** @type {Promise<Purse>} */
             const purseP = facets.helper.purseForBrand(amount.brand);
             const paymentP = E(purseP).withdraw(amount);
@@ -857,7 +857,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             // Use allSettled to ensure we attempt all the deposits, regardless of
             // individual rejections.
             await Promise.allSettled(
-              Array.from(brandPaymentRecord.entries()).map(([b, p]) => {
+              Array.from(brandPaymentRecord.entries()).map(async ([b, p]) => {
                 // Wait for the withdrawal to complete.  This protects against a
                 // race when updating paymentToPurse.
                 const purseP = facets.helper.purseForBrand(b);
@@ -1042,7 +1042,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           return E.when(
             E(publicMarshaller).fromCapData(actionCapData),
             /** @param {BridgeAction} action */
-            action => {
+            async action => {
               try {
                 switch (action.method) {
                   case 'executeOffer': {

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -228,11 +228,11 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     invitationDisplayInfo,
     publicMarshaller,
   } = await provideAll(baggage, {
-    invitationIssuer: () => invitationIssuerP,
-    invitationBrand: () => E(invitationIssuerP).getBrand(),
-    invitationDisplayInfo: () =>
+    invitationIssuer: async () => invitationIssuerP,
+    invitationBrand: async () => E(invitationIssuerP).getBrand(),
+    invitationDisplayInfo: async () =>
       E(E(invitationIssuerP).getBrand()).getDisplayInfo(),
-    publicMarshaller: () => E(board).getReadonlyMarshaller(),
+    publicMarshaller: async () => E(board).getReadonlyMarshaller(),
   });
 
   const registry = makeAssetRegistry(assetPublisher);

--- a/packages/smart-wallet/test/addAsset.test.js
+++ b/packages/smart-wallet/test/addAsset.test.js
@@ -15,7 +15,7 @@ import { makeDefaultTestContext } from './contexts.js';
 import { ActionType, headValue, makeMockTestSpace } from './supports.js';
 import { makeImportContext } from '../src/marshal-contexts.js';
 
-const importSpec = spec =>
+const importSpec = async spec =>
   importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
 /**
@@ -152,7 +152,7 @@ const makeScenario = t => {
     walletUpdates,
   ) => {
     const ctx = makeImportContext();
-    const vsGet = path =>
+    const vsGet = async path =>
       E(vsRPC).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
 
     // Ingest well-known brands, instances.
@@ -228,7 +228,8 @@ test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
    * @param {Record<string, Bundle>} bundles
    */
   const finishBootstrap = async ({ consume }, bundles) => {
-    const kindAdmin = kind => E(consume.agoricNamesAdmin).lookupAdmin(kind);
+    const kindAdmin = async kind =>
+      E(consume.agoricNamesAdmin).lookupAdmin(kind);
 
     const publishAgoricNames = async () => {
       const { board, chainStorage } = consume;
@@ -253,7 +254,7 @@ test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
       const { chainStorage, bankManager, board, feeMintAccess, zoe } = consume;
       const stable = await E(zoe)
         .getFeeIssuer()
-        .then(issuer => {
+        .then(async issuer => {
           return E(issuer)
             .getBrand()
             .then(brand => ({ issuer, brand }));
@@ -311,7 +312,7 @@ test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
     } = await E(zoe).getTerms(instance);
 
     t.log('CoreEval script: share via agoricNames:', brand);
-    const kindAdmin = kind => E(agoricNamesAdmin).lookupAdmin(kind);
+    const kindAdmin = async kind => E(agoricNamesAdmin).lookupAdmin(kind);
     await Promise.all([
       E(kindAdmin('instance')).update('game1', instance),
       E(kindAdmin('issuer')).update('Place', issuer),
@@ -328,7 +329,7 @@ test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
     const { fromEntries } = Object;
     const ctx = makeImportContext();
     await eventLoopIteration();
-    const vsGet = path =>
+    const vsGet = async path =>
       E(rpc).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
 
     // @ts-expect-error unsafe testing cast
@@ -364,11 +365,11 @@ test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
   const { consume, simpleProvideWallet, sendToBridge } = t.context;
 
   const bundles = {
-    game: await importSpec('./gameAssetContract.js').then(spec =>
+    game: await importSpec('./gameAssetContract.js').then(async spec =>
       bundleSource(spec),
     ),
     centralSupply: await importSpec('@agoric/vats/src/centralSupply.js').then(
-      spec => bundleSource(spec),
+      async spec => bundleSource(spec),
     ),
   };
 
@@ -471,7 +472,7 @@ test.serial('non-vbank asset: give before deposit', async t => {
   const goofyClient = async (rpc, walletBridge) => {
     const { fromEntries } = Object;
     const ctx = makeImportContext();
-    const vsGet = path =>
+    const vsGet = async path =>
       E(rpc).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
     // @ts-expect-error unsafe testing cast
     const wkBrand = fromEntries(await vsGet(`agoricNames.brand`));

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -75,7 +75,8 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     anchor,
     invitationBrand: await E(E(zoe).getInvitationIssuer()).getBrand(),
     sendToBridge:
-      walletBridgeManager && (obj => E(walletBridgeManager).toBridge(obj)),
+      walletBridgeManager &&
+      (async obj => E(walletBridgeManager).toBridge(obj)),
     consume,
     simpleProvideWallet,
   };

--- a/packages/smart-wallet/test/gameAssetContract.js
+++ b/packages/smart-wallet/test/gameAssetContract.js
@@ -57,7 +57,7 @@ export const start = async zcf => {
   };
 
   const publicFacet = Far('API', {
-    makeJoinInvitation: () =>
+    makeJoinInvitation: async () =>
       zcf.makeInvitation(joinHook, 'join', undefined, joinShape),
   });
 

--- a/packages/smart-wallet/test/invitation1.test.js
+++ b/packages/smart-wallet/test/invitation1.test.js
@@ -20,7 +20,7 @@ import { prepareSmartWallet } from '../src/smartWallet.js';
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
 const test = anyTest;
 
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+const delay = async ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const nodeRequire = createRequire(import.meta.url);
 const asset = {
@@ -69,7 +69,11 @@ const mockBootstrapPowers = async (
 
 const makeTestContext = async t => {
   const bootKit = await mockBootstrapPowers(t.log);
-  const bundleCache = await makeNodeBundleCache('bundles/', {}, s => import(s));
+  const bundleCache = await makeNodeBundleCache(
+    'bundles/',
+    {},
+    async s => import(s),
+  );
 
   const { agoricNames, board, zoe } = bootKit.powers.consume;
   const startAnyContract = async () => {
@@ -102,7 +106,7 @@ const makeTestContext = async t => {
     const ie = await E(E(agoricNames).lookup('issuer')).entries();
     const byName = Object.fromEntries(ie);
     const descriptors = await Promise.all(
-      be.map(([name, b]) => {
+      be.map(async ([name, b]) => {
         /** @type {Promise<import('../src/smartWallet.js').BrandDescriptor>} */
         const d = allValues({
           brand: b,

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -50,7 +50,7 @@ export const withAmountUtils = kit => {
 /**
  * @param {ERef<StoredFacet>} subscription
  */
-export const subscriptionKey = subscription => {
+export const subscriptionKey = async subscription => {
   return E(subscription)
     .getStoreKey()
     .then(storeKey => {
@@ -163,7 +163,7 @@ export const makeMockTestSpace = async log => {
  * }>} hasTopics
  * @param {string} subscriberName
  */
-export const topicPath = (hasTopics, subscriberName) => {
+export const topicPath = async (hasTopics, subscriberName) => {
   return E(hasTopics)
     .getPublicTopics()
     .then(subscribers => subscribers[subscriberName])

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
@@ -76,11 +76,11 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     invitationDisplayInfo,
     publicMarshaller,
   } = await provideAll(baggage, {
-    invitationIssuer: () => invitationIssuerP,
-    invitationBrand: () => E(invitationIssuerP).getBrand(),
-    invitationDisplayInfo: () =>
+    invitationIssuer: async () => invitationIssuerP,
+    invitationBrand: async () => E(invitationIssuerP).getBrand(),
+    invitationDisplayInfo: async () =>
       E(E(invitationIssuerP).getBrand()).getDisplayInfo(),
-    publicMarshaller: () => E(board).getReadonlyMarshaller(),
+    publicMarshaller: async () => E(board).getReadonlyMarshaller(),
   });
 
   const registry = makeAssetRegistry(assetPublisher);

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-service-upgrade.test.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-service-upgrade.test.js
@@ -12,7 +12,7 @@ import {
 // so paths can be expresssed relative to this file and made absolute
 const bfile = name => new URL(name, import.meta.url).pathname;
 
-const importSpec = spec =>
+const importSpec = async spec =>
   importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
 test('walletFactory service upgrade', async t => {

--- a/packages/solo/public/main.js
+++ b/packages/solo/public/main.js
@@ -240,7 +240,7 @@ function run() {
         setNextHistNum(res.highestHistory + 1);
         // console.debug(`nextHistNum is now ${nextHistNum}`, res);
       })
-      .then(_ => call({ type: 'rebroadcastHistory' }))
+      .then(async _ => call({ type: 'rebroadcastHistory' }))
       .catch(_ => ws.close());
   });
 
@@ -324,7 +324,7 @@ run();
 // Display version information, if possible.
 const fetches = [];
 const fgr = fetch('/git-revision.txt')
-  .then(resp => {
+  .then(async resp => {
     if (resp.status < 200 || resp.status >= 300) {
       throw Error(`status ${resp.status}`);
     }
@@ -340,7 +340,7 @@ const fgr = fetch('/git-revision.txt')
 fetches.push(fgr);
 
 const fpj = fetch('/package.json')
-  .then(resp => resp.json())
+  .then(async resp => resp.json())
   .catch(e => {
     console.log('Cannot fetch /package.json', e);
     return {};

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -137,7 +137,7 @@ export async function connectToChain(
 
   const helperDir = path.join(basedir, 'ag-cosmos-helper-statedir');
 
-  const readOrDefault = (file, dflt) =>
+  const readOrDefault = async (file, dflt) =>
     fs.promises
       .readFile(file, { encoding: 'utf-8' })
       .catch(e => {
@@ -192,7 +192,7 @@ export async function connectToChain(
   }
 
   let goodRpcHref = rpcHrefs[0];
-  const runHelper = (args, stdin = undefined) => {
+  const runHelper = async (args, stdin = undefined) => {
     const fullArgs = [
       ...args,
       `--chain-id=${chainID}`,
@@ -244,7 +244,7 @@ export async function connectToChain(
 
   let currentTxHashPK = makePromiseKit();
   let postponedTxHash;
-  const postponedWaitForTxHash = txHash => {
+  const postponedWaitForTxHash = async txHash => {
     postponedTxHash = txHash;
     return currentTxHashPK.promise;
   };
@@ -467,7 +467,7 @@ export async function connectToChain(
         updater.updateState(undefined);
 
         // Initialize the txHash subscription.
-        const subscribeAndWaitForTxHash = txHash => {
+        const subscribeAndWaitForTxHash = async txHash => {
           const thisPK = currentTxHashPK;
           postponedTxHash = undefined;
           currentTxHashPK = makePromiseKit();
@@ -784,7 +784,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
   };
 
   // Begin the sender when we get the first (empty) mailbox update.
-  void mbNotifier.getUpdateSince().then(() => recurseEachSend());
+  void mbNotifier.getUpdateSince().then(async () => recurseEachSend());
 
   async function deliver(newMessages, acknum) {
     let doSend = false;

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -308,8 +308,8 @@ const buildSwingset = async (
 
   // Our typical user will always want to wait for the results of
   // the boxed promise, so by default, extract it and await it.
-  const queuedDeliverInboundCommand = obj =>
-    queuedBoxedDeliverInboundCommand(obj).then(([p]) => p);
+  const queuedDeliverInboundCommand = async obj =>
+    queuedBoxedDeliverInboundCommand(obj).then(async ([p]) => p);
 
   let intervalMillis;
 
@@ -348,7 +348,7 @@ const buildSwingset = async (
       intervalMillis = interval;
       setTimeout(queuedMoveTimeForward, intervalMillis);
     },
-    resetOutdatedState: withInputQueue(() => {
+    resetOutdatedState: withInputQueue(async () => {
       plugin.reset();
       return processKernel();
     }),

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -131,7 +131,7 @@ export function buildRootObject(vatPowers) {
     },
 
     registerURLHandler,
-    registerAPIHandler: h => registerURLHandler(h, '/api'),
+    registerAPIHandler: async h => registerURLHandler(h, '/api'),
     send,
     doneLoading,
 

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -36,7 +36,7 @@ export async function makeFixture(PORT, noisy = false) {
 
   /** @type {WebSocket} */
   let ws;
-  function connect() {
+  async function connect() {
     process.stdout.write('# connecting');
     async function tryConnect(resolve, reject) {
       process.stdout.write('.');

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -166,7 +166,7 @@ export const makeAtomicProvider = store => {
    *   once after a new value is added to the store
    * @returns {Promise<V>}
    */
-  const provideAsync = (key, makeValue, finishValue) => {
+  const provideAsync = async (key, makeValue, finishValue) => {
     if (store.has(key)) {
       return Promise.resolve(store.get(key));
     }

--- a/packages/store/test/AtomicProvider.test.js
+++ b/packages/store/test/AtomicProvider.test.js
@@ -10,12 +10,12 @@ test('race', async t => {
   const provider = makeAtomicProvider(store);
 
   let i = 0;
-  const make = k =>
+  const make = async k =>
     // in Node 15+ use timers/promise
     new Promise(resolve => setTimeout(() => resolve(`${k} ${(i += 1)}`), 10));
 
   let finishCalled = 0;
-  const finish = () => {
+  const finish = async () => {
     finishCalled += 1;
     return Promise.resolve();
   };
@@ -36,10 +36,10 @@ test('reject', async t => {
   const provider = makeAtomicProvider(store);
 
   let i = 0;
-  const makeFail = k => Promise.reject(Error(`failure ${k} ${(i += 1)}`));
+  const makeFail = async k => Promise.reject(Error(`failure ${k} ${(i += 1)}`));
 
   let finishCalled = 0;
-  const finish = () => {
+  const finish = async () => {
     finishCalled += 1;
     return Promise.resolve();
   };
@@ -62,7 +62,7 @@ test('reject', async t => {
   t.is(finishCalled, 0);
 
   // success after failure
-  const makeValue = () => Promise.resolve('success');
+  const makeValue = async () => Promise.resolve('success');
   t.is(await provider.provideAsync('a', makeValue, finish), 'success');
   t.is(finishCalled, 1);
 });
@@ -77,7 +77,7 @@ test('far keys', async t => {
       getAllegedName: () => `${name} ${(i += 1)}`,
     });
 
-  const makeValue = brand => Promise.resolve(brand.getAllegedName());
+  const makeValue = async brand => Promise.resolve(brand.getAllegedName());
 
   const moola = makeBrand('moola');
   const moolb = makeBrand('moolb');

--- a/packages/swing-store/src/archiver.js
+++ b/packages/swing-store/src/archiver.js
@@ -15,7 +15,7 @@ const streamFinished = promisify(streamFinishedCallback);
 export const makeArchiveSnapshot = (dirPath, powers) => {
   const { fs, path, tmp } = powers;
   fs.mkdirSync(dirPath, { recursive: true });
-  const archiveSnapshot = (name, gzData) => {
+  const archiveSnapshot = async (name, gzData) => {
     const destPath = path.join(dirPath, `${name}.gz`);
     return withDeferredCleanup(async addCleanup => {
       const {
@@ -52,7 +52,7 @@ harden(makeArchiveSnapshot);
 export const makeArchiveTranscript = (dirPath, powers) => {
   const { fs, path, tmp } = powers;
   fs.mkdirSync(dirPath, { recursive: true });
-  const archiveTranscript = (spanName, entries) => {
+  const archiveTranscript = async (spanName, entries) => {
     const destPath = path.join(dirPath, `${spanName}.gz`);
     return withDeferredCleanup(async addCleanup => {
       const {

--- a/packages/swing-store/test/bundles.test.js
+++ b/packages/swing-store/test/bundles.test.js
@@ -53,7 +53,7 @@ function makeExportCallback() {
   };
 }
 
-const tmpDir = prefix =>
+const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
       if (err) {

--- a/packages/swing-store/test/exportImport.test.js
+++ b/packages/swing-store/test/exportImport.test.js
@@ -37,7 +37,7 @@ function makeExportLog() {
  * @param {string} [prefix]
  * @returns {Promise<[string, () => void]>}
  */
-const tmpDir = prefix =>
+const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
       if (err) {

--- a/packages/swing-store/test/exportImport.test.js
+++ b/packages/swing-store/test/exportImport.test.js
@@ -314,7 +314,7 @@ async function testExportImport(
   t.deepEqual(artifactNames, expectedArtifactNames);
 
   const beforeDump = debug.dump(keepSnapshots);
-  function doImport() {
+  async function doImport() {
     return importSwingStore(exporter, null, { artifactMode: importMode });
   }
 

--- a/packages/swing-store/test/state.test.js
+++ b/packages/swing-store/test/state.test.js
@@ -15,7 +15,7 @@ import {
  * @param {string} [prefix]
  * @returns {Promise<[string, () => void]>}
  */
-const tmpDir = prefix =>
+const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
       if (err) {

--- a/packages/swing-store/test/util.js
+++ b/packages/swing-store/test/util.js
@@ -6,7 +6,7 @@ import { createSHA256 } from '../src/hasher.js';
  * @param {string} [prefix]
  * @returns {Promise<[string, () => void]>}
  */
-export const tmpDir = prefix =>
+export const tmpDir = async prefix =>
   new Promise((resolve, reject) => {
     tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
       if (err) {

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -356,7 +356,7 @@ export function makeCollectionManager(
       return prefix(encodedKey);
     }
 
-    function dbKeyToKey(dbKey) {
+    async function dbKeyToKey(dbKey) {
       // convert e.g. vc.5.r0000000001:o+v10/1 to r0000000001:o+v10/1
       const dbEntryKey = dbKey.substring(dbKeyPrefix.length);
       return decodeKey(dbEntryKey);

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -706,7 +706,7 @@ function build(
     };
   }
 
-  function queueMessage(targetSlot, prop, args, returnedP) {
+  async function queueMessage(targetSlot, prop, args, returnedP) {
     const methargs = [prop, args];
 
     meterControl.assertIsMetered(); // else userspace getters could escape
@@ -1321,7 +1321,7 @@ function build(
    * @param {import('./types.js').VatDeliveryObject} delivery
    * @returns {undefined | ReturnType<startVat>}
    */
-  function dispatchToUserspace(delivery) {
+  async function dispatchToUserspace(delivery) {
     let result;
     const [type, ...args] = delivery;
     switch (type) {

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1453,7 +1453,9 @@ function build(
     if (delivery[0] === 'bringOutYourDead') {
       return meterControl.runWithoutMeteringAsync(bringOutYourDead);
     } else if (delivery[0] === 'stopVat') {
-      return meterControl.runWithoutMeteringAsync(() => stopVat(delivery[1]));
+      return meterControl.runWithoutMeteringAsync(async () =>
+        stopVat(delivery[1]),
+      );
     } else {
       // Start user code running, record any internal liveslots errors. We do
       // *not* directly wait for the userspace function to complete, nor for
@@ -1466,7 +1468,7 @@ function build(
       // unmeteredDispatch (or a 'buildRootObject' that fails to
       // complete in time) will be reported to the supervisor (but
       // only after userspace is idle).
-      return gcTools.waitUntilQuiescent().then(() => {
+      return gcTools.waitUntilQuiescent().then(async () => {
         afterDispatchActions();
         // eslint-disable-next-line prefer-promise-reject-errors
         return Promise.race([p, Promise.reject('buildRootObject unresolved')]);

--- a/packages/swingset-liveslots/test/gc-and-finalize.js
+++ b/packages/swingset-liveslots/test/gc-and-finalize.js
@@ -112,7 +112,7 @@ const makeCollectedResultKit = () => {
   };
 };
 
-export function watchCollected(target) {
+export async function watchCollected(target) {
   const kit = makeCollectedResultKit();
   fr.register(target, kit);
 

--- a/packages/swingset-liveslots/test/handled-promises.test.js
+++ b/packages/swingset-liveslots/test/handled-promises.test.js
@@ -174,7 +174,7 @@ test('past-incarnation watched promises', async t => {
   const nextPImport = () => (lastPImport += 1);
   const nextPExport = () => (lastPExport += 1);
   /** @type {typeof rawDispatch} */
-  const dispatchMessage = (...args) => {
+  const dispatchMessage = async (...args) => {
     dispatches += 1;
     return rawDispatch(...args);
   };

--- a/packages/swingset-liveslots/test/waitUntilQuiescent.js
+++ b/packages/swingset-liveslots/test/waitUntilQuiescent.js
@@ -6,7 +6,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 // This can only be imported from the Start Compartment, where 'setImmediate'
 // is available.
 
-export function waitUntilQuiescent() {
+export async function waitUntilQuiescent() {
   // the delivery might cause some number of (native) Promises to be
   // created and resolved, so we use the IO queue to detect when the
   // Promise queue is empty. The IO queue (setImmediate and setTimeout) is

--- a/packages/swingset-liveslots/tools/prepare-strict-test-env.js
+++ b/packages/swingset-liveslots/tools/prepare-strict-test-env.js
@@ -80,7 +80,7 @@ export const startLife = async (
   let buildTools;
   try {
     buildTools = await build(getBaggage());
-    fakeVomKit.wpm.loadWatchedPromiseTable(vref => {
+    fakeVomKit.wpm.loadWatchedPromiseTable(async vref => {
       // See revivePromise in liveslots.js
       const { getValForSlot, valToSlot, setValForSlot } = fakeVomKit.fakeStuff;
       // Assume all promises were decided by the previous incarnation

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -111,7 +111,7 @@ async function build(name, zoe, issuers, payments, publicFacet) {
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
-    build: (zoe, issuers, payments, publicFacet) =>
+    build: async (zoe, issuers, payments, publicFacet) =>
       build(vatParameters.name, zoe, issuers, payments, publicFacet),
   });
 }

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -16,7 +16,7 @@ export async function showPurseBalance(purseP, name, log) {
  * @param {Payment[]} payments
  */
 export async function setupPurses(zoe, issuers, payments) {
-  const purses = issuers.map(issuer => E(issuer).makeEmptyPurse());
+  const purses = issuers.map(async issuer => E(issuer).makeEmptyPurse());
   const [moolaIssuer, simoleanIssuer] = issuers;
   const moolaBrand = await E(moolaIssuer).getBrand();
   const simoleanBrand = await E(simoleanIssuer).getBrand();

--- a/packages/swingset-runner/demo/swapBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/swapBenchmark/exchanger.js
@@ -112,7 +112,7 @@ async function build(name, zoe, issuers, payments, installations) {
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
-    build: (zoe, issuers, payments, installations) =>
+    build: async (zoe, issuers, payments, installations) =>
       build(vatParameters.name, zoe, issuers, payments, installations),
   });
 }

--- a/packages/swingset-runner/demo/swapBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/swapBenchmark/helpers.js
@@ -16,7 +16,7 @@ export async function showPurseBalance(purseP, name, log) {
  * @param {Payment[]} payments
  */
 export async function setupPurses(zoe, issuers, payments) {
-  const purses = issuers.map(issuer => E(issuer).makeEmptyPurse());
+  const purses = issuers.map(async issuer => E(issuer).makeEmptyPurse());
   const [moolaIssuer, simoleanIssuer] = issuers;
   const moolaBrand = await E(moolaIssuer).getBrand();
   const simoleanBrand = await E(simoleanIssuer).getBrand();

--- a/packages/swingset-runner/demo/vaultPerfTest/vat-benchmark.js
+++ b/packages/swingset-runner/demo/vaultPerfTest/vat-benchmark.js
@@ -99,7 +99,7 @@ export function buildRootObject() {
 
       const openN = async n => {
         const range = [...Array(n)].map((_, i) => i + 1);
-        await Promise.all(range.map(i => openVault(i, n)));
+        await Promise.all(range.map(async i => openVault(i, n)));
       };
 
       await openN(1);

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -588,6 +588,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
 export function buildRootObject() {
   return Far('root', {
-    build: (...args) => build(makePrintLog(), ...args),
+    build: async (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -537,6 +537,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
 export function buildRootObject() {
   return Far('root', {
-    build: (...args) => build(makePrintLog(), ...args),
+    build: async (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -69,6 +69,6 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
 export function buildRootObject() {
   return Far('root', {
-    build: (...args) => build(makePrintLog(), ...args),
+    build: async (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -168,6 +168,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
 export function buildRootObject() {
   return Far('root', {
-    build: (...args) => build(makePrintLog(), ...args),
+    build: async (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-xsnap-supervisor/lib/waitUntilQuiescent.js
+++ b/packages/swingset-xsnap-supervisor/lib/waitUntilQuiescent.js
@@ -4,7 +4,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 // This can only be imported from the Start Compartment, where 'setImmediate'
 // is available.
 
-export function waitUntilQuiescent() {
+export async function waitUntilQuiescent() {
   // the delivery might cause some number of (native) Promises to be
   // created and resolved, so we use the IO queue to detect when the
   // Promise queue is empty. The IO queue (setImmediate and setTimeout) is

--- a/packages/swingset-xsnap-supervisor/src/index.js
+++ b/packages/swingset-xsnap-supervisor/src/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { bundlePaths, hashPaths } from './paths.js';
 
-const read = (name, path) => {
+const read = async (name, path) => {
   return fs.promises.readFile(path, { encoding: 'utf-8' }).catch(err => {
     console.error(`unable to read supervisor ${name} at ${path}`);
     console.error(

--- a/packages/telemetry/src/context-aware-slog-file.js
+++ b/packages/telemetry/src/context-aware-slog-file.js
@@ -36,7 +36,7 @@ export const makeSlogSender = async options => {
   };
 
   return Object.assign(slogSender, {
-    forceFlush: () => stream.flush(),
-    shutdown: () => stream.close(),
+    forceFlush: async () => stream.flush(),
+    shutdown: async () => stream.close(),
   });
 };

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -279,7 +279,7 @@ export const makeSlogSenderFromBuffer = ({ writeCircBuf }) => {
     // Prepend a newline so that the file can be more easily manipulated.
     const data = new TextEncoder().encode(`\n${serialized}`);
     // console.log('have obj', obj, data);
-    toWrite = toWrite.then(() => writeCircBuf(data));
+    toWrite = toWrite.then(async () => writeCircBuf(data));
   };
   return Object.assign(writeJSON, {
     forceFlush: async () => {

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -88,7 +88,7 @@ export const makeSlogSender = async (opts = {}) => {
     slogSenderModules.map(async moduleIdentifier =>
       import(moduleIdentifier)
         .then(
-          /** @param {{makeSlogSender: import('./index.js').MakeSlogSender}} module */ ({
+          /** @param {{makeSlogSender: import('./index.js').MakeSlogSender}} module */ async ({
             makeSlogSender: maker,
           }) => {
             if (typeof maker !== 'function') {
@@ -160,13 +160,13 @@ export const makeSlogSender = async (opts = {}) => {
     return Object.assign(slogSender, {
       forceFlush: async () =>
         PromiseAllOrErrors([
-          ...senders.map(sender => sender.forceFlush?.()),
-          ...sendErrors.splice(0).map(err => Promise.reject(err)),
+          ...senders.map(async sender => sender.forceFlush?.()),
+          ...sendErrors.splice(0).map(async err => Promise.reject(err)),
         ]).then(() => {}),
       shutdown: async () =>
-        PromiseAllOrErrors(senders.map(sender => sender.shutdown?.())).then(
-          () => {},
-        ),
+        PromiseAllOrErrors(
+          senders.map(async sender => sender.shutdown?.()),
+        ).then(() => {}),
       usesJsonObject: hasSenderUsingJsonObj,
     });
   }

--- a/packages/telemetry/src/otel-context-aware-slog.js
+++ b/packages/telemetry/src/otel-context-aware-slog.js
@@ -125,7 +125,7 @@ export const makeSlogSender = async options => {
   };
 
   return Object.assign(slogSender, {
-    forceFlush: () => otelLogExporter.forceFlush(),
+    forceFlush: async () => otelLogExporter.forceFlush(),
     shutdown,
   });
 };

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -60,7 +60,7 @@ export const makeSlogSender = async opts => {
      * @template {{type: string}} T
      * @param {T} msg
      */
-    msg =>
+    async msg =>
       /** @type {Promise<void>} */ (
         new Promise((resolve, reject) => {
           cp.send(msg, err => {

--- a/packages/telemetry/test/import.test.js
+++ b/packages/telemetry/test/import.test.js
@@ -3,7 +3,7 @@ import { test } from './prepare-test-env-ava.js';
 
 import { getTelemetryProviders } from '../src/index.js';
 
-const sleep = timeoutMs =>
+const sleep = async timeoutMs =>
   new Promise(resolve => setTimeout(resolve, timeoutMs));
 
 test('get telemetry providers', async t => {

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -18,7 +18,7 @@ import { E } from '@endo/far';
  * >} [handler]
  * @returns {Promise<import('./types.js').ScopedBridgeManager<BridgeId>>}
  */
-export const makeScopedBridge = (bridgeManager, bridgeIdValue, handler) =>
+export const makeScopedBridge = async (bridgeManager, bridgeIdValue, handler) =>
   /** @type {Promise<import('./types.js').ScopedBridgeManager<BridgeId>>} */ (
     E(bridgeManager).register(bridgeIdValue, handler)
   );

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -526,7 +526,7 @@ export const installBootContracts = async ({
     mintHolder,
   })) {
     const idP = E(vatAdminSvc).getBundleIDByName(name);
-    const installationP = idP.then(bundleID =>
+    const installationP = idP.then(async bundleID =>
       E(zoe).installBundleID(bundleID, name),
     );
     producer.resolve(installationP);

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -63,7 +63,7 @@ export const bridgeCoreEval = async allPowers => {
           /** @type {import('@agoric/cosmic-proto/swingset/swingset.js').CoreEvalProposalSDKType} */
           const { evals } = obj;
           return Promise.all(
-            evals.map(({ json_permits: jsonPermit, js_code: code }) =>
+            evals.map(async ({ json_permits: jsonPermit, js_code: code }) =>
               // Run in a new turn to avoid crosstalk of the evaluations.
               Promise.resolve()
                 .then(() => {
@@ -227,7 +227,7 @@ export const setupClientManager = async (
 
   /** @type {ClientCreator} */
   const clientCreator = Far('clientCreator', {
-    createUserBundle: (nickname, clientAddress, powerFlags) => {
+    createUserBundle: async (nickname, clientAddress, powerFlags) => {
       const c = E(clientCreator).createClientFacet(
         nickname,
         clientAddress,
@@ -263,8 +263,8 @@ export const setupClientManager = async (
 
       /** @type {ClientFacet} */
       const clientFacet = Far('chainProvisioner', {
-        getChainBundle: () =>
-          bundleReady.promise.then(_ => allValues(clientHome)),
+        getChainBundle: async () =>
+          bundleReady.promise.then(async _ => allValues(clientHome)),
         getConfiguration: () => notifier,
       });
 

--- a/packages/vats/src/core/client-behaviors.js
+++ b/packages/vats/src/core/client-behaviors.js
@@ -103,7 +103,7 @@ export const startClient = async ({
 
   // Tell the http server about our presences.  This can be called in
   // any order (whether localBundle and/or chainBundle are set or not).
-  const updatePresences = () =>
+  const updatePresences = async () =>
     E(vats.http).setPresences(localBundle, chainBundle, deprecated);
 
   const { D } = vatPowers;

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -104,7 +104,7 @@ export const makeBootstrap = (
     produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
     produce.vatStore.resolve(vatStore);
 
-    const runBehaviors = manifest => {
+    const runBehaviors = async manifest => {
       return runModuleBehaviors({
         allPowers,
         behaviors,
@@ -173,7 +173,7 @@ export const makeBootstrap = (
      * @param {SwingsetVats} vats
      * @param {SoloDevices | ChainDevices} devices
      */
-    bootstrap: (vats, devices) => {
+    bootstrap: async (vats, devices) => {
       for (const [name, root] of Object.entries(vats)) {
         if (name !== 'vatAdmin') {
           vatData.set(name, { root });
@@ -187,7 +187,7 @@ export const makeBootstrap = (
       });
     },
     /** @param {string} name } */
-    consumeItem: name => {
+    consumeItem: async name => {
       assert.typeof(name, 'string');
       return consume[name];
     },

--- a/packages/vats/src/core/promise-space.js
+++ b/packages/vats/src/core/promise-space.js
@@ -168,7 +168,7 @@ export const makePromiseSpace = (optsOrLog = {}) => {
   /** @type {PromiseSpaceOf<T>['consume']} */
   // @ts-expect-error cast
   const consume = new Proxy(harden({}), {
-    get: (_target, name) => {
+    get: async (_target, name) => {
       assert.typeof(name, 'string');
       return provideState(name).pk.promise;
     },

--- a/packages/vats/src/core/sim-behaviors.js
+++ b/packages/vats/src/core/sim-behaviors.js
@@ -33,7 +33,9 @@ export const grantRunBehaviors = async ({
   consume: { client },
 }) => {
   const bundle = {
-    behaviors: Far('behaviors', { run: manifest => runBehaviors(manifest) }),
+    behaviors: Far('behaviors', {
+      run: async manifest => runBehaviors(manifest),
+    }),
   };
   return E(client).assignBundle([_addr => bundle]);
 };

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -24,7 +24,7 @@ const trace = makeTracer('StartWF');
  * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
  */
 // eslint-disable-next-line no-unused-vars
-const startFactoryInstance = (zoe, inst) => E(zoe).startInstance(inst);
+const startFactoryInstance = async (zoe, inst) => E(zoe).startInstance(inst);
 
 const StableUnit = BigInt(10 ** Stable.displayInfo.decimalPlaces);
 

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -178,7 +178,7 @@ harden(extractPowers);
  * @param {Record<string, Record<string, unknown>>} opts.manifest
  * @param {(name: string, permit: Record<string, unknown>) => unknown} opts.makeConfig
  */
-export const runModuleBehaviors = ({
+export const runModuleBehaviors = async ({
   allPowers,
   behaviors,
   manifest,
@@ -221,7 +221,7 @@ export const makePromiseSpaceForNameHub = (nameAdmin, log = noop) => {
         logHooks.onAddKey(name);
       },
       onResolve: (name, valueP) => {
-        void E.when(valueP, value => E(nameAdmin).update(name, value));
+        void E.when(valueP, async value => E(nameAdmin).update(name, value));
       },
       onReset: name => {
         void E(nameAdmin).delete(name);
@@ -361,7 +361,7 @@ export const makeVatSpace = (
   const consume = new Proxy(
     {},
     {
-      get: (_target, name, _rx) => {
+      get: async (_target, name, _rx) => {
         assert.typeof(name, 'string');
         return provideAsync(name, createVatByName).then(vat => {
           if (!durableStore.has(name)) {

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -110,13 +110,13 @@ const provideWeak = (store, key, make) => {
  * @param {import('./types.js').NameHub} hub
  * @param {unknown} [_newValue]
  */
-const updated = (updateCallback, hub, _newValue = undefined) => {
+const updated = async (updateCallback, hub, _newValue = undefined) => {
   if (!updateCallback) {
     return;
   }
 
   // wait for values to settle before writing
-  return E.when(deeplyFulfilledObject(hub.entries()), settledEntries =>
+  return E.when(deeplyFulfilledObject(hub.entries()), async settledEntries =>
     E(updateCallback).write(settledEntries),
   );
 };
@@ -219,7 +219,9 @@ export const prepareNameHubKit = zone => {
             return { nameHub: childHub, nameAdmin: childAdmin };
           }
           const child = makeNameHubKit();
-          await Promise.all(reserved.map(k => child.nameAdmin.reserve(k)));
+          await Promise.all(
+            reserved.map(async k => child.nameAdmin.reserve(k)),
+          );
           void nameAdmin.update(key, child.nameHub, child.nameAdmin);
           return child;
         },

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -43,10 +43,10 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
     ps.push(
       E(vats.ibc)
         .createHandlers(callbacks)
-        .then(({ protocolHandler, bridgeHandler }) =>
+        .then(async ({ protocolHandler, bridgeHandler }) =>
           E(dibcBridgeManager)
             .initHandler(bridgeHandler)
-            .then(() =>
+            .then(async () =>
               E(vats.network).registerProtocolHandler(
                 ['/ibc-port', '/ibc-hop'],
                 protocolHandler,

--- a/packages/vats/src/proposals/transfer-proposal.js
+++ b/packages/vats/src/proposals/transfer-proposal.js
@@ -60,7 +60,7 @@ export const setupTransferMiddleware = async (
     vats.transfer,
   ).makeTransferMiddlewareKit();
   const vtransferID = BRIDGE_ID.VTRANSFER;
-  const provideBridgeTargetKit = bridge =>
+  const provideBridgeTargetKit = async bridge =>
     E(vats.transfer).provideBridgeTargetKit(
       bridge,
       VTRANSFER_IBC_EVENT,

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -748,7 +748,7 @@ const prepareBankManager = (
         }
         // publish settled issuer identity
         void Promise.all([kit.issuer, E(kit.brand).getDisplayInfo()]).then(
-          ([issuer, displayInfo]) =>
+          async ([issuer, displayInfo]) =>
             E(nameAdmin).update(
               denom,
               /** @type {AssetInfo} */ (

--- a/packages/vats/src/vat-provisioning.js
+++ b/packages/vats/src/vat-provisioning.js
@@ -156,7 +156,7 @@ export function buildRootObject(_vatPowers, _vatParameters, baggage) {
           updater.updateState(harden({ clientHome, clientAddress: address }));
         });
         return Far('emulatedClientFacet', {
-          getChainBundle: () => chainBundle,
+          getChainBundle: async () => chainBundle,
           getConfiguration: () => notifier,
         });
       });

--- a/packages/vats/test/bootstrapPayment.test.js
+++ b/packages/vats/test/bootstrapPayment.test.js
@@ -52,7 +52,7 @@ test.before(async (/** @type {CentralSupplyTestContext} */ t) => {
  * @param {CentralSupplyTestContext} t
  * @param {bigint} bootstrapPaymentValue
  */
-const startContract = (t, bootstrapPaymentValue) => {
+const startContract = async (t, bootstrapPaymentValue) => {
   const {
     zoe,
     feeMintAccess,
@@ -123,7 +123,7 @@ test('bootstrap payment - only minted once', async (/** @type {CentralSupplyTest
   const bootstrapPayment2 = E(creatorFacet).getBootstrapPayment();
 
   await t.throwsAsync(
-    () => claim(E(issuers.IST).makeEmptyPurse(), bootstrapPayment2),
+    async () => claim(E(issuers.IST).makeEmptyPurse(), bootstrapPayment2),
     {
       message: /was not a live payment/,
     },

--- a/packages/vats/test/clientBundle.test.js
+++ b/packages/vats/test/clientBundle.test.js
@@ -85,7 +85,7 @@ test('connectFaucet produces payments', async t => {
     Promise.resolve(
       // @ts-expect-error never mind other methods
       Far('mockBankManager', {
-        getBankForAddress: _a =>
+        getBankForAddress: async _a =>
           Far('mockBank', {
             // @ts-expect-error never mind other methods
             getPurse: brand => ({
@@ -140,7 +140,7 @@ test('connectFaucet produces payments', async t => {
   const pmts = await E(userBundle.faucet).tapFaucet();
 
   const detail = await Promise.all(
-    pmts.map(({ issuer, payment, pursePetname }) =>
+    pmts.map(async ({ issuer, payment, pursePetname }) =>
       E(issuer)
         .getAmountOf(payment)
         .then(a => [pursePetname, showAmount(a)]),

--- a/packages/vats/test/lib-board.test.js
+++ b/packages/vats/test/lib-board.test.js
@@ -52,7 +52,7 @@ test('board values must be scalar keys', async t => {
   const board = makeFakeBoard();
   const nonKey = harden({ a: 1 });
   // @ts-expect-error intentional error
-  await t.throwsAsync(() => E(board).getId(nonKey), {
+  await t.throwsAsync(async () => E(board).getId(nonKey), {
     message: /arg 0: A "copyRecord" cannot be a scalar key: {"a":1}/,
   });
 });

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -166,12 +166,12 @@ test('localchain - deposit and withdraw', async t => {
         t.true(AmountMath.isEqual(paymentAmount, oneHundredBldAmt));
 
         await t.throwsAsync(
-          () => E(NonNullish(contractsLca)).withdraw(oneHundredBldAmt),
+          async () => E(NonNullish(contractsLca)).withdraw(oneHundredBldAmt),
           // fake bank is has different error messages than production
         );
 
         await t.throwsAsync(
-          () => E(NonNullish(contractsLca)).withdraw(oneHundredBeanAmt),
+          async () => E(NonNullish(contractsLca)).withdraw(oneHundredBeanAmt),
           {
             message: /not found in collection "brandToAssetRecord"/,
           },

--- a/packages/vats/test/name-hub.test.js
+++ b/packages/vats/test/name-hub.test.js
@@ -47,9 +47,12 @@ test('makeNameHubKit - lookup paths', async t => {
   t.is(await nh1.lookup('path1'), nh2);
   t.is(await nh1.lookup('path1', 'path2'), nh3);
   t.is(await nh1.lookup('path1', 'path2', 'path3'), 'finish2');
-  await t.throwsAsync(() => nh1.lookup('path1', 'path2', 'path3', 'path4'), {
-    message: /^target has no method "lookup", has/,
-  });
+  await t.throwsAsync(
+    async () => nh1.lookup('path1', 'path2', 'path3', 'path4'),
+    {
+      message: /^target has no method "lookup", has/,
+    },
+  );
 });
 
 test('makeNameHubKit - reserve and update', async t => {
@@ -57,7 +60,7 @@ test('makeNameHubKit - reserve and update', async t => {
 
   t.is(nameAdmin.readonly(), nameHub);
 
-  await t.throwsAsync(() => nameHub.lookup('hello'), {
+  await t.throwsAsync(async () => nameHub.lookup('hello'), {
     message: /"nameKey" not found: .*/,
   });
 
@@ -95,7 +98,7 @@ test('makeNameHubKit - reserve and delete', async t => {
 
   t.is(nameAdmin.readonly(), nameHub);
 
-  await t.throwsAsync(() => nameHub.lookup('goodbye'), {
+  await t.throwsAsync(async () => nameHub.lookup('goodbye'), {
     message: /"nameKey" not found: .*/,
   });
 
@@ -124,7 +127,7 @@ test('makeNameHubKit - reserve and delete', async t => {
   });
   t.truthy(lookedUpGoodbye);
 
-  await t.throwsAsync(() => nameHub.lookup('goodbye'), {
+  await t.throwsAsync(async () => nameHub.lookup('goodbye'), {
     message: /"nameKey" not found: .*/,
   });
 });
@@ -195,7 +198,7 @@ test('nameAdmin provideChild', async t => {
     'reserved keys should have a promise',
   );
 
-  await t.throwsAsync(() => namesByAddress.lookup('ag123', 'never'), {
+  await t.throwsAsync(async () => namesByAddress.lookup('ag123', 'never'), {
     message: '"nameKey" not found: "never"',
   });
 });

--- a/packages/vats/test/vat-bank.test.js
+++ b/packages/vats/test/vat-bank.test.js
@@ -149,7 +149,7 @@ test('communication', async t => {
   const it = subscribeEach(sub)[Symbol.asyncIterator]();
 
   const kit = makeIssuerKit('BLD', AssetKind.NAT, harden({ decimalPlaces: 6 }));
-  await t.throwsAsync(() => E(bank).getPurse(kit.brand), {
+  await t.throwsAsync(async () => E(bank).getPurse(kit.brand), {
     message: /not found/,
   });
 
@@ -231,7 +231,7 @@ test('communication', async t => {
   const feePurse = await E(bank).getPurse(feeKit.brand);
   await E(feePurse).withdraw(AmountMath.make(feeKit.brand, 35n));
   await t.throwsAsync(
-    () => E(feePurse).withdraw(AmountMath.make(feeKit.brand, 99n)),
+    async () => E(feePurse).withdraw(AmountMath.make(feeKit.brand, 99n)),
     { instanceOf: Error, message: 'insufficient ufee funds' },
   );
 

--- a/packages/vats/test/vpurse.test.js
+++ b/packages/vats/test/vpurse.test.js
@@ -147,7 +147,7 @@ test('makeVirtualPurse', async t => {
     );
   };
 
-  const performWithdrawal = () => {
+  const performWithdrawal = async () => {
     expected.pullAmount(fungible837);
     return E(vpurse).withdraw(fungible837);
   };
@@ -216,7 +216,7 @@ test('makeVirtualPurse withdraw from escrowPurse', async t => {
   balanceUpdater.updateState(fungible837);
   await checkNotifier();
 
-  const performWithdrawal = () => {
+  const performWithdrawal = async () => {
     expected.pullAmount(fungible837);
     return E(vpurse).withdraw(fungible837);
   };
@@ -309,7 +309,7 @@ test('vpurse.deposit promise', async t => {
 
   await t.throwsAsync(
     // @ts-expect-error deliberate invalid arguments for testing
-    () => E(vpurse).deposit(exclusivePaymentP, fungible25),
+    async () => E(vpurse).deposit(exclusivePaymentP, fungible25),
     {
       message:
         /In "deposit" method of \(VirtualPurseKit purse\): arg 0: .*"\[Promise\]" - Must be a remotable/,

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -106,7 +106,7 @@ export const makePopulatedFakeVatAdmin = () => {
     fakeNameToCap.set(name, cap);
   }
 
-  const createVat = (bundleCap, options) => {
+  const createVat = async (bundleCap, options) => {
     assert(bundleCap);
     if (bundleCap === zcfBundleCap) {
       return fakeVatAdmin.createVat(zcfBundleCap, options);

--- a/packages/vow/src/E.js
+++ b/packages/vow/src/E.js
@@ -102,7 +102,7 @@ const makeEProxyHandler = (recipient, HandledPromise, unwrap) =>
         }[propertyKey],
       );
     },
-    apply: (_target, _thisArg, argArray = []) => {
+    apply: async (_target, _thisArg, argArray = []) => {
       if (onSend && onSend.shouldBreakpoint(recipient, undefined)) {
         // eslint-disable-next-line no-debugger
         debugger; // LOOK UP THE STACK
@@ -194,11 +194,11 @@ const makeEGetProxyHandler = (x, HandledPromise, unwrap) =>
   harden({
     ...baseFreezableProxyHandler,
     has: (_target, _prop) => true,
-    get: (_target, prop) => HandledPromise.get(unwrap(x), prop),
+    get: async (_target, prop) => HandledPromise.get(unwrap(x), prop),
   });
 
 /** @param {any} x */
-const resolve = x => HandledPromise.resolve(x);
+const resolve = async x => HandledPromise.resolve(x);
 
 /**
  * @template [A={}]
@@ -257,7 +257,7 @@ const makeE = (HandledPromise, powers = {}) => {
          * @returns {Promise<Awaited<T>>} handled promise for x
          * @readonly
          */
-        resolve: x => resolve(unwrap(x)),
+        resolve: async x => resolve(unwrap(x)),
 
         /**
          * E.sendOnly returns a proxy similar to E, but for which the results
@@ -289,7 +289,7 @@ const makeE = (HandledPromise, powers = {}) => {
          * @returns {Promise<TResult1 | TResult2>}
          * @readonly
          */
-        when: (x, onfulfilled, onrejected) => {
+        when: async (x, onfulfilled, onrejected) => {
           const unwrapped = resolve(unwrap(x));
           if (onfulfilled == null && onrejected == null) {
             return unwrapped;

--- a/packages/vow/src/tools.js
+++ b/packages/vow/src/tools.js
@@ -69,7 +69,7 @@ export const prepareBasicVowTools = (zone, powers = {}) => {
   const allSettled = maybeVows => watchUtils.allSettled(maybeVows);
 
   /** @type {AsPromiseFunction} */
-  const asPromise = (specimenP, ...watcherArgs) =>
+  const asPromise = async (specimenP, ...watcherArgs) =>
     watchUtils.asPromise(specimenP, ...watcherArgs);
 
   return harden({

--- a/packages/vow/src/vow-utils.js
+++ b/packages/vow/src/vow-utils.js
@@ -64,7 +64,7 @@ harden(getVowPayload);
  * @param {PassableCap | Vow} k
  * @returns {PassableCap}
  */
-export const toPassableCap = k => {
+export const toPassableCap = async k => {
   const payload = getVowPayload(k);
   if (payload === undefined) {
     return /** @type {PassableCap} */ (k);

--- a/packages/vow/src/when.js
+++ b/packages/vow/src/when.js
@@ -79,7 +79,7 @@ export const makeWhen = (
    * @param {(reason: any) => TResult2 | PromiseLike<TResult2>} [onRejected]
    * @returns {Promise<TResult1 | TResult2>}
    */
-  const when = (specimenP, onFulfilled, onRejected) => {
+  const when = async (specimenP, onFulfilled, onRejected) => {
     const unwrapped = unwrap(specimenP);
 
     // We've extracted the final result.

--- a/packages/wallet/api/src/date-now.js
+++ b/packages/wallet/api/src/date-now.js
@@ -17,7 +17,7 @@ export const makeTimerDeviceDateNow =
 
 // Make a function that returns the latest polled time.  This only provides as
 // high resolution as the timer service poll interval.
-export const makeTimerServiceDateNow = (
+export const makeTimerServiceDateNow = async (
   timerService,
   timerPollInterval = DEFAULT_TIMER_SERVICE_POLL_INTERVAL,
 ) => {

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -586,7 +586,7 @@ export function makeWalletRoot({
    * @param {string} id
    * @param {ERef<UserSeat>} seat
    */
-  function subscribeToUpdates(id, seat) {
+  async function subscribeToUpdates(id, seat) {
     return E(E(seat).getExitSubscriber())
       .subscribeAfter()
       .then(update => updateOrResubscribe(id, seat, update));
@@ -1392,7 +1392,7 @@ export function makeWalletRoot({
    * @param {string} boardId
    * @param {string} [dappOrigin]
    */
-  function acceptPetname(
+  async function acceptPetname(
     acceptFn,
     suggestedPetname,
     boardId,

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -670,7 +670,7 @@ export function buildRootObject(vatPowers) {
  * @param {StartupTerms} terms
  * @param {*} _inviteMaker
  */
-export default function spawn(terms, _inviteMaker) {
+export default async function spawn(terms, _inviteMaker) {
   const walletVat = buildRootObject();
   return walletVat.startup(terms).then(_ => walletVat);
 }

--- a/packages/wallet/api/test/lib-wallet.test.js
+++ b/packages/wallet/api/test/lib-wallet.test.js
@@ -226,7 +226,7 @@ test('lib-wallet issuer and purse methods', async t => {
   const moolaPayment = moolaBundle.mint.mintPayment(
     AmountMath.make(moolaBundle.brand, 100n),
   );
-  await waitForUpdate(E(moolaPurse).getCurrentAmountNotifier(), () =>
+  await waitForUpdate(E(moolaPurse).getCurrentAmountNotifier(), async () =>
     wallet.deposit('fun money', moolaPayment),
   );
   t.deepEqual(
@@ -363,7 +363,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   assert(Array.isArray(invitationAmountValue2));
   const [{ handle: inviteHandle2 }] = invitationAmountValue2;
 
-  await waitForUpdate(wallet.getPursesNotifier(), () =>
+  await waitForUpdate(wallet.getPursesNotifier(), async () =>
     wallet.deposit('Default Zoe invite purse', invite2),
   );
 
@@ -711,7 +711,7 @@ test('lib-wallet offer methods', async t => {
   await wallet.makeEmptyPurse('moola', 'Fun budget');
   const moolaPurse = wallet.getPurse('Fun budget');
 
-  await waitForUpdate(E(moolaPurse).getCurrentAmountNotifier(), () =>
+  await waitForUpdate(E(moolaPurse).getCurrentAmountNotifier(), async () =>
     wallet.deposit(
       'Fun budget',
       moolaBundle.mint.mintPayment(AmountMath.make(moolaBundle.brand, 100n)),
@@ -1059,7 +1059,7 @@ test('lib-wallet addOffer for autoswap swap', async t => {
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);
   const { depositedP } = accepted;
-  await t.throwsAsync(() => wallet.getUINotifier(rawId, `unknown`), {
+  await t.throwsAsync(async () => wallet.getUINotifier(rawId, `unknown`), {
     message: 'offerResult must be a record to have a uiNotifier',
   });
 
@@ -1216,7 +1216,7 @@ test('lib-wallet performAction acceptOffer', async t => {
   assert(accepted);
   const { depositedP } = accepted;
   await t.throwsAsync(
-    () => wallet.getUINotifier(rawId, 'http://localhost:3001'),
+    async () => wallet.getUINotifier(rawId, 'http://localhost:3001'),
     {
       message: 'offerResult must be a record to have a uiNotifier',
     },
@@ -1346,7 +1346,7 @@ test('addOffer invitationQuery', async t => {
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);
   const { depositedP } = accepted;
-  await t.throwsAsync(() => wallet.getUINotifier(rawId, `unknown`), {
+  await t.throwsAsync(async () => wallet.getUINotifier(rawId, `unknown`), {
     message: 'offerResult must be a record to have a uiNotifier',
   });
 
@@ -1467,7 +1467,7 @@ test('addOffer offer.invitation', async t => {
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);
   const { depositedP } = accepted;
-  await t.throwsAsync(() => wallet.getUINotifier(rawId, `unknown`), {
+  await t.throwsAsync(async () => wallet.getUINotifier(rawId, `unknown`), {
     message: 'offerResult must be a record to have a uiNotifier',
   });
 

--- a/packages/xsnap-lockdown/src/index.js
+++ b/packages/xsnap-lockdown/src/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { bundlePaths, hashPaths } from './paths.js';
 
-const read = (name, path) => {
+const read = async (name, path) => {
   return fs.promises.readFile(path, { encoding: 'utf-8' }).catch(err => {
     console.error(`unable to read lockdown ${name} at ${path}`);
     console.error(`perhaps run 'yarn build' in @agoric/xsnap-lockdown`);
@@ -27,5 +27,5 @@ const getBundle = async debug => {
   return read('bundle', path).then(bundleString => JSON.parse(bundleString));
 };
 
-export const getLockdownBundle = () => getBundle(false);
-export const getDebugLockdownBundle = () => getBundle(true);
+export const getLockdownBundle = async () => getBundle(false);
+export const getDebugLockdownBundle = async () => getBundle(true);

--- a/packages/xsnap/src/ava-xs.js
+++ b/packages/xsnap/src/ava-xs.js
@@ -11,7 +11,7 @@ import bundleSource from '@endo/bundle-source';
 import { main, makeBundleResolve } from './avaXS.js';
 
 Promise.resolve()
-  .then(_ =>
+  .then(async _ =>
     main(process.argv.slice(2), {
       bundleSource,
       spawn,

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -21,7 +21,7 @@ const avaAssert = `./avaAssertXS.js`;
 const avaHandler = `./avaHandler.cjs`;
 
 /** @type { (ref: string, readFile: typeof import('fs').promises.readFile ) => Promise<string> } */
-const asset = (ref, readFile) =>
+const asset = async (ref, readFile) =>
   readFile(fileURLToPath(new URL(ref, import.meta.url)), 'utf8');
 
 /**
@@ -233,7 +233,7 @@ async function avaConfig(args, options, { glob, readFile }) {
    * @param {string} pattern
    * @returns {Promise<string[]>}
    */
-  const globFiles = pattern =>
+  const globFiles = async pattern =>
     new Promise((res, rej) =>
       glob(pattern, {}, (err, matches) => (err ? rej(err) : res(matches))),
     );
@@ -345,7 +345,9 @@ export async function main(
   const requiredBundles = await Promise.all(
     require
       .filter(specifier => !['esm', ...externals].includes(specifier))
-      .map(specifier => bundleSource(specifier, 'getExport', { externals })),
+      .map(async specifier =>
+        bundleSource(specifier, 'getExport', { externals }),
+      ),
   );
   const requiredScripts = requiredBundles.map(
     ({ source }) => `(${source}\n)()`,

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -31,7 +31,7 @@ const ModdableSDK = {
  */
 function makeCLI(command, { spawn }) {
   /** @param {import('child_process').ChildProcess} child */
-  const wait = child =>
+  const wait = async child =>
     new Promise((resolve, reject) => {
       child.on('close', () => {
         resolve(undefined);
@@ -51,7 +51,7 @@ function makeCLI(command, { spawn }) {
      * @param {string[]} args
      * @param {{ cwd?: string }} [opts]
      */
-    run: (args, opts) => {
+    run: async (args, opts) => {
       const { cwd = '.' } = opts || {};
       const child = spawn(command, args, {
         cwd,
@@ -63,7 +63,7 @@ function makeCLI(command, { spawn }) {
      * @param {string[]} args
      * @param {{ cwd?: string }} [opts]
      */
-    pipe: (args, opts) => {
+    pipe: async (args, opts) => {
       const { cwd = '.' } = opts || {};
       const child = spawn(command, args, {
         cwd,
@@ -370,7 +370,7 @@ async function main(args, { env, stdout, spawn, fs, os }) {
   }
 }
 
-const run = () =>
+const run = async () =>
   main(process.argv.slice(2), {
     env: { ...process.env },
     stdout: process.stdout,

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -274,7 +274,7 @@ export async function xsnap(options) {
   await snapshotLoader?.afterSpawn(snapshotLoadStream);
 
   if (snapshotLoader) {
-    void vatExit.promise.catch(noop).then(() => {
+    void vatExit.promise.catch(noop).then(async () => {
       if (snapshotLoader) {
         const { cleanup } = snapshotLoader;
         snapshotLoader = undefined;

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -62,7 +62,7 @@ async function main() {
    * @param {string} prompt
    * @returns {Promise<string>}
    */
-  function ask(prompt) {
+  async function ask(prompt) {
     const { promise, resolve } = /** @type {PromiseKit<string>} */ (
       makePromiseKit()
     );

--- a/packages/xsnap/test/boot-lockdown.test.js
+++ b/packages/xsnap/test/boot-lockdown.test.js
@@ -16,7 +16,7 @@ import { options, loader } from './message-tools.js';
 const io = { spawn: proc.spawn, os: os.type(), fs, tmpName }; // WARNING: ambient
 const ld = loader(import.meta.url, fs.promises.readFile);
 
-const getBootScript = () =>
+const getBootScript = async () =>
   getLockdownBundle().then(bundle => `(${bundle.source}\n)()`.trim());
 
 /**

--- a/packages/xsnap/test/inspect.test.js
+++ b/packages/xsnap/test/inspect.test.js
@@ -8,7 +8,7 @@ import { getLockdownBundle } from '@agoric/xsnap-lockdown';
 import { xsnap } from '../src/xsnap.js';
 import { options } from './message-tools.js';
 
-const getBootScript = () =>
+const getBootScript = async () =>
   getLockdownBundle().then(bundle => `(${bundle.source}\n)()`.trim());
 const io = { spawn: proc.spawn, os: os.type(), fs, tmpName }; // WARNING: ambient
 const testCases = [

--- a/packages/xsnap/test/xs-js.test.js
+++ b/packages/xsnap/test/xs-js.test.js
@@ -40,7 +40,7 @@ test('accept std regex range', async t => {
 test('simple TextEncoder / TextDecoder are available', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
@@ -54,7 +54,7 @@ test('simple TextEncoder / TextDecoder are available', async t => {
 test('Base64.encode', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const encoder = new TextEncoder();
     globalThis.handleCommand = inputBuffer => {
@@ -72,7 +72,7 @@ test('Base64.encode', async t => {
 test('Base64.encode degenerate input case', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const encoder = new TextEncoder();
     globalThis.handleCommand = inputBuffer => {
@@ -90,7 +90,7 @@ test('Base64.encode degenerate input case', async t => {
 test('Base64.decode', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const decoder = new TextDecoder();
     globalThis.handleCommand = inputBuffer => {
@@ -111,7 +111,7 @@ test('Base64.decode', async t => {
 test('bigint map key', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const encoder = new TextEncoder();
     const send = it => issueCommand(encoder.encode(JSON.stringify(it)).buffer);
@@ -124,7 +124,7 @@ test('bigint map key', async t => {
 test('bigint toString', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const encoder = new TextEncoder();
     const send = it => issueCommand(encoder.encode(JSON.stringify(it)).buffer);
@@ -137,7 +137,7 @@ test('bigint toString', async t => {
 test('keyword in destructuring', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
     const encoder = new TextEncoder();
     const send = it => issueCommand(encoder.encode(JSON.stringify(it)).buffer);
@@ -150,7 +150,7 @@ test('keyword in destructuring', async t => {
 test('round-trip byte sequences via JSON including string literals', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
 
   // Appease typescript.
   const send = _val => /* dummy */ {};
@@ -202,7 +202,7 @@ test('round-trip byte sequences via JSON including string literals', async t => 
 test('Text encode / decode edge cases with CESU-8', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
 
   const send = _val => /* dummy */ {}; // for static checker
 

--- a/packages/xsnap/test/xs-limits.test.js
+++ b/packages/xsnap/test/xs-limits.test.js
@@ -23,7 +23,7 @@ test('heap exhaustion: orderly fail-stop', async t => {
   `;
   for (const debug of [false, true]) {
     const vat = await xsnap({ ...options(io), meteringLimit: 0, debug });
-    t.teardown(() => vat.terminate());
+    t.teardown(async () => vat.terminate());
     await t.throwsAsync(vat.evaluate(grow), {
       code: ExitCode.E_NOT_ENOUGH_MEMORY,
     });
@@ -49,7 +49,7 @@ test.skip('property name space exhaustion: orderly fail-stop', async t => {
   `;
   for (const debug of [false, true]) {
     const vat = await xsnap({ ...options(io), meteringLimit: 0, debug });
-    t.teardown(() => vat.terminate());
+    t.teardown(async () => vat.terminate());
     t.log({ debug, qty: 31000 });
     await t.notThrowsAsync(vat.evaluate(grow(31000)));
     t.log({ debug, qty: 4000000000 });
@@ -87,7 +87,7 @@ test.skip('property name space exhaustion: orderly fail-stop', async t => {
       }k; rep ${qty}; debug ${debug}`, async t => {
         const opts = { ...options(io), meteringLimit: 1e8, debug };
         const vat = await xsnap({ ...opts, parserBufferSize });
-        t.teardown(() => vat.terminate());
+        t.teardown(async () => vat.terminate());
         const expected = failure ? [failure] : [qty * 4 + 2];
         await vat.evaluate(grow(qty));
         t.deepEqual(
@@ -112,7 +112,7 @@ test.skip('property name space exhaustion: orderly fail-stop', async t => {
   for (const statement of challenges) {
     test(`large sizes - abort cluster: ${statement}`, async t => {
       const vat = await xsnap(options(io));
-      t.teardown(() => vat.terminate());
+      t.teardown(async () => vat.terminate());
       await t.throwsAsync(
         vat.evaluate(`
         (() => {

--- a/packages/xsnap/test/xs-perf.test.js
+++ b/packages/xsnap/test/xs-perf.test.js
@@ -21,7 +21,7 @@ const shape = obj => fromEntries(entries(obj).map(([p, v]) => [p, typeof v]));
 test('meter details', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   const result = await vat.evaluate(`
   let m = new Map();
   let s1 = new Set();
@@ -90,7 +90,7 @@ test.skip('meter timestamps', async t => {
   }
   const opts = { ...options(io), handleCommand };
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   addTimestamp('kern send delivery');
   const result = await vat.evaluate(
     `let send = msg => issueCommand(new TextEncoder().encode(msg).buffer); send('1'); send('2')`,
@@ -142,9 +142,9 @@ test.skip('meter timestamps', async t => {
 test('isReady does not compute / allocate', async t => {
   const opts = options(io);
   const vat1 = await xsnap(opts);
-  t.teardown(() => vat1.terminate());
+  t.teardown(async () => vat1.terminate());
   const vat2 = await xsnap(opts);
-  t.teardown(() => vat2.terminate());
+  t.teardown(async () => vat2.terminate());
 
   await vat1.evaluate('null');
   const { meterUsage: m1 } = await vat1.evaluate('null');
@@ -163,7 +163,7 @@ test('isReady does not compute / allocate', async t => {
 test('metering regex - REDOS', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   // Java Classname Evil Regex
   // https://en.wikipedia.org/wiki/ReDoS
   // http://www.owasp.org/index.php/OWASP_Validation_Regex_Repository
@@ -177,7 +177,7 @@ test('metering regex - REDOS', async t => {
 test('meter details are still available with no limit', async t => {
   const opts = options(io);
   const vat = await xsnap({ ...opts, meteringLimit: 0 });
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   const result = await vat.evaluate(`
   for (ix = 0; ix < 200; ix++) {
   }
@@ -195,7 +195,7 @@ test('meter details are still available with no limit', async t => {
 test('high resolution timer', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   await vat.evaluate(`
       const send = it => issueCommand(new TextEncoder().encode(JSON.stringify(it)).buffer);
 
@@ -210,7 +210,7 @@ test('high resolution timer', async t => {
 test('metering can be switched off / on at run-time', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);
-  t.teardown(() => vat.terminate());
+  t.teardown(async () => vat.terminate());
   const {
     meterUsage: { compute: noUnMeteredCompute },
   } = await vat.evaluate(`

--- a/packages/xsnap/test/xsnap-eof.test.js
+++ b/packages/xsnap/test/xsnap-eof.test.js
@@ -197,7 +197,7 @@ const testInterruption = test.macro(
    * @param {(t: import('ava').ExecutionContext, results: Awaited<ReturnType<expectTermination>>) => void} verifyResults
    */
   async (t, beforeWait, onRequest, afterWait, verifyResults) => {
-    const handleCommand = message => {
+    const handleCommand = async message => {
       return onRequest(worker, message);
     };
     const worker = await spawnReflectiveWorker(handleCommand);
@@ -217,7 +217,7 @@ test(
     worker.toXsnap.destroy();
     return new Uint8Array();
   },
-  worker => worker.vat.close(),
+  async worker => worker.vat.close(),
   (t, results) =>
     verifyStdError(t, results, 'Got EOF on netstring read. Has parent died?\n'),
 );
@@ -234,7 +234,7 @@ test(
     worker.fromXsnap.destroy();
     return new Uint8Array();
   },
-  worker => worker.vat.close(),
+  async worker => worker.vat.close(),
   (t, results) =>
     verifyStdError(t, results, 'Caught SIGPIPE. Has parent died?\n'),
 );

--- a/packages/xsnap/test/xsnap.test.js
+++ b/packages/xsnap/test/xsnap.test.js
@@ -381,7 +381,7 @@ test('execute immediately after makeSnapshotStream', async t => {
   t.deepEqual(messages, ['before']);
 });
 
-function delay(ms) {
+async function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -6,7 +6,7 @@
 import { importBundle } from '@endo/import-bundle';
 import { handlePWarning } from '../handleWarning.js';
 
-const evalContractBundle = (bundle, additionalEndowments = {}) => {
+const evalContractBundle = async (bundle, additionalEndowments = {}) => {
   // Make the console more verbose.
   const louderConsole = {
     ...console,

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -66,7 +66,7 @@ export async function buildRootObject(powers, vatParameters, baggage) {
   return Far('contractRunner', {
     // initialize instance-specific state of the contract
     /** @type {StartZcf} */
-    startZcf: (
+    startZcf: async (
       zoeInstanceAdmin,
       instanceRecordFromZoe,
       issuerStorageFromZoe,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -229,7 +229,7 @@ export const makeZCFZygote = async (
    *     }
    * >}
    */
-  const evaluateContract = () => {
+  const evaluateContract = async () => {
     let bundle;
     if (passStyleOf(contractBundleCap) === 'remotable') {
       const bundleCap = contractBundleCap;
@@ -327,7 +327,7 @@ export const makeZCFZygote = async (
       powers.exitVat(completion);
     },
     shutdownWithFailure,
-    stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
+    stopAcceptingOffers: async () => E(zoeInstanceAdmin).stopAcceptingOffers(),
     makeZCFMint,
     registerFeeMint,
     makeEmptySeatKit,
@@ -357,8 +357,9 @@ export const makeZCFZygote = async (
       }
     },
     getInstance: () => getInstanceRecHolder().getInstanceRecord().instance,
-    setOfferFilter: strings => E(zoeInstanceAdmin).setOfferFilter(strings),
-    getOfferFilter: () => E(zoeInstanceAdmin).getOfferFilter(),
+    setOfferFilter: async strings =>
+      E(zoeInstanceAdmin).setOfferFilter(strings),
+    getOfferFilter: async () => E(zoeInstanceAdmin).getOfferFilter(),
   });
 
   // snapshot zygote here //////////////////

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -75,7 +75,7 @@ harden(provideEmptySeat);
  * @param {T} thunks
  * @returns {Promise<{ [K in keyof T]: Awaited<ReturnType<T[K]>> }>}
  */
-export const provideAll = (baggage, thunks) => {
+export const provideAll = async (baggage, thunks) => {
   const keys = Object.keys(thunks);
   // assume if any keys are defined they all are
   const inBaggage = baggage.has(keys[0]);
@@ -112,7 +112,7 @@ harden(provideAll);
  * @param {(value: Awaited<ReturnType<T>>) => void} [withValue]
  * @returns {Promise<Awaited<ReturnType<T>>>}
  */
-export const provideSingleton = (mapStore, key, makeValue, withValue) => {
+export const provideSingleton = async (mapStore, key, makeValue, withValue) => {
   const stored = mapStore.has(key)
     ? undefined
     : E.when(makeValue(), v => mapStore.init(key, harden(v)));

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -200,7 +200,7 @@ export const makeOnewayPriceAuthorityKit = opts => {
           amountOutLimit = coercedAmountOutLimit;
           void fireTriggers(createQuote);
         },
-        getPromise: () => triggerPK.promise,
+        getPromise: async () => triggerPK.promise,
       });
 
       /** @type {PriceQuoteTrigger} */

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -164,8 +164,8 @@ export const makePriceAuthorityTransform = async ({
 
       /** @type {EOnly<MutableQuote>} */
       const mutableQuote = Far('MutableQuote', {
-        cancel: e => E(sourceMutableQuote).cancel(e),
-        updateLevel: (newAmountIn, newAmountOutLimit) => {
+        cancel: async e => E(sourceMutableQuote).cancel(e),
+        updateLevel: async (newAmountIn, newAmountOutLimit) => {
           AmountMath.coerce(actualBrandIn, newAmountIn);
           AmountMath.coerce(actualBrandOut, newAmountOutLimit);
 
@@ -174,7 +174,8 @@ export const makePriceAuthorityTransform = async ({
             makeSourceAmountOut(newAmountOutLimit),
           );
         },
-        getPromise: () => E(sourceMutableQuote).getPromise().then(scaleQuote),
+        getPromise: async () =>
+          E(sourceMutableQuote).getPromise().then(scaleQuote),
       });
       return mutableQuote;
     };

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -239,7 +239,7 @@ export const withdrawFromSeat = async (zcf, seat, amounts) => {
 export const saveAllIssuers = async (zcf, issuerKeywordRecord = harden({})) => {
   const { issuers } = zcf.getTerms();
   const issuersPSaved = Object.entries(issuerKeywordRecord).map(
-    ([keyword, issuer]) => {
+    async ([keyword, issuer]) => {
       // If the keyword does not yet exist, add it and the
       // associated issuer.
       if (issuers[keyword] === undefined) {

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -21,7 +21,7 @@ const start = zcf => {
   assertIssuerKeywords(zcf, harden(['Asset', 'Price']));
 
   /** @type {OfferHandler} */
-  const makeMatchingInvitation = firstSeat => {
+  const makeMatchingInvitation = async firstSeat => {
     assertProposalShape(firstSeat, {
       give: { Asset: null },
       want: { Price: null },

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -114,7 +114,7 @@ const start = zcf => {
     });
   };
 
-  const makeBidInvitation = () => {
+  const makeBidInvitation = async () => {
     /** @type {OfferHandler} */
     const performBid = seat => {
       assert(!isClosed, 'Auction session is closed, no more bidding');

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -23,7 +23,8 @@ const start = zcf => {
     seat.exit();
     return `The offer was accepted`;
   };
-  const makeRefundInvitation = () => zcf.makeInvitation(refund, 'getRefund');
+  const makeRefundInvitation = async () =>
+    zcf.makeInvitation(refund, 'getRefund');
 
   const publicFacet = Far('publicFacet', {
     getOffersCount: () => offersCount,

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -320,16 +320,16 @@ const start = async zcf => {
     return 'Liquidity successfully removed.';
   };
 
-  const makeAddLiquidityInvitation = () =>
+  const makeAddLiquidityInvitation = async () =>
     zcf.makeInvitation(addLiquidityHandler, 'autoswap add liquidity');
 
-  const makeRemoveLiquidityInvitation = () =>
+  const makeRemoveLiquidityInvitation = async () =>
     zcf.makeInvitation(removeLiquidityHandler, 'autoswap remove liquidity');
 
-  const makeSwapInInvitation = () =>
+  const makeSwapInInvitation = async () =>
     zcf.makeInvitation(swapInHandler, 'autoswap swap');
 
-  const makeSwapOutInvitation = () =>
+  const makeSwapOutInvitation = async () =>
     zcf.makeInvitation(swapOutHandler, 'autoswap swap');
 
   /**

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -122,7 +122,8 @@ const start = zcf => {
   };
 
   const publicFacet = Far('publicFacet', {
-    makeInvitation: () => zcf.makeInvitation(exchangeOfferHandler, 'exchange'),
+    makeInvitation: async () =>
+      zcf.makeInvitation(exchangeOfferHandler, 'exchange'),
   });
 
   return { publicFacet };

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -27,7 +27,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
   let seatsExited = 0;
 
   /** @type {MakeOptionInvitation} */
-  function makeOptionInvitation(position) {
+  async function makeOptionInvitation(position) {
     return zcf.makeInvitation(
       // All we do at the time of exercise is resolve the promise.
       seat => seatPromiseKits[position].resolve(seat),

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -58,7 +58,7 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
   );
 
   /** @type {OfferHandler} */
-  const makeOption = sellSeat => {
+  const makeOption = async sellSeat => {
     mustMatch(
       sellSeat.getProposal(),
       M.splitRecord({ exit: { afterDeadline: M.any() } }),

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -68,7 +68,7 @@ const start = zcf => {
   const sellSeatExpiredMsg = `The covered call option is expired.`;
 
   /** @type {OfferHandler} */
-  const makeOption = sellSeat => {
+  const makeOption = async sellSeat => {
     mustMatch(
       sellSeat.getProposal(),
       M.splitRecord({ exit: { afterDeadline: M.any() } }),

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -9,7 +9,7 @@ import { scheduleLiquidation } from './scheduleLiquidation.js';
 // facet given to the borrower.
 
 /** @type {MakeAddCollateralInvitation} */
-export const makeAddCollateralInvitation = (zcf, config) => {
+export const makeAddCollateralInvitation = async (zcf, config) => {
   const { collateralSeat } = config;
 
   /** @type {OfferHandler} */

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -17,7 +17,7 @@ import { makeCloseLoanInvitation } from './close.js';
 import { makeAddCollateralInvitation } from './addCollateral.js';
 
 /** @type {MakeBorrowInvitation} */
-export const makeBorrowInvitation = (zcf, config) => {
+export const makeBorrowInvitation = async (zcf, config) => {
   const {
     mmr, // Maintenance Margin Requirement, as a Ratio
     priceAuthority,
@@ -133,11 +133,11 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     /** @type {BorrowFacet} */
     const borrowFacet = Far('borrowFacet', {
-      makeCloseLoanInvitation: () =>
+      makeCloseLoanInvitation: async () =>
         makeCloseLoanInvitation(zcf, configWithBorrower),
-      makeAddCollateralInvitation: () =>
+      makeAddCollateralInvitation: async () =>
         makeAddCollateralInvitation(zcf, configWithBorrower),
-      getLiquidationPromise: () => liquidationPromiseKit.promise,
+      getLiquidationPromise: async () => liquidationPromiseKit.promise,
       getDebtNotifier,
       getLastCalculationTimestamp,
       getRecentCollateralAmount: () =>

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -11,7 +11,7 @@ import { assertProposalShape } from '../../contractSupport/index.js';
 // given back and the contract is shut down.
 
 /** @type {MakeCloseLoanInvitation} */
-export const makeCloseLoanInvitation = (zcf, config) => {
+export const makeCloseLoanInvitation = async (zcf, config) => {
   const { collateralSeat, getDebt, lenderSeat } = config;
 
   /** @type {OfferHandler} */

--- a/packages/zoe/src/contracts/loan/lend.js
+++ b/packages/zoe/src/contracts/loan/lend.js
@@ -12,9 +12,9 @@ import { makeBorrowInvitation } from './borrow.js';
 // already exited with their loan.)
 
 /** @type {MakeLendInvitation} */
-export const makeLendInvitation = (zcf, config) => {
+export const makeLendInvitation = async (zcf, config) => {
   /** @type {OfferHandler} */
-  const lend = lenderSeat => {
+  const lend = async lenderSeat => {
     // Lender will want the interest earned from the loan + their
     // refund or the results of the liquidation. If the price of
     // collateral drops before we get the chance to liquidate, the

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -45,7 +45,7 @@ const start = zcf => {
    * @param {*} obj.moneyIssuer
    * @param {*} obj.pricePerItem
    */
-  const sellTokens = ({
+  const sellTokens = async ({
     customValueProperties,
     count,
     moneyIssuer,
@@ -94,7 +94,7 @@ const start = zcf => {
       sellItemsTerms,
     );
     return instanceRecordP.then(
-      ({ creatorInvitation, creatorFacet, instance, publicFacet }) => {
+      async ({ creatorInvitation, creatorFacet, instance, publicFacet }) => {
         assert(creatorInvitation);
         return E(zoeService)
           .offer(creatorInvitation, proposal, paymentKeywordRecord)

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -40,7 +40,7 @@ const start = async zcf => {
   const creatorFacet = Far('creatorFacet', {
     // The creator of the instance can send invitations to anyone
     // they wish to.
-    makeInvitation: (value = 1000n) =>
+    makeInvitation: async (value = 1000n) =>
       zcf.makeInvitation(mintPayment(value), 'mint a payment'),
     getTokenIssuer: () => issuer,
   });

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -43,7 +43,7 @@ const start = async zcf => {
     getCurrentFees() {
       return feeSeat.getCurrentAllocation();
     },
-    makeShutdownInvitation: () => {
+    makeShutdownInvitation: async () => {
       const shutdown = seat => {
         revoked = true;
         atomicTransfer(zcf, feeSeat, seat, feeSeat.getCurrentAllocation());

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -131,7 +131,7 @@ const start = zcf => {
      *
      * @returns {Promise<Payment>}
      */
-    makeRemoveInventoryInvitation: () => {
+    makeRemoveInventoryInvitation: async () => {
       return zcf.makeInvitation(removeInventory, 'removeInventory');
     },
     makeQuote,

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -213,7 +213,7 @@ const start = async (zcf, privateArgs) => {
       }
       return E(timer)
         .getCurrentTimestamp()
-        .then(now =>
+        .then(async now =>
           authenticateQuote([{ amountIn, amountOut, timer, timestamp: now }]),
         );
     };
@@ -470,7 +470,7 @@ const start = async (zcf, privateArgs) => {
         });
 
         if (oracleNotifier) {
-          pushFromOracle(oracleNotifier, scaleValueOut, r =>
+          pushFromOracle(oracleNotifier, scaleValueOut, async r =>
             admin.pushResult(r),
           );
         }

--- a/packages/zoe/src/contracts/scaledPriceAuthority.js
+++ b/packages/zoe/src/contracts/scaledPriceAuthority.js
@@ -87,7 +87,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
       getPriceAuthority: M.call().returns(M.promise()),
     }),
     {
-      getPriceAuthority: () => withInitial,
+      getPriceAuthority: async () => withInitial,
     },
   );
   return harden({ publicFacet });

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -126,7 +126,7 @@ const start = zcf => {
     return defaultAcceptanceMsg;
   };
 
-  const makeBuyerInvitation = () => {
+  const makeBuyerInvitation = async () => {
     const itemsAmount = sellerSeat.getAmountAllocated('Items');
     assert(
       sellerSeat && !AmountMath.isEmpty(itemsAmount),

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -127,7 +127,7 @@ const start = zcf => {
     );
   };
 
-  const makeExchangeInvitation = () =>
+  const makeExchangeInvitation = async () =>
     zcf.makeInvitation(exchangeOfferHandler, 'exchange');
 
   const publicFacet = Far('SimpleExchangePublicFacet', {

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -138,8 +138,9 @@ export const provideIssuerStorage = zcfBaggage => {
   const storeIssuerKeywordRecord = async uncleanIssuerKeywordRecord => {
     assertInstantiated();
     cleanKeywords(uncleanIssuerKeywordRecord);
-    const issuerRecordPs = objectMap(uncleanIssuerKeywordRecord, issuerP =>
-      storeIssuer(issuerP),
+    const issuerRecordPs = objectMap(
+      uncleanIssuerKeywordRecord,
+      async issuerP => storeIssuer(issuerP),
     );
     const issuerRecords = await deeplyFulfilledObject(issuerRecordPs);
     const issuers = objectMap(issuerRecords, ({ issuer }) => issuer);

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -52,7 +52,7 @@ export const provideEscrowStorage = baggage => {
 
   /** @type {WithdrawPayments} */
   const withdrawPayments = allocation =>
-    objectMap(allocation, amount =>
+    objectMap(allocation, async amount =>
       E(brandToPurse.get(amount.brand)).withdraw(amount),
     );
 
@@ -64,9 +64,9 @@ export const provideEscrowStorage = baggage => {
    * @param {Amount} amount
    * @returns {Promise<Amount>}
    */
-  const doDepositPayment = (paymentP, amount) => {
+  const doDepositPayment = async (paymentP, amount) => {
     const purse = brandToPurse.get(amount.brand);
-    return E.when(paymentP, payment => E(purse).deposit(payment, amount));
+    return E.when(paymentP, async payment => E(purse).deposit(payment, amount));
   };
 
   // Proposal is cleaned, but payments are not
@@ -96,7 +96,7 @@ export const provideEscrowStorage = baggage => {
     // offer safety and payout liveness are still meaningful as long
     // as issuers are well-behaved. For more, see
     // https://github.com/Agoric/agoric-sdk/issues/1271
-    const depositPs = objectMap(give, (amount, keyword) => {
+    const depositPs = objectMap(give, async (amount, keyword) => {
       payments[keyword] !== undefined ||
         Fail`The ${q(
           keyword,

--- a/packages/zoe/src/zoeService/invitationQueries.js
+++ b/packages/zoe/src/zoeService/invitationQueries.js
@@ -22,11 +22,11 @@ export const makeInvitationQueryFns = invitationIssuer => {
   };
 
   /** @type {GetInstance} */
-  const getInstance = invitation =>
+  const getInstance = async invitation =>
     E.get(getInvitationDetails(invitation)).instance;
 
   /** @type {GetInstallation} */
-  const getInstallation = invitation =>
+  const getInstallation = async invitation =>
     E.get(getInvitationDetails(invitation)).installation;
 
   return harden({

--- a/packages/zoe/src/zoeService/offer/burnInvitation.js
+++ b/packages/zoe/src/zoeService/offer/burnInvitation.js
@@ -14,7 +14,7 @@ import { E } from '@endo/eventual-send';
  *   invitationHandle: InvitationHandle,
  * }>}
  */
-export const burnInvitation = (invitationIssuer, invitation) => {
+export const burnInvitation = async (invitationIssuer, invitation) => {
   const handleRejected = reason => {
     const err = makeError(X`A Zoe invitation is required, not ${invitation}`);
     annotateError(err, X`Due to ${reason}`);

--- a/packages/zoe/src/zoeService/originalZoeSeat.js
+++ b/packages/zoe/src/zoeService/originalZoeSeat.js
@@ -78,7 +78,7 @@ const assertHasNotExited = (c, msg) => {
  * @param {() => PublishKit<any>} makeDurablePublishKit
  */
 export const declareOldZoeSeatAdminKind = (baggage, makeDurablePublishKit) => {
-  const doExit = (
+  const doExit = async (
     zoeSeatAdmin,
     currentAllocation,
     withdrawFacet,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -249,7 +249,7 @@ export const makeStartInstance = (
           privateArgs: newPrivateArgs,
         };
 
-        return E.when(getFreshZcfBundleCap(), bCap =>
+        return E.when(getFreshZcfBundleCap(), async bCap =>
           E(state.adminNode).upgrade(bCap, { vatParameters }),
         );
       },
@@ -263,7 +263,7 @@ export const makeStartInstance = (
           privateArgs: newPrivateArgs,
         };
         state.contractBundleCap = newContractBundleCap;
-        return E.when(getFreshZcfBundleCap(), bCap =>
+        return E.when(getFreshZcfBundleCap(), async bCap =>
           E(state.adminNode).upgrade(bCap, { vatParameters }),
         );
       },

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -91,7 +91,7 @@ const makeDurableZoeKit = ({
   );
 
   // guarantee that vatAdminSvcP has been defined.
-  const getActualVatAdminSvcP = () => {
+  const getActualVatAdminSvcP = async () => {
     if (!vatAdminSvc) {
       throw Fail`createZCFVat did not get bundleCap`;
     }
@@ -99,7 +99,7 @@ const makeDurableZoeKit = ({
   };
 
   /** @type {GetBundleCapForID} */
-  const getBundleCapForID = bundleID => {
+  const getBundleCapForID = async bundleID => {
     return E(getActualVatAdminSvcP()).waitForBundleCap(bundleID);
   };
 
@@ -110,7 +110,7 @@ const makeDurableZoeKit = ({
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
-  const createZCFVat = (contractBundleCap, contractLabel) => {
+  const createZCFVat = async (contractBundleCap, contractLabel) => {
     zcfBundleCap || Fail`createZCFVat did not get bundleCap`;
     const name =
       contractLabel &&

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -57,7 +57,7 @@ export const makeZoeSeatAdminFactory = baggage => {
 
   declareOldZoeSeatAdminKind(baggage, makeDurablePublishKit);
 
-  const doExit = (
+  const doExit = async (
     zoeSeatAdmin,
     currentAllocation,
     withdrawFacet,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -446,7 +446,7 @@ export const makeZoeStorageManager = (
           return state.instanceAdmins.getInstallation(instance);
         },
         getProposalShapeForInvitation,
-        installBundle: (allegedBundle, bundleLabel) => {
+        installBundle: async (allegedBundle, bundleLabel) => {
           return installationStorage.installBundle(allegedBundle, bundleLabel);
         },
         installBundleID(bundleID, bundleLabel) {

--- a/packages/zoe/test/runMintContract.js
+++ b/packages/zoe/test/runMintContract.js
@@ -12,7 +12,7 @@ const start = async (zcf, privateArgs) => {
   const run10 = AmountMath.make(runMint.getIssuerRecord().brand, 10n);
 
   const creatorFacet = Far('creatorFacet', {
-    mintRun: () => {
+    mintRun: async () => {
       const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
       runMint.mintGains(harden({ RUN: run10 }), zcfSeat);
       zcfSeat.exit();

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -29,17 +29,17 @@ const start = zcf => {
     seat.exit();
     return `The offer was accepted`;
   };
-  const makeSafeInvitation = () =>
+  const makeSafeInvitation = async () =>
     zcf.makeInvitation(safeAutoRefund, 'getRefund');
 
   const throwing = () => {
     offersCount += 1n;
     throw Error('someException');
   };
-  const makeThrowingInvitation = () =>
+  const makeThrowingInvitation = async () =>
     zcf.makeInvitation(throwing, 'getRefund');
 
-  const makeMatchingInvitation = firstSeat => {
+  const makeMatchingInvitation = async firstSeat => {
     assertProposalShape(firstSeat, {
       give: { Asset: null },
       want: { Price: null },
@@ -61,7 +61,7 @@ const start = zcf => {
   /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
   const zcfShutdownWithFailure = reason => zcf.shutdownWithFailure(reason);
 
-  const makeSwapInvitation = () =>
+  const makeSwapInvitation = async () =>
     zcf.makeInvitation(makeMatchingInvitation, 'firstOffer');
 
   offersCount += 1n;

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -122,7 +122,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     E(swapSeat)
       .getOfferResult()
       .then(
-        o => {
+        async o => {
           return E(invitationIssuer)
             .isLive(o)
             .then(val => {
@@ -408,6 +408,6 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/makeKind/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-alice.js
@@ -12,6 +12,6 @@ const build = async (log, zoe, installations) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-alice.js
@@ -26,6 +26,6 @@ const build = async (log, zoe, installations) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/privateArgs/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/vat-alice.js
@@ -24,6 +24,6 @@ const build = async (log, zoe, installations) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/runMint/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/runMint/vat-alice.js
@@ -55,7 +55,7 @@ const build = async (log, zoe, installations, feeMintAccess) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (zoe, installations, feeMintAccess) =>
+    build: async (zoe, installations, feeMintAccess) =>
       build(vatPowers.testLog, zoe, installations, feeMintAccess),
   });
 }

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -62,7 +62,7 @@ export const start = async (zcf, _privateArgs, instanceBaggage) => {
   );
 
   /** @type {OfferHandler} */
-  const makeOption = sellSeat => {
+  const makeOption = async sellSeat => {
     mustMatch(
       sellSeat.getProposal(),
       M.split({ exit: { afterDeadline: M.any() } }),

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -99,7 +99,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       const installedPs = vatParameters.contractNames.map(name =>
         E(vatAdminSvc)
           .getNamedBundleCap(name)
-          .then(bcap => E(zoe).installBundleID(D(bcap).getBundleID()))
+          .then(async bcap => E(zoe).installBundleID(D(bcap).getBundleID()))
           .then(installation => {
             installations[name] = installation;
           }),

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -614,6 +614,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -550,6 +550,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -70,6 +70,6 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -169,6 +169,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: async (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/zoe-upgrade.test.js
+++ b/packages/zoe/test/swingsetTests/zoe/zoe-upgrade.test.js
@@ -128,7 +128,7 @@ test('zoe vat upgrade trauma', async t => {
     30n,
   );
   const flow = Object.entries({
-    makeCoveredCallInstance: () =>
+    makeCoveredCallInstance: async () =>
       messageToObject(
         zoe,
         'startInstance',

--- a/packages/zoe/test/unitTests/blockedOffers.test.js
+++ b/packages/zoe/test/unitTests/blockedOffers.test.js
@@ -53,7 +53,7 @@ test(`blockedOffers - deny`, async t => {
   await zcf.setOfferFilter(['offerSeat for test']);
 
   await t.throwsAsync(
-    () =>
+    async () =>
       makeOffer(
         zoe,
         zcf,
@@ -72,7 +72,7 @@ test(`blockedOffers - prefix`, async t => {
   await zcf.setOfferFilter(['offerSeat for:']);
 
   await t.throwsAsync(
-    () =>
+    async () =>
       makeOffer(
         zoe,
         zcf,

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -22,7 +22,7 @@ const start = async zcf => {
   const { oracle, deadline, condition, timer, fee } = zcf.getTerms();
 
   /** @type {(funderSeat: ZCFSeat) => Promise<Invitation>} */
-  function funder(funderSeat) {
+  async function funder(funderSeat) {
     const endowBounty = harden({
       give: { Bounty: null },
     });

--- a/packages/zoe/test/unitTests/contractSupport/depositTo.test.js
+++ b/packages/zoe/test/unitTests/contractSupport/depositTo.test.js
@@ -94,7 +94,7 @@ test(`depositToSeat - mismatched keywords`, async t => {
   );
   const newBucks = bucksMint.mintPayment(bucks(2n));
   await t.throwsAsync(
-    () => depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { D: newBucks }),
+    async () => depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { D: newBucks }),
     {
       message:
         'The "D" keyword in the paymentKeywordRecord was not a keyword in proposal.give, which had keywords: ["C"]',

--- a/packages/zoe/test/unitTests/contractSupport/offerTo.test.js
+++ b/packages/zoe/test/unitTests/contractSupport/offerTo.test.js
@@ -208,7 +208,7 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
   t.deepEqual(toSeatContractA.getCurrentAllocation(), {});
 
   await t.throwsAsync(
-    () =>
+    async () =>
       offerTo(
         zcfA,
         contractBInvitation,

--- a/packages/zoe/test/unitTests/contracts/auction.test.js
+++ b/packages/zoe/test/unitTests/contracts/auction.test.js
@@ -306,7 +306,7 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
 
   // Alice tries to exit, but cannot
   await t.throwsAsync(
-    () => E(aliceSeat).tryExit(),
+    async () => E(aliceSeat).tryExit(),
     { message: /Only seats with the exit rule "onDemand" can exit at will/ },
     `alice can't exit`,
   );
@@ -457,7 +457,7 @@ test('zoe - secondPriceAuction - all bidders try to exit', async t => {
 
   // Alice tries to exit, but cannot
   await t.throwsAsync(
-    () => E(aliceSeat).tryExit(),
+    async () => E(aliceSeat).tryExit(),
     { message: /Only seats with the exit rule "onDemand" can exit at will/ },
     `alice can't exit`,
   );

--- a/packages/zoe/test/unitTests/contracts/automaticRefund.test.js
+++ b/packages/zoe/test/unitTests/contracts/automaticRefund.test.js
@@ -350,7 +350,7 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
 
   t.is(await E(aliceSeat).getOfferResult(), 'The offer was accepted');
 
-  await t.throwsAsync(() => E(aliceSeat).tryExit(), {
+  await t.throwsAsync(async () => E(aliceSeat).tryExit(), {
     message: /seat has (already|been) exited/,
   });
 

--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -13,7 +13,7 @@ const start = zcf => {
   // The Far would not normally happen in the erroneous accident
   // we're "testing". However, if we omit it, we get a completely
   // different error which is besides the point of this test.
-  const makeRefundInvitation = Far('broken make refund', () =>
+  const makeRefundInvitation = Far('broken make refund', async () =>
     zcf.makeInvitation(refund, 'getRefund'),
   );
   // should be makeRefundInvitation(). Intentionally wrong to provoke

--- a/packages/zoe/test/unitTests/contracts/brokenContract.test.js
+++ b/packages/zoe/test/unitTests/contracts/brokenContract.test.js
@@ -29,7 +29,7 @@ test('zoe - brokenAutomaticRefund', async t => {
   // Alice tries to create an instance, but the contract is badly
   // written.
   await t.throwsAsync(
-    () => E(zoe).startInstance(installation, issuerKeywordRecord),
+    async () => E(zoe).startInstance(installation, issuerKeywordRecord),
     { message: 'The contract did not correctly return a creatorInvitation' },
     'startInstance should have thrown',
   );

--- a/packages/zoe/test/unitTests/contracts/callSpread.test.js
+++ b/packages/zoe/test/unitTests/contracts/callSpread.test.js
@@ -20,7 +20,7 @@ const fundedCallSpread = `${dirname}/../../../src/contracts/callSpread/fundedCal
 const pricedCallSpread = `${dirname}/../../../src/contracts/callSpread/pricedCallSpread.js`;
 const simpleExchange = `${dirname}/../../../src/contracts/simpleExchange.js`;
 
-const makeTestPriceAuthority = (brands, priceList, timer) =>
+const makeTestPriceAuthority = async (brands, priceList, timer) =>
   makeFakePriceAuthority({
     actualBrandIn: brands.get('simoleans'),
     actualBrandOut: brands.get('moola'),

--- a/packages/zoe/test/unitTests/contracts/coveredCall.test.js
+++ b/packages/zoe/test/unitTests/contracts/coveredCall.test.js
@@ -317,7 +317,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
 
   // TODO is this await safe?
   await t.throwsAsync(
-    () => E(bobSeat).getOfferResult(),
+    async () => E(bobSeat).getOfferResult(),
     { message: /The covered call option is expired./ },
     'The call option should be expired',
   );

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -96,7 +96,7 @@ const start = zcf => {
         NO: tally.get('NO'),
       });
     },
-    makeVoterInvitation: () => {
+    makeVoterInvitation: async () => {
       assert(electionOpen, 'the election is closed');
       return zcf.makeInvitation(voteHandler, 'voter');
     },

--- a/packages/zoe/test/unitTests/contracts/invitation-details.test.js
+++ b/packages/zoe/test/unitTests/contracts/invitation-details.test.js
@@ -69,7 +69,7 @@ test('plural invitation details', async t => {
 
   const bothPayment = await E(invitePurse).withdraw(bothAmount);
 
-  await t.throwsAsync(() => E(zoe).getInvitationDetails(bothPayment), {
+  await t.throwsAsync(async () => E(zoe).getInvitationDetails(bothPayment), {
     message: 'Expected exactly 1 invitation, not 2',
   });
 });

--- a/packages/zoe/test/unitTests/contracts/loan/borrow.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/borrow.test.js
@@ -152,7 +152,7 @@ test('borrow not enough collateral', async t => {
     () => {},
     () => {},
   );
-  await t.throwsAsync(() => E(borrowSeat).getOfferResult(), {
+  await t.throwsAsync(async () => E(borrowSeat).getOfferResult(), {
     message: /The required margin is .*% but collateral only had value of .*/,
   });
 });
@@ -354,7 +354,7 @@ test('getDebtNotifier with interest', async t => {
 
   const seat = await E(zoe).offer(closeLoanInvitation, proposal, payments);
 
-  await t.throwsAsync(() => seat.getOfferResult(), {
+  await t.throwsAsync(async () => seat.getOfferResult(), {
     message:
       /Not enough Loan assets have been repaid. {2}.* is required, but only .* was repaid./,
   });
@@ -376,7 +376,7 @@ test('borrow collateral just too low', async t => {
     () => {},
   );
 
-  await t.throwsAsync(() => E(borrowSeatBad).getOfferResult(), {
+  await t.throwsAsync(async () => E(borrowSeatBad).getOfferResult(), {
     message: /The required margin is .*% but collateral only had value of .*/,
   });
 });

--- a/packages/zoe/test/unitTests/contracts/loan/liquidate.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/liquidate.test.js
@@ -53,7 +53,7 @@ test('test doLiquidation with mocked autoswap', async t => {
   };
 
   const autoswapPublicFacetP = Promise.resolve({
-    makeSwapInInvitation: () => zcf.makeInvitation(swapHandler, 'swap'),
+    makeSwapInInvitation: async () => zcf.makeInvitation(swapHandler, 'swap'),
   });
 
   await doLiquidation(
@@ -118,11 +118,11 @@ test('test with malfunctioning autoswap', async t => {
   };
 
   const autoswapPublicFacetP = Promise.resolve({
-    makeSwapInInvitation: () => zcf.makeInvitation(swapHandler, 'swap'),
+    makeSwapInInvitation: async () => zcf.makeInvitation(swapHandler, 'swap'),
   });
 
   await t.throwsAsync(
-    () =>
+    async () =>
       doLiquidation(
         zcf,
         collateralSeat,

--- a/packages/zoe/test/unitTests/contracts/oracle.test.js
+++ b/packages/zoe/test/unitTests/contracts/oracle.test.js
@@ -177,8 +177,12 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
     }),
   );
 
-  await t.throwsAsync(() => E(offer2).getOfferResult(), { instanceOf: Error });
-  await t.throwsAsync(() => E(offer4).getOfferResult(), { instanceOf: Error });
+  await t.throwsAsync(async () => E(offer2).getOfferResult(), {
+    instanceOf: Error,
+  });
+  await t.throwsAsync(async () => E(offer4).getOfferResult(), {
+    instanceOf: Error,
+  });
   t.deepEqual(
     await link.issuer.getAmountOf(E(offer4).getPayout('Fee')),
     underAmount,
@@ -198,7 +202,7 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
 
   await E(shutdownSeat)
     .getPayouts()
-    .then(payouts =>
+    .then(async payouts =>
       Promise.all(
         Object.entries(payouts).map(async ([keyword, payment]) => {
           const amount = await link.issuer.getAmountOf(payment);
@@ -216,15 +220,18 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
   const badOffer = E(zoe).offer(badInvitation);
 
   // Ensure the oracle no longer functions after revocation.
-  await t.throwsAsync(() => E(badOffer).getOfferResult(), {
+  await t.throwsAsync(async () => E(badOffer).getOfferResult(), {
     instanceOf: Error,
     message: `No further offers are accepted`,
   });
 
-  await t.throwsAsync(() => E(publicFacet).query({ hello: 'not again' }), {
-    instanceOf: Error,
-    message: `Oracle revoked`,
-  });
+  await t.throwsAsync(
+    async () => E(publicFacet).query({ hello: 'not again' }),
+    {
+      instanceOf: Error,
+      message: `Oracle revoked`,
+    },
+  );
 
   t.deepEqual(
     await link.issuer.getAmountOf(E(withdrawOffer).getPayout('Fee')),

--- a/packages/zoe/test/unitTests/contracts/ownable-counter.js
+++ b/packages/zoe/test/unitTests/contracts/ownable-counter.js
@@ -61,7 +61,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const makeOwnableCounter = prepareOwnable(
     zone,
-    (...args) => zcf.makeInvitation(...args),
+    async (...args) => zcf.makeInvitation(...args),
     'OwnableCounter',
     /** @type {const} */ (['incr', 'getInvitationCustomDetails']),
   );

--- a/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
+++ b/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
@@ -75,10 +75,13 @@ test('zoe - ownable-counter contract', async t => {
     'makeTransferInvitation',
   ]);
 
-  await t.throwsAsync(() => E(firstCounter).getInvitationCustomDetails(), {
-    message: '"OwnableCounter_caretaker" revoked',
-  });
-  await t.throwsAsync(() => E(firstCounter).incr(), {
+  await t.throwsAsync(
+    async () => E(firstCounter).getInvitationCustomDetails(),
+    {
+      message: '"OwnableCounter_caretaker" revoked',
+    },
+  );
+  await t.throwsAsync(async () => E(firstCounter).incr(), {
     message: '"OwnableCounter_caretaker" revoked',
   });
   t.is(await E(viewCounter).view(), 4n);

--- a/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
+++ b/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
@@ -56,7 +56,7 @@ import {
  * }} privateArgs
  */
 // eslint-disable-next-line no-unused-vars -- used for typedef
-const testStartFn = (zcf, privateArgs) => start(zcf, privateArgs);
+const testStartFn = async (zcf, privateArgs) => start(zcf, privateArgs);
 
 /**
  * @typedef {object} TestContext

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -23,10 +23,10 @@ const start = zcf => {
     await depositToSeat(zcf, seat, amounts, payments);
     return 'Should not get here';
   };
-  const makeThrowInOfferHandlerInvitation = () =>
+  const makeThrowInOfferHandlerInvitation = async () =>
     zcf.makeInvitation(throwInOfferHandler, 'throwInOfferHandler');
 
-  const makeThrowInDepositToSeatInvitation = () =>
+  const makeThrowInDepositToSeatInvitation = async () =>
     zcf.makeInvitation(throwInDepositToSeat, 'throwInDepositToSeat');
 
   const creatorFacet = Far('creatorFacet', {

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.test.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.test.js
@@ -39,7 +39,7 @@ test('throw in offerHandler', async t => {
   // Uncomment below to see what the user would see
   // await throwsInOfferHandlerResult;
 
-  await t.throwsAsync(() => throwsInOfferHandlerResult, {
+  await t.throwsAsync(async () => throwsInOfferHandlerResult, {
     message: 'error thrown in offerHandler in contract',
   });
 
@@ -75,7 +75,7 @@ test('throw in offerHandler', async t => {
   // › cleanProposal (src/cleanProposal.js:116:10)
   // › src/zoeService/zoe.js:408:28"
 
-  await t.throwsAsync(() => throwsInDepositToSeatResult, {
+  await t.throwsAsync(async () => throwsInDepositToSeatResult, {
     message:
       // Should be able to use more informative error once SES double
       // disclosure bug is fixed. See

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -57,7 +57,7 @@ const start = zcf => {
 
   const publicFacet = Far('publicFacet', {
     // The only publicFacet method is to make an invitation.
-    makeInvitation: () => zcf.makeInvitation(makeUseObj, 'use object'),
+    makeInvitation: async () => zcf.makeInvitation(makeUseObj, 'use object'),
   });
 
   return harden({ publicFacet });

--- a/packages/zoe/test/unitTests/fakePriceAuthority.test.js
+++ b/packages/zoe/test/unitTests/fakePriceAuthority.test.js
@@ -18,7 +18,7 @@ import { assertAmountsEqual } from '../zoeTestHelpers.js';
 
 const { coerceTimestampRecord } = TimeMath;
 
-const makeTestPriceAuthority = (brands, priceList, timer) =>
+const makeTestPriceAuthority = async (brands, priceList, timer) =>
   makeFakePriceAuthority({
     actualBrandIn: brands.get('moola'),
     actualBrandOut: brands.get('bucks'),

--- a/packages/zoe/test/unitTests/makeKind.test.js
+++ b/packages/zoe/test/unitTests/makeKind.test.js
@@ -34,5 +34,5 @@ test('defineKind non-swingset', async t => {
   t.notThrows(() => VatData.makeScalarBigWeakMapStore());
   t.notThrows(() => VatData.makeScalarBigSetStore());
   t.notThrows(() => VatData.makeScalarBigWeakSetStore());
-  await t.notThrowsAsync(() => E(zoe).startInstance(installation));
+  await t.notThrowsAsync(async () => E(zoe).startInstance(installation));
 });

--- a/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
+++ b/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
@@ -30,7 +30,7 @@ const start = async (zcf, privateArgs) => {
 
   const creatorFacet = Far('mint creator facet', {
     getMintedAmount: () => zcfSeat.getAmountAllocated('Winnings'),
-    getMintedPayout: () => {
+    getMintedPayout: async () => {
       zcfSeat.exit();
       return E(userSeat).getPayout('Winnings');
     },

--- a/packages/zoe/test/unitTests/zcf/zcf.test.js
+++ b/packages/zoe/test/unitTests/zcf/zcf.test.js
@@ -190,7 +190,7 @@ test(`zcf.saveIssuer - bad issuer`, async t => {
   const { moolaKit } = setup();
   const { zcf } = await setupZCFTest();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => zcf.saveIssuer(moolaKit.brand, 'A'), {
+  await t.throwsAsync(async () => zcf.saveIssuer(moolaKit.brand, 'A'), {
     // TODO: improve error message
     // https://github.com/Agoric/agoric-sdk/issues/1701
     message: /target has no method "getBrand", has /,
@@ -211,7 +211,7 @@ test(`zcf.saveIssuer - bad issuer, makeEmptyPurse throws`, async t => {
   });
   await t.throwsAsync(
     // @ts-expect-error deliberate invalid arguments for testing
-    () => zcf.saveIssuer(badIssuer, 'A'),
+    async () => zcf.saveIssuer(badIssuer, 'A'),
     {
       message:
         'A purse could not be created for brand "[Alleged: brand]" because: "[Error: bad issuer]"',
@@ -250,7 +250,7 @@ test(`zcf.saveIssuer - args reversed`, async t => {
 test(`zcf.makeInvitation - no offerHandler`, async t => {
   const { zcf } = await setupZCFTest();
   // @ts-expect-error bad argument
-  t.throws(() => zcf.makeInvitation(undefined, 'myInvitation'), {
+  t.throws(async () => zcf.makeInvitation(undefined, 'myInvitation'), {
     message: / must be provided/,
   });
 });
@@ -276,7 +276,7 @@ test(`zcf.makeInvitation - throwing offerHandler`, async t => {
   const isLive = await E(invitationIssuer).isLive(invitationP);
   t.truthy(isLive);
   const seat = E(zoe).offer(invitationP);
-  await t.throwsAsync(() => E(seat).getOfferResult(), {
+  await t.throwsAsync(async () => E(seat).getOfferResult(), {
     message: 'my error message',
   });
 });
@@ -284,7 +284,7 @@ test(`zcf.makeInvitation - throwing offerHandler`, async t => {
 test(`zcf.makeInvitation - no description`, async t => {
   const { zcf } = await setupZCFTest();
   // @ts-expect-error deliberate invalid arguments for testing
-  t.throws(() => zcf.makeInvitation(() => {}), {
+  t.throws(async () => zcf.makeInvitation(() => {}), {
     message:
       'In "makeInvitation" method of (zcf): Expected at least 2 arguments: ["<redacted raw arg>"]',
   });
@@ -295,7 +295,7 @@ test(`zcf.makeInvitation - non-string description`, async t => {
   // TODO: improve error message
   // https://github.com/Agoric/agoric-sdk/issues/1704
   // @ts-expect-error deliberate invalid arguments for testing
-  t.throws(() => zcf.makeInvitation(() => {}, { something: 'a' }), {
+  t.throws(async () => zcf.makeInvitation(() => {}, { something: 'a' }), {
     message:
       'In "makeInvitation" method of (zcf): arg 1: copyRecord {"something":"a"} - Must be a string',
   });
@@ -358,7 +358,7 @@ test(`zcf.makeInvitation - customDetails stratification`, async t => {
 test(`zcf.makeZCFMint - no keyword`, async t => {
   const { zcf } = await setupZCFTest();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => zcf.makeZCFMint(), {
+  await t.throwsAsync(async () => zcf.makeZCFMint(), {
     message:
       // Should be able to use more informative error once SES double
       // disclosure bug is fixed. See
@@ -372,14 +372,14 @@ test(`zcf.makeZCFMint - no keyword`, async t => {
 test(`zcf.makeZCFMint - keyword already in use`, async t => {
   const { moolaIssuer } = setup();
   const { zcf } = await setupZCFTest({ A: moolaIssuer });
-  await t.throwsAsync(() => zcf.makeZCFMint('A'), {
+  await t.throwsAsync(async () => zcf.makeZCFMint('A'), {
     message: 'keyword "A" must be unique',
   });
 });
 
 test(`zcf.makeZCFMint - bad keyword`, async t => {
   const { zcf } = await setupZCFTest();
-  await t.throwsAsync(() => zcf.makeZCFMint('a'), {
+  await t.throwsAsync(async () => zcf.makeZCFMint('a'), {
     message:
       // Should be able to use more informative error once SES double
       // disclosure bug is fixed. See
@@ -393,7 +393,7 @@ test(`zcf.makeZCFMint - bad keyword`, async t => {
 test(`zcf.makeZCFMint - not a math kind`, async t => {
   const { zcf } = await setupZCFTest();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => zcf.makeZCFMint('A', 'whatever'), {
+  await t.throwsAsync(async () => zcf.makeZCFMint('A', 'whatever'), {
     message:
       'In "makeZoeMint" method of (zoeInstanceAdmin): arg 1?: "whatever" - Must match one of ["nat","set","copySet","copyBag"]',
   });
@@ -910,7 +910,7 @@ test(`userSeat.tryExit from zcf.makeEmptySeatKit - waived`, async t => {
   const { zcf } = await setupZCFTest();
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit({ waived: null });
   t.falsy(zcfSeat.hasExited());
-  await t.throwsAsync(() => E(userSeat).tryExit(), {
+  await t.throwsAsync(async () => E(userSeat).tryExit(), {
     message: 'Only seats with the exit rule "onDemand" can exit at will',
   });
   t.falsy(zcfSeat.hasExited());
@@ -924,7 +924,7 @@ test(`userSeat.tryExit from zcf.makeEmptySeatKit - afterDeadline`, async t => {
     afterDeadline: { timer, deadline: 1n },
   });
   t.falsy(zcfSeat.hasExited());
-  await t.throwsAsync(() => E(userSeat).tryExit(), {
+  await t.throwsAsync(async () => E(userSeat).tryExit(), {
     message: 'Only seats with the exit rule "onDemand" can exit at will',
   });
   t.falsy(zcfSeat.hasExited());
@@ -973,7 +973,7 @@ test(`userSeat.getPayouts, getPayout from zcf.makeEmptySeatKit`, async t => {
   const payoutAP = E(userSeat).getPayout('A');
   const payoutBP = E(userSeat).getPayout('B');
 
-  await t.throwsAsync(() => E(userSeat).getPayout('C'), {
+  await t.throwsAsync(async () => E(userSeat).getPayout('C'), {
     message: /No payout for "C"/,
   });
 
@@ -994,7 +994,7 @@ test(`userSeat.getPayout() should throw from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();
   const { userSeat } = zcf.makeEmptySeatKit();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(userSeat).getPayout(), {
+  await t.throwsAsync(async () => E(userSeat).getPayout(), {
     message:
       'In "getPayout" method of (ZoeUserSeat userSeat): Expected at least 1 arguments: []',
   });
@@ -1192,7 +1192,7 @@ test(`zcf.shutdown - no further offers accepted`, async t => {
   const { zoe, zcf, vatAdminState } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
   zcf.shutdown('sayonara');
-  await t.throwsAsync(() => E(zoe).offer(invitation), {
+  await t.throwsAsync(async () => E(zoe).offer(invitation), {
     message: 'No further offers are accepted',
   });
   t.is(vatAdminState.getExitMessage(), 'sayonara');
@@ -1203,7 +1203,7 @@ test(`zcf.shutdownWithFailure - no further offers accepted`, async t => {
   const { zoe, zcf, vatAdminState } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
   zcf.shutdownWithFailure(Error(`And don't come back`));
-  await t.throwsAsync(() => E(zoe).offer(invitation), {
+  await t.throwsAsync(async () => E(zoe).offer(invitation), {
     message: 'No further offers are accepted',
   });
   t.is(vatAdminState.getExitMessage().message, `And don't come back`);
@@ -1226,7 +1226,7 @@ test(`zcf.stopAcceptingOffers`, async t => {
   await zcf.stopAcceptingOffers();
   t.truthy(await E(invitationIssuer).isLive(invitation2));
   await t.throwsAsync(
-    () => E(zoe).offer(invitation2),
+    async () => E(zoe).offer(invitation2),
     { message: 'No further offers are accepted' },
     `can't make further offers`,
   );
@@ -1237,7 +1237,7 @@ test(`zcf.stopAcceptingOffers`, async t => {
 test(`zcf.setOfferFilter - illegal lists`, async t => {
   const { zcf } = await setupZCFTest();
   // @ts-expect-error invalid argument
-  await t.throwsAsync(() => zcf.setOfferFilter('nonList'), {
+  await t.throwsAsync(async () => zcf.setOfferFilter('nonList'), {
     message: / arg 0: string "nonList" - Must be a copyArray/,
   });
 });
@@ -1313,7 +1313,7 @@ test('numWantsSatisfied: fail', async t => {
   t.is(await E(userSeat).numWantsSatisfied(), 0);
 
   await t.throwsAsync(
-    () => E(E(userSeat).getExitSubscriber()).getUpdateSince(),
+    async () => E(E(userSeat).getExitSubscriber()).getUpdateSince(),
     { message: 'whatever' },
   );
 });

--- a/packages/zoe/test/unitTests/zcf/zcfSeat-exit.test.js
+++ b/packages/zoe/test/unitTests/zcf/zcfSeat-exit.test.js
@@ -57,7 +57,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
 
   const userSeat1 = await E(zoe).offer(invitation1);
 
-  await t.throwsAsync(() => E(userSeat1).getOfferResult(), {
+  await t.throwsAsync(async () => E(userSeat1).getOfferResult(), {
     message:
       'If an offerHandler throws, it must provide a reason of type Error, but the reason was undefined. Please fix the contract code to specify a reason for throwing.',
   });
@@ -72,7 +72,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
 
   const userSeat2 = await E(zoe).offer(invitation2);
 
-  await t.throwsAsync(() => E(userSeat2).getOfferResult(), {
+  await t.throwsAsync(async () => E(userSeat2).getOfferResult(), {
     message: 'here is a string',
   });
   t.falsy(vatAdminState.getHasExited());

--- a/packages/zoe/test/unitTests/zcf/zcfSeat.test.js
+++ b/packages/zoe/test/unitTests/zcf/zcfSeat.test.js
@@ -73,7 +73,7 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
   await t.throwsAsync(E(userSeat2).getOfferResult(), {
     message: 'second seat failed',
   });
-  await t.throwsAsync(() => E(userSeat1).tryExit(), {
+  await t.throwsAsync(async () => E(userSeat1).tryExit(), {
     message: 'Cannot exit; seat has already exited',
   });
   t.falsy(vatAdminState.getHasExited());

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -11,7 +11,7 @@ const start = async zcf => {
   zcf.setTestJig(() => harden({ instance }));
 
   const publicFacet = Far('public facet', {
-    makeInvitation: () => zcf.makeInvitation(() => 17, 'simple'),
+    makeInvitation: async () => zcf.makeInvitation(() => 17, 'simple'),
   });
 
   return { publicFacet };

--- a/packages/zoe/test/unitTests/zcf/zoeHelpersWZcf.test.js
+++ b/packages/zoe/test/unitTests/zcf/zoeHelpersWZcf.test.js
@@ -203,7 +203,7 @@ test(`zcf saveAllIssuers - duplicate keyword`, async t => {
   );
 
   await t.notThrowsAsync(
-    () => saveAllIssuers(zcf, { P: pIssuer }),
+    async () => saveAllIssuers(zcf, { P: pIssuer }),
     'second issuer with same keyword should be ignored.',
   );
   t.is(zcf.getBrandForIssuer(pandaIssuer), pandaBrand, 'gelt');

--- a/packages/zoe/test/unitTests/zoe-startInstance.test.js
+++ b/packages/zoe/test/unitTests/zoe-startInstance.test.js
@@ -14,7 +14,7 @@ const dirname = path.dirname(new URL(import.meta.url).pathname);
 test('bad installation', async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).startInstance(), {
+  await t.throwsAsync(async () => E(zoe).startInstance(), {
     message:
       'In "startInstance" method of (ZoeService): Expected at least 1 arguments: []',
   });
@@ -97,7 +97,7 @@ test('terms, issuerKeywordRecord switched', async t => {
   const installation = await E(zoe).installBundleID('b1-contract');
   const { moolaKit } = setup();
   await t.throwsAsync(
-    () =>
+    async () =>
       E(zoe).startInstance(
         installation,
         // @ts-expect-error intentional error
@@ -126,7 +126,7 @@ test('bad issuer, makeEmptyPurse throws', async t => {
   });
   await t.throwsAsync(
     // @ts-expect-error intentional error
-    () => E(zoe).startInstance(installation, { Money: badIssuer }),
+    async () => E(zoe).startInstance(installation, { Money: badIssuer }),
     {
       message:
         'A purse could not be created for brand "[Alleged: brand]" because: "[Error: bad issuer]"',
@@ -141,7 +141,7 @@ test('unexpected properties', async t => {
   const bundle = await bundleSource(contractPath);
   const installation = await E(zoe).install(bundle);
 
-  await t.throwsAsync(() => E(zoe).startInstance(installation), {
+  await t.throwsAsync(async () => E(zoe).startInstance(installation), {
     message:
       'contract "start" returned unrecognized properties ["unexpectedProperty"]',
   });
@@ -154,7 +154,7 @@ test('prepare and start', async t => {
   const bundle = await bundleSource(contractPath);
   const installation = await E(zoe).install(bundle);
 
-  await t.throwsAsync(() => E(zoe).startInstance(installation), {
+  await t.throwsAsync(async () => E(zoe).startInstance(installation), {
     message: 'contract must provide exactly one of "start" and "prepare"',
   });
 });
@@ -166,7 +166,7 @@ test('before meta', async t => {
   const bundle = await bundleSource(contractPath);
   const installation = await E(zoe).install(bundle);
 
-  await t.throwsAsync(() => E(zoe).startInstance(installation), {
+  await t.throwsAsync(async () => E(zoe).startInstance(installation), {
     message: 'privateArgs: "[undefined]" - Must be: {"greeting":"hello"}',
   });
 

--- a/packages/zoe/test/unitTests/zoe.test.js
+++ b/packages/zoe/test/unitTests/zoe.test.js
@@ -31,7 +31,7 @@ test(`zoe.getInvitationIssuer`, async t => {
 test(`E(zoe).install bad bundle`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).install(), {
+  await t.throwsAsync(async () => E(zoe).install(), {
     message:
       'In "install" method of (ZoeService): Expected at least 1 arguments: []',
   });
@@ -48,7 +48,7 @@ test(`E(zoe).install(bundle)`, async t => {
 test(`E(zoe).installBundleID bad id`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).installBundleID(), {
+  await t.throwsAsync(async () => E(zoe).installBundleID(), {
     message:
       'In "installBundleID" method of (ZoeService): Expected at least 1 arguments: []',
   });
@@ -57,7 +57,7 @@ test(`E(zoe).installBundleID bad id`, async t => {
 test(`E(zoe).installBundleID bad label`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).installBundleID('a', harden([])), {
+  await t.throwsAsync(async () => E(zoe).installBundleID('a', harden([])), {
     message:
       'In "installBundleID" method of (ZoeService): arg 1?: copyArray [] - Must be a string',
   });
@@ -93,7 +93,7 @@ test(`E(zoe).offer - payment instead of paymentKeywordRecord`, async t => {
   const payment = mint.mintPayment(amount);
   const invitation = zcf.makeInvitation(() => {}, 'noop');
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).offer(invitation, proposal, payment), {
+  await t.throwsAsync(async () => E(zoe).offer(invitation, proposal, payment), {
     message:
       'In "offer" method of (ZoeService): arg 2?: remotable "[Alleged: Token payment]" - Must be a copyRecord',
   });
@@ -140,7 +140,7 @@ test(`E(zoe).getPublicFacet promise for instance`, async t => {
 test(`E(zoe).getPublicFacet - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getPublicFacet(), {
+  await t.throwsAsync(async () => E(zoe).getPublicFacet(), {
     message:
       /In "getPublicFacet" method of \(ZoeService\): Expected at least 1 arguments: \[\]/,
   });
@@ -171,7 +171,7 @@ test(`zoe.getIssuers - none`, async t => {
 test(`zoe.getIssuers - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getIssuers(), {
+  await t.throwsAsync(async () => E(zoe).getIssuers(), {
     message:
       /In "getIssuers" method of \(ZoeService\): Expected at least 1 arguments: \[\]/,
   });
@@ -202,7 +202,7 @@ test(`zoe.getBrands - none`, async t => {
 test(`zoe.getBrands - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getBrands(), {
+  await t.throwsAsync(async () => E(zoe).getBrands(), {
     message:
       /In "getBrands" method of \(ZoeService\): Expected at least 1 arguments: \[\]/,
   });
@@ -258,7 +258,7 @@ test(`zoe.getTerms`, async t => {
 test(`zoe.getTerms - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getTerms(), {
+  await t.throwsAsync(async () => E(zoe).getTerms(), {
     message:
       /In "getTerms" method of \(ZoeService\): Expected at least 1 arguments: \[\]/,
   });
@@ -295,7 +295,7 @@ test(`zoe.getInstance`, async t => {
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getInstance(), {
+  await t.throwsAsync(async () => E(zoe).getInstance(), {
     message:
       'In "getInstance" method of (ZoeService): Expected at least 1 arguments: []',
   });
@@ -311,7 +311,7 @@ test(`zoe.getInstallation`, async t => {
 test(`zoe.getInstallation - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getInstallation(), {
+  await t.throwsAsync(async () => E(zoe).getInstallation(), {
     message:
       'In "getInstallation" method of (ZoeService): Expected at least 1 arguments: []',
   });
@@ -320,15 +320,18 @@ test(`zoe.getInstallation - no invitation`, async t => {
 test(`zoe.getInvitationDetails`, async t => {
   const { zcf } = await setupZCFTest();
   // @ts-expect-error
-  await t.throwsAsync(() => E(zcf).makeInvitation(undefined, 'invitation'), {
-    message: 'offerHandler must be provided',
-  });
+  await t.throwsAsync(
+    async () => E(zcf).makeInvitation(undefined, 'invitation'),
+    {
+      message: 'offerHandler must be provided',
+    },
+  );
 });
 
 test(`zoe.getInvitationDetails - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).getInvitationDetails(), {
+  await t.throwsAsync(async () => E(zoe).getInvitationDetails(), {
     message:
       'In "getInvitationDetails" method of (ZoeService): Expected at least 1 arguments: []',
   });

--- a/packages/zoe/test/unitTests/zoe/burnInvitation.test.js
+++ b/packages/zoe/test/unitTests/zoe/burnInvitation.test.js
@@ -29,7 +29,7 @@ test('burnInvitation - not an invitation', async t => {
 
   await t.throwsAsync(
     // @ts-expect-error invalid payment for the purposes of testing
-    () => burnInvitation(mockInvitationKit.issuer, undefined),
+    async () => burnInvitation(mockInvitationKit.issuer, undefined),
     { message: 'A Zoe invitation is required, not "[undefined]"' },
   );
 });
@@ -53,7 +53,7 @@ test('burnInvitation - invitation already used', async t => {
   });
 
   await t.throwsAsync(
-    () => burnInvitation(mockInvitationKit.issuer, invitation),
+    async () => burnInvitation(mockInvitationKit.issuer, invitation),
     {
       message:
         'A Zoe invitation is required, not "[Alleged: mockInvitation payment]"',
@@ -79,7 +79,7 @@ test('burnInvitation - multiple invitations', async t => {
   );
 
   await t.throwsAsync(
-    () => burnInvitation(mockInvitationKit.issuer, invitations),
+    async () => burnInvitation(mockInvitationKit.issuer, invitations),
     {
       message: 'Only one invitation can be redeemed at a time',
     },

--- a/packages/zoe/test/unitTests/zoe/escrowStorage.test.js
+++ b/packages/zoe/test/unitTests/zoe/escrowStorage.test.js
@@ -97,13 +97,13 @@ test('provideEscrowStorage', async t => {
   });
 
   await Promise.all(
-    Object.entries(initialAllocation).map(([keyword, amount]) =>
+    Object.entries(initialAllocation).map(async ([keyword, amount]) =>
       assertAmountsEqual(t, amount, initialAllocation2[keyword]),
     ),
   );
 
   await Promise.all(
-    Object.entries(initialAllocation2).map(([keyword, amount]) =>
+    Object.entries(initialAllocation2).map(async ([keyword, amount]) =>
       assertAmountsEqual(t, amount, initialAllocation[keyword]),
     ),
   );
@@ -166,10 +166,13 @@ test('payments without matching give keywords', async t => {
     },
   });
 
-  await t.throwsAsync(() => depositPayments(proposal, paymentPKeywordRecord), {
-    message:
-      'The "Moola" keyword in the paymentKeywordRecord was not a keyword in proposal.give, which had keywords: ["GameTicket","Money"]',
-  });
+  await t.throwsAsync(
+    async () => depositPayments(proposal, paymentPKeywordRecord),
+    {
+      message:
+        'The "Moola" keyword in the paymentKeywordRecord was not a keyword in proposal.give, which had keywords: ["GameTicket","Money"]',
+    },
+  );
 });
 
 test(`give keywords without matching payments`, async t => {
@@ -201,8 +204,11 @@ test(`give keywords without matching payments`, async t => {
     },
   });
 
-  await t.throwsAsync(() => depositPayments(proposal, paymentPKeywordRecord), {
-    message:
-      'The "Money" keyword in proposal.give did not have an associated payment in the paymentKeywordRecord, which had keywords: ["GameTicket"]',
-  });
+  await t.throwsAsync(
+    async () => depositPayments(proposal, paymentPKeywordRecord),
+    {
+      message:
+        'The "Money" keyword in proposal.give did not have an associated payment in the paymentKeywordRecord, which had keywords: ["GameTicket"]',
+    },
+  );
 });

--- a/packages/zoe/test/unitTests/zoe/instanceAdminStorage.test.js
+++ b/packages/zoe/test/unitTests/zoe/instanceAdminStorage.test.js
@@ -60,7 +60,8 @@ test('add another instance admin for same instance', async t => {
 
   const mockInstanceAdmin2 = Far('mockInstanceAdmin', {});
   await t.throwsAsync(
-    () => ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin2),
+    async () =>
+      ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin2),
     { message: /"\[Alleged: mockInstance\]" already registered/ },
   );
 });

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -3,7 +3,7 @@ import { E } from '@endo/eventual-send';
 
 import { AmountMath, assertValueGetHelpers } from '@agoric/ertp';
 
-export const assertAmountsEqual = (t, amount, expected, label = '') => {
+export const assertAmountsEqual = async (t, amount, expected, label = '') => {
   harden(amount);
   harden(expected);
   const l = label ? `${label} ` : '';
@@ -56,7 +56,7 @@ export const assertPayoutDeposit = (t, payout, purse, amount) => {
   return payout.then(payment => {
     E(purse)
       .deposit(payment)
-      .then(payoutAmount =>
+      .then(async payoutAmount =>
         assertAmountsEqual(
           t,
           payoutAmount,

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -269,7 +269,7 @@ export async function makeFakePriceAuthority(options) {
 
   /** @type {PriceAuthority} */
   const priceAuthority = Far('fake price authority', {
-    getQuoteIssuer: (brandIn, brandOut) => {
+    getQuoteIssuer: async (brandIn, brandOut) => {
       assertBrands(brandIn, brandOut);
       return quoteIssuer;
     },
@@ -281,7 +281,7 @@ export async function makeFakePriceAuthority(options) {
       assertBrands(amountIn.brand, brandOut);
       return makeNotifierFromAsyncIterable(generateQuotes(amountIn, brandOut));
     },
-    quoteAtTime: (timeStamp, amountIn, brandOut) => {
+    quoteAtTime: async (timeStamp, amountIn, brandOut) => {
       timeStamp = TimeMath.absValue(timeStamp);
       assert.typeof(timeStamp, 'bigint');
       assertBrands(amountIn.brand, brandOut);
@@ -306,19 +306,19 @@ export async function makeFakePriceAuthority(options) {
       const timestamp = await E(timer).getCurrentTimestamp();
       return priceOutQuote(brandIn, amountOut, timestamp);
     },
-    quoteWhenGTE: (amountIn, amountOutLimit) => {
+    quoteWhenGTE: async (amountIn, amountOutLimit) => {
       const compareGTE = amount => AmountMath.isGTE(amount, amountOutLimit);
       return resolveQuoteWhen(compareGTE, amountIn, amountOutLimit);
     },
-    quoteWhenGT: (amountIn, amountOutLimit) => {
+    quoteWhenGT: async (amountIn, amountOutLimit) => {
       const compareGT = amount => !AmountMath.isGTE(amountOutLimit, amount);
       return resolveQuoteWhen(compareGT, amountIn, amountOutLimit);
     },
-    quoteWhenLTE: (amountIn, amountOutLimit) => {
+    quoteWhenLTE: async (amountIn, amountOutLimit) => {
       const compareLTE = amount => AmountMath.isGTE(amountOutLimit, amount);
       return resolveQuoteWhen(compareLTE, amountIn, amountOutLimit);
     },
-    quoteWhenLT: (amountIn, amountOutLimit) => {
+    quoteWhenLT: async (amountIn, amountOutLimit) => {
       const compareLT = amount => !AmountMath.isGTE(amount, amountOutLimit);
       return resolveQuoteWhen(compareLT, amountIn, amountOutLimit);
     },

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -242,7 +242,7 @@ export async function makeFakePriceAuthority(options) {
     latestTick = timestamp;
   }
 
-  function resolveQuoteWhen(operator, amountIn, amountOutLimit) {
+  async function resolveQuoteWhen(operator, amountIn, amountOutLimit) {
     assertBrands(amountIn.brand, amountOutLimit.brand);
     const promiseKit = makePromiseKit();
     const req = {

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -54,29 +54,29 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // test-only state can be provided from contracts
   // to their tests.
   const admin = Far('vatAdmin', {
-    getBundleCap: bundleID => {
+    getBundleCap: async bundleID => {
       if (!idToBundleCap.has(bundleID)) {
         idToBundleCap.init(bundleID, bogusBundleCap());
       }
       return Promise.resolve(idToBundleCap.get(bundleID));
     },
-    waitForBundleCap: bundleID => {
+    waitForBundleCap: async bundleID => {
       if (!idToBundleCap.has(bundleID)) {
         idToBundleCap.init(bundleID, bogusBundleCap());
       }
       return Promise.resolve(idToBundleCap.get(bundleID));
     },
-    getNamedBundleCap: name => {
+    getNamedBundleCap: async name => {
       if (name === 'zcf') {
         return Promise.resolve(zcfBundleCap);
       }
       const id = nameToBundleID.get(name);
       return Promise.resolve(idToBundleCap.get(id));
     },
-    getBundleIDByName: name => {
+    getBundleIDByName: async name => {
       return Promise.resolve().then(() => nameToBundleID.get(name));
     },
-    createVat: (bundleCap, { vatParameters = {} } = {}) => {
+    createVat: async (bundleCap, { vatParameters = {} } = {}) => {
       bundleCap === zcfBundleCap || Fail`fakeVatAdmin only knows ZCF`;
       const exitKit = makePromiseKit();
       handlePKitWarning(exitKit);
@@ -114,7 +114,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         harden({
           root,
           adminNode: Far('adminNode', {
-            done: () => {
+            done: async () => {
               return exitKit.promise;
             },
             terminateWithFailure: () => {},

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -55,7 +55,7 @@ export function makeManualPriceAuthority(options) {
     return floorDivideBy(amountOut, currentPrice);
   };
 
-  function createQuote(priceQuery) {
+  async function createQuote(priceQuery) {
     if (disabled) {
       throw Error('disabled');
     }

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -101,7 +101,7 @@ export const buildZoeManualTimer = (
   const toRT = rt =>
     TimeMath.coerceRelativeTimeRecord(rt, timerService.getTimerBrand());
 
-  const tick = msg => {
+  const tick = async msg => {
     const oldTime = timerService.getCurrentTimestamp();
     const newTime = TimeMath.addAbsRel(oldTime, toRT(timeStepValue));
     timerService.advanceTo(TimeMath.absValue(newTime), msg);


### PR DESCRIPTION
refs: #10809

## Description
Functions that return Promises should do so always. If they are synchronous and throw, the caller will get an exception instead of a rejected promise.

This enables https://typescript-eslint.io/rules/promise-function-async/ to ensure that promise-returning functions are marked `async`. Its level is  "warn" until we are confident to always require this.

Marking this draft because the ergonomics aren't great. We might want to add some features upstream before enabling this.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
