### PR TITLE
fix: Properly synchronize slog sender termination

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -216,7 +216,7 @@ export async function makeSwingsetController(
   const sloggingKernelConsole = makeLimitedConsole(level => {
     return (...args) => {
       kernelConsole[level](...args);
-      writeSlogObject({ type: 'console', source: 'kernel', args });
+      writeSlogObject({ type: 'console', source: 'kernel', level, args });
     };
   });
   writeSlogObject({ type: 'import-kernel-start' });

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -96,7 +96,6 @@ export function makeDummySlogger(slogCallbacks, dummyConsole = badConsole) {
     }),
     vatConsole: wrap('vatConsole', () => dummyConsole),
     startup: wrap('startup', () => noopFinisher),
-    replayVatTranscript: wrap('replayVatTranscript', () => noopFinisher),
     delivery: wrap('delivery', () => noopFinisher),
     syscall: wrap('syscall', () => noopFinisher),
     changeCList: wrap('changeCList', () => noopFinisher),
@@ -250,18 +249,6 @@ export function makeSlogger(slogCallbacks, writeObj) {
     return { vatSlog, starting: true };
   }
 
-  function replayVatTranscript(vatID) {
-    safeWrite({ type: 'replay-transcript-start', vatID });
-    function finish() {
-      safeWrite({ type: 'replay-transcript-finish', vatID });
-    }
-    return harden(finish);
-  }
-
-  // function annotateVat(vatID, data) {
-  //   safeWrite({ type: 'annotate-vat', vatID, data });
-  // }
-
   const { wrap, done } = makeFinishersKit(slogCallbacks);
   const slogger = harden({
     provideVatSlogger: wrap('provideVatSlogger', provideVatSlogger),
@@ -271,8 +258,6 @@ export function makeSlogger(slogCallbacks, writeObj) {
     startup: wrap('startup', (vatID, ...args) =>
       provideVatSlogger(vatID).vatSlog.startup(...args),
     ),
-    // TODO: Remove this seemingly dead code.
-    replayVatTranscript,
     delivery: wrap('delivery', (vatID, ...args) =>
       provideVatSlogger(vatID).vatSlog.delivery(...args),
     ),

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -2,6 +2,7 @@ import { q } from '@endo/errors';
 import { objectMap } from '@agoric/internal';
 import { makeLimitedConsole } from '@agoric/internal/src/ses-utils.js';
 
+/** @import {Callable} from '@agoric/internal'; */
 /** @import {LimitedConsole} from '@agoric/internal/src/js-utils.js'; */
 
 const IDLE = 'idle';
@@ -22,7 +23,7 @@ const noopFinisher = harden(() => {});
  * (e.g., its finisher), and are expected to return a finisher of their own that
  * will invoke that wrapped finisher.
  *
- * @template {Record<string, Function>} Methods
+ * @template {Record<string, Callable>} Methods
  * @param {SlogWrappers} slogCallbacks
  * @param {string} unusedMsgPrefix prefix for warn-level logging about unused callbacks
  * @param {Methods} methods to wrap

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -443,7 +443,8 @@ export const makeLaunchChain = (
       serviceName: TELEMETRY_SERVICE_NAME,
     });
 
-    const slogSender = await (testingOverrides.slogSender ||
+    const providedSlogSender = await testingOverrides.slogSender;
+    const slogSender = await (providedSlogSender ||
       makeSlogSender({
         stateDir: stateDBDir,
         env,
@@ -559,7 +560,12 @@ export const makeLaunchChain = (
       swingsetConfig,
     });
     savedChainSends = s.savedChainSends;
-    return s;
+    const shutdown = async () => {
+      await s.shutdown?.();
+      if (providedSlogSender) return;
+      await slogSender?.shutdown?.();
+    };
+    return { ...s, shutdown };
   };
 
   return launchChain;

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -1393,7 +1393,8 @@ export async function launchAndShareInternals({
   }
 
   async function shutdown() {
-    return controller.shutdown();
+    await controller.shutdown();
+    await afterCommitWorkDone;
   }
 
   function writeSlogObject(obj) {

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -47,8 +47,9 @@ export const makeFsStreamWriter = async filePath => {
     return undefined;
   }
 
+  const useStdout = filePath === '-';
   const { handle, stream } = await (async () => {
-    if (filePath === '-') {
+    if (useStdout) {
       return { handle: undefined, stream: process.stdout };
     }
     const fh = await open(filePath, 'a');
@@ -56,7 +57,9 @@ export const makeFsStreamWriter = async filePath => {
   })();
   await fsStreamReady(stream);
   const writeAsync = promisify(stream.write.bind(stream));
-  const endAsync = stream.end && promisify(stream.end.bind(stream));
+  const endAsync = useStdout
+    ? undefined
+    : stream.end && promisify(stream.end.bind(stream));
 
   let flushed = Promise.resolve();
   let closed = false;

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -34,7 +34,10 @@ export const tryFlushSlogSender = async (
   slogSender,
   { env = {}, log } = {},
 ) => {
-  await Promise.resolve(slogSender?.forceFlush?.()).catch(err => {
+  await null;
+  try {
+    await slogSender?.forceFlush?.();
+  } catch (err) {
     log?.('Failed to flush slog sender', err);
     if (err.errors) {
       for (const error of err.errors) {
@@ -44,7 +47,7 @@ export const tryFlushSlogSender = async (
     if (env.SLOGSENDER_FAIL_ON_ERROR) {
       throw err;
     }
-  });
+  }
 };
 
 export const getResourceAttributes = ({

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -158,15 +158,15 @@ export const makeSlogSender = async (opts = {}) => {
       }
     };
     return Object.assign(slogSender, {
-      forceFlush: async () =>
-        PromiseAllOrErrors([
+      forceFlush: async () => {
+        await PromiseAllOrErrors([
           ...senders.map(sender => sender.forceFlush?.()),
           ...sendErrors.splice(0).map(err => Promise.reject(err)),
-        ]).then(() => {}),
-      shutdown: async () =>
-        PromiseAllOrErrors(senders.map(sender => sender.shutdown?.())).then(
-          () => {},
-        ),
+        ]);
+      },
+      shutdown: async () => {
+        await PromiseAllOrErrors(senders.map(sender => sender.shutdown?.()));
+      },
       usesJsonObject: hasSenderUsingJsonObj,
     });
   }

--- a/packages/telemetry/test/flight-recorder.test.js
+++ b/packages/telemetry/test/flight-recorder.test.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { promisify } from 'node:util';
 import tmp from 'tmp';
 import { test } from './prepare-test-env-ava.js';
 
@@ -17,12 +18,21 @@ const bufferTests = test.macro(
   async (t, input) => {
     const BUFFER_SIZE = 512;
 
-    const { name: tmpFile, removeCallback } = tmp.fileSync();
+    const {
+      name: tmpFile,
+      fd,
+      removeCallback,
+    } = tmp.fileSync({ detachDescriptor: true });
+    t.teardown(removeCallback);
+    const fileHandle = /** @type {import('fs/promises').FileHandle} */ ({
+      close: promisify(fs.close.bind(fs, fd)),
+    });
     const { readCircBuf, writeCircBuf } = await input.makeBuffer({
       circularBufferSize: BUFFER_SIZE,
       circularBufferFilename: tmpFile,
     });
-    const slogSender = makeSlogSenderFromBuffer({ writeCircBuf });
+    const slogSender = makeSlogSenderFromBuffer({ fileHandle, writeCircBuf });
+    t.teardown(slogSender.shutdown);
     slogSender({ type: 'start' });
     await slogSender.forceFlush();
     t.is(fs.readFileSync(tmpFile, { encoding: 'utf8' }).length, BUFFER_SIZE);
@@ -73,8 +83,6 @@ const bufferTests = test.macro(
     slogSender(null, 'PRE-SERIALIZED');
     await slogSender.forceFlush();
     t.truthy(fs.readFileSync(tmpFile).includes('PRE-SERIALIZED'));
-    // console.log({ tmpFile });
-    removeCallback();
   },
 );
 


### PR DESCRIPTION
refs: #10925

## Description
This was prompted by https://github.com/Agoric/agoric-sdk/pull/10925#discussion_r1968800342 (calling out missing `level` data for kernel console slog entries), but more fundamentally fixes the interaction between cosmic-swingset, the kernel, and the telemetry system (and performs a few cleanups along the way).

### Security Considerations
Security posture should not be affected.

### Scaling Considerations
None.

### Documentation Considerations
n/a

### Testing Considerations
Manual confirmation per https://github.com/Agoric/agoric-sdk/issues/10776:

<details><summary>slog excerpt</summary>

```
{"type":"syscall","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":19,"replay":false,"ksc":["subscribe","v12","kp140"],"vsc":["subscribe","p+12"],"time":1740527497.795959,"monotime":64.620102064}
{"type":"syscall-result","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":19,"replay":false,"ksr":["ok",null],"vsr":["ok",null],"time":1740527497.79604,"monotime":64.620182996}
{"type":"clist","crankNum":407,"mode":"drop","vatID":"v12","kobj":"kp139","vobj":"p-61","time":1740527497.79643,"monotime":64.620573542}
{"type":"syscall","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":20,"replay":false,"ksc":["resolve","v12",[["kp139",false,{"body":"#\"$0.Alleged: IST payment\"","slots":["ko113"]}]]],"vsc":["resolve",[["p-61",false,{"body":"#\"$0.Alleged: IST payment\"","slots":["o-60"]}]]],"time":1740527497.796508,"monotime":64.620651781}
{"type":"syscall-result","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":20,"replay":false,"ksr":["ok",null],"vsr":["ok",null],"time":1740527497.796697,"monotime":64.62084073199999}
{"type":"syscall","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":21,"replay":false,"ksc":["vatstoreSet","v12","idCounters","{\"exportID\":23,\"collectionID\":14,\"promiseID\":13}"],"vsc":["vatstoreSet","idCounters","{\"exportID\":23,\"collectionID\":14,\"promiseID\":13}"],"time":1740527497.796941,"monotime":64.621084505}
{"type":"syscall-result","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":21,"replay":false,"ksr":["ok",null],"vsr":["ok",null],"time":1740527497.796998,"monotime":64.621141273}
{"type":"syscall","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":22,"replay":false,"ksc":["vatstoreSet","v12","vc.12.|schemata","{\"body\":\"#{\\\"keyShape\\\":{\\\"#tag\\\":\\\"match:scalar\\\",\\\"payload\\\":\\\"#undefined\\\"},\\\"label\\\":\\\"activeZCFSeats\\\"}\",\"slots\":[]}"],"vsc":["vatstoreSet","vc.12.|schemata","{\"body\":\"#{\\\"keyShape\\\":{\\\"#tag\\\":\\\"match:scalar\\\",\\\"payload\\\":\\\"#undefined\\\"},\\\"label\\\":\\\"activeZCFSeats\\\"}\",\"slots\":[]}"],"time":1740527497.797194,"monotime":64.621337016}
{"type":"syscall-result","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":22,"replay":false,"ksr":["ok",null],"vsr":["ok",null],"time":1740527497.797243,"monotime":64.62138665}
{"type":"syscall","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":23,"replay":false,"ksc":["vatstoreSet","v12","vc.13.|schemata","{\"body\":\"#{\\\"keyShape\\\":{\\\"#tag\\\":\\\"match:scalar\\\",\\\"payload\\\":\\\"#undefined\\\"},\\\"label\\\":\\\"zcfSeatToSeatHandle\\\"}\",\"slots\":[]}"],"vsc":["vatstoreSet","vc.13.|schemata","{\"body\":\"#{\\\"keyShape\\\":{\\\"#tag\\\":\\\"match:scalar\\\",\\\"payload\\\":\\\"#undefined\\\"},\\\"label\\\":\\\"zcfSeatToSeatHandle\\\"}\",\"slots\":[]}"],"time":1740527497.797417,"monotime":64.621560356}
{"type":"syscall-result","crankNum":407,"vatID":"v12","deliveryNum":13,"syscallNum":23,"replay":false,"ksr":["ok",null],"vsr":["ok",null],"time":1740527497.797454,"monotime":64.621596915}
{"type":"deliver-result","crankNum":407,"vatID":"v12","deliveryNum":13,"replay":false,"dr":["ok",null,{"meterType":"xs-meter-34","currentHeapCount":392885,"compute":143185,"allocate":46268416,"timestamps":[1740527497.788211,1740527497.788585,1740527497.789082,1740527497.789307,1740527497.789815,1740527497.790001,1740527497.790369,1740527497.790651,1740527497.790798,1740527497.7912,1740527497.791383,1740527497.791439,1740527497.791629,1740527497.791687,1740527497.791946,1740527497.791994,1740527497.7922,1740527497.79224,1740527497.792447,1740527497.792476,1740527497.792649,1740527497.792704,1740527497.792904,1740527497.793317,1740527497.793441,1740527497.793488,1740527497.793621,1740527497.793654,1740527497.793815,1740527497.793846,1740527497.794009,1740527497.794043,1740527497.794202,1740527497.794229,1740527497.794441,1740527497.794554,1740527497.794991,1740527497.795274,1740527497.795742,1740527497.795778,1740527497.796088,1740527497.796216,1740527497.79675,1740527497.796844,1740527497.797045,1740527497.79708,1740527497.797288,1740527497.797317,1740527497.797483,1740527497.797602]}],"time":1740527497.797708,"monotime":64.621851681}
{"type":"terminate","vatID":"v12","shouldReject":false,"info":{"body":"#\"payment retrieved\"","slots":[]},"time":1740527497.798019,"monotime":64.622162789}
{"type":"console","source":"kernel","level":"log","args":["kernel terminating vat v12 (failure=false)"],"time":1740527497.798286,"monotime":64.622429777}
{"type":"crank-finish","crankNum":407,"crankhash":"086f84650ada36d845ee2079ea0dfe6e6e08d6a587f6be46868e75eee0690a6b","activityhash":"ede8ca0d16de82e6eb8748dcfe475d71e908f334bdc7d564867f77384c6d0798","time":1740527497.80501,"monotime":64.629155006}
```

</details> 

### Upgrade Considerations
This fixes a late-discovered flaw in #10925 and would ideally be cherry-picked into agoric-upgrade-19, but if it doesn't make it in then we'll just be missing the kernel console `level` data until agoric-upgrade-20 (which is still acceptable).

Release verification should look for slog entries like the above (type "console", source "kernel", level "log"/"warn"/"error"/etc.).