### PR TITLE
chore(orchestration): trace sequence on IBC packet send

### DIFF
--- a/packages/orchestration/src/exos/ibc-packet.js
+++ b/packages/orchestration/src/exos/ibc-packet.js
@@ -1,10 +1,12 @@
-import { assertAllDefined } from '@agoric/internal';
+import { assertAllDefined, makeTracer } from '@agoric/internal';
 import { base64ToBytes, Shape as NetworkShape } from '@agoric/network';
 import { M } from '@endo/patterns';
 import { E } from '@endo/far';
 
 // As specified in ICS20, the success result is a base64-encoded '\0x1' byte.
 export const ICS20_TRANSFER_SUCCESS_RESULT = 'AQ==';
+
+const trace = makeTracer('IBCP');
 
 /**
  * @import {Key, Pattern} from '@endo/patterns';
@@ -111,6 +113,10 @@ export const prepareIBCTransferSender = (zone, { watch, makeIBCReplyKit }) => {
         onFulfilled([{ sequence }], ctx) {
           const { match } = ctx;
           const { transferMsg } = this.state;
+
+          // sequence + sourceChannel uniquely identifies a transfer.
+          // trace with receiver etc. for forensics
+          trace('sequence', sequence, transferMsg);
 
           // Match the port/channel and sequence number.
           const replyPacketPattern = M.splitRecord({

--- a/packages/orchestration/src/exos/packet-tools.js
+++ b/packages/orchestration/src/exos/packet-tools.js
@@ -13,7 +13,7 @@ const { toCapData } = makeMarshal(undefined, undefined, {
 });
 const just = obj => {
   const { body } = toCapData(obj);
-  return decodeToJustin(JSON.parse(body), true);
+  return decodeToJustin(JSON.parse(body), false);
 };
 
 /**


### PR DESCRIPTION
closes: https://github.com/Agoric/agoric-private/issues/298

## Description

sequence + sourceChannel uniquely identifies a transfer.
trace with receiver etc. for forensics

### Security Considerations

facilitates forensics

### Scaling Considerations

log message could get large / awkward

### Documentation Considerations

SRE should be informed

### Testing Considerations

ci logs from `packages/fast-usdc-deploy/test/fast-usdc.test.ts` include results such [the one below](#discussion_r2040263163).

### Upgrade Considerations

goes out with the next Fast USDC contract upgrade such as
  - #11149 
