### PR TITLE
chore(types): compat with swingset-liveslots exports

### DIFF
--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -14,6 +14,8 @@ import { makeScalarWeakMapStore } from '@agoric/store';
 import { TimeMath } from '@agoric/time';
 
 /**
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {Passable, RemotableObject} from '@endo/pass-style';
  * @import {Key} from '@endo/patterns';
  */

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -18,6 +18,7 @@ import {
 import { makeQuorumCounter } from './quorumCounter.js';
 
 /**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {BuildVoteCounter, OutcomeRecord, Position, QuestionSpec, VoteStatistics} from './types.js';
  */
 

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -16,6 +16,7 @@ import { ElectorateCreatorI, ElectoratePublicI } from './typeGuards.js';
 import { prepareVoterKit } from './voterKit.js';
 
 /**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {ElectorateCreatorFacet, CommitteeElectoratePublic, QuestionDetails, OutcomeRecord, AddQuestion} from './types.js';
  */
 

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -19,6 +19,7 @@ import {
 import { CONTRACT_ELECTORATE } from './governParam.js';
 
 /**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {AnyParamManager, GovernanceSubscriptionState, ParamManagerBase, ParamStateRecord, ParamValueTyped, UpdateParams} from '../types.js';
  */
 

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -3,6 +3,7 @@ import { E } from '@endo/eventual-send';
 import { deeplyFulfilled, Far } from '@endo/marshal';
 
 /**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {VoteCounterCreatorFacet, VoteCounterPublicFacet, QuestionSpec, OutcomeRecord, AddQuestion, AddQuestionReturn} from './types.js';
  */
 

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -19,6 +19,7 @@ import { makeQuorumCounter } from './quorumCounter.js';
 import { breakTie } from './breakTie.js';
 
 /**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {QuestionSpec, BuildMultiVoteCounter, MultiOutcomeRecord, Position, VoteStatistics} from './types.js';
  */
 

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -50,7 +50,7 @@ export {
  */
 // Copy this type because aliasing it by `import('@agoric/swingset-liveslots').Baggage`
 // causes this error in typedoc: Expected a symbol for node with kind Identifier
-/** @typedef {MapStore<string, any>} Baggage */
+/** @typedef {import('@agoric/swingset-liveslots').MapStore<string, any>} Baggage */
 
 // //////////////////////////// deprecated /////////////////////////////////////
 

--- a/packages/zoe/src/contractFacet/offerHandlerStorage.js
+++ b/packages/zoe/src/contractFacet/offerHandlerStorage.js
@@ -7,6 +7,11 @@ import { canBeDurable, provideDurableWeakMapStore } from '@agoric/vat-data';
 import { defineDurableHandle } from '../makeHandle.js';
 
 /**
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {MapStore} from '@agoric/swingset-liveslots';
+ */
+
+/**
  * The following should work. But for some reason, @endo/errors does
  * not export the type `Details`.
  * See https://github.com/endojs/endo/issues/2339

--- a/packages/zoe/src/contractFacet/reallocate.js
+++ b/packages/zoe/src/contractFacet/reallocate.js
@@ -4,6 +4,10 @@ import { makeScalarMapStore } from '@agoric/vat-data';
 import { assertRightsConserved } from './rightsConservation.js';
 import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
 
+/**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
+ */
+
 /** @typedef {Array<AmountKeywordRecord>} TransactionList */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -24,6 +24,11 @@ import { makeAllocationMap } from './reallocate.js';
 import { TransferPartShape } from '../contractSupport/atomicTransfer.js';
 
 /**
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {MapStore} from '@agoric/swingset-liveslots';
+ */
+
+/**
  * The SeatManager holds the active zcfSeats and can reallocate and
  * make new zcfSeats.
  *

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -3,6 +3,10 @@ import { provide } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 
 /**
+ * @import {MapStore} from '@agoric/swingset-liveslots';
+ */
+
+/**
  * SCALE: Only for low cardinality provisioning. Every value from init() will
  * remain in the map for the lifetime of the heap. If a key object is GCed, its
  * representative also remains.

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -7,6 +7,10 @@ import { fromUniqueEntries } from '@agoric/internal';
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
 import { atomicTransfer, fromOnly, toOnly } from './atomicTransfer.js';
 
+/**
+ * @import {Pattern} from '@endo/patterns';
+ */
+
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
 const getKeysSorted = obj => harden(Reflect.ownKeys(obj || {}).sort());

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -9,6 +9,10 @@ import { makeIssuerRecord } from './issuerRecord.js';
 const STORAGE_INSTANTIATED_KEY = 'IssuerStorageInstantiated';
 
 /**
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ */
+
+/**
  * Make the Issuer Storage.
  *
  * @param {import('@agoric/vat-data').Baggage} zcfBaggage

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -10,6 +10,10 @@ import './internal-types.js';
 import { cleanKeywords } from '../cleanProposal.js';
 
 /**
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ */
+
+/**
  * Store the pool purses whose purpose is to escrow assets, with one
  * purse per brand.
  *

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -11,9 +11,12 @@ import {
   UnwrappedInstallationShape,
 } from '../typeGuards.js';
 
-/** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
-/** @typedef { import('@agoric/swingset-vat').BundleID} BundleID */
-/** @import {Baggage} from '@agoric/vat-data' */
+/**
+ * @import {Baggage} from '@agoric/swingset-liveslots';
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {MapStore} from '@agoric/swingset-liveslots';
+ * @import {BundleID, BundleCap} from '@agoric/swingset-vat';
+ */
 
 /**
  * @param {GetBundleCapForID} getBundleCapForID

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -19,6 +19,10 @@ import {
 import { makeZoeSeatAdminFactory } from './zoeSeat.js';
 
 /**
+ * @import {WeakMapStore} from '@agoric/store';
+ */
+
+/**
  * @file Two objects are defined here, both called InstanceAdminSomething.
  * InstanceAdminStorage is a container for individual InstanceAdmins. Each
  * InstanceAdmin is associated with a particular contract instance, and is used

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -132,7 +132,7 @@
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation
- * @property {(invitationHandle: InvitationHandle) => Pattern | undefined} getProposalShapeForInvitation
+ * @property {(invitationHandle: InvitationHandle) => import('@endo/patterns').Pattern | undefined} getProposalShapeForInvitation
  */
 
 /**

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -21,8 +21,11 @@ import {
 
 // import '../internal-types.js';
 
-/** @import {Baggage} from '@agoric/vat-data' */
-/** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
+/**
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {BundleCap, EndoZipBase64Bundle} from '@agoric/swingset-vat';
+ */
 
 /**
  * @param {Pick<ZoeStorageManager, 'makeZoeInstanceStorageManager' | 'unwrapInstallation'>} startInstanceAccess

--- a/packages/zoe/src/zoeService/types-ambient.js
+++ b/packages/zoe/src/zoeService/types-ambient.js
@@ -44,7 +44,7 @@
  * @property {GetFeeIssuer} getFeeIssuer
  * @property {GetConfiguration} getConfiguration
  * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
- * @property {(invitationHandle: InvitationHandle) => Pattern | undefined} getProposalShapeForInvitation
+ * @property {(invitationHandle: InvitationHandle) => import('@endo/patterns').Pattern | undefined} getProposalShapeForInvitation
  *   Return the pattern (if any) associated with the invitationHandle that a
  *   proposal is required to match to be accepted by zoe.offer().
  */

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -12,8 +12,11 @@ import { handlePKitWarning } from '../src/handleWarning.js';
 import { makeHandle } from '../src/makeHandle.js';
 import zcfBundle from '../bundles/bundle-contractFacet.js';
 
-/** @typedef { import('@agoric/swingset-vat').BundleID} BundleID */
-/** @typedef { import('@agoric/swingset-vat').EndoZipBase64Bundle} EndoZipBase64Bundle */
+/**
+ * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {MapStore} from '@agoric/swingset-liveslots';
+ * @import {BundleID, EndoZipBase64Bundle} from '@agoric/swingset-vat';
+ */
 
 // this simulates a bundlecap, which is normally a swingset "device node"
 /** @typedef { import('@agoric/swingset-vat').BundleCap } BundleCap */


### PR DESCRIPTION
refs: #6343

## Description

A recent PR broke the `dependency-graph` check because it's not **Required**. The implication of this is that NPM packages won't publish until a fix is made in master.

This PR fixes it by explicitly importing types that are no long available ambiently. This is an improvement overall.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
no additional

### Upgrade Considerations
none