### PR TITLE
lint swingset-xsnap-supervisor imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -330,11 +330,4 @@ export default [
       '@typescript-eslint/no-floating-promises': 'off',
     },
   },
-  {
-    // Rules specific to swingset-xsnap-supervisor
-    files: ['packages/swingset-xsnap-supervisor/**/*.js'],
-    rules: {
-      'import/no-extraneous-dependencies': 'off',
-    },
-  },
 ];

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -22,14 +22,17 @@
     "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0"
   },
-  "devDependencies": {
-    "@endo/errors": "^1.2.8",
+  "peerDependencies": {
     "@agoric/swingset-liveslots": "^0.10.2",
+    "@endo/errors": "^1.2.8",
+    "@endo/import-bundle": "^1.3.2",
+    "@endo/promise-kit": "^1.1.8"
+  },
+  "devDependencies": {
     "@endo/bundle-source": "^3.5.0",
     "@endo/import-bundle": "^1.3.2",
     "@endo/init": "^1.1.7",
     "@endo/marshal": "^1.6.2",
-    "@endo/promise-kit": "^1.1.8",
     "ava": "^5.3.0",
     "c8": "^10.1.2"
   },


### PR DESCRIPTION
_incidental_

## Description
In #10878 I noticed,
> This missing dependency should have been discovered by our linter, and it’s not clear how it was not.

The package had disabled `import/no-extraneous-dependencies` for some reason. That was carried forward in the recent v9 upgrade: https://github.com/Agoric/agoric-sdk/pull/10846/files#diff-9ab4ae5d071b94a2d5dd874ceb3b9a1e85913fe7ee92e4956cb9801e59777002

This removes the special case and declares the deps so the rule passes.

### Security Considerations
none

### Scaling Considerations
none


### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none