### PR TITLE
chore(release): publish `upgrade-19-rc2`

### DIFF
--- a/packages/agoric-cli/CHANGELOG.md
+++ b/packages/agoric-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.0-u19.2](https://github.com/Agoric/agoric-sdk/compare/agoric@0.22.0-u19.1...agoric@0.22.0-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package agoric
+
+
+
+
+
 ## [0.22.0-u19.1](https://github.com/Agoric/agoric-sdk/compare/agoric@0.22.0-u19.0...agoric@0.22.0-u19.1) (2025-03-03)
 
 **Note:** Version bump only for package agoric

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agoric",
-  "version": "0.22.0-u19.1",
+  "version": "0.22.0-u19.2",
   "description": "Manage the Agoric Javascript smart contract platform",
   "type": "module",
   "main": "src/main.js",
@@ -30,7 +30,7 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
-    "@agoric/cosmic-swingset": "^0.42.0-u19.1",
+    "@agoric/cosmic-swingset": "^0.42.0-u19.2",
     "@agoric/deploy-script-support": "^0.10.4-u19.1",
     "ava": "^5.3.0",
     "c8": "^10.1.2"

--- a/packages/benchmark/CHANGELOG.md
+++ b/packages/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.1-u19.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/benchmark@0.1.1-u19.1...@agoric/benchmark@0.1.1-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package @agoric/benchmark
+
+
+
+
+
 ### [0.1.1-u19.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/benchmark@0.1.1-u19.0...@agoric/benchmark@0.1.1-u19.1) (2025-03-03)
 
 **Note:** Version bump only for package @agoric/benchmark

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/benchmark",
-  "version": "0.1.1-u19.1",
+  "version": "0.1.1-u19.2",
   "private": true,
   "description": "Benchmark support",
   "type": "module",
@@ -22,8 +22,8 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agoric/boot": "^0.2.0-u19.1",
-    "@agoric/cosmic-swingset": "^0.42.0-u19.1",
+    "@agoric/boot": "^0.2.0-u19.2",
+    "@agoric/cosmic-swingset": "^0.42.0-u19.2",
     "@agoric/inter-protocol": "^0.17.0-u19.1",
     "@agoric/internal": "^0.4.0-u19.1",
     "@agoric/vats": "^0.16.0-u19.1",

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u19.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/boot@0.2.0-u19.1...@agoric/boot@0.2.0-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package @agoric/boot
+
+
+
+
+
 ## [0.2.0-u19.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/boot@0.2.0-u19.0...@agoric/boot@0.2.0-u19.1) (2025-03-03)
 
 **Note:** Version bump only for package @agoric/boot

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/boot",
-  "version": "0.2.0-u19.1",
+  "version": "0.2.0-u19.2",
   "private": true,
   "description": "Config and utilities to bootstrap an Agoric chain",
   "type": "module",
@@ -20,10 +20,10 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agoric/builders": "^0.2.0-u19.1",
+    "@agoric/builders": "^0.2.0-u19.2",
     "@agoric/client-utils": "^0.2.0-u19.1",
     "@agoric/cosmic-proto": "^0.5.0-u19.1",
-    "@agoric/cosmic-swingset": "^0.42.0-u19.1",
+    "@agoric/cosmic-swingset": "^0.42.0-u19.2",
     "@agoric/ertp": "^0.16.3-u19.1",
     "@agoric/fast-usdc": "^0.2.0-u19.1",
     "@agoric/governance": "^0.10.4-u19.1",

--- a/packages/builders/CHANGELOG.md
+++ b/packages/builders/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u19.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/builders@0.2.0-u19.1...@agoric/builders@0.2.0-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package @agoric/builders
+
+
+
+
+
 ## [0.2.0-u19.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/builders@0.2.0-u19.0...@agoric/builders@0.2.0-u19.1) (2025-03-03)
 
 **Note:** Version bump only for package @agoric/builders

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/builders",
-  "version": "0.2.0-u19.1",
+  "version": "0.2.0-u19.2",
   "description": "Build scripts for proposals to an Agoric chain",
   "type": "module",
   "main": "./index.js",

--- a/packages/cosmic-swingset/CHANGELOG.md
+++ b/packages/cosmic-swingset/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.42.0-u19.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmic-swingset@0.42.0-u19.1...@agoric/cosmic-swingset@0.42.0-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package @agoric/cosmic-swingset
+
+
+
+
+
 ## [0.42.0-u19.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmic-swingset@0.42.0-u19.0...@agoric/cosmic-swingset@0.42.0-u19.1) (2025-03-03)
 
 

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cosmic-swingset",
-  "version": "0.42.0-u19.1",
+  "version": "0.42.0-u19.2",
   "description": "Agoric's Cosmos blockchain integration",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agoric/builders": "^0.2.0-u19.1",
+    "@agoric/builders": "^0.2.0-u19.2",
     "@agoric/cosmos": "^0.35.0-u19.1",
     "@agoric/deploy-script-support": "^0.10.4-u19.1",
     "@agoric/internal": "^0.4.0-u19.1",

--- a/packages/create-dapp/CHANGELOG.md
+++ b/packages/create-dapp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.1-u19.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/create-dapp@0.1.1-u19.1...@agoric/create-dapp@0.1.1-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package @agoric/create-dapp
+
+
+
+
+
 ### [0.1.1-u19.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/create-dapp@0.1.1-u19.0...@agoric/create-dapp@0.1.1-u19.1) (2025-03-03)
 
 **Note:** Version bump only for package @agoric/create-dapp

--- a/packages/create-dapp/package.json
+++ b/packages/create-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/create-dapp",
-  "version": "0.1.1-u19.1",
+  "version": "0.1.1-u19.2",
   "description": "Create an Agoric Javascript smart contract application",
   "type": "module",
   "bin": {
@@ -24,7 +24,7 @@
     "c8": "^10.1.2"
   },
   "dependencies": {
-    "agoric": "^0.22.0-u19.1"
+    "agoric": "^0.22.0-u19.2"
   },
   "keywords": [],
   "repository": {

--- a/packages/solo/CHANGELOG.md
+++ b/packages/solo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.0-u19.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/solo@0.11.0-u19.1...@agoric/solo@0.11.0-u19.2) (2025-03-06)
+
+**Note:** Version bump only for package @agoric/solo
+
+
+
+
+
 ## [0.11.0-u19.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/solo@0.11.0-u19.0...@agoric/solo@0.11.0-u19.1) (2025-03-03)
 
 **Note:** Version bump only for package @agoric/solo

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/solo",
-  "version": "0.11.0-u19.1",
+  "version": "0.11.0-u19.2",
   "description": "Agoric's Solo vat runner",
   "type": "module",
   "bin": {
@@ -24,7 +24,7 @@
   "dependencies": {
     "@agoric/access-token": "^0.4.22-u19.0",
     "@agoric/cache": "^0.3.3-u19.1",
-    "@agoric/cosmic-swingset": "^0.42.0-u19.1",
+    "@agoric/cosmic-swingset": "^0.42.0-u19.2",
     "@agoric/internal": "^0.4.0-u19.1",
     "@agoric/notifier": "^0.7.0-u19.1",
     "@agoric/spawner": "^0.6.9-u19.1",


### PR DESCRIPTION
## Description

Created as per instructions in MAINTAINERS.md

No package has news for this RC.

## Changes

 - agoric@0.22.0-u19.2
 - @agoric/benchmark@0.1.1-u19.2
 - @agoric/boot@0.2.0-u19.2
 - @agoric/builders@0.2.0-u19.2
 - @agoric/cosmic-swingset@0.42.0-u19.2
 - @agoric/create-dapp@0.1.1-u19.2
 - @agoric/solo@0.11.0-u19.2
