### PR TITLE
chore: Add core-eval for terminating mainnet v194 zcf-b1-991f5f-stATOM-USD_price_feed

### DIFF
--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -175,6 +175,22 @@ func unreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) func(sdk.Conte
 					"@agoric/builders/scripts/smart-wallet/build-wallet-factory2-upgrade.js",
 				),
 			)
+
+			// When upgrading mainnet, terminate vat v194
+			// "zcf-b1-991f5f-stATOM-USD_price_feed" and its governor.
+			variant := getVariantFromUpgradeName(targetUpgrade)
+			if variant == "MAINNET" {
+				terminatePriceFeedStep, err :=
+					buildProposalStepWithArgs(
+						"@agoric/vats/src/proposals/terminate-governed-instance.js",
+						"upgradeVatsProposalBuilder",
+						"board023341:stATOM-USD_price_feed",
+					)
+				if err != nil {
+					return module.VersionMap{}, err
+				}
+				CoreProposalSteps = append(CoreProposalSteps, terminatePriceFeedStep)
+			}
 		}
 
 		app.upgradeDetails = &upgradeDetails{


### PR DESCRIPTION
...and its governor

Ref #9483

## Description

<details><summary>Discovery of magic value "board023341"</summary>

```
$ ./packages/cosmic-swingset/tools/inquisitor.mjs mainnet-post-upgrade-19-swingstore.sqlite
Loading slog sender modules: @agoric/telemetry/src/flight-recorder.js
Launching SwingSet kernel
buildSwingset
[bridge] received { args: [ 'highPriorityQueue.tail' ], method: 'get' }
[bridge] received { args: [ 'highPriorityQueue.head' ], method: 'get' }
[bridge] received { args: [ 'actionQueue.tail' ], method: 'get' }
[bridge] received { args: [ 'actionQueue.head' ], method: 'get' }
Launched SwingSet kernel
endowments: kvStore swingStore getLastBlockInfo pushQueueRecord pushCoreEval runNextBlock EV controller krefOf kser kslot kunser mutations runCoreEval stable
endowments.stable: db getRefs kvGet kvGetJSON kvGlob vatsByID vatsByName
> console.table(
... [...stable.vatsByID.entries()]
... .flatMap(([_vatID, vat]) => /price_feed$/i.test(vat.name) ? [vat] : [])
... .map(({ vatID, name }) => {
...   const kvIter = stable.kvGlob(`${vatID}.*`, undefined, true);
...   let kvCount = 0;
...   for (const _ of kvIter) kvCount++;
...   return { kvCount, vatID, name };
... })
... .sort(({ kvCount: a }, { kvCount: b }) => a < b ? -1 : a > b ? 1 : 0)
... );
┌─────────┬──────────┬────────┬────────────────────────────────────────┐
│ (index) │ kvCount  │ vatID  │ name                                   │
├─────────┼──────────┼────────┼────────────────────────────────────────┤
│ 0       │ 8321     │ 'v218' │ 'zcf-b1-eca5eb-dATOM-USD_price_feed'   │
│ 1       │ 12159    │ 'v194' │ 'zcf-b1-991f5f-stATOM-USD_price_feed'  │
│ 2       │ 12170    │ 'v192' │ 'zcf-b1-991f5f-ATOM-USD_price_feed'    │
│ 3       │ 12179    │ 'v200' │ 'zcf-b1-991f5f-stkATOM-USD_price_feed' │
│ 4       │ 12191    │ 'v196' │ 'zcf-b1-991f5f-stOSMO-USD_price_feed'  │
│ 5       │ 12806    │ 'v198' │ 'zcf-b1-991f5f-stTIA-USD_price_feed'   │
│ 6       │ 7362978  │ 'v111' │ 'zcf-b1-4522b-stkATOM-USD_price_feed'  │
│ 7       │ 11439794 │ 'v98'  │ 'zcf-b1-4522b-stOSMO-USD_price_feed'   │
│ 8       │ 11827121 │ 'v104' │ 'zcf-b1-4522b-stTIA-USD_price_feed'    │
│ 9       │ 15179998 │ 'v68'  │ 'zcf-b1-4522b-stATOM-USD_price_feed'   │
│ 10      │ 15281206 │ 'v29'  │ 'zcf-b1-4522b-ATOM-USD_price_feed'     │
└─────────┴──────────┴────────┴────────────────────────────────────────┘
undefined
> // v194 looks promising...
undefined
> stable.kvGlob(`v2.vs.*`, '*v194*');
[
  {
    key: 'v2.vs.vom.o+d13/189',
    value: '{"vatID":{"body":"#\\"v194\\"","slots":[]}}'
  }
]
> stable.getRefs('o+d13/189', 'v2');
[
  {
    vatID: 'v2',
    kref: 'ko16712786',
    vref: 'o+d13/189',
    kind: 'adminNode'
  },
  { vatID: 'v9', kref: 'ko16712786', vref: 'o-3104459' }
]
> stable.kvGlob(`v9.*`, '*o-3104459*');
[
  { key: 'v9.c.ko16712786', value: 'R o-3104459' },
  {
    key: 'v9.vs.vc.4.sp+1522930',
    value: '{"body":"#[[\\"$0.Alleged: InstanceCompletionWatcher\\",\\"$1.Alleged: instanceAdmin instanceAdmin\\",\\"$2.Alleged: adminNode\\"]]","slots":["o+d1617/1","o+d33/177:1","o-3104459"]}'
  },
  {
    key: 'v9.vs.vom.o+d26/177',
    value: '{"instanceState":{"body":"#\\"$0.Alleged: InstanceRecord\\"","slots":["o+d27/177"]},"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104459"]},"root":{"body":"#\\"$0.Alleged: undefined\\"","slots":["o-3104460"]},"functions":{"body":"#\\"#undefined\\"","slots":[]}}'
  },
  {
    key: 'v9.vs.vom.o+d33/177',
    value: '{"offerFilterStrings":{"body":"#[]","slots":[]},"publicFacet":{"body":"#\\"$0.Alleged: fluxAggregator public\\"","slots":["o-3104463"]},"handleOfferObj":{"body":"#\\"$0.Alleged: handleOfferObj\\"","slots":["o-3104462"]},"zoeInstanceStorageManager":{"body":"#\\"$0.Alleged: InstanceStorageManager instanceStorageManager\\"","slots":["o+d26/177:1"]},"seatHandleToZoeSeatAdmin":{"body":"#\\"$0.Alleged: weakMapStore\\"","slots":["o+d7/24"]},"instanceHandle":{"body":"#\\"$0.Alleged: InstanceHandle\\"","slots":["o+d29/177"]},"acceptingOffers":{"body":"#true","slots":[]},"zoeSeatAdmins":{"body":"#\\"$0.Alleged: setStore\\"","slots":["o+d8/5286"]},"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104459"]}}'
  },
  {
    key: 'v9.vs.vom.o+d34/177',
    value: '{"instanceStorage":{"body":"#\\"$0.Alleged: InstanceStorageManager instanceStorageManager\\"","slots":["o+d26/177:1"]},"instanceAdmin":{"body":"#\\"$0.Alleged: instanceAdmin instanceAdmin\\"","slots":["o+d33/177:1"]},"seatHandleToSeatAdmin":{"body":"#\\"$0.Alleged: weakMapStore\\"","slots":["o+d7/24"]},"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104459"]}}'
  },
  {
    key: 'v9.vs.vom.o+d37/176',
    value: '{"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104459"]},"contractBundleCap":{"body":"#\\"$0.Alleged: device node\\"","slots":["d-99"]}}'
  }
]
> stable.getRefs('o+d37/176', 'v9');
[
  { vatID: 'v1', kref: 'ko16712794', vref: 'o-3121' },
  {
    vatID: 'v9',
    kref: 'ko16712794',
    vref: 'o+d37/176',
    kind: 'adminFacet'
  },
  { vatID: 'v193', kref: 'ko16712794', vref: 'o-69' }
]
> stable.vatsByID.get('v193');
{
  vatID: 'v193',
  name: 'zcf-b1-9f877-stATOM-USD_price_feed-governor',
  isStatic: false,
  source: {
    bundleID: 'b1-5ce9bb36ceb21c4af80b3c11098ac049ddfaa1898cf7a9e33d100c44f5fc68e5a14a96a5d2f9af0117929b3e5b4ab58c4a404416fb5688b03a2c0e398194e6b2'
  },
  options: {
    workerOptions: {
      type: 'xsnap',
      bundleIDs: [
        'b0-b9c432d6a773aea4042a88d7b70ca0576601e61df3e881d047933e5e0fa8bb27',
        'b0-d8da59a32efb421023c36d483f76a20fcfec3d2cc0a9f8a8e36db497ee993764'
      ]
    },
    name: 'zcf-b1-9f877-stATOM-USD_price_feed-governor',
    enableSetup: false,
    enablePipelining: false,
    enableDisavow: false,
    useTranscript: true,
    reapDirtThreshold: {},
    critical: false
  }
}
> // The v194 Zoe adminFacet is held only by v1 bootstrap, v9 zoe, and v193 (its governor)
undefined
> // Let's trace the governor...
undefined
> stable.kvGlob(`v2.vs.*`, '*v193*');
[
  {
    key: 'v2.vs.vom.o+d13/188',
    value: '{"vatID":{"body":"#\\"v193\\"","slots":[]}}'
  }
]
> stable.getRefs('o+d13/188', 'v2');
[
  {
    vatID: 'v2',
    kref: 'ko16712782',
    vref: 'o+d13/188',
    kind: 'adminNode'
  },
  { vatID: 'v9', kref: 'ko16712782', vref: 'o-3104457' }
]
> stable.kvGlob(`v9.*`, '*o-3104457*');
[
  { key: 'v9.c.ko16712782', value: 'R o-3104457' },
  {
    key: 'v9.vs.vc.4.sp+1522925',
    value: '{"body":"#[[\\"$0.Alleged: InstanceCompletionWatcher\\",\\"$1.Alleged: instanceAdmin instanceAdmin\\",\\"$2.Alleged: adminNode\\"]]","slots":["o+d1617/1","o+d33/176:1","o-3104457"]}'
  },
  {
    key: 'v9.vs.vom.o+d26/176',
    value: '{"instanceState":{"body":"#\\"$0.Alleged: InstanceRecord\\"","slots":["o+d27/176"]},"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104457"]},"root":{"body":"#\\"$0.Alleged: undefined\\"","slots":["o-3104458"]},"functions":{"body":"#\\"#undefined\\"","slots":[]}}'
  },
  {
    key: 'v9.vs.vom.o+d33/176',
    value: '{"offerFilterStrings":{"body":"#[]","slots":[]},"publicFacet":{"body":"#\\"$0.Alleged: ContractGovernorKit public\\"","slots":["o-3104466"]},"handleOfferObj":{"body":"#\\"$0.Alleged: handleOfferObj\\"","slots":["o-3104465"]},"zoeInstanceStorageManager":{"body":"#\\"$0.Alleged: InstanceStorageManager instanceStorageManager\\"","slots":["o+d26/176:1"]},"seatHandleToZoeSeatAdmin":{"body":"#\\"$0.Alleged: weakMapStore\\"","slots":["o+d7/24"]},"instanceHandle":{"body":"#\\"$0.Alleged: InstanceHandle\\"","slots":["o+d29/176"]},"acceptingOffers":{"body":"#true","slots":[]},"zoeSeatAdmins":{"body":"#\\"$0.Alleged: setStore\\"","slots":["o+d8/5284"]},"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104457"]}}'
  },
  {
    key: 'v9.vs.vom.o+d34/176',
    value: '{"instanceStorage":{"body":"#\\"$0.Alleged: InstanceStorageManager instanceStorageManager\\"","slots":["o+d26/176:1"]},"instanceAdmin":{"body":"#\\"$0.Alleged: instanceAdmin instanceAdmin\\"","slots":["o+d33/176:1"]},"seatHandleToSeatAdmin":{"body":"#\\"$0.Alleged: weakMapStore\\"","slots":["o+d7/24"]},"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104457"]}}'
  },
  {
    key: 'v9.vs.vom.o+d37/177',
    value: '{"adminNode":{"body":"#\\"$0.Alleged: adminNode\\"","slots":["o-3104457"]},"contractBundleCap":{"body":"#\\"$0.Alleged: device node\\"","slots":["d-75"]}}'
  }
]
> stable.getRefs('o+d37/177', 'v9');
[
  { vatID: 'v1', kref: 'ko16712799', vref: 'o-3114' },
  {
    vatID: 'v9',
    kref: 'ko16712799',
    vref: 'o+d37/177',
    kind: 'adminFacet'
  }
]
> stable.kvGlob(`v1.*`, '*o-3114*');
[
  { key: 'v1.c.ko16712799', value: 'R o-3114' },
  {
    key: 'v1.vs.vc.8.r0000000012:o-3118',
    value: '{"body":"#{\\"adminFacet\\":\\"$0.Alleged: adminFacet\\",\\"creatorFacet\\":\\"$1.Alleged: fluxAggregator creator\\",\\"governor\\":\\"$2.Alleged: InstanceHandle\\",\\"governorAdminFacet\\":\\"$3.Alleged: adminFacet\\",\\"governorCreatorFacet\\":\\"$4.Alleged: ContractGovernorKit creator\\",\\"instance\\":\\"$5.Alleged: InstanceHandle\\",\\"label\\":\\"stATOM-USD_price_feed\\",\\"publicFacet\\":\\"$6.Alleged: fluxAggregator public\\"}","slots":["o-3121","o-3120","o-3116","o-3114","o-3115","o-3118","o-3119"]}'
  }
]
> // We remember from aeb35aa2e3c3d45895c72efeb2002f36639a91ea that v1 bootstrap virtual collection 8 is Bootstrap Powers "governedContractKits".
undefined
> // Let's find the key...
undefined
> stable.getRefs('o-3118', 'v1');
[
  { vatID: 'v1', kref: 'ko16712788', vref: 'o-3118' },
  { vatID: 'v6', kref: 'ko16712788', vref: 'o-178' },
  { vatID: 'v7', kref: 'ko16712788', vref: 'o-1350130' },
  {
    vatID: 'v9',
    kref: 'ko16712788',
    vref: 'o+d29/177',
    kind: 'InstanceHandle'
  },
  { vatID: 'v43', kref: 'ko16712788', vref: 'o-4540373' },
  { vatID: 'v190', kref: 'ko16712788', vref: 'o-92' },
  { vatID: 'v193', kref: 'ko16712788', vref: 'o-71' },
  { vatID: 'v194', kref: 'ko16712788', vref: 'o-54' }
]
> // v7 is the board.
undefined
> stable.kvGlob(`v7.*`, '*o-1350130*');
[
  { key: 'v7.c.ko16712788', value: 'R o-1350130' },
  {
    key: 'v7.vs.vc.5.sboard023341',
    value: '{"body":"#\\"$0.Alleged: InstanceHandle\\"","slots":["o-1350130"]}'
  },
  {
    key: 'v7.vs.vom.o+d11/5',
    value: '{"valueDurability":{"body":"#\\"mandatory\\"","slots":[]},"publishCount":{"body":"#\\"+75\\"","slots":[]},"status":{"body":"#\\"live\\"","slots":[]},"hasValue":{"body":"#true","slots":[]},"value":{"body":"#[[\\"ATOM-USD price feed\\",\\"$0.Alleged: InstanceHandle\\"],[\\"Crabble\\",\\"$1.Alleged: InstanceHandle\\"],[\\"CrabbleCommittee\\",\\"$2.Alleged: InstanceHandle\\"],[\\"CrabbleGovernor\\",\\"$3.Alleged: InstanceHandle\\"],[\\"VaultFactory\\",\\"$4.Alleged: InstanceHandle\\"],[\\"VaultFactoryGovernor\\",\\"$5.Alleged: InstanceHandle\\"],[\\"auctioneer\\",\\"$6.Alleged: InstanceHandle\\"],[\\"dATOM-USD price feed\\",\\"$7.Alleged: InstanceHandle\\"],[\\"econCommitteeCharter\\",\\"$8.Alleged: InstanceHandle\\"],[\\"economicCommittee\\",\\"$9.Alleged: InstanceHandle\\"],[\\"fastUsdc\\",\\"$10.Alleged: InstanceHandle\\"],[\\"kread\\",\\"$11.Alleged: InstanceHandle\\"],[\\"kreadCommittee\\",\\"$12.Alleged: InstanceHandle\\"],[\\"kreadCommitteeCharter\\",\\"$13.Alleged: InstanceHandle\\"],[\\"provisionPool\\",\\"$14.Alleged: InstanceHandle\\"],[\\"psm-IST-DAI_axl\\",\\"$15.Alleged: InstanceHandle\\"],[\\"psm-IST-DAI_grv\\",\\"$16.Alleged: InstanceHandle\\"],[\\"psm-IST-USDC\\",\\"$17.Alleged: InstanceHandle\\"],[\\"psm-IST-USDC_axl\\",\\"$18.Alleged: InstanceHandle\\"],[\\"psm-IST-USDC_grv\\",\\"$19.Alleged: InstanceHandle\\"],[\\"psm-IST-USDT\\",\\"$20.Alleged: InstanceHandle\\"],[\\"psm-IST-USDT_axl\\",\\"$21.Alleged: InstanceHandle\\"],[\\"psm-IST-USDT_grv\\",\\"$22.Alleged: InstanceHandle\\"],[\\"reserve\\",\\"$23.Alleged: InstanceHandle\\"],[\\"reserveGovernor\\",\\"$24.Alleged: InstanceHandle\\"],[\\"scaledPriceAuthority-ATOM\\",\\"$25.Alleged: InstanceHandle\\"],[\\"scaledPriceAuthority-dATOM\\",\\"$26.Alleged: InstanceHandle\\"],[\\"scaledPriceAuthority-stATOM\\",\\"$27.Alleged: InstanceHandle\\"],[\\"scaledPriceAuthority-stOSMO\\",\\"$28.Alleged: InstanceHandle\\"],[\\"scaledPriceAuthority-stTIA\\",\\"$29.Alleged: InstanceHandle\\"],[\\"scaledPriceAuthority-stkATOM\\",\\"$30.Alleged: InstanceHandle\\"],[\\"stATOM-USD price feed\\",\\"$31.Alleged: InstanceHandle\\"],[\\"stOSMO-USD price feed\\",\\"$32.Alleged: InstanceHandle\\"],[\\"stTIA-USD price feed\\",\\"$33.Alleged: InstanceHandle\\"],[\\"stkATOM-USD price feed\\",\\"$34.Alleged: InstanceHandle\\"],[\\"walletFactory\\",\\"$35.Alleged: InstanceHandle\\"],[\\"feeDistributor\\",\\"$36.Alleged: InstanceHandle\\"]]","slots":["o-1350123","o-116341","o-116336","o-116342","o-121","o-134","o-1350166","o-1410605","o-1350120","o-1350098","o-1435092","o-46029","o-46025","o-46022","o-125","o-132","o-133","o-68280","o-128","o-129","o-68305","o-130","o-131","o-119","o-126","o-1350158","o-1410606","o-1350159","o-1350160","o-1350161","o-1350162","o-1350130","o-1350137","o-1350144","o-1350151","o-127","o-1547999"]}}'
  }
]
> // The key is associated with boardID "board023341".
undefined
> // Verify that core-eval code sees the right things.
undefined
> await runCoreEval(`async powers => {
... const { board, governedContractKits, zoe } = powers.consume;
... const contractInstanceHandle = await E(board).getValue('board023341');
... const instanceKit = await E(governedContractKits).get(contractInstanceHandle);
... const logRecord = (label, obj) => {
...   console.log(label);
...   for (const [key, value] of Object.entries(obj)) console.log('  *', key, value);
... };
... logRecord('instanceKit', instanceKit);
... const govTerms = await E(zoe).getTerms(instanceKit.governor);
... logRecord('governor terms', govTerms);
... }`);
instanceKit
  * adminFacet Object [Alleged: adminFacet] {}
  * creatorFacet Object [Alleged: fluxAggregator creator] {}
  * governor Object [Alleged: InstanceHandle] {}
  * governorAdminFacet Object [Alleged: adminFacet] {}
  * governorCreatorFacet Object [Alleged: ContractGovernorKit creator] {}
  * instance Object [Alleged: InstanceHandle] {}
  * label stATOM-USD_price_feed
  * publicFacet Object [Alleged: fluxAggregator public] {}
governor terms
  * brands {}
  * governed { issuerKeywordRecord: undefined, label: 'stATOM-USD_price_feed', terms: { brandIn: Object [Alleged: Brand] {}, brandOut: Object [Alleged: Brand] {}, description: 'stATOM-USD price feed', governedParams: { Electorate: { type: 'invitation', value: { brand: [Object], value: [Array] } } }, maxSubmissionCount: 1000, maxSubmissionValue: 1.157920892373162e+77, minSubmissionCount: 3, minSubmissionValue: 1, restartDelay: 1n, timeout: 10, timer: Object [Alleged: timerService] {}, unitAmountIn: { brand: Object [Alleged: Brand] {}, value: 1_000_000n } } }
  * governedContractInstallation Object [Alleged: BundleIDInstallation] {}
  * issuers {}
  * timer Object [Alleged: timerService] {}
undefined
```

</details>

### Security Considerations
It is absolutely critical that v194 is safe to terminate (i.e., has already been replaced).

### Scaling Considerations
We'll be watching the pace of vat cleanup.

### Documentation Considerations
n/a

### Testing Considerations
We should also find analogous pre-mainnet targets, and probably add an a3p-integration test as well.

### Upgrade Considerations
The pace of termination will be visible in slog entries.