### PR TITLE
test: allow workerThreads in swingset-vat

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -94,8 +94,7 @@
     "require": [
       "@endo/init/debug.js"
     ],
-    "timeout": "20m",
-    "workerThreads": false
+    "timeout": "20m"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
closes: #9392

## Description

Try enabling `workerThreads` (Ava default) to reduce GC flakes.


### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
Once this is green, merge and close #9392. If it recurs then reopen (and we'll know this doesn't solve the flakiness.)

### Upgrade Considerations
none