### PR TITLE
chore(ci): add `waitForBlock(1)` logic to `scripts/fund-provision-pool.ts`

### DIFF
--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -40,7 +40,7 @@ export const txAbbr = tx => {
  * @param {import('@cosmjs/tendermint-rpc').RpcClient} io.rpc
  * @param {(ms: number, info?: unknown) => Promise<void>} io.delay
  */
-const makeBlockTool = ({ rpc, delay }) => {
+export const makeBlockTool = ({ rpc, delay }) => {
   let id = 1;
   const waitForBootstrap = async (period = 2000, info = {}) => {
     await null;


### PR DESCRIPTION
refs: #9934

## Description
Adds `waitForBlock(1)` logic to the `Fund Provision Pool` step in the `multichain-e2e-template.yml` workflow. `agd` determines `sequence` through a query so let's ensure it has the latest view by waiting a block.  Intends to be a cheap fix for account sequence mismatch errors [observed](https://github.com/Agoric/agoric-sdk/issues/9934#issuecomment-2719467121) during this step.

### Security Considerations
None

### Scaling Considerations
Aims to make CI less flaky at the added cost of ~12 seconds.

### Documentation Considerations
None

### Testing Considerations
Tested script changes locally; CI will not pass if there are errors.

```sh
$ make fund-provision-pool

scripts/fund-provision-pool.ts
Funding provision pool at agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 with 999750000uist...
delay { latestHeight: 12849, delay: 1 } ...
delay { latestHeight: 12851, delay: 1 } ...
Fund provision pool completed successfully
```

### Upgrade Considerations
None, CI-only