### PR TITLE
ci(cosmic-swingset): disable rosetta test

### DIFF
--- a/packages/cosmic-swingset/test/make.test.ts
+++ b/packages/cosmic-swingset/test/make.test.ts
@@ -79,7 +79,9 @@ test.serial('make and exec', async t => {
   // TODO: check exit code? It varies.
 });
 
-test.serial('integration test: rosetta CI', async t => {
+// rosetta was renamed to mesh, which broke their install script.
+// disabled until there is a resolution to https://github.com/coinbase/mesh-cli/issues/422
+test.serial.failing('integration test: rosetta CI', async t => {
   // Resume the chain... and concurrently, start a faucet AND run the rosetta-cli tests
   const { scenario2 } = t.context;
 

--- a/packages/cosmic-swingset/test/make.test.ts
+++ b/packages/cosmic-swingset/test/make.test.ts
@@ -81,7 +81,8 @@ test.serial('make and exec', async t => {
 
 // rosetta was renamed to mesh, which broke their install script.
 // disabled until there is a resolution to https://github.com/coinbase/mesh-cli/issues/422
-test.serial.failing('integration test: rosetta CI', async t => {
+// See: https://github.com/Agoric/agoric-sdk/issues/11201
+test.serial.skip('integration test: rosetta CI', async t => {
   // Resume the chain... and concurrently, start a faucet AND run the rosetta-cli tests
   const { scenario2 } = t.context;
 


### PR DESCRIPTION
refs: https://github.com/coinbase/mesh-cli/issues/422

closes: https://github.com/Agoric/agoric-sdk/pull/11198

## Description
Disables rosetta CI test until we figure out a way to fix it.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Disables a test for a feature not well maintained

### Upgrade Considerations
None
