### PR TITLE
fix wallet extract-id CLI

### DIFF
--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -101,6 +101,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 78.19
+    "atLeast": 78.5
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -101,6 +101,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 78.5
+    "atLeast": 78.73
   }
 }

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -55,6 +55,7 @@ export const makeWalletCommand = async command => {
     'wallet commands',
   );
 
+  /** @param {string} literalOrName */
   const normalizeAddress = literalOrName =>
     normalizeAddressWithOptions(literalOrName, wallet.opts());
 
@@ -112,9 +113,9 @@ export const makeWalletCommand = async command => {
     .action(async function (opts) {
       const offerStr = fs.readFileSync(opts.file).toString();
 
-      const { unserializer } = await makeVstorageKit({ fetch }, networkConfig);
+      const { marshaller } = makeVstorageKit({ fetch }, networkConfig);
 
-      const offerObj = unserializer.fromCapData(JSON.parse(offerStr));
+      const offerObj = marshaller.fromCapData(JSON.parse(offerStr));
       console.log(offerObj);
     });
 
@@ -127,9 +128,9 @@ export const makeWalletCommand = async command => {
     .action(async function (opts) {
       const offerStr = fs.readFileSync(opts.offer).toString();
 
-      const { unserializer } = await makeVstorageKit({ fetch }, networkConfig);
+      const { marshaller } = makeVstorageKit({ fetch }, networkConfig);
 
-      const offerObj = unserializer.fromCapData(JSON.parse(offerStr));
+      const offerObj = marshaller.fromCapData(JSON.parse(offerStr));
       console.log(offerObj.offer.id);
     });
 
@@ -204,7 +205,7 @@ export const makeWalletCommand = async command => {
     .command('list')
     .description('list all wallets in vstorage')
     .action(async function () {
-      const { vstorage } = await makeVstorageKit({ fetch }, networkConfig);
+      const { vstorage } = makeVstorageKit({ fetch }, networkConfig);
       const wallets = await vstorage.keys('published.wallet');
       process.stdout.write(wallets.join('\n'));
     });
@@ -218,10 +219,11 @@ export const makeWalletCommand = async command => {
       normalizeAddress,
     )
     .action(async function (opts) {
-      const { readPublished, unserializer, ...vsk } = makeVstorageKit(
-        { fetch },
-        networkConfig,
-      );
+      const {
+        readPublished,
+        marshaller: unserializer,
+        ...vsk
+      } = makeVstorageKit({ fetch }, networkConfig);
       const agoricNames = await makeAgoricNames(vsk.fromBoard, vsk.vstorage);
 
       const leader = makeLeader(networkConfig.rpcAddrs[0]);
@@ -229,6 +231,7 @@ export const makeWalletCommand = async command => {
         `:published.wallet.${opts.from}`,
         leader,
         {
+          // @ts-expect-error xxx follower/marshaller types
           unserializer,
         },
       );

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -5,6 +5,7 @@ import { execFileSync as execFileSyncAmbient } from 'child_process';
 
 /**
  * @import {MinimalNetworkConfig} from '@agoric/client-utils';
+ * @import {ParamsSDKType} from '@agoric/cosmic-proto/agoric/swingset/swingset.js';
  */
 
 const agdBinary = 'agd';
@@ -132,6 +133,7 @@ harden(execSwingsetTransaction);
 /**
  *
  * @param {MinimalNetworkConfig} net
+ * @returns {ParamsSDKType}
  */
 // TODO fetch by HTTP instead of shelling out https://github.com/Agoric/agoric-sdk/issues/9200
 export const fetchSwingsetParams = net => {

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -95,6 +95,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.37
+    "atLeast": 91.27
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -81,6 +81,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 90.93
+    "atLeast": 91.57
   }
 }

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -59,6 +59,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 88.99
+    "atLeast": 89.22
   }
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -69,6 +69,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 83.84
+    "atLeast": 83.4
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -76,6 +76,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 89.49
+    "atLeast": 89.48
   }
 }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -82,6 +82,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 95.58
+    "atLeast": 95.62
   }
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -58,6 +58,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.06
+    "atLeast": 93.04
   }
 }

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -94,6 +94,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 97.29
+    "atLeast": 97.77
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -59,6 +59,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 89.53
+    "atLeast": 89.69
   }
 }

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -66,6 +66,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 75.24
+    "atLeast": 75.2
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -77,6 +77,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.21
+    "atLeast": 90.43
   }
 }

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -44,6 +44,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 73.6
+    "atLeast": 73.54
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -98,6 +98,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 85.06
+    "atLeast": 85.11
   }
 }


### PR DESCRIPTION
closes: #10891

## Description

A recent refactor of agoric-cli introduced an error. It wasn't caught by typecheck because the callsite was `any`. 

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
This PR doesn't have a runtime regression test because this is a very uncommon code path which does have _some_ CI coverage in a3p-integration (https://github.com/Agoric/agoric-sdk/pull/10839/commits/1d018800e573718ed3a7f45611671cdab4c210ec) 

### Upgrade Considerations
Not run on chain.