### PR TITLE
test: Stop leaking kernel promises from EV.sendOnly calls

### DIFF
--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -118,11 +118,21 @@ export const makeRunUtils = (controller, harness) => {
   // promise that can remain pending indefinitely, possibly to be settled by a
   // future message delivery.
 
+  /**
+   * @template {(typeof controller.queueToVatObject) | (typeof controller.queueToVatRoot)} T
+   * @param {T} invoker
+   * @param {Parameters<T>[0]} target
+   * @param {boolean} [voidResult]
+   */
   const makeMethodsProxy = (invoker, target, voidResult = false) =>
     new Proxy(harden({}), {
       get: (_t, method, _rx) => {
+        const resultPolicy = voidResult ? 'none' : undefined;
         const boundMethod = (...args) =>
-          queueAndRun(() => invoker(target, method, args), voidResult);
+          queueAndRun(
+            () => invoker(target, method, args, resultPolicy),
+            voidResult,
+          );
         return harden(boundMethod);
       },
     });

--- a/packages/SwingSet/tools/run-utils.js
+++ b/packages/SwingSet/tools/run-utils.js
@@ -53,7 +53,7 @@ export const makeRunUtils = (controller, harness) => {
   };
 
   /**
-   * @typedef {import('@endo/eventual-send').EProxy | object} EVProxyMethods
+   * @typedef EVProxyMethods
    * @property {(presence: unknown) => Record<string, (...args: any) => Promise<void>>} sendOnly
    *   Returns a "methods proxy" for the presence that ignores the results of
    *   each method invocation.
@@ -137,19 +137,20 @@ export const makeRunUtils = (controller, harness) => {
       },
     });
 
-  /** @type {EVProxy} */
-  const EV = Object.assign(
-    presence => makeMethodsProxy(controller.queueToVatObject, presence),
-    {
-      vat: vatName => makeMethodsProxy(controller.queueToVatRoot, vatName),
-      sendOnly: presence =>
-        makeMethodsProxy(controller.queueToVatObject, presence, true),
-      get: presence =>
-        new Proxy(harden({}), {
-          get: (_t, key, _rx) =>
-            EV.vat('bootstrap').awaitVatObject(presence, [key]),
-        }),
-    },
+  const EV = /** @type {EVProxy} */ (
+    Object.assign(
+      presence => makeMethodsProxy(controller.queueToVatObject, presence),
+      {
+        vat: vatName => makeMethodsProxy(controller.queueToVatRoot, vatName),
+        sendOnly: presence =>
+          makeMethodsProxy(controller.queueToVatObject, presence, true),
+        get: presence =>
+          new Proxy(harden({}), {
+            get: (_t, key, _rx) =>
+              EV.vat('bootstrap').awaitVatObject(presence, [key]),
+          }),
+      },
+    )
   );
   return harden({ queueAndRun, EV });
 };


### PR DESCRIPTION
Fixes #10942

## Description
Sets result policy "ignore" in `EV.sendOnly` calls to prevent kpid allocation.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This code is itself a testing utility.

### Upgrade Considerations
n/a