### PR TITLE
shrink Fast USDC core eval bundle

### DIFF
--- a/a3p-integration/scripts/build-submission.sh
+++ b/a3p-integration/scripts/build-submission.sh
@@ -16,7 +16,7 @@ shift || true
 sdkroot=$(git rev-parse --show-toplevel)
 (
   cd "$sdkroot"
-  yarn agoric run "packages/builders/scripts/$builderScript" "$@"
+  yarn agoric run --verbose "packages/builders/scripts/$builderScript" "$@"
 )
 
 # Create and populate the submission directory.

--- a/packages/fast-usdc/src/type-guards.js
+++ b/packages/fast-usdc/src/type-guards.js
@@ -4,7 +4,7 @@ import {
   CosmosChainInfoShape,
   DenomDetailShape,
   DenomShape,
-} from '@agoric/orchestration';
+} from '@agoric/orchestration/src/typeGuards.js';
 import { PendingTxStatus } from './constants.js';
 
 /**

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -1,8 +1,6 @@
-import type { AnyJson, TypedJson, JsonSafe } from '@agoric/cosmic-proto';
+import type { AnyJson, JsonSafe, TypedJson } from '@agoric/cosmic-proto';
+import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import type {
-  Delegation,
-  DelegationResponse,
-  Redelegation,
   RedelegationResponse,
   UnbondingDelegation,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/staking.js';
@@ -18,7 +16,7 @@ import type {
   RequestQuery,
   ResponseQuery,
 } from '@agoric/cosmic-proto/tendermint/abci/types.js';
-import type { Brand, Purse, Payment, Amount } from '@agoric/ertp/src/types.js';
+import type { Amount, Payment } from '@agoric/ertp/src/types.js';
 import type { Port } from '@agoric/network';
 import type {
   IBCChannelID,
@@ -34,10 +32,8 @@ import type {
   LocalIbcAddress,
   RemoteIbcAddress,
 } from '@agoric/vats/tools/ibc-utils.js';
-import type { QueryDelegationTotalRewardsResponse } from '@agoric/cosmic-proto/cosmos/distribution/v1beta1/query.js';
-import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
-import type { AmountArg, ChainAddress, Denom, DenomAmount } from './types.js';
 import { PFM_RECEIVER } from './exos/chain-hub.js';
+import type { AmountArg, ChainAddress, Denom, DenomAmount } from './types.js';
 
 /** An address for a validator on some blockchain, e.g., cosmos, eth, etc. */
 export type CosmosValidatorAddress = ChainAddress & {


### PR DESCRIPTION
_incidental_

## Description

https://ping.pub/agoric/gov/87 had a surprisingly large core-eval bundle: https://github.com/Agoric/agoric-sdk/releases/tag/fast-usdc-beta-1

The reason was that it imported typeguards from the barrel export of `@agoric/orchestration`, which entrained`@agoric/cosmic-proto`. All it really needed was `typeGuards.js` so this imports that module by deep import.

Eventually we'll want an `"exports"` map for the package but that's out of scope.


### Security Considerations
n/a

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations

```sh
cd a3p-integration/proposals/b:beta-fast-usdc
../../scripts/build-submission.sh fast-usdc/start-fast-usdc.build.js submission --net A3P_INTEGRATION --noNoble
```

**master**
total size: 1636325

**PR**
total size: 586271

(64% reduction)

### Upgrade Considerations
none