### PR TITLE
test(xsnap): Verify npm install build process

### DIFF
--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -28,10 +28,10 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "@endo/errors": "^1.2.9",
     "@agoric/internal": "^0.3.2",
     "@agoric/xsnap-lockdown": "^0.14.0",
     "@endo/bundle-source": "^3.5.1",
+    "@endo/errors": "^1.2.9",
     "@endo/eventual-send": "^1.3.0",
     "@endo/init": "^1.1.8",
     "@endo/netstring": "^1.0.14",
@@ -46,7 +46,8 @@
     "@endo/nat": "^5.0.14",
     "@types/glob": "^8.1.0",
     "ava": "^5.3.0",
-    "c8": "^10.1.2"
+    "c8": "^10.1.2",
+    "execa": "^7.2.0"
   },
   "files": [
     "LICENSE*",

--- a/packages/xsnap/test/install.test.js
+++ b/packages/xsnap/test/install.test.js
@@ -1,0 +1,20 @@
+// building xsnap locally and installing from npm follow different paths
+// through build.js, since installation targets are not obliged to have a git
+// toolchain.
+// This test verifies the post-publish experience.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { $ } from 'execa';
+import test from 'ava';
+
+test('pack and install xsnap', async t => {
+  const tmp = await mkdtemp(join(tmpdir(), 'xsnap-'));
+  t.teardown(() => rm(tmp, { recursive: true }));
+  const { stdout: npmout } = await $`npm pack --json`;
+  const [{ filename }] = JSON.parse(npmout);
+  await $({ cwd: tmp })`tar xvf ${resolve(filename)}`;
+  await $({ cwd: join(tmp, 'package') })`npm install`;
+  t.pass();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6291,7 +6291,7 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-execa@^7.1.1:
+execa@^7.1.1, execa@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-7.2.0.tgz#657e75ba984f42a70f38928cedc87d6f2d4fe4e9"
   integrity sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/pull/9674

## Description
In support of https://github.com/Agoric/agoric-sdk/pull/9674, this change adds a regression test for `npm install` to increase our confidence that changes to `build.js` support both local development and eventual installation from npm.

### Security Considerations
None.

### Scaling Considerations
A design question for this is whether to use a temporary directory for the extracted package. I chose to use the default `package` since this speeds up non-initial test runs. Since `tar xf` overlays the package over the previous version, there’s a small chance that the deletion of a sensitive file might go unnoticed locally, but not in CI.

### Documentation Considerations
None.

### Testing Considerations
It’s a test, Bob.

### Upgrade Considerations
None.