### PR TITLE
fix: minted early tracking

### DIFF
--- a/packages/fast-usdc/src/exos/advancer.js
+++ b/packages/fast-usdc/src/exos/advancer.js
@@ -338,7 +338,6 @@ export const prepareAdvancerKit = (
               e,
             );
           }
-          tmpReturnSeat.exit();
         },
         /**
          * @param {Error} error

--- a/packages/fast-usdc/src/utils/store.js
+++ b/packages/fast-usdc/src/utils/store.js
@@ -1,0 +1,119 @@
+import { Fail } from '@endo/errors';
+
+/**
+ * @import {Key} from '@endo/patterns';
+ */
+
+// TODO provide something like this in a more common place, perhaps as a BagStore
+/**
+ * Creates a bag (multi-set) API that wraps a MapStore where values are counts.
+ *
+ * @template {Key} K
+ * @param {MapStore<K, number>} mapStore
+ */
+export const asMultiset = mapStore =>
+  harden({
+    /**
+     * Add an item to the bag, incrementing its count.
+     *
+     * @param {K} item The item to add
+     * @param {number} [count] How many to add (defaults to 1)
+     */
+    add: (item, count = 1) => {
+      if (count <= 0) {
+        throw Fail`Cannot add a non-positive count ${count} to bag`;
+      }
+
+      if (mapStore.has(item)) {
+        const currentCount = mapStore.get(item);
+        mapStore.set(item, currentCount + count);
+      } else {
+        mapStore.init(item, count);
+      }
+    },
+
+    /**
+     * Remove an item from the bag, decrementing its count. If count reaches
+     * zero, the item is removed completely.
+     *
+     * @param {K} item The item to remove
+     * @param {number} [count] How many to remove (defaults to 1)
+     * @returns {boolean} Whether the removal was successful
+     * @throws {Error} If trying to remove more items than exist
+     */
+    remove: (item, count = 1) => {
+      if (count <= 0) {
+        throw Fail`Cannot remove a non-positive count ${count} from bag`;
+      }
+
+      if (!mapStore.has(item)) {
+        return false;
+      }
+
+      const currentCount = mapStore.get(item);
+      if (currentCount < count) {
+        throw Fail`Cannot remove ${count} of ${item} from bag; only ${currentCount} exist`;
+      }
+
+      if (currentCount === count) {
+        mapStore.delete(item);
+      } else {
+        mapStore.set(item, currentCount - count);
+      }
+      return true;
+    },
+
+    /**
+     * Get the count of an item in the bag.
+     *
+     * @param {K} item The item to check
+     * @returns {number} The count (0 if not present)
+     */
+    count: item => {
+      return mapStore.has(item) ? mapStore.get(item) : 0;
+    },
+
+    /**
+     * Check if the bag contains at least one of the item.
+     *
+     * @param {K} item The item to check
+     * @returns {boolean} Whether the item is in the bag
+     */
+    has: item => {
+      return mapStore.has(item);
+    },
+
+    /**
+     * Get all unique items in the bag.
+     *
+     * @returns {Iterable<K>} Iterable of unique items
+     */
+    keys: () => {
+      return mapStore.keys();
+    },
+
+    /**
+     * Get all entries (item, count) in the bag.
+     *
+     * @returns {Iterable<[K, number]>} Iterable of [item, count] pairs
+     */
+    entries: () => {
+      return mapStore.entries();
+    },
+
+    /**
+     * Get the total number of unique items in the bag.
+     *
+     * @returns {number} Number of unique items
+     */
+    size: () => {
+      return mapStore.getSize();
+    },
+
+    /**
+     * Remove all items from the bag.
+     */
+    clear: () => {
+      mapStore.clear();
+    },
+  });

--- a/packages/fast-usdc/test/utils/store.test.js
+++ b/packages/fast-usdc/test/utils/store.test.js
@@ -1,0 +1,121 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { makeScalarMapStore } from '@agoric/store';
+import { asMultiset } from '../../src/utils/store.js';
+
+test('add and get', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  // Add items
+  multiset.add('apple');
+  multiset.add('banana', 3);
+
+  // Check counts
+  t.is(mapStore.get('apple'), 1);
+  t.is(mapStore.get('banana'), 3);
+});
+
+test('has', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  multiset.add('apple');
+
+  t.true(multiset.has('apple'));
+  t.false(multiset.has('banana'));
+});
+
+test('keys and entries', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  multiset.add('apple', 2);
+  multiset.add('banana', 3);
+
+  // Test keys
+  const keys = [...multiset.keys()];
+  t.deepEqual(keys.sort(), ['apple', 'banana']);
+
+  // Test entries
+  const entries = [...multiset.entries()];
+  t.deepEqual(
+    entries.sort((a, b) => a[0].localeCompare(b[0])),
+    [
+      ['apple', 2],
+      ['banana', 3],
+    ],
+  );
+});
+
+test('clear', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  multiset.add('apple');
+  multiset.add('banana');
+
+  multiset.clear();
+
+  t.false(multiset.has('apple'));
+  t.false(multiset.has('banana'));
+  t.is([...mapStore.keys()].length, 0);
+});
+
+test('add with invalid count', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  // Should throw when adding with count <= 0
+  t.throws(() => multiset.add('apple', 0), {
+    message: /Cannot add a non-positive count/,
+  });
+  t.throws(() => multiset.add('apple', -1), {
+    message: /Cannot add a non-positive count/,
+  });
+});
+
+test('add to existing item', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  multiset.add('apple', 2);
+  multiset.add('apple', 3);
+
+  // Should accumulate counts
+  t.is(mapStore.get('apple'), 5);
+});
+
+test('remove', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  multiset.add('apple', 2);
+  multiset.add('apple', 3);
+
+  multiset.remove('apple', 4);
+  t.is(multiset.count('apple'), 1);
+  t.is(multiset.remove('apple'), true);
+  t.is(multiset.count('apple'), 0);
+
+  // not successful
+  t.is(multiset.remove('apple'), false);
+});
+
+test('remove with excessive count should throw', t => {
+  const mapStore = makeScalarMapStore();
+  const multiset = asMultiset(mapStore);
+
+  multiset.add('apple', 3);
+  t.is(multiset.count('apple'), 3);
+
+  t.throws(() => multiset.remove('apple', 5), {
+    message: /Cannot remove 5 of "apple" from bag; only 3 exist/,
+  });
+
+  t.is(multiset.count('apple'), 3, 'original count remains unchanged');
+
+  // removing exactly as many as exist (should not throw)
+  t.notThrows(() => multiset.remove('apple', 3));
+  t.is(multiset.count('apple'), 0);
+  t.false(multiset.has('apple'));
+});

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -1,6 +1,6 @@
 import { Fail, q } from '@endo/errors';
 import { Far } from '@endo/marshal';
-import { M, matches } from '@endo/patterns';
+import { isCopyMap, isCopySet } from '@endo/patterns';
 
 /**
  * @import {RankCompare} from '@endo/marshal';
@@ -9,29 +9,7 @@ import { M, matches } from '@endo/patterns';
  * @import {Key} from '@endo/patterns';
  */
 
-// TODO: Undate `@endo/patterns` to export the original, and delete the
-// reimplementation here.
-/**
- * Should behave identically to the one in `@endo/patterns`, but reimplemented
- * for now because `@endo/patterns` forgot to export this one. This one is
- * simple enough that I prefer a reimplementation to a deep import.
- *
- * @param {unknown} s
- * @returns {s is CopySet}
- */
-export const isCopySet = s => matches(s, M.set());
-
-// TODO: Undate `@endo/patterns` to export the original, and delete the
-// reimplementation here.
-/**
- * Should behave identically to the one in `@endo/patterns`, but reimplemented
- * for now because `@endo/patterns` forgot to export this one. This one is
- * simple enough that I prefer a reimplementation to a deep import.
- *
- * @param {unknown} m
- * @returns {m is CopyMap}
- */
-export const isCopyMap = m => matches(m, M.map());
+export { isCopyMap, isCopySet };
 
 /**
  * @template {Key} K


### PR DESCRIPTION
## Description
Ensures the `mintedEarly` store can track multiple settlements for the same amount from the same address.

### Security Considerations
Ensures state diagram invariants are upheld.

### Scaling Considerations
Same considerations as #10729 - the mapStore could grow large if an attacker spams the settlementAccount with uusdc. In these changes we ensure to delete map store entries when the count goes to 0.

### Documentation Considerations
Changes should be clear to maintainers.

### Testing Considerations
Adds a new test for the scenario not originally considered.

### Upgrade Considerations
The `mintedEarly` kind is a Remotable, so changing from a `SetStore` to a `MapStore` does not seem to affect upgradability.

These change should be included in the FUSDC GTM CE.