### PR TITLE
Prevent old state-sync snapshots from interfering with acceptance test

### DIFF
--- a/a3p-integration/proposals/z:acceptance/setup-test.sh
+++ b/a3p-integration/proposals/z:acceptance/setup-test.sh
@@ -22,3 +22,6 @@ SNAPSHOT_INTERVAL="$(($LATEST_BLOCK_HEIGHT + 1))"
 sed "s/^snapshot-interval\s*=.*/snapshot-interval = $SNAPSHOT_INTERVAL/" \
   "$AGORIC_HOME/config/app.toml" \
   --in-place
+
+# Nuke old snapshots to prevent them from interfering
+rm -rf "$AGORIC_HOME/data/snapshots/"

--- a/a3p-integration/proposals/z:acceptance/setup-test.sh
+++ b/a3p-integration/proposals/z:acceptance/setup-test.sh
@@ -13,9 +13,12 @@ CHAIN_ID="$(jq --raw-output '.chain_id' < "$AGORIC_HOME/config/genesis.json")"
 IP_ADDRESS="$(hostname --ip-address)"
 NODE_ID="$(agd tendermint show-node-id)"
 
-echo -n "{\"chainName\": \"$CHAIN_ID\", \"rpcAddrs\": [\"$IP_ADDRESS:26657\"], \"gci\": \"$IP_ADDRESS:26657/genesis\", \"peers\":[\"$NODE_ID@$IP_ADDRESS:26656\"], \"seeds\":[]}" > "$MESSAGE_FILE_PATH"
+LATEST_BLOCK_HEIGHT="$(jq --raw-output '.SyncInfo.latest_block_height' < "$STATUS_FILE")"
+LATEST_BLOCK_HASH="$(jq --raw-output '.SyncInfo.latest_block_hash' < "$STATUS_FILE")"
 
-SNAPSHOT_INTERVAL="$(($(jq --raw-output '.SyncInfo.latest_block_height' < "$STATUS_FILE") + 2))"
+echo -n "{\"chainName\": \"$CHAIN_ID\", \"rpcAddrs\": [\"$IP_ADDRESS:26657\"], \"gci\": \"$IP_ADDRESS:26657/genesis\", \"peers\":[\"$NODE_ID@$IP_ADDRESS:26656\"], \"seeds\":[], \"trustedBlockInfo\": {\"height\": \"$LATEST_BLOCK_HEIGHT\", \"hash\": \"$LATEST_BLOCK_HASH\"}}" > "$MESSAGE_FILE_PATH"
+
+SNAPSHOT_INTERVAL="$(($LATEST_BLOCK_HEIGHT + 1))"
 sed "s/^snapshot-interval\s*=.*/snapshot-interval = $SNAPSHOT_INTERVAL/" \
   "$AGORIC_HOME/config/app.toml" \
   --in-place


### PR DESCRIPTION
incidental

## Description
The new a3p images uncovered a latent race condition bug in the follower started by the a3p acceptance test. This updates the setup script to remove old snapshots that may be discovered before the new snapshot is created by acceptance test.

Also provide a recent trusted height to the follower started by the loadgen runner. I though this would prevent old snapshots from being verified, but apparently tendermint can verify backwards. Keeping the change in as it's a good optimization anyway. Corresponding loadgen PR: https://github.com/Agoric/testnet-load-generator/pull/124

Drive-by fix of a shutdown bug in flight-recorder that was preventing CI from passing in the loadgen repo.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Integration tests passing

### Upgrade Considerations
None