### PR TITLE
fix(agoric-cli): Specify active directory when querying workspaces

### DIFF
--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -32,7 +32,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   const rimraf = file => pspawn('rm', ['-rf', file]);
 
   async function getWorktreePackagePaths(cwd = '.', map = new Map()) {
-    for (const { name, location } of listWorkspaces({ execFileSync })) {
+    for (const { name, location } of listWorkspaces({ execFileSync }, cwd)) {
       map.set(name, path.resolve(cwd, location));
     }
     return map;

--- a/packages/agoric-cli/src/lib/packageManager.js
+++ b/packages/agoric-cli/src/lib/packageManager.js
@@ -8,13 +8,15 @@
  * Omits the root
  *
  * @param {{ execFileSync: execFileSync }} io
+ * @param {string} [root]
  * @returns {Array<{ location: string, name: string }>}
  */
-export const listWorkspaces = ({ execFileSync }) => {
+export const listWorkspaces = ({ execFileSync }, root) => {
   const out = execFileSync('npm', ['query', '.workspace'], {
     stdio: ['ignore', 'pipe', 'inherit'],
     shell: true,
     encoding: 'utf-8',
+    cwd: root,
   });
   /** @type {Array<{ location: string, name: string, description: string }>} */
   const result = JSON.parse(out);


### PR DESCRIPTION
closes: #11123
refs: #11012

## Description
`agoric install` was broken for dapps after #11012. The reason was the query for workspaces didn't take into account the intended working directory so it always used the directory from which the command was invoked and packages from `agoric-sdk` were never linked

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Loadgen [build passed](https://github.com/Agoric/testnet-load-generator/actions/runs/13852656508/job/38762668366) using this branch on [#123](https://github.com/Agoric/testnet-load-generator/pull/123)

### Upgrade Considerations
None
