### PR TITLE
test(liveslots): enable ava worker threads

### DIFF
--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -59,8 +59,7 @@
     "require": [
       "@endo/init/debug.js"
     ],
-    "timeout": "20m",
-    "workerThreads": false
+    "timeout": "20m"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
closes: #9392
refs: #10848

## Description
Enable ava workers for liveslots tests since there are some flakes on those tests as well, and we hope it might reduce them.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Keep an eye on test errors and flake alerts

### Upgrade Considerations
None
