### PR TITLE
SwingSet tools for load testing contracts

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -429,6 +429,10 @@ export async function makeSwingsetController(
         return kernel.reapAllVats(previousVatPos);
       },
 
+      async snapshotAllVats() {
+        return kernel.snapshotAllVats();
+      },
+
       changeKernelOptions(options) {
         kernel.changeKernelOptions(options);
       },

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -425,8 +425,8 @@ export async function makeSwingsetController(
         return kernel.shutdown();
       },
 
-      reapAllVats() {
-        kernel.reapAllVats();
+      reapAllVats(previousVatPos) {
+        return kernel.reapAllVats(previousVatPos);
       },
 
       changeKernelOptions(options) {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1946,11 +1946,18 @@ export default function buildKernel(
     }
   }
 
-  function reapAllVats() {
+  /** @returns {Generator<VatID>} */
+  function* getAllVatIds() {
     for (const [_, vatID] of kernelKeeper.getStaticVats()) {
-      kernelKeeper.scheduleReap(vatID);
+      yield vatID;
     }
     for (const vatID of kernelKeeper.getDynamicVats()) {
+      yield vatID;
+    }
+  }
+
+  function reapAllVats() {
+    for (const vatID of getAllVatIds()) {
       kernelKeeper.scheduleReap(vatID);
     }
   }

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1956,10 +1956,41 @@ export default function buildKernel(
     }
   }
 
-  function reapAllVats() {
+  function* getAllVatPosEntries() {
     for (const vatID of getAllVatIds()) {
-      kernelKeeper.scheduleReap(vatID);
+      const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
+      yield /** @type {const} */ ([
+        vatID,
+        vatKeeper.getTranscriptEndPosition(),
+      ]);
     }
+  }
+
+  function reapAllVats(previousVatPos = {}) {
+    /** @type {Record<string, number>} */
+    const currentVatPos = {};
+
+    for (const [vatID, endPos] of getAllVatPosEntries()) {
+      const vatUsesTranscript = endPos !== 0;
+      if (!vatUsesTranscript) {
+        // The comms vat is a little special. It doesn't use a transcript,
+        // doesn't implement BOYD, and is created with a never reap threshold.
+        //
+        // Here we conflate a vat that doesn't use a transcript with a vat
+        // that cannot reap. We do not bother checking the vat options because
+        // in tests we would actually like to force reap normal vats that may
+        // have been configured with a never threshold.
+        continue;
+      } else if ((previousVatPos[vatID] ?? 0) < endPos) {
+        kernelKeeper.scheduleReap(vatID);
+        // We just added one delivery
+        currentVatPos[vatID] = endPos + 1;
+      } else {
+        currentVatPos[vatID] = endPos;
+      }
+    }
+
+    return harden(currentVatPos);
   }
 
   async function step() {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1993,6 +1993,16 @@ export default function buildKernel(
     return harden(currentVatPos);
   }
 
+  async function snapshotAllVats() {
+    const snapshottedVats = [];
+    await null;
+    for (const vatID of getAllVatIds()) {
+      const snapshotted = await vatWarehouse.maybeSaveSnapshot(vatID, 2);
+      if (snapshotted) snapshottedVats.push(vatID);
+    }
+    return harden(snapshottedVats);
+  }
+
   async function step() {
     if (kernelPanic) {
       throw kernelPanic;
@@ -2197,6 +2207,7 @@ export default function buildKernel(
     run,
     shutdown,
     reapAllVats,
+    snapshotAllVats,
     changeKernelOptions,
 
     // the rest are for testing and debugging

--- a/packages/SwingSet/test/reap-all/bootstrap-reap-all.js
+++ b/packages/SwingSet/test/reap-all/bootstrap-reap-all.js
@@ -19,5 +19,9 @@ export function buildRootObject() {
       }
       return roots;
     },
+
+    async getExport() {
+      return Far('Bootstrap exported', {});
+    },
   });
 }

--- a/packages/SwingSet/test/reap-all/reap-all.test.js
+++ b/packages/SwingSet/test/reap-all/reap-all.test.js
@@ -43,41 +43,48 @@ test('reap all vats', async t => {
   const dynamicRoots = kunser(c.kpResolution(kpid));
   for (let i = 0; i < 3; i += 1) {
     for (let j = 0; j < i + 1; j += 1) {
-      c.queueToVatRoot(`staticDumbo${i + 1}`, 'doSomething', [
-        `staticDumbo${i + 1} #${j + 1}`,
-      ]);
+      c.queueToVatRoot(
+        `staticDumbo${i + 1}`,
+        'doSomething',
+        [`staticDumbo${i + 1} #${j + 1}`],
+        'none',
+      );
     }
   }
   for (let i = 0; i < 3; i += 1) {
     for (let j = 0; j < i + 1; j += 1) {
-      c.queueToVatObject(dynamicRoots[i], 'doSomething', [
-        `dynamicDumbo${i + 1} #${j + 1}`,
-      ]);
+      c.queueToVatObject(
+        dynamicRoots[i],
+        'doSomething',
+        [`dynamicDumbo${i + 1} #${j + 1}`],
+        'none',
+      );
     }
   }
   // Note: no call to c.run() here, so all the above messages are still enqueued
 
-  const dumpBefore = c.dump();
-  t.is(dumpBefore.acceptanceQueue.length, 12);
-  t.is(dumpBefore.reapQueue.length, 0);
-  t.is(dumpBefore.runQueue.length, 0);
+  const { activeVats } = c.getStatus();
+  t.log(activeVats.map(({ id, options }) => `${id}: ${options.name}`));
+  const reapable = activeVats.map(({ id }) => id);
+  t.true(reapable.length >= 7); // bootstrap, staticDumbo{1,2,3}, dyn{1,2,3}
+
+  /**
+   * @param {{ reap?: string[], acceptanceLength?: number, runLength?: number }} [expectations]
+   */
+  const checkQueues = (expectations = {}) => {
+    const { reap = [], acceptanceLength = 0, runLength = 0 } = expectations;
+    const dump = c.dump();
+    t.is(dump.acceptanceQueue.length, acceptanceLength);
+    t.is(dump.runQueue.length, runLength);
+    t.is(dump.reapQueue.length, reap.length);
+    t.deepEqual(new Set(dump.reapQueue), new Set(reap));
+  };
+
+  checkQueues({ acceptanceLength: 12 });
 
   c.reapAllVats();
-  const dumpPreReap = c.dump();
-  t.is(dumpPreReap.acceptanceQueue.length, 12);
-  t.is(dumpPreReap.reapQueue.length, 11);
-  t.is(dumpBefore.runQueue.length, 0);
-  // prettier-ignore
-  const reapQueueReference =
-    new Set(['v1', 'v3', 'v6', 'v7', 'v8', 'v5', 'v2', 'v4', 'v9', 'v10', 'v11'])
-  const reapQueueActual = new Set(dumpPreReap.reapQueue);
-  t.deepEqual(reapQueueActual, reapQueueReference);
+  checkQueues({ reap: reapable, acceptanceLength: 12 });
 
   await c.run();
-  const dumpPostReap = c.dump();
-  t.is(dumpPostReap.acceptanceQueue.length, 0);
-  t.is(dumpPostReap.reapQueue.length, 0);
-  t.is(dumpBefore.runQueue.length, 0);
-
-  t.pass();
+  checkQueues();
 });

--- a/packages/SwingSet/test/reap-all/vat-dumbo.js
+++ b/packages/SwingSet/test/reap-all/vat-dumbo.js
@@ -1,9 +1,17 @@
 import { Far } from '@endo/far';
+import { defineKind } from '@agoric/vat-data';
 
 export function buildRootObject() {
+  const makeHolder = defineKind('holder', thing => ({ thing }), {});
+
   return Far('root', {
     doSomething(msg) {
       console.log(`doSomething: ${msg}`);
+    },
+
+    async makeHolder(objP) {
+      const obj = await objP;
+      return makeHolder(obj);
     },
   });
 }

--- a/packages/SwingSet/test/vat-warehouse/reload-snapshot.test.js
+++ b/packages/SwingSet/test/vat-warehouse/reload-snapshot.test.js
@@ -138,6 +138,25 @@ const vatReload = async (t, restartWorkerOnSnapshot, vatConfig) => {
   await c2.run();
   t.deepEqual(c2.dump().log, expected2);
   checkPositions();
+  // Manually snapshot should create a snapshot
+  const expectedSnapshotResult = isSnapshotting ? [vatID] : [];
+  t.deepEqual(await c2.snapshotAllVats(), expectedSnapshotResult);
+  assumeSnapshot();
+  await c2.run();
+  checkPositions();
+  // Snapshotting again should not create a snapshot
+  t.deepEqual(await c2.snapshotAllVats(), []);
+  await c2.run();
+  checkPositions();
+  // A single delivery should enable a snapshot again
+  c2.queueToVatRoot('target', 'count', []);
+  expected2.push(getNextCountLog());
+  await c2.run();
+  t.deepEqual(await c2.snapshotAllVats(), expectedSnapshotResult);
+  assumeSnapshot();
+  await c2.run();
+  checkPositions();
+
   await c2.shutdown();
 };
 

--- a/packages/SwingSet/test/vat-warehouse/reload-snapshot.test.js
+++ b/packages/SwingSet/test/vat-warehouse/reload-snapshot.test.js
@@ -10,17 +10,25 @@ import {
 } from '@agoric/swing-store';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 
-const vatReloadFromSnapshot = async (t, restartWorkerOnSnapshot) => {
+/** @import {SwingSetConfigProperties, VatConfigOptions} from '../../src/types-external.js' */
+
+/** @typedef {[snapPos: number, spanStart: number, spanEnd: number]} ExpectedPosition */
+
+/**
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {boolean} restartWorkerOnSnapshot
+ * @param {SwingSetConfigProperties<VatConfigOptions>} vatConfig
+ */
+const vatReload = async (t, restartWorkerOnSnapshot, vatConfig) => {
+  /** @type {import('../../src/types-external.js').SwingSetConfig} */
   const config = {
     defaultReapInterval: 'never',
     snapshotInitial: 3,
     snapshotInterval: 5,
+    defaultManagerType: 'local',
     vats: {
-      target: {
-        sourceSpec: new URL('vat-warehouse-reload.js', import.meta.url)
-          .pathname,
-        creationOptions: { managerType: 'xs-worker' },
-      },
+      target: vatConfig,
     },
   };
 
@@ -38,70 +46,138 @@ const vatReloadFromSnapshot = async (t, restartWorkerOnSnapshot) => {
   c1.pinVatRoot('target');
   const vatID = c1.vatNameToID('target');
 
-  function getPositions() {
+  const { creationOptions } = vatConfig;
+
+  // Only xs-worker support snapshots
+  const isSnapshotting =
+    creationOptions.managerType === 'xs-worker' ||
+    creationOptions.managerType === 'xsnap';
+
+  const { useTranscript = true } = creationOptions;
+
+  let sturdyCounter = 0;
+  let ephemeralCounter = 0;
+  const getNextCountLog = () => {
+    ephemeralCounter += 1;
+    sturdyCounter += 1;
+    return `ephemeralCounter=${ephemeralCounter} sturdyCounter=${sturdyCounter}`;
+  };
+
+  // initialize-worker, startVat
+  let expectedSystemDeliveries = 2;
+  const assumeSnapshot = () => {
+    if (isSnapshotting) {
+      // BYOD, save-snapshot, load-snapshot
+      expectedSystemDeliveries += 3;
+      // Minus load-snapshot, minus 1 since position is 0 based
+      lastSnapshotPos = expectedSystemDeliveries + ephemeralCounter - 1 - 1;
+    }
+  };
+
+  let lastSnapshotPos = 0;
+  function checkPositions() {
     const snapshotInfo = snapStore.getSnapshotInfo(vatID);
 
     const snap = snapshotInfo ? snapshotInfo.snapPos : 0;
     const bounds = kernelStorage.transcriptStore.getCurrentSpanBounds(vatID);
     const start = bounds.startPos;
     const end = bounds.endPos;
-    return [snap, start, end];
+
+    t.is(snap, lastSnapshotPos, 'snapshot position');
+    if (useTranscript) {
+      t.is(start, lastSnapshotPos && lastSnapshotPos + 1, 'span start');
+      t.is(end, expectedSystemDeliveries + ephemeralCounter, 'span end');
+    } else {
+      t.is(start, 0, 'span start');
+      t.is(end, 0, 'span end');
+    }
   }
 
-  // the deliveries to vat-target are:
-  // * 0: initialize-worker
-  // * 1: startVat
   const expected1 = [];
   c1.queueToVatRoot('target', 'count', []);
-  // * 2: message (count=0)
-  // * then we hit snapshotInitial
-  // * 3: BOYD
-  // * 4: save-snapshot
-  // * 5: load-snapshot
-  expected1.push(`count = 0`);
+  expected1.push(getNextCountLog());
+  assumeSnapshot(); // snapshotInitial
   await c1.run();
   t.deepEqual(c1.dump().log, expected1);
-  t.deepEqual(getPositions(), [4, 5, 6]);
-
-  for (let i = 1; i < 11; i += 1) {
+  checkPositions();
+  let i;
+  for (i = 1; i < 11; i += 1) {
     c1.queueToVatRoot('target', 'count', []);
-    // * 6: message (count=1)
-    // * 7: message (count=2)
-    // * 8: message (count=3)
-    // * 9: message (count=4)
-    // * then we hit snapshotInterval
-    // * 9: BOYD
-    // * 10: save-snapshot
-    // * 11: load-snapshot
-    // * 12: message (count=5)
-    // * 13: message (count=6)
-    // * 15: message (count=7)
-    // * 16: message (count=8)
-    // * then we hit snapshotInterval
-    // * 17: BOYD
-    // * 18: save-snapshot
-    // * 19: load-snapshot
-    // * 20: message (count=9)
-    // * 21: message (count=10)
-    expected1.push(`count = ${i}`);
+    expected1.push(getNextCountLog());
+    // 4 = snapshotInterval - 1 (from load-snapshot)
+    if (i % 4 === 0) {
+      assumeSnapshot();
+    }
   }
   await c1.run();
   t.deepEqual(c1.dump().log, expected1);
-  t.deepEqual(getPositions(), [18, 19, 22]);
+  checkPositions();
   await c1.shutdown();
 
-  // the worker will start with the load-snapshot at d19, and replay d20+d21
-  const c2 = await makeSwingsetController(kernelStorage);
-  const expected2 = [`count = 9`, `count = 10`];
-  t.deepEqual(c2.dump().log, expected2); // replayed 4 deliveries
-  c2.queueToVatRoot('target', 'count', []);
-  // * 22: message(count=11)
-  expected2.push(`count = 11`);
+  const c2 = await makeSwingsetController(kernelStorage, null, runtimeOptions);
+  const expected2 = [];
+  if (useTranscript) {
+    if (isSnapshotting) {
+      const replayedCounts = (i - 1) % 4;
+      t.true(replayedCounts > 0, 'test should have count deliveries to replay');
+      expected2.push(...expected1.slice(-replayedCounts));
+    } else {
+      expected2.push(...expected1);
+    }
+  } else {
+    ephemeralCounter = 0;
+    expectedSystemDeliveries = 0;
+  }
+  t.deepEqual(c2.dump().log, expected2); // replayed deliveries
+  // No longer snapshot automatically
+  c2.changeKernelOptions({ snapshotInterval: Number.MAX_SAFE_INTEGER });
+  for (i = 0; i < 4; i += 1) {
+    c2.queueToVatRoot('target', 'count', []);
+    expected2.push(getNextCountLog());
+  }
   await c2.run();
-  t.deepEqual(c2.dump().log, expected2); // note: *not* 0-11
-  t.deepEqual(getPositions(), [18, 19, 23]);
+  t.deepEqual(c2.dump().log, expected2);
+  checkPositions();
   await c2.shutdown();
 };
 
-test('vat reload from snapshot (restart worker)', vatReloadFromSnapshot, true);
-test('vat reload from snapshot (reuse worker)', vatReloadFromSnapshot, false);
+const liveslotsSourceSpec = new URL('vat-warehouse-reload.js', import.meta.url)
+  .pathname;
+const setupSourceSpec = new URL('../vat-transcript-maybe.js', import.meta.url)
+  .pathname;
+
+test('vat reload from snapshot (restart xs-worker)', vatReload, true, {
+  sourceSpec: liveslotsSourceSpec,
+  creationOptions: {
+    managerType: 'xs-worker',
+  },
+});
+test('vat reload from snapshot (reuse xs-worker)', vatReload, false, {
+  sourceSpec: liveslotsSourceSpec,
+  creationOptions: {
+    managerType: 'xs-worker',
+  },
+});
+test('vat reload (local)', vatReload, undefined, {
+  sourceSpec: liveslotsSourceSpec,
+  creationOptions: {
+    managerType: 'local',
+  },
+});
+test('vat reload (local-setup)', vatReload, undefined, {
+  sourceSpec: setupSourceSpec,
+  creationOptions: {
+    managerType: 'local',
+    useTranscript: true,
+    enableSetup: true,
+  },
+});
+
+test('vat reload (local-setup, no-transcript)', vatReload, undefined, {
+  sourceSpec: setupSourceSpec,
+  creationOptions: {
+    managerType: 'local',
+    useTranscript: false,
+    enableSetup: true,
+  },
+});

--- a/packages/SwingSet/test/vat-warehouse/vat-warehouse-reload.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-warehouse-reload.js
@@ -1,12 +1,21 @@
 import { Far } from '@endo/far';
 
-export function buildRootObject(vatPowers) {
-  const { testLog: log } = vatPowers;
-  let count = 0;
+export function buildRootObject(vatPowers, vatParameters, baggage) {
+  let ephemeralCounter = 0;
   return Far('root', {
     count() {
-      log(`count = ${count}`);
-      count += 1;
+      ephemeralCounter += 1;
+      let sturdyCounter = 1;
+      if (baggage.has('sturdyCounter')) {
+        sturdyCounter = baggage.get('sturdyCounter') + 1;
+        baggage.set('sturdyCounter', sturdyCounter);
+      } else {
+        sturdyCounter = 1;
+        baggage.init('sturdyCounter', sturdyCounter);
+      }
+      vatPowers.testLog(
+        `ephemeralCounter=${ephemeralCounter} sturdyCounter=${sturdyCounter}`,
+      );
     },
   });
 }

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -677,17 +677,17 @@ export const makeSwingsetTestKit = async (
     }
   };
 
-  let slogSender;
-  if (slogFile) {
-    slogSender = await makeSlogSender({
-      stateDir: '.',
-      env: {
-        ...process.env,
-        SLOGFILE: slogFile,
-        SLOGSENDER: '',
-      },
-    });
-  }
+  const slogSender = slogFile
+    ? await makeSlogSender({
+        stateDir: '.',
+        env: {
+          ...process.env,
+          SLOGFILE: slogFile,
+          SLOGSENDER: '',
+        },
+      })
+    : undefined;
+
   const mailboxStorage = new Map();
   const { controller, timer, bridgeInbound } = await buildSwingset(
     // @ts-expect-error missing method 'getNextKey'
@@ -873,6 +873,7 @@ export const makeSwingsetTestKit = async (
     storage,
     swingStore,
     timer,
+    slogSender,
   };
 };
 export type SwingsetTestKit = Awaited<ReturnType<typeof makeSwingsetTestKit>>;


### PR DESCRIPTION
refs: #10955

Best reviewed commit-by-commit

## Description
While reproducing the heap growth investigation for FastUSDC and smart wallet, I found myself wanting more comparable GC and snapshot points.

These change make it possible for the host, in this case a load test like for FastUSDC, to perform GC and snapshotting of vats at a known point. It also performs these only for vats that have seen any activity during the load test.

There is a non trivial change to `maybeSaveSnapshot` which I claim is equivalent to before, just avoids paging in vats unnecessarily when snapshotting is manually triggered.

### Security Considerations
None. This introduces a new host capability that isn't used in production hosts.

### Scaling Considerations
None

### Documentation Considerations
Hopefully we can polish the FastUSDC load test as a reference example.

### Testing Considerations
Manually tested in using [mhofman/fu-impact](https://github.com/Agoric/agoric-sdk/compare/dc-fu-impact...mhofman/fu-impact)

### Upgrade Considerations
None, testing only
