### PR TITLE
chore(scripts): add base release initializer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,8 +29,10 @@ The Release Owner and other appropriate stakeholders must agree on:
 
 - _**base branch**_: This should be `master`, but might need to vary for a patch release.
 
+- _**release number**_: The number associated with the current release (example: `8` for `agoric-upgrade-8`).
+
 - _**release label**_: This is used for the git tags, and is currently expected to follow a
-  sequential pattern (example: `agoric-upgrade-8`).
+  sequential pattern. It ends with the _**release number**_. (example: `agoric-upgrade-8`).
   The mainnet release label is preceded by release candidates numbered from zero
   (example: `agoric-upgrade-8-rc0`), and shares its commit with the final release candidate.
 
@@ -46,18 +48,19 @@ The Release Owner and other appropriate stakeholders must agree on:
 
 - [ ] When a new release is planned, create a new branch from the [_**base branch**_](#assign-release-parameters) (`master`) with a name like `dev-$releaseShortLabel` (example: `dev-upgrade-8`). This can be done from the command line or the [GitHub Branches UI](https://github.com/Agoric/agoric-sdk/branches).
 - [ ] Initialize the new branch for the planned upgrade:
-  - [ ] In **golang/cosmos/app/upgrade.go**
-    - [ ] Update the `upgradeNamesOfThisVersion` constant to list all the [_**upgrade name**_](#assign-release-parameters) used by this release.
-    - [ ] Update the `isPrimaryUpgradeName` function to reflect the updated [_**upgrade name**_](#assign-release-parameters) list.
-    - [ ] Rename the upgrade handler function to match the release, example: `upgrade8Handler`.
-    - [ ] Verify that the upgrade handler function has no logic specific to the previous upgrade (e.g., core proposals).
-  - [ ] In **golang/cosmos/app/app.go**, make sure that the call to `SetUpgradeHandler` uses the renamed upgrade handler function above.
-  - [ ] Verify that **a3p-integration/package.json** has an object-valued `agoricSyntheticChain` property with `fromTag` set to the [agoric-3-proposals Docker images](https://github.com/Agoric/agoric-3-proposals/pkgs/container/agoric-3-proposals) tag associated with the previous release
-    (example: `use-upgrade-7`) or latest core-eval passed on chain (example: `use-vaults-auction`).
-  - [ ] Ensure that the first subdirectory in **a3p-integration/proposals** has the following characteristics. This is commonly created by renaming the `n:upgrade-next` directory after verifying no other proposals exist before that, and updating the **package.json** file in it.
-    - named like "$prefix:[_**release short label**_](#assign-release-parameters)" per [agoric-3-proposals: Naming](https://github.com/Agoric/agoric-3-proposals#naming) (conventionally using "a" for the unreleased $prefix, e.g. `a:upgrade-8`).
-    - containing a **package.json** having an object-valued `agoricProposal` property with `sdkImageTag` set to "unreleased" and `planName` set to the [_**upgrade name**_](#assign-release-parameters)
-    - containing other files appropriate for the upgrade per [agoric-3-proposals: Files](https://github.com/Agoric/agoric-3-proposals#files)
+  - [ ] Run **`scripts/init-release.sh $releaseNumber`** to make base changes for the new release. Verify and make need-based changes accordingly.
+    - [ ] In **golang/cosmos/app/upgrade.go**
+      - [ ] Update/verify the `upgradeNamesOfThisVersion` constant to list all the [_**upgrade name**_](#assign-release-parameters) used by this release.
+      - [ ] Update/verify the `isPrimaryUpgradeName` function to reflect the updated [_**upgrade name**_](#assign-release-parameters) list.
+      - [ ] Rename/verify the upgrade handler function to match the release, example: `upgrade8Handler`.
+      - [ ] Verify that the upgrade handler function has no logic specific to the previous upgrade (e.g., core proposals).
+    - [ ] In **golang/cosmos/app/app.go**, make sure that the call to `SetUpgradeHandler` uses the renamed upgrade handler function above.
+    - [ ] Verify that **a3p-integration/package.json** has an object-valued `agoricSyntheticChain` property with `fromTag` set to the [agoric-3-proposals Docker images](https://github.com/Agoric/agoric-3-proposals/pkgs/container/agoric-3-proposals) tag associated with the previous release
+      (example: `use-upgrade-7`) or latest core-eval passed on chain (example: `use-vaults-auction`).
+    - [ ] Ensure that the first subdirectory in **a3p-integration/proposals** has the following characteristics. This is commonly created by renaming the `n:upgrade-next` directory after verifying no other proposals exist before that, and updating the **package.json** file in it. The `init-release.sh` script takes care of renaming the directory so verify the new proposal directory.
+      - named like "$prefix:[_**release short label**_](#assign-release-parameters)" per [agoric-3-proposals: Naming](https://github.com/Agoric/agoric-3-proposals#naming) (conventionally using "a" for the unreleased $prefix, e.g. `a:upgrade-8`).
+      - containing a **package.json** having an object-valued `agoricProposal` property with `sdkImageTag` set to "unreleased" and `planName` set to the [_**upgrade name**_](#assign-release-parameters)
+      - containing other files appropriate for the upgrade per [agoric-3-proposals: Files](https://github.com/Agoric/agoric-3-proposals#files)
 
     For example, see the [upgrade-17 PR](https://github.com/Agoric/agoric-sdk/pull/10088).
 

--- a/scripts/init-release.sh
+++ b/scripts/init-release.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -ueo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <next_release_number>"
+  echo "Example: $0 19" # for agoric-upgrade-19
+  exit 1
+fi
+
+# for better compatibility
+BSD_SED="$(sed --help 2>&1 | sed 2q | grep -qe '-i ' && echo 1 || true)"
+function sedi() {
+  if [ -n "$BSD_SED" ]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
+NEXT_RELEASE=$1
+if ! [[ "$NEXT_RELEASE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: Release number must be a positive decimal integer"
+  exit 1
+fi
+
+APP_FILE=golang/cosmos/app/app.go
+UPGRADE_FILE=golang/cosmos/app/upgrade.go
+
+# Rename unreleasedUpgradeHandler instances
+sedi -e "s/unreleasedUpgradeHandler/upgrade${NEXT_RELEASE}Handler/g" \
+  -e "s/the unreleased upgrade/upgrade-${NEXT_RELEASE}/g" \
+  ${APP_FILE} \
+  ${UPGRADE_FILE}
+
+echo "Renamed unreleasedUpgradeHandler for release u${NEXT_RELEASE}"
+
+# Rename cosmos-sdk upgrade names
+sedi '/^var upgradeNamesOfThisVersion = \[\]string{/,/^}/ c\var upgradeNamesOfThisVersion = []string{\
+    "agoric-upgrade-'"${NEXT_RELEASE}"'",\
+}' ${UPGRADE_FILE}
+echo "Updated cosmos-sdk upgrade names"
+
+# Rename primary upgrade names
+sedi '/^func isPrimaryUpgradeName(name string) bool {/,/^}/ c\func isPrimaryUpgradeName(name string) bool {\
+  if name == "" {\
+      // An empty upgrade name can happen if there are no upgrade in progress\
+      return false\
+  }\
+  switch name {\
+  case validUpgradeName("agoric-upgrade-'"${NEXT_RELEASE}"'"):\
+      return true\
+  default:\
+      panic(fmt.Errorf("unexpected upgrade name %s", validUpgradeName(name)))\
+  }\
+}' ${UPGRADE_FILE}
+echo "Updated primary upgrade names"
+
+# when done, format the files
+go fmt ${APP_FILE} ${UPGRADE_FILE}
+
+# Rename upgrade-next to a:upgrade-${NEXT_RELEASE}
+if [ -d "a3p-integration/proposals/n:upgrade-next" ]; then
+  mv "a3p-integration/proposals/n:upgrade-next" "a3p-integration/proposals/a:upgrade-${NEXT_RELEASE}"
+  echo "Renamed n:upgrade-next directory to a:upgrade-${NEXT_RELEASE}"
+
+  cat > "a3p-integration/proposals/a:upgrade-${NEXT_RELEASE}/README.md" << EOF
+# Proposal to upgrade the chain software
+
+This holds the draft proposal for agoric-upgrade-${NEXT_RELEASE}, which will be added to
+[agoric-3-proposals](https://github.com/Agoric/agoric-3-proposals) after it
+passes.
+
+The "binaries" property of \`upgradeInfo\` is now required since Cosmos SDK 0.46,
+however it cannot be computed for an unreleased upgrade. To disable the check,
+\`releaseNotes\` is set to \`false\`.
+EOF
+  echo "Updated README.md for a:upgrade-${NEXT_RELEASE}"
+else
+  echo "Warning: n:upgrade-next directory not found. Skipping directory rename and README update."
+fi


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #11142

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Adds an `init-release.sh` script to automate the mundane, repetitive parts of release initialization. Note that this only makes the necessary changes and other need-based changes go case-by-case (and manually) (for example, release with variants). 

Currently, it does the following tasks:
 - updates handler name in `app.go`
 - updates handler name, upgrade names in `upgrade.go`
 - renames `n:upgrade-next` to `a:upgrade-<release-number>`
 - updates the README in `a:upgrade-<release-number>`

In the future, I will keep automating other bits and pieces of release process. However, next on my docket is to update this script to incorporate variants (at least until we get rid of them altogether).

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
None

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
~~Will add to MAINTAINERS.md in a follow up.~~
Updated MAINTAINERS.md 

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
None for the sdk codebase. But for PR verification, can run it locally on master using `./init-release.sh 19` and it will do the needful.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
None, this is a helper script for release process.
