### PR TITLE
make fast-usdc multichain tests repeatable

### DIFF
--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -49,6 +49,7 @@ const makeTestContext = async (t: ExecutionContext) => {
   const { setupTestKeys, ...common } = await commonSetup(t, {
     config: `../config.fusdc${RELAYER_TYPE ? '.' + RELAYER_TYPE : ''}.yaml`,
   });
+
   const {
     chainInfo,
     commonBuilderOpts,
@@ -190,7 +191,10 @@ const makeTestContext = async (t: ExecutionContext) => {
   };
   await provideLpFunds();
 
-  const makeFakeEvidence = prepareCctpTxEvidence(nobleAgoricChannelId, 0);
+  const makeFakeEvidence = prepareCctpTxEvidence(
+    nobleAgoricChannelId,
+    (await vstorageClient.queryChildren('published.fastUsdc.txns')).length,
+  );
 
   const queryTxRecord = async (txHash: string) => {
     const record = await common.smartWalletKit.readPublished(

--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -6,13 +6,9 @@ import type { QueryBalanceResponseSDKType } from '@agoric/cosmic-proto/cosmos/ba
 import { AmountMath } from '@agoric/ertp';
 import { divideBy, multiplyBy } from '@agoric/ertp/src/ratio.js';
 import type { USDCProposalShapes } from '@agoric/fast-usdc/src/pool-share-math.js';
-import type {
-  CctpTxEvidence,
-  EvmAddress,
-  NobleAddress,
-} from '@agoric/fast-usdc/src/types.js';
+import type { CctpTxEvidence } from '@agoric/fast-usdc/src/types.js';
 import { makeTracer } from '@agoric/internal';
-import type { Bech32Address, Denom, DenomDetail } from '@agoric/orchestration';
+import type { Denom, DenomDetail } from '@agoric/orchestration';
 import type { ExecutionContext, TestFn } from 'ava';
 import { makeDenomTools } from '../../tools/asset-info.js';
 import { makeBlocksIterable } from '../../tools/block-iter.js';
@@ -22,6 +18,7 @@ import { createWallet } from '../../tools/wallet.js';
 import { commonSetup } from '../support.js';
 import { makeFeedPolicyPartial, oracleMnemonics } from './config.js';
 import { agoricNamesQ, fastLPQ, makeTxOracle } from './fu-actors.js';
+import { prepareCctpTxEvidence } from './mocks.js';
 
 const { RELAYER_TYPE } = process.env;
 
@@ -193,32 +190,7 @@ const makeTestContext = async (t: ExecutionContext) => {
   };
   await provideLpFunds();
 
-  let callCount = 0;
-  const makeFakeEvidence = (
-    mintAmt: bigint,
-    userForwardingAddr: NobleAddress,
-    recipientAddress: Bech32Address,
-  ) =>
-    harden({
-      // NB these can never be the same between transactions but we don't want the test fixtures to be that dynamic
-      blockHash:
-        '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
-      blockNumber: 21037663n,
-      blockTimestamp: 1632340000n,
-      // Standard prefix to make it easier to find this code from logs
-      // but add `callCount` so it is unique per test.
-      txHash: `0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff3875527617${String(callCount++).padStart(2, '0')}`,
-      tx: {
-        amount: mintAmt,
-        forwardingAddress: userForwardingAddr,
-        sender: '0x9a9eE9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9' as EvmAddress,
-      },
-      aux: {
-        forwardingChannel: nobleAgoricChannelId,
-        recipientAddress,
-      },
-      chainId: 42161,
-    }) as CctpTxEvidence;
+  const makeFakeEvidence = prepareCctpTxEvidence(nobleAgoricChannelId, 0);
 
   const queryTxRecord = async (txHash: string) => {
     const record = await common.smartWalletKit.readPublished(

--- a/multichain-testing/test/fast-usdc/mocks.test.ts
+++ b/multichain-testing/test/fast-usdc/mocks.test.ts
@@ -1,0 +1,65 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import type { Bech32Address } from '@agoric/cosmic-proto/address-hooks.js';
+import type { NobleAddress } from '@agoric/fast-usdc';
+import { prepareCctpTxEvidence } from './mocks.ts';
+import { mustMatch } from '@agoric/internal';
+import { CctpTxEvidenceShape } from '@agoric/fast-usdc/src/type-guards.js';
+
+test('prepareCctpTxEvidence generates valid evidence', t => {
+  const nobleAgoricChannelId = 'channel-123';
+  const fakeCctpTxEvidence = prepareCctpTxEvidence(nobleAgoricChannelId);
+
+  const mintAmt = 1000n;
+  const userForwardingAddr = 'noble1...' as NobleAddress;
+  const recipientAddress = 'agoric1...' as Bech32Address;
+
+  const evidence = fakeCctpTxEvidence(
+    mintAmt,
+    userForwardingAddr,
+    recipientAddress,
+  );
+
+  mustMatch(evidence, CctpTxEvidenceShape);
+  t.is(evidence.tx.amount, mintAmt);
+  t.is(evidence.tx.forwardingAddress, userForwardingAddr);
+  t.is(typeof evidence.tx.sender, 'string');
+  t.is(evidence.aux.forwardingChannel, nobleAgoricChannelId);
+  t.is(evidence.aux.recipientAddress, recipientAddress);
+  t.is(evidence.chainId, 42161);
+});
+
+test('prepareCctpTxEvidence generates unique txHash per call', t => {
+  const nobleAgoricChannelId = 'channel-456';
+  const fakeCctpTxEvidence = prepareCctpTxEvidence(nobleAgoricChannelId, 5); // Start count at 5
+
+  const mintAmt1 = 100n;
+  const userForwardingAddr1 = 'noble1aaa' as NobleAddress;
+  const recipientAddress1 = 'agoric1aaa' as Bech32Address;
+  const evidence1 = fakeCctpTxEvidence(
+    mintAmt1,
+    userForwardingAddr1,
+    recipientAddress1,
+  );
+  mustMatch(evidence1, CctpTxEvidenceShape);
+
+  const mintAmt2 = 200n;
+  const userForwardingAddr2 = 'noble1bbb' as NobleAddress;
+  const recipientAddress2 = 'agoric1bbb' as Bech32Address;
+  const evidence2 = fakeCctpTxEvidence(
+    mintAmt2,
+    userForwardingAddr2,
+    recipientAddress2,
+  );
+  mustMatch(evidence2, CctpTxEvidenceShape);
+
+  t.not(evidence1.txHash, evidence2.txHash, 'txHash should be unique');
+  t.true(
+    evidence1.txHash.endsWith('05'),
+    'First txHash should end with base call count',
+  );
+  t.true(
+    evidence2.txHash.endsWith('06'),
+    'Second txHash should end with incremented call count',
+  );
+});

--- a/multichain-testing/test/fast-usdc/mocks.ts
+++ b/multichain-testing/test/fast-usdc/mocks.ts
@@ -1,0 +1,43 @@
+import type { Bech32Address } from '@agoric/cosmic-proto/address-hooks.js';
+import type {
+  NobleAddress,
+  EvmAddress,
+  CctpTxEvidence,
+} from '@agoric/fast-usdc';
+
+import chainInfo from '@agoric/orchestration/src/cctp-chain-info.js';
+
+export const prepareCctpTxEvidence = (
+  nobleAgoricChannelId: string,
+  baseCallCount = 0,
+) => {
+  let callCount = baseCallCount;
+  const fakeCctpTxEvidence = (
+    mintAmt: bigint,
+    userForwardingAddr: NobleAddress,
+    recipientAddress: Bech32Address,
+  ) =>
+    harden({
+      // NB block info can never be the same between transactions but we leave them fixed
+      // to make it easier to string search if necessary. None of the test logic depends on them.
+      blockHash:
+        '0x90d7343e04f8160892e94f02d6a9b9f255663ed0ac34caca98544c8143fee665',
+      blockNumber: 21037663n,
+      blockTimestamp: 1632340000n,
+      // Standard prefix to make it easier to find this code from logs
+      // but add `callCount` so it is unique per test.
+      txHash: `0xc81bc6105b60a234c7c50ac17816ebcd5561d366df8bf3be59ff3875527617${String(callCount++).padStart(2, '0')}`,
+      tx: {
+        amount: mintAmt,
+        forwardingAddress: userForwardingAddr,
+        // Fake sender address for testing purposes
+        sender: '0x9a9eE9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9' as EvmAddress,
+      },
+      aux: {
+        forwardingChannel: nobleAgoricChannelId,
+        recipientAddress,
+      },
+      chainId: Number(chainInfo.arbitrum.reference),
+    }) as CctpTxEvidence;
+  return fakeCctpTxEvidence;
+};

--- a/multichain-testing/tools/agd-lib.js
+++ b/multichain-testing/tools/agd-lib.js
@@ -2,7 +2,7 @@
 import { makeTracer } from '@agoric/internal';
 import assert from 'node:assert';
 
-const trace = makeTracer('Agd');
+const trace = makeTracer('Agd', false);
 
 const { freeze } = Object;
 

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -236,7 +236,10 @@ const provisionSmartWalletAndMakeDriver = async (
 
   const afterWhale = await retryUntilCondition(
     () => getCosmosBalances(),
-    ({ balances }) => balances.length === balanceEntries.length,
+    ({ balances }) => {
+      // XXX ensures there is at least some faucet but doesn't check that the balance went up
+      return balances.length >= balanceEntries.length;
+    },
     `${address} received tokens from whale`,
   );
   progress(`${address} after whale`, afterWhale);

--- a/multichain-testing/tools/sleep.ts
+++ b/multichain-testing/tools/sleep.ts
@@ -56,7 +56,7 @@ const retryUntilCondition = async <T>(
     await sleep(retryIntervalMs, { log, setTimeout });
   }
 
-  throw Error(`${message} condition failed after ${maxRetries} retries.`);
+  throw Error(`failed after ${maxRetries} retries: ${message}`);
 };
 
 export const makeRetryUntilCondition = (defaultOptions: RetryOptions = {}) => {


### PR DESCRIPTION
_incidental_

## Description
When debugging a test it's helpful to be able to run it again, but they were failing because expecting a clean environment. Starship tests take a long time to setup locally so that would cost ~20min.

This makes the tests able to run again in the same env.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI and I ran it locally repeatedly

### Upgrade Considerations
n/a