### PR TITLE
feat(fast-usdc): skipAdvance when preconditions fail

### DIFF
--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -658,7 +658,7 @@ test.serial('insufficient LP funds; forward path', async t => {
     await useChain(eudChain).getRestEndpoint(),
   );
 
-  await assertTxStatus(evidence.txHash, 'OBSERVED');
+  await assertTxStatus(evidence.txHash, 'ADVANCE_SKIPPED');
 
   nobleTools.mockCctpMint(mintAmt, userForwardingAddr);
 
@@ -788,7 +788,7 @@ test.serial('insufficient LP funds and forward failed', async t => {
   // submit evidences
   await Promise.all(txOracles.map(async o => o.submit(evidence)));
 
-  await assertTxStatus(evidence.txHash, 'OBSERVED');
+  await assertTxStatus(evidence.txHash, 'ADVANCE_SKIPPED');
 
   nobleTools.mockCctpMint(mintAmt, userForwardingAddr);
 

--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -217,7 +217,7 @@ export const prepareAdvancerKit = (
             });
           } catch (error) {
             log('Advancer error:', error);
-            statusManager.observe(evidence);
+            statusManager.skipAdvance(evidence, [error.message]);
           }
         },
         /** @param {ChainAddress} intermediateRecipient */

--- a/packages/fast-usdc/test/exos/advancer.test.ts
+++ b/packages/fast-usdc/test/exos/advancer.test.ts
@@ -275,7 +275,7 @@ test('updates status to ADVANCING in happy path', async t => {
   ]);
 });
 
-test('updates status to OBSERVED on insufficient pool funds', async t => {
+test('updates status to ADVANCE_SKIPPED on insufficient pool funds', async t => {
   const {
     brands: { usdc },
     bootstrap: { storage },
@@ -310,8 +310,16 @@ test('updates status to OBSERVED on insufficient pool funds', async t => {
 
   t.deepEqual(
     storage.getDeserialized(`fun.txns.${evidence.txHash}`),
-    [{ evidence, status: PendingTxStatus.Observed }],
-    'OBSERVED status on insufficient pool funds',
+    [
+      { evidence, status: PendingTxStatus.Observed },
+      {
+        risksIdentified: [
+          'Cannot borrow. Requested {"brand":"[Alleged: USDC brand]","value":"[293999999n]"} must be less than pool balance {"brand":"[Alleged: USDC brand]","value":"[1n]"}.',
+        ],
+        status: 'ADVANCE_SKIPPED',
+      },
+    ],
+    'ADVANCE_SKIPPED status on insufficient pool funds',
   );
 
   t.deepEqual(inspectLogs(), [
@@ -325,7 +333,7 @@ test('updates status to OBSERVED on insufficient pool funds', async t => {
   ]);
 });
 
-test('updates status to OBSERVED if makeChainAddress fails', async t => {
+test('updates status to ADVANCE_SKIPPED if makeChainAddress fails', async t => {
   const {
     bootstrap: { storage },
     extensions: {
@@ -340,8 +348,14 @@ test('updates status to OBSERVED if makeChainAddress fails', async t => {
 
   t.deepEqual(
     storage.getDeserialized(`fun.txns.${evidence.txHash}`),
-    [{ evidence, status: PendingTxStatus.Observed }],
-    'OBSERVED status on makeChainAddress failure',
+    [
+      { evidence, status: PendingTxStatus.Observed },
+      {
+        risksIdentified: ['Chain info not found for bech32Prefix "random"'],
+        status: 'ADVANCE_SKIPPED',
+      },
+    ],
+    'ADVANCE_SKIPPED status on makeChainAddress failure',
   );
 
   t.deepEqual(inspectLogs(), [
@@ -531,7 +545,7 @@ test('logs error if returnToPool fails during AdvanceFailed recovery', async t =
   ]);
 });
 
-test('updates status to OBSERVED if pre-condition checks fail', async t => {
+test('updates status to ADVANCE_SKIPPED if pre-condition checks fail', async t => {
   const {
     bootstrap: { storage },
     extensions: {
@@ -547,8 +561,14 @@ test('updates status to OBSERVED if pre-condition checks fail', async t => {
 
   t.deepEqual(
     storage.getDeserialized(`fun.txns.${evidence.txHash}`),
-    [{ evidence, status: PendingTxStatus.Observed }],
-    'tx is recorded as OBSERVED',
+    [
+      { evidence, status: PendingTxStatus.Observed },
+      {
+        risksIdentified: ['query: {} - Must have missing properties ["EUD"]'],
+        status: 'ADVANCE_SKIPPED',
+      },
+    ],
+    'tx is recorded as ADVANCE_SKIPPED',
   );
 
   t.deepEqual(inspectLogs(), [


### PR DESCRIPTION
closes https://github.com/Agoric/agoric-sdk/issues/10994

## Description

If any of the preconditions throw for making the advance, set the state to `ADVANCE_SKIPPED` rather than `OBSERVED`. This makes it more obvious that the contract has actively chosen to not advance, rather than getting stuck on `OBSERVED` for some reason.

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
I don't think we have any docs that go this granular on the flow.

### Testing Considerations
Updated tests

### Upgrade Considerations
N/A
