### PR TITLE
ci: build sdk image for multi-chain test

### DIFF
--- a/.github/actions/starship-action/README.md
+++ b/.github/actions/starship-action/README.md
@@ -1,0 +1,13 @@
+# Starship Devnet Action (Agoric fork)
+
+This `starship-action` was extracted from https://github.com/hyperweb-io/starship-action/tree/0.3.0
+
+We took:
+- action.yaml
+- install.sh
+- port-forward.sh
+
+Agoric added the `load-docker-images` input parameter to be able to import locally-built Docker images into Starship's Kubernetes cluster.
+
+Also, we ran `yarn prettier --write .github/actions/starship-action` to reformat
+the code to our repository's standards.

--- a/.github/actions/starship-action/action.yaml
+++ b/.github/actions/starship-action/action.yaml
@@ -1,0 +1,189 @@
+# https://github.com/hyperweb-io/starship-action/blob/0.3.0/action.yaml
+# Agoric: added load-docker-images, then prettified.
+name: 'Starship Devnet'
+description: 'Run mini cosmos ecosystem via devnet'
+branding:
+  color: blue
+  icon: anchor
+
+inputs:
+  values:
+    description: 'Values yaml raw data of filename for helm that define the topology for the devnet'
+    required: true
+  port-forward:
+    description: 'Flag weather to perform port forwarding as defined in the values file to local ports (default: true)'
+    required: false
+    default: 'true'
+  kubeconfig:
+    description: 'Kubeconfig file for remote cluster, if set, will be used instead of creating kind cluster'
+    required: false
+    default: ''
+  load-docker-images:
+    description: 'Space-separated local docker images to load into cluster'
+    required: false
+    default: ''
+  version:
+    description: 'Version of devnet chart (default: 0.1.45)'
+    required: false
+    default: '0.2.3'
+  chart:
+    description: 'Name of  the help chart to use. Recommended: use default (default: starship/devnet)'
+    required: false
+    default: 'starship/devnet'
+  repo:
+    description: 'Helm repo to fetch the chart from (default: https://cosmology-tech.github.io/starship)'
+    required: false
+    default: 'https://cosmology-tech.github.io/starship'
+  name:
+    description: 'Helm chart release name for installing helm chart (default: starship-devnet)'
+    required: false
+    default: 'starship-devnet'
+  namespace:
+    description: 'Kubernetes namespace to deploy helm charts on (default: ci-{github.repository}-{github.workflow}-{github.ref} )'
+    required: false
+    default: ''
+  timeout:
+    description: 'Timeout for helm install (default: 10m)'
+    required: false
+    default: '10m'
+
+outputs:
+  namespace:
+    description: 'Kubernetes namespace to which helm charts were deployed'
+    value: ${{ steps.set-namespace.outputs.namespace }}
+  name:
+    description: 'Helm chart release name for installing helm chart'
+    value: ${{ inputs.name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y make sed wget tar jq
+        sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+        sudo chmod +x /usr/bin/yq
+      shell: bash
+
+    - name: Setup helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.10.0
+
+    - name: Setup kubectl
+      uses: azure/setup-kubectl@v3
+      with:
+        version: v1.28.0
+
+    - name: Setup kind cluster
+      if: ${{ inputs.kubeconfig == '' }}
+      uses: helm/kind-action@v1.8.0
+      with:
+        cluster_name: kind-starship
+
+    - name: Load docker images into the kind-starship cluster
+      if: ${{ inputs.load-docker-images != '' && inputs.kubeconfig == '' }}
+      run: |
+        set -ex
+        kind load docker-image $LOAD_DOCKER_IMAGES --name kind-starship
+      env:
+        LOAD_DOCKER_IMAGES: ${{ inputs.load-docker-images }}
+      shell: bash
+
+    - name: Load docker images into an unkind cluster
+      if: ${{ inputs.load-docker-images != '' && inputs.kubeconfig != '' }}
+      run: |
+        echo "UNIMPLEMENTED: Cannot load docker images into a remote cluster: $LOAD_DOCKER_IMAGES"
+        exit 1
+      env:
+        LOAD_DOCKER_IMAGES: ${{ inputs.load-docker-images }}
+      shell: bash
+
+    - name: Create kubeconfig file
+      if: ${{ inputs.kubeconfig != '' }}
+      run: |
+        mkdir -p ~/.kube
+        echo -e "${{ inputs.kubeconfig }}" > ~/.kube/config
+      shell: bash
+
+    - name: Create values.yaml
+      run: |
+        if [[ "${{ inputs.values }}" == *.yaml || "${{ inputs.values }}" == *.yml ]]
+        then
+          cp ${{ inputs.values }} ${{ inputs.name }}-values.yaml
+        else
+          echo -e "${{ inputs.values }}" > ${{ inputs.name }}-values.yaml
+        fi
+        cat ${{ inputs.name }}-values.yaml
+      shell: bash
+
+    - name: Set namespace
+      id: set-namespace
+      run: |
+        namespace="ci-${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}"
+        if [ -n "$INPUT_NAMESPACE" ]; then
+          namespace="$INPUT_NAMESPACE"
+        fi
+        namespace="${namespace// /-}"
+        namespace="${namespace//\//-}"
+        namespace=$(awk '{print tolower($0)}' <<< $namespace)
+        (( ${#namespace} > 62 )) && namespace="$(echo $namespace | cut -c1-59)$((RANDOM%1000))"
+        namespace=$(echo $namespace | cut -c1-60)
+        echo "Setting namespace to $namespace"
+        echo "namespace=$namespace" >> $GITHUB_OUTPUT
+      shell: bash
+      env:
+        INPUT_NAMESPACE: ${{ inputs.namespace }}
+
+    - name: Setup starship helm repo
+      run: |
+        helm version
+        helm repo add starship ${{ inputs.repo }}
+        helm repo update
+        helm search repo starship/devnet
+      shell: bash
+
+    - name: Helm install
+      id: helm-install-1
+      continue-on-error: true
+      run: |
+        helm delete ${{ inputs.name }} --debug --namespace ${{ steps.set-namespace.outputs.namespace }} --wait || true
+        sleep 5
+        ${{ github.action_path }}/install.sh --config ${{ inputs.values }} --name ${{ inputs.name }} --chart ${{ inputs.chart }} --version ${{ inputs.version }} --namespace ${{ steps.set-namespace.outputs.namespace }} --timeout ${{ inputs.timeout }}
+      shell: bash
+
+    - name: Logs
+      if: always()
+      run: |
+        kubectl get pods -n $NAMESPACE
+        for i in `kubectl get po -n $NAMESPACE -o json | jq -r '.items[].metadata.name'`; do
+          echo "==================================================="
+          echo "Logs for $i"
+          kubectl describe pods $i -n $NAMESPACE
+          kubectl logs $i -n $NAMESPACE --all-containers --tail=800
+          echo "==================================================="
+        done
+      env:
+        VALUES_FILE: ${{ inputs.name }}-values.yaml
+        NAMESPACE: ${{ steps.set-namespace.outputs.namespace }}
+      shell: bash
+
+    - name: Helm install again
+      id: helm-install-2
+      if: steps.helm-install-1.outcome == 'failure'
+      run: |
+        helm delete ${{ inputs.name }} --debug --namespace ${{ steps.set-namespace.outputs.namespace }} --wait || true
+        sleep 5
+        kubectl get pods --namespace ${{ steps.set-namespace.outputs.namespace }}
+        ${{ github.action_path }}/install.sh --config ${{ inputs.name }}-values.yaml --name ${{ inputs.name }} --chart ${{ inputs.chart }} --version ${{ inputs.version }} --namespace ${{ steps.set-namespace.outputs.namespace }} --timeout ${{ inputs.timeout }}
+      shell: bash
+
+    - name: Port forward
+      if: ${{ inputs.port-forward == 'true' }}
+      run: |
+        kubectl version
+        ${{ github.action_path }}/port-forward.sh --config=$VALUES_FILE --namespace=$NAMESPACE
+      shell: bash
+      env:
+        VALUES_FILE: ${{ inputs.name }}-values.yaml
+        NAMESPACE: ${{ steps.set-namespace.outputs.namespace }}

--- a/.github/actions/starship-action/install.sh
+++ b/.github/actions/starship-action/install.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# https://github.com/hyperweb-io/starship-action/blob/0.3.0/install.sh
+# Agoric: prettified.
+
+## Script used to install the helm chart for the devnet from a config file
+## Usage:
+## ./scripts/install.sh --coinfig <config_file>
+## Options:
+## -c|--config: config file to use (default: config.yaml)
+## -v|--version: helm chart version (default: 0.1.43)
+
+set -euo pipefail
+
+# read config file from args into variable
+CONFIGFILE="config.yaml"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+echo "Script dir: ${SCRIPT_DIR}"
+
+# default values
+DRY_RUN=""
+TIMEOUT=""
+NAMESPACE=""
+HELM_NAME="starship"
+HELM_CHART="starship/devnet"
+HELM_CHART_VERSION="0.2.3"
+
+function set_helm_args() {
+  if [[ $TIMEOUT ]]; then
+    args="$args --timeout $TIMEOUT --wait --debug"
+  fi
+  if [[ $NAMESPACE ]]; then
+    args="$args --namespace $NAMESPACE --create-namespace"
+  fi
+  if [[ $DRY_RUN ]]; then
+    args="$args --dry-run"
+  fi
+  num_chains=$(yq -r ".chains | length - 1" ${CONFIGFILE})
+  if [[ $num_chains -lt 0 ]]; then
+    echo "No chains to parse: num: $num_chains"
+    return 0
+  fi
+  for i in $(seq 0 $num_chains); do
+    scripts=$(yq -r ".chains[$i].scripts" ${CONFIGFILE})
+    if [[ "$scripts" == "null" ]]; then
+      return 0
+    fi
+    datadir="$(cd "$(dirname -- "${CONFIGFILE}")" >/dev/null; pwd -P)"
+    for script in $(yq -r ".chains[$i].scripts | keys | .[]" ${CONFIGFILE}); do
+      args="$args --set-file chains[$i].scripts.$script.data=$datadir/$(yq -r ".chains[$i].scripts.$script.file" ${CONFIGFILE})"
+    done
+  done
+}
+
+function install_chart() {
+  args=""
+  set_helm_args
+  echo "args: $args"
+  helm install ${HELM_NAME} ${HELM_CHART} --version ${HELM_CHART_VERSION} -f ${CONFIGFILE} $args
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -c|--config)
+      CONFIGFILE="$2"
+      shift 2 # past argument=value
+      ;;
+    -v|--version)
+      HELM_CHART_VERSION="$2"
+      shift 2 # past argument
+      ;;
+    -t|--timeout)
+      TIMEOUT="$2"
+      shift 2 # past argument
+      ;;
+    -n|--name)
+      HELM_NAME="$2"
+      shift 2 # past argument
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift 2 # past argument
+      ;;
+    --chart)
+      HELM_CHART="$2"
+      shift 2 # past argument
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift 2 # past argument
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
+install_chart

--- a/.github/actions/starship-action/install.sh
+++ b/.github/actions/starship-action/install.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # read config file from args into variable
 CONFIGFILE="config.yaml"
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 echo "Script dir: ${SCRIPT_DIR}"
 
 # default values
@@ -45,7 +45,10 @@ function set_helm_args() {
     if [[ "$scripts" == "null" ]]; then
       return 0
     fi
-    datadir="$(cd "$(dirname -- "${CONFIGFILE}")" >/dev/null; pwd -P)"
+    datadir="$(
+      cd "$(dirname -- "${CONFIGFILE}")" > /dev/null
+      pwd -P
+    )"
     for script in $(yq -r ".chains[$i].scripts | keys | .[]" ${CONFIGFILE}); do
       args="$args --set-file chains[$i].scripts.$script.data=$datadir/$(yq -r ".chains[$i].scripts.$script.file" ${CONFIGFILE})"
     done
@@ -61,19 +64,19 @@ function install_chart() {
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    -c|--config)
+    -c | --config)
       CONFIGFILE="$2"
       shift 2 # past argument=value
       ;;
-    -v|--version)
+    -v | --version)
       HELM_CHART_VERSION="$2"
       shift 2 # past argument
       ;;
-    -t|--timeout)
+    -t | --timeout)
       TIMEOUT="$2"
       shift 2 # past argument
       ;;
-    -n|--name)
+    -n | --name)
       HELM_NAME="$2"
       shift 2 # past argument
       ;;
@@ -89,12 +92,12 @@ while [ $# -gt 0 ]; do
       DRY_RUN=1
       shift 2 # past argument
       ;;
-    -*|--*)
+    -* | --*)
       echo "Unknown option $1"
       exit 1
       ;;
-    *)
-      ;;
+    *) ;;
+
   esac
 done
 

--- a/.github/actions/starship-action/port-forward.sh
+++ b/.github/actions/starship-action/port-forward.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# https://github.com/hyperweb-io/starship-action/blob/0.3.0/port-forward.sh 
+# Agoric: prettified.
+
+set -euo pipefail
+
+function color() {
+  local color=$1
+  shift
+  local black=30 red=31 green=32 yellow=33 blue=34 magenta=35 cyan=36 white=37
+  local color_code=${!color:-$green}
+  printf "\033[%sm%s\033[0m\n" "$color_code" "$*"
+}
+
+function stop_port_forward() {
+  color green "Trying to stop all port-forward, if any...."
+  PIDS=$(ps -ef | grep -i -e 'kubectl port-forward' | grep -v 'grep' | cat | awk '{print $2}') || true
+  for p in $PIDS; do
+    kill -15 $p
+  done
+  sleep 2
+}
+
+# Default values
+CHAIN_RPC_PORT=26657
+CHAIN_COMETMOCK_PORT=22331
+CHAIN_GRPC_PORT=9090
+CHAIN_LCD_PORT=1317
+CHAIN_EXPOSER_PORT=8081
+CHAIN_FAUCET_PORT=8000
+RELAYER_REST_PORT=3000
+RELAYER_EXPOSER_PORT=8081
+EXPLORER_LCD_PORT=8080
+REGISTRY_LCD_PORT=8080
+REGISTRY_GRPC_PORT=9090
+MONITORING_PROMETHEUS_PORT=8080
+MONITORING_GRAFANA_PORT=8080
+
+for i in "$@"; do
+  case $i in
+    -c=*|--config=*)
+      CONFIGFILE="${i#*=}"
+      shift # past argument=value
+      ;;
+    -n=*|--namespace=*)
+      NAMESPACE="${i#*=}"
+      shift # past argument=value
+      ;;
+    -*|--*)
+      echo "Unknown option $i"
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
+stop_port_forward
+
+echo "Port forwarding for config ${CONFIGFILE}"
+echo "Port forwarding all chains"
+num_chains=$(yq -r ".chains | length - 1" ${CONFIGFILE})
+if [[ $num_chains -gt -1 ]]; then
+  for i in $(seq 0 $num_chains); do
+    # derive chain pod name from chain id
+    # https://github.com/cosmology-tech/starship/blob/main/charts/devnet/templates/_helpers.tpl#L56
+    chain=$(yq -r ".chains[$i].id" ${CONFIGFILE} )
+    chain=${chain/_/"-"}
+    localrpc=$(yq -r ".chains[$i].ports.rpc" ${CONFIGFILE} )
+    localgrpc=$(yq -r ".chains[$i].ports.grpc" ${CONFIGFILE} )
+    locallcd=$(yq -r ".chains[$i].ports.rest" ${CONFIGFILE} )
+    localexp=$(yq -r ".chains[$i].ports.exposer" ${CONFIGFILE})
+    localfaucet=$(yq -r ".chains[$i].ports.faucet" ${CONFIGFILE})
+    color yellow "chains: forwarded $chain"
+    if [[ $(yq -r ".chains[$i].cometmock.enabled" $CONFIGFILE) == "true" ]];
+    then
+      [[ "$localrpc" != "null" ]] && color yellow "    cometmock rpc to http://localhost:$localrpc" && kubectl port-forward pods/$chain-cometmock-0 $localrpc:$CHAIN_COMETMOCK_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    else
+      [[ "$localrpc" != "null" ]] && color yellow "    rpc to http://localhost:$localrpc" && kubectl port-forward pods/$chain-genesis-0 $localrpc:$CHAIN_RPC_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    fi
+    [[ "$localgrpc" != "null" ]] && color yellow "    grpc to http://localhost:$localgrpc" && kubectl port-forward pods/$chain-genesis-0 $localgrpc:$CHAIN_GRPC_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    [[ "$locallcd" != "null" ]] && color yellow "    lcd to http://localhost:$locallcd" && kubectl port-forward pods/$chain-genesis-0 $locallcd:$CHAIN_LCD_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    [[ "$localexp" != "null" ]] && color yellow "    exposer to http://localhost:$localexp" && kubectl port-forward pods/$chain-genesis-0 $localexp:$CHAIN_EXPOSER_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    [[ "$localfaucet" != "null" ]] && color yellow "    faucet to http://localhost:$localfaucet" && kubectl port-forward pods/$chain-genesis-0 $localfaucet:$CHAIN_FAUCET_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    sleep 1
+  done
+else
+  echo "No chains to port-forward: num: $num_chains"
+fi
+
+
+echo "Port forward relayers"
+num_relayers=$(yq -r ".relayers | length - 1" ${CONFIGFILE})
+if [[ $num_relayers -gt -1 ]]; then
+  for i in $(seq 0 $num_relayers); do
+    # derive chain pod name from chain id
+    # https://github.com/cosmology-tech/starship/blob/main/charts/devnet/templates/_helpers.tpl#L56
+    relayer=$(yq -r ".relayers[$i].name" ${CONFIGFILE} )
+    relayer=$(yq -r ".relayers[$i].type" ${CONFIGFILE} )-${relayer/_/"-"}
+    localrest=$(yq -r ".relayers[$i].ports.rest" ${CONFIGFILE} )
+    localexposer=$(yq -r ".relayers[$i].ports.exposer" ${CONFIGFILE} )
+    color yellow "relayers: forwarded $relayer"
+    [[ "$localrest" != "null" ]] && color yellow "    rpc to http://localhost:$localrest" && kubectl port-forward pods/$relayer-0 $localrest:$RELAYER_REST_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    [[ "$localexposer" != "null" ]] && color yellow "    rpc to http://localhost:$localexposer" && kubectl port-forward pods/$relayer-0 $localexposer:$RELAYER_EXPOSER_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+    sleep 1
+  done
+else
+  echo "No relayer to port-forward: num: $num_relayers"
+fi
+
+
+echo "Port forward services"
+
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
+then
+  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+  sleep 1
+  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+fi
+
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
+then
+  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+  sleep 1
+  color green "Open the explorer to get started.... http://localhost:8080"
+fi
+
+if [[ $(yq -r ".monitoring.enabled" $CONFIGFILE) == "true" ]];
+then
+  color yellow "monitoring port forward:"
+  localgrafana=$(yq -r ".monitoring.ports.grafana" ${CONFIGFILE})
+  localprometheus=$(yq -r ".monitoring.ports.prometheus" ${CONFIGFILE})
+  [[ "$localgrafana" != "null" ]] && color yellow "    grafana to http://localhost:$localgrafana" && kubectl port-forward service/grafana $localgrafana:$MONITORING_GRAFANA_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+  [[ "$localprometheus" != "null" ]] && color yellow "    prometheus to http://localhost:$localprometheus" && kubectl port-forward service/prometheus-service $localprometheus:$MONITORING_PROMETHEUS_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
+  sleep 1
+fi

--- a/.github/actions/starship-action/port-forward.sh
+++ b/.github/actions/starship-action/port-forward.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# https://github.com/hyperweb-io/starship-action/blob/0.3.0/port-forward.sh 
+# https://github.com/hyperweb-io/starship-action/blob/0.3.0/port-forward.sh
 # Agoric: prettified.
 
 set -euo pipefail
@@ -38,20 +38,20 @@ MONITORING_GRAFANA_PORT=8080
 
 for i in "$@"; do
   case $i in
-    -c=*|--config=*)
+    -c=* | --config=*)
       CONFIGFILE="${i#*=}"
       shift # past argument=value
       ;;
-    -n=*|--namespace=*)
+    -n=* | --namespace=*)
       NAMESPACE="${i#*=}"
       shift # past argument=value
       ;;
-    -*|--*)
+    -* | --*)
       echo "Unknown option $i"
       exit 1
       ;;
-    *)
-      ;;
+    *) ;;
+
   esac
 done
 
@@ -64,16 +64,15 @@ if [[ $num_chains -gt -1 ]]; then
   for i in $(seq 0 $num_chains); do
     # derive chain pod name from chain id
     # https://github.com/cosmology-tech/starship/blob/main/charts/devnet/templates/_helpers.tpl#L56
-    chain=$(yq -r ".chains[$i].id" ${CONFIGFILE} )
+    chain=$(yq -r ".chains[$i].id" ${CONFIGFILE})
     chain=${chain/_/"-"}
-    localrpc=$(yq -r ".chains[$i].ports.rpc" ${CONFIGFILE} )
-    localgrpc=$(yq -r ".chains[$i].ports.grpc" ${CONFIGFILE} )
-    locallcd=$(yq -r ".chains[$i].ports.rest" ${CONFIGFILE} )
+    localrpc=$(yq -r ".chains[$i].ports.rpc" ${CONFIGFILE})
+    localgrpc=$(yq -r ".chains[$i].ports.grpc" ${CONFIGFILE})
+    locallcd=$(yq -r ".chains[$i].ports.rest" ${CONFIGFILE})
     localexp=$(yq -r ".chains[$i].ports.exposer" ${CONFIGFILE})
     localfaucet=$(yq -r ".chains[$i].ports.faucet" ${CONFIGFILE})
     color yellow "chains: forwarded $chain"
-    if [[ $(yq -r ".chains[$i].cometmock.enabled" $CONFIGFILE) == "true" ]];
-    then
+    if [[ $(yq -r ".chains[$i].cometmock.enabled" $CONFIGFILE) == "true" ]]; then
       [[ "$localrpc" != "null" ]] && color yellow "    cometmock rpc to http://localhost:$localrpc" && kubectl port-forward pods/$chain-cometmock-0 $localrpc:$CHAIN_COMETMOCK_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
     else
       [[ "$localrpc" != "null" ]] && color yellow "    rpc to http://localhost:$localrpc" && kubectl port-forward pods/$chain-genesis-0 $localrpc:$CHAIN_RPC_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
@@ -88,17 +87,16 @@ else
   echo "No chains to port-forward: num: $num_chains"
 fi
 
-
 echo "Port forward relayers"
 num_relayers=$(yq -r ".relayers | length - 1" ${CONFIGFILE})
 if [[ $num_relayers -gt -1 ]]; then
   for i in $(seq 0 $num_relayers); do
     # derive chain pod name from chain id
     # https://github.com/cosmology-tech/starship/blob/main/charts/devnet/templates/_helpers.tpl#L56
-    relayer=$(yq -r ".relayers[$i].name" ${CONFIGFILE} )
-    relayer=$(yq -r ".relayers[$i].type" ${CONFIGFILE} )-${relayer/_/"-"}
-    localrest=$(yq -r ".relayers[$i].ports.rest" ${CONFIGFILE} )
-    localexposer=$(yq -r ".relayers[$i].ports.exposer" ${CONFIGFILE} )
+    relayer=$(yq -r ".relayers[$i].name" ${CONFIGFILE})
+    relayer=$(yq -r ".relayers[$i].type" ${CONFIGFILE})-${relayer/_/"-"}
+    localrest=$(yq -r ".relayers[$i].ports.rest" ${CONFIGFILE})
+    localexposer=$(yq -r ".relayers[$i].ports.exposer" ${CONFIGFILE})
     color yellow "relayers: forwarded $relayer"
     [[ "$localrest" != "null" ]] && color yellow "    rpc to http://localhost:$localrest" && kubectl port-forward pods/$relayer-0 $localrest:$RELAYER_REST_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
     [[ "$localexposer" != "null" ]] && color yellow "    rpc to http://localhost:$localexposer" && kubectl port-forward pods/$relayer-0 $localexposer:$RELAYER_EXPOSER_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
@@ -108,26 +106,22 @@ else
   echo "No relayer to port-forward: num: $num_relayers"
 fi
 
-
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
   kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
   kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
   sleep 1
   color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
   kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT --namespace $NAMESPACE > /dev/null 2>&1 &
   sleep 1
   color green "Open the explorer to get started.... http://localhost:8080"
 fi
 
-if [[ $(yq -r ".monitoring.enabled" $CONFIGFILE) == "true" ]];
-then
+if [[ $(yq -r ".monitoring.enabled" $CONFIGFILE) == "true" ]]; then
   color yellow "monitoring port forward:"
   localgrafana=$(yq -r ".monitoring.ports.grafana" ${CONFIGFILE})
   localprometheus=$(yq -r ".monitoring.ports.prometheus" ${CONFIGFILE})

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -21,6 +21,13 @@ jobs:
           submodules: 'true'
           path: ./agoric-sdk
 
+      - name: docker build (sdk)
+        # Produces ghcr.io/agoric/agoric-sdk:dev used in the following test.
+        run: |
+          make docker-build-sdk
+          docker tag ghcr.io/agoric/agoric-sdk:unreleased ghcr.io/agoric/agoric-sdk:dev
+        working-directory: ./agoric-sdk/packages/deployment
+
       - uses: ./agoric-sdk/.github/actions/restore-node
         with:
           node-version: 18.x

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -22,10 +22,9 @@ jobs:
           path: ./agoric-sdk
 
       - name: docker build (sdk)
-        # Produces ghcr.io/agoric/agoric-sdk:dev used in the following test.
+        # Produces local ghcr.io/agoric/agoric-sdk:dev used in the following test.
         run: |
-          make docker-build-sdk
-          docker tag ghcr.io/agoric/agoric-sdk:unreleased ghcr.io/agoric/agoric-sdk:dev
+          make docker-build-sdk TAG=dev
         working-directory: ./agoric-sdk/packages/deployment
 
       - uses: ./agoric-sdk/.github/actions/restore-node
@@ -86,6 +85,7 @@ jobs:
           port-forward: true
           version: 0.2.20
           timeout: 30m
+          load-docker-images: ghcr.io/agoric/agoric-sdk:dev
           namespace: ${{ env.NAMESPACE }}
           repo: https://hyperweb-io.github.io/starship
 

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -79,12 +79,15 @@ jobs:
 
       - name: Setup Starship Infrastructure
         id: starship-infra
-        uses: cosmology-tech/starship-action@0.3.0
+        # in lieu of cosmology-tech/starship-action@0.3.0
+        # (see local .github/actions/starship-action/README.md)
+        uses: ./agoric-sdk/.github/actions/starship-action
         with:
           values: ./agoric-sdk/multichain-testing/${{ inputs.config }}
           port-forward: true
           version: 0.2.20
           timeout: 30m
+          # Load the locally-built dev Docker image for the chain into kind.
           load-docker-images: ghcr.io/agoric/agoric-sdk:dev
           namespace: ${{ env.NAMESPACE }}
           repo: https://hyperweb-io.github.io/starship

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -22,6 +22,9 @@ import { makeTracer } from '@agoric/internal';
 
 const trace = makeTracer('E2ET');
 
+// The default of 6 retries was failing.
+const SMART_WALLET_PROVISION_RETRIES = 15;
+
 const BLD = '000000ubld';
 
 export const txAbbr = tx => {
@@ -204,7 +207,10 @@ export const provisionSmartWallet = async (
     () => q.queryData(`published.wallet.${address}.current`),
     result => !!result,
     `wallet in vstorage ${address}`,
-    { log: () => {} }, // suppress logs as this is already noisy
+    {
+      log: () => {}, // suppress logs as this is already noisy
+      maxRetries: SMART_WALLET_PROVISION_RETRIES,
+    },
   );
   progress({
     provisioned: address,


### PR DESCRIPTION
closes: #9805

## Description

Build the SDK Docker image so that the multi-chain test can use an up-to-date SDK image instead of the last published one.

### Security Considerations
None

### Scaling Considerations
This will make multichain tests in CI 5 minutes longer until we can amortize build through a shared step and depot runner, or some other explicit image sharing mechanism between pre-requisite jobs.

### Documentation Considerations
None

### Testing Considerations
Manually verify the integration test output of this PR

### Upgrade Considerations
None, testing only
