### PR TITLE
refactorings to support AccountId pervasively

### DIFF
--- a/multichain-testing/test/fast-usdc/noble-forwarding.test.ts
+++ b/multichain-testing/test/fast-usdc/noble-forwarding.test.ts
@@ -2,7 +2,7 @@ import anyTest from '@endo/ses-ava/prepare-endo.js';
 import type { TestFn } from 'ava';
 import { commonSetup, type SetupContext } from '../support.js';
 import { createWallet } from '../../tools/wallet.js';
-import type { IBCConnectionInfo } from '@agoric/orchestration';
+import type { Bech32Address, IBCConnectionInfo } from '@agoric/orchestration';
 import { makeQueryClient } from '../../tools/query.js';
 
 const test = anyTest as TestFn<SetupContext>;
@@ -12,7 +12,8 @@ test('noble forwarding', async t => {
     await commonSetup(t, { config: '../config.fusdc.yaml' });
 
   const agoricWallet = await createWallet('agoric');
-  const agoricAddr = (await agoricWallet.getAccounts())[0].address;
+  const agoricAddr = (await agoricWallet.getAccounts())[0]
+    .address as Bech32Address;
   t.log('Made agoric wallet:', agoricAddr);
 
   const agoricChainId = useChain('agoric').chain.chain_id;

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-param */
 import { Fail } from '@endo/errors';
 import { type Amount } from '@agoric/ertp';
 import { NonNullish } from '@agoric/internal';

--- a/packages/cosmic-proto/src/address-hooks.js
+++ b/packages/cosmic-proto/src/address-hooks.js
@@ -31,6 +31,14 @@
 import { bech32 } from 'bech32';
 import queryString from 'query-string';
 
+/**
+ * @typedef {`${string}1${string}`} Bech32Address
+ * @example
+ *
+ *    agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346
+ *    cosmosvaloper1npm9gvss52mlmk
+ */
+
 /* global globalThis */
 /** @type {<T>(x: T) => T} */
 const harden = globalThis.harden || Object.freeze;
@@ -94,7 +102,7 @@ harden(decodeBech32);
  * @param {string} humanReadablePart
  * @param {ArrayLike<number>} bytes
  * @param {number} [charLimit]
- * @returns {string}
+ * @returns {Bech32Address}
  */
 export const encodeBech32 = (
   humanReadablePart,
@@ -102,7 +110,9 @@ export const encodeBech32 = (
   charLimit = DEFAULT_HOOKED_ADDRESS_CHAR_LIMIT,
 ) => {
   const words = bech32.toWords(bytes);
-  return bech32.encode(humanReadablePart, words, charLimit);
+  return /** @type {Bech32Address} */ (
+    bech32.encode(humanReadablePart, words, charLimit)
+  );
 };
 harden(encodeBech32);
 
@@ -126,7 +136,7 @@ harden(encodeBech32);
  * @param {string} baseAddress
  * @param {ArrayLike<number>} hookData
  * @param {number} [charLimit]
- * @returns {string}
+ * @returns {Bech32Address}
  */
 export const joinHookedAddress = (
   baseAddress,
@@ -178,6 +188,7 @@ harden(joinHookedAddress);
  * @param {string} baseAddress
  * @param {HookQuery} query
  * @param {number} [charLimit]
+ * @returns {Bech32Address}
  */
 export const encodeAddressHook = (baseAddress, query, charLimit) => {
   const queryStr = queryString.stringify(query);

--- a/packages/cosmic-proto/test/address-hooks.test.js
+++ b/packages/cosmic-proto/test/address-hooks.test.js
@@ -228,7 +228,7 @@ const lengthCheckMacro = test.macro({
  *   [
  *     baseAddress: string,
  *     query: import('../src/address-hooks.js').HookQuery,
- *     expected: string,
+ *     expected: import('../src/address-hooks.js').Bech32Address,
  *   ]
  * >}
  */

--- a/packages/fast-usdc-contract/src/exos/advancer.ts
+++ b/packages/fast-usdc-contract/src/exos/advancer.ts
@@ -45,7 +45,7 @@ import type { ZCF, ZCFSeat } from '@agoric/zoe/src/zoeService/zoe.js';
 import type { Zone } from '@agoric/zone';
 import { Fail, q } from '@endo/errors';
 import { E } from '@endo/far';
-import { M, mustMatch } from '@endo/patterns';
+import { M, mustMatch } from '@agoric/store';
 import type { LiquidityPoolKit } from './liquidity-pool.js';
 import type { SettlerKit } from './settler.js';
 import type { StatusManager } from './status-manager.js';
@@ -200,7 +200,6 @@ export const prepareAdvancerKit = (
             }
             const { EUD } = decoded.query;
             log(`decoded EUD: ${EUD}`);
-            assert.typeof(EUD, 'string');
             // throws if the bech32 prefix is not found
             const destination = chainHub.resolveAccountId(EUD);
 

--- a/packages/fast-usdc-contract/src/exos/settler.ts
+++ b/packages/fast-usdc-contract/src/exos/settler.ts
@@ -17,6 +17,7 @@ import { M } from '@endo/patterns';
 import { decodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
 import { PendingTxStatus } from '@agoric/fast-usdc/src/constants.js';
 import {
+  AddressHookShape,
   CctpTxEvidenceShape,
   EvmHashShape,
   makeNatAmountShape,
@@ -43,7 +44,7 @@ import type {
 } from '@agoric/orchestration';
 import { parseAccountId } from '@agoric/orchestration/src/utils/address.js';
 import type { WithdrawToSeat } from '@agoric/orchestration/src/utils/zoe-tools.js';
-import type { MapStore } from '@agoric/store';
+import { mustMatch, type MapStore } from '@agoric/store';
 import type { IBCChannelID, IBCPacket, VTransferIBCEvent } from '@agoric/vats';
 import type { TargetRegistration } from '@agoric/vats/src/bridge-target.js';
 import type { VowTools } from '@agoric/vow';
@@ -76,15 +77,12 @@ const decodeEventPacket = (
     return { error: ['unexpected denom', { actual, expected: remoteDenom }] };
   }
 
-  let EUD;
+  let EUD: Bech32Address;
   try {
-    ({ EUD } = decodeAddressHook(tx.receiver).query);
-    if (!EUD) {
-      return { error: ['no EUD parameter', tx.receiver] };
-    }
-    if (typeof EUD !== 'string') {
-      return { error: ['EUD is not a string', EUD] };
-    }
+    const decoded = decodeAddressHook(tx.receiver);
+    mustMatch(decoded, AddressHookShape);
+
+    ({ EUD } = decoded.query);
   } catch (e) {
     return { error: ['no query params', tx.receiver] };
   }

--- a/packages/fast-usdc-contract/src/exos/settler.ts
+++ b/packages/fast-usdc-contract/src/exos/settler.ts
@@ -37,6 +37,8 @@ import type {
 } from '@agoric/fast-usdc/src/types.js';
 import type {
   AccountId,
+  AccountIdArg,
+  Bech32Address,
   ChainHub,
   CosmosChainAddress,
   Denom,
@@ -59,7 +61,7 @@ const decodeEventPacket = (
   { data }: IBCPacket,
   remoteDenom: string,
 ):
-  | { nfa: NobleAddress; amount: bigint; EUD: string }
+  | { nfa: NobleAddress; amount: bigint; EUD: AccountId | Bech32Address }
   | { error: unknown[] } => {
   // NB: may not be a FungibleTokenPacketData or even JSON
   let tx: FungibleTokenPacketData;
@@ -360,15 +362,11 @@ export const prepareSettler = (
         /**
          * The intended payee received an advance from the pool. When the funds
          * are minted, disburse them to the pool and fee seats.
-         *
-         * @param {EvmHash} txHash
-         * @param {NatValue} fullValue
-         * @param {AccountId | CosmosChainAddress['value']} EUD
          */
         async disburse(
           txHash: EvmHash,
           fullValue: NatValue,
-          EUD: AccountId | CosmosChainAddress['value'],
+          EUD: AccountId | Bech32Address,
         ) {
           const { repayer, settlementAccount } = this.state;
           const received = AmountMath.make(USDC, fullValue);
@@ -405,7 +403,11 @@ export const prepareSettler = (
          * @param {NatValue} fullValue
          * @param {string} EUD
          */
-        forward(txHash: EvmHash, fullValue: NatValue, EUD: string) {
+        forward(
+          txHash: EvmHash,
+          fullValue: NatValue,
+          EUD: AccountId | Bech32Address,
+        ) {
           const { settlementAccount } = this.state;
           log('forwarding', fullValue, 'to', EUD, 'for', txHash);
 

--- a/packages/fast-usdc-contract/test/exos/advancer.test.ts
+++ b/packages/fast-usdc-contract/test/exos/advancer.test.ts
@@ -330,7 +330,7 @@ test('updates status to ADVANCE_SKIPPED on insufficient pool funds', async t => 
   ]);
 });
 
-test('updates status to ADVANCE_SKIPPED if makeChainAddress fails', async t => {
+test('updates status to ADVANCE_SKIPPED if coerceCosmosAddress fails', async t => {
   const {
     bootstrap: { storage },
     extensions: {
@@ -352,7 +352,7 @@ test('updates status to ADVANCE_SKIPPED if makeChainAddress fails', async t => {
         status: 'ADVANCE_SKIPPED',
       },
     ],
-    'ADVANCE_SKIPPED status on makeChainAddress failure',
+    'ADVANCE_SKIPPED status on coerceCosmosAddress failure',
   );
 
   t.deepEqual(inspectLogs(), [

--- a/packages/fast-usdc-contract/test/exos/settler.test.ts
+++ b/packages/fast-usdc-contract/test/exos/settler.test.ts
@@ -5,24 +5,23 @@ import {
   decodeAddressHook,
   encodeAddressHook,
 } from '@agoric/cosmic-proto/address-hooks.js';
+import { PendingTxStatus, TxStatus } from '@agoric/fast-usdc/src/constants.js';
 import { AddressHookShape } from '@agoric/fast-usdc/src/type-guards.js';
+import type { CctpTxEvidence } from '@agoric/fast-usdc/src/types.js';
+import { makeFeeTools } from '@agoric/fast-usdc/src/utils/fees.js';
 import { defaultMarshaller } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import cctpChainInfo from '@agoric/orchestration/src/cctp-chain-info.js';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
-import type { Zone } from '@agoric/zone';
-import type { EReturn } from '@endo/far';
 import { mustMatch } from '@agoric/store';
 import type {
   AmountKeywordRecord,
   TransferPart,
   ZcfSeatKit,
 } from '@agoric/zoe';
-import { PendingTxStatus, TxStatus } from '@agoric/fast-usdc/src/constants.js';
-import type { CctpTxEvidence } from '@agoric/fast-usdc/src/types.js';
-import { makeFeeTools } from '@agoric/fast-usdc/src/utils/fees.js';
-import type { Baggage } from '@agoric/vat-data';
-import cctpChainInfo from '@agoric/orchestration/src/cctp-chain-info.js';
+import type { Zone } from '@agoric/zone';
+import type { EReturn } from '@endo/far';
 import {
   prepareSettler,
   type SettlerKit,

--- a/packages/fast-usdc-contract/test/exos/settler.test.ts
+++ b/packages/fast-usdc-contract/test/exos/settler.test.ts
@@ -5,12 +5,14 @@ import {
   decodeAddressHook,
   encodeAddressHook,
 } from '@agoric/cosmic-proto/address-hooks.js';
+import { AddressHookShape } from '@agoric/fast-usdc/src/type-guards.js';
 import { defaultMarshaller } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import type { Zone } from '@agoric/zone';
 import type { EReturn } from '@endo/far';
+import { mustMatch } from '@agoric/store';
 import type {
   AmountKeywordRecord,
   TransferPart,
@@ -133,10 +135,9 @@ const makeTestContext = async t => {
       const { txHash } = evidence;
       const { forwardingAddress, amount } = evidence.tx;
       const { recipientAddress } = evidence.aux;
-      const { EUD } = decodeAddressHook(recipientAddress).query;
-      if (typeof EUD !== 'string') {
-        throw Error(`EUD not found in ${recipientAddress}`);
-      }
+      const decoded = decodeAddressHook(recipientAddress);
+      mustMatch(decoded, AddressHookShape);
+      const { EUD } = decoded.query;
       return harden({
         txHash,
         forwardingAddress,
@@ -875,7 +876,7 @@ test('bad packet data', async t => {
   t.deepEqual(inspectLogs().at(-1), [
     'invalid event packet',
     [
-      'no EUD parameter',
+      'no query params',
       'agoric10rchps2sfet5lleu7xhs6ztgeehkm5lz5rpkz0cqzs95zdge',
     ],
   ]);

--- a/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
@@ -28,7 +28,11 @@ import {
   type Publisher,
   type Subscriber,
 } from '@agoric/notifier';
-import type { ChainHub, CosmosChainInfo } from '@agoric/orchestration';
+import type {
+  Bech32Address,
+  ChainHub,
+  CosmosChainInfo,
+} from '@agoric/orchestration';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
@@ -399,7 +403,7 @@ const makeEVM = (template = MockCctpTxEvidences.AGORIC_PLUS_OSMO()) => {
 
   const makeTx = (
     amount: bigint,
-    recipientAddress: string,
+    recipientAddress: Bech32Address,
     nonceOverride?: number,
   ): CctpTxEvidence => {
     nonce += 1;

--- a/packages/fast-usdc-contract/test/fixtures.ts
+++ b/packages/fast-usdc-contract/test/fixtures.ts
@@ -1,6 +1,6 @@
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
-import type { CosmosChainAddress } from '@agoric/orchestration';
+import type { Bech32Address, CosmosChainAddress } from '@agoric/orchestration';
 import type { VTransferIBCEvent } from '@agoric/vats';
 import {
   MockCctpTxEvidences,
@@ -21,9 +21,9 @@ const nobleDefaultVTransferParams = {
 
 export const MockVTransferEvents: Record<
   MockScenario,
-  (receiverAddress?: string) => VTransferIBCEvent
+  (receiverAddress?: Bech32Address) => VTransferIBCEvent
 > = {
-  AGORIC_PLUS_OSMO: (receiverAddress?: string) =>
+  AGORIC_PLUS_OSMO: (receiverAddress?: Bech32Address) =>
     buildVTransferEvent({
       ...nobleDefaultVTransferParams,
       amount: MockCctpTxEvidences.AGORIC_PLUS_OSMO().tx.amount,
@@ -32,7 +32,7 @@ export const MockVTransferEvents: Record<
         receiverAddress ||
         MockCctpTxEvidences.AGORIC_PLUS_OSMO().aux.recipientAddress,
     }),
-  AGORIC_PLUS_DYDX: (receiverAddress?: string) =>
+  AGORIC_PLUS_DYDX: (receiverAddress?: Bech32Address) =>
     buildVTransferEvent({
       ...nobleDefaultVTransferParams,
       amount: MockCctpTxEvidences.AGORIC_PLUS_DYDX().tx.amount,
@@ -41,7 +41,7 @@ export const MockVTransferEvents: Record<
         receiverAddress ||
         MockCctpTxEvidences.AGORIC_PLUS_DYDX().aux.recipientAddress,
     }),
-  AGORIC_PLUS_AGORIC: (receiverAddress?: string) =>
+  AGORIC_PLUS_AGORIC: (receiverAddress?: Bech32Address) =>
     buildVTransferEvent({
       ...nobleDefaultVTransferParams,
       amount: MockCctpTxEvidences.AGORIC_PLUS_AGORIC().tx.amount,
@@ -50,7 +50,7 @@ export const MockVTransferEvents: Record<
         receiverAddress ||
         MockCctpTxEvidences.AGORIC_PLUS_AGORIC().aux.recipientAddress,
     }),
-  AGORIC_NO_PARAMS: (receiverAddress?: string) =>
+  AGORIC_NO_PARAMS: (receiverAddress?: Bech32Address) =>
     buildVTransferEvent({
       ...nobleDefaultVTransferParams,
       amount: MockCctpTxEvidences.AGORIC_NO_PARAMS().tx.amount,
@@ -59,7 +59,7 @@ export const MockVTransferEvents: Record<
         receiverAddress ||
         MockCctpTxEvidences.AGORIC_NO_PARAMS().aux.recipientAddress,
     }),
-  AGORIC_UNKNOWN_EUD: (receiverAddress?: string) =>
+  AGORIC_UNKNOWN_EUD: (receiverAddress?: Bech32Address) =>
     buildVTransferEvent({
       ...nobleDefaultVTransferParams,
       amount: MockCctpTxEvidences.AGORIC_UNKNOWN_EUD().tx.amount,
@@ -69,7 +69,7 @@ export const MockVTransferEvents: Record<
         MockCctpTxEvidences.AGORIC_UNKNOWN_EUD().aux.recipientAddress,
     }),
 
-  AGORIC_PLUS_ETHEREUM: (receiverAddress?: string) =>
+  AGORIC_PLUS_ETHEREUM: (receiverAddress?: Bech32Address) =>
     buildVTransferEvent({
       ...nobleDefaultVTransferParams,
       amount: MockCctpTxEvidences.AGORIC_PLUS_ETHEREUM().tx.amount,

--- a/packages/fast-usdc/tools/mock-evidence.ts
+++ b/packages/fast-usdc/tools/mock-evidence.ts
@@ -1,5 +1,5 @@
 import { encodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
-import type { CosmosChainAddress } from '@agoric/orchestration';
+import type { Bech32Address, CosmosChainAddress } from '@agoric/orchestration';
 import type { CctpTxEvidence, EvmAddress } from '../src/types.js';
 
 const mockScenarios = [
@@ -21,9 +21,9 @@ const blockTimestamp = 1632340000n;
 
 export const MockCctpTxEvidences: Record<
   MockScenario,
-  (receiverAddress?: string) => CctpTxEvidence
+  (receiverAddress?: Bech32Address) => CctpTxEvidence
 > = {
-  AGORIC_PLUS_OSMO: (receiverAddress?: string) => ({
+  AGORIC_PLUS_OSMO: (receiverAddress?: Bech32Address) => ({
     blockHash:
       '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
     blockNumber: 21037663n,
@@ -45,7 +45,7 @@ export const MockCctpTxEvidences: Record<
     },
     chainId: 1,
   }),
-  AGORIC_PLUS_DYDX: (receiverAddress?: string) => ({
+  AGORIC_PLUS_DYDX: (receiverAddress?: Bech32Address) => ({
     blockHash:
       '0x80d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee699',
     blockNumber: 21037669n,
@@ -67,7 +67,7 @@ export const MockCctpTxEvidences: Record<
     },
     chainId: 1,
   }),
-  AGORIC_PLUS_AGORIC: (receiverAddress?: string) => ({
+  AGORIC_PLUS_AGORIC: (receiverAddress?: Bech32Address) => ({
     blockHash:
       '0x80d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee6z9',
     blockNumber: 21037600n,
@@ -89,7 +89,7 @@ export const MockCctpTxEvidences: Record<
     },
     chainId: 1,
   }),
-  AGORIC_NO_PARAMS: (receiverAddress?: string) => ({
+  AGORIC_NO_PARAMS: (receiverAddress?: Bech32Address) => ({
     blockHash:
       '0x70d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee699',
     blockNumber: 21037669n,
@@ -107,7 +107,7 @@ export const MockCctpTxEvidences: Record<
     },
     chainId: 1,
   }),
-  AGORIC_UNKNOWN_EUD: (receiverAddress?: string) => ({
+  AGORIC_UNKNOWN_EUD: (receiverAddress?: Bech32Address) => ({
     blockHash:
       '0x70d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee699',
     blockNumber: 21037669n,
@@ -129,7 +129,7 @@ export const MockCctpTxEvidences: Record<
     },
     chainId: 1,
   }),
-  AGORIC_PLUS_ETHEREUM: (receiverAddress?: string) => ({
+  AGORIC_PLUS_ETHEREUM: (receiverAddress?: Bech32Address) => ({
     blockHash:
       '0x80d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee6z9',
     blockNumber: 21037600n,

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -717,17 +717,16 @@ export const makeChainHub = (
         return harden({
           chainId: parts[1],
           encoding: 'bech32',
-          value: parts[2],
+          value: /** @type {Bech32Address} */ (parts[2]),
         });
       }
 
       assert.equal(parts.length, 1); // no colons
-      const cosmosChainId = resolveCosmosChainId(
-        /** @type {Bech32Address} */ (partialId),
-      );
+      const value = /** @type {Bech32Address} */ (partialId);
+      const cosmosChainId = resolveCosmosChainId(value);
       return harden({
         chainId: cosmosChainId,
-        value: partialId,
+        value,
         encoding: /** @type {const} */ ('bech32'),
       });
     },

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -232,8 +232,8 @@ const ChainHubI = M.interface('ChainHub', {
     M.or(DenomDetailShape, M.undefined()),
   ),
   getDenom: M.call(BrandShape).returns(M.or(M.string(), M.undefined())),
-  makeChainAddress: M.call(AccountIdArgShape).returns(CosmosChainAddressShape),
-  resolveAccountId: M.call(AccountIdArgShape).returns(M.string()),
+  makeChainAddress: M.call(M.string()).returns(CosmosChainAddressShape),
+  resolveAccountId: M.call(M.string()).returns(M.string()),
   makeTransferRoute: M.call(AccountIdArgShape, DenomAmountShape, M.string())
     .optional(ForwardOptsShape)
     .returns(M.or(M.undefined(), TransferRouteShape)),
@@ -679,8 +679,8 @@ export const makeChainHub = (
     },
 
     /**
-     * @param {AccountId | Bech32Address | string} partialId CAIP-10 account ID
-     *   or a Cosmos bech32 address
+     * @param {AccountId | Bech32Address} partialId CAIP-10 account ID or a
+     *   Cosmos bech32 address
      * @returns {AccountId}
      * @throws {Error} if chain info not found for bech32Prefix
      */

--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -777,21 +777,18 @@ export const makeChainHub = (
       }
       const { chainId: holdingChainId } = holdingChainInfo;
 
-      destination =
-        typeof destination === 'string'
-          ? chainHub.coerceCosmosAddress(destination)
-          : destination;
+      const cosmosDest = chainHub.coerceCosmosAddress(destination);
 
       // asset is transferring to or from the issuing chain, return direct route
-      if (baseChainId === destination.chainId || baseName === srcChainName) {
+      if (baseChainId === cosmosDest.chainId || baseName === srcChainName) {
         // TODO use getConnectionInfo once its sync
-        const connKey = connectionKey(holdingChainId, destination.chainId);
+        const connKey = connectionKey(holdingChainId, cosmosDest.chainId);
         connectionInfos.has(connKey) ||
-          Fail`no connection info found for ${holdingChainId}<->${destination.chainId}`;
+          Fail`no connection info found for ${holdingChainId}<->${cosmosDest.chainId}`;
 
         const { transferChannel } = denormalizeConnectionInfo(
           holdingChainId, // from chain (primary)
-          destination.chainId, // to chain (counterparty)
+          cosmosDest.chainId, // to chain (counterparty)
           connectionInfos.get(connKey),
         );
         return harden({
@@ -801,7 +798,7 @@ export const makeChainHub = (
             amount: String(denomAmount.value),
             denom: denomAmount.denom,
           },
-          receiver: destination.value,
+          receiver: cosmosDest.value,
         });
       }
 

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -877,7 +877,7 @@ export const prepareCosmosOrchestrationAccountKit = (
             trace('send', toAccount, amount);
             toAccount =
               typeof toAccount === 'string'
-                ? chainHub.makeChainAddress(toAccount)
+                ? chainHub.coerceCosmosAddress(toAccount)
                 : toAccount;
             const { chainAddress } = this.state;
             toAccount.chainId === chainAddress.chainId ||
@@ -925,11 +925,11 @@ export const prepareCosmosOrchestrationAccountKit = (
           return asVow(() => {
             // `destination` arg can be non-Cosmos per the common `.transfer` method signature
             // but this implementation only supports transferring to another Cosmos chain.
-            // It relies on `makeChainAddress` to throw if `destination` has another namespace.
+            // It relies on `coerceCosmosAddress` to throw if `destination` has another namespace.
             destination =
               typeof destination === 'string'
                 ? // If `destination` is not actually CAIP-10 then this will throw
-                  chainHub.makeChainAddress(destination)
+                  chainHub.coerceCosmosAddress(destination)
                 : destination;
 
             const { helper } = this.facets;

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -875,20 +875,17 @@ export const prepareCosmosOrchestrationAccountKit = (
         send(toAccount, amount) {
           return asVow(() => {
             trace('send', toAccount, amount);
-            toAccount =
-              typeof toAccount === 'string'
-                ? chainHub.coerceCosmosAddress(toAccount)
-                : toAccount;
+            const cosmosDest = chainHub.coerceCosmosAddress(toAccount);
             const { chainAddress } = this.state;
-            toAccount.chainId === chainAddress.chainId ||
-              Fail`bank/send cannot send to a different chain ${q(toAccount.chainId)}`;
+            cosmosDest.chainId === chainAddress.chainId ||
+              Fail`bank/send cannot send to a different chain ${q(cosmosDest.chainId)}`;
             const { helper } = this.facets;
             return watch(
               E(helper.owned()).executeEncodedTx([
                 Any.toJSON(
                   MsgSend.toProtoMsg({
                     fromAddress: chainAddress.value,
-                    toAddress: toAccount.value,
+                    toAddress: cosmosDest.value,
                     amount: [helper.amountToCoin(amount)],
                   }),
                 ),
@@ -925,12 +922,9 @@ export const prepareCosmosOrchestrationAccountKit = (
           return asVow(() => {
             // `destination` arg can be non-Cosmos per the common `.transfer` method signature
             // but this implementation only supports transferring to another Cosmos chain.
-            // It relies on `coerceCosmosAddress` to throw if `destination` has another namespace.
-            destination =
-              typeof destination === 'string'
-                ? // If `destination` is not actually CAIP-10 then this will throw
-                  chainHub.coerceCosmosAddress(destination)
-                : destination;
+            // It relies on `coerceCosmosChainAddress` to throw if `destination` has another namespace.
+
+            const cosmosDest = chainHub.coerceCosmosAddress(destination);
 
             const { helper } = this.facets;
             const token = helper.amountToCoin(amount);
@@ -938,7 +932,7 @@ export const prepareCosmosOrchestrationAccountKit = (
             const connectionInfoV = watch(
               chainHub.getConnectionInfo(
                 this.state.chainAddress.chainId,
-                destination.chainId,
+                cosmosDest.chainId,
               ),
             );
 
@@ -957,7 +951,7 @@ export const prepareCosmosOrchestrationAccountKit = (
             return watch(
               allVows([connectionInfoV, timeoutTimestampVowOrValue]),
               this.facets.transferWatcher,
-              { opts, token, destination },
+              { opts, token, destination: cosmosDest },
             );
           });
         },

--- a/packages/orchestration/src/exos/cosmos-orchestration-account.js
+++ b/packages/orchestration/src/exos/cosmos-orchestration-account.js
@@ -1005,6 +1005,7 @@ export const prepareCosmosOrchestrationAccountKit = (
         },
         /** @type {HostOf<StakingAccountQueries['getDelegation']>} */
         getDelegation(validator) {
+          // @ts-expect-error XXX string template with generics
           return asVow(() => {
             trace('getDelegation', validator);
             const { chainAddress, icqConnection } = this.state;
@@ -1024,6 +1025,7 @@ export const prepareCosmosOrchestrationAccountKit = (
         },
         /** @type {HostOf<StakingAccountQueries['getDelegations']>} */
         getDelegations() {
+          // @ts-expect-error XXX string template with generics
           return asVow(() => {
             trace('getDelegations');
             const { chainAddress, icqConnection } = this.state;
@@ -1119,6 +1121,7 @@ export const prepareCosmosOrchestrationAccountKit = (
         },
         /** @type {HostOf<StakingAccountQueries['getRewards']>} */
         getRewards() {
+          // @ts-expect-error XXX string template with generics
           return asVow(() => {
             trace('getRewards');
             const { chainAddress, icqConnection } = this.state;

--- a/packages/orchestration/src/exos/ica-account-kit.js
+++ b/packages/orchestration/src/exos/ica-account-kit.js
@@ -51,7 +51,9 @@ export const IcaAccountI = M.interface('IcaAccount', {
  *   localAddress: LocalIbcAddress | undefined;
  *   requestedRemoteAddress: string;
  *   remoteAddress: RemoteIbcAddress | undefined;
- *   chainAddress: CosmosChainAddress | undefined;
+ *   chainAddress:
+ *     | (CosmosChainAddress | { value: typeof UNPARSABLE_CHAIN_ADDRESS })
+ *     | undefined;
  *   isInitiatingClose: boolean;
  * }} State
  *   Internal to the IcaAccountKit exo
@@ -103,6 +105,7 @@ export const prepareIcaAccountKit = (zone, { watch, asVow }) =>
       account: {
         /** @returns {CosmosChainAddress} */
         getAddress() {
+          // @ts-expect-error value may be UNPARSABLE_CHAIN_ADDRESS
           return NonNullish(
             this.state.chainAddress,
             'ICA channel creation acknowledgement not yet received.',

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -639,7 +639,7 @@ export const prepareLocalOrchestrationAccountKit = (
             trace('send', toAccount, amount);
             toAccount =
               typeof toAccount === 'string'
-                ? chainHub.makeChainAddress(toAccount)
+                ? chainHub.coerceCosmosAddress(toAccount)
                 : toAccount;
             toAccount.chainId === this.state.address.chainId ||
               Fail`bank/send cannot send to a different chain ${q(toAccount.chainId)}`;

--- a/packages/orchestration/src/exos/local-orchestration-account.js
+++ b/packages/orchestration/src/exos/local-orchestration-account.js
@@ -637,18 +637,15 @@ export const prepareLocalOrchestrationAccountKit = (
         send(toAccount, amount) {
           return asVow(() => {
             trace('send', toAccount, amount);
-            toAccount =
-              typeof toAccount === 'string'
-                ? chainHub.coerceCosmosAddress(toAccount)
-                : toAccount;
-            toAccount.chainId === this.state.address.chainId ||
-              Fail`bank/send cannot send to a different chain ${q(toAccount.chainId)}`;
+            const cosmosDest = chainHub.coerceCosmosAddress(toAccount);
+            cosmosDest.chainId === this.state.address.chainId ||
+              Fail`bank/send cannot send to a different chain ${q(cosmosDest.chainId)}`;
             const { helper } = this.facets;
             return watch(
               E(this.state.account).executeTx([
                 typedJson('/cosmos.bank.v1beta1.MsgSend', {
                   amount: [helper.amountToCoin(amount)],
-                  toAddress: toAccount.value,
+                  toAddress: cosmosDest.value,
                   fromAddress: this.state.address.value,
                 }),
               ]),

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -19,6 +19,7 @@ import type {
   ICQQueryFunction,
   KnownNamespace,
   NobleMethods,
+  Bech32Address,
 } from './types.js';
 import type { ResolvedContinuingOfferResult } from './utils/zoe-tools.js';
 
@@ -85,8 +86,8 @@ export type CosmosChainAddress = {
   /** Within the Cosmos ecosystem. e.g. `agoric-3' or 'cosmoshub-4' */
   chainId: string;
   /** The address value used on-chain */
-  value: string;
-  encoding: 'bech32' | 'ethereum';
+  value: Bech32Address;
+  encoding: 'bech32';
 };
 
 /**

--- a/packages/orchestration/src/utils/cosmos.js
+++ b/packages/orchestration/src/utils/cosmos.js
@@ -3,7 +3,7 @@ import { decodeBase64 } from '@endo/base64';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 
 /**
- * @import {CosmosDelegationResponse, CosmosValidatorAddress, DenomAmount} from '../types.js';
+ * @import {Bech32Address, CosmosDelegationResponse, CosmosValidatorAddress, DenomAmount} from '../types.js';
  * @import {Coin} from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js'
  * @import {DelegationResponse} from '@agoric/cosmic-proto/cosmos/staking/v1beta1/staking.js';
  */
@@ -75,7 +75,7 @@ export const toCosmosDelegationResponse = ({ chainId }, r) => ({
   delegator: {
     chainId,
     encoding: 'bech32',
-    value: r.delegation.delegatorAddress,
+    value: /** @type {Bech32Address} */ (r.delegation.delegatorAddress),
   },
   validator: toCosmosValidatorAddress(r.delegation, chainId),
   amount: toDenomAmount(r.balance),

--- a/packages/orchestration/test/examples/stake-ica.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-ica.contract.test.ts
@@ -152,6 +152,7 @@ test('delegate, undelegate, redelegate, withdrawReward', async t => {
     validatorAddr,
     {
       ...validatorAddr,
+      // @ts-expect-error XXX invalid Bech32
       value: 'cosmosvaloper2test',
     },
     { denom: 'uatom', value: 10n },

--- a/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
+++ b/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
@@ -53,7 +53,7 @@ test('to issuing chain', async t => {
     ]),
   );
 
-  const dest: CosmosChainAddress = chainHub.makeChainAddress('noble1234');
+  const dest = chainHub.coerceCosmosAddress('noble1234');
   {
     // 100 USDC on agoric -> noble
     const amt: DenomAmount = harden({ denom: uusdcOnAgoric, value: 100n });
@@ -94,7 +94,7 @@ test('from issuing chain', async t => {
     harden([assetOn('uist', 'agoric'), assetOn('uosmo', 'osmosis')]),
   );
 
-  const dest: CosmosChainAddress = chainHub.makeChainAddress('noble1234');
+  const dest = chainHub.coerceCosmosAddress('noble1234');
   {
     // IST on agoric -> noble
     const amt: DenomAmount = harden({ denom: 'uist', value: 100n });
@@ -133,7 +133,7 @@ test('through issuing chain', async t => {
     harden([[uusdcOnAgoric, agDetail]]),
   );
 
-  const dest: CosmosChainAddress = chainHub.makeChainAddress('osmo1234');
+  const dest = chainHub.coerceCosmosAddress('osmo1234');
   const amt: DenomAmount = harden({ denom: uusdcOnAgoric, value: 100n });
 
   // 100 USDC on agoric -> osmosis
@@ -191,7 +191,7 @@ test('takes forwardOpts', t => {
     harden([[uusdcOnOsmosis, osDetail]]),
   );
 
-  const dest: CosmosChainAddress = chainHub.makeChainAddress('agoric1234');
+  const dest = chainHub.coerceCosmosAddress('agoric1234');
   const amt: DenomAmount = harden({ denom: uusdcOnOsmosis, value: 100n });
   const forwardOpts = harden({
     retries: 1,
@@ -359,8 +359,8 @@ test('no connection info multi hop', t => {
     ]),
   );
 
-  const osmoDest = chainHub.makeChainAddress('osmo1234');
-  const agoricDest = chainHub.makeChainAddress('agoric1234');
+  const osmoDest = chainHub.coerceCosmosAddress('osmo1234');
+  const agoricDest = chainHub.coerceCosmosAddress('agoric1234');
 
   t.throws(
     () =>
@@ -423,7 +423,7 @@ test('no PFM path', t => {
   t.throws(
     () =>
       chainHub.makeTransferRoute(
-        chainHub.makeChainAddress('osmo1234'),
+        chainHub.coerceCosmosAddress('osmo1234'),
         harden({ denom: uusdcOnAgoric, value: 100n }),
         'agoric',
       ),

--- a/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
+++ b/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
@@ -216,9 +216,9 @@ test('takes forwardOpts', t => {
 
   const nobleAddr = harden({
     value: 'noble1234',
-    encoding: 'bech32' as const,
+    encoding: 'bech32',
     chainId: 'noble-1',
-  });
+  } as const);
 
   t.deepEqual(
     chainHub.makeTransferRoute(dest, amt, 'osmosis', {

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -11,6 +11,7 @@ import {
   registerKnownChains,
 } from '../../src/chain-info.js';
 import type {
+  Bech32Address,
   CosmosChainInfo,
   IBCConnectionInfo,
 } from '../../src/cosmos-api.js';
@@ -187,12 +188,14 @@ test('coerceCosmosAddress', async t => {
 
   t.throws(
     () =>
+      // @ts-expect-error intentionally invalid
       chainHub.coerceCosmosAddress(MOCK_ICA_ADDRESS.replace('osmo1', 'foo1')),
     {
       message: 'Chain info not found for bech32Prefix "foo"',
     },
   );
 
+  // @ts-expect-error intentionally invalid
   t.throws(() => chainHub.coerceCosmosAddress('notbech32'), {
     message: 'No separator character for "notbech32"',
   });
@@ -240,6 +243,7 @@ test('resolveAccountId', async t => {
 
   // Should throw for invalid address format
   t.throws(
+    // @ts-expect-error intentionally invalid
     () => chainHub.resolveAccountId('notbech32'),
     {
       message: 'No separator character for "notbech32"',
@@ -286,7 +290,7 @@ test('updateChain updates existing chain info and mappings', t => {
   chainHub.updateChain('testchain', updatedInfo);
 
   // Verify chain address works with new prefix
-  const address = `${updatedInfo.bech32Prefix}1abc`;
+  const address: Bech32Address = `${updatedInfo.bech32Prefix}1abc`;
   const chainAddress = chainHub.coerceCosmosAddress(address);
   t.deepEqual(chainAddress, {
     chainId: 'chain-1',

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -169,7 +169,7 @@ test('toward asset info in agoricNames (#9572)', async t => {
   }
 });
 
-test('makeChainAddress', async t => {
+test('coerceCosmosAddress', async t => {
   const { chainHub, nameAdmin, vt } = setup();
   // use fetched chain info
   await registerKnownChains(nameAdmin);
@@ -179,24 +179,25 @@ test('makeChainAddress', async t => {
 
   const MOCK_ICA_ADDRESS =
     'osmo1ht7u569vpuryp6utadsydcne9ckeh2v8dkd38v5hptjl3u2ewppqc6kzgd' as const;
-  t.deepEqual(chainHub.makeChainAddress(MOCK_ICA_ADDRESS), {
+  t.deepEqual(chainHub.coerceCosmosAddress(MOCK_ICA_ADDRESS), {
     chainId: 'osmosis-1',
     value: MOCK_ICA_ADDRESS,
     encoding: 'bech32',
   });
 
   t.throws(
-    () => chainHub.makeChainAddress(MOCK_ICA_ADDRESS.replace('osmo1', 'foo1')),
+    () =>
+      chainHub.coerceCosmosAddress(MOCK_ICA_ADDRESS.replace('osmo1', 'foo1')),
     {
       message: 'Chain info not found for bech32Prefix "foo"',
     },
   );
 
-  t.throws(() => chainHub.makeChainAddress('notbech32'), {
+  t.throws(() => chainHub.coerceCosmosAddress('notbech32'), {
     message: 'No separator character for "notbech32"',
   });
 
-  t.throws(() => chainHub.makeChainAddress('1notbech32'), {
+  t.throws(() => chainHub.coerceCosmosAddress('1notbech32'), {
     message: 'Missing prefix for "1notbech32"',
   });
 });
@@ -286,7 +287,7 @@ test('updateChain updates existing chain info and mappings', t => {
 
   // Verify chain address works with new prefix
   const address = `${updatedInfo.bech32Prefix}1abc`;
-  const chainAddress = chainHub.makeChainAddress(address);
+  const chainAddress = chainHub.coerceCosmosAddress(address);
   t.deepEqual(chainAddress, {
     chainId: 'chain-1',
     value: address,
@@ -294,9 +295,12 @@ test('updateChain updates existing chain info and mappings', t => {
   });
 
   // Old prefix should not work
-  t.throws(() => chainHub.makeChainAddress(`${initialInfo.bech32Prefix}1abc`), {
-    message: `Chain info not found for bech32Prefix "${initialInfo.bech32Prefix}"`,
-  });
+  t.throws(
+    () => chainHub.coerceCosmosAddress(`${initialInfo.bech32Prefix}1abc`),
+    {
+      message: `Chain info not found for bech32Prefix "${initialInfo.bech32Prefix}"`,
+    },
+  );
 });
 
 test('updateChain errors on non-existent chain', t => {

--- a/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
+++ b/packages/orchestration/test/exos/cosmos-orchestration-account.test.ts
@@ -96,7 +96,7 @@ test('send (to addr on same chain)', async t => {
   t.assert(account, 'account is returned');
 
   const toAddress: CosmosChainAddress = {
-    value: 'cosmos99test',
+    value: 'cosmos1testrecipient',
     chainId: 'cosmoshub-4',
     encoding: 'bech32',
   };
@@ -115,7 +115,7 @@ test('send (to addr on same chain)', async t => {
     buildTxPacketString([
       MsgSend.toProtoMsg({
         fromAddress: 'cosmos1test',
-        toAddress: 'cosmos99test',
+        toAddress: 'cosmos1testrecipient',
         amount: [
           {
             denom: uistOnCosmos,

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -413,8 +413,8 @@ test('send', async t => {
   const toAddress = {
     value: 'agoric1EOAAccAddress',
     chainId: 'agoric-3',
-    encoding: 'bech32' as const,
-  };
+    encoding: 'bech32',
+  } as const;
 
   t.log(`send 10 bld to ${toAddress.value}`);
   await VE(account).send(toAddress, stake.units(10));

--- a/packages/orchestration/test/exos/make-test-coa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-coa-kit.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-param -- ts types */
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { Far, type EReturn } from '@endo/far';

--- a/packages/orchestration/test/exos/make-test-loa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-loa-kit.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-param -- ts types */
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { Far, type EReturn } from '@endo/far';

--- a/packages/orchestration/test/ibc-mocks.ts
+++ b/packages/orchestration/test/ibc-mocks.ts
@@ -64,12 +64,12 @@ const redelegation = {
 };
 const bankSend = {
   fromAddress: 'cosmos1test',
-  toAddress: 'cosmos99test',
+  toAddress: 'cosmos1testrecipient',
   amount: [{ denom: 'uatom', amount: '10' }],
 };
 const bankSendMulti = {
   fromAddress: 'cosmos1test',
-  toAddress: 'cosmos99test',
+  toAddress: 'cosmos1testrecipient',
   amount: [
     { denom: 'uatom', amount: '10' },
     { denom: 'ibc/1234', amount: '10' },

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -28,6 +28,7 @@ import { makeNameHubKit } from '@agoric/vats';
 import type { Invitation, ZCF } from '@agoric/zoe';
 import { prepareCosmosOrchestrationAccountKit } from '../src/exos/cosmos-orchestration-account.js';
 import type {
+  Bech32Address,
   CosmosChainAddress,
   DenomAmount,
   IcaAccount,
@@ -111,7 +112,7 @@ const dateToTimestamp = (date: Date): Timestamp => ({
 
 const makeScenario = () => {
   const mockAccount = (
-    addr = 'agoric1234',
+    addr = 'agoric1234' as Bech32Address,
     delegations = {} as Record<string, Coin>,
   ) => {
     const calls = [] as Array<{ msgs: AnyJson[] }>;

--- a/packages/orchestration/tools/ibc-mocks.ts
+++ b/packages/orchestration/tools/ibc-mocks.ts
@@ -21,7 +21,10 @@ import type {
 } from '@agoric/vats';
 import { LOCALCHAIN_DEFAULT_ADDRESS } from '@agoric/vats/tools/fake-bridge.js';
 import { atob, btoa, decodeBase64, encodeBase64 } from '@endo/base64';
-import type { CosmosChainAddress } from '../src/orchestration-api.js';
+import type {
+  AccountId,
+  CosmosChainAddress,
+} from '../src/orchestration-api.js';
 import { makeQueryPacket, makeTxPacket } from '../src/utils/packet.js';
 
 interface EncoderCommon<T> {
@@ -157,7 +160,7 @@ type BuildVTransferEventParams = {
   /* defaults to cosmos1AccAddress. set to `agoric1fakeLCAAddress` to simulate an outgoing transfer event */
   sender?: CosmosChainAddress['value'];
   /*  defaults to agoric1fakeLCAAddress. set to a different value to simulate an outgoing transfer event */
-  receiver?: CosmosChainAddress['value'];
+  receiver?: AccountId | CosmosChainAddress['value'];
   target?: CosmosChainAddress['value'];
   amount?: bigint;
   denom?: string;

--- a/packages/orchestration/tools/make-test-address.js
+++ b/packages/orchestration/tools/make-test-address.js
@@ -2,10 +2,14 @@
 import { bech32 } from 'bech32';
 
 /**
+ * @import {Bech32Address} from '../src/cosmos-api.ts';
+ */
+
+/**
  * @param {number} index
  * @param {string} prefix
  * @param {number} byteLength
- * @returns {string} a mock bech32 address for tests
+ * @returns {Bech32Address} a mock bech32 address for tests
  */
 export const makeTestAddress = (
   index = 0,
@@ -17,5 +21,5 @@ export const makeTestAddress = (
   // if index provided, put it in the first byte
   if (index !== 0) bytes[0] = Number(index);
   const words = bech32.toWords(bytes);
-  return bech32.encode(prefix, words);
+  return /** @type {Bech32Address} */ (bech32.encode(prefix, words));
 };

--- a/packages/vats/src/localchain.js
+++ b/packages/vats/src/localchain.js
@@ -102,7 +102,7 @@ export const prepareLocalChainAccountKit = (zone, { watch }) =>
       }),
     },
     /**
-     * @param {string} address
+     * @param {import('@agoric/orchestration').Bech32Address} address
      * @param {AccountPowers} powers
      */
     (address, powers) => ({


### PR DESCRIPTION
_incidental_

## Description

The move from `CosmosChainAddress` to CAIP-10 `AccountId` has been incremental. This smooths out one of the common cases where a function needs to pass along a `CosmosChainAddress` but expanding the `makeChainAddress` function to coerce its AccountIdArg into a CosmosChainAddress. It renames it to `coerceCosmosAddress` to make clear its a coercer and that it's only for Cosmos accounts.

It also does a bunch of type narrowing to make the distinctions clearer.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
This renames a method on ChainHub. That's safe because there's a new one made in each incarnation.