### PR TITLE
ci: use depot runners

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,7 +126,7 @@ jobs:
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
 
-    runs-on: 'ubuntu-22.04-4core-150SSD-16RAM'
+    runs-on: 'depot-ubuntu-22.04-4'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -199,7 +199,7 @@ jobs:
   test-docker-build:
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
-    runs-on: 'ubuntu-22.04-4core-150SSD-16RAM'
+    runs-on: 'depot-ubuntu-22.04-8'
     timeout-minutes: 60
     steps:
       - name: update job environment

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   multichain-e2e:
     name: Multichain E2E (${{ inputs.test_command }})
-    runs-on: ubuntu-latest-16core
+    runs-on: 'depot-ubuntu-24.04-16'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/agoric-sdk/issues/11238

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Replaces standard GH runner machines with depot runners for integration tests.

| Step                                      | Before (Duration & Link)                                                                                       | After (Duration & Link)                                                                                        |
|-------------------------------------------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
| deployment-step                           | [12m 42s](https://github.com/Agoric/agoric-sdk/actions/runs/14417031964/job/40434863743)                       | [5m 33s](https://github.com/Agoric/agoric-sdk/actions/runs/14443230198/job/40497967661)                        |
| test-docker-build build sdk step          | [5m 28s](https://github.com/Agoric/agoric-sdk/actions/runs/14417031964/job/40434863663)                        | [2m 21s](https://github.com/Agoric/agoric-sdk/actions/runs/14443230198/job/40497968240)                        |
| test-docker-build build proposal tests step | [9m 50s](https://github.com/Agoric/agoric-sdk/actions/runs/14417031964/job/40434863663)                        | [6m 19s](https://github.com/Agoric/agoric-sdk/actions/runs/14443230198/job/40497968240)                        |
| test-docker-build run proposal tests step | [22m 51s](https://github.com/Agoric/agoric-sdk/actions/runs/14417031964/job/40434863663)                        | [16m 34s](https://github.com/Agoric/agoric-sdk/actions/runs/14443230198/job/40497968240)                        |

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Nothing new.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Reduces job times by a few minutes (details in description). Sets up a baseline for future docker build caching

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
CI is passing

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
None
