### PR TITLE
refactor(send-anywhere): simplify denom lookup

### DIFF
--- a/packages/boot/test/orchestration/contract-upgrade.test.ts
+++ b/packages/boot/test/orchestration/contract-upgrade.test.ts
@@ -52,6 +52,7 @@ test('resume', async t => {
           'uist',
           {
             baseDenom: 'uist',
+            brandKey: 'IST',
             baseName: 'agoric',
             chainName: 'agoric',
           },
@@ -86,7 +87,7 @@ test('resume', async t => {
   // This log shows the flow started, but didn't get past the IBC Transfer settlement
   t.deepEqual(getLogged(), [
     'sending {0} from cosmoshub to cosmos1whatever',
-    'got info for denoms: ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9, ibc/toyatom, ibc/toyusdc, ubld, uist',
+    'got denom uist for [object Alleged: IST brand guest wrapper]',
     'got info for chain: cosmoshub cosmoshub-4',
     'completed transfer to localAccount',
   ]);
@@ -110,7 +111,7 @@ test('resume', async t => {
 
   t.deepEqual(getLogged(), [
     'sending {0} from cosmoshub to cosmos1whatever',
-    'got info for denoms: ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9, ibc/toyatom, ibc/toyusdc, ubld, uist',
+    'got denom uist for [object Alleged: IST brand guest wrapper]',
     'got info for chain: cosmoshub cosmoshub-4',
     'completed transfer to localAccount',
     'completed transfer to cosmos1whatever',

--- a/packages/boot/test/orchestration/restart-contracts.test.ts
+++ b/packages/boot/test/orchestration/restart-contracts.test.ts
@@ -46,6 +46,7 @@ test.serial('send-anywhere', async t => {
           'uist',
           {
             baseDenom: 'uist',
+            brandKey: 'IST',
             baseName: 'agoric',
             chainName: 'agoric',
           },

--- a/packages/orchestration/src/examples/send-anywhere.contract.js
+++ b/packages/orchestration/src/examples/send-anywhere.contract.js
@@ -65,6 +65,7 @@ export const contract = async (
 
   // orchestrate uses the names on orchestrationFns to do a "prepare" of the associated behavior
   const orchFns = orchestrateAll(flows, {
+    chainHub,
     log,
     sharedLocalAccountP,
     zoeTools,

--- a/packages/orchestration/test/examples/send-anywhere.test.ts
+++ b/packages/orchestration/test/examples/send-anywhere.test.ts
@@ -391,7 +391,7 @@ test('non-vbank asset presented is returned', async t => {
 
   await t.throwsAsync(vt.when(E(userSeat).getOfferResult()), {
     message:
-      '[object Alleged: MOO brand guest wrapper] not registered in vbank',
+      '[object Alleged: MOO brand guest wrapper] not registered in ChainHub',
   });
 
   await E(userSeat).tryExit();


### PR DESCRIPTION
incidental

## Description
Refactors `send-anywhere.flows.js`, an example orchestration contract, to simplify a brand -> denom lookup. This change uses `chainHub.getDenom` instead of querying `agoricNames.vbankAssets`.

### Security Considerations
None

### Scaling Considerations
Reduces computation used in the flow

### Documentation Considerations
Improves example code

### Testing Considerations
Updates existing tests

### Upgrade Considerations
None, example code