### PR TITLE
test incarnation number in RunUtils/boot tests

### DIFF
--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -9,6 +9,7 @@ import { inspect } from 'util';
 
 import type { TypedPublished } from '@agoric/client-utils';
 import { buildSwingset } from '@agoric/cosmic-swingset/src/launch-chain.js';
+import { makeHelpers } from '@agoric/cosmic-swingset/tools/inquisitor.mjs';
 import {
   BridgeId,
   makeTracer,
@@ -45,20 +46,20 @@ import {
 
 import type { ExecutionContext as AvaT } from 'ava';
 
+import type { FastUSDCCorePowers } from '@aglocal/fast-usdc-deploy/src/start-fast-usdc.core.js';
 import type { CoreEvalSDKType } from '@agoric/cosmic-proto/swingset/swingset.js';
 import { computronCounter } from '@agoric/cosmic-swingset/src/computron-counter.js';
 import {
   defaultBeansPerVatCreation,
   defaultBeansPerXsnapComputron,
 } from '@agoric/cosmic-swingset/src/sim-params.js';
-import type { FastUSDCCorePowers } from '@aglocal/fast-usdc-deploy/src/start-fast-usdc.core.js';
 import type { EconomyBootstrapPowers } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
 import type { BridgeHandler, IBCDowncallMethod, IBCMethod } from '@agoric/vats';
 import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
 import type { EProxy } from '@endo/eventual-send';
-import { tmpdir } from 'node:os';
 import { FileSystemCache, NodeFetchCache } from 'node-fetch-cache';
+import { tmpdir } from 'node:os';
 import { icaMocks, protoMsgMockMap, protoMsgMocks } from './ibc/mocks.js';
 
 const trace = makeTracer('BSTSupport', false);
@@ -815,6 +816,25 @@ export const makeSwingsetTestKit = async (
     },
   };
 
+  const getVatDetailsByName = async (nameSubstr: string) => {
+    // XXX make every time because vatsByName is a snapshot during makeHelpers()
+    const { stable } = makeHelpers({
+      db: swingStore.internal.db,
+      EV: runUtils.EV,
+    });
+    // array-ify so we can flatten the array when names collide
+    const allVats = [...stable.vatsByName.values()].flat(1);
+    const matches = allVats.filter(v => v.name.includes(nameSubstr));
+
+    return matches.map(vat => {
+      const stmt = stable.db.prepare(
+        'SELECT incarnation FROM transcriptSpans WHERE isCurrent = 1 AND vatID = ?',
+      );
+      const { incarnation } = stmt.get(vat.vatID) as any;
+      return { ...vat, incarnation };
+    });
+  };
+
   return {
     advanceTimeBy,
     advanceTimeTo,
@@ -823,6 +843,7 @@ export const makeSwingsetTestKit = async (
     controller,
     evalProposal,
     getCrankNumber,
+    getVatDetailsByName,
     jumpTimeTo,
     readLatest,
     readPublished,

--- a/packages/cosmic-swingset/test/inquisitor.test.js
+++ b/packages/cosmic-swingset/test/inquisitor.test.js
@@ -50,6 +50,7 @@ test('smoke test', async t => {
   const { stable: helpers } = makeHelpers({ db });
   t.truthy(helpers.kvGet('vat.names'));
   t.true(Array.isArray(helpers.kvGetJSON('vat.dynamicIDs')));
+  /** @type {any} */
   const vatAdmin = helpers.vatsByName.get('vatAdmin');
   t.like(vatAdmin, { name: 'vatAdmin', isStatic: true }, 'vatAdmin');
   {
@@ -64,6 +65,7 @@ test('smoke test', async t => {
     const rootRefsByKref = helpers.getRefs(rootKref);
     t.deepEqual(rootRefsByKref, rootRefs, 'vatAdmin root object kref');
 
+    /** @type {any} */
     const clist = helpers.kvGlob(`${vatID}.c.*`);
     t.true(clist.length > 0);
     const rootRow = clist.find(row => row.value === rootKref);

--- a/packages/cosmic-swingset/tools/inquisitor.mjs
+++ b/packages/cosmic-swingset/tools/inquisitor.mjs
@@ -62,8 +62,11 @@ import {
 } from '../src/sim-params.js';
 import { makeCosmicSwingsetTestKit } from './test-kit.js';
 
-/** @import { ManagerType, SwingSetConfig } from '@agoric/swingset-vat' */
-/** @import { KVStore } from '../src/helpers/bufferedStorage.js' */
+/**
+ * @import {Database} from 'better-sqlite3';
+ * @import {ManagerType, SwingSetConfig} from '@agoric/swingset-vat';
+ * @import {KVStore} from '../src/helpers/bufferedStorage.js';
+ */
 
 const useColors = process.stdout?.hasColors?.();
 const inspectDepth = 6;
@@ -76,13 +79,28 @@ const parseNumber = input => (input.match(/[0-9]/) ? Number(input) : NaN);
 // cf. packages/swing-store/src/exporter.js
 const storeExportAPI = ['getExportRecords', 'getArtifactNames'];
 
+/**
+ * Partial definition based on log output.
+ * @typedef VatInfo
+ * @property {`v${string}`} vatID
+ * @property {string} name
+ * @property {boolean} isStatic
+ * @property {{bundleID: string}} source
+ * @property {{name: string, critical: boolean}} options
+ */
+
 // TODO: getVatAdminNode('v112') # scan the vatAdmin vom v2.vs.vom.* vrefs for value matching /\b${vatID}\b/
+/**
+ * @param {object} opt
+ * @param {Database} opt.db
+ * @param {any} opt.EV
+ */
 export const makeHelpers = ({ db, EV }) => {
   const sqlKVGet = db
     .prepare('SELECT value FROM kvStore WHERE key = ?')
     .pluck();
   const kvGet = key => sqlKVGet.get(key);
-  const kvGetJSON = key => JSON.parse(kvGet(key));
+  const kvGetJSON = key => JSON.parse(/** @type {string} */ (kvGet(key)));
 
   const sqlKVByRange = db.prepare(
     `SELECT key, value FROM kvStore WHERE key >= :a AND key < :b AND ${[
@@ -122,7 +140,15 @@ export const makeHelpers = ({ db, EV }) => {
     return lazy ? sql.iterate(args) : sql.all(args);
   };
 
+  /**
+   * NB: snapshot never refreshed
+   * @type {Map<`v${string}`, VatInfo>}
+   */
   let vatsByID = new Map();
+  /**
+   * NB: snapshot never refreshed
+   * @type {Map<string, VatInfo | VatInfo[]>}
+   */
   let vatsByName = new Map();
   try {
     // @see {@link ../../SwingSet/src/kernel/state/kernelKeeper.js}
@@ -155,6 +181,7 @@ export const makeHelpers = ({ db, EV }) => {
       ORDER BY vat.rank, vat.idx
     `);
     for (const dbRecord of vatQuery.iterate()) {
+      // @ts-expect-error extract from unknown
       const { vatID, rank, sourceText, optionsText } = dbRecord;
       const isStatic = rank === 1;
       const source = sourceText ? JSON.parse(sourceText) : undefined;
@@ -193,6 +220,7 @@ export const makeHelpers = ({ db, EV }) => {
     const kindMetaJSON =
       kvGet(`${vatID}.vs.vom.dkind.${kindID}.descriptor`) ||
       kvGet(`${vatID}.vs.vom.vkind.${kindID}.descriptor`);
+    assert.typeof(kindMetaJSON, 'string');
     return JSON.parse(kindMetaJSON);
   };
 
@@ -236,6 +264,7 @@ export const makeHelpers = ({ db, EV }) => {
         const value = kvGet(`${vatID}.c.${kref}`);
         if (!value) continue;
         const [_value, _reachabilityFlag, vref] =
+          // @ts-expect-error may not be string
           value.match(krefToVrefValuePatt) ||
           Fail`unexpected c-list value ${value}`;
         const result = { vatID, kref, vref };

--- a/packages/fast-usdc-deploy/test/fast-usdc.test.ts
+++ b/packages/fast-usdc-deploy/test/fast-usdc.test.ts
@@ -368,20 +368,20 @@ test.serial('writes pool metrics to vstorage', async t => {
 });
 
 test.serial('deploy RC2; update Settler reference', async t => {
-  const { evalReleasedProposal } = t.context;
-  const evalP = evalReleasedProposal(
-    'fast-usdc-rc2',
-    'eval-fast-usdc-settler-ref',
-  );
-  await t.notThrowsAsync(evalP);
+  const { evalReleasedProposal, getVatDetailsByName } = t.context;
+  await evalReleasedProposal('fast-usdc-rc2', 'eval-fast-usdc-settler-ref');
+  const [vatDetails] = await getVatDetailsByName('fastUsdc');
+  t.is(vatDetails.incarnation, 2);
 });
 
 test.serial('deploy HEAD; update ChainHub for EVM/Solana', async t => {
-  const { buildProposal, evalProposal } = t.context;
+  const { buildProposal, evalProposal, getVatDetailsByName } = t.context;
   const materials = await buildProposal(
     '@aglocal/fast-usdc-deploy/src/fast-usdc-evm-solana.build.js',
   );
-  await t.notThrowsAsync(evalProposal(materials));
+  await evalProposal(materials);
+  const [vatDetails] = await getVatDetailsByName('fastUsdc');
+  t.is(vatDetails.incarnation, 3);
 });
 
 test.serial('makes usdc advance', async t => {


### PR DESCRIPTION
_incidental_

## Description

synthetic-chain has a way to query the SwingSet DB for vat details, but the RunUtils tests don't. As we do more of our core-eval upgrade testing there, it's conspicuously lacking the ability to test that a Core-Eval upgrading a contract succeeded in running. See https://github.com/Agoric/agoric-sdk/pull/11131#discussion_r2011062740

This lets tests query the in-memory Swingstore to find the incarnation number (and other info) for matching vats.

One step closer to a consistent API,
- https://github.com/Agoric/agoric-sdk/issues/8963

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
CI

### Upgrade Considerations
n/a
