### PR TITLE
refactor(ertp,zoe): minor types gardening

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -158,7 +158,7 @@ const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
  * @param {MathHelpers<AssetValueForKind<K>>} h
  * @param {Amount<K>} leftAmount
  * @param {Amount<K>} rightAmount
- * @returns {[K, K]}
+ * @returns {[AssetValueForKind<K>, AssetValueForKind<K>]}
  */
 const coerceLR = (h, leftAmount, rightAmount) => {
   // @ts-expect-error could be arbitrary subtype

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -9,7 +9,7 @@ import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
 import { ZcfMintI } from './typeGuards.js';
 
 /**
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, TransferPart, ZCF, ZCFMint, ZCFSeat} from '@agoric/zoe';
+ * @import {ZCFMint, ZCFSeat} from '@agoric/zoe';
  */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -21,9 +21,8 @@ import { makeAllocationMap } from './reallocate.js';
 import { TransferPartShape } from '../contractSupport/atomicTransfer.js';
 
 /**
- * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
- * @import {MapStore} from '@agoric/swingset-liveslots';
- * @import {ContractMeta, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {WeakMapStore} from '@agoric/store';
+ * @import {TransferPart, ZCFSeat} from '@agoric/zoe';
  */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -33,7 +33,7 @@ import { ZcfI } from './typeGuards.js';
 
 /**
  * @import {IssuerOptionsRecord} from '@agoric/ertp';
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, SetTestJig, TransferPart, ZCF, ZCFMint, ZCFRegisterFeeMint, ZoeService} from '@agoric/zoe';
+ * @import {ContractMeta, ContractStartFn, SetTestJig, ZCF, ZCFMint, ZCFRegisterFeeMint, ZoeService} from '@agoric/zoe';
  */
 
 /**

--- a/packages/zoe/src/contractSupport/atomicTransfer.js
+++ b/packages/zoe/src/contractSupport/atomicTransfer.js
@@ -2,7 +2,7 @@ import { M } from '@agoric/store';
 import { AmountKeywordRecordShape, SeatShape } from '../typeGuards.js';
 
 /**
- * @import {ContractMeta, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
  */
 
 export const TransferPartShape = M.splitArray(

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -14,7 +14,7 @@ import {
 } from '../contractSupport/index.js';
 
 /**
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {OfferHandler, ZCF} from '@agoric/zoe';
  */
 
 /**

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -34,7 +34,7 @@ import {
  * @import {LegacyMap} from '@agoric/store'
  * @import {ContractOf} from '../zoeService/utils.js';
  * @import {PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {Invitation, ZCF, ZCFSeat} from '@agoric/zoe';
  */
 
 /** @typedef {bigint | number | string} ParsableNumber */

--- a/packages/zoe/src/contracts/valueVow.contract.js
+++ b/packages/zoe/src/contracts/valueVow.contract.js
@@ -2,7 +2,7 @@ import { prepareVowTools } from '@agoric/vow';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 
 /**
- * @import {ContractMeta, ContractStartFn, HandleOffer, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {ContractMeta, HandleOffer, ZCF} from '@agoric/zoe';
  * @import { Baggage } from '@agoric/vat-data';
  */
 

--- a/packages/zoe/src/zoeService/types.ts
+++ b/packages/zoe/src/zoeService/types.ts
@@ -19,7 +19,9 @@ import type {
 } from '../types.js';
 import type { Allocation } from '../types-index.js';
 
-/** @see {@link https://github.com/sindresorhus/type-fest/blob/main/source/is-any.d.ts} */
+/**
+ * @see {@link https://github.com/sindresorhus/type-fest/blob/main/source/is-any.d.ts}
+ */
 type IsAny<T> = 0 extends 1 & NoInfer<T> ? true : false;
 
 /**

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -29,7 +29,7 @@ import {
 
 /**
  * @import {Baggage} from '@agoric/vat-data';
- * @import {ContractMeta, ContractStartFn, InvitationAmount, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {InvitationAmount} from '@agoric/zoe';
  */
 
 const { ownKeys } = Reflect;

--- a/packages/zoe/test/offerArgsUsageContract.js
+++ b/packages/zoe/test/offerArgsUsageContract.js
@@ -1,5 +1,5 @@
 /**
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {OfferHandler, ZCF} from '@agoric/zoe';
  */
 
 /** @param {ZCF} zcf */

--- a/packages/zoe/test/unitTests/blockedOffers.test.js
+++ b/packages/zoe/test/unitTests/blockedOffers.test.js
@@ -16,7 +16,7 @@ import { assertPayoutAmount } from '../zoeTestHelpers.js';
 import { makeOffer } from './makeOffer.js';
 
 /**
- * @import {ContractMeta, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {ZCF} from '@agoric/zoe';
  */
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -4,7 +4,7 @@ import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
 /**
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {ContractStartFn, Invitation, ZCF, ZCFSeat} from '@agoric/zoe';
  */
 
 /**

--- a/packages/zoe/test/unitTests/zcf/zcfSeat.test.js
+++ b/packages/zoe/test/unitTests/zcf/zcfSeat.test.js
@@ -10,7 +10,7 @@ import { setup } from '../setupBasicMints.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 /**
- * @import {ContractMeta, ContractStartFn, Invitation, OfferHandler, TransferPart, ZCF, ZCFSeat} from '@agoric/zoe';
+ * @import {ZCF} from '@agoric/zoe';
  */
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

Just some minor weed pulling. Started as a drive by while working on something else, but enough to stand alone and not wait for those other efforts. Just whitespace, unused type imports, and one internal type correction, none of which should have any runtime effect whatsoever. Hence "refactor".


### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
none
### Upgrade Considerations
none