### PR TITLE
chore(types): explicit ERTP type imports

### DIFF
--- a/packages/fast-usdc/src/cli/lp-commands.js
+++ b/packages/fast-usdc/src/cli/lp-commands.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /**
  * @import {Command} from 'commander';
+ * @import {Amount, Brand} from '@agoric/ertp';
  * @import {OfferSpec} from '@agoric/smart-wallet/src/offers.js';
  * @import {ExecuteOfferAction} from '@agoric/smart-wallet/src/smartWallet.js';
  * @import {USDCProposalShapes} from '../pool-share-math.js';

--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -16,6 +16,7 @@ import { makeFeeTools } from '../utils/fees.js';
 
 /**
  * @import {HostInterface} from '@agoric/async-flow';
+ * @import {Amount, Brand} from '@agoric/ertp';
  * @import {TypedPattern} from '@agoric/internal'
  * @import {NatAmount} from '@agoric/ertp';
  * @import {ChainAddress, ChainHub, Denom, OrchestrationAccount} from '@agoric/orchestration';

--- a/packages/fast-usdc/src/exos/liquidity-pool.js
+++ b/packages/fast-usdc/src/exos/liquidity-pool.js
@@ -20,6 +20,7 @@ import {
 } from '../type-guards.js';
 
 /**
+ * @import {Amount, Brand, Payment} from '@agoric/ertp';
  * @import {Zone} from '@agoric/zone';
  * @import {Remote} from '@agoric/internal'
  * @import {StorageNode} from '@agoric/internal/src/lib-chainStorage.js'

--- a/packages/fast-usdc/src/exos/settler.js
+++ b/packages/fast-usdc/src/exos/settler.js
@@ -16,6 +16,7 @@ import {
 
 /**
  * @import {FungibleTokenPacketData} from '@agoric/cosmic-proto/ibc/applications/transfer/v2/packet.js';
+ * @import {Amount, Brand, NatValue, Payment} from '@agoric/ertp';
  * @import {Denom, OrchestrationAccount, ChainHub, ChainAddress} from '@agoric/orchestration';
  * @import {WithdrawToSeat} from '@agoric/orchestration/src/utils/zoe-tools'
  * @import {IBCChannelID, VTransferIBCEvent} from '@agoric/vats';

--- a/packages/fast-usdc/src/fast-usdc-policy.core.js
+++ b/packages/fast-usdc/src/fast-usdc-policy.core.js
@@ -5,6 +5,7 @@ import { fromExternalConfig } from './utils/config-marshal.js';
 import { FeedPolicyShape } from './type-guards.js';
 
 /**
+ * @import {Issuer} from '@agoric/ertp';
  * @import {Passable} from '@endo/pass-style'
  * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js'
  * @import {LegibleCapData} from './utils/config-marshal.js'

--- a/packages/fast-usdc/src/fast-usdc.start.js
+++ b/packages/fast-usdc/src/fast-usdc.start.js
@@ -16,7 +16,7 @@ import {
 import { fromExternalConfig } from './utils/config-marshal.js';
 
 /**
- * @import {DepositFacet} from '@agoric/ertp/src/types.js'
+ * @import {Amount, Brand, DepositFacet, Issuer, Payment} from '@agoric/ertp';
  * @import {TypedPattern} from '@agoric/internal'
  * @import {Instance, StartParams} from '@agoric/zoe/src/zoeService/utils'
  * @import {Board} from '@agoric/vats'

--- a/packages/fast-usdc/src/pool-share-math.js
+++ b/packages/fast-usdc/src/pool-share-math.js
@@ -10,6 +10,7 @@ import { Fail, q } from '@endo/errors';
 const { getValue, add, isEmpty, isEqual, isGTE, subtract } = AmountMath;
 
 /**
+ * @import {Amount, Brand, DepositFacet, NatValue, Payment} from '@agoric/ertp';
  * @import {PoolStats} from './types';
  * @import {RepayAmountKWR} from './exos/liquidity-pool';
  */

--- a/packages/fast-usdc/src/type-guards.js
+++ b/packages/fast-usdc/src/type-guards.js
@@ -3,6 +3,7 @@ import { M } from '@endo/patterns';
 import { PendingTxStatus } from './constants.js';
 
 /**
+ * @import {Amount, Brand, NatValue, Payment} from '@agoric/ertp';
  * @import {TypedPattern} from '@agoric/internal';
  * @import {FastUsdcTerms} from './fast-usdc.contract.js';
  * @import {USDCProposalShapes} from './pool-share-math.js';

--- a/packages/fast-usdc/test/config-marshal.test.js
+++ b/packages/fast-usdc/test/config-marshal.test.js
@@ -10,7 +10,9 @@ import {
   toLegible,
 } from '../src/utils/config-marshal.js';
 
-/** @import {SmallCapsStructureOf} from '../src/utils/config-marshal.js' */
+/**
+ * @import {Amount, Brand, DepositFacet, NatValue, Payment} from '@agoric/ertp';
+ */
 
 const testMatches = (t, specimen, pattern) => {
   t.notThrows(() => mustMatch(specimen, pattern));

--- a/packages/fast-usdc/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc/test/fast-usdc.contract.test.ts
@@ -31,6 +31,7 @@ import { E } from '@endo/far';
 import { matches } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
 import path from 'path';
+import type { Amount, Issuer, NatValue, Purse } from '@agoric/ertp';
 import type { OperatorKit } from '../src/exos/operator-kit.js';
 import type { FastUsdcSF } from '../src/fast-usdc.contract.js';
 import { CctpTxEvidenceShape, PoolMetricsShape } from '../src/type-guards.js';

--- a/packages/fast-usdc/test/mocks.ts
+++ b/packages/fast-usdc/test/mocks.ts
@@ -1,16 +1,14 @@
 import type { HostInterface } from '@agoric/async-flow';
+import type { Brand, Issuer, Payment } from '@agoric/ertp';
 import type {
   ChainAddress,
   DenomAmount,
   OrchestrationAccount,
 } from '@agoric/orchestration';
-import type { Zone } from '@agoric/zone';
 import type { VowTools } from '@agoric/vow';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
-import type {
-  AmountUtils,
-  withAmountUtils,
-} from '@agoric/zoe/tools/test-utils.js';
+import type { AmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import type { Zone } from '@agoric/zone';
 import type { FeeConfig, LogFn } from '../src/types.js';
 
 export const prepareMockOrchAccounts = (

--- a/packages/fast-usdc/test/pool-share-math.test.ts
+++ b/packages/fast-usdc/test/pool-share-math.test.ts
@@ -1,6 +1,6 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { testProp, fc } from '@fast-check/ava';
-import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit, type Amount } from '@agoric/ertp';
 import {
   multiplyBy,
   parseRatio,

--- a/packages/fast-usdc/test/utils/fees.test.ts
+++ b/packages/fast-usdc/test/utils/fees.test.ts
@@ -1,5 +1,5 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { makeIssuerKit, AmountMath, type Amount } from '@agoric/ertp';
 import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { q } from '@endo/errors';

--- a/packages/inter-protocol/src/interest-math.js
+++ b/packages/inter-protocol/src/interest-math.js
@@ -9,6 +9,10 @@ import {
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 
 /**
+ * @import {Amount, Brand, Payment} from '@agoric/ertp';
+ */
+
+/**
  * @param {Ratio} currentCompoundedInterest as coefficient
  * @param {Ratio} previousCompoundedInterest as coefficient
  * @returns {Ratio} additional compounding since the previous

--- a/packages/zoe/tools/test-utils.js
+++ b/packages/zoe/tools/test-utils.js
@@ -1,6 +1,10 @@
 import { AmountMath } from '@agoric/ertp';
 import { makeRatio } from '../src/contractSupport/ratio.js';
 
+/**
+ * @import {Amount, Brand, DepositFacet, Issuer, IssuerKit, NatValue} from '@agoric/ertp';
+ */
+
 /** @param {Pick<IssuerKit<'nat'>, 'brand' | 'issuer' | 'mint'>} kit */
 export const withAmountUtils = kit => {
   const decimalPlaces = kit.issuer.getDisplayInfo?.()?.decimalPlaces ?? 6;

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -2,6 +2,10 @@
 export {};
 
 /**
+ * @import {Amount, Brand, DepositFacet, Issuer, IssuerKit, Payment} from '@agoric/ertp';
+ */
+
+/**
  * @typedef {object} PriceQuote
  * @property {Amount<'set', PriceDescription>} quoteAmount
  * Amount whose value is a PriceQuoteValue


### PR DESCRIPTION
_incidental_

## Description
While working on https://github.com/Agoric/agoric-subql/pull/46 I ran into type errors because some types in Fast USDC relies on ambients that weren't loaded in this usage.

This makes the imports explicit so they resolve when the package is used outside agoric-sdk.

### Security Considerations
n/a

### Scaling Considerations
n/a
### Documentation Considerations
n/a
### Testing Considerations
CI
### Upgrade Considerations
No compat concerns