### PR TITLE
bump non-matrixed CI jobs from Node 18 to 20

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -36,15 +36,11 @@ jobs:
   dev-canary:
     needs: build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version
-        node-version: ['node-old']
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 'node-new'
 
       # Adapted from https://johnny.sh/notes/publish-canary-lerna-cicd/
       - name: configure NPM token
@@ -94,16 +90,12 @@ jobs:
   coverage:
     needs: build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version
-        node-version: ['node-old']
     if: ${{github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 'node-new'
 
       - name: generate test coverage report
         run: ./scripts/ci/generate-test-coverage-report.sh
@@ -136,16 +128,12 @@ jobs:
   benchmark:
     needs: build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version
-        node-version: ['node-old']
     if: ${{github.event_name == 'push'}}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 'node-new'
 
       - name: benchmark changes
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 'node-old'
+          node-version: 'node-new'
 
       - name: yarn bench (boot)
         shell: bash

--- a/.github/workflows/dump-ci-stats.yml
+++ b/.github/workflows/dump-ci-stats.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
-        with:
-          node-version: '18'
 
       - name: Install GCP Monitoring/Metrics Client
         run: yarn add @google-cloud/monitoring --ignore-workspace-root-check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,7 +64,7 @@ jobs:
       # Prerequisites
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 18.18
+          node-version: node-new
           keep-endo: 'true'
 
       # Select a branch of the
@@ -280,7 +280,7 @@ jobs:
           # and since we can't build core eval submissions from the SDK using a newer endo,
           # simply ignore any endo branch integration (this means we don't have full coverage)
           ignore-endo-branch: 'true'
-          node-version: 'node-old'
+          node-version: 'node-new'
           path: ./agoric-sdk
           # Forces xsnap to initialize all memory to random data, which increases
           # the chances the content of snapshots may deviate between validators

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,8 +140,10 @@ jobs:
           path: ./agoric-sdk
       - uses: ./agoric-sdk/.github/actions/restore-node
         with:
-          # XXX loadgen not compatible with 18.19 https://github.com/Agoric/agoric-sdk/pull/8365#issuecomment-1848003597
-          node-version: 18.18
+          # NB the Dockerfile.sdk based images must match this node version
+          # The node version inside ansible deployment (prepare-machine.yml)
+          # should also match this node version
+          node-version: 20
           path: ./agoric-sdk
       - name: Build cosmic-swingset dependencies
         working-directory: ./agoric-sdk

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -143,39 +143,6 @@ jobs:
           # XXX loadgen not compatible with 18.19 https://github.com/Agoric/agoric-sdk/pull/8365#issuecomment-1848003597
           node-version: 18.18
           path: ./agoric-sdk
-          # Forces xsnap to initialize all memory to random data, which increases
-          # the chances the content of snapshots may deviate between validators
-          xsnap-random-init: '1'
-
-      # Select a branch of the
-      # [load generator dapp repository](https://github.com/Agoric/testnet-load-generator)
-      # to use, defaulting to 'main' but allowing overrides in the pull request
-      # description using lines like `#loadgen-branch: ceelab`
-      - name: Get the appropriate loadgen branch
-        id: get-loadgen-branch
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            let branch = 'main';
-            if (context.payload.pull_request) {
-              const { body } = context.payload.pull_request;
-              const regex = /^\#loadgen-branch:\s+(\S+)/m;
-              const result = regex.exec(body);
-              if (result) {
-                branch = result[1];
-              }
-            }
-            console.log('loadgen branch: ' + branch);
-            return branch;
-
-      - name: Check out loadgen
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.ORG_NAME }}/${{ env.LOADGEN_REPO_NAME }}
-          path: ./${{ env.LOADGEN_REPO_NAME }}
-          ref: ${{steps.get-loadgen-branch.outputs.result}}
-
       - name: Build cosmic-swingset dependencies
         working-directory: ./agoric-sdk
         run: |
@@ -191,8 +158,7 @@ jobs:
         run: |
           set -xe
           DOCKER_VOLUMES="$PWD/../agoric-sdk:/usr/src/agoric-sdk" \
-          LOADGEN=1 \
-          ../agoric-sdk/packages/deployment/scripts/integration-test.sh
+           ../agoric-sdk/packages/deployment/scripts/integration-test.sh
         timeout-minutes: 90
         env:
           NETWORK_NAME: chaintest

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ./agoric-sdk/.github/actions/restore-node
         with:
-          node-version: 'node-old'
+          node-version: 'node-new'
           path: ./agoric-sdk
 
       # Extract chain and relayer information

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -58,7 +58,7 @@ jobs:
       # install node_modules
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 'node-old'
+          node-version: 'node-new'
 
       # Releasing SDK builds all packages in this order during `lerna publish`.
       # Due to ambient types, certain build orders (from the dependency graph)
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 'node-old'
+          node-version: 'node-new'
 
       - name: lint repo format
         run: yarn lint:format
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 'node-old'
+          node-version: 'node-new'
 
       # Check some of a3p-integration in this job that runs on PRs instead of
       # waiting for the slow integration test that by default only runs in the

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['node-old']
+        node-version: ['node-new']
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=$GOCACHE make GIT_COMMIT="$GIT_COMMIT" GIT_REVISIO
 # OTEL fetch
 # from https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 
-FROM node:18-bullseye AS otel
+FROM node:20-bullseye AS otel
 
 ARG OTEL_VERSION=0.48.0
 ARG OTEL_HASH_arm64=846852f4c34f6e494abe202402fdf1d17e2ec3c7a7f96985b6011126ae553249
@@ -35,7 +35,7 @@ RUN set -eux; \
 
 ###############################
 # @agoric/cosmos package
-FROM node:18-bullseye AS cosmos-package
+FROM node:20-bullseye AS cosmos-package
 ENV YARN_CACHE_FOLDER=/root/.yarn
 
 WORKDIR /usr/src/agoric-sdk/golang/cosmos
@@ -59,7 +59,7 @@ RUN mkdir golang/tmp && \
 
 ###############################
 # @agoric/xsnap package
-FROM node:18-bullseye AS xsnap-package
+FROM node:20-bullseye AS xsnap-package
 ENV YARN_CACHE_FOLDER=/root/.yarn
 
 # When changing/adding entries here, make sure to search the whole project for
@@ -90,7 +90,7 @@ RUN rm -rf packages/xsnap/moddable packages/xsnap/xsnap-native/build/tmp
 
 ###############################
 # The js build container
-FROM node:18-bullseye AS build-js
+FROM node:20-bullseye AS build-js
 ENV YARN_CACHE_FOLDER=/root/.yarn
 
 WORKDIR /usr/src/agoric-sdk
@@ -115,7 +115,7 @@ RUN yarn lerna run --ignore "@agoric/xsnap" build
 
 ###############################
 # The install container.
-FROM node:18-bullseye AS install
+FROM node:20-bullseye AS install
 
 # Install some conveniences.
 RUN apt-get --allow-releaseinfo-change update && apt-get install -y vim jq less && apt-get clean -y

--- a/packages/deployment/ansible/prepare-machine.yml
+++ b/packages/deployment/ansible/prepare-machine.yml
@@ -5,6 +5,6 @@
   gather_facts: yes
   strategy: free
   vars:
-    - NODEJS_VERSION: 18
+    - NODEJS_VERSION: 20
   roles:
     - prereq

--- a/packages/fast-usdc/package.json
+++ b/packages/fast-usdc/package.json
@@ -25,7 +25,7 @@
     "@fast-check/ava": "^2.0.1",
     "ava": "^5.3.0",
     "c8": "^10.1.2",
-    "execa": "9.1.0",
+    "nano-spawn": "^0.2.0",
     "ts-blank-space": "^0.4.4"
   },
   "dependencies": {

--- a/packages/fast-usdc/test/cli/cli.test.ts
+++ b/packages/fast-usdc/test/cli/cli.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { execa } from 'execa';
+import spawn from 'nano-spawn';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { initProgram } from '../../src/cli/cli.js';
@@ -10,7 +10,7 @@ const CLI_PATH = join(dir, '../../src/cli/bin.js');
 const runCli = async (args: string[]) => {
   await null;
   try {
-    const { stdout } = await execa(CLI_PATH, args);
+    const { stdout } = await spawn(CLI_PATH, args);
     return stdout;
   } catch (error: any) {
     return error.stderr || error.stdout || error.message;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9283,6 +9283,11 @@ n-readlines@^1.0.0, n-readlines@^1.0.1:
   resolved "https://registry.yarnpkg.com/n-readlines/-/n-readlines-1.0.1.tgz#bbb7364d38bc31a170a199f986fcacfa76b95f6e"
   integrity sha512-z4SyAIVgMy7CkgsoNw7YVz40v0g4+WWvvqy8+ZdHrCtgevcEO758WQyrYcw3XPxcLxF+//RszTz/rO48nzD0wQ==
 
+nano-spawn@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nano-spawn/-/nano-spawn-0.2.0.tgz#855cae42ac99caa6984aa2e9890bf191ef09994c"
+  integrity sha512-IjZBIOLxSlxu+m/kacg9JuP93oUpRemeV0mEuCy64nzBKKIL9m0aLJHtVPcVuzJDHFhElzjpwbW4a3tMzgKoZQ==
+
 napi-build-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"


### PR DESCRIPTION
refs: #8900

## Description

Bumping matrixed jobs requires some coordination because the **required checks** are bound to particular Node versions.

So this bumps everything on Node 18 except those.

It also replaces `execa` with `nano-spawn` to reduce dependencies (not possible before Node 20).

**TODO**
Blocked on,
- https://github.com/Agoric/testnet-load-generator/issues/117

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none