### PR TITLE
test: After updating vaultFactory params, verify the change

### DIFF
--- a/a3p-integration/proposals/z:acceptance/test/governance.test.js
+++ b/a3p-integration/proposals/z:acceptance/test/governance.test.js
@@ -20,8 +20,17 @@ const governanceDriver = await makeGovernanceDriver(fetch, networkConfig);
 test.serial(
   'economic committee can make governance proposal and vote on it',
   async t => {
+    const vaultFactoryParamsBefore = await readLatestHead(
+      'published.vaultFactory.governance',
+    );
+    const newChargingPeriod =
+      // @ts-expect-error it's a record
+      vaultFactoryParamsBefore.current.ChargingPeriod.value === 400n
+        ? 300n
+        : 400n;
+
     const params = {
-      ChargingPeriod: 400n,
+      ChargingPeriod: newChargingPeriod,
     };
     const instanceName = 'VaultFactory';
 
@@ -64,7 +73,7 @@ test.serial(
     t.is(
       // @ts-expect-error it's a record
       vaultFactoryParamsAfter.current.ChargingPeriod.value,
-      400n,
+      newChargingPeriod,
       'vaultFactory governed parameters did not match',
     );
   },

--- a/a3p-integration/proposals/z:acceptance/test/governance.test.js
+++ b/a3p-integration/proposals/z:acceptance/test/governance.test.js
@@ -17,14 +17,21 @@ const governanceAddresses = [GOV4ADDR, GOV2ADDR, GOV1ADDR];
 const { getLastUpdate, readLatestHead } = agdWalletUtils;
 const governanceDriver = await makeGovernanceDriver(fetch, networkConfig);
 
+/**
+ * @typedef {{
+ *   current: { ChargingPeriod: Amount },
+ *  }} ChargingPeriodRecord
+ */
+
 test.serial(
   'economic committee can make governance proposal and vote on it',
   async t => {
+    /** @type {ChargingPeriodRecord} */
+    // @ts-expect-error cast
     const vaultFactoryParamsBefore = await readLatestHead(
       'published.vaultFactory.governance',
     );
     const newChargingPeriod =
-      // @ts-expect-error it's a record
       vaultFactoryParamsBefore.current.ChargingPeriod.value === 400n
         ? 300n
         : 400n;
@@ -66,12 +73,13 @@ test.serial(
 
     await governanceDriver.waitForElection();
 
+    /** @type {ChargingPeriodRecord} */
+    // @ts-expect-error cast
     const vaultFactoryParamsAfter = await readLatestHead(
       'published.vaultFactory.governance',
     );
 
     t.is(
-      // @ts-expect-error it's a record
       vaultFactoryParamsAfter.current.ChargingPeriod.value,
       newChargingPeriod,
       'vaultFactory governed parameters did not match',


### PR DESCRIPTION
## Description

We noticed that after changing params for the VaultFactory, the test verified that the vote had completed, but not that the param change was effective. For a while we suspected that the change didn't take, but a simple enhancement to the test showed that wasn't the case.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Tests should verify the actual changes they make.

### Upgrade Considerations

This was one red herring we chased while validating upgrade. A clearer test would have made that chase shorter.
