### PR TITLE
feat: reset MintLimit to 500K IST in PSMs for USDC, USDT

### DIFF
--- a/packages/inter-protocol/src/proposals/psm-gov-reset-permit.json
+++ b/packages/inter-protocol/src/proposals/psm-gov-reset-permit.json
@@ -1,0 +1,13 @@
+{
+    "consume": {
+        "economicCommitteeCreatorFacet": true,
+        "instancePrivateArgs": true,
+        "psmKit": true,
+        "zoe": true
+    },
+    "brand": {
+        "consume": {
+            "IST": true
+        }
+    }
+}

--- a/packages/inter-protocol/src/proposals/psm-gov-reset.js
+++ b/packages/inter-protocol/src/proposals/psm-gov-reset.js
@@ -75,6 +75,10 @@ const resetPSMMintLimits = async (
     const [_psm, _ist, keyword] = kit.label.split('-');
     trace('PSM name(s)', kit.label, keyword);
     assert(keyword, kit.label);
+    if (!['USDC', 'USDT'].includes(keyword)) {
+      trace('out of scope:', keyword);
+      continue;
+    }
 
     const privateArgsPre = await shallowlyFulfilled(
       // @ts-expect-error instancePrivateArgs is a mixed bag

--- a/packages/inter-protocol/src/proposals/psm-gov-reset.js
+++ b/packages/inter-protocol/src/proposals/psm-gov-reset.js
@@ -1,0 +1,100 @@
+/* global E */
+/**
+ * @import {EconomyBootstrapPowers} from './econ-behaviors'
+ */
+
+const ISTUnit = 1_000_000n;
+const MintLimitValue = 500_000n * ISTUnit;
+
+let tick = 0;
+const trace = (...args) => console.log('--- PGRe', (tick += 1), ...args);
+
+trace('script started');
+
+const { entries, fromEntries } = Object;
+
+/**
+ * Given an object whose properties may be promise-valued, return a promise for
+ * an analogous object in which each such value has been replaced with its
+ * fulfillment. This is a non-recursive form of endo `deeplyFulfilled`.
+ *
+ * @template T
+ * @param {{ [K in keyof T]: T[K] | Promise<T[K]> }} obj
+ * @returns {Promise<T>}
+ */
+const shallowlyFulfilled = async obj => {
+  if (!obj) {
+    return obj;
+  }
+  const awaitedEntries = await Promise.all(
+    entries(obj).map(async ([key, valueP]) => {
+      const value = await valueP;
+      return [key, value];
+    }),
+  );
+  return fromEntries(awaitedEntries);
+};
+
+/**
+ * null case is vestigial
+ *
+ * @typedef {{
+ *   consume: { chainStorage: Promise<StorageNode> };
+ * }} ChainStorageNonNull
+ */
+
+/**
+ * Reset MintLimit on all PSMs to 50K IST.
+ *
+ * parts adapted from packages/vats/src/proposals/upgrade-psm-proposal.js
+ *
+ * @param {EconomyBootstrapPowers & ChainStorageNonNull} powers
+ * @param {object} [opts]
+ * @param {string} opts.bundleID
+ */
+const resetPSMMintLimits = async (
+  powers,
+  opts = {
+    // see psm-bundle-check.test.js
+    bundleID:
+      'b1-29e7a47537e6fedccb75dd2c01e28a4bfdf787c6c3c7d7e06156627ed5b31ba80aa05727d10350fa776af0d13eacf15af586da7a8468e9fa0a3f9d41727fc67a',
+  },
+) => {
+  trace('resetPSMMintLimits', opts);
+  const { economicCommitteeCreatorFacet, instancePrivateArgs, psmKit, zoe } =
+    powers.consume;
+  const { bundleID } = opts;
+
+  const ISTbrand = await powers.brand.consume.IST;
+  const MintLimit = harden({ brand: ISTbrand, value: MintLimitValue });
+  trace({ MintLimit });
+
+  const psmKitMap = await psmKit;
+  for (const kit of psmKitMap.values()) {
+    // const instanceKey = `psm-${Stable.symbol}-${keyword}`;
+    const [_psm, _ist, keyword] = kit.label.split('-');
+    trace('PSM name(s)', kit.label, keyword);
+    assert(keyword, kit.label);
+
+    const privateArgsPre = await shallowlyFulfilled(
+      // @ts-expect-error instancePrivateArgs is a mixed bag
+      await E(instancePrivateArgs).get(kit.psm),
+    );
+    const toPose = await E(economicCommitteeCreatorFacet).getPoserInvitation();
+    const privateArgs = {
+      ...privateArgsPre,
+      paramUpdates: { MintLimit },
+      initialPoserInvitation: toPose,
+    };
+    trace(keyword, 'privateArgs', privateArgs);
+    const it = await E(kit.psmAdminFacet).upgradeContract(
+      bundleID,
+      privateArgs,
+    );
+    trace('upgraded', keyword, it);
+  }
+};
+harden(resetPSMMintLimits);
+
+trace('"export" using completion value', resetPSMMintLimits);
+resetPSMMintLimits;

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -121,6 +121,9 @@ harden(meta);
  *   initialPoserInvitation: Invitation;
  *   storageNode: StorageNode;
  *   marshaller: Marshaller;
+ *   paramUpdates?: {
+ *     MintLimit?: Amount;
+ *   };
  * }} privateArgs
  * @param {Baggage} baggage
  */
@@ -440,6 +443,16 @@ export const start = async (zcf, privateArgs, baggage) => {
     baggage,
     limitedCreatorFacet,
   );
+  const { paramUpdates } = privateArgs;
+  if (paramUpdates) {
+    const { MintLimit } = paramUpdates;
+    if (MintLimit) {
+      const paramMgr = governorFacet.getParamMgrRetriever().get();
+      void paramMgr
+        .updateParams({ MintLimit })
+        .then(() => console.log('updated', { MintLimit }, 'for', anchorBrand));
+    }
+  }
   return harden({
     creatorFacet: governorFacet,
     publicFacet,

--- a/packages/inter-protocol/test/psm/psm-bundle-check.test.js
+++ b/packages/inter-protocol/test/psm/psm-bundle-check.test.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import { createRequire } from 'node:module';
+import { readFile } from 'node:fs/promises';
+
+const nodeRequire = createRequire(import.meta.url);
+
+const asset = {
+  script: nodeRequire.resolve('../../src/proposals/psm-gov-reset.js'),
+  bundle: nodeRequire.resolve('../../bundles/bundle-psm.js'),
+};
+
+test('check bundleID between coreEval and psm.js upgrade', async t => {
+  const script = await readFile(asset.script, 'utf-8');
+  const found = script.match(/'b1-(?<hash>[^']+)'/);
+  if (!found) throw t.fail('bundleID not found in script');
+  const { hash } = found.groups || {};
+  if (!hash) throw t.fail('hash not found in script');
+  t.log('hash', hash);
+  const bundle = await readFile(asset.bundle, 'utf-8');
+  const actual = bundle.indexOf(hash);
+  t.true(actual > 0, 'hash from script not found in bundle');
+});


### PR DESCRIPTION
closes: https://github.com/Agoric/dapp-econ-gov/issues/149
refs: https://github.com/Agoric/agoric-private/issues/313

## Description

work-around for #9982 for PSMs, since we don't seem to have access to governor `adminFacet`s.

 - feat(psm): support MintLimit paramUpdates in privateArgs
 - feat: reset MintLimit to 50K IST in all PSMs
    - [x] core eval permit is TODO
 - test: check bundleID between PSM bundle and coreEval

Does **not** support changes to fees.

### Security Considerations

~~Upgrading a PSM, like starting it, requires `feeMintAccess`.~~ As it turns out, `feeMintAccess` is needed to start but not to upgrade.

`instancePrivateArgs` is used as in `packages/vats/src/proposals/upgrade-psm-proposal.js`

### Scaling Considerations

n/a

### Documentation Considerations

 - [x] explanation to BLD stakers
 - [x] explanation to EC

### Testing Considerations

 - [x] [tested on a local a3p chain](#issuecomment-2807825994)
 - [x] bundleID consistency between the contract and the coreEval is checked by a unit test
 - verification using inquisitor and recent mainnet state ran into limitations around vat upgrade in inquisitor

### Upgrade Considerations

upgrades PSMs for USDC, USDT.
