### PR TITLE
chore(liveslots): remove unnecessary `promiseRegistrations`

### DIFF
--- a/packages/SwingSet/test/vat-admin/slow-termination/slow-termination.test.js
+++ b/packages/SwingSet/test/vat-admin/slow-termination/slow-termination.test.js
@@ -140,9 +140,9 @@ async function doSlowTerminate(t, mode) {
       .get(vatID);
 
   // 20*2 for imports, 21*2 for exports, 20*2 for promises, 20*1 for
-  // vatstore = 142.  Plus 21 for the usual liveslots stuff, and 7 for
+  // vatstore = 142.  Plus 18 for the usual liveslots stuff, and 7 for
   // kernel stuff like vNN.source/options
-  const initialKVCount = 170;
+  const initialKVCount = 167;
 
   t.is(remainingKV().length, initialKVCount);
   t.false(JSON.parse(kvStore.get('vats.terminated')).includes(vatID));
@@ -241,38 +241,37 @@ async function doSlowTerminate(t, mode) {
   await cleanKV(10, 5); // 5 c-list promises
 
   // that finishes the promises, so the next clean will delete the
-  // first five of our 48 other kv entries (20 vatstore plus 28
+  // first five of our 45 other kv entries (20 vatstore plus 25
   // overhead)
 
   await cleanKV(5, 5); // 5 other kv
   // now there are 43 other kv entries left
-  t.is(remainingKV().length, 43);
+  t.is(remainingKV().length, 40);
 
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 38);
+  t.is(remainingKV().length, 35);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 33);
+  t.is(remainingKV().length, 30);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 28);
+  t.is(remainingKV().length, 25);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 23);
+  t.is(remainingKV().length, 20);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 18);
+  t.is(remainingKV().length, 15);
   checkTS();
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 13);
+  t.is(remainingKV().length, 10);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 8);
+  t.is(remainingKV().length, 5);
   await cleanKV(5, 5); // 5 other kv
-  t.is(remainingKV().length, 3);
+  t.is(remainingKV().length, 0);
 
   checkTS();
-
-  // there are three kv left, so this clean will delete those, then 5
-  // of the 7 snapshots
-  await cleanKV(3, 8); // 3 final kv, and 5 snapshots
   t.deepEqual(remainingKV(), []);
   t.is(kernelStorage.kvStore.get(`${vatID}.options`), undefined);
+
+  // there are no kv left, so this clean will delete 5 of the 7 snapshots
+  await cleanKV(0, 5); // 5 snapshots
   expectedRemainingSnapshots -= 5;
   checkTS();
 

--- a/packages/SwingSet/test/virtualObjects/representatives.test.js
+++ b/packages/SwingSet/test/virtualObjects/representatives.test.js
@@ -448,7 +448,7 @@ test('virtual object gc', async t => {
   // prettier-ignore
   t.deepEqual(remainingVOs, {
     [`${v}.vs.baggageID`]: 'o+d6/1',
-    [`${v}.vs.idCounters`]: '{"exportID":11,"collectionID":5,"promiseID":8}',
+    [`${v}.vs.idCounters`]: '{"exportID":11,"collectionID":4,"promiseID":8}',
     [`${v}.vs.kindIDID`]: '1',
     [`${v}.vs.storeKindIDTable`]:
       '{"scalarMapStore":2,"scalarWeakMapStore":3,"scalarSetStore":4,"scalarWeakSetStore":5,"scalarDurableMapStore":6,"scalarDurableWeakMapStore":7,"scalarDurableSetStore":8,"scalarDurableWeakSetStore":9}',
@@ -457,23 +457,20 @@ test('virtual object gc', async t => {
     [`${v}.vs.vc.1.|schemata`]: vstr({ label: 'baggage', keyShape: M.string() }),
     [`${v}.vs.vc.2.|entryCount`]: '0',
     [`${v}.vs.vc.2.|nextOrdinal`]: '1',
-    [`${v}.vs.vc.2.|schemata`]: vstr({ label: 'promiseRegistrations', keyShape: M.scalar() }),
+    [`${v}.vs.vc.2.|schemata`]: vstr({ label: 'promiseWatcherByKind', keyShape: M.scalar() }),
     [`${v}.vs.vc.3.|entryCount`]: '0',
     [`${v}.vs.vc.3.|nextOrdinal`]: '1',
-    [`${v}.vs.vc.3.|schemata`]: vstr({ label: 'promiseWatcherByKind', keyShape: M.scalar() }),
-    [`${v}.vs.vc.4.|entryCount`]: '0',
-    [`${v}.vs.vc.4.|nextOrdinal`]: '1',
-    [`${v}.vs.vc.4.|schemata`]: vstr({ label: 'watchedPromises', keyShape: M.and(M.scalar(), M.string()) }),
+    [`${v}.vs.vc.3.|schemata`]: vstr({ label: 'watchedPromises', keyShape: M.and(M.scalar(), M.string()) }),
     [`${v}.vs.vom.es.o+v10/3`]: 'r',
     [`${v}.vs.vom.o+v10/2`]: `{"label":${vstr('thing #2')}}`,
     [`${v}.vs.vom.o+v10/3`]: `{"label":${vstr('thing #3')}}`,
     [`${v}.vs.vom.o+v10/8`]: `{"label":${vstr('thing #8')}}`,
     [`${v}.vs.vom.o+v10/9`]: `{"label":${vstr('thing #9')}}`,
     [`${v}.vs.vom.rc.o+d6/1`]: '1',
+    [`${v}.vs.vom.rc.o+d6/2`]: '1',
     [`${v}.vs.vom.rc.o+d6/3`]: '1',
-    [`${v}.vs.vom.rc.o+d6/4`]: '1',
     [`${v}.vs.vom.vkind.10.descriptor`]: '{"kindID":"10","tag":"thing"}',
-    [`${v}.vs.watchedPromiseTableID`]: 'o+d6/4',
-    [`${v}.vs.watcherTableID`]: 'o+d6/3',
+    [`${v}.vs.watchedPromiseTableID`]: 'o+d6/3',
+    [`${v}.vs.watcherTableID`]: 'o+d6/2',
   });
 });

--- a/packages/swingset-liveslots/test/gc-helpers.js
+++ b/packages/swingset-liveslots/test/gc-helpers.js
@@ -9,8 +9,8 @@ import { parseVatSlot } from '../src/parseVatSlots.js';
 let aWeakMapStore;
 let aWeakSetStore;
 
-export const mainHolderIdx = 5;
-export const mainHeldIdx = 6;
+export const mainHolderIdx = 4;
+export const mainHeldIdx = 5;
 
 export function buildRootObject(vatPowers) {
   const { VatData } = vatPowers;

--- a/packages/swingset-liveslots/test/handled-promises.test.js
+++ b/packages/swingset-liveslots/test/handled-promises.test.js
@@ -588,8 +588,7 @@ test('watched local promises should not leak slotToVal entries', async t => {
 // The workaround doesn't handle this case because it learns about the
 // settlement before the virtual object system
 // See https://github.com/Agoric/agoric-sdk/issues/10757
-// prettier-ignore
-test.failing('watched imported promises should not leak slotToVal entries', async t => {
+test('watched imported promises should not leak slotToVal entries', async t => {
   const S = 'settlement';
   // cf. src/liveslots.js:initialIDCounters
   const firstPExport = 5;

--- a/packages/swingset-liveslots/test/initial-vrefs.test.js
+++ b/packages/swingset-liveslots/test/initial-vrefs.test.js
@@ -70,34 +70,28 @@ test('initial vatstore contents', async t => {
   t.deepEqual(kunser(JSON.parse(get(`vc.1.|schemata`))), stringSchema);
 
   // then three tables for the promise watcher (one virtual, two durable)
-  t.is(getLabel(`vc.3.|schemata`), 'promiseWatcherByKind'); // durable
-  t.is(getLabel(`vc.4.|schemata`), 'watchedPromises'); // durable
-  // the promiseRegistrations table is not durable, and only gets vc.2
-  // on the first incarnation: it will get a new ID on subsequent
-  // incarnations
-  t.is(getLabel(`vc.2.|schemata`), `promiseRegistrations`); // virtual
+  t.is(getLabel(`vc.2.|schemata`), 'promiseWatcherByKind'); // durable
+  t.is(getLabel(`vc.3.|schemata`), 'watchedPromises'); // durable
 
   const watcherTableVref = get('watcherTableID');
   const watchedPromiseTableVref = get('watchedPromiseTableID');
-  t.is(watcherTableVref, `${dmsBase}/3`);
-  t.is(watchedPromiseTableVref, `${dmsBase}/4`);
+  t.is(watcherTableVref, `${dmsBase}/2`);
+  t.is(watchedPromiseTableVref, `${dmsBase}/3`);
 
   // baggage and the two durable promise-watcher tables are pinned
   t.is(get(`vom.rc.${baggageVref}`), '1');
   t.is(get(`vom.rc.${watcherTableVref}`), '1');
   t.is(get(`vom.rc.${watchedPromiseTableVref}`), '1');
 
-  // promiseRegistrations and promiseWatcherByKind arbitrary scalars as keys
-  const scalarSchema2 = { label: 'promiseRegistrations', keyShape: M.scalar() };
+  // promiseWatcherByKind arbitrary scalars as keys
   const scalarSchema3 = { label: 'promiseWatcherByKind', keyShape: M.scalar() };
-  t.deepEqual(kunser(JSON.parse(get(`vc.2.|schemata`))), scalarSchema2);
-  t.deepEqual(kunser(JSON.parse(get(`vc.3.|schemata`))), scalarSchema3);
+  t.deepEqual(kunser(JSON.parse(get(`vc.2.|schemata`))), scalarSchema3);
   // watchedPromises uses vref (string) keys
   const scalarStringSchema = {
     label: 'watchedPromises',
     keyShape: M.and(M.scalar(), M.string()),
   };
-  t.deepEqual(kunser(JSON.parse(get(`vc.4.|schemata`))), scalarStringSchema);
+  t.deepEqual(kunser(JSON.parse(get(`vc.3.|schemata`))), scalarStringSchema);
 });
 
 test('vrefs', async t => {
@@ -141,11 +135,11 @@ test('vrefs', async t => {
   const dh2Vref = (await run('getDinstance2')).slots[0];
   t.is(dh2Vref, expectedDH2Vref);
 
-  // the liveslots-created collections consume vc.1 through vc.4,
-  // leaving vc.5 for the first user-created collection
-  t.is(getLabel('vc.5.|schemata'), 'store1');
-  const expectedStore1Vref = `o+v${initialKindIDs.scalarMapStore}/5`;
+  // the liveslots-created collections consume vc.1 through vc.3,
+  // leaving vc.4 for the first user-created collection
+  t.is(getLabel('vc.4.|schemata'), 'store1');
+  const expectedStore1Vref = `o+v${initialKindIDs.scalarMapStore}/4`;
   const store1Vref = (await run('getStore1')).slots[0];
   t.is(store1Vref, expectedStore1Vref);
-  t.is(kunser(JSON.parse(fakestore.get(`vc.5.s${'key'}`))), 'value');
+  t.is(kunser(JSON.parse(fakestore.get(`vc.4.s${'key'}`))), 'value');
 });

--- a/packages/swingset-liveslots/test/liveslots-real-gc.test.js
+++ b/packages/swingset-liveslots/test/liveslots-real-gc.test.js
@@ -289,7 +289,7 @@ avaRetry(test.serial, 'GC dispatch.dropExports', async t => {
   t.deepEqual(log.shift(), {
     type: 'vatstoreSet',
     key: 'idCounters',
-    value: '{"exportID":11,"collectionID":5,"promiseID":5}',
+    value: '{"exportID":11,"collectionID":4,"promiseID":5}',
   });
   t.deepEqual(log, []);
 
@@ -369,7 +369,7 @@ avaRetry(
     t.deepEqual(log.shift(), {
       type: 'vatstoreSet',
       key: 'idCounters',
-      value: '{"exportID":11,"collectionID":5,"promiseID":5}',
+      value: '{"exportID":11,"collectionID":4,"promiseID":5}',
     });
     t.deepEqual(log, []);
 

--- a/packages/swingset-liveslots/test/liveslots.test.js
+++ b/packages/swingset-liveslots/test/liveslots.test.js
@@ -713,7 +713,7 @@ test('capdata size limit on syscalls', async t => {
     const label = 'test';
     t.deepEqual(log.shift(), {
       type: 'vatstoreGet',
-      key: 'vc.5.|schemata',
+      key: 'vc.4.|schemata',
       result: JSON.stringify(kser({ label, keyShape: M.scalar() })),
     });
   };
@@ -723,7 +723,7 @@ test('capdata size limit on syscalls', async t => {
   gotSchema();
   t.deepEqual(log.shift(), {
     type: 'vatstoreGet',
-    key: 'vc.5.skey',
+    key: 'vc.4.skey',
     result: undefined,
   });
   expectFail();
@@ -735,7 +735,7 @@ test('capdata size limit on syscalls', async t => {
   gotSchema();
   t.deepEqual(log.shift(), {
     type: 'vatstoreGet',
-    key: 'vc.5.skey',
+    key: 'vc.4.skey',
     result: undefined,
   });
   expectFail();

--- a/packages/swingset-liveslots/test/storeGC/lifecycle.test.js
+++ b/packages/swingset-liveslots/test/storeGC/lifecycle.test.js
@@ -14,12 +14,12 @@ import { parseVatSlot } from '../../src/parseVatSlots.js';
 
 function getLastCollection(v) {
   // makeAndHold() uses makeScalarBigMapStore, and since we call it
-  // early, it always gets "store #6", in vref o+2/6 (o+2 means
-  // scalarMapStore, non-durable, and /6 means collectionID=6)
-  const vref = 'o+v2/6';
+  // early, it always gets "store #5", in vref o+2/5 (o+2 means
+  // scalarMapStore, non-durable, and /5 means collectionID=5)
+  const vref = 'o+v2/5';
   // double-check that at least the collectionID is right
   const { t, fakestore } = v;
-  t.is(JSON.parse(fakestore.get('idCounters')).collectionID, 7); // last was 6
+  t.is(JSON.parse(fakestore.get('idCounters')).collectionID, 6); // last was 5
   return vref;
 }
 

--- a/packages/swingset-liveslots/test/virtual-objects/virtualObjectManager.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/virtualObjectManager.test.js
@@ -590,12 +590,12 @@ test('durable kind IDs can be reanimated', t => {
 
   // Store it in the store without having used it
   placeToPutIt.init('savedKindID', kindHandle);
-  t.is(log.shift(), 'get vc.4.ssavedKindID => undefined');
+  t.is(log.shift(), 'get vc.3.ssavedKindID => undefined');
   t.is(log.shift(), `get vom.rc.${khid} => undefined`);
   t.is(log.shift(), `set vom.rc.${khid} 1`);
-  t.is(log.shift(), `set vc.4.ssavedKindID ${vstr(kind)}`);
-  t.is(log.shift(), 'get vc.4.|entryCount => 0');
-  t.is(log.shift(), 'set vc.4.|entryCount 1');
+  t.is(log.shift(), `set vc.3.ssavedKindID ${vstr(kind)}`);
+  t.is(log.shift(), 'get vc.3.|entryCount => 0');
+  t.is(log.shift(), 'set vc.3.|entryCount 1');
   t.deepEqual(log, []);
 
   // Forget its Representative
@@ -609,7 +609,7 @@ test('durable kind IDs can be reanimated', t => {
 
   // Fetch it from the store, which should reanimate it
   const fetchedKindID = placeToPutIt.get('savedKindID');
-  t.is(log.shift(), `get vc.4.ssavedKindID => ${vstr(kind)}`);
+  t.is(log.shift(), `get vc.3.ssavedKindID => ${vstr(kind)}`);
   t.is(
     log.shift(),
     'get vom.dkind.10.descriptor => {"kindID":"10","tag":"testkind"}',
@@ -658,20 +658,18 @@ test('virtual object gc', t => {
   ];
   t.is(log.shift(), `get storeKindIDTable => undefined`);
   t.is(log.shift(), `set ${skit[0]} ${skit[1]}`);
+  t.is(log.shift(), 'get watcherTableID => undefined');
   t.is(log.shift(), 'set vc.1.|nextOrdinal 1');
   t.is(log.shift(), 'set vc.1.|entryCount 0');
-  t.is(log.shift(), 'get watcherTableID => undefined');
+  t.is(log.shift(), 'set watcherTableID o+d6/1');
+  t.is(log.shift(), 'get vom.rc.o+d6/1 => undefined');
+  t.is(log.shift(), 'set vom.rc.o+d6/1 1');
+  t.is(log.shift(), 'get watchedPromiseTableID => undefined');
   t.is(log.shift(), 'set vc.2.|nextOrdinal 1');
   t.is(log.shift(), 'set vc.2.|entryCount 0');
-  t.is(log.shift(), 'set watcherTableID o+d6/2');
+  t.is(log.shift(), 'set watchedPromiseTableID o+d6/2');
   t.is(log.shift(), 'get vom.rc.o+d6/2 => undefined');
   t.is(log.shift(), 'set vom.rc.o+d6/2 1');
-  t.is(log.shift(), 'get watchedPromiseTableID => undefined');
-  t.is(log.shift(), 'set vc.3.|nextOrdinal 1');
-  t.is(log.shift(), 'set vc.3.|entryCount 0');
-  t.is(log.shift(), 'set watchedPromiseTableID o+d6/3');
-  t.is(log.shift(), 'get vom.rc.o+d6/3 => undefined');
-  t.is(log.shift(), 'set vom.rc.o+d6/3 1');
   t.is(
     log.shift(),
     'set vom.vkind.10.descriptor {"kindID":"10","tag":"thing"}',
@@ -704,8 +702,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.${tbase}/1`, minThing('thing #1')],
     [`vom.${tbase}/2`, minThing('thing #2')],
     [`vom.${tbase}/3`, minThing('thing #3')],
@@ -715,12 +711,12 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 
   // This is what the finalizer would do if the local reference was dropped and GC'd
@@ -750,8 +746,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.es.${tbase}/1`, 'r'],
     [`vom.${tbase}/1`, minThing('thing #1')],
     [`vom.${tbase}/2`, minThing('thing #2')],
@@ -762,12 +756,12 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 
   // drop export -- should delete
@@ -801,8 +795,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.${tbase}/2`, minThing('thing #2')],
     [`vom.${tbase}/3`, minThing('thing #3')],
     [`vom.${tbase}/4`, minThing('thing #4')],
@@ -811,12 +803,12 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 
   // case 2: export, drop export, drop local ref
@@ -838,8 +830,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.es.${tbase}/2`, 's'],
     [`vom.${tbase}/2`, minThing('thing #2')],
     [`vom.${tbase}/3`, minThing('thing #3')],
@@ -849,12 +839,12 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 
   // drop local ref -- should delete
@@ -879,8 +869,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.${tbase}/3`, minThing('thing #3')],
     [`vom.${tbase}/4`, minThing('thing #4')],
     [`vom.${tbase}/5`, minThing('thing #5')],
@@ -888,12 +876,12 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 
   // case 3: drop local ref with no prior export
@@ -919,20 +907,18 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.${tbase}/4`, minThing('thing #4')],
     [`vom.${tbase}/5`, minThing('thing #5')],
     [`vom.${tbase}/6`, minThing('thing #6')],
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 
   // case 4: ref virtually, export, drop local ref, drop export
@@ -949,21 +935,19 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.${tbase}/4`, minThing('thing #4')],
     [`vom.${tbase}/5`, minThing('thing #5')],
     [`vom.${tbase}/6`, minThing('thing #6')],
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     [`vom.rc.${tbase}/4`, '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
   // export
   setExportStatus(`${tbase}/4`, 'reachable');
@@ -1001,8 +985,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.es.${tbase}/4`, 's'],
     [`vom.es.${tbase}/5`, 'r'],
     [`vom.${tbase}/4`, minThing('thing #4')],
@@ -1011,14 +993,14 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     [`vom.rc.${tbase}/4`, '1'],
     [`vom.rc.${tbase}/5`, '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
   // drop local ref -- should not delete because ref'd virtually AND exported
   pretendGC(`${tbase}/5`, false);
@@ -1046,8 +1028,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.es.${tbase}/4`, 's'],
     [`vom.es.${tbase}/5`, 's'],
     [`vom.${tbase}/4`, minThing('thing #4')],
@@ -1056,15 +1036,15 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     [`vom.rc.${tbase}/4`, '1'],
     [`vom.rc.${tbase}/5`, '1'],
     [`vom.rc.${tbase}/6`, '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
   // drop local ref -- should not delete because ref'd virtually
   pretendGC(`${tbase}/6`, false);
@@ -1078,8 +1058,6 @@ test('virtual object gc', t => {
     ['vc.1.|nextOrdinal', '1'],
     ['vc.2.|entryCount', '0'],
     ['vc.2.|nextOrdinal', '1'],
-    ['vc.3.|entryCount', '0'],
-    ['vc.3.|nextOrdinal', '1'],
     [`vom.es.${tbase}/4`, 's'],
     [`vom.es.${tbase}/5`, 's'],
     [`vom.${tbase}/4`, minThing('thing #4')],
@@ -1088,15 +1066,15 @@ test('virtual object gc', t => {
     [`vom.${tbase}/7`, minThing('thing #7')],
     [`vom.${tbase}/8`, minThing('thing #8')],
     [`vom.${tbase}/9`, minThing('thing #9')],
+    ['vom.rc.o+d6/1', '1'],
     ['vom.rc.o+d6/2', '1'],
-    ['vom.rc.o+d6/3', '1'],
     [`vom.rc.${tbase}/4`, '1'],
     [`vom.rc.${tbase}/5`, '1'],
     [`vom.rc.${tbase}/6`, '1'],
     ['vom.vkind.10.descriptor', '{"kindID":"10","tag":"thing"}'],
     ['vom.vkind.11.descriptor', '{"kindID":"11","tag":"ref"}'],
-    ['watchedPromiseTableID', 'o+d6/3'],
-    ['watcherTableID', 'o+d6/2'],
+    ['watchedPromiseTableID', 'o+d6/2'],
+    ['watcherTableID', 'o+d6/1'],
   ]);
 });
 


### PR DESCRIPTION
closes: #10778
refs: #10756

## Description
Gets rid of `promiseRegistrations`, which is not needed.

Solves the remaining `watchPromise` leak, and update tests that manually accounted for this collectionId existing.


### Security Considerations
None

### Scaling Considerations
Removes extra vat store calls for watched promise

### Documentation Considerations
None

### Testing Considerations
Existing test coverage should be sufficient to catch any breakage.

Marked leak test as no longer failing

### Upgrade Considerations
Requires an upgrade of liveslots to be picked up, meaning a chain software upgrade restarting vats.