### PR TITLE
fix type resolution regression in registry test

### DIFF
--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -11,8 +11,17 @@ import { makeReserveTerms } from '../reserve/params.js';
 import { makeGovernedTerms as makeGovernedVFTerms } from '../vaultFactory/params.js';
 
 /**
+ * @import {GovernorCreatorFacet, GovernanceFacetKit, GovernorStartedInstallationKit} from '@agoric/governance/src/types.js';
  * @import {StartedInstanceKit} from '@agoric/zoe/src/zoeService/utils.js';
- * @import {AdminFacet, ContractOf, InvitationAmount, ZCFMint} from '@agoric/zoe';
+ * @import {AdminFacet} from '@agoric/zoe';
+ */
+
+// Duplicated from vaultFactory/types-ambient.js to solve a CI problem.
+// Not worth refactoring to DRY because vaultFactory is going away.
+/**
+ * @typedef {object} InterestTiming
+ * @property {import('@agoric/time').RelativeTime} chargingPeriod in seconds
+ * @property {import('@agoric/time').RelativeTime} recordingPeriod in seconds
  */
 
 const trace = makeTracer('RunEconBehaviors', true);


### PR DESCRIPTION
_incidental_

## Description
https://github.com/Agoric/agoric-sdk/pull/11299 passed CI but after merging the subsequent PRs got errors in the registry/npx test:
https://github.com/Agoric/agoric-sdk/actions/runs/14595251030/job/40939497541#step:6:1544
https://github.com/Agoric/agoric-sdk/actions/runs/14595676787/job/40940897083#step:6:1544

I couldn't repro but this does explicit imports in the failing module to make it robust to variations in the ambient resolution.

It also has a drive-by package dependency acknowledgement.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none