### PR TITLE
252 expand resolve acct

### DIFF
--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -16,7 +16,11 @@ import {
   IBCConnectionInfoShape,
   AccountArgShape,
 } from '../typeGuards.js';
-import { getBech32Prefix, parseAccountIdArg } from '../utils/address.js';
+import {
+  getBech32Prefix,
+  parseAccountId,
+  parseAccountIdArg,
+} from '../utils/address.js';
 
 /**
  * @import {NameHub} from '@agoric/vats';
@@ -612,13 +616,17 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
       return `cosmos:${reference}:${account}`;
     },
     /**
-     * @param {string} partialId CAIP-10 account ID or a Cosmos bech32 address
+     * @param {AccountIdArg} partialId CAIP-10 account ID or a Cosmos bech32
+     *   address
      * @returns {CosmosChainAddress}
      * @throws {Error} if chain info not found for bech32Prefix
      */
     makeChainAddress(partialId) {
-      const parsed = parseAccountIdArg(partialId);
+      if (typeof partialId !== 'string') {
+        return partialId;
+      }
 
+      const parsed = parseAccountIdArg(partialId);
       if ('namespace' in parsed) {
         assert.equal(parsed.namespace, 'cosmos');
         return harden({
@@ -627,7 +635,6 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
           value: parsed.accountAddress,
         });
       }
-
       const chainId = resolveCosmosChainId(parsed.accountAddress);
       return harden({
         chainId,

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -16,7 +16,7 @@ import {
   IBCConnectionInfoShape,
   AccountArgShape,
 } from '../typeGuards.js';
-import { getBech32Prefix, parseAccountId } from '../utils/address.js';
+import { getBech32Prefix, parseAccountIdArg } from '../utils/address.js';
 
 /**
  * @import {NameHub} from '@agoric/vats';
@@ -603,7 +603,7 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
         return `cosmos:${account.chainId}:${account.value}`;
       }
 
-      const parsed = parseAccountId(account);
+      const parsed = parseAccountIdArg(account);
       if ('namespace' in parsed) {
         // It is already fully qualified
         return /** @type {AccountId} */ (account);
@@ -617,7 +617,7 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
      * @throws {Error} if chain info not found for bech32Prefix
      */
     makeChainAddress(partialId) {
-      const parsed = parseAccountId(partialId);
+      const parsed = parseAccountIdArg(partialId);
 
       if ('namespace' in parsed) {
         assert.equal(parsed.namespace, 'cosmos');

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -593,8 +593,8 @@ export const makeChainHub = (zone, agoricNames, vowTools) => {
       return undefined;
     },
     /**
-     * @param {AccountIdArg | string} account CAIP-10 account ID or a
-     *   CosmosChainAddress or bech32
+     * @param {AccountIdArg} account CAIP-10 account ID or a CosmosChainAddress
+     *   or bech32
      * @returns {AccountId}
      * @throws {Error} if chain info not found for bech32Prefix
      */

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -155,7 +155,7 @@ harden(parseAccountIdArg);
  *   - The parsed account details.
  */
 export const parseAccountId = accountId => {
-  if (typeof accountId !== 'string' || accountId.length !== 3) {
+  if (typeof accountId !== 'string') {
     Fail`malformed CAIP-10 accountId: ${q(accountId)}`;
   }
 

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -3,6 +3,7 @@ import { Fail, q } from '@endo/errors';
 /**
  * @import {IBCConnectionID} from '@agoric/vats';
  * @import {CosmosChainAddress, ScopedChainId} from '../types.js';
+ * @import {AccountId} from '../orchestration-api.js';
  * @import {RemoteIbcAddress} from '@agoric/vats/tools/ibc-utils.js';
  */
 
@@ -117,7 +118,7 @@ export const getBech32Prefix = address => {
  *     }}
  *   - The parsed account details.
  */
-export const parseAccountId = partialId => {
+export const parseAccountIdArg = partialId => {
   if (typeof partialId !== 'string' || !partialId.length) {
     Fail`Empty accountId: ${q(partialId)}`;
   }
@@ -139,5 +140,37 @@ export const parseAccountId = partialId => {
   }
 
   throw Fail`Invalid accountId: ${q(partialId)}`;
+};
+harden(parseAccountIdArg);
+
+/**
+ * Parses an account ID into a structured format following CAIP-10 standards.
+ *
+ * @param {AccountId} accountId CAIP-10 account ID
+ * @returns {{
+ *   namespace: string;
+ *   reference: string;
+ *   accountAddress: string;
+ * }}
+ *   - The parsed account details.
+ */
+export const parseAccountId = accountId => {
+  if (typeof accountId !== 'string' || accountId.length !== 3) {
+    Fail`malformed CAIP-10 accountId: ${q(accountId)}`;
+  }
+
+  const parts = accountId.split(':');
+
+  if (parts.length === 3) {
+    // Full CAIP-10
+    const [namespace, reference, accountAddress] = parts;
+    return {
+      namespace,
+      reference,
+      accountAddress,
+    };
+  }
+
+  throw Fail`malformed CAIP-10 accountId: ${q(accountId)}`;
 };
 harden(parseAccountId);

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -236,6 +236,36 @@ test('resolveAccountId', async t => {
     },
     'throws on invalid address format',
   );
+
+  /** @type {CosmosChainAddress} */
+  const COSMOS_CHAIN_ADDR = {
+    chainId: 'base',
+    value: MOCK_ICA_ADDRESS,
+    encoding: 'bech32',
+  };
+
+  t.is(
+    // @ts-expect-error The types match
+    chainHub.resolveAccountId(COSMOS_CHAIN_ADDR),
+    `cosmos:base:${MOCK_ICA_ADDRESS}`,
+  );
+
+  const ETH_ADDR = 'eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb';
+  t.is(chainHub.resolveAccountId(ETH_ADDR), ETH_ADDR);
+
+  const BTC_ADDR =
+    'bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6';
+  t.is(chainHub.resolveAccountId(BTC_ADDR), BTC_ADDR);
+
+  // should throw for CAIP-2
+  const CAIP2_ID = 'cosmos:osmosis-1';
+  t.throws(
+    () => chainHub.resolveAccountId(CAIP2_ID),
+    {
+      message: 'Invalid accountId: "cosmos:osmosis-1"',
+    },
+    'throws on invalid address format',
+  );
 });
 
 test('updateChain updates existing chain info and mappings', t => {


### PR DESCRIPTION
refs: #11037

## Description

Since we widened our accountIds to `AccountIdArg`, (see #11007) `resolveAccountId()` should support it. 

This was extracted from #11037.

### Security Considerations

No impact

### Scaling Considerations

No impact

### Documentation Considerations

Automatically generated docs will be updated.

### Testing Considerations

Adds tests.

### Upgrade Considerations

Internal utilities only. Shouldn't impact upgrade.