### PR TITLE
fixup(golang/.../vstorage/keeper): report absolute values for metrics increase/decrease

### DIFF
--- a/golang/cosmos/x/vstorage/keeper/keeper.go
+++ b/golang/cosmos/x/vstorage/keeper/keeper.go
@@ -128,7 +128,7 @@ const MetricLabelStoreKey = "storeKey"
 
 // reportStoreSizeMetrics exports store size increase/decrease metrics
 // when Cosmos telemetry is enabled.
-func (k Keeper) reportStoreSizeMetrics(increase int, decrease int) {
+func (k Keeper) reportStoreSizeMetrics(increase uint, decrease uint) {
 	metricsLabel := []metrics.Label{
 		telemetry.NewLabel(MetricLabelStoreKey, k.storeKey.Name()),
 	}


### PR DESCRIPTION
closes: #11062

## Description
We need to report absolute values for vstorage metrics increase/decrease as requested in https://github.com/Agoric/agoric-sdk/pull/11063#pullrequestreview-2648964052

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
`store_size_increase` and `store_size_decrease` metrics represent total writes and deletes *issued* respectively, which may differ from the total number of bytes committed/freed to/from the store due to the store's internal implementation.

### Testing Considerations
`vstorage metrics` test passed:
```
$ yarn test test/make.test.js -m 'vstorage metrics'
[ ... ]
after provisioning 2: consensusHeight 28 <= firstHeight 28 5sec...
after provisioning : 29n >= 27n
  ✔ vstorage metrics (1m 14.6s)
    ℹ query vstorage path published.wallet.agoric1sjzh78gpgae4p4waf9up75zux5lg600lh9aywn exits successfully
    ℹ metric start values: {
        store_size_decrease: 1106,
        store_size_increase: 1145,
      }
    ℹ query vstorage path published.wallet.agoric1sjzh78gpgae4p4waf9up75zux5lg600lh9aywn exits successfully
    ℹ provisioned wallet agoric1sjzh78gpgae4p4waf9up75zux5lg600lh9aywn is published
    ℹ metric end values: {
        store_size_decrease: 2180,
        store_size_increase: 3585,
      }
  ─

  1 test passed
Done in 672.46s.
```

### Upgrade Considerations
N/A