### PR TITLE
feat(SwingSet): Echo controller console output to the slog 

### DIFF
--- a/packages/cosmic-swingset/src/anylogger-agoric.js
+++ b/packages/cosmic-swingset/src/anylogger-agoric.js
@@ -14,18 +14,21 @@ const VAT_LOGGER_PREFIXES = Object.freeze([
   'SwingSet:ls', // "ls" for "liveslots"
 ]);
 
-// As documented in ../../../docs/env.md, the log level defaults to "log" when
-// environment variable DEBUG is non-empty or unset, and to the quieter "info"
-// when it is set to an empty string.
 const DEBUG_LIST = getEnvironmentOptionsList('DEBUG');
-/** @type {string | undefined} */
+
+/**
+ * As documented in ../../../docs/env.md, the log level defaults to "log" when
+ * environment variable DEBUG is non-empty or unset, and to the quieter "info"
+ * when it is set to an empty string, but in either case is overridden if DEBUG
+ * is a comma-separated list that contains "agoric:none" or "agoric:${level}" or
+ * "agoric" (the last an alias for "agoric:debug").
+ *
+ * @type {string | undefined}
+ */
 let maxActiveLevel =
   DEBUG_LIST.length > 0 || getEnvironmentOption('DEBUG', 'unset') === 'unset'
     ? 'log'
     : 'info';
-// ...but is overridden if DEBUG is a comma-separated list that contains
-// "agoric:none" or "agoric:${level}" or "agoric" (the last an alias for
-// "agoric:debug").
 for (const selector of DEBUG_LIST) {
   const fullSelector = selector === 'agoric' ? 'agoric:debug' : selector;
   const [_, detail] = fullSelector.match(/^agoric:(.*)/gs) || [];

--- a/packages/cosmic-swingset/src/anylogger-agoric.js
+++ b/packages/cosmic-swingset/src/anylogger-agoric.js
@@ -35,12 +35,12 @@ const maxActiveLevelCode = /** @type {number} */ (
 
 const oldExt = anylogger.ext;
 anylogger.ext = logger => {
-  const l = oldExt(logger);
-  l.enabledFor = lvl => maxActiveLevelCode >= anylogger.levels[lvl];
+  logger = oldExt(logger);
+  logger.enabledFor = lvl => maxActiveLevelCode >= anylogger.levels[lvl];
 
-  const prefix = l.name.replace(/:/g, ': ');
+  const prefix = logger.name.replace(/:/g, ': ');
 
-  const nameColon = `${l.name}:`;
+  const nameColon = `${logger.name}:`;
   const logBelongsToVat = isVatLogNameColon(nameColon);
 
   // If this is a vat log, then it is enabled by a selector in DEBUG_LIST.
@@ -54,20 +54,20 @@ anylogger.ext = logger => {
   for (const [level, code] of Object.entries(anylogger.levels)) {
     if (logMatchesSelector && maxActiveLevelCode >= code) {
       // Enable the printing with a prefix.
-      const doLog = l[level];
+      const doLog = logger[level];
       if (doLog) {
-        l[level] = (...args) => {
+        logger[level] = (...args) => {
           // Add a timestamp.
           const now = new Date().toISOString();
           doLog(`${now} ${prefix}:`, ...args);
         };
       } else {
-        l[level] = () => {};
+        logger[level] = () => {};
       }
     } else {
       // Disable printing.
-      l[level] = () => {};
+      logger[level] = () => {};
     }
   }
-  return l;
+  return logger;
 };

--- a/packages/telemetry/src/serialize-slog-obj.js
+++ b/packages/telemetry/src/serialize-slog-obj.js
@@ -1,4 +1,32 @@
-export const serializeSlogObj = slogObj =>
-  JSON.stringify(slogObj, (_, arg) =>
-    typeof arg === 'bigint' ? Number(arg) : arg,
-  );
+const { hasOwn } = Object;
+
+const replacer = (_key, value) => {
+  switch (typeof value) {
+    case 'object': {
+      if (value instanceof Error) {
+        // Represent each error as a serialization-friendly
+        // { errorType, message, cause?, errors?, stack? } object
+        // (itself subject to recursive replacement, particularly in `cause` and
+        // `errors`).
+        const obj = { errorType: value.name, message: value.message };
+        if (hasOwn(value, 'cause')) obj.cause = value.cause;
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore TS2339 property "errors" is only on AggregateError
+        if (hasOwn(value, 'errors')) obj.errors = value.errors;
+        const stack = value.stack;
+        if (stack) obj.stack = stack;
+        return obj;
+      }
+      break;
+    }
+    case 'bigint':
+      // Represent each bigint as a JSON-serializable number, accepting the
+      // possible loss of precision.
+      return Number(value);
+    default:
+      break;
+  }
+  return value;
+};
+
+export const serializeSlogObj = slogObj => JSON.stringify(slogObj, replacer);

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -63,11 +63,13 @@ const withMutex = operation => {
 
 /** @param {import('.').MakeSlogSenderOptions} options */
 export const makeSlogSender = async options => {
+  const { env = {} } = options;
   const { registerShutdown } = makeShutdown();
 
   const cp = fork(path.join(dirname, 'slog-sender-pipe-entrypoint.js'), [], {
     stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
     serialization: 'advanced',
+    env,
   });
   // logger.log('done fork');
   /** @type {(msg: Record<string, unknown> & {type: string}) => Promise<void>} */


### PR DESCRIPTION
Fixes #11178

## Description
* Cleans up [packages/cosmic-swingset/src/anylogger-agoric.js](https://github.com/Agoric/agoric-sdk/blob/master/packages/cosmic-swingset/src/anylogger-agoric.js), in particular to align it with documentation at [docs/env.md](https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md#debug).
* Updates controller.js to use replace use of global `console` with a `sloggingConsole` global which is progressively enhanced, ultimately to an object that wraps both an anylogger instance with prefix "SwingSet:controller" and an aggregate slog sender that emits entries with type "console" and source "controller".
* Fixes a minor bug in [slog-sender-pipe.js](https://github.com/Agoric/agoric-sdk/blob/master/packages/telemetry/src/slog-sender-pipe.js) that caused its child process to inherit the global process environment rather than the `env` specified in `makeSlogSender` options (which has unprefixed SLOGSENDER_AGENT_* variables).
* Updates slog sender JSON serialization to represent error instances as `{ error, message, ... }` rather than `{}`, so that the new entries are actually useful.

### Security Considerations
The latter two changes can potentially affect circumstances that we've already encountered. The first one results in SLOGSENDER_AGENT_* variables correctly overriding their unprefixed analogs when SLOGSENDER_AGENT is "process" as they do when it is not, and thus is not expected to cause issues. The second one results in increased size of slog entries, but in a way that is presumably desirable (and, to the effect it can be influenced by vat code, is not the only available means of doing so—although the errors being serialized can potentially originate in e.g. liveslots via a vat code trigger, so we must remain vigilant about not overprivileging liveslots).

### Scaling Considerations
No impact expected.

### Documentation Considerations
n/a

### Testing Considerations
I confirmed expected slog entries by manually introducing errors in the kernel.

### Upgrade Considerations
These changes are independent of consensus, and not expected to be covered by release verification. If the latter is desired, we would probably want to artificially introduce a log message upon each enhancement of the controller-global `sloggingConsole`.