### PR TITLE
refactor: move some type imports to @import

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -10,11 +10,12 @@ import { coerceDisplayInfo } from './displayInfo.js';
 import { preparePaymentLedger } from './paymentLedger.js';
 
 /**
- * @import {AdditionalDisplayInfo, RecoverySetsOption, IssuerKit, PaymentLedger} from './types.js';
+ * @import {Key, Pattern} from '@endo/patterns';
+ * @import {Zone} from '@agoric/base-zone';
  * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
  * @import {TypedPattern} from '@agoric/internal';
- * @import {CopyTaggedInterface, Key, RemotableObject} from '@endo/patterns';
- * @import {Pattern} from '@endo/patterns';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {AdditionalDisplayInfo, RecoverySetsOption, IssuerKit, PaymentLedger} from './types.js';
  */
 
 /**
@@ -31,7 +32,7 @@ import { preparePaymentLedger } from './paymentLedger.js';
  *
  * @template {AssetKind} K
  * @param {IssuerRecord<K>} issuerRecord
- * @param {import('@agoric/zone').Zone} issuerZone
+ * @param {Zone} issuerZone
  * @param {RecoverySetsOption} recoverySetsState Omitted from issuerRecord
  *   because it was added in an upgrade.
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
@@ -99,7 +100,7 @@ const RECOVERY_SETS_STATE = 'recoverySetsState';
  * make a new one.
  *
  * @template {AssetKind} K
- * @param {import('@agoric/vat-data').Baggage} issuerBaggage
+ * @param {Baggage} issuerBaggage
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
  *   the middle of an atomic action (which btw should never happen), it
  *   potentially leaves its ledger in a corrupted state. If this function was
@@ -143,7 +144,7 @@ harden(upgradeIssuerKit);
 /**
  * Does baggage already have an issuerKit?
  *
- * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {Baggage} baggage
  */
 export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
 
@@ -183,7 +184,7 @@ export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
  *   basic fungible tokens.
  *
  *   `displayInfo` gives information to the UI on how to display the amount.
- * @param {import('@agoric/vat-data').Baggage} issuerBaggage
+ * @param {Baggage} issuerBaggage
  * @param {string} name
  * @param {K} [assetKind]
  * @param {AdditionalDisplayInfo} [displayInfo]
@@ -242,7 +243,7 @@ harden(makeDurableIssuerKit);
  *   basic fungible tokens.
  *
  *   `displayInfo` gives information to the UI on how to display the amount.
- * @param {import('@agoric/vat-data').Baggage} issuerBaggage
+ * @param {Baggage} issuerBaggage
  * @param {string} name
  * @param {K} [assetKind]
  * @param {AdditionalDisplayInfo} [displayInfo]

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -2,20 +2,21 @@
 
 /// <reference types="@agoric/store/exported.js" />
 
-import { X, q, Fail, annotateError } from '@endo/errors';
+import { q, Fail, annotateError, X } from '@endo/errors';
 import { isPromise } from '@endo/promise-kit';
-import { mustMatch, M, keyEQ } from '@agoric/store';
+import { mustMatch, M, keyEQ } from '@endo/patterns';
 import { AmountMath } from './amountMath.js';
 import { preparePaymentKind } from './payment.js';
 import { preparePurseKind } from './purse.js';
-
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
 /**
  * @import {Key, Pattern} from '@endo/patterns';
- * @import {Amount, AssetKind, DisplayInfo, PaymentLedger, Payment, Brand, RecoverySetsOption, Purse, Issuer, Mint} from './types.js'
- * @import {ShutdownWithFailure} from '@agoric/swingset-vat'
+ * @import {Zone} from '@agoric/base-zone';
  * @import {TypedPattern} from '@agoric/internal';
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {AmountStore} from './amountStore.js';
+ * @import {Amount, AssetKind, DisplayInfo, PaymentLedger, Payment, Brand, RecoverySetsOption, Purse, Issuer, Mint} from './types.js';
  */
 
 /**
@@ -75,7 +76,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * minting and transfer authority originates here.
  *
  * @template {AssetKind} K
- * @param {import('@agoric/zone').Zone} issuerZone
+ * @param {Zone} issuerZone
  * @param {string} name
  * @param {K} assetKind
  * @param {DisplayInfo<K>} displayInfo
@@ -240,7 +241,7 @@ export const preparePaymentLedger = (
   /**
    * Used by the purse code to implement purse.deposit
    *
-   * @param {import('./amountStore.js').AmountStore} balanceStore
+   * @param {AmountStore} balanceStore
    * @param {Payment} srcPayment
    * @param {Pattern} [optAmountShape]
    * @returns {Amount}
@@ -274,7 +275,7 @@ export const preparePaymentLedger = (
   /**
    * Used by the purse code to implement purse.withdraw
    *
-   * @param {import('./amountStore.js').AmountStore} balanceStore
+   * @param {AmountStore} balanceStore
    * @param {Amount} amount - the amount to be withdrawn
    * @param {SetStore<Payment>} [recoverySet]
    * @returns {Payment}

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -397,7 +397,9 @@ export {};
  *
  * @typedef { { vatParameters?: object, upgradeMessage?: string } } VatUpgradeOptions
  * @typedef { { incarnationNumber: number } } VatUpgradeResults
- *
+ */
+
+/**
  * @callback ShutdownWithFailure
  * Called to shut something down because something went wrong, where the reason
  * is supposed to be an Error that describes what went wrong. Some valid
@@ -408,7 +410,9 @@ export {};
  *
  * @param {Error} reason
  * @returns {void}
- *
+ */
+
+/**
  * @typedef {object} VatAdminFacet
  * A powerful object corresponding with a vat
  * that can be used to upgrade it with new code or parameters,
@@ -426,8 +430,9 @@ export {};
  * in which the JS memory space is abandoned. The new image is launched with access to 'baggage'
  * and any durable storage reachable from it, and must fulfill all the obligations of the previous
  * incarnation.
- *
- *
+ */
+
+/**
  * @typedef {{ adminNode: Guarded<VatAdminFacet>, root: object }} CreateVatResults
  *
  * @typedef {object} VatAdminSvc
@@ -436,5 +441,4 @@ export {};
  * @property {(name: string) => ERef<BundleCap>} getNamedBundleCap
  * @property {(name: string) => ERef<BundleID>} getBundleIDByName
  * @property {(bundleCap: BundleCap, options?: DynamicVatOptions) => ERef<CreateVatResults>} createVat
- *
  */

--- a/packages/pegasus/src/contract.js
+++ b/packages/pegasus/src/contract.js
@@ -5,6 +5,7 @@ import { makePegasus } from './pegasus.js';
 
 /**
  * @import {Remote} from '@agoric/vow';
+ * @import {ContractStartFn} from '@agoric/zoe';
  */
 
 /**

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -199,13 +199,19 @@ type WellKnownName = {
 };
 
 type ContractInstallationPromises<
-  StartFns extends Record<WellKnownName['installation'], ContractStartFn>,
+  StartFns extends Record<
+    WellKnownName['installation'],
+    import('@agoric/zoe').ContractStartFn
+  >,
 > = {
   [Property in keyof StartFns]: Promise<Installation<StartFns[Property]>>;
 };
 
 type ContractInstancePromises<
-  StartFns extends Record<WellKnownName['instance'], ContractStartFn>,
+  StartFns extends Record<
+    WellKnownName['instance'],
+    import('@agoric/zoe').ContractStartFn
+  >,
 > = {
   [Property in keyof StartFns]: Promise<
     import('@agoric/zoe/src/zoeService/utils.js').Instance<StartFns[Property]>

--- a/packages/vats/src/vat-mints.js
+++ b/packages/vats/src/vat-mints.js
@@ -1,5 +1,5 @@
 import { Far } from '@endo/far';
-import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 
 import { makeScalarMapStore } from '@agoric/store';
 import { notForProductionUse } from '@agoric/internal/src/magic-cookie-test-only.js';
@@ -13,10 +13,12 @@ export function buildRootObject() {
 
   const api = Far('api', {
     getAllIssuerNames: () => [...mintsAndBrands.keys()],
+
     getIssuer: issuerName => {
       const { mint } = mintsAndBrands.get(issuerName);
       return mint.getIssuer();
     },
+
     /** @param {string[]} issuerNames */
     getIssuers: issuerNames => issuerNames.map(api.getIssuer),
 
@@ -31,22 +33,10 @@ export function buildRootObject() {
       notForProductionUse();
       return mintsAndBrands.get(name).mint;
     },
+
     /** @param {string[]} issuerNames */
     getMints: issuerNames => issuerNames.map(api.getMint),
-    /**
-     * @param {any} issuerNameSingular For example, 'moola', or 'simolean'
-     * @param {[AssetKind?, DisplayInfo?]} issuerArgs
-     */
-    makeMintAndIssuer: (issuerNameSingular, ...issuerArgs) => {
-      notForProductionUse();
-      // makeIssuerKit fails upgrade, this contract is for demo only
-      const { mint, issuer, brand } = makeIssuerKit(
-        issuerNameSingular,
-        ...issuerArgs,
-      );
-      mintsAndBrands.init(issuerNameSingular, { mint, brand });
-      return issuer;
-    },
+
     provideIssuerKit: (issuerName, ...issuerArgs) => {
       notForProductionUse();
       if (mintsAndBrands.has(issuerName)) {
@@ -63,6 +53,7 @@ export function buildRootObject() {
         return { mint, issuer, brand };
       }
     },
+
     /**
      * @param {string} issuerName
      * @param {bigint} value
@@ -75,6 +66,7 @@ export function buildRootObject() {
       const amount = AmountMath.make(brand, value);
       return mint.mintPayment(amount);
     },
+
     /**
      * @param {string[]} issuerNames
      * @param {bigint[]} values

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -19,10 +19,13 @@ import {
 } from '../typeGuards.js';
 import { makeAllocationMap } from './reallocate.js';
 import { TransferPartShape } from '../contractSupport/atomicTransfer.js';
+import '../internal-types.js';
 
 /**
  * @import {WeakMapStore} from '@agoric/store';
- * @import {TransferPart, ZCFSeat} from '@agoric/zoe';
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {Allocation} from './types.js';
  */
 
 /**
@@ -31,8 +34,8 @@ import { TransferPartShape } from '../contractSupport/atomicTransfer.js';
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {import('@agoric/swingset-vat').ShutdownWithFailure} shutdownWithFailure
- * @param {import('@agoric/vat-data').Baggage} zcfBaggage
+ * @param {ShutdownWithFailure} shutdownWithFailure
+ * @param {Baggage} zcfBaggage
  * @returns {{ seatManager: ZcfSeatManager, zcfMintReallocator: ZcfMintReallocator }}
  */
 export const createSeatManager = (

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -19,7 +19,6 @@ import {
 } from '../typeGuards.js';
 import { makeAllocationMap } from './reallocate.js';
 import { TransferPartShape } from '../contractSupport/atomicTransfer.js';
-import '../internal-types.js';
 
 /**
  * @import {WeakMapStore} from '@agoric/store';

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -28,12 +28,13 @@ import { createSeatManager } from './zcfSeat.js';
 import { HandleOfferI, InvitationHandleShape } from '../typeGuards.js';
 import { prepareZcMint } from './zcfMint.js';
 import { ZcfI } from './typeGuards.js';
-
-/// <reference path="../internal-types.js" />
+import '../internal-types.js';
 
 /**
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {Baggage} from '@agoric/vat-data';
  * @import {IssuerOptionsRecord} from '@agoric/ertp';
- * @import {ContractMeta, ContractStartFn, SetTestJig, ZCF, ZCFMint, ZCFRegisterFeeMint, ZoeService} from '@agoric/zoe';
+ * @import {ZoeIssuerRecord, ZCFRegisterFeeMint, ContractStartFn, SetTestJig} from './types.js';
  */
 
 /**
@@ -56,7 +57,7 @@ import { ZcfI } from './typeGuards.js';
  * @param {Issuer<'set'>} invitationIssuer
  * @param {( {zcf}: {zcf: ZCF} ) => void} testJigSetter
  * @param {BundleCap} contractBundleCap
- * @param {import('@agoric/vat-data').Baggage} zcfBaggage
+ * @param {Baggage} zcfBaggage
  * @returns {Promise<ZCFZygote>}
  */
 export const makeZCFZygote = async (
@@ -88,7 +89,7 @@ export const makeZCFZygote = async (
     instantiate: instantiateIssuerStorage,
   } = provideIssuerStorage(zcfBaggage);
 
-  /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
+  /** @type {ShutdownWithFailure} */
   const shutdownWithFailure = reason => {
     void E(zoeInstanceAdmin).failAllSeats(reason);
     seatManager.dropAllReferences();

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -28,7 +28,6 @@ import { createSeatManager } from './zcfSeat.js';
 import { HandleOfferI, InvitationHandleShape } from '../typeGuards.js';
 import { prepareZcMint } from './zcfMint.js';
 import { ZcfI } from './typeGuards.js';
-import '../internal-types.js';
 
 /**
  * @import {ShutdownWithFailure} from '@agoric/swingset-vat';

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -3,6 +3,10 @@ import { AmountMath } from '@agoric/ertp';
 
 import { offerTo } from '../../contractSupport/zoeHelpers.js';
 
+/**
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ */
+
 export const doLiquidation = async (
   zcf,
   collateralSeat,
@@ -37,7 +41,7 @@ export const doLiquidation = async (
     zcf.shutdown('your loan had to be liquidated');
   };
 
-  /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
+  /** @type {ShutdownWithFailure} */
   const closeWithFailure = err => {
     lenderSeat.fail(err);
     collateralSeat.fail(err);

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -11,6 +11,11 @@ import {
   TermsShape,
 } from './typeGuards.js';
 
+/**
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {InstanceRecord} from './zoeService/utils.js';
+ */
+
 const { ownKeys } = Reflect;
 
 /**
@@ -24,7 +29,7 @@ const { ownKeys } = Reflect;
  */
 
 /**
- * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {Baggage} baggage
  * @returns {(ir: InstanceRecord) => InstanceState}
  */
 export const makeInstanceRecordStorage = baggage => {

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -2,8 +2,13 @@
 /// <reference types="@agoric/ertp/exported" />
 
 /**
- * @import {Allocation, AnyTerms, BrandKeywordRecord, Completion, ContractStartFn, InvitationHandle, PaymentPKeywordRecord, UserSeat, ZoeIssuerRecord} from '@agoric/zoe';
+ * @import {RemotableObject, Passable} from '@endo/pass-style';
  * @import {Pattern} from '@endo/patterns';
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {IssuerOptionsRecord, IssuerRecord} from '@agoric/ertp';
+ * @import {Allocation, PaymentPKeywordRecord, UserSeat, Completion, ZoeIssuerRecord} from './types-index.js';
+ * @import {InvitationHandle, BrandKeywordRecord, AnyTerms} from './types.js';
  */
 
 /**
@@ -24,7 +29,7 @@
 
 /**
  * @typedef WithdrawFacet
- * @property {(allocation:Allocation) => PaymentPKeywordRecord} withdrawPayments
+ * @property {(allocation: Allocation) => PaymentPKeywordRecord} withdrawPayments
  */
 
 /**
@@ -48,7 +53,7 @@
  * @param {WithdrawFacet} withdrawFacet
  * @param {ERef<ExitObj>} exitObj
  * @param {ERef<unknown>} [offerResult]
- * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {Baggage} baggage
  * @returns {ZoeSeatAdminKit}
  */
 
@@ -62,12 +67,12 @@
  * @typedef ZoeSeatAdminMethods
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {ZoeSeatAdminExit} exit
- * @property {import('@agoric/swingset-vat').ShutdownWithFailure} fail called with the reason
+ * @property {ShutdownWithFailure} fail called with the reason
  * for calling fail on this seat, where reason is normally an instanceof Error.
  * @property {() => Subscriber<AmountKeywordRecord>} getExitSubscriber
  */
 /**
- * @typedef {import('@endo/marshal').RemotableObject & ZoeSeatAdminMethods} ZoeSeatAdmin
+ * @typedef {RemotableObject & ZoeSeatAdminMethods} ZoeSeatAdmin
  */
 
 /**
@@ -76,7 +81,7 @@
 
 /**
  * @typedef {object} HandleOfferResult
- * @property {Promise<import('@endo/marshal').Passable>} offerResultPromise
+ * @property {Promise<Passable>} offerResultPromise
  * @property {ExitObj} exitObj
  */
 
@@ -101,7 +106,7 @@
  * @property {() => string[]} getOfferFilter
  * @property {() => Installation} getInstallation
  * @property {(completion: Completion) => void} exitAllSeats
- * @property {import('@agoric/swingset-vat').ShutdownWithFailure} failAllSeats
+ * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  * @property {(string: string) => boolean} isBlocked
  * @property {(handleOfferObj: HandleOfferObj, publicFacet: unknown) => void} initDelayedState
@@ -139,7 +144,7 @@
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
  * @property {(completion: Completion) => void} exitAllSeats
- * @property {import('@agoric/swingset-vat').ShutdownWithFailure} failAllSeats
+ * @property {ShutdownWithFailure} failAllSeats
  * @property {(seatHandle: SeatHandle, completion: Completion) => void} exitSeat
  * @property {(seatHandle: SeatHandle, reason: Error) => void} failSeat
  * @property {() => void} stopAcceptingOffers
@@ -169,7 +174,7 @@
  * @param {Keyword} keyword
  * @param {AssetKind} [assetKind]
  * @param {AdditionalDisplayInfo} [displayInfo]
- * @param {import('@agoric/ertp').IssuerOptionsRecord} [options]
+ * @param {IssuerOptionsRecord} [options]
  * @returns {ZoeMint}
  */
 
@@ -196,7 +201,7 @@
 /**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} ZoeMint
- * @property {() => import('@agoric/ertp').IssuerRecord<K>} getIssuerRecord
+ * @property {() => IssuerRecord<K>} getIssuerRecord
  * @property {(totalToMint: Amount<K>) => void} mintAndEscrow
  * @property {(totalToBurn: Amount<K>) => void} withdrawAndBurn
  * Note that the burning is asynchronous, and so may not have happened by

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -5,8 +5,6 @@ import { deeplyFulfilledObject, objectMap } from '@agoric/internal';
 import { provideDurableWeakMapStore } from '@agoric/vat-data';
 
 /// <reference path="./types.js" />
-import '../internal-types.js';
-import './internal-types.js';
 
 import { cleanKeywords } from '../cleanProposal.js';
 

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -5,12 +5,13 @@ import { deeplyFulfilledObject, objectMap } from '@agoric/internal';
 import { provideDurableWeakMapStore } from '@agoric/vat-data';
 
 /// <reference path="./types.js" />
+import '../internal-types.js';
 import './internal-types.js';
 
 import { cleanKeywords } from '../cleanProposal.js';
 
 /**
- * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
+ * @import {WeakMapStore} from '@agoric/store';
  */
 
 /**

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -15,7 +15,9 @@ import { Fail, q } from '@endo/errors';
 import { FeeMintAccessShape } from '../typeGuards.js';
 
 /**
- * @import {FeeIssuerConfig, ZoeService} from '@agoric/zoe';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {FeeIssuerConfig} from './types.js';
  */
 
 /** @deprecated Redundant. Just omit it. */
@@ -30,9 +32,9 @@ export const defaultFeeIssuerConfig = harden(
 );
 
 /**
- * @param {import('@agoric/vat-data').Baggage} zoeBaggage
+ * @param {Baggage} zoeBaggage
  * @param {FeeIssuerConfig} feeIssuerConfig
- * @param {import('@agoric/swingset-vat').ShutdownWithFailure} shutdownZoeVat
+ * @param {ShutdownWithFailure} shutdownZoeVat
  */
 const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const mintBaggage = provideDurableMapStore(zoeBaggage, 'mintBaggage');

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -9,8 +9,6 @@ import {
   InstallationShape,
   UnwrappedInstallationShape,
 } from '../typeGuards.js';
-import '../internal-types.js';
-import './internal-types.js';
 
 /**
  * @import {Baggage} from '@agoric/swingset-liveslots';

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -9,11 +9,12 @@ import {
   InstallationShape,
   UnwrappedInstallationShape,
 } from '../typeGuards.js';
+import '../internal-types.js';
+import './internal-types.js';
 
 /**
  * @import {Baggage} from '@agoric/swingset-liveslots';
- * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
- * @import {MapStore} from '@agoric/swingset-liveslots';
+ * @import {WeakMapStore} from '@agoric/store';
  * @import {BundleID, BundleCap} from '@agoric/swingset-vat';
  * @import {SourceBundle} from '@agoric/zoe';
  */

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -4,8 +4,11 @@ import { Fail, q } from '@endo/errors';
 import { provideDurableMapStore } from '@agoric/vat-data';
 import { AssetKind, hasIssuer, prepareIssuerKit } from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';
+
 /**
- * @import {FeeIssuerConfig, InvitationDetails} from '@agoric/zoe';
+ * @import {Baggage} from '@agoric/vat-data';
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {InvitationDetails} from '../types-index.js';
  */
 
 /**
@@ -14,8 +17,8 @@ import { InvitationElementShape } from '../typeGuards.js';
 const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
 
 /**
- * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {import('@agoric/swingset-vat').ShutdownWithFailure | undefined} shutdownZoeVat
+ * @param {Baggage} baggage
+ * @param {ShutdownWithFailure | undefined} shutdownZoeVat
  */
 export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
   const invitationKitBaggage = provideDurableMapStore(

--- a/packages/zoe/src/zoeService/originalZoeSeat.js
+++ b/packages/zoe/src/zoeService/originalZoeSeat.js
@@ -7,13 +7,13 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { NonNullish } from '@agoric/internal';
 
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
-import '../internal-types.js';
 import {
   AmountKeywordRecordShape,
   ExitObjectShape,
   KeywordShape,
   PaymentPKeywordRecordShape,
 } from '../typeGuards.js';
+import '../internal-types.js';
 
 export const coreUserSeatMethods = harden({
   getProposal: M.call().returns(M.promise()),

--- a/packages/zoe/src/zoeService/originalZoeSeat.js
+++ b/packages/zoe/src/zoeService/originalZoeSeat.js
@@ -13,7 +13,6 @@ import {
   KeywordShape,
   PaymentPKeywordRecordShape,
 } from '../typeGuards.js';
-import '../internal-types.js';
 
 export const coreUserSeatMethods = harden({
   getProposal: M.call().returns(M.promise()),

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -18,8 +18,6 @@ import {
   InstanceAdminI,
   InstanceAdminShape,
 } from '../typeGuards.js';
-import '../internal-types.js';
-import './internal-types.js';
 
 /**
  * @import {Baggage} from '@agoric/vat-data';

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -18,11 +18,13 @@ import {
   InstanceAdminI,
   InstanceAdminShape,
 } from '../typeGuards.js';
+import '../internal-types.js';
+import './internal-types.js';
 
 /**
  * @import {Baggage} from '@agoric/vat-data';
- * @import {LegacyWeakMap, WeakMapStore} from '@agoric/store';
- * @import {BundleCap, EndoZipBase64Bundle} from '@agoric/swingset-vat';
+ * @import {WeakMapStore} from '@agoric/store';
+ * @import {BundleCap} from '@agoric/swingset-vat';
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -27,8 +27,6 @@ import { makeInvitationQueryFns } from './invitationQueries.js';
 import { getZcfBundleCap } from './createZCFVat.js';
 import { defaultFeeIssuerConfig, prepareFeeMint } from './feeMint.js';
 import { ZoeServiceI } from '../typeGuards.js';
-import '../internal-types.js';
-import './internal-types.js';
 
 /**
  * @import {VatAdminSvc, ShutdownWithFailure} from '@agoric/swingset-vat';

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -14,12 +14,12 @@
 /// <reference types="@agoric/notifier/exported.js" />
 /// <reference path="../internal-types.js" />
 
+import { Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { M } from '@endo/patterns';
 import { makeScalarBigMapStore, prepareExo } from '@agoric/vat-data';
-import { M } from '@agoric/store';
 
-import { Fail } from '@endo/errors';
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
 import { makeOfferMethod } from './offer/offer.js';
@@ -27,9 +27,11 @@ import { makeInvitationQueryFns } from './invitationQueries.js';
 import { getZcfBundleCap } from './createZCFVat.js';
 import { defaultFeeIssuerConfig, prepareFeeMint } from './feeMint.js';
 import { ZoeServiceI } from '../typeGuards.js';
+import '../internal-types.js';
+import './internal-types.js';
 
 /**
- * @import {VatAdminSvc} from '@agoric/swingset-vat';
+ * @import {VatAdminSvc, ShutdownWithFailure} from '@agoric/swingset-vat';
  * @import {Baggage} from '@agoric/vat-data';
  * @import {FeeIssuerConfig, FeeMintAccess, ZCFSpec, ZoeService} from './types.js';
  */
@@ -42,7 +44,7 @@ import { ZoeServiceI } from '../typeGuards.js';
  * @param {Promise<VatAdminSvc> | VatAdminSvc} [options.vatAdminSvc] - The vatAdmin Service, which carries the
  * power to create a new vat. If it's not available when makeZoe() is called, it
  * must be provided later using setVatAdminService().
- * @param {import('@agoric/swingset-vat').ShutdownWithFailure} [options.shutdownZoeVat] - a function to
+ * @param {ShutdownWithFailure} [options.shutdownZoeVat] - a function to
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} [options.feeIssuerConfig]
@@ -272,7 +274,7 @@ const makeDurableZoeKit = ({
  * @param {Promise<VatAdminSvc> | VatAdminSvc} [vatAdminSvc] - The vatAdmin Service, which carries the
  * power to create a new vat. If it's not available when makeZoe() is called, it
  * must be provided later using setVatAdminService().
- * @param {import('@agoric/swingset-vat').ShutdownWithFailure} [shutdownZoeVat] - a function to
+ * @param {ShutdownWithFailure} [shutdownZoeVat] - a function to
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} [feeIssuerConfig]

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -26,7 +26,13 @@ import {
   ZoeMintI,
   ZoeStorageManagerIKit,
 } from '../typeGuards.js';
-import '../internal-types.js';
+
+// Deleting this imperative-looking import does not break `yarn lint` in the
+// zoe package. However, clients of zoe such as governance then claim that
+// the `../zoe` package has many "Cannot find name <type>" errors for other
+// types in the zoe package.
+// See https://github.com/Agoric/agoric-sdk/pull/11243#discussion_r2059200058
+// TODO investigate and hopefully fix.
 import './internal-types.js';
 
 /**

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -26,6 +26,8 @@ import {
   ZoeMintI,
   ZoeStorageManagerIKit,
 } from '../typeGuards.js';
+import '../internal-types.js';
+import './internal-types.js';
 
 /**
  * @import {Baggage} from '@agoric/vat-data';
@@ -47,7 +49,7 @@ const { ownKeys } = Reflect;
  * @param {CreateZCFVat} createZCFVat - the ability to create a new
  * ZCF Vat
  * @param {GetBundleCapForID} getBundleCapForID
- * @param {import('@agoric/swingset-vat').ShutdownWithFailure} shutdownZoeVat
+ * @param {ShutdownWithFailure} shutdownZoeVat
  * @param {{
  *    getFeeIssuerKit: GetFeeIssuerKit,
  *    getFeeIssuer: () => Issuer,

--- a/packages/zoe/test/privateArgsUsageContract.js
+++ b/packages/zoe/test/privateArgsUsageContract.js
@@ -1,6 +1,10 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
+/**
+ * @import {ContractStartFn} from '../src/contractFacet/types.js';
+ */
+
 /** @type {ContractStartFn<undefined, {usePrivateArgs: unknown}>} */
 const start = (_zcf, privateArgs) => {
   const creatorFacet = Far('creatorFacet', {

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -7,6 +7,11 @@ import {
 } from '../../../src/contractSupport/index.js';
 
 /**
+ * @import {ShutdownWithFailure} from '@agoric/swingset-vat';
+ * @import {ContractStartFn} from '../../../src/types-index.js';
+ */
+
+/**
  * This is an atomic swap contract to test Zoe handling contract failures.
  *
  * This contract throws exceptions in various
@@ -58,7 +63,7 @@ const start = zcf => {
   };
 
   const zcfShutdown = completion => zcf.shutdown(completion);
-  /** @type {import('@agoric/swingset-vat').ShutdownWithFailure} */
+  /** @type {ShutdownWithFailure} */
   const zcfShutdownWithFailure = reason => zcf.shutdownWithFailure(reason);
 
   const makeSwapInvitation = () =>

--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -1,6 +1,10 @@
 import { Far } from '@endo/marshal';
 
 /**
+ * @import {ContractStartFn} from '../../../src/contractFacet/types.js';
+ */
+
+/**
  * This is a a broken contact to test zoe's error handling
  *
  * @type {ContractStartFn}

--- a/packages/zoe/test/unitTests/contracts/two-invitations.js
+++ b/packages/zoe/test/unitTests/contracts/two-invitations.js
@@ -2,6 +2,10 @@ import { M } from '@endo/patterns';
 import { makeExo } from '@endo/exo';
 
 /**
+ * @import {ContractStartFn} from '../../../src/contractFacet/types.js';
+ */
+
+/**
  * This contract just provides two invitations to support the test in
  * test-invitation-details.js
  *


### PR DESCRIPTION
closes: #XXXX
refs: #11173 https://github.com/Agoric/agoric-sdk/pull/10665

## Description

We have two styles of type import in our js/jsdoc code.
- at each point of use
  ```js
  @param {import('@agoric/base-zone').Zone} issuerZone
  ```
- once per module
  ```js
  @import {Zone} from '@agoric/base-zone';
  ```
  followed by using the simple name at each point of use
  ```js
  @import {Zone} from '@agoric/base-zone';
  ```

We have not yet discussed this, so I am not yet proposing that we adopt one style over the other. However, for code that I'm editing, particularly when I need to think about these jsdoc-imported types, I find the "once per module style" easier to read and think about. It factors out into the header of the module all the inter-module type dependencies.

Thus, for such modules, I "correct" these when I notice them. I noticed the ones in this PR while working on #11173. In addition, while I was at it, I also removed some unused type declarations and added in some missing ones.

This should all be a pure refactoring. None should have observable runtime effect.

- [x] file issues for actually resolving these as company-wide styles, and "enforce" them with additional lint rules.
  - At https://github.com/Agoric/agoric-sdk/pull/11243#issuecomment-2825658608 below, @turadg explains that he's already in progress on this at https://github.com/Agoric/agoric-sdk/pull/10665 . With this, I do not expect any controversy on adopting this as a company-wide style rule, so am checking this box.

Unfortunately, we need to go in the other direction, doing type imports at the point of use, in *.d.ts modules. See the comment at the top of packages/vats/src/core/types-ambient.d.ts
```js
// Ambient type defs. Cannot use top-level import() because that would turn it into a module.
```

- [ ] Is there some way to factor out type imports in *.d.ts modules?

### Security Considerations

Improvements in code understanding helps security. Especially about inter-package and inter-module dependencies.

### Scaling Considerations

none

### Documentation Considerations

 - [ ] See what effects these changes have on the jsdoc-generated documentation

### Testing Considerations

None

### Upgrade Considerations

In addition to purely static type refactoring, this PR makes some runtime changes
- It omits `makeMintAndIssuer` because this seems globally unused.
  - [x] We could instead deprecate it in this PR and only remove it later once we're really confident no one uses it.
    - We are proceeding with this deleted.