### PR TITLE
chore: fix lint in golang, a3p, network, ERTP

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/test/agoricNames.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/test/agoricNames.test.js
@@ -152,12 +152,12 @@ test.serial('check all existing values are preserved', async t => {
   const agoricNamesAfter = await getAgoricNames();
   t.like(agoricNamesAfter, agoricNamesBefore);
 
-  agoricNamesChildren.forEach(child =>
+  for (const child of agoricNamesChildren) {
     assert(
       agoricNamesAfter[child][`test${child}`],
       'we should be able to add new value',
-    ),
-  );
+    );
+  }
 });
 
 test.serial('check testInfo still works', async t => {

--- a/a3p-integration/proposals/z:acceptance/test/initial.test.js
+++ b/a3p-integration/proposals/z:acceptance/test/initial.test.js
@@ -1,3 +1,4 @@
 import test from 'ava';
 
+// eslint-disable-next-line
 test.todo('initial test');

--- a/golang/cosmos/x/vtransfer/handler.go
+++ b/golang/cosmos/x/vtransfer/handler.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vtransfer/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	sdkioerrors "cosmossdk.io/errors"
+	sdktypeserrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // NewHandler returns a handler for "vtransfer" type messages.
@@ -14,7 +16,7 @@ func NewHandler(keeper keeper.Keeper) sdk.Handler {
 		switch msg := msg.(type) {
 		default:
 			errMsg := fmt.Sprintf("Unrecognized vtransfer Msg type: %T", msg)
-			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+			return nil, sdkioerrors.Wrap(sdktypeserrors.ErrUnknownRequest, errMsg)
 		}
 	}
 }

--- a/golang/cosmos/x/vtransfer/keeper/keeper.go
+++ b/golang/cosmos/x/vtransfer/keeper/keeper.go
@@ -10,7 +10,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	sdkioerrors "cosmossdk.io/errors"
+	sdktypeserrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
@@ -249,7 +251,7 @@ func (k Keeper) InterceptOnRecvPacket(ctx sdk.Context, ibcModule porttypes.IBCMo
 	capName := host.ChannelCapabilityPath(portID, channelID)
 	chanCap, ok := k.vibcKeeper.GetCapability(ctx, capName)
 	if !ok {
-		err := sdkerrors.Wrapf(channeltypes.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
+		err := sdkioerrors.Wrapf(channeltypes.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
 
@@ -440,7 +442,7 @@ func (k Keeper) Receive(cctx context.Context, jsonRequest string) (jsonReply str
 	case "BRIDGE_TARGET_UNREGISTER":
 		prefixStore.Delete([]byte(msg.Target))
 	default:
-		return "", sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown action type: %s", msg.Type)
+		return "", sdkioerrors.Wrapf(sdktypeserrors.ErrUnknownRequest, "unknown action type: %s", msg.Type)
 	}
 	return "true", nil
 }

--- a/packages/ERTP/test/unitTests/mintObj.test.js
+++ b/packages/ERTP/test/unitTests/mintObj.test.js
@@ -124,9 +124,9 @@ test('non-fungible tokens example', async t => {
     mint: balletTicketMint,
     issuer: balletTicketIssuer,
     brand,
-  } = /**
-   * @type {IssuerKit<'set', { seat: number; show: string; start: string }>}
-   */ (makeIssuerKit('Agoric Ballet Opera tickets', AssetKind.SET));
+  } = /** @type {IssuerKit<'set', { seat: number; show: string; start: string }>} */ (
+    makeIssuerKit('Agoric Ballet Opera tickets', AssetKind.SET)
+  );
 
   const startDateString = new Date(2020, 1, 17, 20, 30).toISOString();
 

--- a/packages/network/test/fakes.js
+++ b/packages/network/test/fakes.js
@@ -12,7 +12,7 @@ import {
  * @import {Zone} from '@agoric/zone';
  * @import {ListenHandler, MakeEchoConnectionKit} from '../src/index.js';
  */
-
+// eslint-disable-next-line no-constant-condition
 const log = false ? console.log : () => {};
 
 /**


### PR DESCRIPTION
closes: #11034 

## Description

Github lint complaints:
```
Check failure on line 252 in golang/cosmos/x/vtransfer/keeper/keeper.go
GitHub Actions/ golangci-lint (no-failure)
SA1019: sdkerrors.Wrapf is deprecated: functionality of this package has been moved to it's own module: (staticcheck)

```
```
Check failure on line 443 in golang/cosmos/x/vtransfer/keeper/keeper.go
GitHub Actions / golangci-lint (no-failure)
SA1019: sdkerrors.Wrapf is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
```
```
Check failure on line 17 in golang/cosmos/x/vtransfer/handler.go
GitHub Actions / golangci-lint (no-failure)
SA1019: sdkerrors.Wrap is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
```
```
Check warning on line 155 in a3p-integration/proposals/n:upgrade-next/test/agoricNames.test.js
GitHub Actions / lint-rest
Prefer for...of instead of Array.forEach
```
```
Check warning on line 16 in packages/network/test/fakes.js
GitHub Actions / lint-primary
Unexpected constant condition
```
```
Check warning on line 128 in packages/ERTP/test/unitTests/mintObj.test.js
GitHub Actions / lint-primary
Expected JSDoc block to be aligned
```
## Description of the Design

## Security Considerations

## Scaling Considerations

## Test Plan
Run lint.

## Upgrade Considerations
