### PR TITLE
feat(zoe): zoe part of minimal want patterns using `M.containerHas(el,n)`

### DIFF
--- a/packages/zoe/exported.d.ts
+++ b/packages/zoe/exported.d.ts
@@ -10,8 +10,6 @@ import {
   AmountKeywordRecord as _AmountKeywordRecord,
   ContractMeta as _ContractMeta,
   Handle as _Handle,
-  Installation as _Installation,
-  Instance as _Instance,
   Invitation as _Invitation,
   InvitationAmount as _InvitationAmount,
   IssuerKeywordRecord as _IssuerKeywordRecord,
@@ -26,6 +24,11 @@ import {
   ZoeService as _ZoeService,
 } from './src/types-index.js';
 
+import {
+  Installation as _Installation,
+  Instance as _Instance,
+} from './src/zoeService/utils.js';
+
 declare global {
   // @ts-ignore TS2666: Exports and export assignments are not permitted in module augmentations.
   export {
@@ -35,7 +38,7 @@ declare global {
     _FeeIssuerConfig as FeeIssuerConfig,
     _Handle as Handle,
     _Installation as Installation,
-    _Instance as Instance,
+    // _Instance as Instance,
     _Invitation as Invitation,
     _InvitationAmount as InvitationAmount,
     _IssuerKeywordRecord as IssuerKeywordRecord,

--- a/packages/zoe/src/contractFacet/offerSafety.js
+++ b/packages/zoe/src/contractFacet/offerSafety.js
@@ -1,6 +1,10 @@
 import { AmountMath } from '@agoric/ertp';
 
 /**
+ * @import { AmountKeywordRecord, AmountBoundKeywordRecord } from '../zoeService/types.js'
+ */
+
+/**
  * Helper to perform satisfiesWant and satisfiesGive. Is
  * allocationAmount greater than or equal to requiredAmount for every
  * keyword of giveOrWant?
@@ -9,19 +13,19 @@ import { AmountMath } from '@agoric/ertp';
  * isOfferSafe will still be boolean. When we have Multiples, satisfiesWant and
  * satisfiesGive will tell how many times the offer was matched.
  *
- * @param {AmountKeywordRecord} giveOrWant
+ * @param {AmountBoundKeywordRecord} giveOrWant
  * @param {AmountKeywordRecord} allocation
  * @returns {0|1}
  */
 const satisfiesInternal = (giveOrWant = {}, allocation) => {
-  const isGTEByKeyword = ([keyword, requiredAmount]) => {
+  const isGTEByKeyword = ([keyword, requiredAmountBound]) => {
     // If there is no allocation for a keyword, we know the giveOrWant
     // is not satisfied without checking further.
     if (allocation[keyword] === undefined) {
       return 0;
     }
     const allocationAmount = allocation[keyword];
-    return AmountMath.isGTE(allocationAmount, requiredAmount) ? 1 : 0;
+    return AmountMath.isGTE(allocationAmount, requiredAmountBound) ? 1 : 0;
   };
   return Object.entries(giveOrWant).every(isGTEByKeyword) ? 1 : 0;
 };

--- a/packages/zoe/src/contractFacet/types.ts
+++ b/packages/zoe/src/contractFacet/types.ts
@@ -14,9 +14,9 @@ import type { Passable } from '@endo/pass-style';
 import type { Key, Pattern } from '@endo/patterns';
 import type {
   AmountKeywordRecord,
+  AmountBoundKeywordRecord,
   ExitRule,
   FeeMintAccess,
-  Instance,
   InvitationDetails,
   Keyword,
   ProposalRecord,
@@ -24,7 +24,7 @@ import type {
   UserSeat,
   ZoeService,
 } from '../types-index.js';
-import type { ContractStartFunction } from '../zoeService/utils.js';
+import type { ContractStartFunction, Instance } from '../zoeService/utils.js';
 
 /**
  * Any passable non-thenable. Often an explanatory string.
@@ -121,7 +121,7 @@ export type ZCF<CT = Record<string, unknown>> = {
 export type TransferPart = [
   fromSeat?: ZCFSeat,
   toSeat?: ZCFSeat,
-  fromAmounts?: AmountKeywordRecord,
+  fromAmounts?: AmountBoundKeywordRecord,
   toAmounts?: AmountKeywordRecord,
 ];
 

--- a/packages/zoe/src/contractSupport/atomicTransfer.js
+++ b/packages/zoe/src/contractSupport/atomicTransfer.js
@@ -1,12 +1,20 @@
 import { M } from '@agoric/store';
-import { AmountKeywordRecordShape, SeatShape } from '../typeGuards.js';
+import {
+  AmountKeywordRecordShape,
+  AmountBoundKeywordRecordShape,
+  SeatShape,
+} from '../typeGuards.js';
 
 /**
- * @import {TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {TransferPart, ZCF, ZCFSeat, AmountBoundKeywordRecord} from '@agoric/zoe';
  */
 
 export const TransferPartShape = M.splitArray(
-  harden([M.opt(SeatShape), M.opt(SeatShape), M.opt(AmountKeywordRecordShape)]),
+  harden([
+    M.opt(SeatShape),
+    M.opt(SeatShape),
+    M.opt(AmountBoundKeywordRecordShape),
+  ]),
   harden([M.opt(AmountKeywordRecordShape)]),
 );
 
@@ -62,11 +70,11 @@ export const atomicRearrange = (zcf, transfers) => {
  * `fromOnly` are non-optional, as otherwise it doesn't make much sense.
  *
  * @param {ZCFSeat} fromSeat
- * @param {AmountKeywordRecord} fromAmounts
+ * @param {AmountBoundKeywordRecord} fromAmountBounds
  * @returns {TransferPart}
  */
-export const fromOnly = (fromSeat, fromAmounts) =>
-  harden([fromSeat, undefined, fromAmounts]);
+export const fromOnly = (fromSeat, fromAmountBounds) =>
+  harden([fromSeat, undefined, fromAmountBounds]);
 
 /**
  * Sometimes a TransferPart in an atomicRearrange only expresses what amounts

--- a/packages/zoe/src/contracts/auction/firstPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/firstPriceLogic.js
@@ -11,8 +11,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
     want: { Ask: minBid },
   } = sellSeat.getProposal();
 
-  /** @type {Brand<'nat'>} */
-  const bidBrand = minBid.brand;
+  const bidBrand = /** @type {Brand<'nat'>} */ (minBid.brand);
   const emptyBid = AmountMath.makeEmpty(bidBrand);
 
   let highestBid = emptyBid;

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -11,8 +11,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
     want: { Ask: minBid },
   } = sellSeat.getProposal();
 
-  /** @type {Brand<'nat'>} */
-  const bidBrand = minBid.brand;
+  const bidBrand = /** @type {Brand<'nat'>} */ (minBid.brand);
   const emptyBid = AmountMath.makeEmpty(bidBrand);
 
   let highestBid = emptyBid;

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -2,6 +2,7 @@ import { assert, Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { M, mustMatch } from '@endo/patterns';
 import { AmountMath } from '@agoric/ertp';
 
 import {
@@ -16,6 +17,10 @@ import { calculateInterest, makeDebtCalculator } from './updateDebt.js';
 import { makeCloseLoanInvitation } from './close.js';
 import { makeAddCollateralInvitation } from './addCollateral.js';
 
+/**
+ * @import {NatAmount} from '@agoric/ertp';
+ */
+
 /** @type {MakeBorrowInvitation} */
 export const makeBorrowInvitation = (zcf, config) => {
   const {
@@ -28,7 +33,9 @@ export const makeBorrowInvitation = (zcf, config) => {
   } = config;
 
   // We can only lend what the lender has already escrowed.
-  const maxLoan = lenderSeat.getAmountAllocated('Loan');
+  const maxLoan = /** @type {NatAmount} */ (
+    lenderSeat.getAmountAllocated('Loan')
+  );
 
   /** @type {OfferHandler} */
   const borrow = async borrowerSeat => {
@@ -43,7 +50,10 @@ export const makeBorrowInvitation = (zcf, config) => {
         borrowerSeat.getProposal().give.Collateral.brand
       ),
     );
-    const loanWanted = borrowerSeat.getProposal().want.Loan;
+    const loanWanted = /** @type {NatAmount} */ (
+      borrowerSeat.getProposal().want.Loan
+    );
+    mustMatch(loanWanted.value, M.nat());
     const loanBrand = zcf.getTerms().brands.Loan;
 
     // The value of the collateral in the Loan brand

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -1,6 +1,7 @@
 // @jessie-check
 
 import {
+  AmountBoundShape,
   AmountShape,
   AssetKindShape,
   BrandShape,
@@ -31,9 +32,9 @@ export const InstallationShape = M.remotable('Installation');
 export const SeatShape = M.remotable('Seat');
 
 export const AmountKeywordRecordShape = M.recordOf(KeywordShape, AmountShape);
-export const AmountPatternKeywordRecordShape = M.recordOf(
+export const AmountBoundKeywordRecordShape = M.recordOf(
   KeywordShape,
-  M.pattern(),
+  AmountBoundShape,
 );
 export const PaymentPKeywordRecordShape = M.recordOf(
   KeywordShape,
@@ -80,7 +81,7 @@ export const TimerShape = makeHandleShape('timer');
  * @see {ProposalRecord} type
  */
 export const FullProposalShape = {
-  want: AmountPatternKeywordRecordShape,
+  want: AmountBoundKeywordRecordShape,
   give: AmountKeywordRecordShape,
   // To accept only one, we could use M.or rather than M.splitRecord,
   // but the error messages would have been worse. Rather,

--- a/packages/zoe/src/types.ts
+++ b/packages/zoe/src/types.ts
@@ -1,5 +1,6 @@
-import type { Brand, Issuer } from '@agoric/ertp';
+import type { ERef } from '@endo/eventual-send';
 import type { RemotableObject } from '@endo/pass-style';
+import type { Issuer, Brand } from '@agoric/ertp';
 
 /**
  * Alias for RemotableObject
@@ -17,10 +18,7 @@ export type Keyword = string;
  */
 export type InvitationHandle = Handle<'Invitation'>;
 export type IssuerKeywordRecord = Record<Keyword, Issuer<any>>;
-export type IssuerPKeywordRecord = Record<
-  Keyword,
-  import('@endo/far').ERef<Issuer<any>>
->;
+export type IssuerPKeywordRecord = Record<Keyword, ERef<Issuer<any>>>;
 export type BrandKeywordRecord = Record<Keyword, Brand<any>>;
 export type StandardTerms = {
   /**

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -2,8 +2,9 @@
 /// <reference types="@agoric/zoe/exported" />
 
 /**
+ * @import {VatAdminFacet, } from '@agoric/swingset-vat';
  * @import {FeeMintAccess, GetBrands, GetBundleIDFromInstallation, GetIssuers, InstallBundle, InstallBundleID, SourceBundle} from './types.js';
- * @import {InstanceRecord} from './utils.js';
+ * @import {Instance, InstanceRecord, GetPublicFacet, GetTerms} from './utils.js';
  */
 
 /**
@@ -95,7 +96,7 @@
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
  * @property {() => Issuer} getInvitationIssuer
  * @property {() => object} getRoot of CreateVatResults
- * @property {() => import('@agoric/swingset-vat').VatAdminFacet} getAdminNode of CreateVatResults
+ * @property {() => VatAdminFacet} getAdminNode of CreateVatResults
  */
 
 /**
@@ -129,16 +130,16 @@
  * @property {InstallBundle} installBundle
  * @property {InstallBundleID} installBundleID
  * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
- * @property {import('./utils.js').GetPublicFacet} getPublicFacet
+ * @property {GetPublicFacet} getPublicFacet
  * @property {GetBrands} getBrands
  * @property {GetIssuers} getIssuers
- * @property {import('./utils.js').GetTerms} getTerms
- * @property {(instance: import('./utils.js').Instance<any>) => string[]} getOfferFilter
+ * @property {GetTerms} getTerms
+ * @property {(instance: Instance<any>) => string[]} getOfferFilter
  * @property {(instance: Instance, strings: string[]) => any} setOfferFilter
- * @property {(instance: import('./utils.js').Instance<any>) => Promise<Installation>} getInstallationForInstance
+ * @property {(instance: Instance<any>) => Promise<Installation>} getInstallationForInstance
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation
- * @property {(invitationHandle: InvitationHandle) => import('@endo/patterns').Pattern | undefined} getProposalShapeForInvitation
+ * @property {(invitationHandle: InvitationHandle) => Pattern | undefined} getProposalShapeForInvitation
  */
 
 /**

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -12,14 +12,14 @@ type SourceBundle = Record<string, any>;
 /**
  * Installation of a contract, typed by its start function.
  */
-export type Installation<SF extends ContractStartFunction | unknown> =
+export type Installation<SF extends ContractStartFunction | unknown = any> =
   TagContainer<SF> &
     RemotableObject & {
       getBundle: () => SourceBundle;
       getBundleLabel: () => string;
     };
 
-export type Instance<SF extends ContractStartFunction | unknown> =
+export type Instance<SF extends ContractStartFunction | unknown = any> =
   TagContainer<SF> & RemotableObject & Handle<'Instance'>;
 
 export type InstallationStart<I> =

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -79,7 +79,9 @@ export const makeZoeStorageManager = (
   // EscrowStorage holds the purses that Zoe uses for escrow. This
   // object should be closely held and tracked: all of the digital
   // assets that users escrow are contained within these purses.
-  const escrowStorage = provideEscrowStorage(zoeBaggage);
+  const escrowStorage = provideEscrowStorage(zoeBaggage, brand =>
+    issuerStorage.getAssetKindByBrand(brand),
+  );
 
   // Add a purse for escrowing user funds (not for fees). Create the
   // local, non-remote escrow purse for the fee mint immediately.

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -11,10 +11,9 @@ import { M, type Key } from '@endo/patterns';
 // 'prepare' is deprecated but still supported
 import type { Brand } from '@agoric/ertp';
 import type { prepare as scaledPriceAuthorityStart } from '../src/contracts/scaledPriceAuthority.js';
-import type { Instance } from '../src/zoeService/utils.js';
+import type { Instance, Installation } from '../src/zoeService/utils.js';
 import type {
   ContractMeta,
-  Installation,
   Invitation,
   ZCF,
   ZCFSeat,

--- a/packages/zoe/test/unitTests/cleanProposal.test.js
+++ b/packages/zoe/test/unitTests/cleanProposal.test.js
@@ -5,6 +5,10 @@ import { cleanProposal } from '../../src/cleanProposal.js';
 import { setup } from './setupBasicMints.js';
 import buildManualTimer from '../../tools/manualTimer.js';
 
+/**
+ * @import {HasBound} from '@agoric/ertp';
+ */
+
 const proposeGood = (t, proposal, assetKind, expected) =>
   t.deepEqual(
     cleanProposal(harden(proposal), () => assetKind),
@@ -96,17 +100,20 @@ test('cleanProposal - wrong assetKind', t => {
 test('cleanProposal - want patterns', t => {
   const { moola, simoleans } = setup();
   const timer = buildManualTimer(t.log);
+  const wantAsset2HasBound = simoleans(
+    /** @type {HasBound} */ (M.containerHas(M.any())),
+  );
 
   proposeGood(
     t,
     {
-      want: { Asset2: M.any() },
+      want: { Asset2: wantAsset2HasBound },
       give: { Price2: moola(3n) },
       exit: { afterDeadline: { timer, deadline: 100n } },
     },
     'nat',
     {
-      want: { Asset2: M.any() },
+      want: { Asset2: wantAsset2HasBound },
       give: { Price2: moola(3n) },
       exit: { afterDeadline: { timer, deadline: 100n } },
     },
@@ -127,22 +134,22 @@ test('cleanProposal - want patterns', t => {
     t,
     {
       want: { Asset2: simoleans(1n) },
-      give: { Price2: M.any() },
+      give: { Price2: moola(M.containerHas(M.any())) },
       exit: { afterDeadline: { timer, deadline: 100n } },
     },
     'nat',
-    'A passable tagged "match:any" is not a key: "[match:any]"',
+    'A passable tagged "match:containerHas" is not a key: "[match:containerHas]"',
   );
 
   proposeBad(
     t,
     {
       want: { Asset2: simoleans(1n) },
-      give: { Price2: M.any() },
+      give: { Price2: moola(M.containerHas(M.any())) },
       exit: { afterDeadline: { timer, deadline: M.any() } },
     },
     'nat',
-    'A passable tagged "match:any" is not a key: "[match:any]"',
+    'A passable tagged "match:containerHas" is not a key: "[match:containerHas]"',
   );
 });
 

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -1,10 +1,11 @@
-import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { makeIssuerKit } from '@agoric/ertp';
 import { makeScalarMapStore } from '@agoric/store';
 import { makeZoeForTest } from '../../tools/setup-zoe.js';
 import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 
 /**
  * @import {MapStore} from '@agoric/swingset-liveslots';
+ * @import {AmountBound, AmountValueBound} from '@agoric/ertp';
  */
 
 export const setup = () => {
@@ -26,8 +27,13 @@ export const setup = () => {
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const zoe = makeZoeForTest(fakeVatAdmin);
 
-  /** @type {(brand: Brand<'nat'>) => (value: bigint) => Amount<'nat'>} */
-  const makeSimpleMake = brand => value => AmountMath.make(brand, value);
+  // The following more correct type causes an explosion of new lint errors
+  // /**
+  //  * @template {AssetKind} [AK='nat']
+  //  * @param {Brand<AK>} brand
+  //  * @returns {(value: AmountValueBound<AK>) => AmountBound<AK>}
+  //  */
+  const makeSimpleMake = brand => value => harden({ brand, value });
 
   const result = {
     moolaIssuer: moolaKit.issuer,

--- a/packages/zoe/test/unitTests/zoe/escrowStorage.test.js
+++ b/packages/zoe/test/unitTests/zoe/escrowStorage.test.js
@@ -1,7 +1,8 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
-
+import { Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
+
+import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { provideEscrowStorage } from '../../../src/zoeService/escrowStorage.js';
 import {
@@ -13,6 +14,7 @@ test('provideEscrowStorage', async t => {
   const { createPurse, provideLocalPurse, withdrawPayments, depositPayments } =
     provideEscrowStorage(
       makeScalarBigMapStore('zoe baggage', { durable: true }),
+      _brand => 'nat',
     );
 
   const stableKit = makeIssuerKit(
@@ -138,6 +140,7 @@ const setupPurses = async createPurse => {
 test('payments without matching give keywords', async t => {
   const { createPurse, depositPayments } = provideEscrowStorage(
     makeScalarBigMapStore('zoe baggage', { durable: true }),
+    _brand => Fail`Not in a mock test`,
   );
 
   const { ticketKit, stableKit } = await setupPurses(createPurse);
@@ -175,6 +178,7 @@ test('payments without matching give keywords', async t => {
 test(`give keywords without matching payments`, async t => {
   const { createPurse, depositPayments } = provideEscrowStorage(
     makeScalarBigMapStore('zoe baggage', { durable: true }),
+    _brand => Fail`Not in a mock test`,
   );
 
   const { ticketKit, stableKit } = await setupPurses(createPurse);

--- a/packages/zoe/tools/setup-zoe.js
+++ b/packages/zoe/tools/setup-zoe.js
@@ -8,7 +8,8 @@ import fakeVatAdmin, { makeFakeVatAdmin } from './fakeVatAdmin.js';
 
 /**
  * @import {EndoZipBase64Bundle, TestBundle} from '@agoric/swingset-vat';
- * @import {FeeIssuerConfig, Installation} from '../src/types-index.js';
+ * @import {Installation} from '../src/zoeService/utils.js';
+ * @import {FeeIssuerConfig} from '../src/types-index.js';
  */
 
 /**


### PR DESCRIPTION
Staged on https://github.com/Agoric/agoric-sdk/pull/11235 , which provides the E part

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2710 #1905 #1913 #1915 #2155 #2156 #2230 #4212 #4217 #10951 #11235

## Description

Implements minimal want patterns, where the only supported pattern is `M.containerHas`

- [ ] Zoe-level changes to accept want patterns

### Security Considerations

none

### Scaling Considerations

By allowing want patterns, might this make the processing of wants more expensive?

### Documentation Considerations

Need to update the Zoe API docs to explain want-patterns

### Testing Considerations


- [ ] Need to add Zoe tests once the Zoe changes are in

### Upgrade Considerations

None

- [ ] Need to update NEWS.md for Zoe