### PR TITLE
misc for extracting fast-usdc

### DIFF
--- a/packages/base-zone/src/types.js
+++ b/packages/base-zone/src/types.js
@@ -33,7 +33,7 @@ export {};
  * @typedef {object} Stores
  * @property {() => Stores} detached obtain store providers which are detached (the stores are anonymous rather than bound to `label` in the zone)
  * @property {(specimen: unknown) => boolean} isStorable return true if the specimen can be stored in the zone, whether as exo-object state or in a store
- * @property {(label: string, options?: StoreOptions) => MapStore<any, any>} mapStore provide a Map-like store named `label` in the zone
+ * @property {<K, V>(label: string, options?: StoreOptions) => MapStore<K, V>} mapStore provide a Map-like store named `label` in the zone
  * @property {<K>(label: string, options?: StoreOptions) => SetStore<K>} setStore provide a Set-like store named `label` in the zone
  * @property {<K, V>(
  *   label: string, options?: StoreOptions) => WeakMapStore<K, V>

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -131,7 +131,6 @@ export const prepareFluxAggregatorKit = async (
   const makeOracleAdminKit = prepareOracleAdminKit(baggage);
 
   const makeRecorderKit = defineRecorderKit({
-    // @ts-expect-error XXX
     makeDurablePublishKit,
     makeRecorder,
   });

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -402,15 +402,13 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
 /**
  * @param {import('@agoric/swingset-liveslots').Baggage} baggage
  * @param {string} kindName
+ * @returns {<T>(options?: Parameters<typeof initDurablePublishKitState>[0]) => PublishKit<T>}
  */
 export const prepareDurablePublishKit = (baggage, kindName) => {
   // TODO: Once we unify with makePublishKit, we will use a Zone-compatible weak
   // map for memoization.
   const makeMemoizedUpdateRecord = makeUpdateRecordFromPublicationRecord;
 
-  /**
-   * @returns {() => PublishKit<*>}
-   */
   return prepareExoClassKit(
     baggage,
     kindName,

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -88,7 +88,8 @@
   "files": [
     "*.js",
     "*.ts",
-    "src"
+    "src",
+    "tools"
   ],
   "publishConfig": {
     "access": "public"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,10 @@
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,
+    // .ts and rewriting relative paths allow us to include in bundles
+    // files that are JS executable (with TS chars blanked) but end in .ts
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "noEmit": true
   },
   "include": [


### PR DESCRIPTION
refs: #10811

## Description

While working on #10811 I got errors like,
```
  Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/opt/agoric/fast-usdc/node_modules/@agoric/orchestration/tools/ibc-mocks.ts' imported from /opt/agoric/fast-usdc/packages/fast-usdc/test/fixtures.ts
```

That's because the "tools" path was not in the package.json. This fixes that.

It also brings in some commits from https://github.com/Agoric/agoric-sdk/pull/10480/ to support fully using .ts in the new codebase.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI suffices

### Upgrade Considerations
no runtime changes