### PR TITLE
feat(swingset-liveslots): Support adding optional top-level fields to stateShape records

### DIFF
--- a/packages/swingset-liveslots/src/types.js
+++ b/packages/swingset-liveslots/src/types.js
@@ -22,11 +22,12 @@ export {};
  */
 
 /**
- * @typedef {{
- *   enableDisavow?: boolean,
- *   relaxDurabilityRules?: boolean,
- *   allowStateShapeChanges?: boolean,
- * }} LiveSlotsOptions
+ * @typedef {object} LiveSlotsOptions
+ * @property {boolean} [enableDisavow]
+ * @property {boolean} [relaxDurabilityRules]
+ * @property {boolean} [allowStateShapeChanges] somewhat misnamed; this actually
+ *   relates to *arbitrary* changes (per #10200, a non-true value still permits
+ *   backwards-compatible addition of new optional fields)
  *
  * @typedef {import('@endo/marshal').CapData<string>} SwingSetCapData
  *

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -7,6 +7,7 @@ import { assertPattern, mustMatch } from '@agoric/store';
 import { defendPrototype, defendPrototypeKit } from '@endo/exo/tools.js';
 import { Far, passStyleOf } from '@endo/marshal';
 import { Nat } from '@endo/nat';
+import { kindOf } from '@endo/patterns';
 import { parseVatSlot, makeBaseRef } from './parseVatSlots.js';
 import { enumerateKeysWithPrefix } from './vatstore-iterators.js';
 import { makeCache } from './cache.js';
@@ -20,6 +21,8 @@ import {
  * @import {DefineKindOptions} from '@agoric/swingset-liveslots'
  * @import {ClassContextProvider, KitContextProvider} from '@endo/exo'
  * @import {ToCapData, FromCapData} from '@endo/marshal';
+ * @import {Pattern} from '@endo/patterns';
+ * @import {SwingSetCapData} from './types.js';
  */
 
 const {
@@ -241,12 +244,47 @@ const insistDurableCapdata = (vrm, what, capdata, valueFor) => {
   }
 };
 
-const insistSameCapData = (oldCD, newCD) => {
-  // NOTE: this assumes both were marshalled with the same format
-  // (e.g. smallcaps vs pre-smallcaps). To somewhat tolerate new
-  // formats, we'd need to `serialize(unserialize(oldCD))`.
+const isUndefinedPatt = patt =>
+  patt === undefined ||
+  (kindOf(patt) === 'match:kind' && patt.payload === 'undefined');
+
+/**
+ * Assert that a new stateShape either matches the old, or only differs in the
+ * addition of new clearly-optional top-level fields as conveyed by an
+ * [Endo `M.or`]{@link https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html#or}
+ * Pattern with at least one `undefined` alternative.
+ *
+ * @param {SwingSetCapData} oldCD
+ * @param {SwingSetCapData} newCD
+ * @param {{ newShape: Record<string, Pattern>, serialize: ToCapData<string>, unserialize: FromCapData<string> }} powers
+ */
+const insistCompatibleShapeCapData = (
+  oldCD,
+  newCD,
+  { newShape, serialize, unserialize },
+) => {
   if (oldCD.body !== newCD.body) {
-    Fail`durable Kind stateShape mismatch (body)`;
+    // Allow introduction of any clearly-optional new field at top level.
+    const oldShape =
+      unserialize(oldCD) ||
+      Fail`durable Kind stateShape mismatch (no old shape)`;
+    passStyleOf(oldShape) === 'copyRecord' ||
+      Fail`durable Kind stateShape mismatch (invalid old shape)`;
+    assertPattern(oldShape);
+    for (const [name, oldPatt] of Object.entries(oldShape)) {
+      // Assert presence and CapData shape, but save slots for their own clause.
+      (Object.hasOwn(newShape, name) &&
+        serialize(newShape[name]).body === serialize(oldPatt).body) ||
+        Fail`durable Kind stateShape mismatch (body ${name})`;
+    }
+    for (const [name, newPatt] of Object.entries(newShape)) {
+      if (Object.hasOwn(oldShape, name)) continue;
+      kindOf(newPatt) === 'match:or' ||
+        Fail`durable Kind stateShape mismatch (body new field ${name})`;
+      // @ts-expect-error A "match:or" pattern has a `payload` array of Patterns
+      newPatt.payload.some(patt => isUndefinedPatt(patt)) ||
+        Fail`durable Kind stateShape mismatch (body ${name})`;
+    }
   }
   if (oldCD.slots.length !== newCD.slots.length) {
     Fail`durable Kind stateShape mismatch (slots.length)`;
@@ -532,7 +570,7 @@ export const makeVirtualObjectManager = (
    *  tag: string,
    *  unfaceted?: boolean,
    *  facets?: string[],
-   *  stateShapeCapData?: import('./types.js').SwingSetCapData
+   *  stateShapeCapData?: SwingSetCapData
    * }} DurableKindDescriptor
    */
 
@@ -803,7 +841,11 @@ export const makeVirtualObjectManager = (
 
       const oldStateShapeSlots = oldShapeCD ? oldShapeCD.slots : [];
       if (oldShapeCD && !allowStateShapeChanges) {
-        insistSameCapData(oldShapeCD, newShapeCD);
+        insistCompatibleShapeCapData(oldShapeCD, newShapeCD, {
+          newShape: /** @type {Record<string, Pattern>} */ (stateShape),
+          serialize,
+          unserialize,
+        });
       }
       const newStateShapeSlots = newShapeCD.slots;
       vrm.updateReferenceCounts(oldStateShapeSlots, newStateShapeSlots);
@@ -859,9 +901,11 @@ export const makeVirtualObjectManager = (
           const baseRef = getBaseRef(this);
           const record = dataCache.get(baseRef);
           assert(record !== undefined);
-          const { valueMap, capdatas } = record;
+          const { capdatas, valueMap } = record;
           if (!valueMap.has(prop)) {
-            const value = harden(unserialize(capdatas[prop]));
+            const value = hasOwn(capdatas, prop)
+              ? harden(unserialize(capdatas[prop]))
+              : undefined;
             checkStatePropertyValue(value, prop);
             valueMap.set(prop, value);
           }
@@ -877,12 +921,19 @@ export const makeVirtualObjectManager = (
           }
           const record = dataCache.get(baseRef); // mutable
           assert(record !== undefined);
-          const oldSlots = record.capdatas[prop].slots;
+          const { capdatas, valueMap } = record;
+          const oldSlots = hasOwn(capdatas, prop) ? capdatas[prop].slots : [];
           const newSlots = capdata.slots;
           vrm.updateReferenceCounts(oldSlots, newSlots);
-          record.capdatas[prop] = capdata; // modify in place ..
-          record.valueMap.set(prop, value);
-          dataCache.set(baseRef, record); // .. but mark as dirty
+          // modify in place, but mark as dirty
+          defineProperty(capdatas, prop, {
+            value: capdata,
+            writable: true,
+            enumerable: true,
+            configurable: false,
+          });
+          valueMap.set(prop, value);
+          dataCache.set(baseRef, record);
         },
         enumerable: true,
         configurable: false,
@@ -1073,7 +1124,12 @@ export const makeVirtualObjectManager = (
         }
         // eslint-disable-next-line github/array-foreach
         valueCD.slots.forEach(vrm.addReachableVref);
-        capdatas[prop] = valueCD;
+        defineProperty(capdatas, prop, {
+          value: valueCD,
+          writable: true,
+          enumerable: true,
+          configurable: false,
+        });
         valueMap.set(prop, value);
       }
       // dataCache contents remain mutable: state setter modifies in-place

--- a/packages/swingset-liveslots/test/util.js
+++ b/packages/swingset-liveslots/test/util.js
@@ -59,8 +59,8 @@ export function makeMessage(target, method, args = [], result = null) {
   return vatDeliverObject;
 }
 
-export function makeStartVat(vatParameters) {
-  return harden(['startVat', vatParameters]);
+export function makeStartVat(vatParametersCapData = kser(undefined)) {
+  return harden(['startVat', vatParametersCapData]);
 }
 
 export function makeBringOutYourDead() {

--- a/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
@@ -215,7 +215,7 @@ test('durable stateShape refcounts', async t => {
   t.is(ls2.testHooks.getReachableRefCount(vref2), 1);
 });
 
-test.failing('durable stateShape must match or extend', async t => {
+test('durable stateShape must match or extend', async t => {
   const store1 = new Map();
   const { syscall: sc1, log: log1 } = buildSyscall({ kvStore: store1 });
   const gcTools = makeMockGC();

--- a/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
@@ -10,20 +10,29 @@ import { makeStartVat, makeMessage } from '../util.js';
 import { makeMockGC } from '../mock-gc.js';
 import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
 
-function makeGenericRemotable(typeName) {
-  return Far(typeName, {
-    aMethod() {
-      return 'whatever';
-    },
-  });
-}
-const eph1 = makeGenericRemotable('ephemeral1');
-const eph2 = makeGenericRemotable('ephemeral2');
+/** @import {VatData} from '../../src/vatDataTypes.js'; */
 
-const init = value => ({ value });
-const behavior = {
+const eph1 = Far('ephemeral1');
+const eph2 = Far('ephemeral2');
+
+const initHolder = value => ({ value });
+const holderMethods = {
+  get: ({ state }) => state.value,
   set: ({ state }, value) => (state.value = value),
 };
+/**
+ * Define a virtual or durable kind for getting and setting a single value
+ * constrained by the provided shape.
+ *
+ * @template {VatData.defineKind | VatData.defineDurableKind} D
+ * @param {D} defineKind
+ * @param {Parameters<D>[0]} kindIdentifier
+ * @param {import('@endo/patterns').Pattern} valueShape
+ */
+const defineHolder = (defineKind, kindIdentifier, valueShape) =>
+  defineKind(kindIdentifier, initHolder, holderMethods, {
+    stateShape: { value: valueShape },
+  });
 
 // virtual/durable Kinds can specify a 'stateShape', which should be
 // enforced at both initialization and subsequent state changes
@@ -31,9 +40,7 @@ const testStateShape = test.macro((t, valueShape, config) => {
   const { goodValues, badValues, throwsExpectation } = config;
   const { vom } = makeFakeVirtualStuff();
   const { defineKind } = vom;
-  const makeHolder = defineKind('kindTag', init, behavior, {
-    stateShape: { value: valueShape },
-  });
+  const makeHolder = defineHolder(defineKind, 'kindTag', valueShape);
   const instance = goodValues.map(value => makeHolder(value)).at(-1);
   for (const value of goodValues) {
     instance.set(value);
@@ -70,44 +77,44 @@ test('constrain state shape - specific remotable', testStateShape, eph1, {
 
 // durable Kinds serialize and store their stateShape, which must
 // itself be durable
-
 test('durable state shape', t => {
   // note: relaxDurabilityRules defaults to true in fake tools
   const { vom } = makeFakeVirtualStuff({ relaxDurabilityRules: false });
   const { makeKindHandle, defineDurableKind } = vom;
 
-  const make = (which, stateShape) => {
-    const kh = makeKindHandle(`kind${which}`);
-    return defineDurableKind(kh, init, behavior, { stateShape });
+  let kindNumber = 0;
+  const defineNextKind = valueShape => {
+    kindNumber += 1;
+    const kh = makeKindHandle(`kind${kindNumber}`);
+    return defineHolder(defineDurableKind, kh, valueShape);
   };
 
-  const makeKind1 = make(1);
+  const makeKind1 = defineNextKind();
   makeKind1();
 
-  const makeKind2 = make(2);
+  const makeKind2 = defineNextKind();
   makeKind2();
 
-  const makeKind3 = make(3, { value: M.any() });
+  const makeKind3 = defineNextKind(M.any());
   const obj3 = makeKind3();
 
-  const makeKind4 = make(4, { value: M.string() });
+  const makeKind4 = defineNextKind(M.string());
   const obj4 = makeKind4('string');
 
-  const makeKind5 = make(5, { value: M.remotable() });
+  const makeKind5 = defineNextKind(M.remotable());
   const durableValueFail = { message: /value for "value" is not durable/ };
   t.throws(() => makeKind5(eph1), durableValueFail);
 
   const durableShapeFail = { message: /stateShape.*is not durable: slot 0 of/ };
-  t.throws(() => make(6, { value: eph1 }), durableShapeFail);
+  t.throws(() => defineNextKind(eph1), durableShapeFail);
 
-  const makeKind7 = make(7, { value: obj4 }); // obj4 is durable
+  const makeKind7 = defineNextKind(obj4); // obj4 is durable
   makeKind7(obj4);
   const specificRemotableFail = { message: /kind3.*Must be:.*kind4/ };
   t.throws(() => makeKind7(obj3), specificRemotableFail);
 });
 
 // durable Kinds maintain refcounts on their serialized stateShape
-
 test('durable stateShape refcounts', async t => {
   const kvStore = new Map();
   const { syscall: sc1 } = buildSyscall({ kvStore });
@@ -118,12 +125,11 @@ test('durable stateShape refcounts', async t => {
     const { makeKindHandle, defineDurableKind } = VatData;
 
     return Far('root', {
-      accept: _standard1 => 0, // assign it a vref
-      create: standard1 => {
+      accept: _ref => {}, // assigns a vref
+      create: valueShape => {
         const kh = makeKindHandle('shaped');
         baggage.init('kh', kh);
-        const stateShape = { value: standard1 };
-        defineDurableKind(kh, init, behavior, { stateShape });
+        defineHolder(defineDurableKind, kh, valueShape);
       },
     });
   }
@@ -153,10 +159,9 @@ test('durable stateShape refcounts', async t => {
   function build2(vatPowers, vatParameters, baggage) {
     const { VatData } = vatPowers;
     const { defineDurableKind } = VatData;
-    const { standard2 } = vatParameters;
+    const { valueShape } = vatParameters;
     const kh = baggage.get('kh');
-    const stateShape = { value: standard2 };
-    defineDurableKind(kh, init, behavior, { stateShape });
+    defineHolder(defineDurableKind, kh, valueShape);
 
     return Far('root', {});
   }
@@ -177,7 +182,7 @@ test('durable stateShape refcounts', async t => {
   );
 
   const standard2Vref = 'o-2';
-  const vp = { standard2: kslot(standard2Vref) };
+  const vp = { valueShape: kslot(standard2Vref) };
   const startVat2 = makeStartVat(kser(vp));
   await ls2.dispatch(startVat2);
 
@@ -203,7 +208,7 @@ test('durable stateShape must match', async t => {
         const kh = makeKindHandle('shaped');
         baggage.init('kh', kh);
         const stateShape = { x: obj1, y: obj2 };
-        defineDurableKind(kh, init, behavior, { stateShape });
+        defineDurableKind(kh, initHolder, holderMethods, { stateShape });
       },
     });
   }
@@ -233,6 +238,9 @@ test('durable stateShape must match', async t => {
     const { defineDurableKind } = VatData;
     const { obj1, obj2 } = vatParameters;
     const kh = baggage.get('kh');
+    const redefineDurableKind = stateShape => {
+      defineDurableKind(kh, initHolder, holderMethods, { stateShape });
+    };
     // several shapes that are not compatible
     const shape1 = { x: obj1, y: M.any() };
     const shape2 = { x: obj1 };
@@ -240,10 +248,9 @@ test('durable stateShape must match', async t => {
     const shape4 = { x: M.or(obj1, M.string()), y: obj2 };
     const shape5 = { x: obj2, y: obj1 }; // wrong slots
     const trial = shape => {
-      t.throws(
-        () => defineDurableKind(kh, init, behavior, { stateShape: shape }),
-        { message: /durable Kind stateShape mismatch/ },
-      );
+      t.throws(() => redefineDurableKind(shape), {
+        message: /durable Kind stateShape mismatch/,
+      });
     };
     trial(shape1);
     trial(shape2);
@@ -251,7 +258,7 @@ test('durable stateShape must match', async t => {
     trial(shape4);
     trial(shape5);
     const stateShape = { x: obj1, y: obj2 }; // the correct shape
-    defineDurableKind(kh, init, behavior, { stateShape });
+    redefineDurableKind(stateShape);
     t.pass();
 
     return Far('root', {});

--- a/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
@@ -196,8 +196,7 @@ test('durable stateShape must match', async t => {
         defineDurableKind: (x, y) => {
           const kh = makeKindHandle('shaped');
           baggage.init('kh', kh);
-          const stateShape = { x, y };
-          defineDurableKind(kh, initHolder, holderMethods, { stateShape });
+          defineHolder(defineDurableKind, kh, { x, y });
         },
       });
     };
@@ -229,25 +228,21 @@ test('durable stateShape must match', async t => {
       const { defineDurableKind } = VatData;
       const { x, y } = vatParameters;
       const kh = baggage.get('kh');
-      const redefineDurableKind = stateShape => {
-        defineDurableKind(kh, initHolder, holderMethods, { stateShape });
+      const redefineDurableKind = valueShape => {
+        defineHolder(defineDurableKind, kh, valueShape);
       };
       // several shapes that are not compatible
-      const shape1 = { x, y: M.any() };
-      const shape2 = { x };
-      const shape3 = { x, y, z: M.string() };
-      const shape4 = { x: M.or(x, M.string()), y };
-      const shape5 = { x: y, y: x }; // wrong slots
-      const trial = shape => {
-        t.throws(() => redefineDurableKind(shape), {
-          message: /durable Kind stateShape mismatch/,
-        });
-      };
-      trial(shape1);
-      trial(shape2);
-      trial(shape3);
-      trial(shape4);
-      trial(shape5);
+      const badShapes = [
+        { x, y: M.any() },
+        { x },
+        { x, y, z: M.string() },
+        { x: M.or(x, M.string()), y },
+        { x: y, y: x }, // wrong slots
+      ];
+      const expectation = { message: /durable Kind stateShape mismatch/ };
+      for (const valueShape of badShapes) {
+        t.throws(() => redefineDurableKind(valueShape), expectation);
+      }
       // the correct shape
       redefineDurableKind({ x, y });
 

--- a/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
@@ -139,14 +139,13 @@ test('durable stateShape refcounts', async t => {
   await ls1.dispatch(makeStartVat());
   const root = 'o+0';
 
+  // accepting a ref but doing nothing with it does not increment its refcount
   const vref1 = 'o-1';
-  await ls1.dispatch(makeMessage(root, 'acceptRef', []));
+  await ls1.dispatch(makeMessage(root, 'acceptRef', [kslot(vref1)]));
   t.is(ls1.testHooks.getReachableRefCount(vref1), 0);
 
+  // ...but using it in stateShape does
   await ls1.dispatch(makeMessage(root, 'defineDurableKind', [kslot(vref1)]));
-
-  // using our 'vref1' object in stateShape causes its refcount to
-  // be incremented
   t.is(ls1.testHooks.getReachableRefCount(vref1), 1);
 
   // ------

--- a/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
@@ -120,24 +120,23 @@ test('durable stateShape refcounts', async t => {
   const { syscall: sc1 } = buildSyscall({ kvStore });
   const gcTools = makeMockGC();
 
-  function build1(vatPowers, _vp, baggage) {
-    const { VatData } = vatPowers;
-    const { makeKindHandle, defineDurableKind } = VatData;
+  const ls1 = makeLiveSlots(sc1, 'vatA', {}, {}, gcTools, undefined, () => {
+    const buildRootObject = (vatPowers, _vatParameters, baggage) => {
+      const { VatData } = vatPowers;
+      const { makeKindHandle, defineDurableKind } = VatData;
 
-    return Far('root', {
-      accept: _ref => {}, // assigns a vref
-      create: valueShape => {
-        const kh = makeKindHandle('shaped');
-        baggage.init('kh', kh);
-        defineHolder(defineDurableKind, kh, valueShape);
-      },
-    });
-  }
-
-  const makeNS1 = () => ({ buildRootObject: build1 });
-  const ls1 = makeLiveSlots(sc1, 'vatA', {}, {}, gcTools, undefined, makeNS1);
-  const startVat1 = makeStartVat(kser());
-  await ls1.dispatch(startVat1);
+      return Far('root', {
+        accept: _ref => {}, // assigns a vref
+        create: valueShape => {
+          const kh = makeKindHandle('shaped');
+          baggage.init('kh', kh);
+          defineHolder(defineDurableKind, kh, valueShape);
+        },
+      });
+    };
+    return { buildRootObject };
+  });
+  await ls1.dispatch(makeStartVat());
   const rootA = 'o+0';
 
   const standard1Vref = 'o-1';
@@ -156,30 +155,22 @@ test('durable stateShape refcounts', async t => {
   const clonedStore = new Map(kvStore);
   const { syscall: sc2 } = buildSyscall({ kvStore: clonedStore });
 
-  function build2(vatPowers, vatParameters, baggage) {
-    const { VatData } = vatPowers;
-    const { defineDurableKind } = VatData;
-    const { valueShape } = vatParameters;
-    const kh = baggage.get('kh');
-    defineHolder(defineDurableKind, kh, valueShape);
-
-    return Far('root', {});
-  }
-
   // to test refcount increment/decrement, we need to override the
   // usual rule that the new version must exactly match the original
   // stateShape
-  const options = { allowStateShapeChanges: true };
-  const makeNS2 = () => ({ buildRootObject: build2 });
-  const ls2 = makeLiveSlots(
-    sc2,
-    'vatA',
-    {},
-    options,
-    gcTools,
-    undefined,
-    makeNS2,
-  );
+  const opts = { allowStateShapeChanges: true };
+  const ls2 = makeLiveSlots(sc2, 'vatA', {}, opts, gcTools, undefined, () => {
+    const buildRootObject = (vatPowers, vatParameters, baggage) => {
+      const { VatData } = vatPowers;
+      const { defineDurableKind } = VatData;
+      const { valueShape } = vatParameters;
+      const kh = baggage.get('kh');
+      defineHolder(defineDurableKind, kh, valueShape);
+
+      return Far('root', {});
+    };
+    return { buildRootObject };
+  });
 
   const standard2Vref = 'o-2';
   const vp = { valueShape: kslot(standard2Vref) };
@@ -199,24 +190,23 @@ test('durable stateShape must match', async t => {
   const { syscall: sc1 } = buildSyscall({ kvStore });
   const gcTools = makeMockGC();
 
-  function build1(vatPowers, _vp, baggage) {
-    const { VatData } = vatPowers;
-    const { makeKindHandle, defineDurableKind } = VatData;
+  const ls1 = makeLiveSlots(sc1, 'vatA', {}, {}, gcTools, undefined, () => {
+    const buildRootObject = (vatPowers, _vatParameters, baggage) => {
+      const { VatData } = vatPowers;
+      const { makeKindHandle, defineDurableKind } = VatData;
 
-    return Far('root', {
-      create: (obj1, obj2) => {
-        const kh = makeKindHandle('shaped');
-        baggage.init('kh', kh);
-        const stateShape = { x: obj1, y: obj2 };
-        defineDurableKind(kh, initHolder, holderMethods, { stateShape });
-      },
-    });
-  }
-
-  const makeNS1 = () => ({ buildRootObject: build1 });
-  const ls1 = makeLiveSlots(sc1, 'vatA', {}, {}, gcTools, undefined, makeNS1);
-  const startVat1 = makeStartVat(kser());
-  await ls1.dispatch(startVat1);
+      return Far('root', {
+        create: (obj1, obj2) => {
+          const kh = makeKindHandle('shaped');
+          baggage.init('kh', kh);
+          const stateShape = { x: obj1, y: obj2 };
+          defineDurableKind(kh, initHolder, holderMethods, { stateShape });
+        },
+      });
+    };
+    return { buildRootObject };
+  });
+  await ls1.dispatch(makeStartVat());
   const rootA = 'o+0';
 
   const vref1 = 'o-1';
@@ -233,50 +223,42 @@ test('durable stateShape must match', async t => {
   const clonedStore = new Map(kvStore);
   const { syscall: sc2 } = buildSyscall({ kvStore: clonedStore });
 
-  function build2(vatPowers, vatParameters, baggage) {
-    const { VatData } = vatPowers;
-    const { defineDurableKind } = VatData;
-    const { obj1, obj2 } = vatParameters;
-    const kh = baggage.get('kh');
-    const redefineDurableKind = stateShape => {
-      defineDurableKind(kh, initHolder, holderMethods, { stateShape });
-    };
-    // several shapes that are not compatible
-    const shape1 = { x: obj1, y: M.any() };
-    const shape2 = { x: obj1 };
-    const shape3 = { x: obj1, y: obj2, z: M.string() };
-    const shape4 = { x: M.or(obj1, M.string()), y: obj2 };
-    const shape5 = { x: obj2, y: obj1 }; // wrong slots
-    const trial = shape => {
-      t.throws(() => redefineDurableKind(shape), {
-        message: /durable Kind stateShape mismatch/,
-      });
-    };
-    trial(shape1);
-    trial(shape2);
-    trial(shape3);
-    trial(shape4);
-    trial(shape5);
-    const stateShape = { x: obj1, y: obj2 }; // the correct shape
-    redefineDurableKind(stateShape);
-    t.pass();
-
-    return Far('root', {});
-  }
-
   // we do *not* override allowStateShapeChanges
-  // const options = { allowStateShapeChanges: true };
-  const options = undefined;
-  const makeNS2 = () => ({ buildRootObject: build2 });
-  const ls2 = makeLiveSlots(
-    sc2,
-    'vatA',
-    {},
-    options,
-    gcTools,
-    undefined,
-    makeNS2,
-  );
+  // const opts = { allowStateShapeChanges: true };
+  const opts = undefined;
+  const ls2 = makeLiveSlots(sc2, 'vatA', {}, opts, gcTools, undefined, () => {
+    const buildRootObject = (vatPowers, vatParameters, baggage) => {
+      const { VatData } = vatPowers;
+      const { defineDurableKind } = VatData;
+      const { obj1, obj2 } = vatParameters;
+      const kh = baggage.get('kh');
+      const redefineDurableKind = stateShape => {
+        defineDurableKind(kh, initHolder, holderMethods, { stateShape });
+      };
+      // several shapes that are not compatible
+      const shape1 = { x: obj1, y: M.any() };
+      const shape2 = { x: obj1 };
+      const shape3 = { x: obj1, y: obj2, z: M.string() };
+      const shape4 = { x: M.or(obj1, M.string()), y: obj2 };
+      const shape5 = { x: obj2, y: obj1 }; // wrong slots
+      const trial = shape => {
+        t.throws(() => redefineDurableKind(shape), {
+          message: /durable Kind stateShape mismatch/,
+        });
+      };
+      trial(shape1);
+      trial(shape2);
+      trial(shape3);
+      trial(shape4);
+      trial(shape5);
+      const stateShape = { x: obj1, y: obj2 }; // the correct shape
+      redefineDurableKind(stateShape);
+      t.pass();
+
+      return Far('root', {});
+    };
+    return { buildRootObject };
+  });
 
   const vp = { obj1: kslot(vref1), obj2: kslot(vref2) };
   const startVat2 = makeStartVat(kser(vp));

--- a/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/state-shape.test.js
@@ -44,24 +44,29 @@ const dispatchForResult = async (ls, syscallLog, message) => {
 const eph1 = Far('ephemeral1');
 const eph2 = Far('ephemeral2');
 
-const initHolder = value => ({ value });
+const initHolder = fields => ({ ...fields });
 const holderMethods = {
-  get: ({ state }) => state.value,
-  set: ({ state }, value) => (state.value = value),
+  get: ({ state }, ...fields) =>
+    // We require fields to be explicit because they are currently defined on
+    // the state *prototype*.
+    Object.fromEntries(
+      fields.flatMap(key => (key in state ? [[key, state[key]]] : [])),
+    ),
+  set: ({ state }, fields) => {
+    Object.assign(state, fields);
+  },
 };
 /**
- * Define a virtual or durable kind for getting and setting a single value
- * constrained by the provided shape.
+ * Define a virtual or durable kind for getting and setting state constrained
+ * by the provided shape.
  *
  * @template {VatData.defineKind | VatData.defineDurableKind} D
  * @param {D} defineKind
  * @param {Parameters<D>[0]} kindIdentifier
- * @param {import('@endo/patterns').Pattern} valueShape
+ * @param {import('@endo/patterns').Pattern} stateShape
  */
-const defineHolder = (defineKind, kindIdentifier, valueShape) =>
-  defineKind(kindIdentifier, initHolder, holderMethods, {
-    stateShape: { value: valueShape },
-  });
+const defineHolder = (defineKind, kindIdentifier, stateShape) =>
+  defineKind(kindIdentifier, initHolder, holderMethods, { stateShape });
 
 // virtual/durable Kinds can specify a 'stateShape', which should be
 // enforced at both initialization and subsequent state changes
@@ -69,14 +74,14 @@ const testStateShape = test.macro((t, valueShape, config) => {
   const { goodValues, badValues, throwsExpectation } = config;
   const { vom } = makeFakeVirtualStuff();
   const { defineKind } = vom;
-  const makeHolder = defineHolder(defineKind, 'kindTag', valueShape);
-  const instance = goodValues.map(value => makeHolder(value)).at(-1);
+  const makeHolder = defineHolder(defineKind, 'kindTag', { value: valueShape });
+  const instance = goodValues.map(value => makeHolder({ value })).at(-1);
   for (const value of goodValues) {
-    instance.set(value);
+    instance.set({ value });
   }
   for (const value of badValues || []) {
-    t.throws(() => makeHolder(value), throwsExpectation);
-    t.throws(() => instance.set(value), throwsExpectation);
+    t.throws(() => makeHolder({ value }), throwsExpectation);
+    t.throws(() => instance.set({ value }), throwsExpectation);
   }
   t.pass();
 });
@@ -115,11 +120,11 @@ test('durable state shape', t => {
   const defineNextKind = valueShape => {
     kindNumber += 1;
     const kh = makeKindHandle(`kind${kindNumber}`);
-    return defineHolder(defineDurableKind, kh, valueShape);
+    return defineHolder(defineDurableKind, kh, { value: valueShape });
   };
 
   const makeKind1 = defineNextKind();
-  makeKind1();
+  makeKind1({ value: undefined });
 
   const makeKind2 = defineNextKind();
   makeKind2();
@@ -128,19 +133,19 @@ test('durable state shape', t => {
   const obj3 = makeKind3();
 
   const makeKind4 = defineNextKind(M.string());
-  const obj4 = makeKind4('string');
+  const obj4 = makeKind4({ value: 'string' });
 
   const makeKind5 = defineNextKind(M.remotable());
   const durableValueFail = { message: /value for "value" is not durable/ };
-  t.throws(() => makeKind5(eph1), durableValueFail);
+  t.throws(() => makeKind5({ value: eph1 }), durableValueFail);
 
   const durableShapeFail = { message: /stateShape.*is not durable: slot 0 of/ };
   t.throws(() => defineNextKind(eph1), durableShapeFail);
 
   const makeKind7 = defineNextKind(obj4); // obj4 is durable
-  makeKind7(obj4);
+  makeKind7({ value: obj4 });
   const specificRemotableFail = { message: /kind3.*Must be:.*kind4/ };
-  t.throws(() => makeKind7(obj3), specificRemotableFail);
+  t.throws(() => makeKind7({ value: obj3 }), specificRemotableFail);
 });
 
 // durable Kinds maintain refcounts on their serialized stateShape
@@ -159,7 +164,7 @@ test('durable stateShape refcounts', async t => {
         defineDurableKind: valueShape => {
           const kh = makeKindHandle('shaped');
           baggage.init('kh', kh);
-          defineHolder(defineDurableKind, kh, valueShape);
+          defineHolder(defineDurableKind, kh, { value: valueShape });
         },
       });
     };
@@ -193,7 +198,7 @@ test('durable stateShape refcounts', async t => {
       const { defineDurableKind } = VatData;
       const { valueShape } = vatParameters;
       const kh = baggage.get('kh');
-      defineHolder(defineDurableKind, kh, valueShape);
+      defineHolder(defineDurableKind, kh, { value: valueShape });
 
       return Far('root', {});
     };
@@ -210,11 +215,12 @@ test('durable stateShape refcounts', async t => {
   t.is(ls2.testHooks.getReachableRefCount(vref2), 1);
 });
 
-test('durable stateShape must match', async t => {
-  const kvStore = new Map();
-  const { syscall: sc1, log: log1 } = buildSyscall({ kvStore });
+test.failing('durable stateShape must match or extend', async t => {
+  const store1 = new Map();
+  const { syscall: sc1, log: log1 } = buildSyscall({ kvStore: store1 });
   const gcTools = makeMockGC();
 
+  const fields = ['x', 'x2', 'y']; // but "x2" is not initially present
   const ls1 = makeLiveSlots(sc1, 'vatA', {}, {}, gcTools, undefined, () => {
     const buildRootObject = (vatPowers, _vatParameters, baggage) => {
       const { VatData } = vatPowers;
@@ -236,33 +242,39 @@ test('durable stateShape must match', async t => {
 
   const vref1 = 'o-1';
   const vref2 = 'o-2';
+  const passables = new Map([
+    [vref1, kslot(vref1, vref1)],
+    [vref2, kslot(vref2, vref2)],
+  ]);
   const instance1 = await dispatchForResult(ls1, log1, [
     root,
     'makeShapedDurable',
-    [kslot(vref1), kslot(vref2)],
+    [passables.get(vref1), passables.get(vref2)],
   ]);
-  const instance1Ref = instance1.getKref();
-  const state1 = await dispatchForResult(ls1, log1, [instance1Ref, 'get']);
-  t.deepEqual(kser(state1), kser({ x: kslot(vref1), y: kslot(vref2) }));
+  const objRef = instance1.getKref();
+  const state1 = await dispatchForResult(ls1, log1, [objRef, 'get', fields]);
+  t.deepEqual(
+    kser(state1),
+    kser({ x: passables.get(vref1), y: passables.get(vref2) }),
+  );
 
   // ------
 
   // Simulate upgrade by starting from the non-empty kvStore.
-  const clonedStore = new Map(kvStore);
-  const { syscall: sc2, log: log2 } = buildSyscall({ kvStore: clonedStore });
+  const store2 = new Map(store1);
+  const { syscall: sc2, log: log2 } = buildSyscall({ kvStore: store2 });
 
   // we do *not* override allowStateShapeChanges
   // const opts = { allowStateShapeChanges: true };
   const opts = undefined;
+  const stateShapeMismatch = { message: /durable Kind stateShape mismatch/ };
   const ls2 = makeLiveSlots(sc2, 'vatA', {}, opts, gcTools, undefined, () => {
     const buildRootObject = (vatPowers, vatParameters, baggage) => {
       const { VatData } = vatPowers;
-      const { defineDurableKind } = VatData;
       const { x, y } = vatParameters;
       const kh = baggage.get('kh');
-      const redefineDurableKind = valueShape => {
-        defineHolder(defineDurableKind, kh, valueShape);
-      };
+      const redefineDurableKind = stateShape =>
+        defineHolder(VatData.defineDurableKind, kh, stateShape);
       // several shapes that are not compatible
       const badShapes = [
         { x, y: M.any() },
@@ -271,9 +283,8 @@ test('durable stateShape must match', async t => {
         { x: M.or(x, M.string()), y },
         { x: y, y: x }, // wrong slots
       ];
-      const expectation = { message: /durable Kind stateShape mismatch/ };
-      for (const valueShape of badShapes) {
-        t.throws(() => redefineDurableKind(valueShape), expectation);
+      for (const stateShape of badShapes) {
+        t.throws(() => redefineDurableKind(stateShape), stateShapeMismatch);
       }
       // the correct shape
       redefineDurableKind({ x, y });
@@ -283,9 +294,96 @@ test('durable stateShape must match', async t => {
     return { buildRootObject };
   });
 
-  const vatParameters = { x: kslot(vref1), y: kslot(vref2) };
-  await ls2.dispatch(makeStartVat(kser(vatParameters)));
+  const vatParameters2 = { x: passables.get(vref1), y: passables.get(vref2) };
+  await ls2.dispatch(makeStartVat(kser(vatParameters2)));
 
-  const state2 = await dispatchForResult(ls2, log2, [instance1Ref, 'get']);
+  const state2 = await dispatchForResult(ls2, log2, [objRef, 'get', fields]);
   t.deepEqual(kser(state2), kser(state1));
+
+  // ------
+
+  // Now upgrade again, first to add a new optional stateShape field x2 and then
+  // to preserve the new shape.
+  const store3 = new Map(store2);
+  const { syscall: sc3, log: log3 } = buildSyscall({ kvStore: store3 });
+  const ls3 = makeLiveSlots(sc3, 'vatA', {}, {}, gcTools, undefined, () => {
+    const buildRootObject = ({ VatData }, vatParameters, baggage) => {
+      const { x, y } = vatParameters;
+      const kh = baggage.get('kh');
+      const redefineDurableKind = stateShape =>
+        defineHolder(VatData.defineDurableKind, kh, stateShape);
+      const badShapes = [{ x, x2: x, y }];
+      for (const stateShape of badShapes) {
+        t.throws(() => redefineDurableKind(stateShape), stateShapeMismatch);
+      }
+      redefineDurableKind({ x, x2: M.or(M.undefined(), x), y });
+      return Far('root', {});
+    };
+    return { buildRootObject };
+  });
+  const vatParameters3 = { x: passables.get(vref1), y: passables.get(vref2) };
+  await ls3.dispatch(makeStartVat(kser(vatParameters3)));
+
+  const state3 = await dispatchForResult(ls3, log3, [objRef, 'get', fields]);
+  t.deepEqual(kser(state3), kser({ ...state1, x2: undefined }));
+  const makeVerificationCase = (x, x2, y, throwsMessage) => [
+    `{ x: ${x}, x2: ${x2}, y: ${y} }`,
+    { x: passables.get(x), x2: passables.get(x2), y: passables.get(y) },
+    throwsMessage,
+  ];
+  const verifications = [
+    makeVerificationCase(vref1, vref2, vref2, 'rejected'),
+    makeVerificationCase(vref1, vref1, vref2),
+    makeVerificationCase(vref1, undefined, vref2),
+  ];
+  let lastState = state3;
+  for (const [label, value, message] of verifications) {
+    const tryUpdate = () =>
+      dispatchForResult(ls3, log3, [objRef, 'set', [value]]);
+    await (message
+      ? t.throwsAsync(tryUpdate, { message }, `${label} ${message}`)
+      : tryUpdate());
+    const state = await dispatchForResult(ls3, log3, [objRef, 'get', fields]);
+    const expectState = message ? lastState : value;
+    t.deepEqual(kser(state), kser(expectState), `${label}`);
+    lastState = state;
+  }
+
+  const store4 = new Map(store3);
+  const { syscall: sc4, log: log4 } = buildSyscall({ kvStore: store4 });
+  const ls4 = makeLiveSlots(sc4, 'vatA', {}, {}, gcTools, undefined, () => {
+    const buildRootObject = ({ VatData }, vatParameters, baggage) => {
+      const { x, y } = vatParameters;
+      const kh = baggage.get('kh');
+      const redefineDurableKind = stateShape =>
+        defineHolder(VatData.defineDurableKind, kh, stateShape);
+      const badShapes = [
+        // Removing optionality from x2.
+        { x, x2: x, y },
+        // Equivalent but not *equal* to M.or(M.undefined(), x).
+        { x, x2: M.or(undefined, x), y },
+        { x, x2: M.or(x, M.undefined()), y },
+      ];
+      for (const stateShape of badShapes) {
+        t.throws(() => redefineDurableKind(stateShape), stateShapeMismatch);
+      }
+      redefineDurableKind({ x, x2: M.or(M.undefined(), x), y });
+      return Far('root', {});
+    };
+    return { buildRootObject };
+  });
+  const vatParameters4 = { x: passables.get(vref1), y: passables.get(vref2) };
+  await ls4.dispatch(makeStartVat(kser(vatParameters4)));
+
+  for (const [label, value, message] of verifications) {
+    const tryUpdate = () =>
+      dispatchForResult(ls4, log4, [objRef, 'set', [value]]);
+    await (message
+      ? t.throwsAsync(tryUpdate, { message }, `${label} ${message}`)
+      : tryUpdate());
+    const state = await dispatchForResult(ls4, log4, [objRef, 'get', fields]);
+    const expectState = message ? lastState : value;
+    t.deepEqual(kser(state), kser(expectState), `${label}`);
+    lastState = state;
+  }
 });


### PR DESCRIPTION
Fixes #10200

## Description
Updates the liveslots virtual object manager (VOM) to allow a new incarnation to add top-level fields to an existing kind stateShape, as long as they are clearly optional (consisting of a ["match:or" Pattern](https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html#or) in which at least one alternative is `undefined`) and regardless of `allowStateShapeChanges` configuration (i.e., they are allowed even when that setting is false, because they are backwards compatible).

### Security Considerations
Any code specifying a stateShape in which a field can be undefined is responsible for accommodating old values in which that field _is_ undefined.
The VOM state record field accessors are also updated to tolerate values missing in the backing store, but such a change is safe because those accessors only exist for known fields.

### Scaling Considerations
`buildRootObject` will be slower when the new stateShape does not match the old, because we will now be deserializing the old and serializing the old and new patterns for comparison. But stateShape records are not expected to be large.

### Documentation Considerations
None known.

### Testing Considerations
packages/swingset-liveslots/test/virtual-objects/state-shape.test.js should provide sufficient coverage, although exo-specific testing could also be added.

### Upgrade Considerations
New vat code can only take advantage of this with an updated liveslots, which should happen as part of vat upgrade anyway.