### PR TITLE
chore(SwingSet): Remove URL from kernel compartment endowments

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -229,7 +229,6 @@ export async function makeSwingsetController(
       require: harden(
         what => Fail`kernelRequire unprepared to satisfy require(${what})`,
       ),
-      URL: globalThis.URL, // Unavailable only on XSnap
       Base64: globalThis.Base64, // Available only on XSnap
     },
   });

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -229,7 +229,7 @@ export async function makeSwingsetController(
       require: harden(
         what => Fail`kernelRequire unprepared to satisfy require(${what})`,
       ),
-      URL: globalThis.Base64, // Unavailable only on XSnap
+      URL: globalThis.URL, // Unavailable only on XSnap
       Base64: globalThis.Base64, // Available only on XSnap
     },
   });


### PR DESCRIPTION
Ref #3273

## Description
Fixes a longstanding but apparently not-yet-relevant typo.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Skipping for this trivial change.

### Upgrade Considerations
AFAIK, this should only affect code in the kernel and in local workers (the latter of which must not be affected or else we would already have found this).