### PR TITLE
misc Fast USDC cleanup 

### DIFF
--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -23,8 +23,8 @@ import { makeTracer } from '@agoric/internal';
 const trace = makeTracer('E2ET');
 
 // The default of 6 retries was failing.
-// XXX even 15 wasn't enough
-const SMART_WALLET_PROVISION_RETRIES = 30;
+// XXX also tried 15, 30. There's probably something deeper to fix.
+const SMART_WALLET_PROVISION_RETRIES = 100;
 
 const BLD = '000000ubld';
 

--- a/packages/fast-usdc/src/exos/transaction-feed.js
+++ b/packages/fast-usdc/src/exos/transaction-feed.js
@@ -1,7 +1,7 @@
 import { makeTracer } from '@agoric/internal';
 import { prepareDurablePublishKit } from '@agoric/notifier';
 import { keyEQ, M } from '@endo/patterns';
-import { Fail } from '@endo/errors';
+import { Fail, quote } from '@endo/errors';
 import { CctpTxEvidenceShape, RiskAssessmentShape } from '../type-guards.js';
 import { defineInertInvitation } from '../utils/zoe.js';
 import { prepareOperatorKit } from './operator-kit.js';
@@ -221,7 +221,7 @@ export const prepareTransactionFeedKit = (zone, zcf) => {
                   '!=',
                   next,
                 );
-                Fail`conflicting evidence for ${txHash}`;
+                Fail`conflicting evidence for ${quote(txHash)}`;
               }
             }
             lastEvidence = next;

--- a/packages/fast-usdc/test/exos/liquidity-pool.test.ts
+++ b/packages/fast-usdc/test/exos/liquidity-pool.test.ts
@@ -2,6 +2,12 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { stateShape } from '../../src/exos/liquidity-pool.js';
 
+// NB: We don't test more than this because the Exo has so many runtime dependencies
+// for which we don't have viable mocks.
+// The Exo is tested by fast-usdc.contract.test.js, but that doesn't appear in code coverage.
+// We can solve that by getting code coverage for bundles https://github.com/Agoric/agoric-sdk/issues/1817
+// or by testing without bundling https://github.com/Agoric/agoric-sdk/issues/10558
+
 test('stateShape', t => {
   t.snapshot(stateShape);
 });


### PR DESCRIPTION
closes: #9934

## Description
Increases the threshold for multichain that has been timing out (à la #9934)

Also includes a couple tiny improvements to docs and logging.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
