### PR TITLE
chore(swingset-liveslots): export TypeScript definitions

### DIFF
--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -14,7 +14,9 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint .",
+    "prepack": "tsc --build tsconfig.build.json",
+    "postpack": "git clean -f ':!src/types-index.d.ts' '*.d.ts*' '*.tsbuildinfo'"
   },
   "dependencies": {
     "@endo/errors": "^1.2.8",
@@ -36,9 +38,8 @@
     "@agoric/kmarshal": "^0.1.0"
   },
   "files": [
-    "src/**/*.js",
-    "src/**/*.d.ts",
-    "test/**/*.js",
+    "src",
+    "test",
     "tools",
     "exported.js"
   ],

--- a/packages/swingset-liveslots/tsconfig.build.json
+++ b/packages/swingset-liveslots/tsconfig.build.json
@@ -2,9 +2,5 @@
     "extends": [
         "./tsconfig.json",
         "../../tsconfig-build-options.json"
-    ],
-    "exclude": [
-        "src/types-index.js",
-        "test",
     ]
 }

--- a/packages/swingset-liveslots/tsconfig.build.json
+++ b/packages/swingset-liveslots/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    "extends": [
+        "./tsconfig.json",
+        "../../tsconfig-build-options.json"
+    ],
+    "exclude": [
+        "src/types-index.js",
+        "test",
+    ]
+}

--- a/packages/swingset-liveslots/tsconfig.json
+++ b/packages/swingset-liveslots/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {},
   "include": [
-    "*.js",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }


### PR DESCRIPTION
refs: #6343

## Description

Properly expose TypeScript definitions from `@agoric/swingset-liveslots` package by adding TypeScript build steps in `package.json` which generate the definitions.

### Security Considerations
No security impact - only affects TypeScript type definitions which are stripped at compile time.

### Scaling Considerations
No scaling impact - changes only affect development-time TypeScript support.

### Documentation Considerations
No documentation updates needed - this is a developer-facing change for TypeScript users.

### Testing Considerations
Existing type coverage tests continue to pass. No additional testing needed as this only affects type definition exposure.

### Upgrade Considerations
No upgrade impact - purely development-time TypeScript support changes.