### PR TITLE
test(cosmic-swingset): create `vstorage metrics` test.

### DIFF
--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -225,12 +225,20 @@ const walletProvisioning = test.macro({
 test.serial(walletProvisioning, 'wallet provisioning');
 
 const prometheusUrl = 'http://localhost:26660/metrics';
-const metricsToVerify = [
+const testMetricNames = [
   'store_size_decrease{storeKey="vstorage"}',
   'store_size_increase{storeKey="vstorage"}',
 ];
-const metricNameSet = new Set(metricsToVerify);
+const testMetricNamesSet = new Set(testMetricNames);
 
+/**
+ * getMetrics fetches the metrics from the Prometheus URL and returns the metrics
+ * as an object with metric names as keys and their values as values.
+ *
+ * @param {*} url             Prometheus URL
+ * @param {*} metricNames     Array of metric names to fetch
+ * @returns {Promise<Record<string, any>>}
+ */
 const getMetrics = async (url, metricNames) => {
   const metricsResponse = await fetch(url);
   if (!metricsResponse.ok) {
@@ -303,13 +311,13 @@ let startMetricNameSet;
  * @returns {Promise<void>}
  */
 const startCounterMetricVerifier = async t => {
-  startMetrics = await getMetrics(prometheusUrl, metricsToVerify);
+  startMetrics = await getMetrics(prometheusUrl, testMetricNames);
   startMetricNameSet = new Set(Object.keys(startMetrics));
   t.log('metric start values:', startMetrics);
 
-  if (!areSetsEqual(startMetricNameSet, metricNameSet)) {
+  if (!areSetsEqual(startMetricNameSet, testMetricNamesSet)) {
     t.fail(
-      `start metric name set must be the same as the verification metric name set. start set: ${startMetricNameSet}, expected set: ${metricNameSet}`,
+      `start metric name set must be the same as the verification metric name set. start set: ${startMetricNameSet}, expected set: ${testMetricNamesSet}`,
     );
     return;
   }
@@ -331,7 +339,7 @@ const startCounterMetricVerifier = async t => {
  * @returns {Promise<void>}
  */
 const stopCounterMetricVerifier = async t => {
-  const metrics = await getMetrics(prometheusUrl, metricsToVerify);
+  const metrics = await getMetrics(prometheusUrl, testMetricNames);
   const stopMetricNameSet = new Set(Object.keys(metrics));
   t.log('metric stop values:', metrics);
 

--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -232,12 +232,12 @@ const testMetricNames = [
 const testMetricNamesSet = new Set(testMetricNames);
 
 /**
- * getMetrics fetches the metrics from the Prometheus URL and returns the metrics
- * as an object with metric names as keys and their values as values.
+ * getMetrics reads data from the Prometheus URL and returns the selected
+ * metrics as an object.
  *
- * @param {*} url             Prometheus URL
- * @param {*} metricNames     Array of metric names to fetch
- * @returns {Promise<Record<string, any>>}
+ * @param {string} url            Prometheus URL
+ * @param {string[]} metricNames  Selected metric names
+ * @returns {Promise<Record<string, number>>}
  */
 const getMetrics = async (url, metricNames) => {
   const metricsResponse = await fetch(url);

--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -268,6 +268,7 @@ const getMetrics = async (url, metricNames) => {
       })
       .filter((entry) => !!entry)
   );
+  );
   const allMetrics = new Map(allMetricsEntries);
   const metricsEntries = metricNames.map(metricName => {
     const value = allMetrics.get(metricName);

--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -268,7 +268,6 @@ const getMetrics = async (url, metricNames) => {
       })
       .filter((entry) => !!entry)
   );
-  );
   const allMetrics = new Map(allMetricsEntries);
   const metricsEntries = metricNames.map(metricName => {
     const value = allMetrics.get(metricName);

--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -253,20 +253,20 @@ const getMetrics = async (url, metricNames) => {
   );
   const allMetricsEntries = /** @type {Array<[string, number]>} */ (
     metricsText
-      .split("\n")
-      .map((line) => {
+      .split('\n')
+      .map(line => {
         const [_, metricName, value] = line.match(samplePatt) || [];
         if (!metricName) return undefined;
-        if (value === "NaN") return [metricName, NaN];
-        if (value === "+Inf") return [metricName, Infinity];
-        if (value === "-Inf") return [metricName, -Infinity];
+        if (value === 'NaN') return [metricName, NaN];
+        if (value === '+Inf') return [metricName, Infinity];
+        if (value === '-Inf') return [metricName, -Infinity];
         const valueNum = parseFloat(value);
         if (Number.isNaN(valueNum)) {
           throw Error(`${value} is not a decimal value`);
         }
         return [metricName, valueNum];
       })
-      .filter((entry) => !!entry)
+      .filter(entry => !!entry)
   );
   const allMetrics = new Map(allMetricsEntries);
   const metricsEntries = metricNames.map(metricName => {

--- a/packages/cosmic-swingset/test/make.test.js
+++ b/packages/cosmic-swingset/test/make.test.js
@@ -251,22 +251,23 @@ const getMetrics = async (url, metricNames) => {
     String.raw`^(${metricNamePatt}(?:[{]${labelPatt}(?:,${labelPatt})*,?[}])?) +(\S+)( +-?[0-9]+)?$`,
     'u',
   );
-  /** @type {Iterable<any, any>} */
-  const allMetricsEntries = metricsText
-    .split('\n')
-    .map(line => {
-      const [_, metricName, value] = line.match(samplePatt) || [];
-      if (!metricName) return;
-      if (value === 'NaN') return [metricName, NaN];
-      if (value === '+Inf') return [metricName, Infinity];
-      if (value === '-Inf') return [metricName, -Infinity];
-      const valueNum = parseFloat(value);
-      if (Number.isNaN(valueNum)) {
-        throw Error(`${value} is not a decimal value`);
-      }
-      return [metricName, valueNum];
-    })
-    .filter(entry => !!entry);
+  const allMetricsEntries = /** @type {Array<[string, number]>} */ (
+    metricsText
+      .split("\n")
+      .map((line) => {
+        const [_, metricName, value] = line.match(samplePatt) || [];
+        if (!metricName) return undefined;
+        if (value === "NaN") return [metricName, NaN];
+        if (value === "+Inf") return [metricName, Infinity];
+        if (value === "-Inf") return [metricName, -Infinity];
+        const valueNum = parseFloat(value);
+        if (Number.isNaN(valueNum)) {
+          throw Error(`${value} is not a decimal value`);
+        }
+        return [metricName, valueNum];
+      })
+      .filter((entry) => !!entry)
+  );
   const allMetrics = new Map(allMetricsEntries);
   const metricsEntries = metricNames.map(metricName => {
     const value = allMetrics.get(metricName);


### PR DESCRIPTION
refs: #11062

## Description
Convert `wallet provisioning` to a macro and use it for `vstorage metrics` test.

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
N/A

### Testing Considerations
new `vstorage metrics` test passes when executed manually, as well as in CI:
```
  ✔ vstorage metrics (1m 6.3s)
    ℹ query vstorage path published.wallet.agoric1dcdry77cu0xcut2g3rsh2xtyxdunqujuwy37m7 exits successfully
    ℹ metric start values: {
        'store_size_decrease{storeKey="vstorage"}': 283,
        'store_size_increase{storeKey="vstorage"}': 322,
      }
    ℹ query vstorage path published.wallet.agoric1dcdry77cu0xcut2g3rsh2xtyxdunqujuwy37m7 exits successfully
    ℹ provisioned wallet agoric1dcdry77cu0xcut2g3rsh2xtyxdunqujuwy37m7 is published
    ℹ metric stop values: {
        'store_size_decrease{storeKey="vstorage"}': 738,
        'store_size_increase{storeKey="vstorage"}': 2143,
      }
  ─

  1 test passed
```

### Upgrade Considerations
N/A
