### PR TITLE
fix(swingset-xsnap-supervisor): Add missing promise-kit dependency

### DIFF
--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -29,6 +29,7 @@
     "@endo/import-bundle": "^1.3.2",
     "@endo/init": "^1.1.7",
     "@endo/marshal": "^1.6.2",
+    "@endo/promise-kit": "^1.1.8",
     "ava": "^5.3.0",
     "c8": "^10.1.2"
   },


### PR DESCRIPTION

## Description

Toward [better format preservation in Endo bundles](https://github.com/endojs/endo/pull/2444), this change fixes a missing dependency in the XSnap SwingSet supervisor bundle that the current bundler tolerates and the upcoming bundler will not.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

This missing dependency should have been discovered by our linter, and it’s not clear how it was not.

### Upgrade Considerations

This change is safe, but implies certain risks for swapping out the internals of `nestedEvaluate` and `getExport` bundle generators since the new bundler is more sensitive, which is a breaking change. Landing changes like this make it less of a practically breaking change, but a risk none-the-less. We may need to ramp the major version of `@endo/bundle-source`.