### PR TITLE
test(orchestration): CCTP address encoding fixtures based on observed traffic

### DIFF
--- a/multichain-testing/scripts/cctp-lab.ts
+++ b/multichain-testing/scripts/cctp-lab.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+/**
+ * @file verify CCTP mintRecipient encoding by sending
+ * a burn transaction to noble and verifying that
+ * it results in a CCTP attestation.
+ *
+ * Noble source address, signature is based on $MNEMONIC.
+ * Set $CCTP_DEST to a CAIP-10 accountId such as eip155:58008:0x3dA3050... ...
+ */
+import '@endo/init';
+
+import { MsgDepositForBurn } from '@agoric/cosmic-proto/circle/cctp/v1/tx.js';
+import type { NobleAddress } from '@agoric/fast-usdc';
+import {
+  accountIdTo32Bytes,
+  parseAccountId,
+} from '@agoric/orchestration/src/utils/address.js';
+import { keccak256 } from '@cosmjs/crypto';
+import { fromBase64, toHex } from '@cosmjs/encoding';
+import {
+  DirectSecp256k1HdWallet,
+  Registry,
+  type GeneratedType,
+} from '@cosmjs/proto-signing';
+import { SigningStargateClient } from '@cosmjs/stargate';
+import type { AccountId } from '@agoric/orchestration';
+
+export const cctpTypes: ReadonlyArray<[string, GeneratedType]> = [
+  [
+    '/circle.cctp.v1.MsgDepositForBurn',
+    // @ts-expect-error type of encode doesn't match. not sure why
+    MsgDepositForBurn,
+  ],
+];
+
+const configs = {
+  test: {
+    circle: {
+      iris: 'https://iris-api-sandbox.circle.com',
+    },
+    noble: {
+      explorer: 'https://mintscan.io/noble-testnet',
+      rpc: 'https://noble-testnet-rpc.polkachu.com:443',
+      api: 'https://noble-testnet-api.polkachu.com:443',
+    },
+    dest: {
+      eth: {
+        explorer: 'https://sepolia.etherscan.io',
+        chainRef: 'eip155:58008',
+        domain: 0,
+      },
+      solana: {
+        chainRef: 'solana:8E9rvCKLFQia2Y35HXjjpWzj8weVo44K',
+        domain: 5,
+      },
+    },
+  },
+  main: {
+    circle: {
+      iris: 'https://iris-api.circle.com',
+    },
+    noble: {
+      explorer: 'https://mintscan.io/noble',
+      rpc: 'https://noble-rpc.polkachu.com:443',
+    },
+    dest: {
+      eth: {
+        explorer: 'https://etherscan.io',
+        chainRef: 'eip155:1',
+        domain: 0,
+      },
+    },
+  },
+};
+const config = configs.test;
+
+const fee1 = {
+  amount: [{ denom: 'uusdc', amount: '0' }],
+  gas: '200000',
+};
+
+const makeBurnMsg = (from: NobleAddress, destId: string, amount = 1n) => {
+  // parseAccountId is defensive; can handle string
+  const dest = parseAccountId(destId as AccountId);
+  const mintRecipient = accountIdTo32Bytes(destId as AccountId);
+  const destInfo = Object.values(config.dest).find(
+    info => info.chainRef === `${dest.namespace}:${dest.reference}`,
+  );
+  if (!destInfo)
+    throw Error(`unsupported: ${dest.namespace}:${dest.reference}`);
+  const msg = {
+    typeUrl: '/circle.cctp.v1.MsgDepositForBurn',
+    value: {
+      from,
+      amount: `${amount}` as `${number}`,
+      destinationDomain: destInfo.domain,
+      mintRecipient,
+      burnToken: 'uusdc' as const,
+      // If using DepositForBurnWithCaller, add destinationCaller here
+    },
+  };
+
+  return msg;
+};
+
+/**
+ * @see {@link https://docs.noble.xyz/cctp/manual_relaying#fetching-attestation-from-circle}
+ *
+ * @param tx DepositForBurn transaction (from API)
+ */
+const attestationKey = tx => {
+  const { events } = tx.tx_response;
+  const sent = events.find(e => e.type === 'circle.cctp.v1.MessageSent');
+  const message64: string = JSON.parse(
+    sent.attributes.find(a => a.key === 'message').value,
+  );
+  const message = fromBase64(message64);
+  const hash = keccak256(message);
+  return `0x${toHex(hash)}`;
+};
+
+const makePoll = (setTimeout: typeof globalThis.setTimeout, period = 2_000) => {
+  async function* poll<T>(thunk: () => Promise<{ done: boolean; value: T }>) {
+    for (;;) {
+      const step = await thunk();
+      yield step.value;
+      if (step.done) break;
+      await new Promise(resolve => setTimeout(resolve, period));
+    }
+  }
+  return poll;
+};
+
+const main = async ({
+  env: { MNEMONIC, CCTP_DEST } = process.env,
+  connectWithSigner = SigningStargateClient.connectWithSigner,
+  fetch = globalThis.fetch,
+  setTimeout = globalThis.setTimeout,
+} = {}) => {
+  const fetchJSON = async (url: string) => {
+    const res = await fetch(url);
+    if (!res.ok) throw Error(res.statusText);
+    return res.json();
+  };
+
+  const makeNobleClient = async (mnemonic: string) => {
+    const wallet = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
+      prefix: 'noble',
+    });
+    const [{ address }] = await wallet.getAccounts();
+    console.log('source addr:', address);
+    assert(address.startsWith('noble1'));
+    const clientOpts = { registry: new Registry(cctpTypes) };
+    const client = await connectWithSigner(
+      config.noble.rpc,
+      wallet,
+      clientOpts,
+    );
+    const api = async (path: string) => fetchJSON(`${config.noble.api}${path}`);
+    return { address: address as NobleAddress, client, api };
+  };
+
+  const { client, address, api } = await makeNobleClient(MNEMONIC!);
+
+  const dest = CCTP_DEST!;
+  console.log('minting on:', dest);
+
+  const burn = makeBurnMsg(address, dest);
+  console.log('broadcasting', burn, MsgDepositForBurn.toProtoMsg(burn.value));
+  const txResp = await client.signAndBroadcast(address, [burn], fee1);
+  console.log(
+    `Burned on Noble: ${config.noble.explorer}/tx/${txResp.transactionHash}`,
+  );
+
+  const tx = await api(`/cosmos/tx/v1beta1/txs/${txResp.transactionHash}`);
+
+  const key = attestationKey(tx);
+  console.log('GET attestation', `${config.circle.iris}/attestations/${key}`);
+  const iris = (path: string) => fetchJSON(`${config.circle.iris}${path}`);
+  const tryGetAttestation = async () => {
+    try {
+      const current = await iris(`/attestations/${key}`);
+      return { done: current.status === 'complete', value: current };
+    } catch (e) {
+      return { done: false, value: e };
+    }
+  };
+  for await (const x of makePoll(setTimeout)(tryGetAttestation)) {
+    if (x instanceof Error && x.message === 'Not Found') continue;
+    console.log('attestation?', x);
+  }
+};
+
+main().catch(err => console.error(err));

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -253,6 +253,7 @@ __metadata:
     "@endo/marshal": "npm:^1.6.4"
     "@endo/patterns": "npm:^1.5.0"
     "@noble/hashes": "npm:^1.5.0"
+    bs58: "npm:^6.0.0"
   languageName: node
   linkType: soft
 
@@ -2147,6 +2148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-x@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "base-x@npm:5.0.1"
+  checksum: 10c0/4ab6b02262b4fd499b147656f63ce7328bd5f895450401ce58a2f9e87828aea507cf0c320a6d8725389f86e8a48397562661c0bca28ef3276a22821b30f7a713
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -2275,6 +2283,15 @@ __metadata:
   version: 1.1.0
   resolution: "brorand@npm:1.1.0"
   checksum: 10c0/6f366d7c4990f82c366e3878492ba9a372a73163c09871e80d82fb4ae0d23f9f8924cb8a662330308206e6b3b76ba1d528b4601c9ef73c2166b440b2ea3b7571
+  languageName: node
+  linkType: hard
+
+"bs58@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "bs58@npm:6.0.0"
+  dependencies:
+    base-x: "npm:^5.0.0"
+  checksum: 10c0/61910839746625ee4f69369f80e2634e2123726caaa1da6b3bcefcf7efcd9bdca86603360fed9664ffdabe0038c51e542c02581c72ca8d44f60329fe1a6bc8f4
   languageName: node
   linkType: hard
 

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -52,7 +52,8 @@
     "@endo/far": "^1.1.11",
     "@endo/marshal": "^1.6.4",
     "@endo/patterns": "^1.5.0",
-    "@noble/hashes": "^1.5.0"
+    "@noble/hashes": "^1.5.0",
+    "bs58": "^6.0.0"
   },
   "devDependencies": {
     "@agoric/swingset-liveslots": "^0.10.2",

--- a/packages/orchestration/src/utils/address.js
+++ b/packages/orchestration/src/utils/address.js
@@ -1,5 +1,6 @@
-import { Fail, q } from '@endo/errors';
 import { fromHex } from '@cosmjs/encoding';
+import { Fail, q } from '@endo/errors';
+import bs58 from 'bs58';
 
 /**
  * @import {IBCConnectionID} from '@agoric/vats';
@@ -172,6 +173,10 @@ export const leftPadEthAddressTo32Bytes = rawAddress => {
   return fromHex(paddedAddress);
 };
 
+/** @param {string} solanaAddress */
+const solanaAddressToCctpRecipient = solanaAddress =>
+  bs58.decode(solanaAddress);
+
 /**
  * @param {AccountId} accountId
  * @returns {Uint8Array}
@@ -182,6 +187,8 @@ export const accountIdTo32Bytes = accountId => {
   switch (namespace) {
     case 'eip155':
       return leftPadEthAddressTo32Bytes(accountAddress);
+    case 'solana':
+      return solanaAddressToCctpRecipient(accountAddress);
     default:
       throw new Error(`namespace ${namespace} not supported`);
   }

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -1,16 +1,17 @@
-import test from '@endo/ses-ava/prepare-endo.js';
 import { validateRemoteIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
+import test from '@endo/ses-ava/prepare-endo.js';
+import type { Bech32Address } from '../../src/cosmos-api.ts';
+import type { CosmosChainAddress } from '../../src/orchestration-api.ts';
 import {
-  makeICAChannelAddress,
-  makeICQChannelAddress,
+  accountIdTo32Bytes,
+  chainOfAccount,
   findAddressField,
   getBech32Prefix,
+  makeICAChannelAddress,
+  makeICQChannelAddress,
   parseAccountId,
   parseAccountIdArg,
-  chainOfAccount,
 } from '../../src/utils/address.js';
-import type { CosmosChainAddress } from '../../src/orchestration-api.ts';
-import type { Bech32Address } from '../../src/cosmos-api.ts';
 
 test('makeICAChannelAddress', t => {
   // @ts-expect-error intentional
@@ -223,3 +224,41 @@ test('extract CaipChainId from AccountIdArg', t => {
     },
   );
 });
+const cctpFixture = [
+  {
+    accountId: 'eip155:58008:0x3dA3050208a3F2e0d04b33674aAa7b1A9F9B313C',
+    mintRecipient: new Uint8Array([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 61, 163, 5, 2, 8, 163, 242, 224, 208,
+      75, 51, 103, 74, 170, 123, 26, 159, 155, 49, 60,
+    ]),
+    // verified experimentally
+    burnTx:
+      'https://mintscan.io/noble-testnet/tx/EF34EA1B0620869DBA191D07F357828F86736E38BBF1A68871570C126BC3479A',
+    attestation:
+      'https://iris-api-sandbox.circle.com/attestations/0x7fdda79bd91072a047aec03131d35a77fd002b2bde65ed5906bd11a77023bc6c',
+  },
+  {
+    accountId:
+      'solana:8E9rvCKLFQia2Y35HXjjpWzj8weVo44K:DRsKHgyrdeySBA7vjoLd9myYSVeU7T2Dkeh6pTm8ycPW',
+    mintRecipient: new Uint8Array([
+      184, 171, 19, 0, 220, 48, 13, 27, 166, 63, 130, 223, 74, 14, 79, 50, 54,
+      171, 220, 245, 113, 108, 79, 231, 48, 127, 30, 138, 24, 49, 45, 181,
+    ]),
+    burnTx:
+      'https://mintscan.io/noble-testnet/tx/E18052508A5FE77C429BC4872A63EF5477E072BECD57EAA38BD12BF4E176C4B1',
+    attestation:
+      'https://iris-api-sandbox.circle.com/attestations/0xbc1d4e14884ab29b36dd46293de5ef83ed09a44ef699cadef9607f71f3fa9fe5',
+  },
+];
+
+const mintRecipientMacro = test.macro({
+  title(txt = '', { accountId, mintRecipient: _ }) {
+    return `CCTP mintRecipient: ${accountId.slice(0, 24)}...`;
+  },
+  exec(t, { accountId, mintRecipient }) {
+    const actual = accountIdTo32Bytes(accountId);
+    t.deepEqual(actual, mintRecipient);
+  },
+});
+
+cctpFixture.forEach(detail => test(mintRecipientMacro, detail));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,6 +4424,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
+
 base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -4575,6 +4580,13 @@ browserslist@^4.22.2, browserslist@^4.22.3, browserslist@^4.23.1:
     electron-to-chromium "^1.5.41"
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
+
+bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
closes: https://github.com/Agoric/agoric-private/issues/293

## Description / Testing Considerations

 - observed CCTP depositForBurn transactions and attestations
 - captured the results as test fixtures for `accountIdTo32Bytes`
 - feat: solana support for `accountIdTo32Bytes`

### Security / Scaling Considerations / Upgrade Considerations

n/a

### Documentation Considerations

`cctp-lab.ts` shows how the fixture was generated. Is it worth keeping?
