### PR TITLE
Advance fail test

### DIFF
--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -439,7 +439,7 @@ test.serial(advanceAndSettleScenario, LP_DEPOSIT_AMOUNT / 4n, 'osmosis');
 test.serial(advanceAndSettleScenario, LP_DEPOSIT_AMOUNT / 8n, 'noble');
 test.serial(advanceAndSettleScenario, LP_DEPOSIT_AMOUNT / 5n, 'agoric');
 
-test.skip('advance failed (e.g. to missing chain)', async t => {
+test.serial('advance failed', async t => {
   const mintAmt = LP_DEPOSIT_AMOUNT / 10n;
   const {
     assertTxStatus,
@@ -451,7 +451,7 @@ test.skip('advance failed (e.g. to missing chain)', async t => {
   } = t.context;
 
   // EUD wallet on the specified chain
-  const eudWallet = await createWallet('cosmos');
+  const eudWallet = await createWallet('unreachable');
   const EUD = (await eudWallet.getAccounts())[0].address;
   t.log(`EUD wallet created: ${EUD}`);
 
@@ -487,13 +487,12 @@ test.skip('advance failed (e.g. to missing chain)', async t => {
   // submit evidences
   await Promise.all(txOracles.map(async o => o.submit(evidence)));
 
-  // XXX Not sure if the behavior should actually be ADVANCE_FAILED.
-  // It only reaches that state if the destination chain is valid.
-  await assertTxStatus(evidence.txHash, 'OBSERVED');
+  await assertTxStatus(evidence.txHash, 'ADVANCE_FAILED');
 
   nobleTools.mockCctpMint(mintAmt, userForwardingAddr);
 
   await assertTxStatus(evidence.txHash, 'FORWARD_FAILED');
+  await sleep(5000, { log: t.log, setTimeout });
 });
 
 test.serial('lp withdraws', async t => {

--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -492,7 +492,6 @@ test.serial('advance failed', async t => {
   nobleTools.mockCctpMint(mintAmt, userForwardingAddr);
 
   await assertTxStatus(evidence.txHash, 'FORWARD_FAILED');
-  await sleep(5000, { log: t.log, setTimeout });
 });
 
 test.serial('lp withdraws', async t => {

--- a/multichain-testing/test/support.ts
+++ b/multichain-testing/test/support.ts
@@ -102,6 +102,26 @@ export const commonSetup = async (
   const unreachableChain: CosmosChainInfo = {
     chainId: 'unreachable-chain',
     bech32Prefix: 'unreachable',
+    connections: {
+      noblelocal: {
+        client_id: '07-tendermint-898989',
+        counterparty: {
+          client_id: '07-tendermint-989898',
+          connection_id: 'connection-767676',
+        },
+        id: 'connection-424242',
+        state: 3,
+        transferChannel: {
+          channelId: 'channel-242424',
+          counterPartyChannelId: 'channel-656565',
+          counterPartyPortId: 'transfer',
+          ordering: 0,
+          portId: 'transfer',
+          state: 3,
+          version: 'ics20-1',
+        },
+      },
+    },
   };
 
   const chainInfo = {

--- a/multichain-testing/test/support.ts
+++ b/multichain-testing/test/support.ts
@@ -3,7 +3,10 @@ import { dirname, join } from 'path';
 import { execa } from 'execa';
 import fse from 'fs-extra';
 import childProcess from 'node:child_process';
-import { withChainCapabilities } from '@agoric/orchestration';
+import {
+  withChainCapabilities,
+  type CosmosChainInfo,
+} from '@agoric/orchestration';
 import { makeAgdTools } from '../tools/agd-tools.js';
 import { type E2ETools } from '../tools/e2e-tools.js';
 import {
@@ -95,7 +98,16 @@ export const commonSetup = async (
   const relayer = makeRelayer(childProcess);
   const nobleTools = makeNobleTools(childProcess);
   const assetInfo = makeAssetInfo(starshipChainInfo);
-  const chainInfo = withChainCapabilities(starshipChainInfo);
+
+  const unreachableChain: CosmosChainInfo = {
+    chainId: 'unreachable-chain',
+    bech32Prefix: 'unreachable',
+  };
+
+  const chainInfo = {
+    ...withChainCapabilities(starshipChainInfo),
+    ...withChainCapabilities({ unreachableChain }),
+  };
   const faucetTools = makeFaucetTools(
     t,
     tools.agd,

--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -32,12 +32,12 @@ import { makeFeeTools } from '../utils/fees.js';
  * @typedef {{
  *  chainHub: ChainHub;
  *  feeConfig: FeeConfig;
- *  localTransfer: ZoeTools['localTransfer'];
  *  log?: LogFn;
  *  statusManager: StatusManager;
  *  usdc: { brand: Brand<'nat'>; denom: Denom; };
  *  vowTools: VowTools;
  *  zcf: ZCF;
+ *  zoeTools: ZoeTools;
  * }} AdvancerKitPowers
  */
 
@@ -69,6 +69,16 @@ const AdvancerKitI = harden({
     ),
     onRejected: M.call(M.error(), AdvancerVowCtxShape).returns(M.undefined()),
   }),
+  withdrawHandler: M.interface('WithdrawHandlerI', {
+    onFulfilled: M.call(M.undefined(), {
+      advanceAmount: AnyNatAmountShape,
+      tmpReturnSeat: M.remotable(),
+    }).returns(M.undefined()),
+    onRejected: M.call(M.error(), {
+      advanceAmount: AnyNatAmountShape,
+      tmpReturnSeat: M.remotable(),
+    }).returns(M.undefined()),
+  }),
 });
 
 /**
@@ -98,12 +108,12 @@ export const prepareAdvancerKit = (
   {
     chainHub,
     feeConfig,
-    localTransfer,
     log = makeTracer('Advancer', true),
     statusManager,
     usdc,
     vowTools: { watch, when },
     zcf,
+    zoeTools: { localTransfer, withdrawToSeat },
   },
 ) => {
   assertAllDefined({
@@ -287,10 +297,55 @@ export const prepareAdvancerKit = (
          * @param {AdvancerVowCtx} ctx
          */
         onRejected(error, ctx) {
-          const { notifier } = this.state;
+          const { notifier, poolAccount } = this.state;
           log('Advance failed', error);
-          const { advanceAmount: _, ...restCtx } = ctx;
+          const { advanceAmount, ...restCtx } = ctx;
           notifier.notifyAdvancingResult(restCtx, false);
+          const { zcfSeat: tmpReturnSeat } = zcf.makeEmptySeatKit();
+          const withdrawV = withdrawToSeat(
+            // @ts-expect-error LocalAccountMethods vs OrchestrationAccount
+            poolAccount,
+            tmpReturnSeat,
+            harden({ USDC: advanceAmount }),
+          );
+          void watch(withdrawV, this.facets.withdrawHandler, {
+            advanceAmount,
+            tmpReturnSeat,
+          });
+        },
+      },
+      withdrawHandler: {
+        /**
+         *
+         * @param {undefined} result
+         * @param {{ advanceAmount: Amount<'nat'>; tmpReturnSeat: ZCFSeat; }} ctx
+         */
+        onFulfilled(result, { advanceAmount, tmpReturnSeat }) {
+          const { borrower } = this.state;
+          try {
+            borrower.returnToPool(tmpReturnSeat, advanceAmount);
+          } catch (e) {
+            // If we reach here, the unused advance funds will remain in `tmpReturnSeat`
+            // and must be retrieved from recovery sets.
+            log(
+              `🚨 return ${q(advanceAmount)} to pool failed. funds remain on "tmpReturnSeat"`,
+              e,
+            );
+          }
+          tmpReturnSeat.exit();
+        },
+        /**
+         * @param {Error} error
+         * @param {{ advanceAmount: Amount<'nat'>; tmpReturnSeat: ZCFSeat; }} ctx
+         */
+        onRejected(error, { advanceAmount, tmpReturnSeat }) {
+          log(
+            `🚨 withdraw ${q(advanceAmount)} from "poolAccount" to return to pool failed`,
+            error,
+          );
+          // If we reach here, the unused advance funds will remain in the `poolAccount`.
+          // A contract update will be required to return them to the LiquidityPool.
+          tmpReturnSeat.exit();
         },
       },
     },

--- a/packages/fast-usdc/src/exos/settler.js
+++ b/packages/fast-usdc/src/exos/settler.js
@@ -338,7 +338,13 @@ export const prepareSettler = (
          */
         forward(txHash, fullValue, EUD) {
           const { settlementAccount, intermediateRecipient } = this.state;
-          const dest = chainHub.makeChainAddress(EUD);
+          let dest;
+          try {
+            dest = chainHub.makeChainAddress(EUD);
+          } catch (e) {
+            log('⚠️ forward transfer failed!', e, txHash);
+            return statusManager.forwarded(txHash, false);
+          }
           const txfrV = E(settlementAccount).transfer(
             dest,
             AmountMath.make(USDC, fullValue),

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -125,11 +125,10 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     chainHub,
   });
 
-  const { localTransfer } = makeZoeTools(zcf, vowTools);
+  const zoeTools = makeZoeTools(zcf, vowTools);
   const makeAdvancer = prepareAdvancer(zone, {
     chainHub,
     feeConfig,
-    localTransfer,
     usdc: harden({
       brand: terms.brands.USDC,
       denom: terms.usdcDenom,
@@ -137,6 +136,7 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     statusManager,
     vowTools,
     zcf,
+    zoeTools,
   });
 
   const makeFeedKit = prepareTransactionFeedKit(zone, zcf);


### PR DESCRIPTION
It seems like in this scenario, the encumbered balance is not returning to 0. The lp-withdraw test next in the sequence fails because there's not enough USDC in the pool for all the LP tokens. I tried adding a `sleep` to see if it was just a delay, but I checked the vstorage viewer for my local chain several minutes later and it's still not reconstituted:

Partial test logs: https://gist.github.com/samsiegart/5d58b1e9e81b636fd3eb63a8940f8433
Chain logs for test run: https://gist.github.com/samsiegart/66776e48893a77f4cbd5a61e64abf87e

Vstorage after running test:
```
{"blockHeight":"854","values":[{"encumberedBalance":{"brand":{},"value":1583980000},"shareWorth":{"denominator":{"brand":{},"value":8000000001},"numerator":{"brand":{},"value":8036824001}},"totalBorrows":{"brand":{},"value":6137950000},"totalContractFees":{"brand":{},"value":9206000},"totalPoolFees":{"brand":{},"value":36824000},"totalRepays":{"brand":{},"value":4553970000}}]}
```
<img width="279" alt="Screenshot 2025-02-09 at 11 14 09 AM" src="https://github.com/user-attachments/assets/a1dbfec5-40df-41be-a5ad-3aa3ee82d634" />
