### PR TITLE
chore: Update README.md Go version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to use.
 Prerequisites are enforced in various places that should be kept synchronized with this section (e.g., [repoconfig.sh](./repoconfig.sh) defines `golang_version_check` and `nodejs_version_check` shell functions).
 
 * Git
-* Go ^1.20.2
+* Go ^1.22.2
 * Node.js ^18.12 or ^20.9
   * we generally support the latest LTS release: use [nvm](https://github.com/nvm-sh/nvm) to keep your local system up-to-date
 * Yarn (`npm install -g yarn`)


### PR DESCRIPTION
## Description
Matches the de facto requirement already mentioned in [agoric-upgrade-18a](https://github.com/Agoric/agoric-sdk/releases/tag/agoric-upgrade-18a).

### Upgrade Considerations
[repoconfig.sh](https://github.com/Agoric/agoric-sdk/blob/master/repoconfig.sh) already cross-references this, but maybe we need to be more diligent about verification? We could add a test, but that seems like overkill to me.