### PR TITLE
Update all orchestration vats

### DIFF
--- a/a3p-integration/.yarnrc.yml
+++ b/a3p-integration/.yarnrc.yml
@@ -1,1 +1,1 @@
-nodeLinker: pnpm
+nodeLinker: node-modules

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -16,7 +16,7 @@
     "doctor": "yarn synthetic-chain doctor"
   },
   "dependencies": {
-    "@agoric/synthetic-chain": "^0.5.3",
+    "@agoric/synthetic-chain": "^0.5.6",
     "@types/better-sqlite3": "^7.6.11"
   },
   "devDependencies": {

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -23,6 +23,6 @@
     "eslint": "^8.57.1",
     "npm-run-all": "^4.1.5"
   },
-  "packageManager": "yarn@4.8.1",
+  "packageManager": "yarn@4.9.1",
   "license": "Apache-2.0"
 }

--- a/a3p-integration/proposals/f:fast-usdc-cctp/package.json
+++ b/a3p-integration/proposals/f:fast-usdc-cctp/package.json
@@ -27,5 +27,5 @@
   "scripts": {
     "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops"
   },
-  "packageManager": "yarn@4.7.0"
+  "packageManager": "yarn@4.9.1"
 }

--- a/a3p-integration/proposals/f:fast-usdc-cctp/test/deploy.test.js
+++ b/a3p-integration/proposals/f:fast-usdc-cctp/test/deploy.test.js
@@ -24,9 +24,9 @@ test('accounts', async t => {
   t.true(settlementAccount.startsWith('agoric1'));
 });
 
-test(`fastUsdc incarnation reflects rc2`, async t => {
-  const history = { beta: 0, rc1: 1, rc2: 2 };
-  t.is(await getIncarnation('fastUsdc'), history.rc2);
+test(`fastUsdc incarnation reflects cctp`, async t => {
+  const history = { beta: 0, rc1: 1, gtm: 2, cctp: 3 };
+  t.is(await getIncarnation('fastUsdc'), history.cctp);
 });
 
 test('feedPolicy updated for GTM', async t => {

--- a/a3p-integration/proposals/n:upgrade-next/package.json
+++ b/a3p-integration/proposals/n:upgrade-next/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops"
   },
-  "packageManager": "yarn@4.8.1",
+  "packageManager": "yarn@4.9.1",
   "devDependencies": {
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",

--- a/a3p-integration/proposals/n:upgrade-next/package.json
+++ b/a3p-integration/proposals/n:upgrade-next/package.json
@@ -14,7 +14,7 @@
     "@agoric/client-utils": "dev",
     "@agoric/ertp": "dev",
     "@agoric/internal": "dev",
-    "@agoric/synthetic-chain": "^0.5.2",
+    "@agoric/synthetic-chain": "^0.5.6",
     "@agoric/zoe": "dev",
     "@endo/errors": "^1.2.10",
     "@endo/init": "^1.1.9",

--- a/a3p-integration/proposals/n:upgrade-next/test/initial.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/test/initial.test.js
@@ -4,11 +4,11 @@ import '@endo/init/debug.js';
 import { getVatDetails } from '@agoric/synthetic-chain';
 
 const vats = {
-  network: { incarnation: 2 },
+  network: { incarnation: 3 },
   ibc: { incarnation: 3 },
-  localchain: { incarnation: 2 },
-  orchestration: { incarnation: 1 },
-  transfer: { incarnation: 2 },
+  localchain: { incarnation: 3 },
+  orchestration: { incarnation: 2 },
+  transfer: { incarnation: 3 },
   walletFactory: { incarnation: 7 },
   zoe: { incarnation: 3 },
 };

--- a/a3p-integration/proposals/n:upgrade-next/test/initial.test.js
+++ b/a3p-integration/proposals/n:upgrade-next/test/initial.test.js
@@ -9,10 +9,8 @@ const vats = {
   localchain: { incarnation: 2 },
   orchestration: { incarnation: 1 },
   transfer: { incarnation: 2 },
-  walletFactory: { incarnation: 6 },
+  walletFactory: { incarnation: 7 },
   zoe: { incarnation: 3 },
-  // Terminated in a future proposal.
-  '-ATOM-USD_price_feed-governor': { incarnation: 0 },
 };
 
 test(`vat details`, async t => {

--- a/a3p-integration/proposals/n:upgrade-next/yarn.lock
+++ b/a3p-integration/proposals/n:upgrade-next/yarn.lock
@@ -825,9 +825,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@agoric/synthetic-chain@npm:0.5.2"
+"@agoric/synthetic-chain@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@agoric/synthetic-chain@npm:0.5.6"
   dependencies:
     "@endo/zip": "npm:^1.0.9"
     better-sqlite3: "npm:^11.8.1"
@@ -835,9 +835,10 @@ __metadata:
     cosmjs-types: "npm:^0.9.0"
     execa: "npm:^9.5.2"
     glob: "npm:^11.0.1"
+    tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/190939c33f47a1d71558356f42d4b4b10a4caf3176d31281a250877f97d25d5df5b5d261fd507489fd481e24e6ba5ec12e8dc267a0461b67e9f02a8f8769700c
+  checksum: 10c0/dc4832319caaa819c07ceb8f141f64b53a9abd1909414d54c2664070c00c5cc385f590a5fabda2521adb7aa54d0fb5c8756146013c34632db2c372a24ea7b6de
   languageName: node
   linkType: hard
 
@@ -6306,7 +6307,7 @@ __metadata:
     "@agoric/client-utils": "npm:dev"
     "@agoric/ertp": "npm:dev"
     "@agoric/internal": "npm:dev"
-    "@agoric/synthetic-chain": "npm:^0.5.2"
+    "@agoric/synthetic-chain": "npm:^0.5.6"
     "@agoric/zoe": "npm:dev"
     "@endo/errors": "npm:^1.2.10"
     "@endo/init": "npm:^1.1.9"
@@ -6973,19 +6974,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tmp@npm:0.2.3, tmp@npm:^0.2.1":
+  version: 0.2.3
+  resolution: "tmp@npm:0.2.3"
+  checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
+  languageName: node
+  linkType: hard
+
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
   dependencies:
     os-tmpdir: "npm:~1.0.2"
   checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.1":
-  version: 0.2.3
-  resolution: "tmp@npm:0.2.3"
-  checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
   languageName: node
   linkType: hard
 

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -97,7 +97,7 @@
   "scripts": {
     "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops"
   },
-  "packageManager": "yarn@4.8.1",
+  "packageManager": "yarn@4.9.1",
   "devDependencies": {
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -19,7 +19,7 @@
     "@agoric/inter-protocol": "dev",
     "@agoric/internal": "dev",
     "@agoric/store": "dev",
-    "@agoric/synthetic-chain": "^0.5.2",
+    "@agoric/synthetic-chain": "^0.5.6",
     "@agoric/zoe": "dev",
     "@cosmjs/stargate": "^0.33.0",
     "@cosmjs/tendermint-rpc": "^0.33.0",

--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -346,9 +346,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@agoric/synthetic-chain@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@agoric/synthetic-chain@npm:0.5.2"
+"@agoric/synthetic-chain@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@agoric/synthetic-chain@npm:0.5.6"
   dependencies:
     "@endo/zip": "npm:^1.0.9"
     better-sqlite3: "npm:^11.8.1"
@@ -356,9 +356,10 @@ __metadata:
     cosmjs-types: "npm:^0.9.0"
     execa: "npm:^9.5.2"
     glob: "npm:^11.0.1"
+    tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/190939c33f47a1d71558356f42d4b4b10a4caf3176d31281a250877f97d25d5df5b5d261fd507489fd481e24e6ba5ec12e8dc267a0461b67e9f02a8f8769700c
+  checksum: 10c0/dc4832319caaa819c07ceb8f141f64b53a9abd1909414d54c2664070c00c5cc385f590a5fabda2521adb7aa54d0fb5c8756146013c34632db2c372a24ea7b6de
   languageName: node
   linkType: hard
 
@@ -4992,7 +4993,7 @@ __metadata:
     "@agoric/inter-protocol": "npm:dev"
     "@agoric/internal": "npm:dev"
     "@agoric/store": "npm:dev"
-    "@agoric/synthetic-chain": "npm:^0.5.2"
+    "@agoric/synthetic-chain": "npm:^0.5.6"
     "@agoric/zoe": "npm:dev"
     "@cosmjs/stargate": "npm:^0.33.0"
     "@cosmjs/tendermint-rpc": "npm:^0.33.0"
@@ -5595,19 +5596,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tmp@npm:0.2.3, tmp@npm:^0.2.1":
+  version: 0.2.3
+  resolution: "tmp@npm:0.2.3"
+  checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
+  languageName: node
+  linkType: hard
+
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
   dependencies:
     os-tmpdir: "npm:~1.0.2"
   checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.1":
-  version: 0.2.3
-  resolution: "tmp@npm:0.2.3"
-  checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
   languageName: node
   linkType: hard
 

--- a/a3p-integration/yarn.lock
+++ b/a3p-integration/yarn.lock
@@ -5,9 +5,9 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@agoric/synthetic-chain@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "@agoric/synthetic-chain@npm:0.5.3"
+"@agoric/synthetic-chain@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@agoric/synthetic-chain@npm:0.5.6"
   dependencies:
     "@endo/zip": "npm:^1.0.9"
     better-sqlite3: "npm:^11.8.1"
@@ -18,7 +18,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/47e984c05a64fd520c1c7063b3f0a63d231f0da431bd169e0dece1cba5535696c3c582d32afc7771d869ecb6aa9f2945991c47e1ae015ba321d43a465e37573b
+  checksum: 10c0/dc4832319caaa819c07ceb8f141f64b53a9abd1909414d54c2664070c00c5cc385f590a5fabda2521adb7aa54d0fb5c8756146013c34632db2c372a24ea7b6de
   languageName: node
   linkType: hard
 
@@ -2672,7 +2672,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@agoric/synthetic-chain": "npm:^0.5.3"
+    "@agoric/synthetic-chain": "npm:^0.5.6"
     "@types/better-sqlite3": "npm:^7.6.11"
     eslint: "npm:^8.57.1"
     npm-run-all: "npm:^4.1.5"

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -157,26 +157,14 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 				return module.VersionMap{}, fmt.Errorf("cannot run %s as first upgrade", plan.Name)
 			}
 
-			upgradeIbcVatStep, err :=
-				buildProposalStepWithArgs(
-					"@agoric/builders/scripts/vats/upgrade-vats.js",
-					"upgradeVatsProposalBuilder",
-					// Map iteration is randomised; use an anonymous struct instead.
-					struct {
-						Ibc string `json:"ibc"`
-					}{
-						Ibc: "@agoric/vats/src/vat-ibc.js",
-					},
-				)
-			if err != nil {
-				return module.VersionMap{}, err
-			}
-
 			// Each CoreProposalStep runs sequentially, and can be constructed from
 			// one or more modules executing in parallel within the step.
 			CoreProposalSteps = append(CoreProposalSteps,
-				// Accommodate string sequence numbers.
-				upgradeIbcVatStep,
+				// Orchestration vats: Fix memory leak in vow tools
+				// vat-ibc (included in orchestration): Accommodate string sequence numbers.
+				vm.CoreProposalStepForModules(
+					"@agoric/builders/scripts/vats/upgrade-orchestration.js",
+				),
 				// Register a new ZCF to be used for all future contract instances and upgrades
 				vm.CoreProposalStepForModules(
 					"@agoric/builders/scripts/vats/upgrade-zcf.js",

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -9,7 +9,7 @@
     "test:main": "ava --config ava.rest.config.js",
     "test:fast-usdc": "ava --config ava.fusdc.config.js"
   },
-  "packageManager": "yarn@4.8.1",
+  "packageManager": "yarn@4.9.1",
   "devDependencies": {
     "@agoric/cosmic-proto": "dev",
     "@agoric/fast-usdc": "dev",


### PR DESCRIPTION
refs: #11117
refs: #10794 #11118

## Description
We have a couple known heap leaks affecting orchestration vats, this restarts them to pick up the fixes

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
I'm not confident in our upgrade testing coverage of orchestration vats in regards to orchestrated contracts like fast-usdc, so this may require manual testing once deployed.

### Upgrade Considerations
Upgrading a few more vats
