### PR TITLE
fix fund-provision-pool

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# Agoric SDK Development Guide
+
+## Build/Test/Lint Commands
+- Build all: `yarn build`
+- Build TypeScript: `yarn build-ts`
+- Test all: `yarn test`
+- Test single package: `cd packages/package-name && yarn test`
+- Test single test file: `cd packages/package-name && yarn test test/file.test.js`
+- Lint: `yarn lint`
+- Format code: `yarn format`
+
+## Code Style Guidelines
+- Use ESM imports/exports (`import/export` not `require()`)
+- TypeScript: strict null checks, no unchecked side effects
+- Follow Prettier formatting (enforced by linting)
+- Use JSDocs for function documentation
+- Async functions: handle promises properly, no floating promises
+- Avoid deprecated terminology (see eslint.config.mjs)
+- Test files in `packages/*/test/**/*.test.*`
+- Follow conventional commit messages
+- Each PR should modify a single package when possible
+- Keep the history tidy - avoid overlapping branches
+- All work should happen on branches with issue numbers (e.g., `123-description`)
+
+## Error Handling
+- Always return vows rather than promises in orchestration code
+- Use `@typescript-eslint/no-floating-promises` rule
+- Handle errors explicitly rather than letting them propagate

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -67,19 +67,13 @@ clean-kind:
 ###############################################################################
 ###                          Agoric Setup                                   ###
 ###############################################################################
-PROVISION_POOL_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346
-# Fund the vbank/provision module account so it can provision smart wallets.
-# Each wallet gets 0.25 IST when provisioned, so this make allows 399 accounts.
-# (400 would be more round and make the number less apparent in logs.)
-PROVISION_POOL_COIN=999750000uist
 
 # add address
 add-address:
 	kubectl exec -i agoriclocal-genesis-0 -c validator -- agd keys add user1
 
 fund-provision-pool:
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- agd tx bank send faucet $(PROVISION_POOL_ADDR) $(PROVISION_POOL_COIN) -y -b block
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- agd query bank balances $(PROVISION_POOL_ADDR)
+	scripts/fund-provision-pool.ts
 
 override-chain-registry:
 	scripts/fetch-starship-chain-info.ts && \

--- a/multichain-testing/scripts/fund-provision-pool.ts
+++ b/multichain-testing/scripts/fund-provision-pool.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+/* eslint-env node */
+import { execa } from 'execa';
+import assert from 'node:assert/strict';
+import { parseArgs } from 'node:util';
+
+// Default values from Makefile
+const DEFAULT_PROVISION_POOL_ADDR =
+  'agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346';
+/**
+ * Each wallet gets 0.25 IST when provisioned, so this make allows 399 accounts.
+ * (400 would be more round and make the number less apparent in logs.)
+ */
+const DEFAULT_PROVISION_POOL_COIN = '999750000uist';
+
+/**
+ * Fund the vbank/provision module account so it can provision smart wallets.
+ */
+async function fundProvisionPool(args: {
+  address?: string;
+  amount?: string;
+  pod?: string;
+  container?: string;
+}) {
+  const {
+    address = DEFAULT_PROVISION_POOL_ADDR,
+    amount = DEFAULT_PROVISION_POOL_COIN,
+    pod = 'agoriclocal-genesis-0',
+    container = 'validator',
+  } = args;
+
+  console.log(`Funding provision pool at ${address} with ${amount}...`);
+
+  try {
+    // Execute the bank send transaction
+    const { stdout: txResult } = await execa('kubectl', [
+      'exec',
+      '-i',
+      pod,
+      '-c',
+      container,
+      '--',
+      'agd',
+      'tx',
+      'bank',
+      'send',
+      'faucet',
+      address,
+      amount,
+      '-y',
+      '-b',
+      'block',
+    ]);
+    const resultData = JSON.parse(txResult);
+    if (resultData.code !== 0) {
+      throw new Error(`Transaction failed: ${resultData['raw_log']}`);
+    }
+
+    // Query the balance to confirm
+    const { stdout: balanceResult } = await execa('kubectl', [
+      'exec',
+      '-i',
+      pod,
+      '-c',
+      container,
+      '--',
+      'agd',
+      'query',
+      'bank',
+      'balances',
+      address,
+    ]);
+    const balanceData = JSON.parse(balanceResult);
+    assert(balanceData.balances.length > 0, 'No balances found');
+
+    console.log('Fund provision pool completed successfully');
+    return true;
+  } catch (error) {
+    console.error('Error funding provision pool:', error);
+    return false;
+  }
+}
+
+async function main() {
+  // Parse command-line arguments
+  const { values } = parseArgs({
+    options: {
+      address: { type: 'string', short: 'a' },
+      amount: { type: 'string', short: 'm' },
+      pod: { type: 'string', short: 'p' },
+      container: { type: 'string', short: 'c' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    console.log(`
+Usage: fund-provision-pool.ts [options]
+
+Fund the vbank/provision module account so it can provision smart wallets.
+Each wallet gets 0.25 IST when provisioned.
+
+Options:
+  -a, --address     The provision pool address (default: ${DEFAULT_PROVISION_POOL_ADDR})
+  -m, --amount      Amount to fund (default: ${DEFAULT_PROVISION_POOL_COIN})
+  -p, --pod         Pod name (default: agoriclocal-genesis-0)
+  -c, --container   Container name (default: validator)
+  -h, --help        Show this help message
+`);
+    process.exit(0);
+  }
+
+  const success = await fundProvisionPool({
+    address: values.address,
+    amount: values.amount,
+    pod: values.pod,
+    container: values.container,
+  });
+
+  process.exit(success ? 0 : 1);
+}
+
+main().catch(error => {
+  console.error('An unhandled error occurred:', error);
+  process.exit(1);
+});

--- a/multichain-testing/scripts/fund-provision-pool.ts
+++ b/multichain-testing/scripts/fund-provision-pool.ts
@@ -111,12 +111,20 @@ Options:
     process.exit(0);
   }
 
-  const success = await fundProvisionPool({
-    address: values.address,
-    amount: values.amount,
-    pod: values.pod,
-    container: values.container,
-  });
+  const attempt = () =>
+    fundProvisionPool({
+      address: values.address,
+      amount: values.amount,
+      pod: values.pod,
+      container: values.container,
+    });
+
+  let success = await attempt();
+
+  if (!success) {
+    console.log('Trying again...');
+    success = await attempt();
+  }
 
   process.exit(success ? 0 : 1);
 }

--- a/multichain-testing/tools/agd-lib.js
+++ b/multichain-testing/tools/agd-lib.js
@@ -132,6 +132,7 @@ export const makeAgd = ({ execFileSync }) => {
           ...keyringArgs,
           ...flags({ 'chain-id': chainId, from }),
           ...flags({
+            // FIXME removed in cosmos-sdk https://github.com/Agoric/agoric-sdk/issues/9016
             'broadcast-mode': 'block',
             gas: 'auto',
             'gas-adjustment': '1.4',

--- a/multichain-testing/tools/noble-tools.ts
+++ b/multichain-testing/tools/noble-tools.ts
@@ -48,7 +48,8 @@ export const makeNobleTools = (
         address,
         '--from=genesis',
         '-y',
-        '-b',
+        // FIXME removed in cosmos-sdk https://github.com/Agoric/agoric-sdk/issues/9016
+        '--broadcast-mode',
         'block',
       ]),
     );
@@ -70,7 +71,8 @@ export const makeNobleTools = (
         denomAmount,
         '--from=faucet',
         '-y',
-        '-b',
+        // FIXME removed in cosmos-sdk https://github.com/Agoric/agoric-sdk/issues/9016
+        '--broadcast-mode',
         'block',
       ]),
     );


### PR DESCRIPTION
closes: #9934

## Description

The multichain flake with provisioning wallets was because the fund-provision-pool step failed. I'm not sure why that didn't fail in CI itself.

This makes the step fail when provisioning doesn't succeed. It also retries once in that case, which is enough to work around the `account sequence mismatch`. We need a deeper solution but that's ongoing work,
- https://github.com/Agoric/agoric-sdk/issues/9016

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
Tried to leave a trail about this "block mode" problem

### Testing Considerations
CI suffices

### Upgrade Considerations
none