### PR TITLE
252 simplify parse account

### DIFF
--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -115,6 +115,12 @@ export type ChainInfo = Readonly<BaseChainInfo | CosmosChainInfo>;
  */
 export type AccountIdArg = AccountId | CosmosChainAddress;
 
+export type Caip10Record = {
+  namespace: string;
+  reference: string;
+  accountAddress: string;
+};
+
 /**
  * Object that controls an account on a particular chain.
  *

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -245,6 +245,23 @@ test('resolveAccountId', async t => {
     },
     'throws on invalid address format',
   );
+
+  const ETH_ADDR = 'eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb';
+  t.is(chainHub.resolveAccountId(ETH_ADDR), ETH_ADDR);
+
+  const BTC_ADDR =
+    'bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6';
+  t.is(chainHub.resolveAccountId(BTC_ADDR), BTC_ADDR);
+
+  // should throw for CAIP-2
+  const CAIP2_ID = 'cosmos:osmosis-1';
+  t.throws(
+    () => chainHub.resolveAccountId(CAIP2_ID),
+    {
+      message: 'Chain info not found for bech32Prefix "cosmos:osmosis-"',
+    },
+    'throws on invalid address format',
+  );
 });
 
 test('updateChain updates existing chain info and mappings', t => {

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -5,7 +5,10 @@ import {
   makeICQChannelAddress,
   findAddressField,
   getBech32Prefix,
+  parseAccountId,
+  parseAccountIdArg,
 } from '../../src/utils/address.js';
+import type { CosmosChainAddress } from '../../src/orchestration-api.ts';
 
 test('makeICAChannelAddress', t => {
   // @ts-expect-error intentional
@@ -138,3 +141,65 @@ test(
   null,
   'Missing prefix for "1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"',
 );
+
+const CAIP10_ETH = 'eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb';
+const CAIP10_COSMOS =
+  'cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0';
+const COSMOS_NOBLE_RECORD: CosmosChainAddress = {
+  chainId: 'noble-1',
+  value: 'noble1test',
+  encoding: 'bech32',
+};
+const COSMOS_AG_RECORD: CosmosChainAddress = {
+  chainId: 'agoric-3',
+  encoding: 'bech32',
+  value: 'agoric13rj0cc0hm5ac2nt0sdup2l7gvkx4v9tyvgq3h2',
+};
+
+test(`parse CAIP-10`, async t => {
+  t.deepEqual(parseAccountId(CAIP10_ETH), {
+    namespace: 'eip155',
+    reference: '1',
+    accountAddress: `0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb`,
+  });
+  t.deepEqual(parseAccountId(CAIP10_COSMOS), {
+    namespace: 'cosmos',
+    reference: 'cosmoshub-3',
+    accountAddress: `cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0`,
+  });
+});
+
+test(`parse COSMOS`, async t => {
+  t.deepEqual(parseAccountIdArg(COSMOS_NOBLE_RECORD), {
+    namespace: 'cosmos',
+    reference: 'noble-1',
+    accountAddress: COSMOS_NOBLE_RECORD.value,
+  });
+  t.deepEqual(parseAccountIdArg(COSMOS_AG_RECORD), {
+    namespace: 'cosmos',
+    reference: 'agoric-3',
+    accountAddress: COSMOS_AG_RECORD.value,
+  });
+});
+
+test(`parse BECH32 (fail)`, async t => {
+  const BECH32_ADDRESS =
+    'osmo1ht7u569vpuryp6utadsydcne9ckeh2v8dkd38v5hptjl3u2ewppqc6kzgd';
+
+  t.throws(
+    () =>
+      // @ts-expect-error illegal type
+      parseAccountIdArg(BECH32_ADDRESS),
+    {
+      message: `malformed CAIP-10 accountId: "${BECH32_ADDRESS}"`,
+    },
+  );
+  t.throws(
+    () =>
+      // @ts-expect-error illegal type
+      parseAccountId(BECH32_ADDRESS),
+    {
+      message: `malformed CAIP-10 accountId: "${BECH32_ADDRESS}"`,
+    },
+  );
+});


### PR DESCRIPTION
refs: #11037
refs: #11146

## Description

Since we widened our accountIds to `AccountIdArg`, (see #11007) this updates `parseAccountId()` to support it more cleanly (and renamed it to `parseAccountIdArg()`), added a separate `parseAccountId()` that parses CAIP-10 addresses to their constituent parts.

`ChainHub.resolveAccountId()` and `ChainHub.makeChainAddreess()`, which need to support bare bech32 addresses, no longer use `parseAccountId`.

This grew out of #11037.  (It replaces #11146, which tried to go in a different direction.)

### Security Considerations

No impact.

### Scaling Considerations

No impact.

### Documentation Considerations

Automatically generated docs will be updated.

### Testing Considerations

Adds tests

### Upgrade Considerations

Internal utilities only. Shouldn't impact upgrade.
