### PR TITLE
fix multichain-testing waitForBlock

### DIFF
--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -83,7 +83,7 @@ const makeBlockTool = ({ rpc, delay }) => {
     }
   };
 
-  return { waitForBootstrap, waitForBlock };
+  return { waitForBlock };
 };
 /** @typedef {ReturnType<makeBlockTool>} BlockTool */
 

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -23,7 +23,8 @@ import { makeTracer } from '@agoric/internal';
 const trace = makeTracer('E2ET');
 
 // The default of 6 retries was failing.
-const SMART_WALLET_PROVISION_RETRIES = 15;
+// XXX even 15 wasn't enough
+const SMART_WALLET_PROVISION_RETRIES = 30;
 
 const BLD = '000000ubld';
 
@@ -65,21 +66,25 @@ const makeBlockTool = ({ rpc, delay }) => {
     }
   };
 
-  let last;
-  const waitForBlock = async (times = 1, info = {}) => {
+  /**
+   * @param {number} [advance] number of blocks to wait for
+   * @param {object} [info] add to logging
+   * @returns {Promise<void>}
+   */
+  const waitForBlock = async (advance = 1, info = {}) => {
     await null;
-    for (let time = 0; time < times; time += 1) {
-      for (;;) {
-        const cur = await waitForBootstrap(2000, { ...info, last });
+    const startHeight = await waitForBootstrap();
+    for (
+      let latestHeight = startHeight;
+      latestHeight < startHeight + advance;
 
-        if (cur !== last) {
-          last = cur;
-          break;
-        }
-
-        await delay(1000, info);
-      }
-      time += 1;
+    ) {
+      // Give some time for a new block
+      await delay(1000, { ...info, latestHeight });
+      latestHeight = await waitForBootstrap(2000, {
+        ...info,
+        startHeight,
+      });
     }
   };
 
@@ -171,11 +176,13 @@ export const provisionSmartWallet = async (
   progress({ send: balances, to: address });
 
   /**
+   * Submit the `bank send` and wait for the next block.
+   * (Clients have an obligation not to submit >1 tx/block.)
+   *
    * @param {string} denom
    * @param {bigint} value
    */
   const sendFromWhale = async (denom, value) => {
-    trace('sendFromWhale', address, denom, value);
     const amount = `${value}${denom}`;
     progress({ amount, to: address });
     // TODO: refactor agd.tx to support a per-sender object
@@ -186,7 +193,7 @@ export const provisionSmartWallet = async (
       from: whale,
       yes: true,
     });
-    await blockTool.waitForBlock(1, { step: 'bank send' });
+    await blockTool.waitForBlock(1, { address, step: 'bank send' });
   };
 
   for await (const [name, qty] of Object.entries(balances)) {
@@ -206,12 +213,12 @@ export const provisionSmartWallet = async (
     { chainId, from: address, yes: true },
   );
 
+  trace('waiting for wallet to appear in vstorage', address);
   const info = await retryUntilCondition(
     () => q.queryData(`published.wallet.${address}.current`),
     result => !!result,
     `wallet in vstorage ${address}`,
     {
-      log: () => {}, // suppress logs as this is already noisy
       maxRetries: SMART_WALLET_PROVISION_RETRIES,
     },
   );


### PR DESCRIPTION
closes: #9934

## Description

It appears that when provisioning multiple wallets, `waitForBlock`  only runs on the first one. See `delay` in these logs:
<details><summary>provisioning log</summary>
<pre>

{ provisioning: 'agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl' }
----- Agd.10  8 $ agd tx swingset provision-one my-wallet agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl SMART_WALLET --keyring-backend test --chain-id agoriclocal --from agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl --broadcast-mode block --gas auto --gas-adjustment 1.4 --yes --output json
----- Agd.10  9 agd returned; {
  height: '428',
  txhash: 'B23153D1E23F536A16AA386338F29BF6AC98F6C27F93F4F2444BDA6AFFCCB909',
  codespace: '',
  code: 0,
  data: '12270A252F61676F7269632E7377696E677365742E4D736750726F766973696F6E526573706F6E7365',
  raw_log: '[{"msg_index":0,"events":[{"type":"coin_received","attributes":[{"key":"receiver","value":"agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl"},{"key":"amount","value":"10000000ubld"}]},{"type":"coin_spent","attributes":[{"key":"spender","value":"agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl"},{"key":"amount","value":"10000000ubld"}]},{"type":"message","attributes":[{"key":"action","value":"/agoric.swingset.MsgProvision"},{"key":"sender","value":"agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl"}]},{"type":"transfer","attributes":[{"key":"recipient","value":"agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl"},{"key":"sender","value":"agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl"},{"key":"amount","value":"10000000ubld"}]}]}]',
  logs: [ { msg_index: 0, log: '', events: [Array] } ],
  info: '',
  gas_wanted: '169174',
  gas_used: '119101',
  tx: null,
  timestamp: '',
  events: [
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'message', attributes: [Array] },
    { type: 'coin_spent', attributes: [Array] },
    { type: 'coin_received', attributes: [Array] },
    { type: 'transfer', attributes: [Array] },
    { type: 'message', attributes: [Array] }
  ]
}
----- E2ET.11  8 delay { step: 'bank send', delay: 1 } ...



{ provisioning: 'agoric1ujmk0492mauq2f2vrcn7ylq3w3x55k0ap9mt2p' }
----- Agd.10  10 $ agd tx swingset provision-one my-wallet agoric1ujmk0492mauq2f2vrcn7ylq3w3x55k0ap9mt2p SMART_WALLET --keyring-backend test --chain-id agoriclocal --from agoric1ujmk0492mauq2f2vrcn7ylq3w3x55k0ap9mt2p --broadcast-mode block --gas auto --gas-adjustment 1.4 --yes --output json
----- Agd.10  11 agd returned; {
  height: '429',
  txhash: 'D54B21B3AABC44660E800DCE758AD42533F4AAB408D0EAA8CA91CFD420790223',
  codespace: '',
  code: 0,
  data: '12270A252F61676F7269632E7377696E677365742E4D736750726F766973696F6E526573706F6E7365',
  raw_log: '[{"msg_index":0,"events":[{"type":"coin_received","attributes":[{"key":"receiver","value":"agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl"},{"key":"amount","value":"10000000ubld"}]},{"type":"coin_spent","attributes":[{"key":"spender","value":"agoric1ujmk0492mauq2f2vrcn7ylq3w3x55k0ap9mt2p"},{"key":"amount","value":"10000000ubld"}]},{"type":"message","attributes":[{"key":"action","value":"/agoric.swingset.MsgProvision"},{"key":"sender","value":"agoric1ujmk0492mauq2f2vrcn7ylq3w3x55k0ap9mt2p"}]},{"type":"transfer","attributes":[{"key":"recipient","value":"agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl"},{"key":"sender","value":"agoric1ujmk0492mauq2f2vrcn7ylq3w3x55k0ap9mt2p"},{"key":"amount","value":"10000000ubld"}]}]}]',
  logs: [ { msg_index: 0, log: '', events: [Array] } ],
  info: '',
  gas_wanted: '164596',
  gas_used: '115831',
  tx: null,
  timestamp: '',
  events: [
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'message', attributes: [Array] },
    { type: 'coin_spent', attributes: [Array] },
    { type: 'coin_received', attributes: [Array] },
    { type: 'transfer', attributes: [Array] },
    { type: 'message', attributes: [Array] }
  ]
}





{ provisioning: 'agoric1dh04lnl7epr7l4cpvqqprxvam7ewdswj7yv6ep' }
----- Agd.10  12 $ agd tx swingset provision-one my-wallet agoric1dh04lnl7epr7l4cpvqqprxvam7ewdswj7yv6ep SMART_WALLET --keyring-backend test --chain-id agoriclocal --from agoric1dh04lnl7epr7l4cpvqqprxvam7ewdswj7yv6ep --broadcast-mode block --gas auto --gas-adjustment 1.4 --yes --output json
----- Agd.10  13 agd returned; {
  height: '430',
  txhash: '25CC5888D26EB595DDF11C7F1741E1B5509D875A7FDC06E7A7227530B646F17D',
  codespace: '',
  code: 0,
  data: '12270A252F61676F7269632E7377696E677365742E4D736750726F766973696F6E526573706F6E7365',
  raw_log: '[{"msg_index":0,"events":[{"type":"coin_received","attributes":[{"key":"receiver","value":"agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl"},{"key":"amount","value":"10000000ubld"}]},{"type":"coin_spent","attributes":[{"key":"spender","value":"agoric1dh04lnl7epr7l4cpvqqprxvam7ewdswj7yv6ep"},{"key":"amount","value":"10000000ubld"}]},{"type":"message","attributes":[{"key":"action","value":"/agoric.swingset.MsgProvision"},{"key":"sender","value":"agoric1dh04lnl7epr7l4cpvqqprxvam7ewdswj7yv6ep"}]},{"type":"transfer","attributes":[{"key":"recipient","value":"agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl"},{"key":"sender","value":"agoric1dh04lnl7epr7l4cpvqqprxvam7ewdswj7yv6ep"},{"key":"amount","value":"10000000ubld"}]}]}]',
  logs: [ { msg_index: 0, log: '', events: [Array] } ],
  info: '',
  gas_wanted: '164596',
  gas_used: '115831',
  tx: null,
  timestamp: '',
  events: [
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'message', attributes: [Array] },
    { type: 'coin_spent', attributes: [Array] },
    { type: 'coin_received', attributes: [Array] },
    { type: 'transfer', attributes: [Array] },
    { type: 'message', attributes: [Array] }
  ]
}


</pre>
</details> 

This fixes `waitForBlock` to advance by the number of blocks in the argument.

It also removes `waitForBootstrap` which is a legacy fn that's not used.

### Security Considerations
n/a, tests

### Scaling Considerations
n/a, tests

### Documentation Considerations
none

### Testing Considerations
per se

### Upgrade Considerations
none