### PR TITLE
fix(a3p-integration): replaceFeeDistributor flakiness fix

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/test/replaceFeeDistributor.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/test/replaceFeeDistributor.test.js
@@ -90,12 +90,12 @@ const produceFeesAndWait = async (vstorage, feeAmount) => {
   await retryUntilCondition(
     () => vstorage.readLatestHead('published.reserve.metrics'),
     metrics =>
-      AmountMath.isEqual(
+      AmountMath.isGTE(
         // @ts-expect-error metrics has these fields.
         metrics.allocations.Fee,
         AmountMath.add(metricsBefore.allocations.Fee, feeAmount),
       ),
-    'Fee not received',
+    `At least ${feeAmount.value} amount of fee not received`,
     { log: console.log, setTimeout, ...config.retryOptions },
   );
 };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #10998

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
In #10998, we see a flake introduced after `a3p-integration/p:upgrade-19` tests migrated to `a3p-integration/n:upgrade-next`.  The investigations showed that `feeDistributor` was collecting more fees than our test is producing.

### Passing
```
2025-02-11T22:51:00.145Z SwingSet: vat: v36: ----- ReserveKit.5  9 received collateral { brand: Object [Alleged: IST brand] {}, value: 500_000n }
```

### Failing
```
2025-02-11T22:04:40.861Z SwingSet: vat: v36: ----- ReserveKit.5  8 received collateral { brand: Object [Alleged: IST brand] {}, value: 550_000n }
```

My argument is, priorly we were introducing the new `feeDistributor` dedicated to testing during our test initiation phase. And after introduction of the `feeDistributor`, we were waiting for one full `collectionInterval` to clear any leftover fees that haven't been collected by the old `feeDistributor`. And only then we start producing new fees. I confirmed that this is not the current behavior after the `n:upgrade-next` migration as of the commit https://github.com/Agoric/agoric-sdk/commit/271c55fcdcc40b5d7a7833f730f7478216ed690a#diff-7dd0ed44de879823d10b252f6483f52174e4fb9240966e7fcd1754298b41b0d7L161

```js
  await evalBundles(coreEvalDir);
  // Wait for a round to give the new feeDistributor time to clear out outstanding fees, if any.
  await sleep(collectionInterval + 5000, { log: console.log, setTimeout });
```

As of the migration to `upgrade-19`, we introduce the new `feeDistributor` in `uprage.go` which causes fees produced by other tests to get in the way of `replaceFeeDistributor.test.js` in a flakey way since the `collectionInterval` is 30 seconds.


### Solution
Just switch from `AmountMath.isEqual` to `AmountMath.isGTE` when polling for results.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Make sure integration tests pass in a consistent way.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
Get rid of the flake so `upgrade-19` shipment isn't blocked.
