### PR TITLE
ci: use `depot build` for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,6 +40,25 @@ jobs:
   pre_check:
     uses: ./.github/workflows/pre-check-integration.yml
 
+  build-docker-sdk:
+    permissions:
+      contents: read
+      id-token: write
+    needs: pre_check
+    if: needs.pre_check.outputs.should_run == 'true'
+    runs-on: 'depot-ubuntu-22.04-8'
+    steps:
+      - uses: depot/setup-action@v1
+      - uses: actions/checkout@v4
+        with:
+          path: ./agoric-sdk
+      - name: prelim docker build (sdk)
+        # Produces ghcr.io/agoric/agoric-sdk:unreleased used in the following upgrade test.
+        # run: cd packages/deployment && ./scripts/test-docker-build.sh | $TEST_COLLECT
+        # XXX skip TAP test output and collection for now; it hides the output from the logs
+        run: make docker-build-sdk
+        working-directory: agoric-sdk/packages/deployment
+
   # This job is meant to emulate what developers working with the Agoric
   # platform will experience.
   # It should be kept in sync with the "getting started" workflow at
@@ -200,7 +219,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    needs: pre_check
+    needs: [pre_check, build-docker-sdk]
     if: needs.pre_check.outputs.should_run == 'true'
     runs-on: 'depot-ubuntu-22.04-8'
     timeout-minutes: 60
@@ -379,7 +398,7 @@ jobs:
           datadog-token: ${{ secrets.DATADOG_API_KEY }}
 
   test-multichain-e2e:
-    needs: pre_check
+    needs: [pre_check, build-docker-sdk]
     if: needs.pre_check.outputs.should_run == 'true'
     uses: ./.github/workflows/multichain-e2e.yml
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -197,6 +197,9 @@ jobs:
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
 
   test-docker-build:
+    permissions:
+      contents: read
+      id-token: write
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
     runs-on: 'depot-ubuntu-22.04-8'
@@ -224,6 +227,7 @@ jobs:
           echo "=== After cleanup:"
           df -h
 
+      - uses: depot/setup-action@v1
       - uses: actions/checkout@v4
         with:
           path: ./agoric-sdk

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -13,10 +13,14 @@ on:
 
 jobs:
   multichain-e2e:
+    permissions:
+      contents: read
+      id-token: write
     name: Multichain E2E (${{ inputs.test_command }})
     runs-on: 'depot-ubuntu-24.04-16'
 
     steps:
+      - uses: depot/setup-action@v1
       - uses: actions/checkout@v4
         with:
           submodules: 'true'

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -1,7 +1,11 @@
 REPOSITORY = ghcr.io/agoric/cosmic-swingset
 REPOSITORY_SDK = ghcr.io/agoric/agoric-sdk
 SS := ../cosmic-swingset/
-DOCKER_BUILD ?= docker build
+ifdef CI
+	DOCKER_BUILD ?= depot build --load
+else
+	DOCKER_BUILD ?= docker build
+endif
 
 TAG := unreleased
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #XXXX

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Incorporates depot for building images.


1st run link: https://github.com/Agoric/agoric-sdk/actions/runs/14467247431/job/40572420602
2nd run link: https://github.com/Agoric/agoric-sdk/actions/runs/14467979535/job/40574735616?pr=11271

### Build Time Comparison

"before" defines the state prior to using depot build (but using depot runners)
#### `test-docker-build`

| Step                         | Before | After (1st run) | After (2nd run) |
|------------------------------|--------|-----------------|-----------------|
| Build SDK                    | 2m 21s | 1m 9s           | 54s             |
| Build Proposal Tests         | 6m 19s | 5m 2s           | 4m 56s          |

#### `test-multichain-e2e`

| Step       | Before | After (1st run) | After (2nd run) |
|------------|--------|-----------------|-----------------|
| Build SDK  | 2m 12s      | 45s             | 45s             |

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Reduces time for building docker images.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
CI is passing

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
None
