### PR TITLE
docs: `multichain-testing` resource reqs

### DIFF
--- a/multichain-testing/README.md
+++ b/multichain-testing/README.md
@@ -13,6 +13,10 @@ The `agoric` software revision includes the vats necessary for building and test
 - vat-transfer
 - vat-orchestration
 
+## Resource Requirements
+
+The Kubernetes deployments in `config.yaml` and `config.fusdc.yaml` are configured to request approximately 6.5 CPU cores and 9.5 GiB of memory from the host machine. Make sure your local Kubernetes environment (Docker Desktop or similar) has sufficient resources allocated.
+
 ## Initial Setup
 
 Install the relevant dependencies:


### PR DESCRIPTION
incidental

## Description
Documents resources required to run `multichain-testing` e2e environment.

These numbers can be gleaned from `multichain-testing/config.yml` and [starship](https://github.com/hyperweb-io/starship/) defaults, but were pulled from a running environment:
```sh
kubectl get pods -o json | jq '
  .items | reduce .[] as $pod (
    {"cpu": 0, "mem": 0};
    . + {
      "cpu": (.cpu + ($pod.spec.containers | map(.resources.requests.cpu |
        if test("m$") then (.[:-1] | tonumber) / 1000 else tonumber end) | add)),
      "mem": (.mem + ($pod.spec.containers | map(.resources.requests.memory |
        if test("Gi$") then (.[:-2] | tonumber)
        elif test("G$") then (.[:-1] | tonumber)
        elif test("Mi$") then (.[:-2] | tonumber) / 1024
        elif test("M$") then (.[:-1] | tonumber) / 1024
        else 0 end) | add))
    }
  ) | "CPU Cores: \(.cpu)\nMemory GiB: \(.mem)"
'
"CPU Cores: 6.500000000000001\nMemory GiB: 9.41796875"
```

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
docs only change

### Testing Considerations
N/A

### Upgrade Considerations
N/A