### PR TITLE
boot testing supports for external packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ typings/
 # Optional eslint cache
 .eslintcache
 
+# General cache (e.g. by node-fetch-cache
+.cache
+
 # Optional REPL history
 .node_repl_history
 

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -20,7 +20,6 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
-    "@endo/errors": "^1.2.9",
     "@agoric/builders": "^0.1.0",
     "@agoric/client-utils": "^0.1.0",
     "@agoric/cosmic-proto": "^0.4.0",
@@ -45,6 +44,7 @@
     "@agoric/zone": "^0.2.2",
     "@endo/bundle-source": "^3.5.1",
     "@endo/captp": "^4.4.4",
+    "@endo/errors": "^1.2.9",
     "@endo/eventual-send": "^1.3.0",
     "@endo/far": "^1.1.10",
     "@endo/init": "^1.1.8",
@@ -62,6 +62,7 @@
     "@endo/patterns": "^1.4.8",
     "ava": "^5.3.0",
     "c8": "^10.1.2",
+    "node-fetch-cache": "^4.1.2",
     "ts-blank-space": "^0.4.4"
   },
   "files": [

--- a/packages/boot/test/fast-usdc/fast-usdc.test.ts
+++ b/packages/boot/test/fast-usdc/fast-usdc.test.ts
@@ -15,7 +15,6 @@ import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { Fail } from '@endo/errors';
 import { makeMarshal } from '@endo/marshal';
-import NodeFetchCache, { FileSystemCache } from 'node-fetch-cache';
 import {
   AckBehavior,
   fetchCoreEvalRelease,
@@ -26,13 +25,6 @@ import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
 } from '../bootstrapTests/walletFactory.js';
-
-// Releases are immutable, so we can cache them.
-// Doesn't help in CI but speeds up local development.
-// CI is on Github Actions, so fetching is reliable.
-const fetchCached = NodeFetchCache.create({
-  cache: new FileSystemCache(),
-}) as unknown as typeof globalThis.fetch;
 
 const test: TestFn<
   WalletFactoryTestContext & {
@@ -84,16 +76,11 @@ test.serial('oracles provision before contract deployment', async t => {
 test.serial('prop 87: Beta', async t => {
   const { evalProposal, bridgeUtils } = t.context;
 
-  const materials = await fetchCoreEvalRelease(
-    {
-      fetch: fetchCached,
-    },
-    {
-      repo: 'Agoric/agoric-sdk',
-      release: 'fast-usdc-beta-1',
-      name: 'start-fast-usdc',
-    },
-  );
+  const materials = await fetchCoreEvalRelease({
+    repo: 'Agoric/agoric-sdk',
+    release: 'fast-usdc-beta-1',
+    name: 'start-fast-usdc',
+  });
 
   // Proposal 87 doesn't quite complete: noble ICA is mis-configured
   bridgeUtils.setAckBehavior(

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -101,6 +101,16 @@ const keysToObject = <K extends PropertyKey, V>(
  * AVA's default t.deepEqual() is nearly unreadable for sorted arrays of
  * strings.
  */
+/**
+ * Compare two arrays of property keys for equality in a way that's more readable
+ * in AVA test output than the default t.deepEqual().
+ *
+ * @param t - AVA test context
+ * @param a - First array of property keys to compare
+ * @param b - Second array of property keys to compare
+ * @param message - Optional message to display on failure
+ * @returns The result of t.deepEqual() on objects created from the arrays
+ */
 export const keyArrayEqual = (
   t: AvaT,
   a: PropertyKey[],
@@ -112,6 +122,16 @@ export const keyArrayEqual = (
   return t.deepEqual(aobj, bobj, message);
 };
 
+/**
+ * Prepares a SwingSet configuration for testing vaults.
+ *
+ * @param options - Configuration options
+ * @param options.bundleDir - Directory to store bundle cache files
+ * @param options.specifier - Path to the base config file
+ * @param options.defaultManagerType - SwingSet manager type to use
+ * @param options.discriminator - Optional string to include in the config filename
+ * @returns Path to the generated config file
+ */
 export const getNodeTestVaultsConfig = async ({
   bundleDir = 'bundles',
   specifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
@@ -164,6 +184,14 @@ interface Powers {
   fs: typeof import('node:fs/promises');
 }
 
+/**
+ * Creates a function that can build and extract proposal data from package scripts.
+ *
+ * @param powers - Object containing required capabilities
+ * @param powers.childProcess - Node child_process module for executing commands
+ * @param powers.fs - Node fs/promises module for file operations
+ * @returns A function that builds and extracts proposal data
+ */
 export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
   const getPkgPath = (pkg, fileName = '') =>
     importSpec(`../../${pkg}/${fileName}`);
@@ -253,6 +281,15 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
 };
 harden(makeProposalExtractor);
 
+/**
+ * Compares two references for equality using krefOf.
+ *
+ * @param t - AVA test context
+ * @param ref1 - First reference to compare
+ * @param ref2 - Second reference to compare
+ * @param message - Optional message to display on failure
+ * @returns The result of t.is() on the kref values
+ */
 export const matchRef = (
   t: AvaT,
   ref1: unknown,
@@ -260,6 +297,15 @@ export const matchRef = (
   message?: string,
 ) => t.is(krefOf(ref1), krefOf(ref2), message);
 
+/**
+ * Compares an amount object with expected brand and value.
+ *
+ * @param t - AVA test context
+ * @param amount - Amount object to test
+ * @param refBrand - Expected brand reference
+ * @param refValue - Expected value
+ * @param message - Optional message to display on failure
+ */
 export const matchAmount = (
   t: AvaT,
   amount: Amount,
@@ -271,6 +317,14 @@ export const matchAmount = (
   t.is(amount.value, refValue, message);
 };
 
+/**
+ * Compares a value object with a reference value object.
+ * Checks brand, denom, issuer, issuerName, and proposedName.
+ *
+ * @param t - AVA test context
+ * @param value - Value object to test
+ * @param ref - Reference value object to compare against
+ */
 export const matchValue = (t: AvaT, value, ref) => {
   matchRef(t, value.brand, ref.brand);
   t.is(value.denom, ref.denom);
@@ -279,11 +333,21 @@ export const matchValue = (t: AvaT, value, ref) => {
   t.is(value.proposedName, ref.proposedName);
 };
 
+/**
+ * Checks that an iterator is not done and its current value matches the reference.
+ *
+ * @param t - AVA test context
+ * @param iter - Iterator to test
+ * @param valueRef - Reference value to compare against the iterator's current value
+ */
 export const matchIter = (t: AvaT, iter, valueRef) => {
   t.is(iter.done, false);
   matchValue(t, iter.value, valueRef);
 };
 
+/**
+ * Enumeration of acknowledgment behaviors for IBC bridge messages.
+ */
 export const AckBehavior = {
   /** inbound responses are queued. use `flushInboundQueue()` to simulate the remote response */
   Queued: 'QUEUED',
@@ -321,6 +385,26 @@ type AckBehaviorType = (typeof AckBehavior)[keyof typeof AckBehavior];
  * @param [options.debugVats]
  * @param [options.defaultManagerType]
  * @param [options.harness]
+ */
+/**
+ * Creates a SwingSet test environment with various utilities for testing.
+ *
+ * This function sets up a complete SwingSet kernel with mocked bridges and
+ * utilities for time manipulation, proposal evaluation, and more.
+ *
+ * @param log - Logging function
+ * @param bundleDir - Directory to store bundle cache files
+ * @param options - Configuration options
+ * @param options.configSpecifier - Path to the base config file
+ * @param options.label - Optional label for the test environment
+ * @param options.storage - Storage kit to use (defaults to fake storage)
+ * @param options.verbose - Whether to enable verbose logging
+ * @param options.slogFile - Path to write slog output
+ * @param options.profileVats - Array of vat names to profile
+ * @param options.debugVats - Array of vat names to debug
+ * @param options.defaultManagerType - SwingSet manager type to use
+ * @param options.harness - Optional run harness
+ * @returns A test kit with various utilities for interacting with the SwingSet
  */
 export const makeSwingsetTestKit = async (
   log: (..._: any[]) => void,
@@ -742,6 +826,14 @@ export type SwingsetTestKit = Awaited<ReturnType<typeof makeSwingsetTestKit>>;
  * counting run policy (and queried for the count of computrons recorded since
  * the last reset).
  */
+/**
+ * Creates a harness for measuring computron usage in SwingSet tests.
+ *
+ * The harness can be dynamically configured to provide a computron-counting
+ * run policy and queried for the count of computrons recorded since the last reset.
+ *
+ * @returns A harness object with methods to control and query computron counting
+ */
 export const makeSwingsetHarness = () => {
   const c2b = defaultBeansPerXsnapComputron;
   const beansPerUnit = {
@@ -779,6 +871,12 @@ export const makeSwingsetHarness = () => {
  *
  * @param {string} mt
  * @returns {asserts mt is ManagerType}
+ */
+/**
+ * Validates that a string is a valid SwingSet manager type.
+ *
+ * @param mt - The manager type string to validate
+ * @throws If the string is not a valid manager type
  */
 export function insistManagerType(mt) {
   assert(['local', 'node-subprocess', 'xsnap', 'xs-worker'].includes(mt));

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -51,6 +51,7 @@ import type { SwingsetController } from '@agoric/swingset-vat/src/controller/con
 import type { BridgeHandler, IBCDowncallMethod, IBCMethod } from '@agoric/vats';
 import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
 import type { EProxy } from '@endo/eventual-send';
+import { tmpdir } from 'node:os';
 import { icaMocks, protoMsgMockMap, protoMsgMocks } from './ibc/mocks.js';
 
 const trace = makeTracer('BSTSupport', false);
@@ -192,9 +193,6 @@ interface Powers {
  * @returns A function that builds and extracts proposal data
  */
 export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
-  const getPkgPath = (pkg, fileName = '') =>
-    importSpec(`../../${pkg}/${fileName}`);
-
   const runPackageScript = (
     outputDir: string,
     scriptPath: string,
@@ -236,8 +234,9 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
   };
 
   const buildAndExtract = async (builderPath: string, args: string[] = []) => {
+    // XXX rebuilds every time
     const tmpDir = await fsAmbientPromises.mkdtemp(
-      join(getPkgPath('builders'), 'proposal-'),
+      join(tmpdir(), 'agoric-proposal-'),
     );
 
     const built = parseProposalParts(

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -127,20 +127,19 @@ export const keyArrayEqual = (
  *
  * @param options - Configuration options
  * @param options.bundleDir - Directory to store bundle cache files
- * @param options.specifier - Path to the base config file
+ * @param options.configPath - Path to the base config file
  * @param options.defaultManagerType - SwingSet manager type to use
  * @param options.discriminator - Optional string to include in the config filename
  * @returns Path to the generated config file
  */
 export const getNodeTestVaultsConfig = async ({
-  bundleDir = 'bundles',
-  specifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
+  bundleDir,
+  configPath,
   defaultManagerType = 'local' as ManagerType,
   discriminator = '',
 }) => {
-  const fullPath = importSpec(specifier);
   const config: SwingSetConfig & { coreProposals?: any[] } = NonNullish(
-    await loadSwingsetConfigFile(fullPath),
+    await loadSwingsetConfigFile(configPath),
   );
 
   // Manager types:
@@ -168,7 +167,7 @@ export const getNodeTestVaultsConfig = async ({
     discriminator,
     new Date().toISOString().replaceAll(/[^0-9TZ]/g, ''),
     `${Math.random()}`.replace(/.*[.]/, '').padEnd(8, '0').slice(0, 8),
-    basename(specifier),
+    basename(configPath),
   ].filter(s => !!s);
   const testConfigPath = `${bundleDir}/${configFilenameParts.join('.')}`;
   await fsAmbientPromises.writeFile(
@@ -410,7 +409,7 @@ export const makeSwingsetTestKit = async (
   log: (..._: any[]) => void,
   bundleDir = 'bundles',
   {
-    configSpecifier = undefined as string | undefined,
+    configSpecifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
     label = undefined as string | undefined,
     storage = makeFakeStorageKit('bootstrapTests'),
     verbose = false,
@@ -424,7 +423,7 @@ export const makeSwingsetTestKit = async (
   console.time('makeBaseSwingsetTestKit');
   const configPath = await getNodeTestVaultsConfig({
     bundleDir,
-    specifier: configSpecifier,
+    configPath: importSpec(configSpecifier),
     discriminator: label,
     defaultManagerType,
   });

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -60,8 +60,6 @@ const trace = makeTracer('BSTSupport', false);
 const importSpec = spec =>
   new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
-const cliEntrypoint = importSpec('agoric/src/entrypoint.js');
-
 type ConsumeBootrapItem = <N extends string>(
   name: N,
 ) => N extends keyof FastUSDCCorePowers['consume']
@@ -201,7 +199,7 @@ export const makeProposalExtractor = ({ childProcess, fs }: Powers) => {
   ) => {
     console.info('running package script:', scriptPath);
     return childProcess.execFileSync(
-      cliEntrypoint,
+      importSpec('agoric/src/entrypoint.js'),
       ['run', scriptPath, ...cliArgs],
       {
         cwd: outputDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,6 +3608,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@2.6.11":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node@*", "@types/node@>=13.7.0", "@types/node@^22.9.0":
   version "22.9.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
@@ -4616,6 +4624,24 @@ cacache@^17.0.0:
     lru-cache "^7.7.1"
     minipass "^5.0.0"
     minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    p-map "^4.0.0"
+    ssri "^10.0.0"
+    tar "^6.1.11"
+    unique-filename "^3.0.0"
+
+cacache@^18.0.1:
+  version "18.0.4"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.4.tgz#4601d7578dadb59c66044e157d02a3314682d6a5"
+  integrity sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    fs-minipass "^3.0.0"
+    glob "^10.2.2"
+    lru-cache "^10.0.1"
+    minipass "^7.0.3"
+    minipass-collect "^2.0.1"
     minipass-flush "^1.0.5"
     minipass-pipeline "^1.2.4"
     p-map "^4.0.0"
@@ -8370,6 +8396,11 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
+locko@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/locko/-/locko-1.1.0.tgz#43930d87a0d25f20c8d2974c3c4613e50a2978a9"
+  integrity sha512-pYB2dzRY93fJkg2RIl41AMNgTQftEjyTK9vlPrGOJvuGQsOjb267VJBw15BjiN3RBd1oBoKkOu9E2dRdFKIfAA==
+
 lodash.camelcase@4.3.0, lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -8440,7 +8471,7 @@ long@*, long@^5.0.0, long@^5.2.0, long@^5.2.1:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
-lru-cache@^10.2.0:
+lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -9060,6 +9091,13 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass-collect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
+  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
+  dependencies:
+    minipass "^7.0.3"
+
 minipass-fetch@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-2.1.2.tgz#95560b50c472d81a3bc76f20ede80eaed76d8add"
@@ -9300,7 +9338,18 @@ node-addon-api@^5.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
   integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
-node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0:
+node-fetch-cache@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch-cache/-/node-fetch-cache-4.1.2.tgz#4fdbd152c80ec5de76749076a1c4bb16510af8ee"
+  integrity sha512-pcdJlxXE/fT0wcCY13RJUAyZeMKW4altG7P1GKLn1d4z1nLzM9Ua0ZIBiZUp90ppI/UqenZ+8UKWq+cKBk1fFA==
+  dependencies:
+    "@types/node-fetch" "2.6.11"
+    cacache "^18.0.1"
+    form-data "^4.0.0"
+    locko "^1.1.0"
+    node-fetch "2.7.0"
+
+node-fetch@2.7.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
refs: #10811

## Description

Features to support external packages. Needed by https://github.com/Agoric/agoric-sdk/tree/10811-separate-fastusdc/dapps/fast-usdc

- Remove release artifacts from SCM
- Instead fetch from Github Release, but cache for local development
- Feature on utils that have to resolve paths to provide a base


### Security Considerations

`fetchCoreEvalRelease` exports ambient authority. I think this should be allowed as a test utility and for better developer ergonomics.

### Scaling Considerations
n/a

### Documentation Considerations
jsdoc

### Testing Considerations
per se

### Upgrade Considerations
n/a