### PR TITLE
test(fast-usdc): boot test for forward

### DIFF
--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -254,6 +254,7 @@ test.serial('makes usdc advance', async t => {
     storage,
     agoricNamesRemotes,
     harness,
+    runUtils: { EV },
   } = t.context;
   const oracles = await Promise.all([
     wfd.provideSmartWallet('agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8'),
@@ -316,6 +317,11 @@ test.serial('makes usdc advance', async t => {
     { evidence, status: 'OBSERVED' }, // observation includes evidence observed
     { status: 'ADVANCING' },
   ]);
+
+  // Restart contract to make sure it doesn't break advance flow
+  const kit = await EV.vat('bootstrap').consumeItem('fastUsdcKit');
+  const actual = await EV(kit.adminFacet).restartContract(kit.privateArgs);
+  t.deepEqual(actual, { incarnationNumber: 1 });
 
   const { runInbound } = t.context.bridgeUtils;
   await runInbound(
@@ -501,14 +507,6 @@ test.serial('LP withdraws', async t => {
     BigInt(lpBankDeposits[2].amount) >= 369_000n,
     'vbank GIVEs USDC back to LP',
   );
-});
-
-test.serial('restart contract', async t => {
-  const { EV } = t.context.runUtils;
-  await null;
-  const kit = await EV.vat('bootstrap').consumeItem('fastUsdcKit');
-  const actual = await EV(kit.adminFacet).restartContract(kit.privateArgs);
-  t.deepEqual(actual, { incarnationNumber: 1 });
 });
 
 test.serial('replace operators', async t => {


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/10623

I changed the test to simulate the vtransfer event *before* the oracles submit the evidence. I'd expect this to land in the forwarded state but it seems to just write `undefined` to vstorage.
Test failing:
```
 test/fast-usdc/fast-usdc.test.ts:353

   352:                                         
   353:   t.like(getTxStatus(evidence.txHash), [
   354:     { status: 'OBSERVED' },             

  Difference (- actual, + expected):

    [
      {
        status: 'OBSERVED',
      },
  -   undefined,
  -   undefined,
  +   {
  +     status: 'FORWARDING',
  +   },
  +   {
  +     status: 'FORWARDED',
  +   },
    ]
```

It seems from the logs that it executed this course of action. I'm not sure if the boot test environment just messed things up, or the contract actually isn't updating vstorage correctly. More logs from test:

```
inbound vtransfer {
  type: 'VTRANSFER_IBC_EVENT',
  blockHeight: 0,
  blockTime: 0,
  event: 'acknowledgementPacket',
  acknowledgement: 'eyJyZXN1bHQiOiJBUT09In0=',
  relayer: 'agoric123',
  target: 'agoric1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp7zqht',
  packet: {
    data: 'eyJkZW5vbSI6InVhdG9tIiwiYW1vdW50IjoiMTAiLCJzZW5kZXIiOiJhZ29yaWMxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFwN3pxaHQiLCJyZWNlaXZlciI6ImFnb3JpYzFmYWtlTENBQWRkcmVzcyIsIm1lbW8iOiIifQ==',
    destination_channel: 'channel-0',
    source_channel: 'channel-62',
    destination_port: 'transfer',
    source_port: 'transfer',
    sequence: '1'
  }
}
Trying 0 current patterns and 0 pending patterns against {
  acknowledgement: "eyJyZXN1bHQiOiJBUT09In0=",
  blockHeight: 0,
  blockTime: 0,
  event: "acknowledgementPacket",
  packet: {
    data: "eyJkZW5vbSI6InVhdG9tIiwiYW1vdW50IjoiMTAiLCJzZW5kZXIiOiJhZ29yaWMxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFwN3pxaHQiLCJyZWNlaXZlciI6ImFnb3JpYzFmYWtlTENBQWRkcmVzcyIsIm1lbW8iOiIifQ==",
    destination_channel: "channel-0",
    destination_port: "transfer",
    sequence: "1",
    source_channel: "channel-62",
    source_port: "transfer",
  },
  relayer: "agoric123",
  target: "agoric1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp7zqht",
  type: "VTRANSFER_IBC_EVENT",
}
No match yet.
inbound vtransfer {
  type: 'VTRANSFER_IBC_EVENT',
  blockHeight: 0,
  blockTime: 0,
  event: 'acknowledgementPacket',
  acknowledgement: 'eyJyZXN1bHQiOiJBUT09In0=',
  relayer: 'agoric123',
  target: 'agoric1qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc09z0g',
  packet: {
    data: 'eyJkZW5vbSI6InV1c2RjIiwiYW1vdW50IjoiMTUwMDAwMDAwIiwic2VuZGVyIjoibm9ibGUxeDB5ZGc2OWRoNmZxdnIyN3hqdnA2bWFxbXJsZGFtNnlmZWxxa2QiLCJyZWNlaXZlciI6ImFnb3JpYzEwcmNocXFncXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxMDY5MjR6cjZlcmV2M3VyemN0dzA5NnhzNnR3dnVxcGduenhlcW0iLCJtZW1vIjoiIn0=',
    destination_channel: 'channel-62',
    source_channel: 'channel-21',
    destination_port: 'transfer',
    source_port: 'transfer',
    sequence: '1'
  }
}
Trying 0 current patterns and 0 pending patterns against {
  acknowledgement: "eyJyZXN1bHQiOiJBUT09In0=",
  blockHeight: 0,
  blockTime: 0,
  event: "acknowledgementPacket",
  packet: {
    data: "eyJkZW5vbSI6InV1c2RjIiwiYW1vdW50IjoiMTUwMDAwMDAwIiwic2VuZGVyIjoibm9ibGUxeDB5ZGc2OWRoNmZxdnIyN3hqdnA2bWFxbXJsZGFtNnlmZWxxa2QiLCJyZWNlaXZlciI6ImFnb3JpYzEwcmNocXFncXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxMDY5MjR6cjZlcmV2M3VyemN0dzA5NnhzNnR3dnVxcGduenhlcW0iLCJtZW1vIjoiIn0=",
    destination_channel: "channel-62",
    destination_port: "transfer",
    sequence: "1",
    source_channel: "channel-21",
    source_port: "transfer",
  },
  relayer: "agoric123",
  target: "agoric1qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc09z0g",
  type: "VTRANSFER_IBC_EVENT",
}
No match yet.
----- Settler.14  3 upcall event 1 0
----- Settler.14  4 dequeued undefined for noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd 150000000n
----- Settler.14  5 ⚠️ tap: minted before observed noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd 150000000n
wallet agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8 starting executeOffer submit-mock-evidence-osmo
----- TxFeed.11  8 attest agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8 {
  aux: {
    forwardingChannel: 'channel-21',
    recipientAddress: 'agoric10rchqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq06924zr6erev3urzctw096xs6twvuqpgnzxeqm'
  },
  blockHash: '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
  blockNumber: 21037663n,
  chainId: 1,
  tx: {
    amount: 150000000n,
    forwardingAddress: 'noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd',
    sender: '0xDefaultFakeEthereumAddress'
  },
  txHash: '0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702'
}
----- TxFeed.11  9 transaction 0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702 has 1 of 2 necessary attestations
----- ZoeUtils.9  2 ℹ️ An offer was made on an inert invitation for submitting evidence
wallet agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8 submit-mock-evidence-osmo seated
wallet agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8 offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  proposal: {},
  result: 'inert; nothing should be expected from this offer'
}
wallet agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8 offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  proposal: {},
  result: 'inert; nothing should be expected from this offer',
  numWantsSatisfied: 1
}
wallet agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8 offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  numWantsSatisfied: 1,
  proposal: {},
  result: 'inert; nothing should be expected from this offer',
  payouts: {}
}
wallet agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr starting executeOffer submit-mock-evidence-osmo
----- TxFeed.11  10 attest agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr {
  aux: {
    forwardingChannel: 'channel-21',
    recipientAddress: 'agoric10rchqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq06924zr6erev3urzctw096xs6twvuqpgnzxeqm'
  },
  blockHash: '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
  blockNumber: 21037663n,
  chainId: 1,
  tx: {
    amount: 150000000n,
    forwardingAddress: 'noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd',
    sender: '0xDefaultFakeEthereumAddress'
  },
  txHash: '0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702'
}
----- TxFeed.11  11 transaction 0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702 has 2 of 2 necessary attestations
----- TxFeed.11  12 publishing evidence {
  aux: {
    forwardingChannel: 'channel-21',
    recipientAddress: 'agoric10rchqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq06924zr6erev3urzctw096xs6twvuqpgnzxeqm'
  },
  blockHash: '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
  blockNumber: 21037663n,
  chainId: 1,
  tx: {
    amount: 150000000n,
    forwardingAddress: 'noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd',
    sender: '0xDefaultFakeEthereumAddress'
  },
  txHash: '0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702'
} []
----- Advancer.15  2 decoded EUD: dydx1anything
----- Settler.14  6 matched minted early key, initiating forward noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd 150000000n
----- LocalOrchAccount.5  2 Transferring funds over IBC
----- LocalOrchAccount.5  3 got transfer route {
  sourcePort: 'transfer',
  sourceChannel: 'channel-62',
  token: {
    amount: '150000000',
    denom: 'ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9'
  },
  receiver: 'noble1test',
  forwardInfo: {
    forward: {
      receiver: 'dydx1anything',
      port: 'transfer',
      channel: 'channel-33',
      retries: 3,
      timeout: '10m',
      intermediateRecipient: [Object]
    }
  }
}
watchPacketPattern onFulfilled makeTagged("match:or", [
  makeTagged("match:splitRecord", [
    {
      acknowledgement: makeTagged("match:string", [] ),
      event: "acknowledgementPacket",
      packet: makeTagged("match:splitRecord", [
        {
          sequence: makeTagged("match:or", [
            1n,
            1,
            "1",
          ]),
          source_channel: "channel-62",
          source_port: "transfer",
        },
      ]),
    },
  ]),
  makeTagged("match:splitRecord", [
    {
      event: "timeoutPacket",
      packet: makeTagged("match:splitRecord", [
        {
          sequence: makeTagged("match:or", [
            1n,
            1,
            "1",
          ]),
          source_channel: "channel-62",
          source_port: "transfer",
        },
      ]),
    },
  ]),
])
No match yet. Save the pattern for later.
----- ZoeUtils.9  3 ℹ️ An offer was made on an inert invitation for submitting evidence
wallet agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr submit-mock-evidence-osmo seated
wallet agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  proposal: {},
  result: 'inert; nothing should be expected from this offer'
}
wallet agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  proposal: {},
  result: 'inert; nothing should be expected from this offer',
  numWantsSatisfied: 1
}
wallet agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  numWantsSatisfied: 1,
  proposal: {},
  result: 'inert; nothing should be expected from this offer',
  payouts: {}
}
wallet agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj starting executeOffer submit-mock-evidence-osmo
----- TxFeed.11  13 attest agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj {
  aux: {
    forwardingChannel: 'channel-21',
    recipientAddress: 'agoric10rchqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq06924zr6erev3urzctw096xs6twvuqpgnzxeqm'
  },
  blockHash: '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
  blockNumber: 21037663n,
  chainId: 1,
  tx: {
    amount: 150000000n,
    forwardingAddress: 'noble1x0ydg69dh6fqvr27xjvp6maqmrldam6yfelqkd',
    sender: '0xDefaultFakeEthereumAddress'
  },
  txHash: '0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702'
}
----- TxFeed.11  14 transaction 0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff387552761702 has 1 of 2 necessary attestations
----- ZoeUtils.9  4 ℹ️ An offer was made on an inert invitation for submitting evidence
wallet agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj submit-mock-evidence-osmo seated
wallet agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  proposal: {},
  result: 'inert; nothing should be expected from this offer'
}
wallet agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  proposal: {},
  result: 'inert; nothing should be expected from this offer',
  numWantsSatisfied: 1
}
wallet agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj offerStatus {
  id: 'submit-mock-evidence-osmo',
  invitationSpec: {
    invitationArgs: [ [Object] ],
    invitationMakerName: 'SubmitEvidence',
    previousOffer: 'claim-oracle-invitation',
    source: 'continuing'
  },
  numWantsSatisfied: 1,
  proposal: {},
  result: 'inert; nothing should be expected from this offer',
  payouts: {}
}
  ✘ [fail]: makes usdc advance
  ```