### PR TITLE
disable jsdoc/require-param

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -271,6 +271,7 @@ export default [
     files: ['**/*.ts'],
 
     rules: {
+      'jsdoc/require-param': 'off',
       'jsdoc/require-param-type': 'off',
       'no-undef': 'off',
     },

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns-type, @jessie.js/safe-await-separator */
+/* eslint-disable jsdoc/require-returns-type, @jessie.js/safe-await-separator */
 /* eslint-env node */
 
 import childProcessAmbient from 'child_process';

--- a/packages/fast-usdc-contract/src/exos/operator-kit.ts
+++ b/packages/fast-usdc-contract/src/exos/operator-kit.ts
@@ -6,6 +6,7 @@ import type {
   CctpTxEvidence,
   RiskAssessment,
 } from '@agoric/fast-usdc/src/types.js';
+import type { Invitation } from '@agoric/zoe';
 
 const trace: (...args: unknown[]) => void = makeTracer('TxOperator');
 

--- a/packages/fast-usdc-contract/src/exos/transaction-feed.ts
+++ b/packages/fast-usdc-contract/src/exos/transaction-feed.ts
@@ -15,6 +15,7 @@ import type {
   EvidenceWithRisk,
   RiskAssessment,
 } from '@agoric/fast-usdc/src/types.js';
+import type { ZCF, Invitation } from '@agoric/zoe';
 import { defineInertInvitation } from '../utils/zoe.ts';
 import { prepareOperatorKit } from './operator-kit.ts';
 

--- a/packages/fast-usdc-contract/src/fast-usdc.contract.ts
+++ b/packages/fast-usdc-contract/src/fast-usdc.contract.ts
@@ -1,4 +1,4 @@
-import { AssetKind } from '@agoric/ertp';
+import { AssetKind, type Amount } from '@agoric/ertp';
 import {
   FastUSDCTermsShape,
   FeeConfigShape,
@@ -39,6 +39,7 @@ import type {
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
 import type { Zone } from '@agoric/zone';
+import type { ContractMeta, Invitation, ZCF } from '@agoric/zoe';
 import { prepareAdvancer } from './exos/advancer.ts';
 import { prepareLiquidityPoolKit } from './exos/liquidity-pool.ts';
 import { prepareSettler } from './exos/settler.ts';

--- a/packages/fast-usdc-contract/test/exos/advancer.test.ts
+++ b/packages/fast-usdc-contract/test/exos/advancer.test.ts
@@ -22,6 +22,7 @@ import {
   MockCctpTxEvidences,
   settlementAddress,
 } from '@agoric/fast-usdc/tools/mock-evidence.js';
+import type { ZCFSeat } from '@agoric/zoe';
 import { prepareAdvancer, stateShape } from '../../src/exos/advancer.ts';
 import {
   makeAdvanceDetailsShape,

--- a/packages/fast-usdc-contract/test/exos/settler.test.ts
+++ b/packages/fast-usdc-contract/test/exos/settler.test.ts
@@ -11,7 +11,11 @@ import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import type { Zone } from '@agoric/zone';
 import type { EReturn } from '@endo/far';
-import type { ZcfSeatKit } from '@agoric/zoe';
+import type {
+  AmountKeywordRecord,
+  TransferPart,
+  ZcfSeatKit,
+} from '@agoric/zoe';
 import { PendingTxStatus, TxStatus } from '@agoric/fast-usdc/src/constants.js';
 import type { CctpTxEvidence } from '@agoric/fast-usdc/src/types.js';
 import { makeFeeTools } from '@agoric/fast-usdc/src/utils/fees.js';

--- a/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
@@ -27,9 +27,12 @@ import {
   multiplyBy,
   parseRatio,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
-import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
+import type {
+  Installation,
+  Instance,
+} from '@agoric/zoe/src/zoeService/utils.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E, type EReturn } from '@endo/far';
+import { E, type ERef, type EReturn } from '@endo/far';
 import { matches } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
 import path from 'path';
@@ -42,6 +45,7 @@ import type {
 } from '@agoric/fast-usdc/src/types.js';
 import { makeFeeTools } from '@agoric/fast-usdc/src/utils/fees.js';
 import { MockCctpTxEvidences } from '@agoric/fast-usdc/tools/mock-evidence.js';
+import type { ZoeService, Invitation } from '@agoric/zoe';
 import type { FastUsdcSF } from '../src/fast-usdc.contract.ts';
 import type { OperatorOfferResult } from '../src/exos/transaction-feed.ts';
 import { commonSetup, uusdcOnAgoric } from './supports.js';

--- a/packages/fast-usdc-contract/tsconfig.json
+++ b/packages/fast-usdc-contract/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "checkJs": false, // This package has only .ts source files so avoid checking imported .js files
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",// Can override "bundler" because this package isn't published
   },
   "include": [
     "scripts",

--- a/packages/fast-usdc/src/types.ts
+++ b/packages/fast-usdc/src/types.ts
@@ -12,6 +12,12 @@ import type { CopyRecord, Passable } from '@endo/pass-style';
 import type { PendingTxStatus, TxStatus } from './constants.js';
 import type { RepayAmountKWR } from './utils/fees.js';
 
+// XXX duped with Zoe contractSupport ambient types
+type Ratio = {
+  numerator: Amount<'nat'>;
+  denominator: Amount<'nat'>;
+};
+
 /**
  * Block hash is calculated using the keccak256 algorithm that always results
  * in 32 bytes (64 hex characters prepended by 0x) no matter the input length.

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -27,6 +27,7 @@ import { isUpgradeDisconnection } from '@agoric/internal/src/upgrade-api.js';
  * @import {EReturn} from '@endo/far';
  * @import {BridgeMessage} from '@agoric/cosmic-swingset/src/types.js';
  * @import {Amount, Brand, Payment, Purse} from '@agoric/ertp';
+ * @import {StorageNode} from '@agoric/internal/src/lib-chainStorage.js';
  * @import {ZCF} from '@agoric/zoe';
  * @import {ERef} from '@endo/far'
  * @import {Bank, BankManager} from '@agoric/vats/src/vat-bank.js'

--- a/packages/vats/src/localchain.js
+++ b/packages/vats/src/localchain.js
@@ -13,7 +13,7 @@ import { Shape as NetworkShape } from '@agoric/network';
 const { Vow$ } = NetworkShape;
 
 /**
- * @import {EReturn} from '@endo/far';
+ * @import {ERef, EReturn} from '@endo/far';
  * @import {Key, Pattern} from '@endo/patterns';
  * @import {TypedJson, ResponseTo, JsonSafe} from '@agoric/cosmic-proto';
  * @import {Amount, Brand, Payment} from '@agoric/ertp';

--- a/packages/vats/src/transfer.js
+++ b/packages/vats/src/transfer.js
@@ -7,6 +7,7 @@ import { coerceToByteSource, byteSourceToBase64 } from '@agoric/network';
 import { TargetAppI, AppTransformerI } from './bridge-target.js';
 
 /**
+ * @import {ERef} from '@endo/far';
  * @import {TargetApp, TargetHost} from './bridge-target.js'
  * @import {VTransferIBCEvent} from './types.js';
  */


### PR DESCRIPTION
refs: #10811

## Description

First this disables `jsdoc/require-param` as I think @dckc and @samsiegart requested.

It also tightens up fast-usdc-contract to not rely on `bundler` moduleResolution.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
No changes