### PR TITLE
chore: u19 cherrypicks for rc3

### DIFF
--- a/golang/cosmos/e2e_test/go.mod
+++ b/golang/cosmos/e2e_test/go.mod
@@ -1,4 +1,4 @@
-module github.com/Agoric/agoric-sdk/golang/cosmos/e2etest
+module github.com/Agoric/agoric-sdk/golang/cosmos/e2e_test
 
 go 1.20
 
@@ -225,7 +225,7 @@ replace (
 	github.com/cosmos/iavl => github.com/cosmos/iavl v0.19.7
 
 	// Use a version of ibc-go that is compatible with the above forks.
-	github.com/cosmos/ibc-go/v6 => github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.2
+	github.com/cosmos/ibc-go/v6 => github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.4
 
 // use cometbft
 // Use our fork at least until post-v0.34.14 is released with

--- a/golang/cosmos/e2e_test/go.sum
+++ b/golang/cosmos/e2e_test/go.sum
@@ -87,8 +87,8 @@ github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrd
 github.com/Workiva/go-datastructures v1.0.53 h1:J6Y/52yX10Xc5JjXmGtWoSSxs3mZnGSaq37xZZh7Yig=
 github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.5 h1:cwbONQaVbGEPzfVqvTY9PGcLZptlR9LTPunZ9La0QCg=
 github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.5/go.mod h1:Yny/YE+GJ+y/++UgvraITGzfLhXCnwETSWw3dAY5NDg=
-github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.2 h1:vEzy4JaExzlWNHV3ZSVXEVZcRE9loEFUjieE2TXwDdI=
-github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.2/go.mod h1:L1xcBjCLIHN7Wd9j6cAQvZertn56pq+eRGFZjRO5bsY=
+github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.4 h1:dlzsn/JzNsMWFh14lRn+pjog4L4C72SH3PNNO93xN+4=
+github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.4/go.mod h1:pNhYr/yk5M0b4tWX6Nh+SopaE/YaY0oigx1qwepLlLg=
 github.com/agoric-labs/interchaintest/v6 v6.0.1-agoriclabs h1:OG3Z7F9YsqFKCi2w/JZVhMWs+VWNsAEujy39/I2Clxo=
 github.com/agoric-labs/interchaintest/v6 v6.0.1-agoriclabs/go.mod h1:B/KLzyRfuZI+uFKDQe+AXrvjJKRBjl5gds27iOwT9mM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -204,7 +204,7 @@ replace (
 	github.com/cosmos/iavl => github.com/cosmos/iavl v0.19.7
 
 	// Use a version of ibc-go that is compatible with the above forks.
-	github.com/cosmos/ibc-go/v6 => github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.3
+	github.com/cosmos/ibc-go/v6 => github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.4
 
 	// use cometbft
 	// Use our fork at least until post-v0.34.14 is released with

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -235,8 +235,8 @@ github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.5 h1:cwbONQaVbGEPzfVqv
 github.com/agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.5/go.mod h1:Yny/YE+GJ+y/++UgvraITGzfLhXCnwETSWw3dAY5NDg=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
-github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.3 h1:PMPDsOllIpRo9QeeeOe1i7tMSyIJ7fTrqI9evdqY81I=
-github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.3/go.mod h1:L1xcBjCLIHN7Wd9j6cAQvZertn56pq+eRGFZjRO5bsY=
+github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.4 h1:dlzsn/JzNsMWFh14lRn+pjog4L4C72SH3PNNO93xN+4=
+github.com/agoric-labs/ibc-go/v6 v6.3.1-alpha.agoric.4/go.mod h1:pNhYr/yk5M0b4tWX6Nh+SopaE/YaY0oigx1qwepLlLg=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
### Description

Does not include any new upgrade names because we plan to deploy this change as a hotfix patch without an upgrade proposal on emerynet (only case where a new upgrade name would have been needed). Cherrypicks the following PR from master:
 - https://github.com/Agoric/agoric-sdk/pull/11105

using the following rebase-todo:
```
# PR #11105 Branch build-cosmos-use-latest-agoric-labs-ibc-go-branch-11105-
label base-build-cosmos-use-latest-agoric-labs-ibc-go-branch-11105-
pick fb0c2d3e42 build(cosmos): use latest `agoric-labs/ibc-go` branch
pick 77b597f485 chore(cosmos): `go mod tidy`
label pr-11105--build-cosmos-use-latest-agoric-labs-ibc-go-branch-11105-
reset base-build-cosmos-use-latest-agoric-labs-ibc-go-branch-11105-
merge -C a7fc433ecf pr-11105--build-cosmos-use-latest-agoric-labs-ibc-go-branch-11105- # build(cosmos): use latest `agoric-labs/ibc-go` branch (#11105)
```