### PR TITLE
fix(cosmos-vstorage): split 'size_delta' counter into 'size_increase' and 'size_decrease'

### DIFF
--- a/golang/cosmos/x/vstorage/keeper/keeper.go
+++ b/golang/cosmos/x/vstorage/keeper/keeper.go
@@ -119,8 +119,8 @@ func NewKeeper(storeKey storetypes.StoreKey) Keeper {
 	}
 }
 
-var MetricKeyStoreAllocated = []string{"store", "allocated"}
-var MetricKeyStoreReleased = []string{"store", "released"}
+var MetricKeyStoreSizeIncrease = []string{"store", "size_increase"}
+var MetricKeyStoreSizeDecrese = []string{"store", "size_decrease"}
 const MetricLabelStoreKey = "storeKey"
 
 func ReportStoreSizeMetrics(k Keeper, sizeDelta float32) {
@@ -128,9 +128,9 @@ func ReportStoreSizeMetrics(k Keeper, sizeDelta float32) {
 		telemetry.NewLabel(MetricLabelStoreKey, k.storeKey.Name()),
 	}
 	if sizeDelta >= 0 {
-		telemetry.IncrCounterWithLabels(MetricKeyStoreAllocated, sizeDelta, metricsLabel)
+		telemetry.IncrCounterWithLabels(MetricKeyStoreSizeIncrease, sizeDelta, metricsLabel)
 	} else {
-		telemetry.IncrCounterWithLabels(MetricKeyStoreReleased, -sizeDelta, metricsLabel)
+		telemetry.IncrCounterWithLabels(MetricKeyStoreSizeDecrese, -sizeDelta, metricsLabel)
 	}
 }
 


### PR DESCRIPTION
refs: #11062
refs: #10938 

## Description
[Despite testing](https://github.com/Agoric/agoric-sdk/pull/10997#discussion_r1956583919), `telemetry.IncrCounterWithLabels()` appears to only accept non-negative numbers. As a workaround, we will be reporting vstorage size increase and decrease as two separate counters.

### Security Considerations
N/A

### Scaling Considerations
One extra metric not an issue as long as number of keeper instances is low.

### Documentation Considerations

New metrics:
```
# HELP store_size_increase store_size_increase
# TYPE store_size_increase counter
store_size_increase{storeKey="vstorage"} 42386

# HELP store_size_decrease store_size_decrease
# TYPE store_size_decrease counter
store_size_decrease{storeKey="vstorage"} 335
```

### Testing Considerations
Manual Testing; Automated testing will be submitted as a separate PR.

First terminal:
```
cd agoric-sdk/packages/cosmic-swingset
make scenario2-setup scenario2-run-chain
```

Second terminal (after Block 17)
```
cd agoric-sdk/packages/cosmic-swingset
make fund-provision-pool
make provision-acct ACCT_ADDR=$(cat t1/8000/ag-cosmos-helper-address)
```

Third terminal (start before Block 17):
```
cd agoric-sdk/packages/cosmic-swingset
while true; do curl -s -G 'http://localhost:26660/metrics' | grep 'store_size_'; sleep 10; done
[...]
# HELP store_size_increase store_size_increase
# TYPE store_size_increase counter
store_size_increase{storeKey="vstorage"} 42386
# HELP store_size_decrease store_size_decrease
# TYPE store_size_decrease counter
store_size_decrease{storeKey="vstorage"} 335
# HELP store_size_increase store_size_increase
# TYPE store_size_increase counter
store_size_increase{storeKey="vstorage"} 284
# HELP store_size_decrease store_size_decrease
# TYPE store_size_decrease counter
store_size_decrease{storeKey="vstorage"} 335
# HELP store_size_increase store_size_increase
# TYPE store_size_increase counter
store_size_increase{storeKey="vstorage"} 284
# HELP store_size_decrease store_size_decrease
# TYPE store_size_decrease counter
store_size_decrease{storeKey="vstorage"} 788
```

### Upgrade Considerations
N/A
