### PR TITLE
fix(vow): watch-utils leak in non storable results

### DIFF
--- a/packages/vow/src/watch-utils.js
+++ b/packages/vow/src/watch-utils.js
@@ -191,10 +191,16 @@ export const prepareWatchUtils = (
             // Resolution of the returned vow happened already.
             return;
           }
+          const idToNonStorableResults = provideLazyMap(
+            utilsToNonStorableResults,
+            this.facets.utils,
+            () => new Map(),
+          );
           const { remaining, resultsMap, resolver } = idToVowState.get(id);
           if (!isAllSettled && status === 'rejected') {
             // For 'all', we reject immediately on the first rejection
             idToVowState.delete(id);
+            idToNonStorableResults.delete(id);
             resolver.reject(result);
             return;
           }
@@ -206,11 +212,6 @@ export const prepareWatchUtils = (
               })
             : result;
 
-          const idToNonStorableResults = provideLazyMap(
-            utilsToNonStorableResults,
-            this.facets.utils,
-            () => new Map(),
-          );
           const nonStorableResults = provideLazyMap(
             idToNonStorableResults,
             id,
@@ -235,6 +236,7 @@ export const prepareWatchUtils = (
           }
           // We're done!  Extract the array.
           idToVowState.delete(id);
+          idToNonStorableResults.delete(id);
           const results = new Array(numResults);
           let numLost = 0;
           for (let i = 0; i < numResults; i += 1) {


### PR DESCRIPTION
refs: #10955
refs: #10794

## Description
The fast-usdc contract is leaking (#10955). One of the leak source is from the vow watch-utils allocating a heap Map to track vow resolution results, but that doesn't cleanup once settled.

### Security Considerations
None

### Scaling Considerations
Removes a heap leak

### Documentation Considerations
None

### Testing Considerations
Verified manually using [mhofman/fu-impact](https://github.com/Agoric/agoric-sdk/compare/dc-fu-impact...mhofman/fu-impact). I don't see how to unit test this besides creating an intrusive `Map` mock, and we're not structured to easily test heap size growth.

### Upgrade Considerations
All vats using vow watch-utils would need to upgrade to pick up this fix. That includes any vat that uses orchestration's `zoeTools`.

Using the regex `(?<!Promise\.)(\ballSettled\b|\ballVows\b|\ball\b)\(`, I have found:
- fast-usdc
- network
- orchestration
- smart-wallet
