### PR TITLE
fix(ci): docker-build-test failing with out of disk error

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,7 +126,7 @@ jobs:
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
 
-    runs-on: ubuntu-22.04 # jammy (LTS)
+    runs-on: 'ubuntu-22.04-4core-150SSD-16RAM'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -231,7 +231,7 @@ jobs:
   test-docker-build:
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-22.04-4core-150SSD-16RAM'
     timeout-minutes: 60
     steps:
       - name: update job environment


### PR DESCRIPTION
closes: #11213

## Description
Increased the storage of the runner by using a large runner

### Security Considerations
None

### Scaling Considerations
The default scaling of the standard runner is used

### Documentation Considerations
None

### Testing Considerations
The PR tests should pass

### Upgrade Considerations
None
