### PR TITLE
Ms/transfer osmo

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "build": "yarn workspaces run build && scripts/agd-builder.sh stamp yarn-built",
     "postinstall": "patch-package && scripts/agd-builder.sh stamp yarn-installed",
     "build-ts": "tsc --build tsconfig.build.json",
-    "build-xs-worker": "cd packages/xs-vat-worker && yarn build:xs-lin"
+    "build-xs-worker": "cd packages/xs-vat-worker && yarn build:xs-lin",
+    "test:examples": "yarn lerna run --no-bail test:examples"
   },
   "ava": {
     "files": [

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -19,7 +19,8 @@
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc",
     "lint:eslint": "eslint .",
-    "lint-fix": "yarn lint:eslint --fix"
+    "lint-fix": "yarn lint:eslint --fix",
+    "test:examples": "ava test/examples/omniflixTip.test.ts"
   },
   "repository": {
     "type": "git",
@@ -34,8 +35,8 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/async-flow": "^0.1.0",
-    "@agoric/cosmic-proto": "^0.4.0",
-    "@agoric/ertp": "^0.16.2",
+    "@agoric/cosmic-proto": "^0.5.0-u19.1",
+    "@agoric/ertp": "^0.16.3-u19.1",
     "@agoric/internal": "^0.3.2",
     "@agoric/network": "^0.1.0",
     "@agoric/notifier": "^0.6.2",
@@ -44,7 +45,7 @@
     "@agoric/vat-data": "^0.5.2",
     "@agoric/vats": "^0.15.1",
     "@agoric/vow": "^0.1.0",
-    "@agoric/zoe": "^0.26.2",
+    "@agoric/zoe": "^0.27.0-u19.1",
     "@agoric/zone": "^0.2.2",
     "@endo/base64": "^1.0.9",
     "@endo/errors": "^1.2.9",

--- a/packages/orchestration/src/examples/omniflixTip.contract.js
+++ b/packages/orchestration/src/examples/omniflixTip.contract.js
@@ -4,12 +4,13 @@ import { makeTracer } from '@agoric/internal';
 import { withOrchestration } from '@agoric/orchestration/src/utils/start-helper.js';
 import { ChainInfoShape } from '@agoric/orchestration/src/typeGuards.js';
 import { M } from '@endo/patterns';
+import { AnyNatAmountShape } from '../typeGuards.js';
 import * as flows from './omniflixTip.flows.js';
 
 const trace = makeTracer('OmniflixTip');
 
 const SingleAmountRecord = M.and(
-  M.recordOf(M.string(), AmountShape, { numPropertiesLimit: 1 }),
+  M.recordOf(M.string(), AnyNatAmountShape, { numPropertiesLimit: 1 }),
   M.not(harden({})),
 );
 
@@ -67,11 +68,7 @@ const contract = async (
           tipOnOmniflix,
           'Tip FLIX on Omniflix',
           undefined,
-          harden({
-            give: SingleAmountRecord,
-            want: {},
-            exit: M.any(),
-          }),
+          M.splitRecord({ give: SingleAmountRecord }),
         );
       },
     },

--- a/packages/orchestration/src/examples/omniflixTip.contract.js
+++ b/packages/orchestration/src/examples/omniflixTip.contract.js
@@ -1,0 +1,89 @@
+import { AmountShape } from '@agoric/ertp';
+import { makeTracer } from '@agoric/internal';
+import { withOrchestration } from '@agoric/orchestration/src/utils/start-helper.js';
+import { ChainInfoShape } from '@agoric/orchestration/src/typeGuards.js';
+import { M } from '@endo/patterns';
+import * as flows from './omniflixTip.flows.js';
+
+const trace = makeTracer('OmniflixTip');
+
+const SingleAmountRecord = M.and(
+  M.recordOf(M.string(), AmountShape, { numPropertiesLimit: 1 }),
+  M.not(harden({})),
+);
+
+const OrchestrationPowersShape = M.splitRecord({
+  localchain: M.remotable('localchain'),
+  orchestrationService: M.remotable('orchestrationService'),
+  storageNode: M.remotable('storageNode'),
+  timerService: M.remotable('timerService'),
+  agoricNames: M.remotable('agoricNames'),
+});
+
+/** @type {ContractMeta} */
+export const meta = {
+  privateArgsShape: M.and(
+    OrchestrationPowersShape,
+    M.splitRecord({
+      marshaller: M.remotable('marshaller'),
+    }),
+  ),
+  customTermsShape: {
+    chainDetails: M.recordOf(M.string(), ChainInfoShape),
+  },
+};
+harden(meta);
+
+const contract = async (
+  zcf,
+  privateArgs,
+  zone,
+  { orchestrateAll, zoeTools, chainHub },
+) => {
+  trace('Starting OmniflixTip contract');
+
+  const { chainDetails } = zcf.getTerms();
+  for (const [name, info] of Object.entries(chainDetails)) {
+    chainHub.registerChain(name, info);
+    const { connections = {} } = info;
+    for (const [chainId, connInfo] of Object.entries(connections)) {
+      chainHub.registerConnection(info.chainId, chainId, connInfo);
+    }
+  }
+
+  const { tipOnOmniflix } = orchestrateAll(flows, {
+    localTransfer: zoeTools.localTransfer,
+  });
+
+  const publicFacet = zone.exo(
+    'OmniflixTip Public Facet',
+    M.interface('OmniflixTip PF', {
+      makeTipInvitation: M.callWhen().returns(M.promise()),
+    }),
+    {
+      makeTipInvitation() {
+        return zcf.makeInvitation(
+          tipOnOmniflix,
+          'Tip FLIX on Omniflix',
+          undefined,
+          harden({
+            give: SingleAmountRecord,
+            want: {},
+            exit: M.any(),
+            args: {
+              chainId: M.string(),
+              tokenDenom: M.string(),
+              recipientAddress: M.string(),
+              slippage: M.number(),
+            },
+          }),
+        );
+      },
+    },
+  );
+
+  return { publicFacet };
+};
+
+export const start = withOrchestration(contract);
+harden(start);

--- a/packages/orchestration/src/examples/omniflixTip.contract.js
+++ b/packages/orchestration/src/examples/omniflixTip.contract.js
@@ -1,4 +1,5 @@
 import { AmountShape } from '@agoric/ertp';
+import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { makeTracer } from '@agoric/internal';
 import { withOrchestration } from '@agoric/orchestration/src/utils/start-helper.js';
 import { ChainInfoShape } from '@agoric/orchestration/src/typeGuards.js';
@@ -58,7 +59,7 @@ const contract = async (
   const publicFacet = zone.exo(
     'OmniflixTip Public Facet',
     M.interface('OmniflixTip PF', {
-      makeTipInvitation: M.callWhen().returns(M.promise()),
+      makeTipInvitation: M.callWhen().returns(InvitationShape),
     }),
     {
       makeTipInvitation() {
@@ -70,12 +71,6 @@ const contract = async (
             give: SingleAmountRecord,
             want: {},
             exit: M.any(),
-            args: {
-              chainId: M.string(),
-              tokenDenom: M.string(),
-              recipientAddress: M.string(),
-              slippage: M.number(),
-            },
           }),
         );
       },

--- a/packages/orchestration/src/examples/omniflixTip.flows.js
+++ b/packages/orchestration/src/examples/omniflixTip.flows.js
@@ -53,21 +53,18 @@ export const tipOnOmniflix = async (
   const blnc4=await localAccount.getBalances();
   debugger
   // Swap input token to uflix on Osmosis and send to recipient
-  const transferMsg = orcUtils.makeOsmosisSwap({
-    destChain: 'omniflixhub',
-    destAddress: recipientAddress,
-    amountIn: amount,
-    brandOut: 'uflix',
-    slippage: slippage || 0.03, // Default 3%
-    inputDenom: tokenDenom,
-    inputChainId: chainId,
-  });
   // const blnc = await localAccount.getBalances();
   // const blnc2 = await osmosisAccount.getBalances();
   debugger
   try {
     trace('Executing swap and transfer...');
-    await   localAccount.transferSteps(amount, transferMsg);
+    await localAccount.transfer({
+      chainId: 'omniflixhub',
+      value: recipientAddress,
+      encoding: 'bech32',
+    }, amount, {
+      memo: 'tip',
+    })
     debugger;
     seat.exit();
   } catch (e) {

--- a/packages/orchestration/src/examples/omniflixTip.flows.js
+++ b/packages/orchestration/src/examples/omniflixTip.flows.js
@@ -1,0 +1,74 @@
+import { M, mustMatch } from '@endo/patterns';
+import { makeTracer } from '@agoric/internal';
+import { orcUtils } from '@agoric/orchestration/src/utils/orc.js';
+
+const trace = makeTracer('OmniflixTipFlows');
+
+/**
+ * Swaps an input token to FLIX on Osmosis and tips a recipient on Omniflix.
+ * @param {import('@agoric/orchestration').Orchestrator} orch
+ * @param {Object} ctx
+ * @param {import('../utils/zoe-tools.js').LocalTransfer} ctx.localTransfer
+ * @param {ZCFSeat} seat
+ * @param {Object} offerArgs
+ * @param {string} offerArgs.chainId - Source chain ID
+ * @param {string} offerArgs.tokenDenom - Source token denomination
+ * @param {string} offerArgs.recipientAddress - Omniflix recipient address
+ * @param {number} offerArgs.slippage - Slippage tolerance
+ */
+export const tipOnOmniflix = async (
+  orch,
+  { localTransfer },
+  seat,
+  { chainId, tokenDenom, recipientAddress, slippage },
+) => {
+  trace('Starting tipOnOmniflix', { chainId, tokenDenom, recipientAddress });
+
+  mustMatch({ chainId, tokenDenom, recipientAddress, slippage }, {
+    chainId: M.string(),
+    tokenDenom: M.string(),
+    recipientAddress: M.string(),
+    slippage: M.number(),
+  });
+
+  const { give } = seat.getProposal();
+  const [[_kw, amount]] = Object.entries(give);
+
+  // Create accounts on Agoric and Osmosis
+  const [agoric, osmosis] = await Promise.all([
+    orch.getChain('agoric'),
+    orch.getChain('osmosis'),
+  ]);
+
+  const localAccount = await agoric.makeAccount();
+  const osmosisAccount = await osmosis.makeAccount();
+
+  const osmosisAddress = osmosisAccount.getAddress();
+
+  // Transfer input token from user to local Agoric account
+  await localTransfer(seat, localAccount, give);
+
+  // Swap input token to uflix on Osmosis and send to recipient
+  const transferMsg = orcUtils.makeOsmosisSwap({
+    destChain: 'omniflixhub',
+    destAddress: recipientAddress,
+    amountIn: amount,
+    brandOut: 'uflix',
+    slippage: slippage || 0.03, // Default 3%
+    inputDenom: tokenDenom,
+    inputChainId: chainId,
+  });
+
+  try {
+    trace('Executing swap and transfer...');
+    await localAccount.transferSteps(amount, transferMsg);
+    seat.exit();
+  } catch (e) {
+    trace('Error during swap/transfer:', e);
+    await localTransfer(localAccount, seat, give); // Refund on failure
+    throw new Error(`Tipping failed: ${e.message}`);
+  } finally {
+    await Promise.all([localAccount.close(), osmosisAccount.close()]);
+  }
+};
+harden(tipOnOmniflix);

--- a/packages/orchestration/src/examples/omniflixTip.proposal.js
+++ b/packages/orchestration/src/examples/omniflixTip.proposal.js
@@ -1,0 +1,186 @@
+import { E } from '@endo/far';
+import { makeTracer } from '@agoric/internal';
+
+/// <reference types="@agoric/vats/src/core/types-ambient"/>
+/// <reference types="@agoric/zoe/src/contractFacet/types-ambient"/>
+
+const trace = makeTracer('OmniflixTipProposal');
+const { entries, fromEntries } = Object;
+
+trace('Starting proposal module evaluation');
+
+const contractName = 'omniflixTip';
+
+/** @type {import('@agoric/orchestration').IBCConnectionInfo} */
+const osmosisToOmniflixConnection = harden({
+  id: 'connection-0',
+  client_id: 'client-0',
+  state: 3, // OPEN
+  counterparty: {
+    client_id: 'client-0',
+    connection_id: 'connection-0',
+    prefix: { key_prefix: 'key-prefix-0' },
+  },
+  transferChannel: {
+    portId: 'transfer',
+    channelId: 'channel-0',
+    counterPartyPortId: 'transfer',
+    counterPartyChannelId: 'channel-1',
+    ordering: 2, // ORDERED
+    version: '1',
+    state: 3, // OPEN
+  },
+});
+
+/** @type {Record<string, import('@agoric/orchestration').ChainInfo>} */
+export const chainDetails = harden({
+  agoric: {
+    chainId: 'agoriclocal',
+    stakingTokens: [{ denom: 'ubld' }],
+    connections: { osmosislocal: osmosisToOmniflixConnection },
+  },
+  osmosis: {
+    chainId: 'osmosislocal',
+    stakingTokens: [{ denom: 'uosmo' }],
+    connections: { omniflixlocal: osmosisToOmniflixConnection },
+  },
+  omniflix: {
+    chainId: 'omniflixlocal',
+    stakingTokens: [{ denom: 'uflix' }],
+  },
+});
+
+/**
+ * Resolves all promise values in a record.
+ * @type {<T extends Record<string, import('@endo/far').ERef<any>>>(obj: T) => Promise<{ [K in keyof T]: Awaited<T[K]>}>}
+ */
+export const allValues = async obj => {
+  const es = await Promise.all(
+    entries(obj).map(([k, vp]) => E.when(vp, v => [k, v])),
+  );
+  return fromEntries(es);
+};
+
+/**
+ * Starts the OmniflixTip contract.
+ * @param {import('@agoric/vats/src/core/lib-boot.js').BootstrapPowers & { installation: { consume: { omniflixTip: import('@agoric/zoe/src/zoeService/utils.js').Installation<any> }}}} permittedPowers
+ * @param {{ options: { [contractName]: { bundleID: string; chainDetails: Record<string, import('@agoric/orchestration').ChainInfo> }}}} config
+ */
+export const startOmniflixTipContract = async (permittedPowers, config) => {
+  trace('Starting startOmniflixTipContract', config);
+
+  const {
+    consume: {
+      agoricNames,
+      board,
+      chainTimerService,
+      localchain,
+      chainStorage,
+      cosmosInterchainService,
+      startUpgradable,
+    },
+    installation: {
+      consume: { omniflixTip: omniflixTipInstallation },
+    },
+    instance: {
+      produce: { omniflixTip: produceInstance },
+    },
+  } = permittedPowers;
+
+  const installation = await omniflixTipInstallation;
+
+  const storageNode = await E(chainStorage).makeChildNode('omniflixTip');
+  const marshaller = await E(board).getPublishingMarshaller();
+
+  const { chainDetails: nameToInfo = chainDetails } =
+    config.options[contractName];
+
+  /** @type {import('@agoric/zoe/src/zoeService/utils.js').StartUpgradableOpts<any>} */
+  const startOpts = {
+    label: 'omniflixTip',
+    installation,
+    terms: { chainDetails: nameToInfo },
+    privateArgs: {
+      localchain: await localchain,
+      orchestrationService: await cosmosInterchainService,
+      storageNode,
+      timerService: await chainTimerService,
+      agoricNames: await agoricNames,
+      marshaller,
+    },
+  };
+
+  trace('startOpts', startOpts);
+  const { instance } = await E(startUpgradable)(startOpts);
+
+  trace(contractName, '(re)started WITH RESET');
+  produceInstance.reset();
+  produceInstance.resolve(instance);
+};
+
+/** @type {import('@agoric/vats/src/core/lib-boot.js').BootstrapManifest} */
+const omniflixTipManifest = harden({
+  [startOmniflixTipContract.name]: {
+    consume: {
+      agoricNames: true,
+      board: true,
+      chainStorage: true,
+      startUpgradable: true,
+      zoe: true,
+      localchain: true,
+      chainTimerService: true,
+      cosmosInterchainService: true,
+    },
+    installation: {
+      produce: { omniflixTip: true },
+      consume: { omniflixTip: true },
+    },
+    instance: {
+      produce: { omniflixTip: true },
+    },
+  },
+});
+
+/**
+ * Returns the manifest for deploying the OmniflixTip contract.
+ * @param {{ restoreRef: (ref: string) => any }} options
+ * @param {{ installKeys: Record<string, string>, chainDetails: Record<string, import('@agoric/orchestration').ChainInfo> }} config
+ */
+export const getManifestForOmniflixTip = (
+  { restoreRef },
+  { installKeys, chainDetails },
+) => {
+  trace('getManifestForOmniflixTip', installKeys);
+  return harden({
+    manifest: omniflixTipManifest,
+    installations: {
+      [contractName]: restoreRef(installKeys[contractName]),
+    },
+    options: {
+      [contractName]: { chainDetails },
+    },
+  });
+};
+
+/** Permissions required for the OmniflixTip contract */
+export const permit = harden({
+  consume: {
+    agoricNames: true,
+    board: true,
+    chainStorage: true,
+    startUpgradable: true,
+    zoe: true,
+    localchain: true,
+    chainTimerService: true,
+    cosmosInterchainService: true,
+  },
+  installation: {
+    consume: { omniflixTip: true },
+    produce: { omniflixTip: true },
+  },
+  instance: { produce: { omniflixTip: true } },
+  brand: { consume: {}, produce: {} },
+  issuer: { consume: {}, produce: {} },
+});
+
+export const main = startOmniflixTipContract;

--- a/packages/orchestration/test/examples/omniflixTip.test.ts
+++ b/packages/orchestration/test/examples/omniflixTip.test.ts
@@ -22,94 +22,146 @@ const txChannelDefaults = {
 };
 
 test('successful tip on Omniflix', async t => {
-    const { zoe, bundleAndInstall } = await setUpZoeForTest();
-    const {
-      bootstrap,
-      commonPrivateArgs,
-      brands: { flix, osmo, bld },
-      customTerms,
-    } = await commonSetup(t);
-    const vt = bootstrap.vowTools;
-  
-    const installation = await bundleAndInstall('/Users/bhavesh/Agoric/agoric-sdk/packages/orchestration/src/examples/omniflixTip.contract.js');
-    const storageNode = await E(bootstrap.storage.rootNode).makeChildNode('omniflixTip');
-    const tipKit = await t.throwsAsync(
-      await E(zoe).startInstance(
-      installation,
-      { FLIX: flix.issuer, OSMO: osmo.issuer, BLD: bld.issuer },
-      {},
-      { ...commonPrivateArgs, storageNode, customTerms }
-    ), {
-      message: 'customTerms: {"chainDetails":{"agoric":{"chainId":"agoric"},"omniflixlocal":{"chainId":"omniflixlocal"},"osmosislocal":{"chainId":"osmosislocal"}}} - Must not have unexpected properties: ["chainDetails"]',
-    });
-    const flixChainInfo = harden({
-      chainId: 'omniflixlocal',
-      stakingTokens: [{ denom: 'uflix'}],
-      ...chainInfoDefaults,
-    }) as CosmosChainInfo;
-    
-    const osmoChainInfo = harden({
-      chainId: 'osmosislocal',
-      stakingTokens: [{ denom: 'uosmo'}],
-      ...chainInfoDefaults,
-    }) as CosmosChainInfo;
-    t.log('admin adds chains with creatorFacet',flixChainInfo.chainId, osmoChainInfo.chainId)
-    const agoricToOsmoConnection = {
-      id: 'connection-1',
-      client_id: '07-tendermint-1',
-      state: 3, // STATE_OPEN
-      counterparty: {
-        client_id: '07-tendermint-2109',
-        connection_id: 'connection-1649',
-      },
-      transferChannel: {
-        counterPartyChannelId: 'channel-1',
-        channelId: 'channel-0',
-        ...txChannelDefaults,
-      },
-    } as IBCConnectionInfo;
-    const chainName = 'osmosislocal';
-    await E(tipKit.creatorFacet).registerChain(
-      chainName,
-      osmoChainInfo,
-      agoricToOsmoConnection,
-    );
-    const osmoToFlixConnection = {
-      id: 'connection-2',
-      client_id: '07-tendermint-2',
-      state: 3, // STATE_OPEN
-      counterparty: {
-        client_id: '07-tendermint-2110',
-        connection_id: 'connection-1650',
-      },
-      transferChannel: {
-        counterPartyChannelId: 'channel-1',
-        channelId: 'channel-1',
-        ...txChannelDefaults,
-      },
-    } as IBCConnectionInfo;
-    const chainNameFlix = 'flix-chain-0';
-    await E(tipKit.creatorFacet).registerChain(
-      chainNameFlix,
-      flixChainInfo,
-      osmoToFlixConnection,
-    );  
+  const { zoe, bundleAndInstall } = await setUpZoeForTest();
+  const {
+    facadeServices: { chainHub },
+    bootstrap,
+    commonPrivateArgs,
+    brands: { flix, osmo, bld },
+    customTerms,
+  } = await commonSetup(t);
+  const vt = bootstrap.vowTools;
 
+  const installation = await bundleAndInstall(
+    './src/examples/omniflixTip.contract.js',
+  );
+  const storageNode = await E(bootstrap.storage.rootNode).makeChildNode(
+    'omniflixTip',
+  );
+  // Create chainDetails object with the required chain information
+  // const chainDetails = {
+  //   agoric: { chainId: 'agoric' },
+  //   omniflixlocal: { chainId: 'omniflixlocal' },
+  //   osmosislocal: { chainId: 'osmosislocal' }
+  // };
+  /** @type {IBCConnectionInfo} */
+const c1 = harden({
+  id: 'connection-0',
+  client_id: 'client-0',
+  state: 3, // OPEN
+  counterparty: harden({
+    client_id: 'client-0',
+    connection_id: 'connection-0',
+    // prefix: {
+    //   key_prefix: 'key-prefix-0',
+    // },
+  }),
+  transferChannel: harden({
+    portId: 'transfer',
+    channelId: 'channel-0',
+    counterPartyPortId: 'transfer',
+    counterPartyChannelId: 'channel-1',
+    ordering: 2, // ORDERED
+    version: '1',
+    state: 3, // OPEN
+  }),
+});
 
-    const publicFacet = await E(zoe).getPublicFacet(tipKit.instance);
-    const inv = E(publicFacet).makeTipInvitation();
-  
-    const anAmt = flix.make(10n);
-    const Flix = flix.mint.mintPayment(anAmt);
-    const userSeat = await E(zoe).offer(
-      inv,
-      { give: { Flix: anAmt } },
-      { Flix },
-      { chainId: 'osmosislocal', tokenDenom: 'uosmo', recipientAddress: 'omniflix1destAddr', slippage: 0.03 },
-    );
-  
-    await t.notThrowsAsync(E(userSeat).getOfferResult());
-    const payouts = await E(userSeat).getPayouts();
-    const amountReturned = await flix.issuer.getAmountOf(payouts.Flix);
-    t.deepEqual(anAmt, amountReturned, 'give is returned');
+// TODO: rename chainDetails to defaultChainDetails? or move back to test?
+/** @type {Record<string, ChainInfo>} */
+const chainDetails = harden({
+  agoric: {
+    chainId: `agoriclocal`,
+    stakingTokens: [{ denom: 'ubld' }],
+    connections: { osmosislocal: c1 },
+  },
+  osmosis: {
+    chainId: `osmosislocal`,
+    stakingTokens: [{ denom: 'uosmo' }],
+  },
+});
+
+  const tipKit = await E(zoe).startInstance(
+    installation,
+    { FLIX: flix.issuer, OSMO: osmo.issuer, BLD: bld.issuer },
+    { chainDetails },
+    { ...commonPrivateArgs, storageNode },
+  );
+  const flixChainInfo = harden({
+    chainId: 'omniflixlocal',
+    stakingTokens: [{ denom: 'uflix' }],
+    ...chainInfoDefaults,
+  }) as CosmosChainInfo;
+
+  const osmoChainInfo = harden({
+    chainId: 'osmosis',
+    stakingTokens: [{ denom: 'uosmo' }],
+    ...chainInfoDefaults,
+  }) as CosmosChainInfo;
+  t.log(
+    'admin adds chains with creatorFacet',
+    flixChainInfo.chainId,
+    osmoChainInfo.chainId,
+  );
+  const agoricToOsmoConnection = {
+    id: 'connection-1',
+    client_id: '07-tendermint-1',
+    state: 3, // STATE_OPEN
+    counterparty: {
+      client_id: '07-tendermint-2109',
+      connection_id: 'connection-1649',
+    },
+    transferChannel: {
+      counterPartyChannelId: 'channel-1',
+      channelId: 'channel-0',
+      ...txChannelDefaults,
+    },
+  } as IBCConnectionInfo;
+  const chainName = 'osmosis';
+  chainHub.registerChain(chainName, osmoChainInfo);
+  chainHub.registerConnection('agoric', 'osmosis', agoricToOsmoConnection);
+  const osmoToFlixConnection = {
+    id: 'connection-2',
+    client_id: '07-tendermint-2',
+    state: 3, // STATE_OPEN
+    counterparty: {
+      client_id: '07-tendermint-2110',
+      connection_id: 'connection-1650',
+    },
+    transferChannel: {
+      counterPartyChannelId: 'channel-1',
+      channelId: 'channel-1',
+      ...txChannelDefaults,
+    },
+  } as IBCConnectionInfo;
+  const chainNameFlix = 'flix-chain-0';
+  chainHub.registerChain(chainNameFlix, flixChainInfo);
+  chainHub.registerConnection(chainName, chainNameFlix, osmoToFlixConnection);
+
+  const publicFacet = await E(zoe).getPublicFacet(tipKit.instance);
+  const inv = await E(publicFacet).makeTipInvitation();
+
+  const TipAmt = flix.make(10n);
+  const Flix = flix.issuerKit.mint.mintPayment(TipAmt);
+  const offerArgs = harden({
+    chainId: 'osmosis',
+    tokenDenom: 'uosmo',
+    recipientAddress: 'omniflix1destAddr',
+    slippage: 0.03,
   });
+  const userSeat = await E(zoe).offer(
+    inv,
+    {
+      give: { TipAmt },
+      want: {},
+      exit: { onDemand: null },
+    },
+    { TipAmt: Flix },
+    offerArgs,
+  );
+
+  await t.notThrowsAsync(E(userSeat).getOfferResult());
+  const payouts = await E(userSeat).getPayouts();
+  const amountReturned = await flix.issuer.getAmountOf(payouts.Flix);
+  t.deepEqual(anAmt, amountReturned, 'give is returned');
+});

--- a/packages/orchestration/test/examples/omniflixTip.test.ts
+++ b/packages/orchestration/test/examples/omniflixTip.test.ts
@@ -1,0 +1,115 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { E } from '@endo/far';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { makeIssuerKit } from '@agoric/ertp';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import { commonSetup } from '../supports.js';
+import type {
+  CosmosChainInfo,
+  IBCConnectionInfo,
+} from '../../src/cosmos-api.js';
+
+const chainInfoDefaults = {
+  connections: {},
+};
+
+const txChannelDefaults = {
+  counterPartyPortId: 'transfer',
+  version: 'ics20-1',
+  portId: 'transfer',
+  ordering: 1, // ORDER_UNORDERED
+  state: 3, // STATE_OPEN
+};
+
+test('successful tip on Omniflix', async t => {
+    const { zoe, bundleAndInstall } = await setUpZoeForTest();
+    const {
+      bootstrap,
+      commonPrivateArgs,
+      brands: { flix, osmo, bld },
+      customTerms,
+    } = await commonSetup(t);
+    const vt = bootstrap.vowTools;
+  
+    const installation = await bundleAndInstall('/Users/bhavesh/Agoric/agoric-sdk/packages/orchestration/src/examples/omniflixTip.contract.js');
+    const storageNode = await E(bootstrap.storage.rootNode).makeChildNode('omniflixTip');
+    const tipKit = await t.throwsAsync(
+      await E(zoe).startInstance(
+      installation,
+      { FLIX: flix.issuer, OSMO: osmo.issuer, BLD: bld.issuer },
+      {},
+      { ...commonPrivateArgs, storageNode, customTerms }
+    ), {
+      message: 'customTerms: {"chainDetails":{"agoric":{"chainId":"agoric"},"omniflixlocal":{"chainId":"omniflixlocal"},"osmosislocal":{"chainId":"osmosislocal"}}} - Must not have unexpected properties: ["chainDetails"]',
+    });
+    const flixChainInfo = harden({
+      chainId: 'omniflixlocal',
+      stakingTokens: [{ denom: 'uflix'}],
+      ...chainInfoDefaults,
+    }) as CosmosChainInfo;
+    
+    const osmoChainInfo = harden({
+      chainId: 'osmosislocal',
+      stakingTokens: [{ denom: 'uosmo'}],
+      ...chainInfoDefaults,
+    }) as CosmosChainInfo;
+    t.log('admin adds chains with creatorFacet',flixChainInfo.chainId, osmoChainInfo.chainId)
+    const agoricToOsmoConnection = {
+      id: 'connection-1',
+      client_id: '07-tendermint-1',
+      state: 3, // STATE_OPEN
+      counterparty: {
+        client_id: '07-tendermint-2109',
+        connection_id: 'connection-1649',
+      },
+      transferChannel: {
+        counterPartyChannelId: 'channel-1',
+        channelId: 'channel-0',
+        ...txChannelDefaults,
+      },
+    } as IBCConnectionInfo;
+    const chainName = 'osmosislocal';
+    await E(tipKit.creatorFacet).registerChain(
+      chainName,
+      osmoChainInfo,
+      agoricToOsmoConnection,
+    );
+    const osmoToFlixConnection = {
+      id: 'connection-2',
+      client_id: '07-tendermint-2',
+      state: 3, // STATE_OPEN
+      counterparty: {
+        client_id: '07-tendermint-2110',
+        connection_id: 'connection-1650',
+      },
+      transferChannel: {
+        counterPartyChannelId: 'channel-1',
+        channelId: 'channel-1',
+        ...txChannelDefaults,
+      },
+    } as IBCConnectionInfo;
+    const chainNameFlix = 'flix-chain-0';
+    await E(tipKit.creatorFacet).registerChain(
+      chainNameFlix,
+      flixChainInfo,
+      osmoToFlixConnection,
+    );  
+
+
+    const publicFacet = await E(zoe).getPublicFacet(tipKit.instance);
+    const inv = E(publicFacet).makeTipInvitation();
+  
+    const anAmt = flix.make(10n);
+    const Flix = flix.mint.mintPayment(anAmt);
+    const userSeat = await E(zoe).offer(
+      inv,
+      { give: { Flix: anAmt } },
+      { Flix },
+      { chainId: 'osmosislocal', tokenDenom: 'uosmo', recipientAddress: 'omniflix1destAddr', slippage: 0.03 },
+    );
+  
+    await t.notThrowsAsync(E(userSeat).getOfferResult());
+    const payouts = await E(userSeat).getPayouts();
+    const amountReturned = await flix.issuer.getAmountOf(payouts.Flix);
+    t.deepEqual(anAmt, amountReturned, 'give is returned');
+  });


### PR DESCRIPTION
several changes:
- In the contract file, I changed the shape of proposal a bit, i.e.,  `give: SingleNatAmountRecord`, which is defined as:
```
export const SingleNatAmountRecord = M.and(
  M.recordOf(M.string(), AnyNatAmountShape, {
    numPropertiesLimit: 1,
  }),
  M.not(harden({})),
);
harden(SingleNatAmountRecord);
```
- I registered chains, assets, and connections as they are supposed to be used.
- Using `withdrawToSeat` to refund assets to seat in case the transfer fails.
- Before use, confirmed that `denom` is registered in vBank, i.e., `agoric.getVBankAssetInfo()`
- Fixed parameters of `tarnsfer`
- Minor changes in test file, specifically important to note is the fact that `payouts` won't contain any asset unless a refund was made.