### PR TITLE
enable erasableSyntaxOnly with TypeScript 5.8

### DIFF
--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -39,7 +39,7 @@
     "patch-package": "^8.0.0",
     "starshipjs": "2.4.1",
     "ts-blank-space": "^0.4.4",
-    "typescript": "~5.7.2"
+    "typescript": "~5.8.0-beta"
   },
   "resolutions": {
     "axios": "1.6.7",

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -4925,7 +4925,7 @@ __metadata:
     patch-package: "npm:^8.0.0"
     starshipjs: "npm:2.4.1"
     ts-blank-space: "npm:^0.4.4"
-    typescript: "npm:~5.7.2"
+    typescript: "npm:~5.8.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -5458,7 +5458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.1.6 - 5.7.x, typescript@npm:^5.4.5, typescript@npm:~5.7.2":
+"typescript@npm:5.1.6 - 5.7.x, typescript@npm:^5.4.5":
   version: 5.7.2
   resolution: "typescript@npm:5.7.2"
   bin:
@@ -5468,13 +5468,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.1.6 - 5.7.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.7.2#optional!builtin<compat/typescript>":
+"typescript@npm:~5.8.0-beta":
+  version: 5.8.0-dev.20250130
+  resolution: "typescript@npm:5.8.0-dev.20250130"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/20852f1703f109576c925a6710d6d0001656ecc77d60fca4ea94ecd562290cef4aa529f919f45f6ab3c8334d3746a938ecca700ed7d2fd563d7cbc3dbf75f2bf
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A5.1.6 - 5.7.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
   version: 5.7.2
   resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A~5.8.0-beta#optional!builtin<compat/typescript>":
+  version: 5.8.0-dev.20250130
+  resolution: "typescript@patch:typescript@npm%3A5.8.0-dev.20250130#optional!builtin<compat/typescript>::version=5.8.0-dev.20250130&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/8cc5b8c72a84ff58ca8c2e3bdd25ea50e98aed8b6c079ddfa43f14744cd20d97529edd61ca930e99deb9c9d6321650fd69030169bbbd546187c426fcff83d360
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "type-coverage": "^2.27.1",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
-    "typescript": "~5.7.3",
+    "typescript": "~5.8.0-beta",
     "typescript-eslint": "^8.22.0"
   },
   "resolutions": {

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -157,7 +157,7 @@
     "ava": "^5.3.1",
     "rimraf": "^5.0.0",
     "tsd": "^0.31.1",
-    "typescript": "~5.7.1"
+    "typescript": "^5.8.0-beta"
   },
   "dependencies": {
     "@endo/base64": "^1.0.9",

--- a/packages/internal/test/ts-erasureSyntaxOnly.ts
+++ b/packages/internal/test/ts-erasureSyntaxOnly.ts
@@ -1,0 +1,11 @@
+// NB: not a test that runs.
+
+// Test the `--erasureSyntaxOnly` option of TypeScript 5.8
+// https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option
+
+// @ts-expect-error ts(1294) This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+enum Foo {
+  A = 1,
+  B = 2,
+  C = 3,
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "strictNullChecks": true,
     "noImplicitThis": true,
     "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,
     "noEmit": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12289,7 +12289,7 @@ typescript-eslint@^7.3.1, typescript-eslint@^8.14.0, typescript-eslint@^8.22.0:
     "@typescript-eslint/parser" "8.22.0"
     "@typescript-eslint/utils" "8.22.0"
 
-"typescript@5.1.6 - 5.7.x", typescript@^5.4.5, typescript@~5.7.1, typescript@~5.7.3:
+"typescript@5.1.6 - 5.7.x", typescript@^5.4.5:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
@@ -12298,6 +12298,11 @@ typescript-eslint@^7.3.1, typescript-eslint@^8.14.0, typescript-eslint@^8.22.0:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.8.0-beta, typescript@~5.8.0-beta:
+  version "5.8.0-dev.20250130"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.0-dev.20250130.tgz#eede4cf5d813f9845c6ee2b508d2392d544cb76e"
+  integrity sha512-qeH56cqOnOE0NO4zUsuuc5kyIQlzOPurHcguomUpSTfUE2He5dABg+fBBUeYIf4MreflM6ArXyj/rIrcHQ5g0g==
 
 typescript@~5.6.3:
   version "5.6.3"


### PR DESCRIPTION
_evergreen_

## Description
[TypeScript 5.8 beta](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/) adds an [erasableSyntaxOnly](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option) option.

This bumps the TypeScript dependency so we can use that option and adopts it.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations

I added non-erasable syntax locally to verify it errors:
```
src/types.ts:10:6 - error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.

10 enum Foo {}
```

EDIT: also [test: erasureSyntaxOnly regression](https://github.com/Agoric/agoric-sdk/pull/10916/commits/2d784cfccc0909441d3506c2d160a0b2894a2e27)

### Upgrade Considerations
none