### PR TITLE
feat(cosmic-swingset): Add vat upgrade support to inquisitor.mjs

### DIFF
--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -183,6 +183,7 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.13"
     "@endo/stream": "npm:^1.2.13"
     anylogger: "npm:^0.21.0"
+    import-meta-resolve: "npm:^4.1.0"
     jessie.js: "npm:^0.3.4"
   languageName: node
   linkType: soft

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -192,6 +192,7 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.13"
     "@endo/stream": "npm:^1.2.13"
     anylogger: "npm:^0.21.0"
+    import-meta-resolve: "npm:^4.1.0"
     jessie.js: "npm:^0.3.4"
   languageName: node
   linkType: soft

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -6,7 +6,7 @@ import { assert, b, Fail } from '@endo/errors';
 import { deepCopyJsonable, makeTracer } from '@agoric/internal';
 import { mustMatch } from '@agoric/store';
 import bundleSource from '@endo/bundle-source';
-import { resolve as resolveModuleSpecifier } from 'import-meta-resolve';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { ManagerType } from '../typeGuards.js';
 import { provideBundleCache } from '../../tools/bundleTool.js';
 import { kdebugEnable } from '../lib/kdebug.js';
@@ -179,7 +179,7 @@ export function loadBasedir(basedir, options = {}) {
 async function resolveSpecFromConfig(referrer, specPath) {
   await null;
   try {
-    return new URL(await resolveModuleSpecifier(specPath, referrer)).pathname;
+    return new URL(await importMetaResolve(specPath, referrer)).pathname;
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND' && e.code !== 'ERR_MODULE_NOT_FOUND') {
       throw e;

--- a/packages/SwingSet/tools/vat-puppet-v2.js
+++ b/packages/SwingSet/tools/vat-puppet-v2.js
@@ -1,0 +1,11 @@
+import { Far } from '@endo/far';
+import { makeReflectionMethods } from './vat-puppet.js';
+
+export function buildRootObject(vatPowers, _vatParameters, baggage) {
+  const methods = makeReflectionMethods(vatPowers, baggage);
+  return Far('root', {
+    ...methods,
+
+    getVersion: () => 2,
+  });
+}

--- a/packages/SwingSet/tools/vat-puppet.js
+++ b/packages/SwingSet/tools/vat-puppet.js
@@ -93,6 +93,20 @@ export const makeReflectionMethods = (vatPowers, baggage, vatParameters) => {
   };
 
   return {
+    baggageHas: key => {
+      return baggage.has(key);
+    },
+    baggageGet: key => {
+      return baggage.get(key);
+    },
+    baggageSet: (key, value) => {
+      if (!baggage.has(key)) {
+        baggage.init(key, value);
+      } else {
+        baggage.set(key, value);
+      }
+    },
+
     /** @type {Die} */
     dieHappy: (completion, finalSend) => {
       vatPowers.exitVat(completion);

--- a/packages/SwingSet/tools/vat-puppet.js
+++ b/packages/SwingSet/tools/vat-puppet.js
@@ -217,7 +217,7 @@ harden(makeReflectionMethods);
 
 export function buildRootObject(vatPowers, vatParameters, baggage) {
   const methods = makeReflectionMethods(vatPowers, baggage, vatParameters);
-  const rootObject = Far('root', methods);
+  const rootObject = Far('root', { ...methods, getVersion: () => 1 });
 
   // Invoke specified methods of the new root object *before* returning,
   // supporting use of previous results as top-level arguments by interpreting

--- a/packages/cosmic-swingset/test/inquisitor.test.ts
+++ b/packages/cosmic-swingset/test/inquisitor.test.ts
@@ -61,11 +61,7 @@ test('makeHelpers', async t => {
     }
     Fail`port ${q(destPortName)} not implemented for message ${msg}`;
   };
-  const env = {
-    ...process.env,
-    CHAIN_BOOTSTRAP_VAT_CONFIG: '@agoric/vm-config/decentral-core-config.json',
-  };
-  const testKit = await makeCosmicSwingsetTestKit(receiveBridgeSend, { env });
+  const testKit = await makeCosmicSwingsetTestKit(receiveBridgeSend);
   const { pushCoreEval, runNextBlock, swingStore, shutdown } = testKit;
   t.teardown(shutdown);
 

--- a/packages/cosmic-swingset/test/inquisitor.test.ts
+++ b/packages/cosmic-swingset/test/inquisitor.test.ts
@@ -1,17 +1,44 @@
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
 
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import pathlib from 'node:path';
+
+import tmp from 'tmp';
+
 import { Fail, q } from '@endo/errors';
 
-import { BridgeId, VBankAccount } from '@agoric/internal';
+import {
+  BridgeId,
+  VBankAccount,
+  deepCopyJsonable,
+  objectMap,
+} from '@agoric/internal';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import type { SwingSetConfigDescriptor } from '@agoric/swingset-vat';
+import { provideBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 
-import { makeHelpers } from '../tools/inquisitor.mjs';
+import type { SwingStore } from '@agoric/swing-store';
+import { makeHelpers, makeSwingStoreOverlay } from '../tools/inquisitor.mjs';
 import { makeCosmicSwingsetTestKit } from '../tools/test-kit.js';
+
+const resolveToPath = createRequire(import.meta.url).resolve;
 
 const test = anyTest as TestFn;
 
-test('smoke test', async t => {
+/**
+ * Converts a Record<name, specifierString> into Record<name, { sourceSpec }>
+ * for defining e.g. a `bundles` group.
+ */
+const makeSourceDescriptors = (
+  src: Record<string, string>,
+): SwingSetConfigDescriptor => {
+  const hardened = objectMap(src, sourceSpec => ({ sourceSpec }));
+  return deepCopyJsonable(hardened);
+};
+
+test('makeHelpers', async t => {
   const fakeStorageKit = makeFakeStorageKit('');
   const { toStorage: handleVstorage } = fakeStorageKit;
   const receiveBridgeSend = (destPortName: string, msg: any) => {
@@ -80,5 +107,129 @@ test('smoke test', async t => {
       { key: `${vatID}.c.${rootVref}`, value: rootKref },
       'kvGlob',
     );
+  }
+});
+
+// This is really a test of makeCosmicSwingsetTestKit, but inquisitor relies
+// upon that so we include it here.
+test('vat lifecycle', async t => {
+  let swingStore: SwingStore | undefined;
+  let shutdown:
+    | ((options?: { kernelOnly?: boolean }) => Promise<void>)
+    | undefined;
+  t.teardown(() => shutdown?.());
+  const fakeStorageKit = makeFakeStorageKit('');
+  const { toStorage: handleVstorage } = fakeStorageKit;
+  const receiveBridgeSend = (destPortName: string, msg: any) => {
+    switch (destPortName) {
+      case BridgeId.STORAGE: {
+        return handleVstorage(msg);
+      }
+      case BridgeId.BANK: {
+        if (msg.type === 'VBANK_GET_MODULE_ACCOUNT_ADDRESS') {
+          const matchesRequest = (desc: { module: string }) =>
+            desc.module === msg.moduleName;
+          const found = Object.values(VBankAccount).find(matchesRequest);
+          if (found) return found.address;
+          return { error: `module account ${q(msg.moduleName)} not found` };
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    Fail`port ${q(destPortName)} not implemented for message ${msg}`;
+  };
+
+  // Launch the swingset and make a vat with some state.
+  {
+    const testKit = await makeCosmicSwingsetTestKit(receiveBridgeSend, {
+      bundles: makeSourceDescriptors({
+        puppet: '@agoric/swingset-vat/tools/vat-puppet.js',
+      }),
+    });
+    const { EV } = testKit;
+    ({ swingStore, shutdown } = testKit);
+
+    const puppet = await EV.vat('bootstrap').createVat('puppet');
+    t.is(await EV(puppet).getVersion(), 1);
+    const held = await EV.vat('bootstrap').makeRemotable('held', { data: 42 });
+    t.deepEqual(
+      [await EV(puppet).holdInHeap(held), await EV(puppet).holdInHeap(held)],
+      [1, 2],
+      'vat must holdInHeap',
+    );
+    await EV(puppet).baggageSet('imported', held);
+    const got = await EV(puppet).baggageGet('imported');
+    t.is(await EV(got).data(), 42, 'vat must hold in baggage');
+
+    await shutdown({ kernelOnly: true });
+  }
+
+  // Restart the swingset with an overlay swing-store and verify state
+  // preservation, then upgrade the vat to a previously-unknown bundle, then
+  // discard the overlay and do it all again.
+  const {
+    name: tmpName,
+    fd,
+    removeCallback,
+  } = tmp.fileSync({ detachDescriptor: true });
+  t.teardown(() => removeCallback());
+  fs.writeSync(fd, swingStore.debug.serialize());
+  const bundleDir = pathlib.resolve('bundles');
+  const bundleCache = await provideBundleCache(bundleDir, {}, s => import(s));
+  const bundle = await bundleCache.load(
+    resolveToPath('@agoric/swingset-vat/tools/vat-puppet-v2.js'),
+  );
+  const bundleID = `b1-${bundle.endoZipBase64Sha512}`;
+  for (const label of ['first overlay', 'second overlay']) {
+    t.log(label);
+    const { swingStore: overlay } = makeSwingStoreOverlay(tmpName);
+    const testKit = await makeCosmicSwingsetTestKit(receiveBridgeSend, {
+      swingStore: overlay,
+    });
+    const { EV } = testKit;
+    ({ shutdown } = testKit);
+
+    const puppet = await EV.vat('bootstrap').getVatRoot('puppet');
+    t.is(await EV(puppet).getVersion(), 1, `${label} starting vat version`);
+    const held = await EV(puppet).baggageGet('imported');
+    t.is(
+      await EV(held).data(),
+      42,
+      `${label} swingset restart must preserve vat baggage`,
+    );
+    t.deepEqual(
+      [await EV(puppet).holdInHeap(held), await EV(puppet).holdInHeap(held)],
+      [3, 4],
+      `${label} swingset restart must preserve vat heap`,
+    );
+
+    await overlay.kernelStorage.bundleStore.addBundle(bundleID, bundle);
+    t.is(
+      await EV.vat('bootstrap').upgradeVat('puppet', bundleID),
+      1,
+      `${label} upgrade incarnation (0-indexed)`,
+    );
+    const puppetV2 = await EV.vat('bootstrap').getVatRoot('puppet');
+    t.is(
+      await EV(puppetV2).getVersion(),
+      2,
+      `${label} vat upgrade code version`,
+    );
+    const got = await EV(puppet).baggageGet('imported');
+    t.is(
+      await EV(got).data(),
+      42,
+      `${label} upgraded vat must inherit baggage`,
+    );
+    t.deepEqual(
+      [await EV(puppet).holdInHeap(got), await EV(puppet).holdInHeap(got)],
+      [1, 2],
+      `${label} upgraded vat must have fresh heap`,
+    );
+
+    await shutdown({ kernelOnly: true });
+    shutdown = undefined;
   }
 });

--- a/packages/cosmic-swingset/tools/inquisitor.mjs
+++ b/packages/cosmic-swingset/tools/inquisitor.mjs
@@ -67,9 +67,7 @@ import { makeCosmicSwingsetTestKit } from './test-kit.js';
  * @import {ManagerType, SwingSetConfig} from '@agoric/swingset-vat';
  * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js';
  * @import {CoreEvalSDKType} from '@agoric/cosmic-proto/swingset/swingset.js';
- * @import {makeTranscriptStore} from '@agoric/swing-store';
- * @import {makeSnapStore} from '@agoric/swing-store';
- * @import {SnapshotResult} from '@agoric/swing-store';
+ * @import {makeSnapStore, makeTranscriptStore, SnapshotInfo, SnapshotResult} from '@agoric/swing-store';
  */
 
 const useColors = process.stdout?.hasColors?.();
@@ -558,19 +556,46 @@ export const makeSwingStoreOverlay = (dbPath, wrapStore = wrapSubstore) => {
         },
         readSpan: (vatID, startPos) => {
           const reader = function* reader() {
-            try {
-              // Read from the base store.
-              yield* transcriptStore.readSpan(vatID, startPos);
-            } catch (_err) {}
-            // Read from the overlay, assuming that any transcripts of vatID
-            // are for the current span.
+            // startPos defaults to the latest value, which will match the base
+            // store unless the overlay includes a rollover.
+            // So read from the base store if startPos is explicit *or* if there
+            // is no such rollover, and then read from the overlay.
             const pendingItems = pendingItemsByVat.get(vatID) || [];
-            for (const { item, startPos: itemStartPos } of pendingItems) {
-              if (startPos !== undefined && itemStartPos !== startPos) break;
-              yield item;
+            const baseOk =
+              startPos !== undefined ||
+              !pendingItems.find(item => item.hash === '<initial>');
+            if (baseOk) {
+              try {
+                yield* transcriptStore.readSpan(vatID, startPos);
+              } catch (_err) {}
+            }
+            if (startPos === undefined) {
+              startPos = pendingItems.at(-1)?.startPos;
+            }
+            for (const { item, startPos: itemStartPos, hash } of pendingItems) {
+              // Skip synthetic rollover markers.
+              if (hash === '<initial>') continue;
+              if (itemStartPos === startPos) yield item;
             }
           };
           return reader();
+        },
+        rolloverIncarnation: vatID => {
+          recordCall('transcriptStore', 'rolloverIncarnation', vatID);
+          if (wrapHelpers.isStale(vatID)) return;
+          const pendingItems = pendingItemsByVat.get(vatID) || [];
+          const { endPos, incarnation } =
+            pendingItems.at(-1) || transcriptStore.getCurrentSpanBounds(vatID);
+          // Indicate the rollover with a synthetic marker.
+          const rolloverMarker = {
+            startPos: endPos,
+            endPos,
+            hash: '<initial>',
+            incarnation: incarnation + 1,
+          };
+          pendingItems.push(rolloverMarker);
+          pendingItemsByVat.set(vatID, pendingItems);
+          return rolloverMarker.incarnation;
         },
       };
       return wrapStore('transcriptStore', transcriptStoreOverride, {
@@ -578,11 +603,15 @@ export const makeSwingStoreOverlay = (dbPath, wrapStore = wrapSubstore) => {
         logAndMark: [
           'initTranscript',
           'rolloverSpan',
-          'rolloverIncarnation',
           'stopUsingTranscript',
           ['deleteVatTranscripts', () => harden({ done: true, cleanups: 0 })],
         ],
-        warnIfStale: ['addItem', 'getCurrentSpanBounds', 'readSpan'],
+        warnIfStale: [
+          'addItem',
+          'getCurrentSpanBounds',
+          'readSpan',
+          'rolloverIncarnation',
+        ],
         allowIfClean: [
           ...storeExportAPI,
           'exportSpan',
@@ -599,34 +628,67 @@ export const makeSwingStoreOverlay = (dbPath, wrapStore = wrapSubstore) => {
     },
     wrapSnapStore: snapStore => {
       const wrapHelpers = makeWrapHelpers();
+      /**
+       * Keep overlay-only snapshots as {info, chunks} records and overlay-only
+       * snapshot abandonment as `null`s.
+       *
+       * @type {Map<string, {info: SnapshotInfo, chunks: Uint8Array[]} | null>}
+       */
+      const pendingSnapshotsByVat = new Map();
       /** @type {ReturnType<makeSnapStore>} */
       const snapStoreOverride = {
         ...snapStore,
         saveSnapshot: async (vatID, snapPos, dataStream) => {
           const entryPrefix = ['snapStore', 'saveSnapshot', vatID, snapPos];
-          wrapHelpers.markStale(vatID);
           await null;
-          let size = 0;
+          /** @type {Uint8Array[]} */
+          const chunks = [];
+          const getSize = () =>
+            chunks.reduce((sum, chunk) => sum + chunk.length, 0);
           try {
-            for await (const chunk of dataStream) size += chunk.length;
+            for await (const chunk of dataStream) chunks.push(chunk);
+            const size = getSize();
             recordCall(...entryPrefix, `<${size} bytes>`);
+            const result = harden({
+              hash: `<snapPos ${snapPos}>`,
+              uncompressedSize: size,
+              compressedSize: size,
+            });
+            const pending = harden({ info: { snapPos, ...result }, chunks });
+            pendingSnapshotsByVat.set(vatID, pending);
+            return /** @type {SnapshotResult} */ (result);
           } catch (err) {
-            recordCall(...entryPrefix, `<error after ${size} bytes>`);
+            recordCall(...entryPrefix, `<error after ${getSize()} bytes>`);
             throw err;
           }
-          return /** @type {SnapshotResult} */ (
-            harden({ uncompressedSize: size })
-          );
+        },
+        stopUsingLastSnapshot: vatID => {
+          recordCall('snapStore', 'stopUsingLastSnapshot', vatID);
+          pendingSnapshotsByVat.set(vatID, null);
+        },
+        getSnapshotInfo: vatID => {
+          const found = pendingSnapshotsByVat.get(vatID);
+          if (found) return found.info;
+          if (found === null) return /** @type {any} */ (undefined);
+          return snapStore.getSnapshotInfo(vatID);
+        },
+        async *loadSnapshot(vatID) {
+          const found = pendingSnapshotsByVat.get(vatID);
+          if (found) {
+            yield* found.chunks;
+            return;
+          }
+          found !== null || Fail`no current snapshot for vat ${q(vatID)}`;
+          yield* snapStore.loadSnapshot(vatID);
         },
       };
       return wrapStore('snapStore', snapStoreOverride, {
         ...wrapHelpers,
-        allow: ['saveSnapshot'],
+        allow: ['saveSnapshot', 'stopUsingLastSnapshot'],
         logAndMark: [
           ['deleteVatSnapshots', () => harden({ done: true, cleanups: 0 })],
-          'stopUsingLastSnapshot',
         ],
-        warnIfStale: ['loadSnapshot', 'getSnapshotInfo', 'hasHash'],
+        warnIfStale: ['getSnapshotInfo', 'hasHash', 'loadSnapshot'],
         allowIfClean: [
           ...storeExportAPI,
           'exportSnapshot',
@@ -906,6 +968,9 @@ Example commands:
 * stable.getRefs('o+10', 'v1');
 * board = await EV.vat('bootstrap').consumeItem('board');
 * obj = await EV(board).getValue('board02963');
+* await (
+    async b => swingStore.kernelStorage.bundleStore.addBundle(\`b1-\${b.endoZipBase64Sha512}\`, b)
+  )( JSON.parse(fs.readFileSync('/path/to/bundle.json')) );
 * await runCoreEval(\`async powers => {
     const ref = await E.get(powers.consume.auctioneerKit).governorAdminFacet;
     console.log(ref);

--- a/packages/cosmic-swingset/tools/inquisitor.mjs
+++ b/packages/cosmic-swingset/tools/inquisitor.mjs
@@ -502,7 +502,7 @@ harden(wrapSubstore);
  * functionality into swing-store itself.
  *
  * @param {string} dbPath to a swingstore.sqlite file
- * @param {typeof wrapSubstore} wrapStore a function to replace swing-store sub-stores (kvStore/transcriptStore/etc.)
+ * @param {typeof wrapSubstore} [wrapStore] a function to replace swing-store sub-stores (kvStore/transcriptStore/etc.)
  */
 export const makeSwingStoreOverlay = (dbPath, wrapStore = wrapSubstore) => {
   /** @type {Array<[storeName: string, operation: string, ...args: unknown[]]>} */

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -35,6 +35,7 @@
     "@endo/promise-kit": "^1.1.13",
     "@endo/stream": "^1.2.13",
     "anylogger": "^0.21.0",
+    "import-meta-resolve": "^4.1.0",
     "jessie.js": "^0.3.4"
   },
   "devDependencies": {

--- a/packages/internal/src/module-utils.js
+++ b/packages/internal/src/module-utils.js
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { search } from '@endo/compartment-mapper';
 import { Fail } from '@endo/errors';
 
@@ -25,3 +26,18 @@ export const getSpecifier = async fileUrl => {
   return `${name}/${moduleSpecifier.replace(/^\.\//, '')}`;
 };
 harden(getSpecifier);
+
+/**
+ * Given an import specifier and importer URL (usually import.meta.url), return
+ * a file system path corresponding with the specifier for the importer.
+ *
+ * @param {string} specifier
+ * @param {string} baseURL
+ * @returns {string}
+ */
+export const resolveToPath = (specifier, baseURL) => {
+  const resolved = importMetaResolve(specifier, baseURL);
+  const resolvedURL = new URL(resolved);
+  return fileURLToPath(resolvedURL);
+};
+harden(resolveToPath);

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1257,9 +1257,9 @@ function build(
   let baggage;
   async function startVat(vatParametersCapData) {
     insistCapData(vatParametersCapData);
-    assert(!didStartVat);
+    !didStartVat || Fail`already started`;
     didStartVat = true;
-    assert(!didStopVat);
+    !didStopVat || Fail`already stopped`;
 
     // Build the `vatPowers` provided to `buildRootObject`. We include
     // vatGlobals and inescapableGlobalProperties to make it easier to write

--- a/packages/vats/tools/bootstrap-chain-reflective.js
+++ b/packages/vats/tools/bootstrap-chain-reflective.js
@@ -116,6 +116,63 @@ export const buildRootObject = (vatPowers, bootstrapParameters, baggage) => {
 
   const reflectionMethods = makeReflectionMethods(vatPowers, baggage);
 
+  /**
+   * @param {string} bundleIdOrName
+   * @returns {Promise<import('@agoric/swingset-vat').BundleCap>}
+   */
+  const getBundleCapByIdOrName = bundleIdOrName =>
+    bundleIdOrName.startsWith('b1-')
+      ? E(vatAdminP).getBundleCap(bundleIdOrName)
+      : E(vatAdminP).getNamedBundleCap(bundleIdOrName);
+
+  /**
+   * @template BundleIdentifier
+   * @callback CreateVat
+   * @param {string} vatName
+   * @param {BundleIdentifier} bundleIdentifier
+   * @param {{ vatParameters?: object } & Record<string, unknown>} [vatOptions]
+   * @returns {Promise<DynamicVatRecord['root']>} root object of the new vat
+   */
+
+  /** @type {CreateVat<import('@agoric/swingset-vat').BundleCap>} */
+  const createVat = async (vatName, bundleCap, vatOptions = {}) => {
+    const { root, adminNode } = await E(vatAdminP).createVat(bundleCap, {
+      vatParameters: {},
+      ...vatOptions,
+    });
+    vatRecords.set(vatName, { root, adminNode, bundleCap });
+    return root;
+  };
+
+  /**
+   * @template BundleIdentifier
+   * @callback UpgradeVat
+   * @param {string} vatName
+   * @param {BundleIdentifier} bundleIdentifier
+   * @param {{ vatParameters?: object } & Record<string, unknown>} [vatOptions]
+   * @returns {Promise<number>} the resulting incarnation number
+   */
+
+  /**
+   * @type {UpgradeVat<
+   *   import('@agoric/swingset-vat').BundleCap | undefined
+   * >}
+   */
+  const upgradeVat = async (vatName, bundleCap, vatOptions = {}) => {
+    const vatRecord = /** @type {DynamicVatRecord} */ (
+      vatRecords.get(vatName) || Fail`unknown vat name: ${q(vatName)}`
+    );
+    vatRecord.adminNode ||
+      Fail`no adminNode for vat ${q(vatName)}; is it static?`;
+    const upgradeOptions = { vatParameters: {}, ...vatOptions };
+    const { incarnationNumber } = await E(vatRecord.adminNode).upgrade(
+      bundleCap || vatRecord.bundleCap,
+      upgradeOptions,
+    );
+    vatRecord.incarnationNumber = incarnationNumber;
+    return incarnationNumber;
+  };
+
   return Far('root', {
     ...reflectionMethods,
 
@@ -157,42 +214,49 @@ export const buildRootObject = (vatPowers, bootstrapParameters, baggage) => {
       return root;
     },
 
-    /**
-     * @param {string} vatName
-     * @param {string} [bundleCapName]
-     * @param {{ vatParameters?: object } & Record<string, unknown>} [vatOptions]
-     * @returns {Promise<DynamicVatRecord['root']>} root object of the new vat
-     */
-    createVat: async (vatName, bundleCapName = vatName, vatOptions = {}) => {
-      const bundleCap = await E(vatAdminP).getNamedBundleCap(bundleCapName);
-      const { root, adminNode } = await E(vatAdminP).createVat(bundleCap, {
-        vatParameters: {},
-        ...vatOptions,
-      });
-      vatRecords.set(vatName, { root, adminNode, bundleCap });
-      return root;
+    /** @type {CreateVat<string>} */
+    createVatByBundleID: async (vatName, bundleID, vatOptions) => {
+      const bundleCap = await E(vatAdminP).getBundleCap(bundleID);
+      return createVat(vatName, bundleCap, vatOptions);
     },
 
-    /**
-     * @param {string} vatName
-     * @param {string} [bundleCapName]
-     * @param {{ vatParameters?: object } & Record<string, unknown>} [vatOptions]
-     * @returns {Promise<number>} the resulting incarnation number
-     */
-    upgradeVat: async (vatName, bundleCapName, vatOptions = {}) => {
-      const vatRecord = /** @type {DynamicVatRecord} */ (
-        vatRecords.get(vatName) || Fail`unknown vat name: ${q(vatName)}`
-      );
-      const bundleCap = await (bundleCapName
-        ? E(vatAdminP).getNamedBundleCap(bundleCapName)
-        : vatRecord.bundleCap);
-      const upgradeOptions = { vatParameters: {}, ...vatOptions };
-      const { incarnationNumber } = await E(vatRecord.adminNode).upgrade(
-        bundleCap,
-        upgradeOptions,
-      );
-      vatRecord.incarnationNumber = incarnationNumber;
-      return incarnationNumber;
+    /** @type {CreateVat<string | undefined>} */
+    createVatByBundleName: async (
+      vatName,
+      bundleName = vatName,
+      vatOptions,
+    ) => {
+      const bundleCap = await E(vatAdminP).getNamedBundleCap(bundleName);
+      return createVat(vatName, bundleCap, vatOptions);
+    },
+
+    /** @type {CreateVat<string | undefined>} */
+    createVat: async (vatName, bundleIdOrName = vatName, vatOptions) => {
+      const bundleCap = await getBundleCapByIdOrName(bundleIdOrName);
+      return createVat(vatName, bundleCap, vatOptions);
+    },
+
+    /** @type {UpgradeVat<string | undefined>} */
+    upgradeVatByBundleID: async (vatName, bundleID, vatOptions) => {
+      vatRecords.has(vatName) || Fail`unknown vat name: ${q(vatName)}`;
+      const bundleCap = await (bundleID && E(vatAdminP).getBundleCap(bundleID));
+      return upgradeVat(vatName, bundleCap, vatOptions);
+    },
+
+    /** @type {UpgradeVat<string | undefined>} */
+    upgradeVatByBundleName: async (vatName, bundleName, vatOptions) => {
+      vatRecords.has(vatName) || Fail`unknown vat name: ${q(vatName)}`;
+      const bundleCap = await (bundleName &&
+        E(vatAdminP).getNamedBundleCap(bundleName));
+      return upgradeVat(vatName, bundleCap, vatOptions);
+    },
+
+    /** @type {UpgradeVat<string | undefined>} */
+    upgradeVat: async (vatName, bundleIdOrName, vatOptions) => {
+      vatRecords.has(vatName) || Fail`unknown vat name: ${q(vatName)}`;
+      const bundleCap = await (bundleIdOrName &&
+        getBundleCapByIdOrName(bundleIdOrName));
+      return upgradeVat(vatName, bundleCap, vatOptions);
     },
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,6 +821,7 @@ __metadata:
     "@fast-check/ava": "npm:^2.0.1"
     anylogger: "npm:^0.21.0"
     ava: "npm:^5.3.0"
+    import-meta-resolve: "npm:^4.1.0"
     jessie.js: "npm:^0.3.4"
     tsd: "npm:^0.33.0"
   languageName: unknown


### PR DESCRIPTION
## Description
Vat upgrade [includes](https://github.com/Agoric/agoric-sdk/blob/31be2992aec21c06633699b7d8095423845b0530/packages/SwingSet/src/kernel/state/vatKeeper.js#L728) calling `snapStore.stopUsingLastSnapshot(vatID)` (expecting a subsequent for the new incarnation `snapStore.getSnapshotInfo(vatID)` to return undefined) and `transcriptStore.rolloverIncarnation(vatID)` (expecting subsequent `transcriptStore.readSpan(vatID)` to return items only for the new span). This PR adds support for such patterns to inquisitor.mjs.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This developer tool should be exercised by use. In this case, the commands were something like
```js
void( fs = await import('fs') );
Object.keys( bundle = JSON.parse(fs.readFileSync("/tmp/psm-bundle.json", "utf-8")) );
await swingStore.kernelStorage.bundleStore.addBundle($bundleID, bundle);
await runCoreEval(fs.readFileSync("/tmp/psm-core-eval.js", "utf-8"));
```

Testing covers analogous use of the supporting libraries.

### Upgrade Considerations
n/a