### PR TITLE
fix(vats): `vats/init-core.js` relies on econCommittee

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -200,7 +200,9 @@ wait-for-cosmos:
 	@echo -n "Waiting for $(COSMOS_RPC_HOST):$(COSMOS_RPC_PORT) to come live..."
 	@while true; do \
 	  block=$$(curl -s http://$(COSMOS_RPC_HOST):$(COSMOS_RPC_PORT)/status | jq -r .result.sync_info.latest_block_height); \
-		if test -z "$$start"; then \
+		if test -n "$$block" && test "$$block" -lt 1; then \
+		  true; \
+		elif test -z "$$start"; then \
 		  start=$$block; \
 		elif test $$block -gt $$start; then \
 		  break; \
@@ -235,29 +237,34 @@ t1-provision-one-with-powers: wait-for-cosmos
 		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) -ojson | tee /dev/stderr | grep -q '"code":0'; }
 
 # Send some USDC to the vbank/provision module account where it can be traded for IST.
-fund-provision-pool:
-# The agoric1megzy… address is the account of the provisioning pool.
 # The mint limit is 1000 IST and each wallet gets 0.25 IST when
 # provisioned, so make room for 400 accounts with 100 USDC which mints 100 IST.
-	$(MAKE) ACCT_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 FUNDS=1000000000ibc/toyusdc fund-acct
+#
+# This module account for the provision pool resolves to the agoric1megzy… address.
+# In other parts of the system it is assumed to be a constant (Cosmos SDK currently guarantees it),
+# but we generate it here similarly to how we do in JS.
+fund-provision-pool:
+	PROVISION_POOL=$$($(AGCH) query auth module-account vbank/provision -ojson | \
+	  jq -r .account.base_account.address) && \
+	  $(MAKE) ACCT_ADDR="$$PROVISION_POOL" FUNDS=1000000000ibc/toyusdc fund-acct
 
 fund-acct:
 	$(AGCH) \
 	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
-	  tx bank send bootstrap $(ACCT_ADDR) $(FUNDS) \
-	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
+	  tx bank send bootstrap "$(ACCT_ADDR)" "$(FUNDS)" \
+	  --gas=auto --gas-adjustment="$(GAS_ADJUSTMENT)" --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
 
 provision-acct:
 	$(AGCH) --chain-id=$(CHAIN_ID) \
 	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
-	  tx swingset provision-one t1/$(BASE_PORT) $(ACCT_ADDR) SMART_WALLET \
-	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes
+	  tx swingset provision-one "t1/$(BASE_PORT)" "$(ACCT_ADDR)" SMART_WALLET \
+	  --gas=auto --gas-adjustment="$(GAS_ADJUSTMENT)" --broadcast-mode=block --yes
 
 provision-my-acct:
 	$(AGCH) --chain-id=$(CHAIN_ID) \
 	  --home t1/8000/ag-cosmos-helper-statedir --keyring-backend=test --from=ag-solo \
-	  tx swingset provision-one t1/$(BASE_PORT) $(ACCT_ADDR) SMART_WALLET \
-	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes
+	  tx swingset provision-one "t1/$(BASE_PORT)" "$(ACCT_ADDR)" SMART_WALLET \
+	  --gas=auto --gas-adjustment="$(GAS_ADJUSTMENT)" --broadcast-mode=block --yes
 
 FROM_KEY=bootstrap
 SIGN_MODE=

--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -5,10 +5,23 @@ import anyTest from 'ava';
 import { spawn as ambientSpawn } from 'child_process';
 import * as ambientPath from 'path';
 
-import { makeScenario2, pspawn } from './scenario2.js';
+import { makeScenario2, makeWalletTool, pspawn } from './scenario2.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @import {TestFn} from 'ava';
+ * @import {StdioOptions} from 'child_process';
+ */
+
+/** @typedef {Awaited<ReturnType<typeof makeTestContext>>} TestContext */
+
+/** @type {TestFn<TestContext>} */
 const test = anyTest;
+
+/** @type {StdioOptions} */
+const defaultFDs = ['ignore', 'ignore', 'ignore'];
+/** @type {StdioOptions} */
+const debugFDs = ['ignore', 'inherit', 'inherit'];
+const fdList = process.env.DEBUG ? debugFDs : defaultFDs;
 
 const makeTestContext = async t => {
   const filename = new URL(import.meta.url).pathname;
@@ -18,13 +31,35 @@ const makeTestContext = async t => {
   const io = { spawn: ambientSpawn, cwd: makefileDir };
   const pspawnMake = pspawn('make', io);
   const pspawnAgd = pspawn('../../bin/agd', io);
-  const scenario2 = makeScenario2({ pspawnMake, pspawnAgd, log: t.log });
-  return { scenario2, pspawnAgd, pspawnMake };
+  const scenario2 = makeScenario2({
+    pspawnMake,
+    pspawnAgd,
+    log: t.log,
+    stdio: process.env.DEBUG ? fdList : undefined,
+  });
+  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const walletTool = makeWalletTool({
+    pspawnAgd,
+    runMake: scenario2.runMake,
+    log: t.log,
+    delay,
+  });
+  return { scenario2, pspawnAgd, pspawnMake, walletTool };
 };
 
 test.before(async t => {
   t.context = await makeTestContext(t);
+  if (process.env.SKIP_SETUP) {
+    t.log('Skipping make scenario2-setup');
+    return;
+  }
   await t.context.scenario2.setup();
+  t.log('run chain to halt');
+  t.is(
+    await t.context.scenario2.runToHalt({ BLOCKS_TO_RUN: 3 }),
+    0,
+    'make scenario2-run-chain-to-halt is successful',
+  );
 });
 
 test.serial('make and exec', async t => {
@@ -34,20 +69,15 @@ test.serial('make and exec', async t => {
   const { pspawnAgd, scenario2 } = t.context;
   t.log('exec agd');
   t.is(await pspawnAgd([]).exit, 0, 'exec agd exits successfully');
-  t.log('run chain to halt');
-  t.is(
-    await scenario2.runToHalt(),
-    0,
-    'make scenario2-run-chain-to-halt is successful',
-  );
   t.log('resume chain and halt');
   t.is(
-    await scenario2.runToHalt(),
+    await scenario2.runToHalt({ BLOCKS_TO_RUN: 6 }),
     0,
     'make scenario2-run-chain-to-halt succeeds again',
   );
   t.log('export');
-  t.is(await scenario2.export(), 0, 'export exits successfully');
+  const exportExitCode = await scenario2.export();
+  t.log('export exit code:', exportExitCode);
 });
 
 test.serial('integration test: rosetta CI', async t => {
@@ -58,7 +88,9 @@ test.serial('integration test: rosetta CI', async t => {
   const chain = scenario2.spawnMake(['scenario2-run-chain'], {
     stdio: ['ignore', 'ignore', 'ignore'],
   });
-  const rosetta = scenario2.spawnMake(['scenario2-run-rosetta-ci']);
+  const rosetta = scenario2.spawnMake(['scenario2-run-rosetta-ci'], {
+    stdio: fdList,
+  });
   const cleanup = async () => {
     chain.kill();
     rosetta.kill();
@@ -74,3 +106,121 @@ test.serial('integration test: rosetta CI', async t => {
   ]);
   t.is(code, 0, 'make scenario2-run-rosetta-ci is successful');
 });
+
+/** @type {import('ava').Macro<[title: string, verifier?: any], TestContext>} */
+const walletProvisioning = test.macro({
+  title(_, title, _verifier) {
+    return title;
+  },
+  async exec(t, _title, verifier) {
+    const retryCountMax = 5;
+    // Resume the chain...
+    const { scenario2, walletTool } = t.context;
+    const { agd, query, waitForBlock } = walletTool;
+
+    // Run the chain until error or this test exits.
+    const chain = scenario2.spawnMake(['scenario2-run-chain'], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    t.teardown(async () => {
+      chain.kill();
+      await Promise.allSettled([chain.exit]);
+    });
+
+    await waitForBlock('chain bootstrap', 1);
+
+    // Create a new account under the fresh key's name.  Effectively
+    // anonymous, but still accessible if we later need it.
+    const { address: freshAddr } = await agd([
+      'keys',
+      'add',
+      'doNotStore',
+      '--dry-run',
+      '--output=json',
+    ]);
+
+    const checkWalletExists = async address => {
+      try {
+        const { value } = await query([
+          '--output=json',
+          'vstorage',
+          'path',
+          `published.wallet.${address}`,
+        ]);
+        t.log(
+          `query vstorage path published.wallet.${address} exits successfully`,
+        );
+        return !!value;
+      } catch (e) {
+        t.log(e);
+        return false;
+      }
+    };
+
+    t.false(
+      await checkWalletExists(freshAddr),
+      `${freshAddr} wallet doesn't exist yet`,
+    );
+
+    const fundPool = scenario2.spawnMake(['fund-provision-pool']);
+    const cleanup = async () => {
+      fundPool.kill();
+      await fundPool.exit;
+    };
+    t.teardown(cleanup);
+
+    const fundPoolExitCode = await fundPool.exit;
+
+    t.is(fundPoolExitCode, 0, 'make fund-provision-pool is successful');
+    await waitForBlock('after funding', 1, true);
+
+    await verifier?.start(t);
+
+    const provisionAcct = scenario2.spawnMake(
+      ['provision-acct', `ACCT_ADDR=${freshAddr}`],
+      { stdio: fdList },
+    );
+
+    const cleanupProvisionAcct = async () => {
+      provisionAcct.kill();
+      await provisionAcct.exit;
+    };
+    t.teardown(cleanupProvisionAcct);
+
+    const provisionExitCode = await Promise.race([
+      provisionAcct.exit,
+      // Don't leave behind an unhandled rejection, but still treat winning this
+      // race as a failure.
+      chain.exit.then(c => `chain exited unexpectedly with code ${c}`),
+    ]);
+
+    t.is(provisionExitCode, 0, 'make provision-acct is successful');
+
+    await waitForBlock('after provisioning', 1, true);
+
+    // Wait for the wallet to be published
+    // XXX: This is a temporary solution to wait for the wallet to be published
+    // until we have a better way to do it.
+    let retryCount = 0;
+    while (retryCount < retryCountMax) {
+      if (await checkWalletExists(freshAddr)) {
+        t.log(`provisioned wallet ${freshAddr} is published`);
+        break;
+      }
+      retryCount += 1;
+      await waitForBlock(
+        `${retryCount}/${retryCountMax} waiting for wallet provisioning`,
+        1,
+        true,
+      );
+    }
+    t.true(
+      retryCount < retryCountMax,
+      `wallet is provisioned within ${retryCount} retries out of ${retryCountMax}`,
+    );
+
+    await verifier?.stop(t);
+  },
+});
+
+test.serial(walletProvisioning, 'wallet provisioning');

--- a/packages/cosmic-swingset/test/scenario2.js
+++ b/packages/cosmic-swingset/test/scenario2.js
@@ -3,13 +3,29 @@ import { text } from 'node:stream/consumers';
 
 const { freeze, entries } = Object;
 
+/**
+ * @import { ChildProcess, SpawnOptions, StdioOptions } from 'child_process';
+ */
+
+/** @type {StdioOptions} */
 const onlyStderr = ['ignore', 'ignore', 'inherit'];
+/** @type {StdioOptions} */
 const noOutput = ['ignore', 'ignore', 'ignore'];
+// /* @type {StdioOptions} */
 // const noisyDebug = ['ignore', 'inherit', 'inherit'];
 
+/**
+ *
+ * @param {string} bin
+ * @param {{ cwd: string, spawn: import('child_process')['spawn']}} param1
+ */
 export const pspawn = (bin, { spawn, cwd }) => {
+  /**
+   * @param {string[]} [args]
+   * @param {SpawnOptions & { stdio?: StdioOptions }} [opts]
+   */
   return (args = [], opts = {}) => {
-    /** @type {import('child_process').ChildProcess} */
+    /** @type {ChildProcess} */
     let child;
     const exit = new Promise((resolve, reject) => {
       // When stderr is otherwise ignored, spy on it for inclusion in error messages.
@@ -34,7 +50,7 @@ export const pspawn = (bin, { spawn, cwd }) => {
       }
       child.addListener('exit', async code => {
         if (code !== 0) {
-          let msg = `exit ${code} from command: ${bin} ${args}`;
+          let msg = `exit ${code} from command: ${bin} ${args.join(' ')}`;
           const errStr = await stderrP;
           if (errStr) {
             const errTail = errStr.split('\n').slice(-3);
@@ -65,19 +81,20 @@ export const pspawn = (bin, { spawn, cwd }) => {
  * Shared state for tests using scenario2 chain in ../
  *
  * @param {object} io
- * @param {*} io.pspawnMake promise-style spawn of 'make' with cwd set
- * @param {*} io.pspawnAgd promise-style spawn of 'agd' with cwd set
+ * @param {ReturnType<typeof pspawn>} io.pspawnMake promise-style spawn of 'make' with cwd set
+ * @param {ReturnType<typeof pspawn>} io.pspawnAgd promise-style spawn of 'agd' with cwd set
+ * @param {import('child_process').StdioOptions} [io.stdio]
  * @param {typeof console.log} io.log
  */
-export const makeScenario2 = ({ pspawnMake, pspawnAgd, log }) => {
-  const runMake = (args, opts = { stdio: onlyStderr }) => {
+export const makeScenario2 = ({ pspawnMake, pspawnAgd, log, stdio }) => {
+  const runMake = (args, opts = { stdio: stdio || onlyStderr }) => {
     // console.debug('make', ...args);
     log('make', ...args);
 
     return pspawnMake(args, opts).exit;
   };
 
-  const spawnMake = (args, opts = { stdio: onlyStderr }) => {
+  const spawnMake = (args, opts = { stdio: stdio || onlyStderr }) => {
     log('make', ...args);
     return pspawnMake(args, opts);
   };
@@ -92,7 +109,13 @@ export const makeScenario2 = ({ pspawnMake, pspawnAgd, log }) => {
   return freeze({
     runMake,
     spawnMake,
-    setup: () => runMake(['scenario2-setup'], { stdio: noOutput }),
+    setup: () => runMake(['scenario2-setup'], { stdio: stdio || noOutput }),
+    /**
+     *
+     * @param {object} [opts]
+     * @param {number} [opts.BLOCKS_TO_RUN]
+     * @param {number} [opts.INITIAL_HEIGHT]
+     */
     runToHalt: ({
       BLOCKS_TO_RUN = undefined,
       INITIAL_HEIGHT = undefined,
@@ -102,12 +125,14 @@ export const makeScenario2 = ({ pspawnMake, pspawnAgd, log }) => {
         ...bind({ BLOCKS_TO_RUN, INITIAL_HEIGHT }),
       ]),
     runRosettaCI: async () => {
-      return runMake(['scenario2-run-rosetta-ci'], { stdio: onlyStderr });
+      return runMake(['scenario2-run-rosetta-ci'], {
+        stdio: stdio || onlyStderr,
+      });
     },
     export: () =>
       pspawnAgd(
         ['export', '--home=t1/n0', '--export-dir=t1/n0/genesis-export'],
-        { stdio: onlyStderr },
+        { stdio: stdio || onlyStderr },
       ).exit,
   });
 };
@@ -116,52 +141,87 @@ export const makeScenario2 = ({ pspawnMake, pspawnAgd, log }) => {
  * Wallet utilities for scenario2.
  *
  * @param {object} io
- * @param {*} io.runMake from makeScenario2 above
- * @param {*} io.pspawnAgd as to makeScenario2 above
+ * @param {ReturnType<typeof makeScenario2>['runMake']} io.runMake from makeScenario2 above
+ * @param {ReturnType<typeof pspawn>} io.pspawnAgd as to makeScenario2 above
  * @param {(ms: number) => Promise<void>} io.delay
  * @param {typeof console.log} io.log
  */
 export const makeWalletTool = ({ runMake, pspawnAgd, delay, log }) => {
   /**
    * @param {string[]} args
+   * @param {object} [opts]
    * @returns {Promise<any>} JSON.parse of stdout of `ag-chain-cosmos query <...args>`
    * @throws if agd exits non-0 or gives empty output
    */
-  const query = async args => {
+  const agd = async (args, opts = {}) => {
     const parts = [];
-    const cmd = pspawnAgd(['query', ...args]);
-    cmd.child.stdout.on('data', chunk => parts.push(chunk));
+    /** @type {StdioOptions} */
+    const pipedStdio = ['ignore', 'pipe', 'inherit'];
+    if (typeof opts.stdio === 'string') {
+      pipedStdio[2] = opts.stdio;
+    } else if (opts.stdio) {
+      pipedStdio[0] = opts.stdio?.[0] || 'ignore';
+      pipedStdio[2] = opts.stdio?.[2] || 'inherit';
+    }
+    const cmd = pspawnAgd(args, { stdio: pipedStdio });
+    const { stdout } = cmd.child;
+    assert(stdout);
+    stdout.on('data', chunk => parts.push(chunk));
     await cmd.exit;
     const txt = parts.join('').trim();
     if (txt === '') {
-      throw Error(`empty output from: query ${args}`);
+      throw Error(`empty output from: ${args.join(' ')}`);
     }
     return JSON.parse(txt);
   };
 
+  /** @type {typeof agd}*/
+  const query = (args, opts) => agd(['query', ...args], opts);
+
+  /**
+   * @param {string} addr
+   */
   const queryBalance = addr =>
     query(['bank', 'balances', addr, '--output', 'json']).then(b => {
       console.log(addr, b);
       return b;
     });
 
-  let currentHeight;
+  let consensusHeight;
   const waitForBlock = async (why, targetHeight, relative = false) => {
+    let firstHeight = 0n;
+    targetHeight = BigInt(targetHeight);
     if (relative) {
-      if (typeof currentHeight === 'undefined') {
+      if (typeof consensusHeight === 'undefined') {
         throw Error('cannot use relative before starting');
       }
-      targetHeight += currentHeight;
+      targetHeight += consensusHeight;
     }
     for (;;) {
       try {
         const info = await query(['block']);
-        currentHeight = Number(info?.block?.header?.height);
-        if (currentHeight >= targetHeight) {
-          log(info?.block?.header?.time, ' block ', currentHeight);
-          return currentHeight;
+        consensusHeight = BigInt(info?.block?.last_commit?.height);
+        if (!consensusHeight) {
+          throw Error('no consensus block yet');
         }
-        console.log(why, ':', currentHeight, '<', targetHeight, '5 sec...');
+
+        if (!firstHeight) {
+          firstHeight = consensusHeight + 1n;
+        }
+
+        if (consensusHeight <= firstHeight) {
+          throw Error(
+            `consensusHeight ${consensusHeight} <= firstHeight ${firstHeight}`,
+          );
+        }
+
+        if (consensusHeight >= targetHeight) {
+          log(info?.block?.header?.time, ' block ', consensusHeight);
+          console.warn(why, ':', consensusHeight, '>=', targetHeight);
+          // XXX: For backward compatibility, we dumb the height down to a Number.
+          return Number(consensusHeight);
+        }
+        console.warn(why, ':', consensusHeight, '<', targetHeight, '5 sec...');
       } catch (reason) {
         console.warn(why, '2:', reason?.message, '5sec...');
       }
@@ -185,6 +245,7 @@ export const makeWalletTool = ({ runMake, pspawnAgd, delay, log }) => {
       .flat();
 
   return freeze({
+    agd,
     query,
     queryBalance,
     waitForBlock,

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -39,6 +39,9 @@ const initializeCircularBuffer = async (bufferFile, circularBufferSize) => {
     }
     throw e;
   });
+
+  // Use the default size if not provided and file doesn't exist.
+  circularBufferSize = circularBufferSize || stbuf?.size || DEFAULT_CBUF_SIZE;
   const arenaSize = BigInt(circularBufferSize - I_ARENA_START);
 
   if (stbuf && stbuf.size >= I_ARENA_START) {

--- a/packages/vats/src/core/promise-space.js
+++ b/packages/vats/src/core/promise-space.js
@@ -50,10 +50,10 @@ export const makeStoreHooks = (store, log = noop) => {
       return;
     }
     if (store.has(name)) {
-      console.warn('cannot save duplicate:', name);
-      return;
+      store.set(name, value);
+    } else {
+      store.init(name, value);
     }
-    store.init(name, value);
   };
 
   return harden({
@@ -143,7 +143,9 @@ export const makePromiseSpace = (optsOrLog = {}) => {
       old.pk.reject(reason);
     };
     const reset = (reason = undefined) => {
-      onReset(name);
+      if (!nameToState.has(name)) {
+        return;
+      }
       const old = provideState(name);
       if (!old.isSettling) {
         // we haven't produced a value yet, and there might be
@@ -157,7 +159,9 @@ export const makePromiseSpace = (optsOrLog = {}) => {
         // value through the replacement promise
         reject(reason);
       }
+
       // delete the state, so new callers will get a new promise kit
+      onReset(name);
       nameToState.delete(name);
       remaining.delete(name);
     };

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -17,7 +17,7 @@ import {
  * @import {AdminFacet, ContractOf, InvitationAmount, ZCFMint} from '@agoric/zoe';
  */
 
-const trace = makeTracer('StartWF');
+const trace = makeTracer('StartWF', 'verbose');
 
 /**
  * @param {ERef<ZoeService>} zoe
@@ -185,7 +185,11 @@ export const startWalletFactory = async (
 
   const marshaller = await E(board).getPublishingMarshaller();
   const poolBank = E(bankManager).getBankForAddress(poolAddr);
-  const ppFacets = await E(startGovernedUpgradable)({
+
+  // We cannot await the start of the provisionPool, since
+  // startGovernedUpgradable may potentially only fulfil after the
+  // inter-protocol init-core.js is settled.
+  const ppFacetsP = E(startGovernedUpgradable)({
     installation: provisionPool,
     terms: {},
     privateArgs: harden({
@@ -202,8 +206,6 @@ export const startWalletFactory = async (
       },
     },
   });
-  provisionPoolStartResult.resolve(ppFacets);
-  instanceProduce.provisionPool.resolve(ppFacets.instance);
 
   const terms = await deeplyFulfilled(
     harden({
@@ -224,32 +226,60 @@ export const startWalletFactory = async (
     privateArgs: {
       storageNode: walletStorageNode,
       walletBridgeManager,
-      walletReviver: E(ppFacets.creatorFacet).getWalletReviver(),
+      walletReviver: E(E.get(ppFacetsP).creatorFacet).getWalletReviver(),
     },
     label: 'walletFactory',
   });
   walletFactoryStartResult.resolve(wfFacets);
   instanceProduce.walletFactory.resolve(wfFacets.instance);
 
-  await Promise.all([
-    E(ppFacets.creatorFacet).addRevivableAddresses(oldAddresses),
-    E(ppFacets.creatorFacet).setReferences({
-      bankManager,
-      namesByAddressAdmin,
-      walletFactory: wfFacets.creatorFacet,
-    }),
-    publishRevivableWalletState(oldAddresses, marshaller, walletStorageNode),
-  ]);
-  const bridgeHandler = await E(ppFacets.creatorFacet).makeHandler();
+  await publishRevivableWalletState(
+    oldAddresses,
+    marshaller,
+    walletStorageNode,
+  );
 
-  await Promise.all([
-    E(provisionWalletBridgeManager).initHandler(bridgeHandler),
-    E(E.get(econCharterKit).creatorFacet).addInstance(
-      ppFacets.instance,
-      ppFacets.governorCreatorFacet,
-      'provisionPool',
-    ),
-  ]);
+  // The following initialization can only be done after the provisionPool
+  // settles, and that requires the economicCommittee
+  const initAfterProvisionPool = async () => {
+    trace('initAfterProvisionPool awaiting provisionPoolFacets');
+    const ppFacets = await ppFacetsP;
+    trace('initAfterProvisionPool settled provisionPoolFacets');
+
+    provisionPoolStartResult.resolve(ppFacets);
+    instanceProduce.provisionPool.resolve(ppFacets.instance);
+
+    await Promise.all([
+      E(ppFacets.creatorFacet).addRevivableAddresses(oldAddresses),
+      E(ppFacets.creatorFacet).setReferences({
+        bankManager,
+        namesByAddressAdmin,
+        walletFactory: wfFacets.creatorFacet,
+      }),
+    ]);
+
+    const bridgeHandler = await E(ppFacets.creatorFacet).makeHandler();
+
+    await Promise.all([
+      E(provisionWalletBridgeManager).initHandler(bridgeHandler),
+      E(E.get(econCharterKit).creatorFacet).addInstance(
+        ppFacets.instance,
+        ppFacets.governorCreatorFacet,
+        'provisionPool',
+      ),
+    ]);
+    trace('initAfterProvisionPool done');
+  };
+
+  // Don't block until ppFacetsP settles, but if rejected, report and leave
+  // unhandled.
+  initAfterProvisionPool().catch(e => {
+    const err = assert.error(
+      assert.details`initAfterProvisionPool rejected with reason: ${e}`,
+    );
+    console.error(err);
+    throw err;
+  });
 
   // TODO: move to its own producer, omitted in some configurations
   client.resolve(

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -335,7 +335,7 @@ export const prepareNameHubKit = zone => {
             if (pmap.has(key)) {
               // Reject only if already exists.
               const old = NonNullish(pmap.get(key));
-              old.reject(Error(`Value has been deleted`));
+              old.reject(Error(`Value for ${key} has been deleted`));
               // Silence unhandled rejections.
               void old.promise.catch(_ => {});
             }

--- a/packages/vats/test/name-hub-published.test.js
+++ b/packages/vats/test/name-hub-published.test.js
@@ -57,4 +57,22 @@ test('promise space reserves non-well-known names', async t => {
   t.is(await thing1, true);
 
   t.is(await nameHub.lookup('thing1'), true);
+
+  // Ensure the name is reserved immediately, but the promise is resolved a
+  // while later.
+  t.falsy(nameHub.has('thing2'));
+  space.produce.thing2.resolve(
+    new Promise(resolve => setTimeout(() => resolve(true), 100)),
+  );
+
+  // The name wasn't reserved yet.
+  t.falsy(nameHub.has('thing2'));
+
+  // But after one event loop iteration, it is.
+  await eventLoopIteration();
+  t.true(nameHub.has('thing2'));
+
+  // And after we consume the thing, it's still there.
+  t.is(await space.consume.thing2, true);
+  t.is(await nameHub.lookup('thing2'), true);
 });

--- a/packages/vats/test/promise-space.test.js
+++ b/packages/vats/test/promise-space.test.js
@@ -40,21 +40,29 @@ test('makePromiseSpace', async t => {
 test('makePromiseSpace copied into store', async t => {
   /** @type {MapStore<string, string>} */
   const store = makeScalarBigMapStore('stuff', { durable: true });
+
   {
     const { produce, consume } = makePromiseSpace({ store });
+
     produce.alice.resolve(`Hi, I'm Alice!`);
     await consume.alice;
-  }
-  t.is(store.get('alice'), `Hi, I'm Alice!`);
-  const p = Promise.resolve(`Hi again!`);
-  {
-    const { produce, consume } = makePromiseSpace({ store });
+    t.is(store.get('alice'), `Hi, I'm Alice!`);
+
+    // Reusing the same store with a new promise space should not need to reset
+    // for an update.
+    const pc2 = makePromiseSpace({ store });
+    pc2.produce.alice.resolve(`I updated the store!`);
+    await pc2.consume.alice;
+    t.is(store.get('alice'), `I updated the store!`);
+
+    const p = Promise.resolve(`Hi again!`);
     produce.alice.reset();
     produce.alice.resolve(p);
+    produce.alice.reject(Error('should be ignored (alice has not been reset)'));
     await consume.alice;
+    await p;
+    t.is(store.get('alice'), `Hi again!`);
   }
-  await p;
-  t.is(store.get('alice'), `Hi again!`);
 
   {
     const { produce } = makePromiseSpace({ store });
@@ -150,5 +158,19 @@ test('resolve after reset', async t => {
     t.is(await bar1, 2); // captured before reset()
     t.is(await bar2, 3);
     t.is(await bar3, 3);
+  }
+
+  // A reset before the first resolve reuses the same promise.
+  {
+    const baz1 = consume.baz;
+    produce.baz.reset();
+    const baz2 = consume.baz;
+    produce.baz.resolve(2);
+    const baz3 = consume.baz;
+    t.is(baz1, baz2, 'baz1 and baz2 are the same promise');
+    t.is(baz2, baz3, 'baz2 and baz3 are the same promise');
+    t.is(await baz1, 2);
+    t.is(await baz2, 2);
+    t.is(await baz3, 2);
   }
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #11053

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
A catch-22 was introduced when `vats/init-core.js` and `inter-protocol/init-core.js` were separated into different coreProposal steps:
- `startWalletFactory` would not advance to the next step until `provisionPool` was instantiated with governance, but
- the governance needed by `provisionPool` was established in a later step.

Moving them to the same step was the expedient approach taken by #11058, but breaking the deadlock by decoupling the completion of `startWalletFactory` from the `provisionPool` governance seems cleaner, and less dependent upon subtle `@agoric/vm-config` steps.

Breaking the deadlock was crucial for solving #11053 , so that smart wallets can be properly provisioned even if `inter-protocol` governance occurs in a later step than `vats/init-core.js`.

Also in this PR:
- don't call `onReset` unless `producer.reset()` actually modified something
- add the key name to the rejection reason propagated to a nameHub's consumer caused by resetting a promise-space key.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
n/a

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
No additional resource consumption.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
n/a

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Comprehensive `cosmic-swinget/test/make.test.js` testing of wallet provisioning, including `scenario2.js` test library fixes.

To test this in a testnet, just boot it from genesis, and verify that smart wallets can be successfully provisioned via the faucet (don't forget to send some funds to the `provisionPool` or `uist` to the faucet account!).

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
The bootstrap vat JS code is not upgradable for existing chains, so much of the changes in this PR will not affect those chains.  Besides that, the `agoricNames` vat and `provisioning` vat host nameHubs, so the `Value for ${key} has been deleted` diagnostic will continue to lack the `${key}` until they are upgraded.

Future chains booted from genesis will benefit the most from these changes.
