### PR TITLE
chore: export @agoric/store types

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,9 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint .",
+    "prepack": "tsc --build tsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"
   },
   "repository": {
     "type": "git",

--- a/packages/store/tsconfig.build.json
+++ b/packages/store/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": [
+        "./tsconfig.json",
+        "../../tsconfig-build-options.json"
+    ]
+}

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {},
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
   ],


### PR DESCRIPTION
refs: #6343

## Description

Properly expose TypeScript definitions from `@agoric/store` package by adding TypeScript build steps in `package.json` which generate the definitions.

### Security Considerations
No security impact - only affects TypeScript type definitions which are stripped at compile time.

### Scaling Considerations
No scaling impact - changes only affect development-time TypeScript support.

### Documentation Considerations
No documentation updates needed - this is a developer-facing change for TypeScript users.

### Testing Considerations
Existing type coverage tests continue to pass. No additional testing needed as this only affects type definition exposure.

### Upgrade Considerations
No upgrade impact - purely development-time TypeScript support changes.