### PR TITLE
fix(swing-store): Update archiveTranscript to wait for write stream conclusion

### DIFF
--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -27,7 +27,6 @@
     "@endo/check-bundle": "^1.0.14",
     "@endo/errors": "^1.2.10",
     "@endo/nat": "^5.1.0",
-    "@endo/promise-kit": "^1.1.10",
     "better-sqlite3": "^9.1.1"
   },
   "devDependencies": {

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -21,12 +21,13 @@
     "lint:eslint": "eslint ."
   },
   "dependencies": {
-    "@endo/errors": "^1.2.10",
     "@agoric/internal": "^0.3.2",
     "@endo/base64": "^1.0.9",
     "@endo/bundle-source": "^4.0.0",
     "@endo/check-bundle": "^1.0.14",
+    "@endo/errors": "^1.2.10",
     "@endo/nat": "^5.1.0",
+    "@endo/promise-kit": "^1.1.10",
     "better-sqlite3": "^9.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
closes: #11293

## Description
`archiveTranscript` creates a WriteStream `writer` and a gzip stream `gzip`, connects them by `gzip.pipe(writer)`, and then waits for `streamFinished(gzip)` before returning. But `writer` can still have pending activity even after `gzip` finished, which seems to be the root cause of #11293.

This PR updates `archiveTranscript` to instead wait for conclusion of _`writer`_, currently by ~~listening for error/finish/close events (but I'm open to alternatives that also accomplish the same goal)~~ <code>await <a href="https://nodejs.org/docs/latest/api/stream.html#streampipelinesource-transforms-destination-options">pipeline</a>(source, createGzip(), writer);</code>.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This is fixing racy behavior, and thus impractical to test specifically. We'll instead rely on the existing coverage that alerted us to begin with.

### Upgrade Considerations
n/a