### PR TITLE
chore: reflect minimum go version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@ packages/stat-logger
 **/__pycache__
 **/*.egg-info
 **/swingset-kernel-state
+**/.cache
 **/_agstate
 .vagrant
 endo-sha.txt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to use.
 Prerequisites are enforced in various places that should be kept synchronized with this section (e.g., [repoconfig.sh](./repoconfig.sh) defines `golang_version_check` and `nodejs_version_check` shell functions).
 
 * Git
-* Go ^1.20.2
+* Go ^1.22.12
 * Node.js ^18.12 or ^20.9
   * we generally support the latest LTS release: use [nvm](https://github.com/nvm-sh/nvm) to keep your local system up-to-date
 * Yarn (`npm install -g yarn`)

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # shellcheck disable=SC2034
 NODEJS_VERSION=v20
-GOLANG_VERSION=1.22
+GOLANG_VERSION=1.22.12
 GOLANG_DIR=golang/cosmos
 GOLANG_DAEMON=$GOLANG_DIR/build/agd
 
@@ -9,9 +9,10 @@ GOLANG_DAEMON=$GOLANG_DIR/build/agd
 golang_version_check() {
   # Keep synchronized with README.md section "Prerequisites".
   {
-    [ "$1" -eq 1 ] && [ "$2" -ge 22 ] && return 0
+    [ "$1" -eq 1 ] && [ "$2" -eq 22 ] && [ "$3" -ge 12 ] && return 0
+    [ "$1" -eq 1 ] && [ "$2" -ge 23 ] && return 0
   } 2> /dev/null
-  echo 1>&2 "need Go version 1.22+, found $4"
+  echo 1>&2 "need Go version $GOLANG_VERSION+, found $4"
   return 1
 }
 


### PR DESCRIPTION
refs: #10944
refs: https://github.com/Agoric/agoric-sdk/issues/9769#issuecomment-2702235846

## Description
Use a full "semver" go version in `repoconfig.sh` to allow gvm autodownload

Reflect the minimum go version in the Readme

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
Already documented elsewhere, we forgot to update the readme in #10944

### Testing Considerations
Locally ran `SKIP_DOWNLOAD=false bin/agd build` on a system with out of date `go`

### Upgrade Considerations
If possible cherry-pick into `dev-upgrade-19`
