### PR TITLE
refactor: suppress connectToNoble() in FastUSDC proposals in A3p tests

### DIFF
--- a/packages/fast-usdc-deploy/src/fast-usdc-settler-ref.build.js
+++ b/packages/fast-usdc-deploy/src/fast-usdc-settler-ref.build.js
@@ -1,10 +1,11 @@
 /**
  * Usage:
- * agoric run fast-usdc-settler-ref.build.js
+ * agoric run fast-usdc-settler-ref.build.js [configuration]
  *
  * (see update-settler-reference.core.js)
  */
 import { makeHelpers } from '@agoric/deploy-script-support';
+import { parseArgs } from 'node:util';
 import { getManifestForUpdateSettlerReference } from './update-settler-reference.core.js';
 
 /**
@@ -13,13 +14,10 @@ import { getManifestForUpdateSettlerReference } from './update-settler-reference
 
 /**
  * @param {Parameters<CoreEvalBuilder>[0]} powers
- * @param {{}} options
+ * @param {{ net: string }} options
  * @satisfies {CoreEvalBuilder}
  */
-export const proposalBuilder = async (
-  { publishRef, install },
-  options = {},
-) => {
+export const proposalBuilder = async ({ publishRef, install }, options) => {
   return harden({
     sourceSpec: './update-settler-reference.core.js',
     /** @type {[string, Parameters<typeof getManifestForUpdateSettlerReference>[1]]} */
@@ -42,8 +40,14 @@ export const proposalBuilder = async (
 /** @type {DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  const { scriptArgs } = endowments;
+  const { positionals } = parseArgs({
+    args: scriptArgs,
+    allowPositionals: true,
+  });
+  const net = positionals[0];
 
   await writeCoreEval('eval-fast-usdc-settler-ref', utils =>
-    proposalBuilder(utils),
+    proposalBuilder(utils, { net }),
   );
 };

--- a/packages/fast-usdc-deploy/src/update-settler-reference.core.js
+++ b/packages/fast-usdc-deploy/src/update-settler-reference.core.js
@@ -6,7 +6,6 @@ import { E } from '@endo/far';
 const trace = makeTracer('FUSD-3', true);
 
 /**
- * @import {CopyRecord} from '@endo/pass-style';
  * @import {ManifestBundleRef} from '@agoric/deploy-script-support/src/externalTypes.js';
  * @import {BundleID} from '@agoric/swingset-vat';
  * @import {BootstrapManifest} from '@agoric/vats/src/core/lib-boot.js';
@@ -17,17 +16,18 @@ const { keys } = Object;
 
 /**
  * @typedef {object} UpdateOpts
+ * @property {string} net
  * @property {{bundleID: BundleID}} [fastUsdcCode]
  */
 
 /**
  * @param {BootstrapPowers & FastUSDCCorePowers} powers
- * @param {object} [config]
- * @param {UpdateOpts} [config.options]
+ * @param {object} config
+ * @param {UpdateOpts} config.options
  */
 export const updateSettlerReference = async (
   { consume: { fastUsdcKit } },
-  { options = {} } = {},
+  { options },
 ) => {
   trace('options', options);
   const { fastUsdcCode = assert.fail('missing bundleID') } = options;
@@ -40,7 +40,13 @@ export const updateSettlerReference = async (
   );
   trace('fastUsdc upgraded', upgraded);
 
-  await E(creatorFacet).connectToNoble();
+  if (options.net === 'A3P-INTEGRATION') {
+    // A3P-INTEGRATION has no connection to Noble.
+    console.log('skipping connectToNoble for ', options.net);
+  } else {
+    await E(creatorFacet).connectToNoble();
+  }
+
   trace('updateSettlerReference done');
 };
 
@@ -48,7 +54,7 @@ export const updateSettlerReference = async (
  * @param {unknown} _utils
  * @param {{
  *   installKeys: { fastUsdc: ERef<ManifestBundleRef> };
- *   options: Omit<UpdateOpts, 'fastUsdcCode'> & CopyRecord;
+ *   options: { net: string };
  * }} opts
  */
 export const getManifestForUpdateSettlerReference = (


### PR DESCRIPTION
refs: #[305](https://github.com/Agoric/agoric-private/issues/305)
refs: #[230](https://github.com/Agoric/agoric-3-proposals/pull/230)
refs: #[228](https://github.com/Agoric/agoric-3-proposals/pull/228)

## Description

Require a _platform_ parameter when building  the proposal for *fastUSDC-GTM*, so we can suppress the call to `connectToNoble()` on A3P, where there is no Noble connections.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

The proposal builder complains if it doesn't get a parameter. The only value it compares to is *A3P-INTEGRATION*.

### Testing Considerations

This enabled adding proposal 89 to `agoric-3-proposals`.

### Upgrade Considerations

Moving tests from `a3p-integration` to `agoric-3-proposals` unblocks preparing new releases. The affected upgrade has already been applied to mainNet.
