### PR TITLE
feat(ertp): ertp-only part of minimal want-patterns

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -43,11 +43,13 @@
     "@agoric/store": "workspace:*",
     "@agoric/vat-data": "workspace:*",
     "@agoric/zone": "workspace:*",
+    "@endo/common": "^1.2.13",
     "@endo/errors": "^1.2.13",
     "@endo/eventual-send": "^1.3.4",
     "@endo/far": "^1.1.14",
     "@endo/marshal": "^1.8.0",
     "@endo/nat": "^5.1.3",
+    "@endo/pass-style": "^1.6.3",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13"
   },

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -40,6 +40,8 @@ export const claim = async (
 ) => {
   const srcPayment = await srcPaymentP;
   return E.when(E(recoveryPurse).deposit(srcPayment, optAmountShape), amount =>
+    // @ts-expect-error Why doesn't TS know that an Amount is a kind
+    // of AmountBound?
     E(recoveryPurse).withdraw(amount),
   );
 };
@@ -87,6 +89,8 @@ export const combine = async (
   if (optTotalAmount !== undefined) {
     mustMatch(total, optTotalAmount, 'amount');
   }
+  // @ts-expect-error Why doesn't TS know that an Amount is a kind
+  // of AmountBound?
   return E(recoveryPurse).withdraw(total);
 };
 harden(combine);
@@ -111,7 +115,11 @@ export const split = async (recoveryPurse, srcPaymentP, paymentAmountA) => {
   const srcAmount = await E(recoveryPurse).deposit(srcPayment);
   const paymentAmountB = AmountMath.subtract(srcAmount, paymentAmountA);
   return Promise.all([
+    // @ts-expect-error Why doesn't TS know that an Amount is a kind
+    // of AmountBound?
     E(recoveryPurse).withdraw(paymentAmountA),
+    // @ts-expect-error Why doesn't TS know that an Amount is a kind
+    // of AmountBound?
     E(recoveryPurse).withdraw(paymentAmountB),
   ]);
 };
@@ -147,6 +155,12 @@ export const splitMany = async (recoveryPurse, srcPaymentP, amounts) => {
   AmountMath.isEqual(srcAmount, total) ||
     Fail`rights were not conserved: ${total} vs ${srcAmount}`;
 
-  return Promise.all(amounts.map(amount => E(recoveryPurse).withdraw(amount)));
+  return Promise.all(
+    amounts.map(amount =>
+      // @ts-expect-error Why doesn't TS know that an Amount is a kind
+      // of AmountBound?
+      E(recoveryPurse).withdraw(amount),
+    ),
+  );
 };
 harden(splitMany);

--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -11,12 +11,15 @@ import {
   bagDisjointSubtract,
 } from '@agoric/store';
 
-/** @import {MathHelpers} from '../types.js' */
+/**
+ * @import {Key, CopyBag} from '@endo/patterns'
+ * @import {MathHelpers} from '../types.js'
+ */
 
-/** @type {import('@endo/patterns').CopyBag} */
+/** @type {CopyBag} */
 const empty = makeCopyBag([]);
 
-/** @type {MathHelpers<import('@endo/patterns').CopyBag>} */
+/** @type {MathHelpers<'copyBag', Key, CopyBag<Key>>} */
 export const copyBagMathHelpers = harden({
   doCoerce: bag => {
     mustMatch(bag, M.bag(), 'bag of amount');

--- a/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
@@ -9,17 +9,17 @@ import {
   setIsSuperset,
   setDisjointUnion,
   setDisjointSubtract,
-} from '@agoric/store';
+} from '@endo/patterns';
 
 /**
+ * @import {Key, CopySet} from '@endo/patterns'
  * @import {MathHelpers} from '../types.js'
- * @import {CopySet} from '@endo/patterns'
  */
 
 /** @type {CopySet} */
 const empty = makeCopySet([]);
 
-/** @type {MathHelpers<CopySet>} */
+/** @type {MathHelpers<'copySet', Key, CopySet<Key>>} */
 export const copySetMathHelpers = harden({
   doCoerce: set => {
     mustMatch(set, M.set(), 'set of amount');

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -3,7 +3,10 @@
 import { Fail } from '@endo/errors';
 import { Nat, isNat } from '@endo/nat';
 
-/** @import {MathHelpers, NatValue} from '../types.js' */
+/**
+ * @import {Key} from '@endo/patterns'
+ * @import {MathHelpers, NatValue} from '../types.js'
+ */
 
 const empty = 0n;
 
@@ -16,7 +19,7 @@ const empty = 0n;
  * smallest whole unit such that the `natMathHelpers` never deals with
  * fractional parts.
  *
- * @type {MathHelpers<NatValue>}
+ * @type {MathHelpers<'nat', Key, NatValue>}
  */
 export const natMathHelpers = harden({
   doCoerce: nat => {

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-import { passStyleOf } from '@endo/marshal';
+import { passStyleOf } from '@endo/pass-style';
 import {
   assertKey,
   elementsIsSuperset,
@@ -8,9 +8,12 @@ import {
   elementsDisjointSubtract,
   coerceToElements,
   elementsCompare,
-} from '@agoric/store';
+} from '@endo/patterns';
 
-/** @import {MathHelpers, SetValue} from '../types.js' */
+/**
+ * @import {Key} from '@endo/patterns'
+ * @import {MathHelpers, SetValue} from '../types.js'
+ */
 
 // Operations for arrays with unique objects identifying and providing
 // information about digital assets. Used for Zoe invites.
@@ -19,7 +22,7 @@ const empty = harden([]);
 
 /**
  * @deprecated Replace array-based SetMath with CopySet-based CopySetMath
- * @type {MathHelpers<SetValue>}
+ * @type {MathHelpers<'set', Key, SetValue<Key>>}
  */
 export const setMathHelpers = harden({
   doCoerce: list => {

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -1,8 +1,6 @@
 // @jessie-check
 
-/// <reference types="@agoric/store/exported.js" />
-
-import { q, Fail, annotateError, X } from '@endo/errors';
+import { X, q, Fail, annotateError } from '@endo/errors';
 import { isPromise } from '@endo/promise-kit';
 import { mustMatch, M, keyEQ } from '@endo/patterns';
 import { AmountMath } from './amountMath.js';
@@ -11,7 +9,8 @@ import { preparePurseKind } from './purse.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
 /**
- * @import {Key, Pattern} from '@endo/patterns';
+ * @import {Pattern} from '@endo/patterns';
+ * @import {WeakMapStore, SetStore} from '@agoric/store';
  * @import {Zone} from '@agoric/base-zone';
  * @import {TypedPattern} from '@agoric/internal';
  * @import {ShutdownWithFailure} from '@agoric/swingset-vat';

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,10 +1,13 @@
 import { Fail } from '@endo/errors';
-import { M, makeCopySet } from '@agoric/store';
+import { kindOf, M, makeCopySet } from '@endo/patterns';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 import { makeAmountStore } from './amountStore.js';
 
-/** @import {AssetKind, RecoverySetsOption, Brand, Payment} from './types.js' */
+/**
+ * @import {WeakMapStore, SetStore} from '@agoric/store';
+ * @import {AssetKind, RecoverySetsOption, Brand, Payment} from './types.js'
+ */
 
 const EMPTY_COPY_SET = makeCopySet([]);
 
@@ -108,13 +111,19 @@ export const preparePurseKind = (
           updateBalance(purse, balanceStore.getAmount());
           return srcPaymentBalance;
         },
-        withdraw(amount) {
+        withdraw(amountBound) {
           const { state } = this;
           const { purse } = this.facets;
 
           const optRecoverySet = maybeRecoverySet(state);
           const balanceStore = makeAmountStore(state, 'currentBalance');
-          // Note COMMIT POINT within withdraw.
+          let amount;
+          if (kindOf(amountBound) === 'match:containerHas') {
+            throw Fail`TODO: purse withdraw does not yet support amount patterns`;
+          } else {
+            amount = amountBound;
+          }
+          // Note COMMIT POINT within withdrawInternal.
           const payment = withdrawInternal(
             balanceStore,
             amount,

--- a/packages/ERTP/src/ratio.js
+++ b/packages/ERTP/src/ratio.js
@@ -116,7 +116,7 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
  * @returns {Amount<'nat'>}
  */
 const multiplyHelper = (amount, ratio, divideOp) => {
-  AmountMath.coerce(amount.brand, amount);
+  amount = AmountMath.coerce(amount.brand, amount);
   assertIsRatio(ratio);
   amount.brand === ratio.denominator.brand ||
     Fail`amount's brand ${q(amount.brand)} must match ratio's denominator ${q(

--- a/packages/ERTP/src/transientNotifier.js
+++ b/packages/ERTP/src/transientNotifier.js
@@ -5,8 +5,9 @@ import { provideLazy } from '@agoric/store';
 import { makeNotifierKit } from '@agoric/notifier';
 
 /**
- * @import {Purse} from './types.js';
+ * @import {WeakMapStore} from '@agoric/store';
  * @import {NotifierRecord} from '@agoric/notifier';
+ * @import {Purse} from './types.js';
  */
 
 // Note: Virtual for high cardinality, but *not* durable, and so

--- a/packages/ERTP/test/unitTests/mathHelpers/copyBagMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/copyBagMathHelpers.test.js
@@ -25,8 +25,7 @@ test('copyBag with strings make', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
-      message:
-        'value "abc" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "abc" must be an AmountValue, not "string"',
     },
     `'abc' is not a valid string array`,
   );
@@ -51,8 +50,7 @@ test('copyBag with strings coerce', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
     {
-      message:
-        'value "6" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "6" must be an AmountValue, not "string"',
     },
     `'6' is not a valid array`,
   );

--- a/packages/ERTP/test/unitTests/mathHelpers/copySetBoundMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/copySetBoundMathHelpers.test.js
@@ -1,0 +1,60 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M, makeCopySet } from '@endo/patterns';
+
+import { AmountMath as m } from '../../../src/index.js';
+import { mockCopySetBrand as mockBrand } from './mockBrand.js';
+
+const mock = value => harden({ brand: mockBrand, value });
+const mockCopySet = elements => mock(makeCopySet(elements));
+
+// The "unit tests" for MathHelpers actually make the calls through
+// AmountMath so that we can test that any duplication is handled
+// correctly.
+
+test('set minus setBound', t => {
+  const specimen = mockCopySet(['a', 'b', 'c']);
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any(), 1n))),
+    mockCopySet(['b', 'c']),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas('a', 1n))),
+    mockCopySet(['b', 'c']),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any(), 1n))),
+    mockCopySet(['b', 'c']),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any(), 3n))),
+    mockCopySet([]),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any()))),
+    mockCopySet(['b', 'c']),
+  );
+
+  t.throws(() => m.subtract(specimen, mock(M.containerHas(M.any(), 4n))), {
+    message: 'Has only "[3n]" matches, but needs "[4n]"',
+  });
+
+  t.throws(() => m.subtract(specimen, mock(M.containerHas('d', 1n))), {
+    message: 'Has only "[0n]" matches, but needs "[1n]"',
+  });
+
+  t.throws(() => m.subtract(specimen, mock(M.containerHas('d'))), {
+    message: 'Has only "[0n]" matches, but needs "[1n]"',
+  });
+});
+
+test('set isGTE setBound', t => {
+  const specimen = mockCopySet(['a', 'b', 'c']);
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any(), 1n))));
+  t.true(m.isGTE(specimen, mock(M.containerHas('a', 1n))));
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any(), 1n))));
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any(), 3n))));
+  t.false(m.isGTE(specimen, mock(M.containerHas(M.any(), 4n))));
+  t.false(m.isGTE(specimen, mock(M.containerHas('d', 1n))));
+
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any()))));
+});

--- a/packages/ERTP/test/unitTests/mathHelpers/copySetMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/copySetMathHelpers.test.js
@@ -24,8 +24,7 @@ test('copySet with strings make', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
-      message:
-        'value "abc" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "abc" must be an AmountValue, not "string"',
     },
     `'abc' is not a valid string array`,
   );
@@ -57,8 +56,7 @@ test('copySet with strings coerce', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
     {
-      message:
-        'value "6" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "6" must be an AmountValue, not "string"',
     },
     `'6' is not a valid array`,
   );
@@ -287,7 +285,7 @@ test('copySet with strings subtract', t => {
       harden({ brand: mockBrand, value: makeCopySet(['a']) }),
     ),
     { brand: mockBrand, value: makeCopySet(['b']) },
-    `['a', 'b'] - ['a'] = ['a']`,
+    `['a', 'b'] - ['a'] = ['b']`,
   );
 });
 

--- a/packages/ERTP/test/unitTests/mathHelpers/natMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/natMathHelpers.test.js
@@ -13,15 +13,13 @@ test('natMathHelpers make', t => {
   t.deepEqual(m.make(mockBrand, 4n), { brand: mockBrand, value: 4n });
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => m.make(mockBrand, 4), {
-    message:
-      'value 4 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 4 must be an AmountValue, not "number"',
   });
   t.throws(
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
-      message:
-        'value "abc" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "abc" must be an AmountValue, not "string"',
     },
     `'abc' is not a nat`,
   );
@@ -29,8 +27,7 @@ test('natMathHelpers make', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, -1),
     {
-      message:
-        'value -1 must be a bigint, copySet, copyBag, or an array, not "number"',
+      message: 'value -1 must be an AmountValue, not "number"',
     },
     `- 1 is not a valid Nat`,
   );
@@ -101,8 +98,7 @@ test('natMathHelpers getValue', t => {
   t.is(m.getValue(mockBrand, m.make(mockBrand, 4n)), 4n);
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => m.getValue(mockBrand, m.make(mockBrand, 4)), {
-    message:
-      'value 4 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 4 must be an AmountValue, not "number"',
   });
 });
 
@@ -157,8 +153,7 @@ test('natMathHelpers isEmpty', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.isEmpty(harden({ brand: mockBrand, value: 'abc' })),
     {
-      message:
-        'value "abc" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "abc" must be an AmountValue, not "string"',
     },
     `isEmpty('abc') throws because it cannot be coerced`,
   );

--- a/packages/ERTP/test/unitTests/mathHelpers/setBoundMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/setBoundMathHelpers.test.js
@@ -1,0 +1,59 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M } from '@endo/patterns';
+
+import { AmountMath as m } from '../../../src/index.js';
+import { mockSetBrand as mockBrand } from './mockBrand.js';
+
+const mock = value => harden({ brand: mockBrand, value });
+
+// The "unit tests" for MathHelpers actually make the calls through
+// AmountMath so that we can test that any duplication is handled
+// correctly.
+
+test('set minus setBound', t => {
+  const specimen = mock(['a', 'b', 'c']);
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any(), 1n))),
+    mock(['b', 'c']),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas('a', 1n))),
+    mock(['b', 'c']),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any(), 1n))),
+    mock(['b', 'c']),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any(), 3n))),
+    mock([]),
+  );
+  t.deepEqual(
+    m.subtract(specimen, mock(M.containerHas(M.any()))),
+    mock(['b', 'c']),
+  );
+
+  t.throws(() => m.subtract(specimen, mock(M.containerHas(M.any(), 4n))), {
+    message: 'Has only "[3n]" matches, but needs "[4n]"',
+  });
+
+  t.throws(() => m.subtract(specimen, mock(M.containerHas('d', 1n))), {
+    message: 'Has only "[0n]" matches, but needs "[1n]"',
+  });
+
+  t.throws(() => m.subtract(specimen, mock(M.containerHas('d'))), {
+    message: 'Has only "[0n]" matches, but needs "[1n]"',
+  });
+});
+
+test('set isGTE setBound', t => {
+  const specimen = mock(['a', 'b', 'c']);
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any(), 1n))));
+  t.true(m.isGTE(specimen, mock(M.containerHas('a', 1n))));
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any(), 1n))));
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any(), 3n))));
+  t.false(m.isGTE(specimen, mock(M.containerHas(M.any(), 4n))));
+  t.false(m.isGTE(specimen, mock(M.containerHas('d', 1n))));
+
+  t.true(m.isGTE(specimen, mock(M.containerHas(M.any()))));
+});

--- a/packages/ERTP/test/unitTests/mathHelpers/setMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/setMathHelpers.test.js
@@ -9,7 +9,11 @@ import { mockSetBrand as mockBrand } from './mockBrand.js';
 // AmountMath so that we can test that any duplication is handled
 // correctly.
 
-const runSetMathHelpersTests = (t, [a, b, c], a2) => {
+const runSetMathHelpersTests = (
+  t,
+  [a, b, c],
+  a2 = /** @type {any} */ (undefined),
+) => {
   // a2 is a copy of a which should have the same values but not same
   // identity. This doesn't make sense to use for handle tests, but
   // makes sense for anything where the identity is based on data.
@@ -51,8 +55,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2) => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'a'),
     {
-      message:
-        'value "a" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "a" must be an AmountValue, not "string"',
     },
     'strings are not valid',
   );
@@ -98,8 +101,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2) => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: 'a' })),
     {
-      message:
-        'value "a" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "a" must be an AmountValue, not "string"',
     },
     'strings are not valid',
   );
@@ -134,8 +136,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2) => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.isEmpty(harden({ brand: mockBrand, value: {} })),
     {
-      message:
-        'value {} must be a bigint, copySet, copyBag, or an array, not "copyRecord"',
+      message: 'value {} must be an AmountValue, not "copyRecord"',
     },
     `m.isEmpty({}) throws`,
   );

--- a/packages/ERTP/test/unitTests/mathHelpers/strSetMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/strSetMathHelpers.test.js
@@ -20,8 +20,7 @@ test('set with strings make', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
-      message:
-        'value "abc" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "abc" must be an AmountValue, not "string"',
     },
     `'abc' is not a valid string array`,
   );
@@ -46,8 +45,7 @@ test('set with strings coerce', t => {
     // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
     {
-      message:
-        'value "6" must be a bigint, copySet, copyBag, or an array, not "string"',
+      message: 'value "6" must be an AmountValue, not "string"',
     },
     `'6' is not a valid array`,
   );

--- a/packages/ERTP/test/unitTests/ratio.test.js
+++ b/packages/ERTP/test/unitTests/ratio.test.js
@@ -107,23 +107,19 @@ test('ratio - multiplyBy non Amount', t => {
   });
   // @ts-expect-error Incorrect values for testing
   t.throws(() => floorMultiplyBy(badAmount, makeRatio(25n, brand)), {
-    message:
-      'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 3.5 must be an AmountValue, not "number"',
   });
   // @ts-expect-error Incorrect values for testing
   t.throws(() => ceilMultiplyBy(badAmount, makeRatio(25n, brand)), {
-    message:
-      'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 3.5 must be an AmountValue, not "number"',
   });
   // @ts-expect-error Incorrect values for testing
   t.throws(() => floorDivideBy(badAmount, makeRatio(25n, brand)), {
-    message:
-      'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 3.5 must be an AmountValue, not "number"',
   });
   // @ts-expect-error Incorrect values for testing
   t.throws(() => ceilDivideBy(badAmount, makeRatio(25n, brand)), {
-    message:
-      'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 3.5 must be an AmountValue, not "number"',
   });
 });
 
@@ -202,8 +198,7 @@ test('ratio - Nats', t => {
 
   // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatio(10.1, brand), {
-    message:
-      'value 10.1 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 10.1 must be an AmountValue, not "number"',
   });
 });
 
@@ -241,13 +236,11 @@ test('ratio bad inputs', t => {
   const moe = value => AmountMath.make(brand, value);
   // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatio(-3, brand), {
-    message:
-      'value -3 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value -3 must be an AmountValue, not "number"',
   });
   // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatio(3n, brand, 100.5), {
-    message:
-      'value 100.5 must be a bigint, copySet, copyBag, or an array, not "number"',
+    message: 'value 100.5 must be an AmountValue, not "number"',
   });
   // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatioFromAmounts(3n, moe(30n)), {

--- a/packages/store/test/borrow-guards.js
+++ b/packages/store/test/borrow-guards.js
@@ -19,8 +19,27 @@ export const AmountShape = harden({
   value: AmountValueShape,
 });
 
+/**
+ * TODO: need a pattern to test `kindOf(specimen) === 'match:containerHas'` to
+ * to ensure that the pattern-level invariants are met.
+ *
+ * TODO: check all uses of M.tagged to see if they have the same weakness.
+ *
+ * @see {HasBound}
+ */
+export const HasBoundShape = M.tagged('match:containerHas');
+
+/** @see {AmountValueBound} */
+const AmountValueBoundShape = M.or(AmountValueShape, HasBoundShape);
+
+/** @see {AmountBound} */
+export const AmountBoundShape = harden({
+  brand: BrandShape,
+  value: AmountValueBoundShape,
+});
+
 const AmountKeywordRecordShape = M.recordOf(M.string(), AmountShape);
-const AmountPatternKeywordRecordShape = M.recordOf(M.string(), M.pattern());
+const AmountBoundKeywordRecordShape = M.recordOf(M.string(), AmountBoundShape);
 
 const TimerBrandShape = M.remotable('TimerBrand');
 const TimestampValueShape = M.nat();
@@ -31,7 +50,7 @@ const TimestampRecordShape = harden({
 const TimestampShape = M.or(TimestampRecordShape, TimestampValueShape);
 
 export const FullProposalShape = harden({
-  want: AmountPatternKeywordRecordShape,
+  want: AmountBoundKeywordRecordShape,
   give: AmountKeywordRecordShape,
   // To accept only one, we could use M.or rather than M.partial,
   // but the error messages would have been worse. Rather,

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -31,6 +31,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     const debt = getDebt();
 
     // All debt must be repaid.
+    // @ts-expect-error TODO Why is it specializing isGTE to NatAmount?
     AmountMath.isGTE(repaid, debt) ||
       Fail`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`;
 


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/endojs/endo/pull/2710 #1905 #1913 #1915 #2155 #2156 #2230 #4212 #4217 #10951 #10952 

## Description

Implements the ERTP part of minimal want patterns, where the only supported pattern is `M.containerHas`. #10952 then implements the zoe portion.

### Security Considerations

none

### Scaling Considerations

at the ERTP level, none.

### Documentation Considerations

Need to update ERTP docs to explain the use of `M.has` patterns in `AmountMath.isGTE` and `AmountMath.subtract`.

### Testing Considerations

ERTP tests already added.

### Upgrade Considerations

None

- [ ] Need to update NEWS.md for ERTP