### PR TITLE
standards-compliant import.meta.resolve

### DIFF
--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -141,7 +141,7 @@ __metadata:
     "@endo/marshal": "npm:^1.6.3"
     "@endo/nat": "npm:^5.0.14"
     "@endo/promise-kit": "npm:^1.1.9"
-    import-meta-resolve: "npm:^2.2.1"
+    import-meta-resolve: "npm:^4.1.0"
   languageName: node
   linkType: soft
 
@@ -331,7 +331,7 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     anylogger: "npm:^0.21.0"
     better-sqlite3: "npm:^9.1.1"
-    import-meta-resolve: "npm:^2.2.1"
+    import-meta-resolve: "npm:^4.1.0"
     microtime: "npm:^3.1.0"
     semver: "npm:^6.3.0"
     tmp: "npm:^0.2.1"
@@ -420,7 +420,7 @@ __metadata:
     "@endo/pass-style": "npm:^1.4.8"
     "@endo/patterns": "npm:^1.4.8"
     "@endo/promise-kit": "npm:^1.1.9"
-    import-meta-resolve: "npm:^2.2.1"
+    import-meta-resolve: "npm:^4.1.0"
     jessie.js: "npm:^0.3.4"
   languageName: node
   linkType: soft
@@ -3778,10 +3778,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:^2.2.1":
-  version: 2.2.2
-  resolution: "import-meta-resolve@npm:2.2.2"
-  checksum: 10c0/80873aebf0d2a66e824e278fb6cbb16a6660f86df49b367404e5de80928720ecb44f643243b46dc5c5fae506abb666ef54d6f281b45ee0f1034951acb2261eb5
+"import-meta-resolve@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "import-meta-resolve@npm:4.1.0"
+  checksum: 10c0/42f3284b0460635ddf105c4ad99c6716099c3ce76702602290ad5cbbcd295700cbc04e4bdf47bacf9e3f1a4cec2e1ff887dabc20458bef398f9de22ddff45ef5
   languageName: node
   linkType: hard
 

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -179,7 +179,7 @@ __metadata:
     "@endo/marshal": "npm:^1.6.3"
     "@endo/nat": "npm:^5.0.14"
     "@endo/promise-kit": "npm:^1.1.9"
-    import-meta-resolve: "npm:^2.2.1"
+    import-meta-resolve: "npm:^4.1.0"
   languageName: node
   linkType: soft
 
@@ -370,7 +370,7 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     anylogger: "npm:^0.21.0"
     better-sqlite3: "npm:^9.1.1"
-    import-meta-resolve: "npm:^2.2.1"
+    import-meta-resolve: "npm:^4.1.0"
     microtime: "npm:^3.1.0"
     semver: "npm:^6.3.0"
     tmp: "npm:^0.2.1"
@@ -443,7 +443,7 @@ __metadata:
     "@endo/pass-style": "npm:^1.4.8"
     "@endo/patterns": "npm:^1.4.8"
     "@endo/promise-kit": "npm:^1.1.9"
-    import-meta-resolve: "npm:^2.2.1"
+    import-meta-resolve: "npm:^4.1.0"
     jessie.js: "npm:^0.3.4"
   languageName: node
   linkType: soft
@@ -3540,10 +3540,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:^2.2.1":
-  version: 2.2.2
-  resolution: "import-meta-resolve@npm:2.2.2"
-  checksum: 10c0/80873aebf0d2a66e824e278fb6cbb16a6660f86df49b367404e5de80928720ecb44f643243b46dc5c5fae506abb666ef54d6f281b45ee0f1034951acb2261eb5
+"import-meta-resolve@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "import-meta-resolve@npm:4.1.0"
+  checksum: 10c0/42f3284b0460635ddf105c4ad99c6716099c3ce76702602290ad5cbbcd295700cbc04e4bdf47bacf9e3f1a4cec2e1ff887dabc20458bef398f9de22ddff45ef5
   languageName: node
   linkType: hard
 

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -57,7 +57,7 @@
     "ansi-styles": "^6.2.1",
     "anylogger": "^0.21.0",
     "better-sqlite3": "^9.1.1",
-    "import-meta-resolve": "^2.2.1",
+    "import-meta-resolve": "^4.1.0",
     "microtime": "^3.1.0",
     "semver": "^6.3.0",
     "tmp": "^0.2.1",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -51,7 +51,7 @@
     "@endo/marshal": "^1.6.3",
     "@endo/promise-kit": "^1.1.9",
     "@endo/stream": "^1.2.9",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {
     "@agoric/deploy-script-support": "^0.10.3",

--- a/packages/boot/test/configs.test.js
+++ b/packages/boot/test/configs.test.js
@@ -12,10 +12,9 @@ import { mustMatch } from '@agoric/store';
 import { loadSwingsetConfigFile, shape as ssShape } from '@agoric/swingset-vat';
 import { provideBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 
-const importConfig = configName =>
-  importMetaResolve(`@agoric/vm-config/${configName}`, import.meta.url).then(
-    u => new URL(u).pathname,
-  );
+const importConfig = async configName =>
+  new URL(importMetaResolve(`@agoric/vm-config/${configName}`, import.meta.url))
+    .pathname;
 
 const test =
   /** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>}} */ (

--- a/packages/boot/test/upgrading/upgrade-contracts.test.js
+++ b/packages/boot/test/upgrading/upgrade-contracts.test.js
@@ -13,8 +13,8 @@ import { buildVatController } from '@agoric/swingset-vat';
 const test = anyTest;
 
 const bfile = name => new URL(name, import.meta.url).pathname;
-const importSpec = spec =>
-  importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
+const importSpec = async spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 test('upgrade mintHolder', async t => {
   /** @type {SwingSetConfig} */

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -12,8 +12,8 @@ import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
 import type { buildRootObject as buildTestMintVat } from './vat-mint.js';
 
 const bfile = name => new URL(name, import.meta.url).pathname;
-const importSpec = spec =>
-  importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
+const importSpec = async spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 const makeCallOutbound = t => (srcID, obj) => {
   t.log(`callOutbound(${srcID}, ${obj})`);

--- a/packages/boot/tools/authorityViz.js
+++ b/packages/boot/tools/authorityViz.js
@@ -274,7 +274,8 @@ const run = async () => {
     stdout: process.stdout,
     fsp,
     meta: {
-      resolve: metaResolve.resolve,
+      resolve: async (specifier, parent) =>
+        metaResolve.resolve(specifier, parent),
       url: import.meta.url,
       load: specifier => import(specifier),
     },

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -115,9 +115,8 @@ export const getNodeTestVaultsConfig = async ({
   defaultManagerType = 'local' as ManagerType,
   discriminator = '',
 }) => {
-  const fullPath = importMetaResolve(specifier, import.meta.url).then(
-    u => new URL(u).pathname,
-  );
+  const fullPath = new URL(importMetaResolve(specifier, import.meta.url))
+    .pathname;
   const config: SwingSetConfig & { coreProposals?: any[] } = NonNullish(
     await loadSwingsetConfigFile(fullPath),
   );

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -115,7 +115,7 @@ export const getNodeTestVaultsConfig = async ({
   defaultManagerType = 'local' as ManagerType,
   discriminator = '',
 }) => {
-  const fullPath = await importMetaResolve(specifier, import.meta.url).then(
+  const fullPath = importMetaResolve(specifier, import.meta.url).then(
     u => new URL(u).pathname,
   );
   const config: SwingSetConfig & { coreProposals?: any[] } = NonNullish(

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -163,12 +163,12 @@ interface Powers {
   fs: typeof import('node:fs/promises');
 }
 
+const importSpec = async spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
+
 export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
   const getPkgPath = (pkg, fileName = '') =>
     new URL(`../../${pkg}/${fileName}`, import.meta.url).pathname;
-
-  const importSpec = spec =>
-    importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
   const runPackageScript = (
     outputDir: string,

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -40,7 +40,7 @@
     "@endo/patterns": "^1.4.8",
     "@endo/promise-kit": "^1.1.9",
     "@endo/stream": "^1.2.9",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {
     "@endo/errors": "^1.2.9",

--- a/packages/builders/test/inter-proposals.test.js
+++ b/packages/builders/test/inter-proposals.test.js
@@ -13,9 +13,8 @@ const test = anyTest;
 const makeTestContext = t => {
   /** @param {string} specifier */
   const loadConfig = async specifier => {
-    const fullPath = importMetaResolve(specifier, import.meta.url).then(
-      u => new URL(u).pathname,
-    );
+    const fullPath = new URL(importMetaResolve(specifier, import.meta.url))
+      .pathname;
     t.is(typeof fullPath, 'string');
     const txt = await ambientFs.promises.readFile(fullPath, 'utf-8');
     t.is(typeof txt, 'string');

--- a/packages/builders/test/inter-proposals.test.js
+++ b/packages/builders/test/inter-proposals.test.js
@@ -13,7 +13,7 @@ const test = anyTest;
 const makeTestContext = t => {
   /** @param {string} specifier */
   const loadConfig = async specifier => {
-    const fullPath = await importMetaResolve(specifier, import.meta.url).then(
+    const fullPath = importMetaResolve(specifier, import.meta.url).then(
       u => new URL(u).pathname,
     );
     t.is(typeof fullPath, 'string');

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/sdk-metrics": "~1.30.1",
     "anylogger": "^0.21.0",
     "deterministic-json": "^1.0.5",
-    "import-meta-resolve": "^2.2.1",
+    "import-meta-resolve": "^4.1.0",
     "ses": "^1.11.0",
     "tmp": "^0.2.1"
   },

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -424,7 +424,7 @@ export const makeLaunchChain = (
       bootMsg: makeInitMsg(initAction),
     };
     const getVatConfig = async () => {
-      const href = await importMetaResolve(
+      const href = importMetaResolve(
         env.CHAIN_BOOTSTRAP_VAT_CONFIG ||
           argv.bootMsg.params.bootstrap_vat_config,
         import.meta.url,

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -83,7 +83,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   };
 
   const getVatConfig = async () => {
-    const href = await importMetaResolve(
+    const href = importMetaResolve(
       env.CHAIN_BOOTSTRAP_VAT_CONFIG ||
         argv.bootMsg.params.bootstrap_vat_config,
       import.meta.url,

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -54,7 +54,7 @@
     "@agoric/vats": "^0.15.1",
     "@endo/init": "^1.1.8",
     "ava": "^5.3.0",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "files": [
     "src",

--- a/packages/deploy-script-support/test/unitTests/install.test.js
+++ b/packages/deploy-script-support/test/unitTests/install.test.js
@@ -25,7 +25,7 @@ test('install', async t => {
   const board = makeFakeBoard();
   const install = makeInstall(bundleSource, zoe, installationManager, board);
 
-  const resolvedUrl = await importMetaResolve(
+  const resolvedUrl = importMetaResolve(
     '@agoric/zoe/src/contracts/automaticRefund.js',
     import.meta.url,
   );

--- a/packages/deploy-script-support/test/unitTests/offer.test.js
+++ b/packages/deploy-script-support/test/unitTests/offer.test.js
@@ -36,7 +36,7 @@ test('offer', async t => {
   };
   const zoe = makeZoeForTest();
 
-  const bundleUrl = await importMetaResolve(
+  const bundleUrl = importMetaResolve(
     '@agoric/zoe/src/contracts/automaticRefund.js',
     import.meta.url,
   );

--- a/packages/deploy-script-support/test/unitTests/startInstance.test.js
+++ b/packages/deploy-script-support/test/unitTests/startInstance.test.js
@@ -21,7 +21,7 @@ test('startInstance', async t => {
   const zoe = makeZoeForTest();
 
   const bundleUrl = new URL(
-    await importMetaResolve(
+    importMetaResolve(
       '@agoric/zoe/src/contracts/automaticRefund.js',
       import.meta.url,
     ),

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -46,7 +46,7 @@
     "@endo/marshal": "^1.6.3",
     "@endo/nat": "^5.0.14",
     "@endo/promise-kit": "^1.1.9",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.32.2",

--- a/packages/governance/test/unitTests/paramGovernance.test.js
+++ b/packages/governance/test/unitTests/paramGovernance.test.js
@@ -23,7 +23,7 @@ const contractGovernorRoot = '../../src/contractGovernor.js';
 const committeeRoot = '../../src/committee.js';
 
 const makeBundle = async sourceRoot => {
-  const url = await importMetaResolve(sourceRoot, import.meta.url);
+  const url = importMetaResolve(sourceRoot, import.meta.url);
   const path = new URL(url).pathname;
   const contractBundle = await bundleSource(path);
   return contractBundle;

--- a/packages/governance/test/unitTests/puppetContractGovernor.test.js
+++ b/packages/governance/test/unitTests/puppetContractGovernor.test.js
@@ -17,7 +17,7 @@ import { MALLEABLE_NUMBER } from '../swingsetTests/contractGovernor/governedCont
  */
 
 const makeBundle = async sourceRoot => {
-  const url = await importMetaResolve(sourceRoot, import.meta.url);
+  const url = importMetaResolve(sourceRoot, import.meta.url);
   const path = new URL(url).pathname;
   const contractBundle = await bundleSource(path);
   return contractBundle;

--- a/packages/governance/tools/puppetGovernance.js
+++ b/packages/governance/tools/puppetGovernance.js
@@ -8,7 +8,7 @@ import { CONTRACT_ELECTORATE, ParamTypes } from '../src/index.js';
  */
 
 const makeBundle = async sourceRoot => {
-  const url = await importMetaResolve(sourceRoot, import.meta.url);
+  const url = importMetaResolve(sourceRoot, import.meta.url);
   const path = new URL(url).pathname;
   const contractBundle = await bundleSource(path);
   return contractBundle;

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -61,7 +61,7 @@
     "ava": "^5.3.0",
     "c8": "^10.1.2",
     "deep-object-diff": "^1.1.9",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "files": [
     "scripts",

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -26,7 +26,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 /** @param {ZoeService} zoe */
 export const setUpInstallations = async zoe => {
   const autoRefund = '@agoric/zoe/src/contracts/automaticRefund.js';
-  const autoRefundUrl = await importMetaResolve(autoRefund, import.meta.url);
+  const autoRefundUrl = importMetaResolve(autoRefund, import.meta.url);
   const autoRefundPath = new URL(autoRefundUrl).pathname;
 
   const bundleCache = await unsafeMakeBundleCache('./bundles/'); // package-relative

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/fluxAggregator-service-upgrade.test.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/fluxAggregator-service-upgrade.test.js
@@ -8,6 +8,8 @@ import { faV1BundleName } from './bootstrap-fluxAggregator-service-upgrade.js';
 
 // so paths can be expresssed relative to this file and made absolute
 const bfile = name => new URL(name, import.meta.url).pathname;
+const resolvePathname = spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 test('fluxAggregator service upgrade', async t => {
   /** @type {SwingSetConfig} */
@@ -21,36 +23,25 @@ test('fluxAggregator service upgrade', async t => {
         sourceSpec: bfile('bootstrap-fluxAggregator-service-upgrade.js'),
       },
       zoe: {
-        sourceSpec: importMetaResolve(
-          '@agoric/vats/src/vat-zoe.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/vats/src/vat-zoe.js'),
       },
     },
     bundles: {
       zcf: {
-        sourceSpec: importMetaResolve(
-          '@agoric/zoe/src/contractFacet/vatRoot.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/zoe/src/contractFacet/vatRoot.js'),
       },
       committee: {
-        sourceSpec: importMetaResolve(
-          '@agoric/governance/src/committee.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/governance/src/committee.js'),
       },
       puppetContractGovernor: {
-        sourceSpec: importMetaResolve(
+        sourceSpec: resolvePathname(
           '@agoric/governance/tools/puppetContractGovernor.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        ),
       },
       [faV1BundleName]: {
-        sourceSpec: importMetaResolve(
+        sourceSpec: resolvePathname(
           '@agoric/inter-protocol/src/price/fluxAggregatorContract.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        ),
       },
     },
   };

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/fluxAggregator-service-upgrade.test.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/fluxAggregator-service-upgrade.test.js
@@ -21,7 +21,7 @@ test('fluxAggregator service upgrade', async t => {
         sourceSpec: bfile('bootstrap-fluxAggregator-service-upgrade.js'),
       },
       zoe: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/vats/src/vat-zoe.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
@@ -29,25 +29,25 @@ test('fluxAggregator service upgrade', async t => {
     },
     bundles: {
       zcf: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/zoe/src/contractFacet/vatRoot.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       committee: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/governance/src/committee.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       puppetContractGovernor: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/governance/tools/puppetContractGovernor.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       [faV1BundleName]: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/inter-protocol/src/price/fluxAggregatorContract.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/psm-upgrade.test.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/psm-upgrade.test.js
@@ -21,7 +21,7 @@ test('PSM service upgrade', async t => {
         sourceSpec: bfile('bootstrap-psm-upgrade.js'),
       },
       zoe: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/vats/src/vat-zoe.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
@@ -29,25 +29,25 @@ test('PSM service upgrade', async t => {
     },
     bundles: {
       zcf: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/zoe/src/contractFacet/vatRoot.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       committee: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/governance/src/committee.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       puppetContractGovernor: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/governance/tools/puppetContractGovernor.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       [psmV1BundleName]: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/inter-protocol/src/psm/psm.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/psm-upgrade.test.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/psm-upgrade.test.js
@@ -8,6 +8,8 @@ import { psmV1BundleName } from './bootstrap-psm-upgrade.js';
 
 // so paths can be expresssed relative to this file and made absolute
 const bfile = name => new URL(name, import.meta.url).pathname;
+const resolvePathname = spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 test('PSM service upgrade', async t => {
   /** @type {SwingSetConfig} */
@@ -21,36 +23,23 @@ test('PSM service upgrade', async t => {
         sourceSpec: bfile('bootstrap-psm-upgrade.js'),
       },
       zoe: {
-        sourceSpec: importMetaResolve(
-          '@agoric/vats/src/vat-zoe.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/vats/src/vat-zoe.js'),
       },
     },
     bundles: {
       zcf: {
-        sourceSpec: importMetaResolve(
-          '@agoric/zoe/src/contractFacet/vatRoot.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/zoe/src/contractFacet/vatRoot.js'),
       },
       committee: {
-        sourceSpec: importMetaResolve(
-          '@agoric/governance/src/committee.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/governance/src/committee.js'),
       },
       puppetContractGovernor: {
-        sourceSpec: importMetaResolve(
+        sourceSpec: resolvePathname(
           '@agoric/governance/tools/puppetContractGovernor.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        ),
       },
       [psmV1BundleName]: {
-        sourceSpec: importMetaResolve(
-          '@agoric/inter-protocol/src/psm/psm.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/inter-protocol/src/psm/psm.js'),
       },
     },
   };

--- a/packages/inter-protocol/test/swingsetTests/reserve/assetReserve-upgrade.test.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/assetReserve-upgrade.test.js
@@ -21,7 +21,7 @@ test('assetReserve service upgrade', async t => {
         sourceSpec: bfile('bootstrap-assetReserve-upgrade.js'),
       },
       zoe: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/vats/src/vat-zoe.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
@@ -29,25 +29,25 @@ test('assetReserve service upgrade', async t => {
     },
     bundles: {
       zcf: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/zoe/src/contractFacet/vatRoot.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       committee: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/governance/src/committee.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       puppetContractGovernor: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/governance/tools/puppetContractGovernor.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),
       },
       [arV1BundleName]: {
-        sourceSpec: await importMetaResolve(
+        sourceSpec: importMetaResolve(
           '@agoric/inter-protocol/src/reserve/assetReserve.js',
           import.meta.url,
         ).then(href => new URL(href).pathname),

--- a/packages/inter-protocol/test/swingsetTests/reserve/assetReserve-upgrade.test.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/assetReserve-upgrade.test.js
@@ -8,6 +8,8 @@ import { arV1BundleName } from './bootstrap-assetReserve-upgrade.js';
 
 // so paths can be expresssed relative to this file and made absolute
 const bfile = name => new URL(name, import.meta.url).pathname;
+const resolvePathname = spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 test('assetReserve service upgrade', async t => {
   /** @type {SwingSetConfig} */
@@ -21,36 +23,25 @@ test('assetReserve service upgrade', async t => {
         sourceSpec: bfile('bootstrap-assetReserve-upgrade.js'),
       },
       zoe: {
-        sourceSpec: importMetaResolve(
-          '@agoric/vats/src/vat-zoe.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/vats/src/vat-zoe.js'),
       },
     },
     bundles: {
       zcf: {
-        sourceSpec: importMetaResolve(
-          '@agoric/zoe/src/contractFacet/vatRoot.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/zoe/src/contractFacet/vatRoot.js'),
       },
       committee: {
-        sourceSpec: importMetaResolve(
-          '@agoric/governance/src/committee.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        sourceSpec: resolvePathname('@agoric/governance/src/committee.js'),
       },
       puppetContractGovernor: {
-        sourceSpec: importMetaResolve(
+        sourceSpec: resolvePathname(
           '@agoric/governance/tools/puppetContractGovernor.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        ),
       },
       [arV1BundleName]: {
-        sourceSpec: importMetaResolve(
+        sourceSpec: resolvePathname(
           '@agoric/inter-protocol/src/reserve/assetReserve.js',
-          import.meta.url,
-        ).then(href => new URL(href).pathname),
+        ),
       },
     },
   };

--- a/packages/inter-protocol/test/vaultFactory/vault-interest.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-interest.test.js
@@ -40,7 +40,7 @@ const { zoe, feeMintAccessP: feeMintAccess } = await setUpZoeForTest({
  * @param {string} sourceRoot
  */
 async function launch(zoeP, sourceRoot) {
-  const contractUrl = await importMetaResolve(sourceRoot, import.meta.url);
+  const contractUrl = importMetaResolve(sourceRoot, import.meta.url);
   const contractPath = new URL(contractUrl).pathname;
   const contractBundle = await bundleSource(contractPath);
   const installation = await E(zoeP).install(contractBundle);

--- a/packages/inter-protocol/test/vaultFactory/vault.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vault.test.js
@@ -41,7 +41,7 @@ trace('makeZoe');
  * @param {string} sourceRoot
  */
 async function launch(zoeP, sourceRoot) {
-  const contractUrl = await importMetaResolve(sourceRoot, import.meta.url);
+  const contractUrl = importMetaResolve(sourceRoot, import.meta.url);
   const contractPath = new URL(contractUrl).pathname;
   const contractBundle = await bundleSource(contractPath);
   const installation = await E(zoeP).install(contractBundle);

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "ava": "^5.3.0",
     "c8": "^10.1.2",
-    "import-meta-resolve": "^2.2.1",
+    "import-meta-resolve": "^4.1.0",
     "@agoric/vat-data": "^0.5.2"
   },
   "files": [

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -24,7 +24,7 @@
     "@endo/captp": "^4.4.4",
     "@endo/init": "^1.1.8",
     "ava": "^5.3.0",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "dependencies": {
     "@endo/errors": "^1.2.9",

--- a/packages/smart-wallet/test/addAsset.test.js
+++ b/packages/smart-wallet/test/addAsset.test.js
@@ -15,8 +15,8 @@ import { makeDefaultTestContext } from './contexts.js';
 import { ActionType, headValue, makeMockTestSpace } from './supports.js';
 import { makeImportContext } from '../src/marshal-contexts.js';
 
-const importSpec = spec =>
-  importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
+const importSpec = async spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 /**
  * @type {import('ava').TestFn<

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-service-upgrade.test.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-service-upgrade.test.js
@@ -12,8 +12,8 @@ import {
 // so paths can be expresssed relative to this file and made absolute
 const bfile = name => new URL(name, import.meta.url).pathname;
 
-const importSpec = spec =>
-  importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
+const importSpec = async spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 test('walletFactory service upgrade', async t => {
   /** @type {SwingSetConfig} */

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -47,7 +47,7 @@
     "esm": "agoric-labs/esm#Agoric-built",
     "express": "^5.0.1",
     "http-proxy-middleware": "^2.0.6",
-    "import-meta-resolve": "^2.2.1",
+    "import-meta-resolve": "^4.1.0",
     "minimist": "^1.2.0",
     "morgan": "^1.10.0",
     "temp": "^0.9.1",

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -367,7 +367,7 @@ const deployWallet = async ({ agWallet, deploys, hostport }) => {
   // This part only runs if there were wallet deploys to do.
   const resolvedDeploys = deploys.map(dep => path.resolve(agWallet, dep));
 
-  const resolvedUrl = await importMetaResolve(
+  const resolvedUrl = importMetaResolve(
     'agoric/src/entrypoint.js',
     import.meta.url,
   );
@@ -483,7 +483,7 @@ const start = async (basedir, argv) => {
   // Remove wallet traces.
   await unlink('html/wallet').catch(_ => {});
 
-  const packageUrl = await importMetaResolve(
+  const packageUrl = importMetaResolve(
     `${wallet}/package.json`,
     import.meta.url,
   );
@@ -498,7 +498,7 @@ const start = async (basedir, argv) => {
   );
 
   const agWallet = path.dirname(pjs);
-  const agWalletHtmlUrl = await importMetaResolve(htmlBasePath, packageUrl);
+  const agWalletHtmlUrl = importMetaResolve(htmlBasePath, packageUrl);
   const agWalletHtml = new URL(agWalletHtmlUrl).pathname;
 
   let hostport;

--- a/packages/solo/test/home.test.js
+++ b/packages/solo/test/home.test.js
@@ -30,7 +30,7 @@ export const Stable = harden(
 //#region setup (ambient authority is confined to this region)
 test.before('setup', async t => {
   const loadBundle = async specifier => {
-    const contractUrl = await importMetaResolve(specifier, import.meta.url);
+    const contractUrl = importMetaResolve(specifier, import.meta.url);
     const contractRoot = new URL(contractUrl).pathname;
     t.log({ contractRoot });
     const bundle = await bundleSourceAmbient(contractRoot);

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -9,7 +9,7 @@ const CONTRACT_FILES = ['simpleExchange.js'];
 
 const generateBundlesP = Promise.all(
   CONTRACT_FILES.map(async contract => {
-    const contractUrl = await importMetaResolve(
+    const contractUrl = importMetaResolve(
       `@agoric/zoe/src/contracts/${contract}`,
       import.meta.url,
     );

--- a/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
@@ -9,7 +9,7 @@ const CONTRACT_FILES = ['atomicSwap.js'];
 
 const generateBundlesP = Promise.all(
   CONTRACT_FILES.map(async contract => {
-    const contractUrl = await importMetaResolve(
+    const contractUrl = importMetaResolve(
       `@agoric/zoe/src/contracts/${contract}`,
       import.meta.url,
     );

--- a/packages/swingset-runner/demo/zoeTests/prepareContracts.js
+++ b/packages/swingset-runner/demo/zoeTests/prepareContracts.js
@@ -30,7 +30,7 @@ const generateBundlesP = Promise.all(
     } else {
       ({ bundleName, contractPath } = settings);
     }
-    const sourceUrl = await importMetaResolve(
+    const sourceUrl = importMetaResolve(
       `@agoric/zoe/src/contracts/${contractPath}.js`,
       import.meta.url,
     );

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "ava": "^5.3.0",
     "c8": "^10.1.2",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -43,7 +43,7 @@
     "@endo/pass-style": "^1.4.8",
     "@endo/patterns": "^1.4.8",
     "@endo/promise-kit": "^1.1.9",
-    "import-meta-resolve": "^2.2.1",
+    "import-meta-resolve": "^4.1.0",
     "jessie.js": "^0.3.4"
   },
   "devDependencies": {

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -36,7 +36,7 @@
     "@endo/marshal": "^1.6.3",
     "@endo/nat": "^5.0.14",
     "@endo/promise-kit": "^1.1.9",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "keywords": [],
   "repository": {

--- a/packages/wallet/api/test/lib-wallet.test.js
+++ b/packages/wallet/api/test/lib-wallet.test.js
@@ -137,7 +137,7 @@ test.before(async t => {
   const zoe = makeZoeForTest();
 
   // Create AutomaticRefund instance
-  const automaticRefundContractUrl = await importMetaResolve(
+  const automaticRefundContractUrl = importMetaResolve(
     '@agoric/zoe/src/contracts/automaticRefund.js',
     import.meta.url,
   );
@@ -149,7 +149,7 @@ test.before(async t => {
   );
 
   // Create Autoswap instance
-  const autoswapContractUrl = await importMetaResolve(
+  const autoswapContractUrl = importMetaResolve(
     '@agoric/zoe/src/contracts/autoswap.js',
     import.meta.url,
   );
@@ -1491,7 +1491,7 @@ test('addOffer makeContinuingInvitation', async t => {
   const board = makeFakeBoard();
 
   // Create ContinuingInvitationExample instance
-  const url = await importMetaResolve(
+  const url = importMetaResolve(
     './continuingInvitationExample.js',
     import.meta.url,
   );

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -23,7 +23,7 @@
     "@agoric/wallet-ui": "0.1.3-solo.0",
     "babel-eslint": "^10.0.3",
     "eslint-plugin-eslint-comments": "^3.1.2",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^4.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -74,7 +74,7 @@
     "@agoric/kmarshal": "^0.1.0",
     "ava": "^5.3.0",
     "c8": "^10.1.2",
-    "import-meta-resolve": "^2.2.1",
+    "import-meta-resolve": "^4.1.0",
     "tsd": "^0.31.1"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7343,10 +7343,10 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-import-meta-resolve@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.2.1.tgz#80fdeddbc15d7f3992c37425023ffb4aca7cb583"
-  integrity sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==
+import-meta-resolve@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz#f9db8bead9fafa61adb811db77a2bf22c5399706"
+  integrity sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==
 
 import-modules@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
closes: #10986

## Description
`import.meta.resolve` is synchronous now

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations

Kink to sort out with dapp integration test:
```
➤ YN0071: Cannot link @agoric/cosmic-swingset into @agoric/documentation@workspace:. dependency import-meta-resolve@npm:4.1.0 conflicts with parent dependency import-meta-resolve@npm:2.2.2
➤ YN0071: Cannot link @agoric/solo into @agoric/documentation@workspace:. dependency import-meta-resolve@npm:4.1.0 conflicts with parent dependency import-meta-resolve@npm:2.2.2
➤ YN0071: Cannot link @agoric/vats into @agoric/documentation@workspace:. dependency import-meta-resolve@npm:4.1.0 conflicts with parent dependency import-meta-resolve@npm:2.2.2
```

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
