### PR TITLE
fix(fast-usdc): .exit() all internal temporary seats

### DIFF
--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -37,7 +37,7 @@ const {
 } = process.env;
 
 test.before('bootstrap', async t => {
-  const config = '@agoric/vm-config/decentral-itest-orchestration-config.json';
+  const config = '@agoric/vm-config/decentral-itest-fast-usdc-config.json';
   insistManagerType(defaultManagerType);
   const harness = ['xs-worker', 'xsnap'].includes(defaultManagerType)
     ? makeSwingsetHarness()

--- a/packages/fast-usdc/scripts/delete-completed-txs.js
+++ b/packages/fast-usdc/scripts/delete-completed-txs.js
@@ -1,0 +1,21 @@
+// import { E } from '@endo/far';
+/* global E */
+
+/** @import {FastUSDCCorePowers} from '../src/start-fast-usdc.core' */
+
+const trace = (...args) => console.log('FUPS', ...args);
+trace('script starting');
+
+/** @param {BootstrapPowers & FastUSDCCorePowers} powers */
+const pruneFastUsdcStorage = async powers => {
+  trace('pruneFastUsdcStorage');
+  const { fastUsdcKit } = powers.consume;
+  const { creatorFacet } = await fastUsdcKit;
+  trace(creatorFacet);
+  // @ts-expect-error core eval scripts get E as an endowment
+  await E(creatorFacet).deleteCompletedTxs();
+  trace('done');
+};
+
+trace('script finishing');
+pruneFastUsdcStorage;

--- a/packages/fast-usdc/src/clientSupport.js
+++ b/packages/fast-usdc/src/clientSupport.js
@@ -14,7 +14,7 @@ import { assertAllDefined } from '@agoric/internal';
  * @param {string} opts.offerId
  * @param {bigint} opts.fastLPAmount
  * @param {bigint} opts.usdcAmount
- * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
+ * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec & {proposal: USDCProposalShapes['deposit']}}
  */
 const makeDepositOffer = ({ brand }, { offerId, fastLPAmount, usdcAmount }) => {
   assertAllDefined({ offerId, fastLPAmount, usdcAmount });

--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -223,7 +223,8 @@ export const prepareAdvancerKit = (
         onFulfilled(result, ctx) {
           const { poolAccount, intermediateRecipient, settlementAddress } =
             this.state;
-          const { destination, advanceAmount, tmpSeat: _, ...detail } = ctx;
+          const { destination, advanceAmount, tmpSeat, ...detail } = ctx;
+          tmpSeat.exit();
           const amount = harden({
             denom: usdc.denom,
             value: advanceAmount.value,
@@ -260,6 +261,7 @@ export const prepareAdvancerKit = (
             const { borrower, notifier } = this.state;
             notifier.notifyAdvancingResult(restCtx, false);
             borrower.returnToPool(tmpSeat, advanceAmount);
+            tmpSeat.exit();
           } catch (e) {
             log('🚨 deposit to localOrchAccount failure recovery failed', e);
           }

--- a/packages/fast-usdc/src/exos/liquidity-pool.js
+++ b/packages/fast-usdc/src/exos/liquidity-pool.js
@@ -192,7 +192,9 @@ export const prepareLiquidityPoolKit = (zone, zcf, USDC, tools) => {
           zcf.atomicRearrange(
             harden([[borrowSeat, repaySeat, { USDC: amount }, returnAmounts]]),
           );
-          return this.facets.repayer.repay(repaySeat, returnAmounts);
+          this.facets.repayer.repay(repaySeat, returnAmounts);
+          borrowSeat.exit();
+          repaySeat.exit();
         },
       },
       repayer: {

--- a/packages/fast-usdc/src/exos/settler.js
+++ b/packages/fast-usdc/src/exos/settler.js
@@ -327,6 +327,7 @@ export const prepareSettler = (
             harden([[settlingSeat, settlingSeat, { In: received }, split]]),
           );
           repayer.repay(settlingSeat, split);
+          settlingSeat.exit();
 
           // update status manager, marking tx `DISBURSED`
           statusManager.disbursed(txHash, split);

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -193,6 +193,9 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
       await publishAddresses(storageNode, addresses);
       return addresses;
     },
+    deleteCompletedTxs() {
+      return statusManager.deleteCompletedTxs();
+    },
   });
 
   const publicFacet = zone.exo('Fast USDC Public', undefined, {

--- a/packages/fast-usdc/test/exos/advancer.test.ts
+++ b/packages/fast-usdc/test/exos/advancer.test.ts
@@ -47,6 +47,8 @@ const LOCAL_DENOM = `ibc/${denomHash({
 
 type CommonSetup = EReturn<typeof commonSetup>;
 
+const theExit = harden(() => {}); // for ava comparison
+
 const createTestExtensions = (t, common: CommonSetup) => {
   const {
     facadeServices: { chainHub },
@@ -77,7 +79,9 @@ const createTestExtensions = (t, common: CommonSetup) => {
   );
 
   const mockZCF = Far('MockZCF', {
-    makeEmptySeatKit: () => ({ zcfSeat: Far('MockZCFSeat', {}) }),
+    makeEmptySeatKit: () => ({
+      zcfSeat: Far('MockZCFSeat', { exit: theExit }),
+    }),
   });
 
   const localTransferVK = vowTools.makeVowKit<void>();
@@ -551,7 +555,7 @@ test('returns payment to LP if zoeTools.localTransfer fails', async t => {
   const { borrow, returnToPool } = inspectBorrowerFacetCalls();
 
   const expectedArguments = [
-    Far('MockZCFSeat', {}),
+    Far('MockZCFSeat', { exit: theExit }),
     usdc.make(146999999n), // net of fees
   ];
 

--- a/packages/fast-usdc/test/exos/settler.test.ts
+++ b/packages/fast-usdc/test/exos/settler.test.ts
@@ -33,6 +33,7 @@ const mockZcf = (zone: Zone) => {
 
   const makeSeatKit = zone.exoClassKit('MockSeatKit', undefined, () => ({}), {
     zcfSeat: {
+      exit() {},
       getCurrentAllocation() {
         return {};
       },

--- a/packages/vm-config/decentral-itest-fast-usdc-config.json
+++ b/packages/vm-config/decentral-itest-fast-usdc-config.json
@@ -1,0 +1,143 @@
+{
+    "$comment": "This SwingSet config file (see loadSwingsetConfigFile) is designed to bring up vats to test Fast USDC. Compared to decentral-itest-orchestration-config.json, it lacks write-chain-info.",
+    "bootstrap": "bootstrap",
+    "defaultReapInterval": 1000,
+    "coreProposals": [
+        "@agoric/builders/scripts/vats/init-core.js",
+        "@agoric/builders/scripts/vats/init-network.js",
+        "@agoric/builders/scripts/vats/init-localchain.js",
+        "@agoric/builders/scripts/vats/init-transfer.js",
+        "@agoric/builders/scripts/vats/init-orchestration.js",
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+            "entrypoint": "defaultProposalBuilder",
+            "args": [
+                {
+                    "econCommitteeOptions": {
+                        "committeeSize": 3
+                    },
+                    "referencedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
+                    "minInitialPoolLiquidity": "0"
+                }
+            ]
+        },
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "defaultProposalBuilder",
+            "args": [
+                {
+                    "interestRateValue": 1000,
+                    "interchainAssetOptions": {
+                        "denom": "ibc/toyatom",
+                        "decimalPlaces": 6,
+                        "initialPrice": 12.34,
+                        "keyword": "ATOM",
+                        "oracleBrand": "ATOM",
+                        "proposedName": "ATOM"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "psmProposalBuilder",
+            "args": [
+                {
+                    "anchorOptions": {
+                        "denom": "ibc/toyusdc",
+                        "decimalPlaces": 6,
+                        "keyword": "USDC_axl",
+                        "proposedName": "USD Coin"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "psmProposalBuilder",
+            "args": [
+                {
+                    "anchorOptions": {
+                        "denom": "ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9",
+                        "decimalPlaces": 6,
+                        "keyword": "USDC",
+                        "proposedName": "USDC"
+                    }
+                }
+            ]
+        },
+        {
+            "$comment": "XXX orchesration works without oracles but some test setup dependency fails to resolve without this",
+            "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+            "entrypoint": "defaultProposalBuilder",
+            "args": [
+                {
+                    "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+                    "oracleAddresses": [
+                        "@PRIMARY_ADDRESS@",
+                        "agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y"
+                    ],
+                    "IN_BRAND_LOOKUP": [
+                        "agoricNames",
+                        "oracleBrand",
+                        "ATOM"
+                    ],
+                    "IN_BRAND_DECIMALS": 6,
+                    "OUT_BRAND_LOOKUP": [
+                        "agoricNames",
+                        "oracleBrand",
+                        "USD"
+                    ],
+                    "OUT_BRAND_DECIMALS": 4
+                }
+            ]
+        }
+    ],
+    "vats": {
+        "bootstrap": {
+            "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
+            "creationOptions": {
+                "critical": true
+            }
+        }
+    },
+    "bundles": {
+        "agoricNames": {
+            "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+        },
+        "bank": {
+            "sourceSpec": "@agoric/vats/src/vat-bank.js"
+        },
+        "board": {
+            "sourceSpec": "@agoric/vats/src/vat-board.js"
+        },
+        "bridge": {
+            "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+        },
+        "centralSupply": {
+            "sourceSpec": "@agoric/vats/src/centralSupply.js"
+        },
+        "mintHolder": {
+            "sourceSpec": "@agoric/vats/src/mintHolder.js"
+        },
+        "priceAuthority": {
+            "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+        },
+        "provisionPool": {
+            "sourceSpec": "@agoric/inter-protocol/src/provisionPool.js"
+        },
+        "provisioning": {
+            "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+        },
+        "walletFactory": {
+            "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+        },
+        "zcf": {
+            "sourceSpec": "@agoric/zoe/contractFacet.js"
+        },
+        "zoe": {
+            "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+        }
+    },
+    "defaultManagerType": "xs-worker"
+}


### PR DESCRIPTION
closes #10890

refs:
  - #10931

## Description

mainly:

 - fix: .exit() all internal temporary seats

Also, to exercise pruning vstorage:

 - feat: core eval script to deleteCompletedTxs
    - expose deleteCompletedTx via creatorFacet

To speed up testing and match it with expected deployment:

 - chore: don't write-chain-info when testing Fast USDC

Plus a misc type refinement:
 
 - chore: refine return type of Offers.deposit


### Security / Scaling Considerations

Reducing leaks improves scalability which improves availability.

### Documentation Considerations

I don't think so.

### Testing Considerations

Tests are in #10931 ; they're somewhat rough and not included in this PR.

### Upgrade Considerations

Some undiagnosed heap growth remains. A fix for that might go out in a future upgrade.
