### PR TITLE
chore(SwingSet): Harden outbound slog entry objects

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -182,7 +182,7 @@ export async function makeSwingsetController(
     };
 
     // rearrange the fields a bit to make it more legible to humans
-    slogSender({ type, ...props, ...timings });
+    slogSender(harden({ type, ...props, ...timings }));
   }
   /**
    * Capture an extended process in the slog, writing an entry with `type`

--- a/packages/telemetry/src/slog-sender-pipe-entrypoint.js
+++ b/packages/telemetry/src/slog-sender-pipe-entrypoint.js
@@ -110,7 +110,7 @@ const main = async () => {
           logger.warn('Received send with no sender available');
         } else {
           try {
-            slogSender(msg.obj);
+            slogSender(harden(msg.obj));
           } catch (e) {
             sendErrors.push(e);
           }


### PR DESCRIPTION
Fixes #11176

## Description
`harden` outbound slog entry objects to indicate that mutation thereof is not acceptable.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Updated existing slogSender tests to used hardned slog entries.

### Upgrade Considerations
None; this is kernel code and all known slogSender implementations are already compatible with hardened inputs.