### PR TITLE
test(internal): fake vstorage advance blockHeight

### DIFF
--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -100,6 +100,14 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
   const resolvedOptions = { sequence: true, ...rootOptions };
   /** @type {TotalMap<string, string>} */
   const data = new Map();
+  let currentBlockHeight = 0;
+
+  const updateNewCellBlockHeight = (blockHeight = currentBlockHeight + 1) => {
+    blockHeight > currentBlockHeight ||
+      Fail`blockHeight ${blockHeight} must be greater than ${currentBlockHeight}`;
+    currentBlockHeight = blockHeight;
+  };
+
   /** @param {string} prefix */
   const getChildEntries = prefix => {
     assert(prefix.endsWith('.'));
@@ -177,10 +185,13 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
                 streamCell = undefined;
               }
             }
-            if (streamCell === undefined) {
+            if (
+              streamCell === undefined ||
+              Number(streamCell.blockHeight) !== currentBlockHeight
+            ) {
               streamCell = {
-                blockHeight: '0',
-                values: oldVal != null ? [oldVal] : [],
+                blockHeight: String(currentBlockHeight),
+                values: !streamCell && oldVal != null ? [oldVal] : [],
               };
             }
             streamCell.values.push(value);
@@ -219,6 +230,7 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
     rootNode,
     // eslint-disable-next-line object-shorthand
     data: /** @type {Map<string, string>} */ (data),
+    updateNewCellBlockHeight,
     getValues,
     messages,
     toStorage,

--- a/packages/internal/test/storage-test-utils.test.js
+++ b/packages/internal/test/storage-test-utils.test.js
@@ -192,9 +192,10 @@ test('makeFakeStorageKit', async t => {
 
 test('makeFakeStorageKit sequence data', async t => {
   const rootPath = 'root';
-  const { rootNode, messages } = makeFakeStorageKit(rootPath, {
-    sequence: true,
-  });
+  const { rootNode, messages, updateNewCellBlockHeight, getValues } =
+    makeFakeStorageKit(rootPath, {
+      sequence: true,
+    });
 
   await t.throwsAsync(
     // @ts-expect-error
@@ -233,6 +234,7 @@ test('makeFakeStorageKit sequence data', async t => {
     [{ method: 'append', args: [[deepPath, 'foo']] }],
     'auto-sequence grandchild setValue message',
   );
+  t.deepEqual(getValues(deepPath), ['foo']);
   deepNode = childNode.makeChildNode('grandchild', { sequence: false });
   await deepNode.setValue('bar');
   t.deepEqual(
@@ -240,13 +242,15 @@ test('makeFakeStorageKit sequence data', async t => {
     [{ method: 'set', args: [[deepPath, 'bar']] }],
     'manual-single grandchild setValue message',
   );
+  t.throws(() => getValues(deepPath), { name: 'SyntaxError' });
   childNode = rootNode.makeChildNode('child', { sequence: false });
-  await childNode.setValue('bar');
+  await childNode.setValue(''); // Results in removal
   t.deepEqual(
     messages.slice(-1),
-    [{ method: 'set', args: [[childPath, 'bar']] }],
+    [{ method: 'set', args: [[childPath]] }],
     'manual-single child setValue message',
   );
+  t.throws(() => getValues(childPath), { message: /^no data at path/ });
   deepNode = childNode.makeChildNode('grandchild');
   await deepNode.setValue('baz');
   t.deepEqual(
@@ -261,6 +265,22 @@ test('makeFakeStorageKit sequence data', async t => {
     [{ method: 'append', args: [[deepPath, 'qux']] }],
     'manual-sequence grandchild setValue message',
   );
+  t.deepEqual(getValues(deepPath), ['baz', 'qux']);
+  await deepNode.setValue('quux');
+  t.deepEqual(
+    messages.slice(-1),
+    [{ method: 'append', args: [[deepPath, 'quux']] }],
+    'manual-sequence grandchild setValue message',
+  );
+  t.deepEqual(getValues(deepPath), ['baz', 'qux', 'quux']);
+  updateNewCellBlockHeight();
+  await deepNode.setValue('quuz');
+  t.deepEqual(
+    messages.slice(-1),
+    [{ method: 'append', args: [[deepPath, 'quuz']] }],
+    'manual-sequence grandchild setValue message',
+  );
+  t.deepEqual(getValues(deepPath), ['quuz']);
 });
 
 const testUnmarshaller = test.macro((t, format) => {


### PR DESCRIPTION
refs: #10890
refs: #10931

## Description
Add a driver to update the block height in fake vstorage cells.

Add test of `sequence: false` based deletion.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
Internal test hooks

### Testing Considerations
Updated unit tests of fake storage

### Upgrade Considerations
None
