### PR TITLE
chore: u19 cherrypicks

### DIFF
--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -204,7 +204,7 @@ replace (
 	github.com/cosmos/iavl => github.com/cosmos/iavl v0.19.7
 
 	// Use a version of ibc-go that is compatible with the above forks.
-	github.com/cosmos/ibc-go/v6 => github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.2
+	github.com/cosmos/ibc-go/v6 => github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.3
 
 	// use cometbft
 	// Use our fork at least until post-v0.34.14 is released with

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -235,8 +235,8 @@ github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.5 h1:cwbONQaVbGEPzfVqv
 github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.5/go.mod h1:Yny/YE+GJ+y/++UgvraITGzfLhXCnwETSWw3dAY5NDg=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
-github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.2 h1:vEzy4JaExzlWNHV3ZSVXEVZcRE9loEFUjieE2TXwDdI=
-github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.2/go.mod h1:L1xcBjCLIHN7Wd9j6cAQvZertn56pq+eRGFZjRO5bsY=
+github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.3 h1:PMPDsOllIpRo9QeeeOe1i7tMSyIJ7fTrqI9evdqY81I=
+github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.3/go.mod h1:L1xcBjCLIHN7Wd9j6cAQvZertn56pq+eRGFZjRO5bsY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -216,7 +216,7 @@ export async function makeSwingsetController(
   const sloggingKernelConsole = makeLimitedConsole(level => {
     return (...args) => {
       kernelConsole[level](...args);
-      writeSlogObject({ type: 'console', source: 'kernel', args });
+      writeSlogObject({ type: 'console', source: 'kernel', level, args });
     };
   });
   writeSlogObject({ type: 'import-kernel-start' });

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -96,7 +96,6 @@ export function makeDummySlogger(slogCallbacks, dummyConsole = badConsole) {
     }),
     vatConsole: wrap('vatConsole', () => dummyConsole),
     startup: wrap('startup', () => noopFinisher),
-    replayVatTranscript: wrap('replayVatTranscript', () => noopFinisher),
     delivery: wrap('delivery', () => noopFinisher),
     syscall: wrap('syscall', () => noopFinisher),
     changeCList: wrap('changeCList', () => noopFinisher),
@@ -250,18 +249,6 @@ export function makeSlogger(slogCallbacks, writeObj) {
     return { vatSlog, starting: true };
   }
 
-  function replayVatTranscript(vatID) {
-    safeWrite({ type: 'replay-transcript-start', vatID });
-    function finish() {
-      safeWrite({ type: 'replay-transcript-finish', vatID });
-    }
-    return harden(finish);
-  }
-
-  // function annotateVat(vatID, data) {
-  //   safeWrite({ type: 'annotate-vat', vatID, data });
-  // }
-
   const { wrap, done } = makeFinishersKit(slogCallbacks);
   const slogger = harden({
     provideVatSlogger: wrap('provideVatSlogger', provideVatSlogger),
@@ -271,8 +258,6 @@ export function makeSlogger(slogCallbacks, writeObj) {
     startup: wrap('startup', (vatID, ...args) =>
       provideVatSlogger(vatID).vatSlog.startup(...args),
     ),
-    // TODO: Remove this seemingly dead code.
-    replayVatTranscript,
     delivery: wrap('delivery', (vatID, ...args) =>
       provideVatSlogger(vatID).vatSlog.delivery(...args),
     ),

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -2,6 +2,7 @@ import { q } from '@endo/errors';
 import { objectMap } from '@agoric/internal';
 import { makeLimitedConsole } from '@agoric/internal/src/ses-utils.js';
 
+/** @import {Callable} from '@agoric/internal'; */
 /** @import {LimitedConsole} from '@agoric/internal/src/js-utils.js'; */
 
 const IDLE = 'idle';
@@ -22,7 +23,7 @@ const noopFinisher = harden(() => {});
  * (e.g., its finisher), and are expected to return a finisher of their own that
  * will invoke that wrapped finisher.
  *
- * @template {Record<string, Function>} Methods
+ * @template {Record<string, Callable>} Methods
  * @param {SlogWrappers} slogCallbacks
  * @param {string} unusedMsgPrefix prefix for warn-level logging about unused callbacks
  * @param {Methods} methods to wrap

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -439,7 +439,8 @@ export const makeLaunchChain = (
       serviceName: TELEMETRY_SERVICE_NAME,
     });
 
-    const slogSender = await (testingOverrides.slogSender ||
+    const providedSlogSender = await testingOverrides.slogSender;
+    const slogSender = await (providedSlogSender ||
       makeSlogSender({
         stateDir: stateDBDir,
         env,
@@ -552,7 +553,12 @@ export const makeLaunchChain = (
       swingsetConfig,
     });
     savedChainSends = s.savedChainSends;
-    return s;
+    const shutdown = async () => {
+      await s.shutdown?.();
+      if (providedSlogSender) return;
+      await slogSender?.shutdown?.();
+    };
+    return { ...s, shutdown };
   };
 
   return launchChain;

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -1393,7 +1393,8 @@ export async function launch({
   }
 
   async function shutdown() {
-    return controller.shutdown();
+    await controller.shutdown();
+    await afterCommitWorkDone;
   }
 
   function writeSlogObject(obj) {

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -47,8 +47,9 @@ export const makeFsStreamWriter = async filePath => {
     return undefined;
   }
 
+  const useStdout = filePath === '-';
   const { handle, stream } = await (async () => {
-    if (filePath === '-') {
+    if (useStdout) {
       return { handle: undefined, stream: process.stdout };
     }
     const fh = await open(filePath, 'a');
@@ -56,7 +57,9 @@ export const makeFsStreamWriter = async filePath => {
   })();
   await fsStreamReady(stream);
   const writeAsync = promisify(stream.write.bind(stream));
-  const endAsync = stream.end && promisify(stream.end.bind(stream));
+  const endAsync = useStdout
+    ? undefined
+    : stream.end && promisify(stream.end.bind(stream));
 
   let flushed = Promise.resolve();
   let closed = false;

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -34,7 +34,10 @@ export const tryFlushSlogSender = async (
   slogSender,
   { env = {}, log } = {},
 ) => {
-  await Promise.resolve(slogSender?.forceFlush?.()).catch(err => {
+  await null;
+  try {
+    await slogSender?.forceFlush?.();
+  } catch (err) {
     log?.('Failed to flush slog sender', err);
     if (err.errors) {
       for (const error of err.errors) {
@@ -44,7 +47,7 @@ export const tryFlushSlogSender = async (
     if (env.SLOGSENDER_FAIL_ON_ERROR) {
       throw err;
     }
-  });
+  }
 };
 
 export const getResourceAttributes = ({

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -158,15 +158,15 @@ export const makeSlogSender = async (opts = {}) => {
       }
     };
     return Object.assign(slogSender, {
-      forceFlush: async () =>
-        PromiseAllOrErrors([
+      forceFlush: async () => {
+        await PromiseAllOrErrors([
           ...senders.map(sender => sender.forceFlush?.()),
           ...sendErrors.splice(0).map(err => Promise.reject(err)),
-        ]).then(() => {}),
-      shutdown: async () =>
-        PromiseAllOrErrors(senders.map(sender => sender.shutdown?.())).then(
-          () => {},
-        ),
+        ]);
+      },
+      shutdown: async () => {
+        await PromiseAllOrErrors(senders.map(sender => sender.shutdown?.()));
+      },
       usesJsonObject: hasSenderUsingJsonObj,
     });
   }

--- a/packages/telemetry/test/flight-recorder.test.js
+++ b/packages/telemetry/test/flight-recorder.test.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { promisify } from 'node:util';
 import tmp from 'tmp';
 import { test } from './prepare-test-env-ava.js';
 
@@ -17,12 +18,21 @@ const bufferTests = test.macro(
   async (t, input) => {
     const BUFFER_SIZE = 512;
 
-    const { name: tmpFile, removeCallback } = tmp.fileSync();
+    const {
+      name: tmpFile,
+      fd,
+      removeCallback,
+    } = tmp.fileSync({ detachDescriptor: true });
+    t.teardown(removeCallback);
+    const fileHandle = /** @type {import('fs/promises').FileHandle} */ ({
+      close: promisify(fs.close.bind(fs, fd)),
+    });
     const { readCircBuf, writeCircBuf } = await input.makeBuffer({
       circularBufferSize: BUFFER_SIZE,
       circularBufferFilename: tmpFile,
     });
-    const slogSender = makeSlogSenderFromBuffer({ writeCircBuf });
+    const slogSender = makeSlogSenderFromBuffer({ fileHandle, writeCircBuf });
+    t.teardown(slogSender.shutdown);
     slogSender({ type: 'start' });
     await slogSender.forceFlush();
     t.is(fs.readFileSync(tmpFile, { encoding: 'utf8' }).length, BUFFER_SIZE);
@@ -73,8 +83,6 @@ const bufferTests = test.macro(
     slogSender(null, 'PRE-SERIALIZED');
     await slogSender.forceFlush();
     t.truthy(fs.readFileSync(tmpFile).includes('PRE-SERIALIZED'));
-    // console.log({ tmpFile });
-    removeCallback();
   },
 );
 


### PR DESCRIPTION
### Description

Cherrypicks the following changes:
 - https://github.com/Agoric/agoric-sdk/pull/11065
 - https://github.com/Agoric/agoric-sdk/pull/11052

Using the following rebase-todo:
```
# PR #11065 Branch fix-cosmos-upgrade-to-agoric-labs-ibc-go-v6-3-1-alpha-agoric-3-11065-
label base-fix-cosmos-upgrade-to-agoric-labs-ibc-go-v6-3-1-alpha-agoric-3-11065-
pick 52fb6cfe95 build(deps): use new version of ibc-go
pick 3dbb1bcc0b chore(golang): `go mod tidy`
label pr-11065--fix-cosmos-upgrade-to-agoric-labs-ibc-go-v6-3-1-alpha-agoric-3-11065-
reset base-fix-cosmos-upgrade-to-agoric-labs-ibc-go-v6-3-1-alpha-agoric-3-11065-
merge -C ee18609f4a pr-11065--fix-cosmos-upgrade-to-agoric-labs-ibc-go-v6-3-1-alpha-agoric-3-11065- # fix(cosmos): upgrade to `agoric-labs/ibc-go` `v6.3.1-alpha.agoric.3` (#11065)

# PR #11052 Branch fix-Properly-synchronize-slog-sender-termination-11052-
label base-fix-Properly-synchronize-slog-sender-termination-11052-
pick ec3c1a2d88 chore(SwingSet): Remove unused code and comments
pick 9ab1630aa6 fix(SwingSet): Include level in kernel console slog output
pick fcfb944964 refactor(SwingSet): Simplify makeFinishersKit into addSlogCallbacks
pick d8a59477c8 refactor(SwingSet): Improve addSlogCallbacks parameter/variable names
pick f83c01d89d fix: Properly synchronize slog sender termination
pick 318269e300 chore(telemetry): Use more readable async patterns
pick fa1f04a29d chore(SwingSet): Prefer type Callable over Function
pick 117c766c38 fix(internal): Exempt process.stdout from being closed by makeFsStreamWriter
pick 6c6fba4d2f refactor(internal): Prefer fs.WriteStream close() over stream.Writable end()
label pr-11052--fix-Properly-synchronize-slog-sender-termination-11052-
reset base-fix-Properly-synchronize-slog-sender-termination-11052- # fix: minted early tracking (#11066)
merge -C 42d5764ab9 pr-11052--fix-Properly-synchronize-slog-sender-termination-11052- # fix: Properly synchronize slog sender termination (#11052)
```