### PR TITLE
test(ci): parallelize multichain-testing

### DIFF
--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
         description: 'Test command to run (e.g., "test:main" or "test:fast-usdc")'
+      test_suite_name:
+        required: true
+        type: string
+        description: 'Identifier for the test suite that will be used as part of the filename name for logs'
 
 jobs:
   multichain-e2e:
@@ -149,5 +153,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: multichain-e2e-logs-${{ env.NAMESPACE }}-${{ github.run_id }}-${{ github.job }}
+          name: multichain-e2e-logs-${{ env.NAMESPACE }}-${{ inputs.test_suite_name }}-${{ github.run_id }}-${{ github.job }}
           path: ${{ env.LOG_DIR }}

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -8,10 +8,12 @@ on:
         type: choice
         required: true
         options:
-          - orchestration-api-hermes
+          - fast-usdc-go-relayer
           - fast-usdc-hermes
           - orchestration-api-go-relayer
-          - fast-usdc-go-relayer
+          - orchestration-api-hermes
+          - orchestration-staking-go-relayer
+          - orchestration-staking-hermes
   workflow_call:
 
 jobs:
@@ -25,6 +27,7 @@ jobs:
     with:
       config: config.yaml
       test_command: yarn test:main
+      test_suite_name: orchestration-api-hermes
 
   fast-usdc-hermes:
     name: Fast USDC - Hermes
@@ -36,6 +39,7 @@ jobs:
     with:
       config: config.fusdc.yaml
       test_command: yarn test:fast-usdc
+      test_suite_name: fast-usdc-hermes
 
   orchestration-api-go-relayer:
     name: Orchestration API - Go Relayer
@@ -45,6 +49,7 @@ jobs:
     with:
       config: config.go-relayer.yaml
       test_command: RELAYER_TYPE=go-relayer yarn test:main
+      test_suite_name: orchestration-api-go-relayer
 
   fast-usdc-go-relayer:
     name: Fast USDC - Go Relayer
@@ -54,3 +59,26 @@ jobs:
     with:
       config: config.fusdc.go-relayer.yaml
       test_command: RELAYER_TYPE=go-relayer yarn test:fast-usdc
+      test_suite_name: fast-usdc-api-go-relayer
+
+  orchestration-staking-go-relayer:
+    name: Orchestration Staking - Go Relayer
+    # run on dispatch only
+    if: github.event_name == 'workflow_dispatch' && inputs.test_type == 'orchestration-staking-go-relayer'
+    uses: ./.github/workflows/multichain-e2e-template.yml
+    with:
+      config: config.go-relayer.yaml
+      test_command: RELAYER_TYPE=go-relayer yarn test:staking
+      test_suite_name: orchestration-staking-go-relayer
+
+  orchestration-staking-hermes:
+    name: Orchestration Staking - Hermes
+    if: |
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' && inputs.test_type == 'orchestration-staking-hermes')
+    uses: ./.github/workflows/multichain-e2e-template.yml
+    with:
+      config: config.yaml
+      test_command: yarn test:staking
+      test_suite_name: orchestration-staking-hermes

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -14,6 +14,8 @@ on:
           - orchestration-api-hermes
           - orchestration-staking-go-relayer
           - orchestration-staking-hermes
+          - orchestration-queries-go-relayer
+          - orchestration-queries-hermes
   workflow_call:
 
 jobs:
@@ -82,3 +84,25 @@ jobs:
       config: config.yaml
       test_command: yarn test:staking
       test_suite_name: orchestration-staking-hermes
+
+  orchestration-queries-go-relayer:
+    name: Orchestration Queries - Go Relayer
+    # run on dispatch only
+    if: github.event_name == 'workflow_dispatch' && inputs.test_type == 'orchestration-queries-go-relayer'
+    uses: ./.github/workflows/multichain-e2e-template.yml
+    with:
+      config: config.go-relayer.yaml
+      test_command: RELAYER_TYPE=go-relayer yarn test:queries
+      test_suite_name: orchestration-queries-go-relayer
+
+  orchestration-queries-hermes:
+    name: Orchestration Queries - Hermes
+    if: |
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' && inputs.test_type == 'orchestration-queries-hermes')
+    uses: ./.github/workflows/multichain-e2e-template.yml
+    with:
+      config: config.yaml
+      test_command: yarn test:queries
+      test_suite_name: orchestration-queries-hermes

--- a/multichain-testing/README.md
+++ b/multichain-testing/README.md
@@ -96,13 +96,18 @@ kubectl logs hermes-agoric-cosmoshub-0 --container=relayer --follow
 kubectl logs hermes-osmosis-cosmoshub-0 --container=relayer --follow
 ```
 
+## Test Suites
+
+To run test suites, see [./test//README.md](./test//README.md)
+
 ## Running with Go Relayer
 
 ```sh
-# run tests with go-relayer configuration
+# start containers with go-relayer configuration
 make start FILE=config.go-relayer.yaml
 
-RELAYER_TYPE=go-relayer yarn test
+# run tests with go-relayer configuration
+RELAYER_TYPE=go-relayer yarn test:main
 ```
 
 ## Agoric Smart Wallet

--- a/multichain-testing/ava.queries.config.js
+++ b/multichain-testing/ava.queries.config.js
@@ -1,0 +1,6 @@
+import mainConfig from './ava.config.js';
+
+export default {
+  ...mainConfig,
+  files: ['test/queries/**/*.test.ts'],
+};

--- a/multichain-testing/ava.rest.config.js
+++ b/multichain-testing/ava.rest.config.js
@@ -5,6 +5,7 @@ export default {
   files: [
     'test/**/*.test.*',
     '!test/fast-usdc/**/*.test.*',
+    '!test/queries/**/*.test.*',
     '!test/staking/**/*.test.*',
   ],
 };

--- a/multichain-testing/ava.rest.config.js
+++ b/multichain-testing/ava.rest.config.js
@@ -1,5 +1,11 @@
 import mainConfig from './ava.config.js';
 
+/**
+ * XXX Ensure glob patterns are properly maintained.
+ * If this omits a glob tests will be repeated and we won't get an error. If it
+ * gets an extra ignore (or a glob is removed somewhere else but not here) the
+ * tests simply won't run.
+ */
 export default {
   ...mainConfig,
   files: [

--- a/multichain-testing/ava.rest.config.js
+++ b/multichain-testing/ava.rest.config.js
@@ -2,5 +2,9 @@ import mainConfig from './ava.config.js';
 
 export default {
   ...mainConfig,
-  files: ['test/**/*.test.*', '!test/fast-usdc/**/*.test.*'],
+  files: [
+    'test/**/*.test.*',
+    '!test/fast-usdc/**/*.test.*',
+    '!test/staking/**/*.test.*',
+  ],
 };

--- a/multichain-testing/ava.staking.config.js
+++ b/multichain-testing/ava.staking.config.js
@@ -1,0 +1,6 @@
+import mainConfig from './ava.config.js';
+
+export default {
+  ...mainConfig,
+  files: ['test/staking/**/*.test.ts'],
+};

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -7,7 +7,8 @@
     "lint": "yarn tsc && yarn eslint .",
     "test": "echo 'Run specific test suites:\nyarn test:main (needs `make start`)\nyarn test:fast-usdc (needs `make start FILE=config.fusdc.yaml`)'",
     "test:main": "ava --config ava.rest.config.js",
-    "test:fast-usdc": "ava --config ava.fusdc.config.js"
+    "test:fast-usdc": "ava --config ava.fusdc.config.js",
+    "test:staking": "ava --config ava.staking.config.js"
   },
   "packageManager": "yarn@4.9.1",
   "devDependencies": {

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -8,6 +8,7 @@
     "test": "echo 'Run specific test suites:\nyarn test:main (needs `make start`)\nyarn test:fast-usdc (needs `make start FILE=config.fusdc.yaml`)'",
     "test:main": "ava --config ava.rest.config.js",
     "test:fast-usdc": "ava --config ava.fusdc.config.js",
+    "test:queries": "ava --config ava.queries.config.js",
     "test:staking": "ava --config ava.staking.config.js"
   },
   "packageManager": "yarn@4.9.1",

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "exit 0",
     "lint": "yarn tsc && yarn eslint .",
-    "test": "echo 'Run specific test suites:\nyarn test:main (needs `make start`)\nyarn test:fast-usdc (needs `make start FILE=config.fusdc.yaml`)'",
+    "test": "echo 'Run specific test suites: `main`, `queries`, `staking`, `fast-usdc`\nyarn test:main (needs `make start`)\nyarn test:fast-usdc (needs `make start FILE=config.fusdc.yaml`)'",
     "test:main": "ava --config ava.rest.config.js",
     "test:fast-usdc": "ava --config ava.fusdc.config.js",
     "test:queries": "ava --config ava.queries.config.js",

--- a/multichain-testing/test/README.md
+++ b/multichain-testing/test/README.md
@@ -9,8 +9,56 @@ make start
 
 ## Run Tests
 
+The testing framework is organized into multiple test suites:
+- `test:main` - Main orchestration API tests
+- `test:fast-usdc` - Fast USDC tests (requires `make start FILE=config.fusdc.yaml`)
+- `test:queries` - Query functionality tests
+- `test:staking` - Staking functionality tests
+
+To run the main test suite:
+
 ```sh
 yarn test:main
+```
+
+Each test suite has its own configuration and must be run independently.
+Calling `yarn test` will warn to pick a specific suite. See the subdirectories
+for specific test suite documentation.
+
+## Running with Different Relayer Configurations
+
+The tests can be run with either Hermes relayers (default) or Go relayers. Each
+configuration requires the appropriate starship configuration file and
+environment variables.
+
+### Hermes Relayer (Default)
+
+```sh
+# Start with default Hermes relayer configuration
+make start
+
+# Run tests
+yarn test:main
+```
+
+### Go Relayer
+
+```sh
+# Start with Go relayer configuration
+make start FILE=config.go-relayer.yaml
+
+# Run tests with Go relayer environment variable
+RELAYER_TYPE=go-relayer yarn test:main
+```
+
+### Fast USDC with Go Relayer
+
+```sh
+# Start with Fast USDC Go relayer configuration
+make start FILE=config.fusdc.go-relayer.yaml
+
+# Run Fast USDC tests with Go relayer environment variable
+RELAYER_TYPE=go-relayer yarn test:fast-usdc
 ```
 
 ## Stop Chains

--- a/multichain-testing/test/README.md
+++ b/multichain-testing/test/README.md
@@ -1,0 +1,20 @@
+## Start Chains
+
+Runs agoric, cosmoshub, and osmosis with hermes relayers.
+
+```sh
+# start starship with default configuration
+make start
+```
+
+## Run Tests
+
+```sh
+yarn test:main
+```
+
+## Stop Chains
+
+```sh
+make stop
+```

--- a/multichain-testing/test/queries/README.md
+++ b/multichain-testing/test/queries/README.md
@@ -1,0 +1,20 @@
+## Start Chains
+
+Runs agoric, cosmoshub, and osmosis with hermes relayers.
+
+```sh
+# start starship with default configuration
+make start
+```
+
+## Run Tests
+
+```sh
+yarn test:queries
+```
+
+## Stop Chains
+
+```sh
+make stop
+```

--- a/multichain-testing/test/queries/account-balance-queries.test.ts
+++ b/multichain-testing/test/queries/account-balance-queries.test.ts
@@ -5,10 +5,10 @@ import {
   commonSetup,
   type SetupContextWithWallets,
   chainConfig,
-} from './support.js';
-import { makeDoOffer } from '../tools/e2e-tools.js';
-import chainInfo from '../starship-chain-info.js';
-import { MAKE_ACCOUNT_AND_QUERY_BALANCE_TIMEOUT } from './config.js';
+} from '../support.js';
+import { makeDoOffer } from '../../tools/e2e-tools.js';
+import chainInfo from '../../starship-chain-info.js';
+import { MAKE_ACCOUNT_AND_QUERY_BALANCE_TIMEOUT } from '../config.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 

--- a/multichain-testing/test/queries/chain-queries.test.ts
+++ b/multichain-testing/test/queries/chain-queries.test.ts
@@ -13,10 +13,10 @@ import {
   type SetupContextWithWallets,
   chainConfig,
   FAUCET_POUR,
-} from './support.js';
-import { makeDoOffer } from '../tools/e2e-tools.js';
-import { createWallet } from '../tools/wallet.js';
-import { makeQueryClient } from '../tools/query.js';
+} from '../support.js';
+import { makeDoOffer } from '../../tools/e2e-tools.js';
+import { createWallet } from '../../tools/wallet.js';
+import { makeQueryClient } from '../../tools/query.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 

--- a/multichain-testing/test/staking/README.md
+++ b/multichain-testing/test/staking/README.md
@@ -1,0 +1,20 @@
+## Start Chains
+
+Runs agoric, cosmoshub, and osmosis with hermes relayers.
+
+```sh
+# start starship with default configuration
+make start
+```
+
+## Run Tests
+
+```sh
+yarn test:staking
+```
+
+## Stop Chains
+
+```sh
+make stop
+```

--- a/multichain-testing/test/staking/auto-stake-it.test.ts
+++ b/multichain-testing/test/staking/auto-stake-it.test.ts
@@ -1,12 +1,12 @@
 import anyTest from '@endo/ses-ava/prepare-endo.js';
 import type { TestFn } from 'ava';
-import starshipChainInfo from '../starship-chain-info.js';
-import { makeDoOffer } from '../tools/e2e-tools.js';
-import { makeFundAndTransfer } from '../tools/ibc-transfer.js';
-import { makeQueryClient } from '../tools/query.js';
-import type { SetupContextWithWallets } from './support.js';
-import { chainConfig, commonSetup } from './support.js';
-import { AUTO_STAKE_IT_DELEGATIONS_TIMEOUT } from './config.js';
+import starshipChainInfo from '../../starship-chain-info.js';
+import { makeDoOffer } from '../../tools/e2e-tools.js';
+import { makeFundAndTransfer } from '../../tools/ibc-transfer.js';
+import { makeQueryClient } from '../../tools/query.js';
+import type { SetupContextWithWallets } from '../support.js';
+import { chainConfig, commonSetup } from '../support.js';
+import { AUTO_STAKE_IT_DELEGATIONS_TIMEOUT } from '../config.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 

--- a/multichain-testing/test/staking/stake-ica.test.ts
+++ b/multichain-testing/test/staking/stake-ica.test.ts
@@ -4,11 +4,11 @@ import {
   commonSetup,
   type SetupContextWithWallets,
   FAUCET_POUR,
-} from './support.js';
-import { makeDoOffer } from '../tools/e2e-tools.js';
-import { makeQueryClient } from '../tools/query.js';
-import { sleep } from '../tools/sleep.js';
-import { STAKING_REWARDS_TIMEOUT } from './config.js';
+} from '../support.js';
+import { makeDoOffer } from '../../tools/e2e-tools.js';
+import { makeQueryClient } from '../../tools/query.js';
+import { sleep } from '../../tools/sleep.js';
+import { STAKING_REWARDS_TIMEOUT } from '../config.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 


### PR DESCRIPTION
incidental

## Description
Split Orchestration API `multichain-testing` tests (`yarn test:main`) into `yarn test:staking` and `yarn test:queries` to reduce overall length of  integration tests in CI.

| Test Command          | Before    | After     | Improvement |
|-----------------------|-----------|-----------|-------------|
| yarn test:main        | 38m 45s   | 27m 15s   | -11m 30s    |
| yarn test:staking     | N/A       | 26m 49s   | N/A         |
| yarn test:queries     | N/A       | 22m 33s   | N/A         |
| yarn test:fast-usdc   | 19m 20s   | 19m 20s   | 0m 0s       |

For the longest suite, the ava test takes ~9m 38s. We could look to parallelize further, but there is a fixed cost of ~17m 37s for `multichain-e2e-template.yml`.

### Security Considerations
None

### Scaling Considerations
Reduces CI time for `multichain-e2e (Orchestration API)` job at the expense of adding ~38 mins of 16-core minutes per CI run that includes integration tests.

### Documentation Considerations
Adds READMEs for each test suite. 

### Testing Considerations
None

### Upgrade Considerations
None