### PR TITLE
fix A3P test of fast-usdc

### DIFF
--- a/a3p-integration/proposals/f:fast-usdc/README.md
+++ b/a3p-integration/proposals/f:fast-usdc/README.md
@@ -1,0 +1,6 @@
+# proposal for deploying fast-usdc
+
+Note that this will run after upgrade-next but for iteration speed it runs before n:upgrade-next in the build sequence.
+
+A consequence of this is that it can't use `yarn link` to get `@agoric/fast-usdc` because it's not in the base image. Instead it sources the packages from NPM using `dev` to get the latest master builds.
+

--- a/a3p-integration/proposals/f:fast-usdc/deploy.test.js
+++ b/a3p-integration/proposals/f:fast-usdc/deploy.test.js
@@ -1,17 +1,20 @@
 // @ts-check
-/* global globalThis */
+/* eslint-env node */
 import test from 'ava';
 import '@endo/init/legacy.js'; // axios compat
-import { makeVstorageKit } from '@agoric/client-utils';
+import { makeSmartWalletKit } from '@agoric/client-utils';
 
-const io = { fetch: globalThis.fetch };
+const io = {
+  delay: ms => new Promise(resolve => setTimeout(() => resolve(undefined), ms)),
+  fetch: global.fetch,
+};
 const networkConfig = {
   rpcAddrs: ['http://0.0.0.0:26657'],
   chainName: 'agoriclocal',
 };
 
 test('fastUsdc is in agoricNames.instance', async t => {
-  const { agoricNames } = await makeVstorageKit(io, networkConfig);
+  const { agoricNames } = await makeSmartWalletKit(io, networkConfig);
 
   t.log('agoricNames.instance keys', Object.keys(agoricNames.instance));
   t.truthy(agoricNames.instance.fastUsdc);

--- a/a3p-integration/proposals/f:fast-usdc/package.json
+++ b/a3p-integration/proposals/f:fast-usdc/package.json
@@ -13,6 +13,7 @@
     "@agoric/fast-usdc": "dev",
     "@agoric/synthetic-chain": "^0.4.3",
     "@endo/init": "^1.1.7",
+    "agoric": "dev",
     "ava": "^5.3.1"
   },
   "ava": {

--- a/a3p-integration/proposals/f:fast-usdc/package.json
+++ b/a3p-integration/proposals/f:fast-usdc/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/client-utils": "dev",
+    "@agoric/fast-usdc": "dev",
     "@agoric/synthetic-chain": "^0.4.3",
     "@endo/init": "^1.1.7",
     "ava": "^5.3.1"

--- a/a3p-integration/proposals/f:fast-usdc/test-cli.sh
+++ b/a3p-integration/proposals/f:fast-usdc/test-cli.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
+set -euo pipefail
 
-# FIXME these commands are run against the `@agoric/fast-usdc` pulled from NPM
-# but should be run against the local SDK. The `yarn link` command described in
-# a3p-integration/README.md is supposed to make that work but it's not working.
+# XXX the from address is gov1 but using that causes:
+# Error: gov1 is not a valid name or address: decoding bech32 failed: invalid bech32 string length 4
+# Usage:
+#   agd keys show [name_or_address [name_or_address...]] [flags]
 
-yarn @agoric/fast-usdc operator accept >| accept.json
+yarn fast-usdc operator accept >| accept.json
 cat accept.json
-yarn agoric wallet send --offer accept.json --from gov1 --keyring-backend="test"
+yarn agoric wallet send --offer accept.json --from agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q --keyring-backend test
 ACCEPT_OFFER_ID=$(agoric wallet extract-id --offer accept.json)
 
-# FIXME attest something
-yarn @agoric/fast-usdc operator attest --previousOfferId "$ACCEPT_OFFER_ID" >| attest.json
+yarn fast-usdc operator attest --previousOfferId="$ACCEPT_OFFER_ID" --forwardingChannel=foo --recipientAddress=agoric1foo --blockHash=0xfoo --blockNumber=1 --chainId=3 --amount=123 --forwardingAddress=noble1foo --sender 0xfoo --txHash=0xtx >| attest.json
 cat attest.json
-yarn agoric wallet send --offer attest.json --from gov1 --keyring-backend="test"
+yarn agoric wallet send --offer attest.json --from agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q --keyring-backend test
+
+# The data above are bogus and result in errors in the logs:
+# SwingSet: vat: v72: ----- TxFeed.11  8 publishing evidence { aux: { forwardingChannel: 'foo', recipientAddress: 'agoric1foo' }, blockHash: '0xfoo', blockNumber: 1n, chainId: 3, tx: { amount: 123n, forwardingAddress: 'noble1foo', sender: '0xfoo' }, txHash: '0xtx' } []
+# SwingSet: vat: v72: ----- Advancer.15  2 Advancer error: (Error#4)
+# SwingSet: vat: v72: Error#4: Data too short

--- a/a3p-integration/proposals/f:fast-usdc/test.sh
+++ b/a3p-integration/proposals/f:fast-usdc/test.sh
@@ -3,5 +3,4 @@ set -euo pipefail
 
 yarn ava
 
-# TODO get CLI test passing and part of CI
-./test-cli.sh || echo "CLI test failed"
+./test-cli.sh

--- a/a3p-integration/proposals/f:fast-usdc/yarn.lock
+++ b/a3p-integration/proposals/f:fast-usdc/yarn.lock
@@ -12,6 +12,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/access-token@npm:0.4.22-dev-4c2be7c.0+4c2be7c":
+  version: 0.4.22-dev-4c2be7c.0
+  resolution: "@agoric/access-token@npm:0.4.22-dev-4c2be7c.0"
+  dependencies:
+    n-readlines: "npm:^1.0.0"
+    proper-lockfile: "npm:^4.1.2"
+    tmp: "npm:^0.2.1"
+  checksum: 10c0/850796906a095a98a9350b70c7cb417bccbd13e24f33ea9536683d9a6c88510e51463ac9364c041e6e5eceb6e305e32a8bfb9d7c65d774f25e8cc005b90c2ccd
+  languageName: node
+  linkType: hard
+
 "@agoric/async-flow@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
   version: 0.1.1-dev-4c2be7c.0
   resolution: "@agoric/async-flow@npm:0.1.1-dev-4c2be7c.0"
@@ -54,6 +65,20 @@ __metadata:
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
   checksum: 10c0/2345d348d1cb8220014436c9361bc107231c468cb2e0ec52ae0327443c8606fa4d7e1f4fd6ddad663ce698b55900e157fb22f371848829f3614542260c9b01cf
+  languageName: node
+  linkType: hard
+
+"@agoric/cache@npm:0.3.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.3.3-dev-4c2be7c.0
+  resolution: "@agoric/cache@npm:0.3.3-dev-4c2be7c.0"
+  dependencies:
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@endo/far": "npm:^1.1.9"
+    "@endo/marshal": "npm:^1.6.2"
+  checksum: 10c0/f505ed6e8a2ac59d28e101dc80edd3bc5fffd497b3129ea6ebbd35010b58584fcbd91b737811fdad046e400a14045f6cc752b430cbdc666573357cf9df1df0a0
   languageName: node
   linkType: hard
 
@@ -188,6 +213,32 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.8"
     import-meta-resolve: "npm:^2.2.1"
   checksum: 10c0/cfe017f67d62887d857e69025be4c62a53502b5a3161449815df97783beebf792fa293249d831654a4af15e95b2d00c4d41e33b9cfdc44f45e66ad3ed658653d
+  languageName: node
+  linkType: hard
+
+"@agoric/inter-protocol@npm:0.16.2-dev-4c2be7c.0+4c2be7c":
+  version: 0.16.2-dev-4c2be7c.0
+  resolution: "@agoric/inter-protocol@npm:0.16.2-dev-4c2be7c.0"
+  dependencies:
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/governance": "npm:0.10.4-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/time": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vats": "npm:0.15.2-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
+    "@endo/captp": "npm:^4.4.3"
+    "@endo/errors": "npm:^1.2.8"
+    "@endo/eventual-send": "npm:^1.2.8"
+    "@endo/far": "npm:^1.1.9"
+    "@endo/marshal": "npm:^1.6.2"
+    "@endo/nat": "npm:^5.0.13"
+    "@endo/promise-kit": "npm:^1.1.8"
+    jessie.js: "npm:^0.3.4"
+  checksum: 10c0/33930a690c03b48d0c698f22a080e58eb6f31d0e5feece96861c5bbf7cb1e08563f83385af62eae6d47f94a476a1f1902e1e8d29d93530c1774a12acfeaeb86c
   languageName: node
   linkType: hard
 
@@ -634,6 +685,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
 "@confio/ics23@npm:^0.6.8":
   version: 0.6.8
   resolution: "@confio/ics23@npm:0.6.8"
@@ -641,6 +699,38 @@ __metadata:
     "@noble/hashes": "npm:^1.0.0"
     protobufjs: "npm:^6.8.8"
   checksum: 10c0/2f3f5032cd6a34c9b2fbd64bbf7e1cdec75ca71f348a770f7b5474b5027b12202bfbcd404eca931efddb5901f769af035a87cb8bddbf3f23d7e5d93c9d3d7f6f
+  languageName: node
+  linkType: hard
+
+"@confio/relayer@npm:^0.11.3":
+  version: 0.11.3
+  resolution: "@confio/relayer@npm:0.11.3"
+  dependencies:
+    "@cosmjs/cosmwasm-stargate": "npm:^0.32.1"
+    "@cosmjs/crypto": "npm:^0.32.1"
+    "@cosmjs/encoding": "npm:^0.32.1"
+    "@cosmjs/faucet-client": "npm:^0.32.1"
+    "@cosmjs/math": "npm:^0.32.1"
+    "@cosmjs/proto-signing": "npm:^0.32.1"
+    "@cosmjs/stargate": "npm:^0.32.1"
+    "@cosmjs/stream": "npm:^0.32.1"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.1"
+    "@cosmjs/utils": "npm:^0.32.1"
+    ajv: "npm:7.1.1"
+    axios: "npm:^1.6.7"
+    commander: "npm:7.1.0"
+    cosmjs-types: "npm:^0.9.0"
+    fast-safe-stringify: "npm:2.0.4"
+    js-yaml: "npm:4.0.0"
+    lodash: "npm:4.17.21"
+    prom-client: "npm:13.1.0"
+    table: "npm:^6.7.1"
+    triple-beam: "npm:1.3.0"
+    winston: "npm:3.3.3"
+  bin:
+    ibc-relayer: build/binary/ibc-relayer/index.js
+    ibc-setup: build/binary/ibc-setup/index.js
+  checksum: 10c0/f6519a21a7e2b7d79835558305bbac6f6712b90f0e10f2c156ae74583ca170da0b97ec456272c25a2ffdcbe0343ad425e67886b792f2aed1f5303e34b93edf40
   languageName: node
   linkType: hard
 
@@ -668,7 +758,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/crypto@npm:^0.32.3, @cosmjs/crypto@npm:^0.32.4":
+"@cosmjs/cosmwasm-stargate@npm:^0.32.1":
+  version: 0.32.4
+  resolution: "@cosmjs/cosmwasm-stargate@npm:0.32.4"
+  dependencies:
+    "@cosmjs/amino": "npm:^0.32.4"
+    "@cosmjs/crypto": "npm:^0.32.4"
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@cosmjs/math": "npm:^0.32.4"
+    "@cosmjs/proto-signing": "npm:^0.32.4"
+    "@cosmjs/stargate": "npm:^0.32.4"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.4"
+    "@cosmjs/utils": "npm:^0.32.4"
+    cosmjs-types: "npm:^0.9.0"
+    pako: "npm:^2.0.2"
+  checksum: 10c0/f7e285c51ef8b1098a9ea5ca2546a1e226b4fa0a990d95faa6f3b752f3638b6c55f36a56b6f4b11f0a66fd61e3ae8772921d8e99418218df0b2205efe1c82f37
+  languageName: node
+  linkType: hard
+
+"@cosmjs/crypto@npm:^0.32.1, @cosmjs/crypto@npm:^0.32.3, @cosmjs/crypto@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/crypto@npm:0.32.4"
   dependencies:
@@ -694,7 +802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/encoding@npm:^0.32.3, @cosmjs/encoding@npm:^0.32.4":
+"@cosmjs/encoding@npm:^0.32.1, @cosmjs/encoding@npm:^0.32.3, @cosmjs/encoding@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/encoding@npm:0.32.4"
   dependencies:
@@ -702,6 +810,15 @@ __metadata:
     bech32: "npm:^1.1.4"
     readonly-date: "npm:^1.0.0"
   checksum: 10c0/4a30d5ae1a2d1247d44bda46101ce208c7666d8801ca9a33de94edc35cc22460c16b4834ec84d5a65ffef5e2a4b58605e0a0a056c46bc0a042979ec84acf20cd
+  languageName: node
+  linkType: hard
+
+"@cosmjs/faucet-client@npm:^0.32.1":
+  version: 0.32.4
+  resolution: "@cosmjs/faucet-client@npm:0.32.4"
+  dependencies:
+    axios: "npm:^1.6.0"
+  checksum: 10c0/1651cb370eb5fa2b12b6f94e06d1dc9a6306e34cad3fc87d9263d8b8a225d500449e10a9f6e326534f65261778208dab7fada6a70efb63195589ad08f58e1008
   languageName: node
   linkType: hard
 
@@ -724,7 +841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/math@npm:^0.32.3, @cosmjs/math@npm:^0.32.4":
+"@cosmjs/math@npm:^0.32.1, @cosmjs/math@npm:^0.32.3, @cosmjs/math@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/math@npm:0.32.4"
   dependencies:
@@ -747,7 +864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/proto-signing@npm:^0.32.3, @cosmjs/proto-signing@npm:^0.32.4":
+"@cosmjs/proto-signing@npm:^0.32.1, @cosmjs/proto-signing@npm:^0.32.3, @cosmjs/proto-signing@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/proto-signing@npm:0.32.4"
   dependencies:
@@ -791,7 +908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/stargate@npm:^0.32.3, @cosmjs/stargate@npm:^0.32.4":
+"@cosmjs/stargate@npm:^0.32.1, @cosmjs/stargate@npm:^0.32.3, @cosmjs/stargate@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/stargate@npm:0.32.4"
   dependencies:
@@ -809,7 +926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/stream@npm:^0.32.3, @cosmjs/stream@npm:^0.32.4":
+"@cosmjs/stream@npm:^0.32.1, @cosmjs/stream@npm:^0.32.3, @cosmjs/stream@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/stream@npm:0.32.4"
   dependencies:
@@ -818,7 +935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/tendermint-rpc@npm:^0.32.3, @cosmjs/tendermint-rpc@npm:^0.32.4":
+"@cosmjs/tendermint-rpc@npm:^0.32.1, @cosmjs/tendermint-rpc@npm:^0.32.3, @cosmjs/tendermint-rpc@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/tendermint-rpc@npm:0.32.4"
   dependencies:
@@ -836,10 +953,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/utils@npm:^0.32.3, @cosmjs/utils@npm:^0.32.4":
+"@cosmjs/utils@npm:^0.32.1, @cosmjs/utils@npm:^0.32.3, @cosmjs/utils@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/utils@npm:0.32.4"
   checksum: 10c0/d5ff8b235094be1150853a715116049f73eb5cdfeea8ce8e22ecccc61ec99792db457404d4307782b1a2f935dcf438f5c485beabfcfbc1dc5df26eb6e6da9062
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: "npm:1.1.x"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: 10c0/a5133df8492802465ed01f2f0a5784585241a1030c362d54a602ed1839816d6c93d71dde05cf2ddb4fd0796238c19774406bd62fa2564b637907b495f52425fe
   languageName: node
   linkType: hard
 
@@ -1146,6 +1274,13 @@ __metadata:
   peerDependencies:
     ava: ^4 || ^5 || ^6
   checksum: 10c0/3800098fd7e8098102544a2f7a595351d063a7ebaeca18ed4901df5ec2679da2330ba8c0db2c820721d4cbb3e23d817ba22fec6d058957930e229f44fa71a684
+  languageName: node
+  linkType: hard
+
+"@iarna/toml@npm:^2.2.3":
+  version: 2.2.5
+  resolution: "@iarna/toml@npm:2.2.5"
+  checksum: 10c0/d095381ad4554aca233b7cf5a91f243ef619e5e15efd3157bc640feac320545450d14b394aebbf6f02a2047437ced778ae598d5879a995441ab7b6c0b2c2f201
   languageName: node
   linkType: hard
 
@@ -1495,6 +1630,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -1556,6 +1698,94 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agoric@npm:dev":
+  version: 0.21.2-dev-4c2be7c.0
+  resolution: "agoric@npm:0.21.2-dev-4c2be7c.0"
+  dependencies:
+    "@agoric/access-token": "npm:0.4.22-dev-4c2be7c.0+4c2be7c"
+    "@agoric/cache": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/casting": "npm:0.4.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/client-utils": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/cosmic-proto": "npm:0.4.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/governance": "npm:0.10.4-dev-4c2be7c.0+4c2be7c"
+    "@agoric/inter-protocol": "npm:0.16.2-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/network": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/smart-wallet": "npm:0.5.4-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-vat": "npm:0.32.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vats": "npm:0.15.2-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
+    "@confio/relayer": "npm:^0.11.3"
+    "@cosmjs/crypto": "npm:^0.32.3"
+    "@cosmjs/encoding": "npm:^0.32.3"
+    "@cosmjs/math": "npm:^0.32.3"
+    "@cosmjs/proto-signing": "npm:^0.32.3"
+    "@cosmjs/stargate": "npm:^0.32.3"
+    "@endo/bundle-source": "npm:^3.5.0"
+    "@endo/captp": "npm:^4.4.3"
+    "@endo/compartment-mapper": "npm:^1.4.0"
+    "@endo/env-options": "npm:^1.1.8"
+    "@endo/errors": "npm:^1.2.8"
+    "@endo/far": "npm:^1.1.9"
+    "@endo/init": "npm:^1.1.7"
+    "@endo/marshal": "npm:^1.6.2"
+    "@endo/nat": "npm:^5.0.13"
+    "@endo/patterns": "npm:^1.4.7"
+    "@endo/promise-kit": "npm:^1.1.8"
+    "@endo/zip": "npm:^1.0.9"
+    "@iarna/toml": "npm:^2.2.3"
+    anylogger: "npm:^0.21.0"
+    chalk: "npm:^5.2.0"
+    commander: "npm:^12.1.0"
+    deterministic-json: "npm:^1.0.5"
+    esm: "github:agoric-labs/esm#Agoric-built"
+    inquirer: "npm:^8.2.2"
+    opener: "npm:^1.5.2"
+    tmp: "npm:^0.2.1"
+    ws: "npm:^7.2.0"
+  bin:
+    agops: src/bin-agops.js
+    agoric: src/entrypoint.js
+  checksum: 10c0/7a7301a3ae2f48afcd874339fe95082a10e68c50b97b5f38c3705c5ed36701479dc4d0ee76436d45187de05f5d2c96ff52aa0f614b1627c519f2624291d04e4f
+  languageName: node
+  linkType: hard
+
+"ajv@npm:7.1.1":
+  version: 7.1.1
+  resolution: "ajv@npm:7.1.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+    uri-js: "npm:^4.2.2"
+  checksum: 10c0/328a86011a67dc10eff41e3e2ef412f88f5de546ad2288c8a3d2a563c203dd4dd479660c07f99fd9499e36c723afee212704b25f5599815991409528fd638329
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.1":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
+  languageName: node
+  linkType: hard
+
+"ansi-escapes@npm:^4.2.1":
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
+  dependencies:
+    type-fest: "npm:^0.21.3"
+  checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -1570,7 +1800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0":
+"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -1612,6 +1842,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
+  languageName: node
+  linkType: hard
+
 "array-find-index@npm:^1.0.1":
   version: 1.0.2
   resolution: "array-find-index@npm:1.0.2"
@@ -1630,6 +1867,20 @@ __metadata:
   version: 3.0.0
   resolution: "arrify@npm:3.0.0"
   checksum: 10c0/2e26601b8486f29780f1f70f7ac05a226755814c2a3ab42e196748f650af1dc310cd575a11dd4b9841c70fd7460b2dd2b8fe6fb7a3375878e2660706efafa58e
+  languageName: node
+  linkType: hard
+
+"astral-regex@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "astral-regex@npm:2.0.0"
+  checksum: 10c0/f63d439cc383db1b9c5c6080d1e240bd14dae745f15d11ec5da863e182bbeca70df6c8191cffef5deba0b566ef98834610a68be79ac6379c95eeb26e1b310e25
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.1.0":
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
   languageName: node
   linkType: hard
 
@@ -1709,6 +1960,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.6.7":
+  version: 1.7.9
+  resolution: "axios@npm:1.7.9"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/b7a41e24b59fee5f0f26c1fc844b45b17442832eb3a0fb42dd4f1430eb4abc571fe168e67913e8a1d91c993232bd1d1ab03e20e4d1fee8c6147649b576fc1b0b
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -1764,7 +2026,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.3":
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 10c0/132944b20c93c1a8f97bf8aa25980a76c6eb4291b7f2df2dbcd01cb5b417c287d3ee0847c7260c9f05f3d5a4233aaa03dec95114e97f308abe9cc3f72bed4a44
+  languageName: node
+  linkType: hard
+
+"bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -1868,6 +2137,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "call-bind-apply-helpers@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/acb2ab68bf2718e68a3e895f0d0b73ccc9e45b9b6f210f163512ba76f91dab409eb8792f6dae188356f9095747512a3101646b3dea9d37fb8c7c6bf37796d18c
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "call-bind@npm:1.0.8"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10c0/a13819be0681d915144467741b69875ae5f4eba8961eb0bf322aab63ec87f8250eb6d6b0dcbb2e1349876412a56129ca338592b3829ef4343527f5f18a0752d4
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "call-bound@npm:1.0.3"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    get-intrinsic: "npm:^1.2.6"
+  checksum: 10c0/45257b8e7621067304b30dbd638e856cac913d31e8e00a80d6cf172911acd057846572d0b256b45e652d515db6601e2974a1b1a040e91b4fc36fb3dd86fa69cf
+  languageName: node
+  linkType: hard
+
 "callsites@npm:^4.0.0":
   version: 4.2.0
   resolution: "callsites@npm:4.2.0"
@@ -1884,10 +2185,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^5.2.0, chalk@npm:^5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 10c0/8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
   languageName: node
   linkType: hard
 
@@ -1968,6 +2286,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-cursor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "cli-cursor@npm:3.1.0"
+  dependencies:
+    restore-cursor: "npm:^3.1.0"
+  checksum: 10c0/92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:^2.5.0":
+  version: 2.9.2
+  resolution: "cli-spinners@npm:2.9.2"
+  checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
+  languageName: node
+  linkType: hard
+
 "cli-truncate@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-truncate@npm:3.1.0"
@@ -1975,6 +2309,13 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^5.0.0"
   checksum: 10c0/a19088878409ec0e5dc2659a5166929629d93cfba6d68afc9cde2282fd4c751af5b555bf197047e31c87c574396348d011b7aa806fec29c4139ea4f7f00b324c
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-width@npm:3.0.0"
+  checksum: 10c0/125a62810e59a2564268c80fdff56c23159a7690c003e34aeb2e68497dccff26911998ff49c33916fcfdf71e824322cc3953e3f7b48b27267c7a062c81348a9a
   languageName: node
   linkType: hard
 
@@ -1989,12 +2330,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clone@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "clone@npm:1.0.4"
+  checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
+  languageName: node
+  linkType: hard
+
 "code-excerpt@npm:^4.0.0":
   version: 4.0.0
   resolution: "code-excerpt@npm:4.0.0"
   dependencies:
     convert-to-spaces: "npm:^2.0.1"
   checksum: 10c0/b6c5a06e039cecd2ab6a0e10ee0831de8362107d1f298ca3558b5f9004cb8e0260b02dd6c07f57b9a0e346c76864d2873311ee1989809fdeb05bd5fbbadde773
+  languageName: node
+  linkType: hard
+
+"color-convert@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "color-convert@npm:1.9.3"
+  dependencies:
+    color-name: "npm:1.1.3"
+  checksum: 10c0/5ad3c534949a8c68fca8fbc6f09068f435f0ad290ab8b2f76841b9e6af7e0bb57b98cb05b0e19fe33f5d91e5a8611ad457e5f69e0a484caad1f7487fd0e8253c
   languageName: node
   linkType: hard
 
@@ -2007,10 +2364,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:1.1.3":
+  version: 1.1.3
+  resolution: "color-name@npm:1.1.3"
+  checksum: 10c0/566a3d42cca25b9b3cd5528cd7754b8e89c0eb646b7f214e8e2eaddb69994ac5f0557d9c175eb5d8f0ad73531140d9c47525085ee752a91a2ab15ab459caf6d6
+  languageName: node
+  linkType: hard
+
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: "npm:^1.0.0"
+    simple-swizzle: "npm:^0.2.2"
+  checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.3"
+    color-string: "npm:^1.6.0"
+  checksum: 10c0/39345d55825884c32a88b95127d417a2c24681d8b57069413596d9fcbb721459ef9d9ec24ce3e65527b5373ce171b73e38dbcd9c830a52a6487e7f37bf00e83c
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: "npm:^3.1.3"
+    text-hex: "npm:1.0.x"
+  checksum: 10c0/af5f91ff7f8e146b96e439ac20ed79b197210193bde721b47380a75b21751d90fa56390c773bb67c0aedd34ff85091883a437ab56861c779bd507d639ba7e123
   languageName: node
   linkType: hard
 
@@ -2020,6 +2414,13 @@ __metadata:
   dependencies:
     delayed-stream: "npm:~1.0.0"
   checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
+"commander@npm:7.1.0":
+  version: 7.1.0
+  resolution: "commander@npm:7.1.0"
+  checksum: 10c0/1c114cc2e0c7c980068d7f2472f3fc9129ea5d6f2f0a8699671afe5a44a51d5707a6c73daff1aaa919424284dea9fca4017307d30647935a1116518699d54c9d
   languageName: node
   linkType: hard
 
@@ -2152,7 +2553,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-data-property@npm:^1.0.1":
+"defaults@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "defaults@npm:1.0.4"
+  dependencies:
+    clone: "npm:^1.0.2"
+  checksum: 10c0/9cfbe498f5c8ed733775db62dfd585780387d93c17477949e1670bfcfb9346e0281ce8c4bf9f4ac1fc0f9b851113bd6dc9e41182ea1644ccd97de639fa13c35a
+  languageName: node
+  linkType: hard
+
+"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
   version: 1.1.4
   resolution: "define-data-property@npm:1.1.4"
   dependencies:
@@ -2188,12 +2598,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deterministic-json@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "deterministic-json@npm:1.0.5"
+  dependencies:
+    json-stable-stringify: "npm:^1.0.1"
+  checksum: 10c0/e29679601cd3b05c73665529dcd0132b48797fd7dfbac6793238a479e82b5f3905114316fbb316332da58b4497e35df9aea77b41ff92fd74fe298a6f31b93d40
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
+  languageName: node
+  linkType: hard
+
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
   languageName: node
   linkType: hard
 
@@ -2240,6 +2670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 10c0/3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -2281,10 +2718,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
+  languageName: node
+  linkType: hard
+
 "es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-object-atoms@npm:1.0.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10c0/1fed3d102eb27ab8d983337bb7c8b159dd2a1e63ff833ec54eea1311c96d5b08223b433060ba240541ca8adba9eee6b0a60cdbf2f80634b784febc9cc8b687b4
   languageName: node
   linkType: hard
 
@@ -2302,10 +2755,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "escape-string-regexp@npm:1.0.5"
+  checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^2.0.0":
   version: 2.0.0
   resolution: "escape-string-regexp@npm:2.0.0"
   checksum: 10c0/2530479fe8db57eace5e8646c9c2a9c80fa279614986d16dcc6bcaceb63ae77f05a851ba6c43756d816c61d7f4534baf56e3c705e3e0d884818a46808811c507
+  languageName: node
+  linkType: hard
+
+"esm@github:agoric-labs/esm#Agoric-built":
+  version: 3.2.25
+  resolution: "esm@https://github.com/agoric-labs/esm.git#commit=3603726ad4636b2f865f463188fcaade6375638e"
+  checksum: 10c0/fc1e112a3a681e7b4152d4f5c76dd5aa9e30496d2020490ffa0fb61aaf57d1e12dae0c1074fdd2e0f08949ab2df7e00e750262356781f072e4119955ee10b754
   languageName: node
   linkType: hard
 
@@ -2386,12 +2853,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"external-editor@npm:^3.0.3":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
 "fast-check@npm:^3.0.0":
   version: 3.23.1
   resolution: "fast-check@npm:3.23.1"
   dependencies:
     pure-rand: "npm:^6.1.0"
   checksum: 10c0/d61ee4a7a2e1abc5126bf2f1894413f532f686b3d1fc15c67fefb60dcca66024934b69a6454d3eba92e6568ac1abbb9882080e212d255865c3b3bbe52c5bf702
+  languageName: node
+  linkType: hard
+
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
   languageName: node
   linkType: hard
 
@@ -2415,12 +2900,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-safe-stringify@npm:2.0.4":
+  version: 2.0.4
+  resolution: "fast-safe-stringify@npm:2.0.4"
+  checksum: 10c0/5e4fbafe8b8c4a1681c2ab259ed8ce6672fc209683a141876f020c36a2cbec73bfe25c417c269f439797020996d04ed2d7c4c6b2c5cf393d6febbf7f4d8a5f53
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.0.5
+  resolution: "fast-uri@npm:3.0.5"
+  checksum: 10c0/f5501fd849e02f16f1730d2c8628078718c492b5bc00198068bc5c2880363ae948287fdc8cebfff47465229b517dbeaf668866fbabdff829b4138a899e5c2ba3
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.17.1
   resolution: "fastq@npm:1.17.1"
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/1095f16cea45fb3beff558bb3afa74ca7a9250f5a670b65db7ed585f92b4b48381445cd328b3d87323da81e43232b5d5978a8201bde84e0cd514310f1ea6da34
+  languageName: node
+  linkType: hard
+
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
+  languageName: node
+  linkType: hard
+
+"figures@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "figures@npm:3.2.0"
+  dependencies:
+    escape-string-regexp: "npm:^1.0.5"
+  checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
   languageName: node
   linkType: hard
 
@@ -2464,6 +2979,13 @@ __metadata:
     locate-path: "npm:^7.1.0"
     path-exists: "npm:^5.0.0"
   checksum: 10c0/07e0314362d316b2b13f7f11ea4692d5191e718ca3f7264110127520f3347996349bf9e16805abae3e196805814bc66ef4bff2b8904dc4a6476085fc9b0eba07
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 10c0/8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
   languageName: node
   linkType: hard
 
@@ -2576,6 +3098,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.6":
+  version: 1.2.7
+  resolution: "get-intrinsic@npm:1.2.7"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    function-bind: "npm:^1.1.2"
+    get-proto: "npm:^1.0.0"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/b475dec9f8bff6f7422f51ff4b7b8d0b68e6776ee83a753c1d627e3008c3442090992788038b37eff72e93e43dceed8c1acbdf2d6751672687ec22127933080d
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
+  languageName: node
+  linkType: hard
+
 "get-stream@npm:^8.0.1":
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
@@ -2668,14 +3218,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.6":
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
   languageName: node
   linkType: hard
 
-"has-property-descriptors@npm:^1.0.0":
+"has-flag@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "has-flag@npm:4.0.0"
+  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-property-descriptors@npm:1.0.2"
   dependencies:
@@ -2695,6 +3259,13 @@ __metadata:
   version: 1.0.3
   resolution: "has-symbols@npm:1.0.3"
   checksum: 10c0/e6922b4345a3f37069cdfe8600febbca791c94988c01af3394d86ca3360b4b93928bbf395859158f88099cb10b19d98e3bbab7c9ff2c1bd09cf665ee90afa2c3
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
   languageName: node
   linkType: hard
 
@@ -2759,6 +3330,15 @@ __metadata:
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0"
   checksum: 10c0/5a9359073fe17a8b58e5a085e9a39a950366d9f00217c4ff5878bd312e09d80f460536ea6a3f260b5943a01fe55c158d1cea3fc7bee3d0520aeef04f6d915c82
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
   languageName: node
   linkType: hard
 
@@ -2844,6 +3424,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inquirer@npm:^8.2.2":
+  version: 8.2.6
+  resolution: "inquirer@npm:8.2.6"
+  dependencies:
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.1"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^3.0.0"
+    external-editor: "npm:^3.0.3"
+    figures: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mute-stream: "npm:0.0.8"
+    ora: "npm:^5.4.1"
+    run-async: "npm:^2.4.0"
+    rxjs: "npm:^7.5.5"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    through: "npm:^2.3.6"
+    wrap-ansi: "npm:^6.0.1"
+  checksum: 10c0/eb5724de1778265323f3a68c80acfa899378cb43c24cdcb58661386500e5696b6b0b6c700e046b7aa767fe7b4823c6f04e6ddc268173e3f84116112529016296
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -2858,6 +3461,13 @@ __metadata:
   version: 3.5.0
   resolution: "irregular-plurals@npm:3.5.0"
   checksum: 10c0/7c033bbe7325e5a6e0a26949cc6863b6ce273403d4cd5b93bd99b33fecb6605b0884097c4259c23ed0c52c2133bf7d1cdcdd7a0630e8c325161fe269b3447918
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 10c0/f59b43dc1d129edb6f0e282595e56477f98c40278a2acdc8b0a5c57097c9eff8fe55470493df5775478cf32a4dc8eaf6d3a749f07ceee5bc263a78b2434f6a54
   languageName: node
   linkType: hard
 
@@ -2925,6 +3535,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-interactive@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-interactive@npm:1.0.0"
+  checksum: 10c0/dd47904dbf286cd20aa58c5192161be1a67138485b9836d5a70433b21a45442e9611b8498b8ab1f839fc962c7620667a50535fdfb4a6bc7989b8858645c06b4d
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
@@ -2969,6 +3586,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-stream@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
+  languageName: node
+  linkType: hard
+
 "is-stream@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-stream@npm:3.0.0"
@@ -2976,10 +3600,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: 10c0/00cbe3455c3756be68d2542c416cab888aebd5012781d6819749fefb15162ff23e38501fe681b3d751c73e8ff561ac09a5293eba6f58fdf0178462ce6dcb3453
+  languageName: node
+  linkType: hard
+
 "is-unicode-supported@npm:^1.2.0":
   version: 1.3.0
   resolution: "is-unicode-supported@npm:1.3.0"
   checksum: 10c0/b8674ea95d869f6faabddc6a484767207058b91aea0250803cbf1221345cb0c56f466d4ecea375dc77f6633d248d33c47bd296fb8f4cdba0b4edba8917e83d8a
+  languageName: node
+  linkType: hard
+
+"isarray@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "isarray@npm:2.0.5"
+  checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
   languageName: node
   linkType: hard
 
@@ -3042,6 +3680,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:4.0.0":
+  version: 4.0.0
+  resolution: "js-yaml@npm:4.0.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/ef8489b87d9796b45df9f0bf3eefbb343b5063e39a9911d7b8ddbd4518cafaf73b49150d1f5865f54ee68719642ff0ab86110b9a332ff88bb05cd3bcf3039de1
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^3.14.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
@@ -3079,6 +3728,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-stable-stringify@npm:^1.0.1":
+  version: 1.2.1
+  resolution: "json-stable-stringify@npm:1.2.1"
+  dependencies:
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.3"
+    isarray: "npm:^2.0.5"
+    jsonify: "npm:^0.0.1"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/e623e7ce89282f089d56454087edb717357e8572089b552fbc6980fb7814dc3943f7d0e4f1a19429a36ce9f4428b6c8ee6883357974457aaaa98daba5adebeea
+  languageName: node
+  linkType: hard
+
+"jsonify@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "jsonify@npm:0.0.1"
+  checksum: 10c0/7f5499cdd59a0967ed35bda48b7cec43d850bbc8fb955cdd3a1717bb0efadbe300724d5646de765bb7a99fc1c3ab06eb80d93503c6faaf99b4ff50a3326692f6
+  languageName: node
+  linkType: hard
+
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 10c0/0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
 "libsodium-sumo@npm:^0.7.15":
   version: 0.7.15
   resolution: "libsodium-sumo@npm:0.7.15"
@@ -3111,10 +3794,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15":
+"lodash.truncate@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.truncate@npm:4.4.2"
+  checksum: 10c0/4e870d54e8a6c86c8687e057cec4069d2e941446ccab7f40b4d9555fa5872d917d0b6aa73bece7765500a3123f1723bcdba9ae881b679ef120bba9e1a0b0ed70
+  languageName: node
+  linkType: hard
+
+"lodash@npm:4.17.21, lodash@npm:^4.17.15, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
+"log-symbols@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: "npm:^4.1.0"
+    is-unicode-supported: "npm:^0.1.0"
+  checksum: 10c0/67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.2.0, logform@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "logform@npm:2.7.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/4789b4b37413c731d1835734cb799240d31b865afde6b7b3e06051d6a4127bfda9e88c99cfbf296d084a315ccbed2647796e6a56b66e725bcb268c586f57558f
   languageName: node
   linkType: hard
 
@@ -3176,6 +3890,13 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^5.0.0"
   checksum: 10c0/eda5471fc9d5b7264d63c81727824adc3585ddb5cfdc5fce5a9b7c86f946ff181610735d330b1c37a84811df872d1290bf4e9401d2be2a414204343701144b18
+  languageName: node
+  linkType: hard
+
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
   languageName: node
   linkType: hard
 
@@ -3246,6 +3967,13 @@ __metadata:
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "mimic-fn@npm:2.1.0"
+  checksum: 10c0/b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
   languageName: node
   linkType: hard
 
@@ -3402,10 +4130,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.3":
+"ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:0.0.8":
+  version: 0.0.8
+  resolution: "mute-stream@npm:0.0.8"
+  checksum: 10c0/18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
+  languageName: node
+  linkType: hard
+
+"n-readlines@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "n-readlines@npm:1.0.3"
+  checksum: 10c0/436c27ac071409314093da35dc3a4c5198c94fb10ad12b1c4d2b3e44bdb634da0a7a8ab0c107c1f4815788cbf5e0c7c180e3037ba3d974f34637cab363a95a74
   languageName: node
   linkType: hard
 
@@ -3522,12 +4264,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 10c0/6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^5.1.0":
+  version: 5.1.2
+  resolution: "onetime@npm:5.1.2"
+  dependencies:
+    mimic-fn: "npm:^2.1.0"
+  checksum: 10c0/ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
+  languageName: node
+  linkType: hard
+
 "onetime@npm:^6.0.0":
   version: 6.0.0
   resolution: "onetime@npm:6.0.0"
   dependencies:
     mimic-fn: "npm:^4.0.0"
   checksum: 10c0/4eef7c6abfef697dd4479345a4100c382d73c149d2d56170a54a07418c50816937ad09500e1ed1e79d235989d073a9bade8557122aee24f0576ecde0f392bb6c
+  languageName: node
+  linkType: hard
+
+"opener@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 10c0/dd56256ab0cf796585617bc28e06e058adf09211781e70b264c76a1dbe16e90f868c974e5bf5309c93469157c7d14b89c35dc53fe7293b0e40b4d2f92073bc79
+  languageName: node
+  linkType: hard
+
+"ora@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "ora@npm:5.4.1"
+  dependencies:
+    bl: "npm:^4.1.0"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-spinners: "npm:^2.5.0"
+    is-interactive: "npm:^1.0.0"
+    is-unicode-supported: "npm:^0.1.0"
+    log-symbols: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    wcwidth: "npm:^1.0.1"
+  checksum: 10c0/10ff14aace236d0e2f044193362b22edce4784add08b779eccc8f8ef97195cae1248db8ec1ec5f5ff076f91acbe573f5f42a98c19b78dba8c54eefff983cae85
+  languageName: node
+  linkType: hard
+
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -3594,6 +4387,13 @@ __metadata:
   version: 1.0.1
   resolution: "package-json-from-dist@npm:1.0.1"
   checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
+"pako@npm:^2.0.2":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 10c0/8e8646581410654b50eb22a5dfd71159cae98145bd5086c9a7a816ec0370b5f72b4648d08674624b3870a521e6a3daffd6c2f7bc00fdefc7063c9d8232ff5116
   languageName: node
   linkType: hard
 
@@ -3734,6 +4534,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:13.1.0":
+  version: 13.1.0
+  resolution: "prom-client@npm:13.1.0"
+  dependencies:
+    tdigest: "npm:^0.1.1"
+  checksum: 10c0/0f117e044bdbc7e8fb3a926e16e0e76ff3fb308dbc98fdb084dfa16ad52a0b68cf6a79a31e907b1c4ac9009b1d50848e3e72fb36ed43893291148e1505844fc2
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -3741,6 +4550,17 @@ __metadata:
     err-code: "npm:^2.0.2"
     retry: "npm:^0.12.0"
   checksum: 10c0/9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
+  languageName: node
+  linkType: hard
+
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    retry: "npm:^0.12.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/2f265dbad15897a43110a02dae55105c04d356ec4ed560723dcb9f0d34bc4fb2f13f79bb930e7561be10278e2314db5aca2527d5d3dcbbdee5e6b331d1571f6d
   languageName: node
   linkType: hard
 
@@ -3785,6 +4605,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
 "pure-rand@npm:^6.1.0":
   version: 6.1.0
   resolution: "pure-rand@npm:6.1.0"
@@ -3824,7 +4651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -3855,6 +4682,13 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
   languageName: node
   linkType: hard
 
@@ -3900,6 +4734,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "restore-cursor@npm:3.1.0"
+  dependencies:
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -3936,9 +4780,17 @@ __metadata:
     "@agoric/fast-usdc": "npm:dev"
     "@agoric/synthetic-chain": "npm:^0.4.3"
     "@endo/init": "npm:^1.1.7"
+    agoric: "npm:dev"
     ava: "npm:^5.3.1"
   languageName: unknown
   linkType: soft
+
+"run-async@npm:^2.4.0":
+  version: 2.4.1
+  resolution: "run-async@npm:2.4.1"
+  checksum: 10c0/35a68c8f1d9664f6c7c2e153877ca1d6e4f886e5ca067c25cdd895a6891ff3a1466ee07c63d6a9be306e9619ff7d509494e6d9c129516a36b9fd82263d579ee1
+  languageName: node
+  linkType: hard
 
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
@@ -3949,6 +4801,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.5.5":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/3c49c1ecd66170b175c9cacf5cef67f8914dcbc7cd0162855538d365c83fea631167cacb644b3ce533b2ea0e9a4d0b12175186985f89d75abe73dbd8f7f06f68
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -3956,7 +4817,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
+  languageName: node
+  linkType: hard
+
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -3999,6 +4867,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-function-length@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10c0/82850e62f412a258b71e123d4ed3873fa9377c216809551192bb6769329340176f109c2eeae8c22a8d386c76739855f78e8716515c818bcaef384b51110f0f3c
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -4012,6 +4894,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "signal-exit@npm:3.0.7"
+  checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
   languageName: node
   linkType: hard
 
@@ -4040,10 +4929,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: "npm:^0.3.1"
+  checksum: 10c0/df5e4662a8c750bdba69af4e8263c5d96fe4cd0f9fe4bdfa3cbdeb45d2e869dff640beaaeb1ef0e99db4d8d2ec92f85508c269f50c972174851bc1ae5bd64308
+  languageName: node
+  linkType: hard
+
 "slash@npm:^4.0.0":
   version: 4.0.0
   resolution: "slash@npm:4.0.0"
   checksum: 10c0/b522ca75d80d107fd30d29df0549a7b2537c83c4c4ecd12cd7d4ea6c8aaca2ab17ada002e7a1d78a9d736a0261509f26ea5b489082ee443a3a810586ef8eff18
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "slice-ansi@npm:4.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    astral-regex: "npm:^2.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+  checksum: 10c0/6c25678db1270d4793e0327620f1e0f9f5bea4630123f51e9e399191bc52c87d6e6de53ed33538609e5eacbd1fab769fae00f3705d08d029f02102a540648918
   languageName: node
   linkType: hard
 
@@ -4136,6 +5045,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
+  languageName: node
+  linkType: hard
+
 "stack-utils@npm:^2.0.6":
   version: 2.0.6
   resolution: "stack-utils@npm:2.0.6"
@@ -4220,6 +5136,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
+  languageName: node
+  linkType: hard
+
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
@@ -4231,6 +5156,19 @@ __metadata:
   version: 2.0.3
   resolution: "symbol-observable@npm:2.0.3"
   checksum: 10c0/03fb8766b75bfa65a3c7d68ae1e51a13a5ff71b40d6d53b17a0c9c77b1685c20a3bfbf45547ab36214a079665c3f551e250798f6b2f83a2a40762d864ed87f78
+  languageName: node
+  linkType: hard
+
+"table@npm:^6.7.1":
+  version: 6.9.0
+  resolution: "table@npm:6.9.0"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/35646185712bb65985fbae5975dda46696325844b78735f95faefae83e86df0a265277819a3e67d189de6e858c509b54e66ca3958ffd51bde56ef1118d455bf4
   languageName: node
   linkType: hard
 
@@ -4273,6 +5211,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tdigest@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "tdigest@npm:0.1.2"
+  dependencies:
+    bintrees: "npm:1.0.2"
+  checksum: 10c0/10187b8144b112fcdfd3a5e4e9068efa42c990b1e30cd0d4f35ee8f58f16d1b41bc587e668fa7a6f6ca31308961cbd06cd5d4a4ae1dc388335902ae04f7d57df
+  languageName: node
+  linkType: hard
+
 "temp-dir@npm:^3.0.0":
   version: 3.0.0
   resolution: "temp-dir@npm:3.0.0"
@@ -4280,10 +5227,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
+"through@npm:^2.3.6":
+  version: 2.3.8
+  resolution: "through@npm:2.3.8"
+  checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
+  languageName: node
+  linkType: hard
+
 "time-zone@npm:^1.0.0":
   version: 1.0.0
   resolution: "time-zone@npm:1.0.0"
   checksum: 10c0/d00ebd885039109011b6e2423ebbf225160927333c2ade6d833e9cc4676db20759f1f3855fafde00d1bd668c243a6aa68938ce71fe58aab0d514e820d59c1d81
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
   languageName: node
   linkType: hard
 
@@ -4303,6 +5273,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"triple-beam@npm:1.3.0":
+  version: 1.3.0
+  resolution: "triple-beam@npm:1.3.0"
+  checksum: 10c0/a6da96495f25b6c04b3629df5161c7eb84760927943f16665fd8dcd3a643daadf73d69eee78306b4b68d606937f22f8703afe763bc8d3723632ffb1f3a798493
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 10c0/4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
+  languageName: node
+  linkType: hard
+
 "ts-blank-space@npm:^0.4.1":
   version: 0.4.3
   resolution: "ts-blank-space@npm:0.4.3"
@@ -4319,6 +5303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.1.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
 "tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -4332,6 +5323,13 @@ __metadata:
   version: 0.13.1
   resolution: "type-fest@npm:0.13.1"
   checksum: 10c0/0c0fa07ae53d4e776cf4dac30d25ad799443e9eef9226f9fddbb69242db86b08584084a99885cfa5a9dfe4c063ebdc9aa7b69da348e735baede8d43f1aeae93b
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
   languageName: node
   linkType: hard
 
@@ -4400,10 +5398,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
+"wcwidth@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wcwidth@npm:1.0.1"
+  dependencies:
+    defaults: "npm:^1.0.3"
+  checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
   languageName: node
   linkType: hard
 
@@ -4436,6 +5452,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"winston-transport@npm:^4.4.0":
+  version: 4.9.0
+  resolution: "winston-transport@npm:4.9.0"
+  dependencies:
+    logform: "npm:^2.7.0"
+    readable-stream: "npm:^3.6.2"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/e2990a172e754dbf27e7823772214a22dc8312f7ec9cfba831e5ef30a5d5528792e5ea8f083c7387ccfc5b2af20e3691f64738546c8869086110a26f98671095
+  languageName: node
+  linkType: hard
+
+"winston@npm:3.3.3":
+  version: 3.3.3
+  resolution: "winston@npm:3.3.3"
+  dependencies:
+    "@dabh/diagnostics": "npm:^2.0.2"
+    async: "npm:^3.1.0"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.2.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.4.0"
+  checksum: 10c0/18205fa1e3ebb88dc910fbe5337e3c9d2dbd94310978adca5ab77444b854d5679dec0a70fed425e77cf93e237390c7670bb937f14c492b8415e594ab21540d3d
+  languageName: node
+  linkType: hard
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -4444,6 +5488,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^6.0.1":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
   languageName: node
   linkType: hard
 
@@ -4490,7 +5545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7":
+"ws@npm:^7, ws@npm:^7.2.0":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
   peerDependencies:

--- a/a3p-integration/proposals/f:fast-usdc/yarn.lock
+++ b/a3p-integration/proposals/f:fast-usdc/yarn.lock
@@ -5,6 +5,32 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@adraffy/ens-normalize@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@adraffy/ens-normalize@npm:1.10.1"
+  checksum: 10c0/fdd647604e8fac6204921888aaf5a6bc65eabf0d2921bc5f93b64d01f4bc33ead167c1445f7de05468d05cd92ac31b74c68d2be840c62b79d73693308f885c06
+  languageName: node
+  linkType: hard
+
+"@agoric/async-flow@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/async-flow@npm:0.1.1-dev-4c2be7c.0"
+  dependencies:
+    "@agoric/base-zone": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@endo/common": "npm:^1.2.8"
+    "@endo/errors": "npm:^1.2.8"
+    "@endo/eventual-send": "npm:^1.2.8"
+    "@endo/marshal": "npm:^1.6.2"
+    "@endo/pass-style": "npm:^1.4.7"
+    "@endo/patterns": "npm:^1.4.7"
+    "@endo/promise-kit": "npm:^1.1.8"
+  checksum: 10c0/85704c19211932b1b2288df7460d83087d74d80e6a8fe47e808bd6f715a1f1e8dcee3ff544053cf13cdb7923a239d677a5aa646ac803158e3d6a9269693782ba
+  languageName: node
+  linkType: hard
+
 "@agoric/babel-generator@npm:^7.17.6":
   version: 7.17.6
   resolution: "@agoric/babel-generator@npm:7.17.6"
@@ -16,28 +42,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/base-zone@npm:0.1.1-dev-9c61393.0+9c61393":
-  version: 0.1.1-dev-9c61393.0
-  resolution: "@agoric/base-zone@npm:0.1.1-dev-9c61393.0"
+"@agoric/base-zone@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/base-zone@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
     "@endo/common": "npm:^1.2.8"
     "@endo/errors": "npm:^1.2.8"
     "@endo/exo": "npm:^1.5.7"
     "@endo/far": "npm:^1.1.9"
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
-  checksum: 10c0/cb872856e25ddb0ea00714194d58db5058fefc306f6a74cb048de7fd75ff06e6283ad990e20c845b0633fadd9ef07f35d59e44a632dc763e9d506214772dc5d7
+  checksum: 10c0/2345d348d1cb8220014436c9361bc107231c468cb2e0ec52ae0327443c8606fa4d7e1f4fd6ddad663ce698b55900e157fb22f371848829f3614542260c9b01cf
   languageName: node
   linkType: hard
 
-"@agoric/casting@npm:0.4.3-dev-9c61393.0+9c61393":
-  version: 0.4.3-dev-9c61393.0
-  resolution: "@agoric/casting@npm:0.4.3-dev-9c61393.0"
+"@agoric/casting@npm:0.4.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.4.3-dev-4c2be7c.0
+  resolution: "@agoric/casting@npm:0.4.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/notifier": "npm:0.6.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
     "@cosmjs/encoding": "npm:^0.32.3"
     "@cosmjs/proto-signing": "npm:^0.32.3"
     "@cosmjs/stargate": "npm:^0.32.3"
@@ -48,19 +74,19 @@ __metadata:
     "@endo/lockdown": "npm:^1.0.13"
     "@endo/marshal": "npm:^1.6.2"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/2d491ae19f8264ec368bdb16db5f120a8f94de7c8fd54614434439a7f457f7d5539c123e8429b7af5a28fefe13e9543cba177f48fe0b0feb469e2482c8c1b7b7
+  checksum: 10c0/db7767ace541c67c728888383a3822b7eb48deb143e5da759ecaa54296a23cf750ac2a7b31b7598b51e09262426c601c67141ccc7ad45258d46135d60c0ecdea
   languageName: node
   linkType: hard
 
-"@agoric/client-utils@npm:dev":
-  version: 0.1.1-dev-9c61393.0
-  resolution: "@agoric/client-utils@npm:0.1.1-dev-9c61393.0"
+"@agoric/client-utils@npm:0.1.1-dev-4c2be7c.0+4c2be7c, @agoric/client-utils@npm:dev":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/client-utils@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
-    "@agoric/casting": "npm:0.4.3-dev-9c61393.0+9c61393"
-    "@agoric/ertp": "npm:0.16.3-dev-9c61393.0+9c61393"
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/smart-wallet": "npm:0.5.4-dev-9c61393.0+9c61393"
-    "@agoric/vats": "npm:0.15.2-dev-9c61393.0+9c61393"
+    "@agoric/casting": "npm:0.4.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/smart-wallet": "npm:0.5.4-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vats": "npm:0.15.2-dev-4c2be7c.0+4c2be7c"
     "@cosmjs/stargate": "npm:^0.32.3"
     "@cosmjs/tendermint-rpc": "npm:^0.32.3"
     "@endo/common": "npm:^1.2.8"
@@ -69,28 +95,30 @@ __metadata:
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/41792664f534d9e07e442ce726d6af675e967b4986aedc1b66758b0315c7fd10b4fe1ad2b509f8ddf54759f218f1da2d8a5347c1514c13ccfe56288b6c63e257
+  checksum: 10c0/a948544f7434baa38f6ef9dbe8c787157e52f4e0c03a57b4be28a4a1371ba051e3cfffb81166ca96fc0ecd6395295369f97ff2492a4aba16db3d392f10b6a82c
   languageName: node
   linkType: hard
 
-"@agoric/cosmic-proto@npm:0.4.1-dev-9c61393.0+9c61393":
-  version: 0.4.1-dev-9c61393.0
-  resolution: "@agoric/cosmic-proto@npm:0.4.1-dev-9c61393.0"
+"@agoric/cosmic-proto@npm:0.4.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.4.1-dev-4c2be7c.0
+  resolution: "@agoric/cosmic-proto@npm:0.4.1-dev-4c2be7c.0"
   dependencies:
     "@endo/base64": "npm:^1.0.9"
     "@endo/init": "npm:^1.1.7"
-  checksum: 10c0/55d09b61206feccfab98a67d41aa90381fa724d8b7018f5bf7d93db92f485f9fe8e1513c96be94be1e5377c3bc462d05aaf7a78064647166450e949150903603
+    bech32: "npm:^2.0.0"
+    query-string: "npm:^9.1.1"
+  checksum: 10c0/1d8bf3eb99e6b6687f487baec51cb19f63202a30c126826c036eba858619172d868f5a2c5924c0642a89f8d8db2bd6f1f9706b50efb5e81f12ca12129a439c14
   languageName: node
   linkType: hard
 
-"@agoric/ertp@npm:0.16.3-dev-9c61393.0+9c61393":
-  version: 0.16.3-dev-9c61393.0
-  resolution: "@agoric/ertp@npm:0.16.3-dev-9c61393.0"
+"@agoric/ertp@npm:0.16.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.16.3-dev-4c2be7c.0
+  resolution: "@agoric/ertp@npm:0.16.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/notifier": "npm:0.6.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
-    "@agoric/zone": "npm:0.2.3-dev-9c61393.0+9c61393"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/eventual-send": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
@@ -98,21 +126,58 @@ __metadata:
     "@endo/nat": "npm:^5.0.13"
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/c54db24d131c3f703e8d363650e747fbaa0ffb91e675169a90073483d28a6a1324c80085eb3c2a382971a918990202bcbda9e8548549e37db9ea54adeafd26da
+  checksum: 10c0/07e4ab7be77fc8e7c39668fbbd0d5b46abcdd6fc6b8609ba8318acd8fa23d78d2a3b89471f4b39e9615a9f29e7b99662afae3753b4bbd90eb08a8038121409ad
   languageName: node
   linkType: hard
 
-"@agoric/governance@npm:0.10.4-dev-9c61393.0+9c61393":
-  version: 0.10.4-dev-9c61393.0
-  resolution: "@agoric/governance@npm:0.10.4-dev-9c61393.0"
+"@agoric/fast-usdc@npm:dev":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/fast-usdc@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
-    "@agoric/ertp": "npm:0.16.3-dev-9c61393.0+9c61393"
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/notifier": "npm:0.6.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/time": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
-    "@agoric/zoe": "npm:0.26.3-dev-9c61393.0+9c61393"
+    "@agoric/client-utils": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/cosmic-proto": "npm:0.4.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/orchestration": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
+    "@cosmjs/proto-signing": "npm:^0.32.4"
+    "@cosmjs/stargate": "npm:^0.32.4"
+    "@endo/base64": "npm:^1.0.9"
+    "@endo/common": "npm:^1.2.8"
+    "@endo/errors": "npm:^1.2.8"
+    "@endo/eventual-send": "npm:^1.2.8"
+    "@endo/far": "npm:^1.1.9"
+    "@endo/init": "npm:^1.1.7"
+    "@endo/marshal": "npm:^1.6.2"
+    "@endo/nat": "npm:^5.0.13"
+    "@endo/pass-style": "npm:^1.4.7"
+    "@endo/patterns": "npm:^1.4.7"
+    "@endo/promise-kit": "npm:^1.1.8"
+    "@nick134-bit/noblejs": "npm:0.0.2"
+    bech32: "npm:^2.0.0"
+    commander: "npm:^12.1.0"
+    ethers: "npm:^6.13.4"
+  bin:
+    fast-usdc: src/cli/bin.js
+  checksum: 10c0/8b37bb8b0571736bcf57b855f153481d7bc1a9949c9964fc8bc7cea0adcf411b24a5580938b492ed6b086c75a74418e2231ac921c669d275b740e30f5d41fef0
+  languageName: node
+  linkType: hard
+
+"@agoric/governance@npm:0.10.4-dev-4c2be7c.0+4c2be7c":
+  version: 0.10.4-dev-4c2be7c.0
+  resolution: "@agoric/governance@npm:0.10.4-dev-4c2be7c.0"
+  dependencies:
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/time": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
     "@endo/bundle-source": "npm:^3.5.0"
     "@endo/captp": "npm:^4.4.3"
     "@endo/errors": "npm:^1.2.8"
@@ -122,15 +187,15 @@ __metadata:
     "@endo/nat": "npm:^5.0.13"
     "@endo/promise-kit": "npm:^1.1.8"
     import-meta-resolve: "npm:^2.2.1"
-  checksum: 10c0/374a3e54c2b332feb515dc25afeb316c0db8304337b07f9161e7ef9d833246d5f3a6bd89df23e143b3d6d78787028c47f38bfd77aafc215a4721aaa29b44e123
+  checksum: 10c0/cfe017f67d62887d857e69025be4c62a53502b5a3161449815df97783beebf792fa293249d831654a4af15e95b2d00c4d41e33b9cfdc44f45e66ad3ed658653d
   languageName: node
   linkType: hard
 
-"@agoric/internal@npm:0.3.3-dev-9c61393.0+9c61393":
-  version: 0.3.3-dev-9c61393.0
-  resolution: "@agoric/internal@npm:0.3.3-dev-9c61393.0"
+"@agoric/internal@npm:0.3.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.3.3-dev-4c2be7c.0
+  resolution: "@agoric/internal@npm:0.3.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/base-zone": "npm:0.1.1-dev-9c61393.0+9c61393"
+    "@agoric/base-zone": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
     "@endo/common": "npm:^1.2.8"
     "@endo/errors": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
@@ -142,110 +207,137 @@ __metadata:
     "@endo/stream": "npm:^1.2.8"
     anylogger: "npm:^0.21.0"
     jessie.js: "npm:^0.3.4"
-  checksum: 10c0/5dab64b83cb6a6a311f53722ce5283e61a8a9a3142c2065d9e9baee277a1fecbc3f5edb6fd99e0c3215e897fdfb9e1dce00e5369797a9374e315b3a899dac64e
+  checksum: 10c0/65cd83c43b6801219ee0fe32b7495546b320f6183f34a21d0c37994a20658cb9cc0aa9648cd15b38d987d4940e20886b74faf44f7679c04e1ea088033195bbba
   languageName: node
   linkType: hard
 
-"@agoric/kmarshal@npm:0.1.1-dev-9c61393.0+9c61393":
-  version: 0.1.1-dev-9c61393.0
-  resolution: "@agoric/kmarshal@npm:0.1.1-dev-9c61393.0"
+"@agoric/kmarshal@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/kmarshal@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
     "@endo/errors": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
     "@endo/marshal": "npm:^1.6.2"
-  checksum: 10c0/38006a8dc82a32e5445c7ef9253ef2a66e53d5ae9e58d6ca5224b79b3155878f3a3ef53e476878ea95270a494a582ce036af78a1440f7f4573a36ac78f456cf4
+  checksum: 10c0/a26f22fe4df2773d1f64d3ade38c839c418765f41deb7da3f84b48448e33f7b3f0677fe24a50bb85602025b79d6160e4a3f672e138137b817f00dec380ec445a
   languageName: node
   linkType: hard
 
-"@agoric/network@npm:0.1.1-dev-9c61393.0+9c61393":
-  version: 0.1.1-dev-9c61393.0
-  resolution: "@agoric/network@npm:0.1.1-dev-9c61393.0"
+"@agoric/network@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/network@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
     "@endo/base64": "npm:^1.0.9"
     "@endo/errors": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/935ec80ad05ea3297f456af1d4e5491eb89725b2bb9984dfdbcedc2ba757ae06e9927b3cfc94dd3b2bada4b8de4b33dedb2dd00cb33a1d6bf113c48a213afb3b
+  checksum: 10c0/630961dabea341642a8823363e12104568d950800df53560886cc6321a20fbabf2791cf32922eef8298da99e93031e693f713da263beeb7c98b491d21a15ce75
   languageName: node
   linkType: hard
 
-"@agoric/notifier@npm:0.6.3-dev-9c61393.0+9c61393":
-  version: 0.6.3-dev-9c61393.0
-  resolution: "@agoric/notifier@npm:0.6.3-dev-9c61393.0"
+"@agoric/notifier@npm:0.6.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.6.3-dev-4c2be7c.0
+  resolution: "@agoric/notifier@npm:0.6.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
     "@endo/marshal": "npm:^1.6.2"
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/9e28ffad908521f8289afde305248ec93d386b631f0e9271ee64bf56940c67bfbc25cb874ce1aeb9177155331a27663ae1c45eb41bd82a2258a7b68e5953523c
+  checksum: 10c0/d018ef8d78c580abe4b9cf6ed69c952729710007b0af4126fb7c04a59fe2ff6e8f13274c78e83a6785894392cf0e3160c011c0b1273d2a30f9579f8055d835f3
   languageName: node
   linkType: hard
 
-"@agoric/smart-wallet@npm:0.5.4-dev-9c61393.0+9c61393":
-  version: 0.5.4-dev-9c61393.0
-  resolution: "@agoric/smart-wallet@npm:0.5.4-dev-9c61393.0"
+"@agoric/orchestration@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/orchestration@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
-    "@agoric/ertp": "npm:0.16.3-dev-9c61393.0+9c61393"
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/notifier": "npm:0.6.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
-    "@agoric/vats": "npm:0.15.2-dev-9c61393.0+9c61393"
-    "@agoric/vow": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/zoe": "npm:0.26.3-dev-9c61393.0+9c61393"
-    "@agoric/zone": "npm:0.2.3-dev-9c61393.0+9c61393"
+    "@agoric/async-flow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/cosmic-proto": "npm:0.4.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/network": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/time": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vats": "npm:0.15.2-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
+    "@endo/base64": "npm:^1.0.9"
+    "@endo/errors": "npm:^1.2.8"
+    "@endo/far": "npm:^1.1.9"
+    "@endo/marshal": "npm:^1.6.2"
+    "@endo/patterns": "npm:^1.4.7"
+    "@noble/hashes": "npm:^1.5.0"
+  checksum: 10c0/9a0501f645398cd7e3e87c91a162d1214c9e4d2762247af3a1ea7c8bd89c7df7ec97b29af51d8ac7bbd6f71487189cbabf810fe7a7cf143a5f650428d39f43e0
+  languageName: node
+  linkType: hard
+
+"@agoric/smart-wallet@npm:0.5.4-dev-4c2be7c.0+4c2be7c":
+  version: 0.5.4-dev-4c2be7c.0
+  resolution: "@agoric/smart-wallet@npm:0.5.4-dev-4c2be7c.0"
+  dependencies:
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vats": "npm:0.15.2-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/eventual-send": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
     "@endo/marshal": "npm:^1.6.2"
     "@endo/nat": "npm:^5.0.13"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/2f197adcc84f5dbc32347e2d6e4c4b5626141c283a77793e33fd1562d412034c01d4f3c0110649dc05db843cc404a96213b2f96ee79cef21ee3ee56eb825453d
+  checksum: 10c0/1029d8b5573c9400d7059cbe06bf9b302b4c4d8d08d07f4728e3812c813d25e6dca090e26224d9576ddcac0a20c51d59ff94b60159b6d293d5eac26cdeb15746
   languageName: node
   linkType: hard
 
-"@agoric/store@npm:0.9.3-dev-9c61393.0+9c61393":
-  version: 0.9.3-dev-9c61393.0
-  resolution: "@agoric/store@npm:0.9.3-dev-9c61393.0"
+"@agoric/store@npm:0.9.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.9.3-dev-4c2be7c.0
+  resolution: "@agoric/store@npm:0.9.3-dev-4c2be7c.0"
   dependencies:
     "@endo/errors": "npm:^1.2.8"
     "@endo/exo": "npm:^1.5.7"
     "@endo/marshal": "npm:^1.6.2"
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
-  checksum: 10c0/3772d5502c47734edc27b7cc64ccf890fcaf3130c21804140b45e7d227dafb83ee1028dc02dff84ad0e14b3155bed1548e0852606dbde9bf414ab699ccadc504
+  checksum: 10c0/146f0b0d9b6aa88c2c0b125c589ce6f0667a1aa5947c24873969a05493c14d6bfdd6ad20e6620e8a4c4a33a1ea8c3d57d697fd2776acf0013a9f8a56b94c3ad1
   languageName: node
   linkType: hard
 
-"@agoric/swing-store@npm:0.9.2-dev-9c61393.0+9c61393":
-  version: 0.9.2-dev-9c61393.0
-  resolution: "@agoric/swing-store@npm:0.9.2-dev-9c61393.0"
+"@agoric/swing-store@npm:0.9.2-dev-4c2be7c.0+4c2be7c":
+  version: 0.9.2-dev-4c2be7c.0
+  resolution: "@agoric/swing-store@npm:0.9.2-dev-4c2be7c.0"
   dependencies:
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
     "@endo/base64": "npm:^1.0.9"
     "@endo/bundle-source": "npm:^3.5.0"
     "@endo/check-bundle": "npm:^1.0.12"
     "@endo/errors": "npm:^1.2.8"
     "@endo/nat": "npm:^5.0.13"
     better-sqlite3: "npm:^9.1.1"
-  checksum: 10c0/422c32d0efd6f053292d8207cc58a989da314ec613a333b6c8a5b415d9bb3df9adeb0c9b7864ff1b8995c53cbb1d1a9552cf1041b27a7a7f1992084014b20dc6
+  checksum: 10c0/57cede42846d790a8da0f29dae5303a1cef5995c6cc686c1640755bb5ca7c150dfe3c1da93b7347c6224514494ff84158aafbe1f3f86d13f1d29cb4c549d8922
   languageName: node
   linkType: hard
 
-"@agoric/swingset-liveslots@npm:0.10.3-dev-9c61393.0+9c61393":
-  version: 0.10.3-dev-9c61393.0
-  resolution: "@agoric/swingset-liveslots@npm:0.10.3-dev-9c61393.0"
+"@agoric/swingset-liveslots@npm:0.10.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.10.3-dev-4c2be7c.0
+  resolution: "@agoric/swingset-liveslots@npm:0.10.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
     "@endo/env-options": "npm:^1.1.8"
     "@endo/errors": "npm:^1.2.8"
     "@endo/eventual-send": "npm:^1.2.8"
@@ -257,23 +349,23 @@ __metadata:
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/576708817e95f8de695b0e7dfdc09d099b51aa71e708e485f4a324f9fdeacfff395057e0a1180711471c0d32d6c5cd46d84316f535654b32192b7e3f5338937d
+  checksum: 10c0/1b9939243b51325a3038792d2c7c66d6eab41ae10332793c160acc60abc2af0094dc086c1e312778770715c0f8805df1ec0fe70dd47a20db6810ec2206a7d19a
   languageName: node
   linkType: hard
 
-"@agoric/swingset-vat@npm:0.32.3-dev-9c61393.0+9c61393":
-  version: 0.32.3-dev-9c61393.0
-  resolution: "@agoric/swingset-vat@npm:0.32.3-dev-9c61393.0"
+"@agoric/swingset-vat@npm:0.32.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.32.3-dev-4c2be7c.0
+  resolution: "@agoric/swingset-vat@npm:0.32.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/kmarshal": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/swing-store": "npm:0.9.2-dev-9c61393.0+9c61393"
-    "@agoric/swingset-liveslots": "npm:0.10.3-dev-9c61393.0+9c61393"
-    "@agoric/swingset-xsnap-supervisor": "npm:0.10.3-dev-9c61393.0+9c61393"
-    "@agoric/time": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
-    "@agoric/xsnap-lockdown": "npm:0.14.1-dev-9c61393.0+9c61393"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/kmarshal": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swing-store": "npm:0.9.2-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-xsnap-supervisor": "npm:0.10.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/time": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/xsnap-lockdown": "npm:0.14.1-dev-4c2be7c.0+4c2be7c"
     "@endo/base64": "npm:^1.0.9"
     "@endo/bundle-source": "npm:^3.5.0"
     "@endo/captp": "npm:^4.4.3"
@@ -305,75 +397,75 @@ __metadata:
     ava: ^5.3.0
   bin:
     vat: bin/vat
-  checksum: 10c0/64cc1dd51a40f7617a793b141dec9b8c4ea006b594e86691f06a859b163cb58ee289e11c4e8666faaa5c48b129b69ae4d0d86f561b861f06501c3ed838c125c0
+  checksum: 10c0/91f17782b0c21723f67280d5171e98e76b80e2c1d7a2b0896b78e0adf2481f48e51daf2abb9d89bb76e4454dcc1ffff9b49900dab661c6cda7b5d2eafdf3dda8
   languageName: node
   linkType: hard
 
-"@agoric/swingset-xsnap-supervisor@npm:0.10.3-dev-9c61393.0+9c61393":
-  version: 0.10.3-dev-9c61393.0
-  resolution: "@agoric/swingset-xsnap-supervisor@npm:0.10.3-dev-9c61393.0"
-  checksum: 10c0/9710fbb28e35949b786835ecbcc4179853a968b0bb63a759213450993c1ca69d08b4cbdf3745c0710640b42d7790ea9984cec4ae2dc0631c1327b6019bb5c134
+"@agoric/swingset-xsnap-supervisor@npm:0.10.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.10.3-dev-4c2be7c.0
+  resolution: "@agoric/swingset-xsnap-supervisor@npm:0.10.3-dev-4c2be7c.0"
+  checksum: 10c0/3bc96b2165b992d03d64c59fd9c78b4d96c3b6aad66ff5cd6a3f6bab361b1a3c4d3468d2bb48d7c5dc339bc9c8a63dae37164f6b677241338938cea8100c744d
   languageName: node
   linkType: hard
 
 "@agoric/synthetic-chain@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@agoric/synthetic-chain@npm:0.4.3"
+  version: 0.4.5
+  resolution: "@agoric/synthetic-chain@npm:0.4.5"
   dependencies:
     "@endo/zip": "npm:^1.0.7"
     better-sqlite3: "npm:^9.6.0"
     chalk: "npm:^5.3.0"
     cosmjs-types: "npm:^0.9.0"
-    execa: "npm:^9.3.1"
+    execa: "npm:8.x"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/b904b531bf2d4066322e4b86b7653fa4fd88d52cce86d82d82ebaecedd526a83832488e1f82b5d0ece23cf5b13fa6bf4e49b4c25339a3c17a658c1302ef9321b
+  checksum: 10c0/f693b52550fc54faa1e04450d9e4b399c929cdd4b5a177c20790465308a66407695ef0d19ac8d69298aba8cb32a912a2b06427b012e170a7ce2f1cf6b149abd2
   languageName: node
   linkType: hard
 
-"@agoric/time@npm:0.3.3-dev-9c61393.0+9c61393":
-  version: 0.3.3-dev-9c61393.0
-  resolution: "@agoric/time@npm:0.3.3-dev-9c61393.0"
+"@agoric/time@npm:0.3.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.3.3-dev-4c2be7c.0
+  resolution: "@agoric/time@npm:0.3.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/nat": "npm:^5.0.13"
     "@endo/patterns": "npm:^1.4.7"
-  checksum: 10c0/9c89e51041829351c9698b96f624362d3712d2c959780db1a3d5ce29d45f83077fba192b8157da4055e1832f269799e7c621ad0d526ce16b7be254004b5116cb
+  checksum: 10c0/fa377c398f1a92a73857d02ac41454c624ea348f0a5fb39f37fabec167bdcba586ee0d162944b6f08a04d8bd314288493e4782f4c95d06561cfb0b838990aea3
   languageName: node
   linkType: hard
 
-"@agoric/vat-data@npm:0.5.3-dev-9c61393.0+9c61393":
-  version: 0.5.3-dev-9c61393.0
-  resolution: "@agoric/vat-data@npm:0.5.3-dev-9c61393.0"
+"@agoric/vat-data@npm:0.5.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.5.3-dev-4c2be7c.0
+  resolution: "@agoric/vat-data@npm:0.5.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/base-zone": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/swingset-liveslots": "npm:0.10.3-dev-9c61393.0+9c61393"
+    "@agoric/base-zone": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/exo": "npm:^1.5.7"
     "@endo/patterns": "npm:^1.4.7"
-  checksum: 10c0/ba27f0acd8c148279067dd47755776a70a26d88b5e45e0675e5e23da610626b6c5169f057591c6992a7744d8ee05f7fd230fc6c20665da34502f5c787648f209
+  checksum: 10c0/afcb295048392b619b8288c25f2ece69836ea4f558e9fe4a31f858ea1c076bf35de67e9a4b3824a767dda07cbcff82ef30437600dce1353c4dc3bec53da71e37
   languageName: node
   linkType: hard
 
-"@agoric/vats@npm:0.15.2-dev-9c61393.0+9c61393":
-  version: 0.15.2-dev-9c61393.0
-  resolution: "@agoric/vats@npm:0.15.2-dev-9c61393.0"
+"@agoric/vats@npm:0.15.2-dev-4c2be7c.0+4c2be7c":
+  version: 0.15.2-dev-4c2be7c.0
+  resolution: "@agoric/vats@npm:0.15.2-dev-4c2be7c.0"
   dependencies:
-    "@agoric/cosmic-proto": "npm:0.4.1-dev-9c61393.0+9c61393"
-    "@agoric/ertp": "npm:0.16.3-dev-9c61393.0+9c61393"
-    "@agoric/governance": "npm:0.10.4-dev-9c61393.0+9c61393"
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/network": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/notifier": "npm:0.6.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/swingset-vat": "npm:0.32.3-dev-9c61393.0+9c61393"
-    "@agoric/time": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
-    "@agoric/vow": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/zoe": "npm:0.26.3-dev-9c61393.0+9c61393"
-    "@agoric/zone": "npm:0.2.3-dev-9c61393.0+9c61393"
+    "@agoric/cosmic-proto": "npm:0.4.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/governance": "npm:0.10.4-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/network": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-vat": "npm:0.32.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/time": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zoe": "npm:0.26.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
     "@endo/import-bundle": "npm:^1.3.2"
@@ -384,48 +476,48 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.8"
     import-meta-resolve: "npm:^2.2.1"
     jessie.js: "npm:^0.3.4"
-  checksum: 10c0/e96d1c83c0b6907c69c0f85e87e3b477b50eba49f4d76db98cb4e7f605938f275e3830a5992c057882d12faa54f983ac63ad02e3e6c05d2ef2c9d3b2839caa09
+  checksum: 10c0/3df2f391db6357a8d0d3d9bd6272a22fef60a53500f3c35e221712cd08f0ad7e57fd269b152ed5feaee996f8a3370c8786d09f680ca1d9d42710ab33749c7399
   languageName: node
   linkType: hard
 
-"@agoric/vow@npm:0.1.1-dev-9c61393.0+9c61393":
-  version: 0.1.1-dev-9c61393.0
-  resolution: "@agoric/vow@npm:0.1.1-dev-9c61393.0"
+"@agoric/vow@npm:0.1.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.1.1-dev-4c2be7c.0
+  resolution: "@agoric/vow@npm:0.1.1-dev-4c2be7c.0"
   dependencies:
-    "@agoric/base-zone": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
+    "@agoric/base-zone": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
     "@endo/env-options": "npm:^1.1.8"
     "@endo/errors": "npm:^1.2.8"
     "@endo/eventual-send": "npm:^1.2.8"
     "@endo/pass-style": "npm:^1.4.7"
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
-  checksum: 10c0/7ad19095660f8312224b2a19e892d296da292e66146f3aab8127fdaf6e2ec999958401b5e8052b465e8eb97ff49a0db9f4db9aa445abbd8a51bc9a1216036f57
+  checksum: 10c0/5dc1a4ddd7f77b5f476f2c92923f889935a9dbefb38a471fee1bac54ab3ea9c8adc576cf7d165fc582139c5f0acc789031e68fb3953e35f1af2615703d44e1f9
   languageName: node
   linkType: hard
 
-"@agoric/xsnap-lockdown@npm:0.14.1-dev-9c61393.0+9c61393":
-  version: 0.14.1-dev-9c61393.0
-  resolution: "@agoric/xsnap-lockdown@npm:0.14.1-dev-9c61393.0"
-  checksum: 10c0/f53416887d03a9b96586d96ac47917a898613722a99b6a1f9cb74712f788fd077d0f9530169b46bc40b40ec68fd001446561260799dc1d65a57eb08144069913
+"@agoric/xsnap-lockdown@npm:0.14.1-dev-4c2be7c.0+4c2be7c":
+  version: 0.14.1-dev-4c2be7c.0
+  resolution: "@agoric/xsnap-lockdown@npm:0.14.1-dev-4c2be7c.0"
+  checksum: 10c0/5ad3790a5c2e9a0bac0b070b0f9e51e0516a6bb2201337992c0cfceafbfbf1ce2f98351a9ef0edc2d4d399b47623483f7b0aa41741e079e027d4c4b75d17082b
   languageName: node
   linkType: hard
 
-"@agoric/zoe@npm:0.26.3-dev-9c61393.0+9c61393":
-  version: 0.26.3-dev-9c61393.0
-  resolution: "@agoric/zoe@npm:0.26.3-dev-9c61393.0"
+"@agoric/zoe@npm:0.26.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.26.3-dev-4c2be7c.0
+  resolution: "@agoric/zoe@npm:0.26.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/base-zone": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/ertp": "npm:0.16.3-dev-9c61393.0+9c61393"
-    "@agoric/internal": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/notifier": "npm:0.6.3-dev-9c61393.0+9c61393"
-    "@agoric/store": "npm:0.9.3-dev-9c61393.0+9c61393"
-    "@agoric/swingset-liveslots": "npm:0.10.3-dev-9c61393.0+9c61393"
-    "@agoric/swingset-vat": "npm:0.32.3-dev-9c61393.0+9c61393"
-    "@agoric/time": "npm:0.3.3-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
-    "@agoric/vow": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/zone": "npm:0.2.3-dev-9c61393.0+9c61393"
+    "@agoric/base-zone": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/ertp": "npm:0.16.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/internal": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/notifier": "npm:0.6.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/store": "npm:0.9.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/swingset-vat": "npm:0.32.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/time": "npm:0.3.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vow": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/zone": "npm:0.2.3-dev-4c2be7c.0+4c2be7c"
     "@endo/bundle-source": "npm:^3.5.0"
     "@endo/captp": "npm:^4.4.3"
     "@endo/common": "npm:^1.2.8"
@@ -440,20 +532,20 @@ __metadata:
     "@endo/patterns": "npm:^1.4.7"
     "@endo/promise-kit": "npm:^1.1.8"
     yargs-parser: "npm:^21.1.1"
-  checksum: 10c0/945a3480ca196bf94552c63c37dba97eea5d8cb21e5f9aed4a6d8a6b627a07b83cc2ee0e8ebaa735e3b73e90a1dc1c645d06b89e61f62cc4e838f77ee2ce3e80
+  checksum: 10c0/ac0336c3ee6c6f49579dd0a562b638d9b8d9a95f33b259eb976c424e355689c280cbf23504cb9fbc0dfc16b92b829d00413f17c2ffcb335f95566087d4189642
   languageName: node
   linkType: hard
 
-"@agoric/zone@npm:0.2.3-dev-9c61393.0+9c61393":
-  version: 0.2.3-dev-9c61393.0
-  resolution: "@agoric/zone@npm:0.2.3-dev-9c61393.0"
+"@agoric/zone@npm:0.2.3-dev-4c2be7c.0+4c2be7c":
+  version: 0.2.3-dev-4c2be7c.0
+  resolution: "@agoric/zone@npm:0.2.3-dev-4c2be7c.0"
   dependencies:
-    "@agoric/base-zone": "npm:0.1.1-dev-9c61393.0+9c61393"
-    "@agoric/vat-data": "npm:0.5.3-dev-9c61393.0+9c61393"
+    "@agoric/base-zone": "npm:0.1.1-dev-4c2be7c.0+4c2be7c"
+    "@agoric/vat-data": "npm:0.5.3-dev-4c2be7c.0+4c2be7c"
     "@endo/errors": "npm:^1.2.8"
     "@endo/far": "npm:^1.1.9"
     "@endo/pass-style": "npm:^1.4.7"
-  checksum: 10c0/a3434bf4b2d8be2d2325af3a19fde83b06fdb6b6922e5ec1cf3355ffc15a79a9a4ee6c6968349d92f039808ab521dc7ec20830cc34d2356c5771d9f69c5e3e20
+  checksum: 10c0/8379dfbe79ace8c199edb5a21f44d9a8e7f34566a69d0ccda61d4bc457f3c5c7204ef5492125d2766ee32d29de2934334f0946b7556ce585d77b7d8aeb75743f
   languageName: node
   linkType: hard
 
@@ -552,7 +644,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/amino@npm:^0.32.4":
+"@cosmjs/amino@npm:0.32.3":
+  version: 0.32.3
+  resolution: "@cosmjs/amino@npm:0.32.3"
+  dependencies:
+    "@cosmjs/crypto": "npm:^0.32.3"
+    "@cosmjs/encoding": "npm:^0.32.3"
+    "@cosmjs/math": "npm:^0.32.3"
+    "@cosmjs/utils": "npm:^0.32.3"
+  checksum: 10c0/6f3da2ba6d88257d6717898af798aad9f2a51bb2c0d0b61cd40cf103c86a1431f4fa5086df350f81371d3282b8a28bcbc4f97c6d9eb83a9831fad473ae1ab492
+  languageName: node
+  linkType: hard
+
+"@cosmjs/amino@npm:^0.32.3, @cosmjs/amino@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/amino@npm:0.32.4"
   dependencies:
@@ -564,7 +668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/crypto@npm:^0.32.4":
+"@cosmjs/crypto@npm:^0.32.3, @cosmjs/crypto@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/crypto@npm:0.32.4"
   dependencies:
@@ -576,6 +680,17 @@ __metadata:
     elliptic: "npm:^6.5.4"
     libsodium-wrappers-sumo: "npm:^0.7.11"
   checksum: 10c0/94e742285eb8c7c5393055ba0635f10c06bf87710e953aedc71e3edc2b8e21a12a0d9b5e8eff37e326765f57c9eb3c7fd358f24f639efad4f1a6624eb8189534
+  languageName: node
+  linkType: hard
+
+"@cosmjs/encoding@npm:0.32.3":
+  version: 0.32.3
+  resolution: "@cosmjs/encoding@npm:0.32.3"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    bech32: "npm:^1.1.4"
+    readonly-date: "npm:^1.0.0"
+  checksum: 10c0/3c3d4b610093c2c8ca13437664e4736d60cdfb309bf2671f492388c59a9bca20f1a75ab4686a7b73d48aa6208f454bee56c84c0fe780015473ea53353a70266a
   languageName: node
   linkType: hard
 
@@ -600,12 +715,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/math@npm:^0.32.4":
+"@cosmjs/math@npm:0.32.3":
+  version: 0.32.3
+  resolution: "@cosmjs/math@npm:0.32.3"
+  dependencies:
+    bn.js: "npm:^5.2.0"
+  checksum: 10c0/cad8b13a0db739ef4a416b334e39ea9f55874315ebdf91dc38772676c2ead6caccaf8a28b9e8803fc48680a72cf5a9fde97564f5efbfbe9a9073c95665f31294
+  languageName: node
+  linkType: hard
+
+"@cosmjs/math@npm:^0.32.3, @cosmjs/math@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/math@npm:0.32.4"
   dependencies:
     bn.js: "npm:^5.2.0"
   checksum: 10c0/91e47015be5634d27d71d14c5a05899fb4992b69db02cab1558376dedf8254f96d5e24f097c5601804ae18ed33c7c25d023653ac2bf9d20250fd3e5637f6b101
+  languageName: node
+  linkType: hard
+
+"@cosmjs/proto-signing@npm:0.32.3":
+  version: 0.32.3
+  resolution: "@cosmjs/proto-signing@npm:0.32.3"
+  dependencies:
+    "@cosmjs/amino": "npm:^0.32.3"
+    "@cosmjs/crypto": "npm:^0.32.3"
+    "@cosmjs/encoding": "npm:^0.32.3"
+    "@cosmjs/math": "npm:^0.32.3"
+    "@cosmjs/utils": "npm:^0.32.3"
+    cosmjs-types: "npm:^0.9.0"
+  checksum: 10c0/d44511d3a50489c1a3f61f28f68ca8cac87d6bdbb69e434cb0916dfc1d79e6a68ca0c09e074d4be73624f26fbb215024848225b862201b7f8d1d6a44014fd819
   languageName: node
   linkType: hard
 
@@ -635,7 +773,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/stargate@npm:^0.32.3":
+"@cosmjs/stargate@npm:0.32.3":
+  version: 0.32.3
+  resolution: "@cosmjs/stargate@npm:0.32.3"
+  dependencies:
+    "@confio/ics23": "npm:^0.6.8"
+    "@cosmjs/amino": "npm:^0.32.3"
+    "@cosmjs/encoding": "npm:^0.32.3"
+    "@cosmjs/math": "npm:^0.32.3"
+    "@cosmjs/proto-signing": "npm:^0.32.3"
+    "@cosmjs/stream": "npm:^0.32.3"
+    "@cosmjs/tendermint-rpc": "npm:^0.32.3"
+    "@cosmjs/utils": "npm:^0.32.3"
+    cosmjs-types: "npm:^0.9.0"
+    xstream: "npm:^11.14.0"
+  checksum: 10c0/c82db0355f4b15ca988f0452f8142102b44840319fe48d44c8dc9c1a316cbe3c9e765eb90970348bd5b5fddd6d9452d5a556e14dbbbd93eda6a6c92ceb616241
+  languageName: node
+  linkType: hard
+
+"@cosmjs/stargate@npm:^0.32.3, @cosmjs/stargate@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/stargate@npm:0.32.4"
   dependencies:
@@ -653,7 +809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/stream@npm:^0.32.4":
+"@cosmjs/stream@npm:^0.32.3, @cosmjs/stream@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/stream@npm:0.32.4"
   dependencies:
@@ -680,7 +836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/utils@npm:^0.32.4":
+"@cosmjs/utils@npm:^0.32.3, @cosmjs/utils@npm:^0.32.4":
   version: 0.32.4
   resolution: "@cosmjs/utils@npm:0.32.4"
   checksum: 10c0/d5ff8b235094be1150853a715116049f73eb5cdfeea8ce8e22ecccc61ec99792db457404d4307782b1a2f935dcf438f5c485beabfcfbc1dc5df26eb6e6da9062
@@ -1049,10 +1205,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1, @noble/hashes@npm:^1.0.0":
-  version: 1.5.0
-  resolution: "@noble/hashes@npm:1.5.0"
-  checksum: 10c0/1b46539695fbfe4477c0822d90c881a04d4fa2921c08c552375b444a48cac9930cb1ee68de0a3c7859e676554d0f3771999716606dc4d8f826e414c11692cdd9
+"@nick134-bit/noblejs@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@nick134-bit/noblejs@npm:0.0.2"
+  dependencies:
+    "@cosmjs/amino": "npm:0.32.3"
+    "@cosmjs/encoding": "npm:0.32.3"
+    "@cosmjs/math": "npm:0.32.3"
+    "@cosmjs/proto-signing": "npm:0.32.3"
+    "@cosmjs/stargate": "npm:0.32.3"
+    typescript: "npm:^5.4.5"
+  checksum: 10c0/93a0d28459caf9649722d085f8a06f828ad878c2a2948beeb38eb583ebcb305ba15bff5f66ccc712e6068df93fb0cbd1b09bdf7681cc72ef37138f8c5484c287
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@noble/curves@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": "npm:1.3.2"
+  checksum: 10c0/0bac7d1bbfb3c2286910b02598addd33243cb97c3f36f987ecc927a4be8d7d88e0fcb12b0f0ef8a044e7307d1844dd5c49bb724bfa0a79c8ec50ba60768c97f6
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@noble/hashes@npm:1.3.2"
+  checksum: 10c0/2482cce3bce6a596626f94ca296e21378e7a5d4c09597cbc46e65ffacc3d64c8df73111f2265444e36a3168208628258bbbaccba2ef24f65f58b2417638a20e7
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.5.0":
+  version: 1.7.0
+  resolution: "@noble/hashes@npm:1.7.0"
+  checksum: 10c0/1ef0c985ebdb5a1bd921ea6d959c90ba826af3ae05b40b459a703e2a5e9b259f190c6e92d6220fb3800e2385521e4159e238415ad3f6b79c52f91dd615e491dc
   languageName: node
   linkType: hard
 
@@ -1261,20 +1447,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sec-ant/readable-stream@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@sec-ant/readable-stream@npm:0.4.1"
-  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
-  languageName: node
-  linkType: hard
-
-"@sindresorhus/merge-streams@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
-  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
-  languageName: node
-  linkType: hard
-
 "@types/estree@npm:*, @types/estree@npm:^1.0.0":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
@@ -1305,6 +1477,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:22.7.5":
+  version: 22.7.5
+  resolution: "@types/node@npm:22.7.5"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10c0/cf11f74f1a26053ec58066616e3a8685b6bcd7259bc569738b8f752009f9f0f7f85a1b2d24908e5b0f752482d1e8b6babdf1fbb25758711ec7bb9500bfcd6e60
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:1.17.1":
   version: 1.17.1
   resolution: "@types/resolve@npm:1.17.1"
@@ -1330,21 +1511,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.8.2":
-  version: 8.13.0
-  resolution: "acorn@npm:8.13.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10c0/f35dd53d68177c90699f4c37d0bb205b8abe036d955d0eb011ddb7f14a81e6fd0f18893731c457c1b5bd96754683f4c3d80d9a5585ddecaa53cdf84e0b3d68f7
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.2.4":
+"acorn@npm:^8.11.0, acorn@npm:^8.2.4, acorn@npm:^8.8.2":
   version: 8.14.0
   resolution: "acorn@npm:8.14.0"
   bin:
     acorn: bin/acorn
   checksum: 10c0/6d4ee461a7734b2f48836ee0fbb752903606e576cc100eb49340295129ca0b452f3ba91ddd4424a1d4406a98adfb2ebb6bd0ff4c49d7a0930c10e462719bbfd7
+  languageName: node
+  linkType: hard
+
+"aes-js@npm:4.0.0-beta.5":
+  version: 4.0.0-beta.5
+  resolution: "aes-js@npm:4.0.0-beta.5"
+  checksum: 10c0/444f4eefa1e602cbc4f2a3c644bc990f93fd982b148425fee17634da510586fc09da940dcf8ace1b2d001453c07ff042e55f7a0482b3cc9372bf1ef75479090c
   languageName: node
   linkType: hard
 
@@ -1548,6 +1727,13 @@ __metadata:
   version: 1.1.4
   resolution: "bech32@npm:1.1.4"
   checksum: 10c0/5f62ca47b8df99ace9c0e0d8deb36a919d91bf40066700aaa9920a45f86bb10eb56d537d559416fd8703aa0fb60dddb642e58f049701e7291df678b2033e5ee5
+  languageName: node
+  linkType: hard
+
+"bech32@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bech32@npm:2.0.0"
+  checksum: 10c0/45e7cc62758c9b26c05161b4483f40ea534437cf68ef785abadc5b62a2611319b878fef4f86ddc14854f183b645917a19addebc9573ab890e19194bc8f521942
   languageName: node
   linkType: hard
 
@@ -1837,6 +2023,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
+  languageName: node
+  linkType: hard
+
 "common-path-prefix@npm:^3.0.0":
   version: 3.0.0
   resolution: "common-path-prefix@npm:3.0.0"
@@ -1888,18 +2081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
-  dependencies:
-    path-key: "npm:^3.1.0"
-    shebang-command: "npm:^2.0.0"
-    which: "npm:^2.0.1"
-  checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -1937,6 +2119,13 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  languageName: node
+  linkType: hard
+
+"decode-uri-component@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "decode-uri-component@npm:0.4.1"
+  checksum: 10c0/a180bbdb5398ec8270d236a3ac07cb988bbf6097428481780b85840f088951dc0318a8d8f9d56796e1a322b55b29859cea29982f22f9b03af0bc60974c54e591
   languageName: node
   linkType: hard
 
@@ -2151,23 +2340,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^9.3.1":
-  version: 9.5.1
-  resolution: "execa@npm:9.5.1"
+"ethers@npm:^6.13.4":
+  version: 6.13.5
+  resolution: "ethers@npm:6.13.5"
   dependencies:
-    "@sindresorhus/merge-streams": "npm:^4.0.0"
+    "@adraffy/ens-normalize": "npm:1.10.1"
+    "@noble/curves": "npm:1.2.0"
+    "@noble/hashes": "npm:1.3.2"
+    "@types/node": "npm:22.7.5"
+    aes-js: "npm:4.0.0-beta.5"
+    tslib: "npm:2.7.0"
+    ws: "npm:8.17.1"
+  checksum: 10c0/64bc7b8907de199392b8a88c15c9a085892919cff7efa2e5326abc7fe5c426001726c51d91e10c74e5fc5e2547188297ce4127f6e52ea42a97ade0b2ae474677
+  languageName: node
+  linkType: hard
+
+"execa@npm:8.x":
+  version: 8.0.1
+  resolution: "execa@npm:8.0.1"
+  dependencies:
     cross-spawn: "npm:^7.0.3"
-    figures: "npm:^6.1.0"
-    get-stream: "npm:^9.0.0"
-    human-signals: "npm:^8.0.0"
-    is-plain-obj: "npm:^4.1.0"
-    is-stream: "npm:^4.0.1"
-    npm-run-path: "npm:^6.0.0"
-    pretty-ms: "npm:^9.0.0"
+    get-stream: "npm:^8.0.1"
+    human-signals: "npm:^5.0.0"
+    is-stream: "npm:^3.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^5.1.0"
+    onetime: "npm:^6.0.0"
     signal-exit: "npm:^4.1.0"
-    strip-final-newline: "npm:^4.0.0"
-    yoctocolors: "npm:^2.0.0"
-  checksum: 10c0/1a628d535c5a088f9e17a735bb3143efc4198095392b319ba877b2975d5c3c57724536dccb6f68f1cd9b3af331c5a9e8c1aeb338d52ab316b1e008ff453374a7
+    strip-final-newline: "npm:^3.0.0"
+  checksum: 10c0/2c52d8775f5bf103ce8eec9c7ab3059909ba350a5164744e9947ed14a53f51687c040a250bda833f906d1283aa8803975b84e6c8f7a7c42f99dc8ef80250d1af
   languageName: node
   linkType: hard
 
@@ -2233,15 +2434,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "figures@npm:6.1.0"
-  dependencies:
-    is-unicode-supported: "npm:^2.0.0"
-  checksum: 10c0/9159df4264d62ef447a3931537de92f5012210cf5135c35c010df50a2169377581378149abfe1eb238bd6acbba1c0d547b1f18e0af6eee49e30363cedaffcfe4
-  languageName: node
-  linkType: hard
-
 "file-uri-to-path@npm:1.0.0":
   version: 1.0.0
   resolution: "file-uri-to-path@npm:1.0.0"
@@ -2255,6 +2447,13 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"filter-obj@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "filter-obj@npm:5.1.0"
+  checksum: 10c0/716e8ad2bc352e206556b3e5695b3cdff8aab80c53ea4b00c96315bbf467b987df3640575100aef8b84e812cf5ea4251db4cd672bbe33b1e78afea88400c67dd
   languageName: node
   linkType: hard
 
@@ -2377,13 +2576,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "get-stream@npm:9.0.1"
-  dependencies:
-    "@sec-ant/readable-stream": "npm:^0.4.1"
-    is-stream: "npm:^4.0.1"
-  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
+"get-stream@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "get-stream@npm:8.0.1"
+  checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
   languageName: node
   linkType: hard
 
@@ -2559,10 +2755,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-signals@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "human-signals@npm:8.0.0"
-  checksum: 10c0/e4dac4f7d3eb791ed04129fc6a85bd454a9102d3e3b76c911d0db7057ebd60b2956b435b5b5712aec18960488ede3c21ef7c56e42cdd70760c0d84d3c05cd92e
+"human-signals@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "human-signals@npm:5.0.0"
+  checksum: 10c0/5a9359073fe17a8b58e5a085e9a39a950366d9f00217c4ff5878bd312e09d80f460536ea6a3f260b5943a01fe55c158d1cea3fc7bee3d0520aeef04f6d915c82
   languageName: node
   linkType: hard
 
@@ -2750,13 +2946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "is-plain-obj@npm:4.1.0"
-  checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
-  languageName: node
-  linkType: hard
-
 "is-plain-object@npm:^5.0.0":
   version: 5.0.0
   resolution: "is-plain-object@npm:5.0.0"
@@ -2780,10 +2969,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-stream@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "is-stream@npm:4.0.1"
-  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
+"is-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-stream@npm:3.0.0"
+  checksum: 10c0/eb2f7127af02ee9aa2a0237b730e47ac2de0d4e76a4a905a50a11557f2339df5765eaea4ceb8029f1efa978586abe776908720bfcb1900c20c6ec5145f6f29d8
   languageName: node
   linkType: hard
 
@@ -2791,13 +2980,6 @@ __metadata:
   version: 1.3.0
   resolution: "is-unicode-supported@npm:1.3.0"
   checksum: 10c0/b8674ea95d869f6faabddc6a484767207058b91aea0250803cbf1221345cb0c56f466d4ecea375dc77f6633d248d33c47bd296fb8f4cdba0b4edba8917e83d8a
-  languageName: node
-  linkType: hard
-
-"is-unicode-supported@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-unicode-supported@npm:2.1.0"
-  checksum: 10c0/a0f53e9a7c1fdbcf2d2ef6e40d4736fdffff1c9f8944c75e15425118ff3610172c87bf7bc6c34d3903b04be59790bb2212ddbe21ee65b5a97030fc50370545a5
   languageName: node
   linkType: hard
 
@@ -3013,6 +3195,13 @@ __metadata:
     map-age-cleaner: "npm:^0.1.3"
     mimic-fn: "npm:^4.0.0"
   checksum: 10c0/c2c56141399e520d8f0e50186bb7e4b49300b33984dc919682f3f13e53dec0e6608fbd327d5ae99494f45061a3a05a8ee04ccba6dcf795c3c215b5aa906eb41f
+  languageName: node
+  linkType: hard
+
+"merge-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-stream@npm:2.0.0"
+  checksum: 10c0/867fdbb30a6d58b011449b8885601ec1690c3e41c759ecd5a9d609094f7aed0096c37823ff4a7190ef0b8f22cc86beb7049196ff68c016e3b3c671d0dac91ce5
   languageName: node
   linkType: hard
 
@@ -3308,13 +3497,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "npm-run-path@npm:6.0.0"
+"npm-run-path@npm:^5.1.0":
+  version: 5.3.0
+  resolution: "npm-run-path@npm:5.3.0"
   dependencies:
     path-key: "npm:^4.0.0"
-    unicorn-magic: "npm:^0.3.0"
-  checksum: 10c0/b223c8a0dcd608abf95363ea5c3c0ccc3cd877daf0102eaf1b0f2390d6858d8337fbb7c443af2403b067a7d2c116d10691ecd22ab3c5273c44da1ff8d07753bd
+  checksum: 10c0/124df74820c40c2eb9a8612a254ea1d557ddfab1581c3e751f825e3e366d9f00b0d76a3c94ecd8398e7f3eee193018622677e95816e8491f0797b21e30b2deba
   languageName: node
   linkType: hard
 
@@ -3331,6 +3519,15 @@ __metadata:
   dependencies:
     wrappy: "npm:1"
   checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "onetime@npm:6.0.0"
+  dependencies:
+    mimic-fn: "npm:^4.0.0"
+  checksum: 10c0/4eef7c6abfef697dd4479345a4100c382d73c149d2d56170a54a07418c50816937ad09500e1ed1e79d235989d073a9bade8557122aee24f0576ecde0f392bb6c
   languageName: node
   linkType: hard
 
@@ -3404,13 +3601,6 @@ __metadata:
   version: 3.0.0
   resolution: "parse-ms@npm:3.0.0"
   checksum: 10c0/056b4a32a9d3749f3f4cfffefb45c45540491deaa8e1d8ad43c2ddde7ba04edd076bd1b298f521238bb5fb084a9b2c4a2ebb78aefa651afbc4c2b0af4232fc54
-  languageName: node
-  linkType: hard
-
-"parse-ms@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "parse-ms@npm:4.0.0"
-  checksum: 10c0/a7900f4f1ebac24cbf5e9708c16fb2fd482517fad353aecd7aefb8c2ba2f85ce017913ccb8925d231770404780df46244ea6fec598b3bde6490882358b4d2d16
   languageName: node
   linkType: hard
 
@@ -3537,15 +3727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-ms@npm:^9.0.0":
-  version: 9.2.0
-  resolution: "pretty-ms@npm:9.2.0"
-  dependencies:
-    parse-ms: "npm:^4.0.0"
-  checksum: 10c0/ab6d066f90e9f77020426986e1b018369f41575674544c539aabec2e63a20fec01166d8cf6571d0e165ad11cfe5a8134a2a48a36d42ab291c59c6deca5264cbb
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^4.1.0, proc-log@npm:^4.2.0":
   version: 4.2.0
   resolution: "proc-log@npm:4.2.0"
@@ -3608,6 +3789,17 @@ __metadata:
   version: 6.1.0
   resolution: "pure-rand@npm:6.1.0"
   checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
+  languageName: node
+  linkType: hard
+
+"query-string@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "query-string@npm:9.1.1"
+  dependencies:
+    decode-uri-component: "npm:^0.4.1"
+    filter-obj: "npm:^5.1.0"
+    split-on-first: "npm:^3.0.0"
+  checksum: 10c0/16481f17754f660aec3cae7abb838a70e383dfcf152414d184e0d0f81fae426acf112b4d51bf754f9c256eaf83ba4241241ba907c8d58b6ed9704425e1712e8c
   languageName: node
   linkType: hard
 
@@ -3741,6 +3933,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@agoric/client-utils": "npm:dev"
+    "@agoric/fast-usdc": "npm:dev"
     "@agoric/synthetic-chain": "npm:^0.4.3"
     "@endo/init": "npm:^1.1.7"
     ava: "npm:^5.3.1"
@@ -3913,6 +4106,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "split-on-first@npm:3.0.0"
+  checksum: 10c0/a1262eae12b68de235e1a08e011bf5b42c42621985ddf807e6221fb1e2b3304824913ae7019f18436b96b8fab8aef5f1ad80dedd2385317fdc51b521c3882cd0
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
@@ -3994,10 +4194,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-final-newline@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "strip-final-newline@npm:4.0.0"
-  checksum: 10c0/b0cf2b62d597a1b0e3ebc42b88767f0a0d45601f89fd379a928a1812c8779440c81abba708082c946445af1d6b62d5f16e2a7cf4f30d9d6587b89425fae801ff
+"strip-final-newline@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-final-newline@npm:3.0.0"
+  checksum: 10c0/a771a17901427bac6293fd416db7577e2bc1c34a19d38351e9d5478c3c415f523f391003b42ed475f27e33a78233035df183525395f731d3bfb8cdcbd4da08ce
   languageName: node
   linkType: hard
 
@@ -4112,6 +4312,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.7.0":
+  version: 2.7.0
+  resolution: "tslib@npm:2.7.0"
+  checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6
+  languageName: node
+  linkType: hard
+
 "tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -4138,6 +4345,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.4.5":
+  version: 5.7.2
+  resolution: "typescript@npm:5.7.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/a873118b5201b2ef332127ef5c63fb9d9c155e6fdbe211cbd9d8e65877283797cca76546bad742eea36ed7efbe3424a30376818f79c7318512064e8625d61622
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.1.6 - 5.6.x#optional!builtin<compat/typescript>":
   version: 5.6.3
   resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
@@ -4148,17 +4365,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.8":
-  version: 6.19.8
-  resolution: "undici-types@npm:6.19.8"
-  checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
+"typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
+  version: 5.7.2
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
   languageName: node
   linkType: hard
 
-"unicorn-magic@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "unicorn-magic@npm:0.3.0"
-  checksum: 10c0/0a32a997d6c15f1c2a077a15b1c4ca6f268d574cf5b8975e778bb98e6f8db4ef4e86dfcae4e158cd4c7e38fb4dd383b93b13eefddc7f178dea13d3ac8a603271
+"undici-types@npm:~6.19.2, undici-types@npm:~6.19.8":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
   languageName: node
   linkType: hard
 
@@ -4255,6 +4475,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/f4a49064afae4500be772abdc2211c8518f39e1c959640457dcee15d4488628620625c783902a52af2dd02f68558da2868fd06e6fd0e67ebcd09e6881b1b5bfe
+  languageName: node
+  linkType: hard
+
 "ws@npm:^7":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
@@ -4320,12 +4555,5 @@ __metadata:
   version: 1.1.1
   resolution: "yocto-queue@npm:1.1.1"
   checksum: 10c0/cb287fe5e6acfa82690acb43c283de34e945c571a78a939774f6eaba7c285bacdf6c90fbc16ce530060863984c906d2b4c6ceb069c94d1e0a06d5f2b458e2a92
-  languageName: node
-  linkType: hard
-
-"yoctocolors@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "yoctocolors@npm:2.1.1"
-  checksum: 10c0/85903f7fa96f1c70badee94789fade709f9d83dab2ec92753d612d84fcea6d34c772337a9f8914c6bed2f5fc03a428ac5d893e76fab636da5f1236ab725486d0
   languageName: node
   linkType: hard


### PR DESCRIPTION
_leftover_

## Description
A previous PR added an A3P test of fast-usdc CLI but didn't get it working.

This fixes it by providing the proper dependencies and usage. It also documents why the `yarn link` approach doesn't work for this package.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a
### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
