### PR TITLE
fix: remove `intermediateRecipient` from `ForwardInfo`

### DIFF
--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -720,6 +720,7 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
         connectionInfos.get(issuerToDestKey),
       );
 
+      const { intermediateRecipient, ...rest } = forwardOpts ?? {};
       /** @type {ForwardInfo} */
       const forwardInfo = harden({
         forward: {
@@ -727,7 +728,7 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
           port: issuerToDest.transferChannel.portId,
           channel: issuerToDest.transferChannel.channelId,
           ...DefaultPfmTimeoutOpts,
-          ...forwardOpts,
+          .../** @type {ForwardInfo} */ (rest), // timeout and retries
         },
       });
       return harden({
@@ -741,7 +742,7 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
          * purposely using invalid bech32
          * {@link https://github.com/cosmos/ibc-apps/blob/26f3ad8f58e4ffc7769c6766cb42b954181dc100/middleware/packet-forward-middleware/README.md#minimal-example---chain-forward-a-b-c}
          */
-        receiver: forwardOpts?.intermediateRecipient?.value || PFM_RECEIVER,
+        receiver: intermediateRecipient?.value || PFM_RECEIVER,
         forwardInfo,
       });
     },

--- a/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
+++ b/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
@@ -220,17 +220,28 @@ test('takes forwardOpts', t => {
     chainId: 'noble-1',
   });
 
-  t.like(
+  t.deepEqual(
     chainHub.makeTransferRoute(dest, amt, 'osmosis', {
       timeout: '99m',
       intermediateRecipient: nobleAddr,
     }),
     {
       receiver: nobleAddr.value,
+      sourceChannel: 'channel-750',
+      sourcePort: 'transfer',
       forwardInfo: {
         forward: {
+          channel: 'channel-21',
           timeout: '99m' as const,
+          port: 'transfer',
+          receiver: 'agoric1234',
+          retries: 3,
         },
+      },
+      token: {
+        amount: '100',
+        denom:
+          'ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4',
       },
     },
     'each field is optional',

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -304,12 +304,23 @@ test(expectUnhandled(1), 'transfer', async t => {
     ),
   );
 
-  t.like(lastestTxMsg(), {
-    receiver: PFM_RECEIVER,
-    memo: '{"forward":{"receiver":"dydx1test","port":"transfer","channel":"channel-33","retries":3,"timeout":"10m"}}',
+  t.is(lastestTxMsg().receiver, PFM_RECEIVER, 'defaults to "pfm" receiver');
+  t.deepEqual(JSON.parse(lastestTxMsg().memo), {
+    forward: {
+      receiver: 'dydx1test',
+      port: 'transfer',
+      channel: 'channel-33',
+      retries: 3,
+      timeout: '10m',
+    },
   });
 
   t.log('accepts pfm `forwardOpts`');
+  const intermediateRecipient: CosmosChainAddress = {
+    chainId: 'noble-1',
+    value: 'noble1testintermediaterecipient',
+    encoding: 'bech32',
+  };
   await t.notThrowsAsync(
     doTransfer(
       aDenomAmount,
@@ -317,15 +328,21 @@ test(expectUnhandled(1), 'transfer', async t => {
       {
         forwardOpts: {
           timeout: '999m',
+          intermediateRecipient,
         },
       },
       fetchedChainInfo.agoric.connections['noble-1'].transferChannel.channelId,
     ),
   );
 
-  t.like(JSON.parse(lastestTxMsg().memo), {
+  t.is(lastestTxMsg().receiver, intermediateRecipient.value);
+  t.deepEqual(JSON.parse(lastestTxMsg().memo), {
     forward: {
       timeout: '999m',
+      channel: 'channel-33',
+      port: 'transfer',
+      receiver: 'dydx1test',
+      retries: 3,
     },
   });
 });

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -244,7 +244,7 @@ test(expectUnhandled(1), 'transfer', async t => {
     return promise;
   };
 
-  const lastestTxMsg = () => {
+  const latestTxMsg = () => {
     const tx = inspectLocalBridge().at(-1);
     if (tx.type !== 'VLOCALCHAIN_EXECUTE_TX') {
       throw new Error('last message was not VLOCALCHAIN_EXECUTE_TX');
@@ -258,7 +258,7 @@ test(expectUnhandled(1), 'transfer', async t => {
     }),
     'can create transfer msg with memo',
   );
-  t.like(lastestTxMsg(), {
+  t.like(latestTxMsg(), {
     memo: 'hello',
   });
 
@@ -304,8 +304,8 @@ test(expectUnhandled(1), 'transfer', async t => {
     ),
   );
 
-  t.is(lastestTxMsg().receiver, PFM_RECEIVER, 'defaults to "pfm" receiver');
-  t.deepEqual(JSON.parse(lastestTxMsg().memo), {
+  t.is(latestTxMsg().receiver, PFM_RECEIVER, 'defaults to "pfm" receiver');
+  t.deepEqual(JSON.parse(latestTxMsg().memo), {
     forward: {
       receiver: 'dydx1test',
       port: 'transfer',
@@ -335,8 +335,8 @@ test(expectUnhandled(1), 'transfer', async t => {
     ),
   );
 
-  t.is(lastestTxMsg().receiver, intermediateRecipient.value);
-  t.deepEqual(JSON.parse(lastestTxMsg().memo), {
+  t.is(latestTxMsg().receiver, intermediateRecipient.value);
+  t.deepEqual(JSON.parse(latestTxMsg().memo), {
     forward: {
       timeout: '999m',
       channel: 'channel-33',


### PR DESCRIPTION
incidental

## Description
Updates `ChainHub.makeTransferRoute` to ensure it only includes PFM `forward` fields  specified by the protocol. While debugging I noticed a regression from https://github.com/Agoric/agoric-sdk/pull/10626 where `intermediateRecipient: ChainAddress` was in the memo payload. 

**There are no observable runtime errors without this change** - pfm transfers still work with extraneous fields - but it still warrants fixing. 

### Security Considerations
None

### Scaling Considerations
Stops sending extraneous data in ibc packets for pfm scenarios where `intermediateRecipient` is set.

### Documentation Considerations
None

### Testing Considerations
 - adds tests scenarios for when `IBCMsgTransferOptions.forwardOpts.intermediateRecipient` is set in `.transfer()`
 - updates existing tests to prefer `.deepEqual` to `.like` so full packet contents are more apparent

### Upgrade Considerations
Only changes library code. Not planned for a release, but would be included in the next FUSDC release as it relies on `@agoric/orchestration/src/exos/chain-hub.js`