### PR TITLE
fix async assertions in multichain-testing

### DIFF
--- a/multichain-testing/test/devex.test.ts
+++ b/multichain-testing/test/devex.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @file Demonstrates why not to use t.notThrowsAsync within context
+ */
+import test from '@endo/ses-ava/prepare-endo.js';
+
+test.before(async t => {
+  const assertTxStatusPlain = async (txHash: string, status: string) =>
+    Promise.reject(
+      new Error(`Transaction ${txHash} failed to reach status ${status}`),
+    );
+  const assertTxStatusWrapped = async (txHash: string, status: string) =>
+    t.notThrowsAsync(
+      Promise.reject(
+        new Error(`Transaction ${txHash} failed to reach status ${status}`),
+      ),
+    );
+  t.context = { assertTxStatusPlain, assertTxStatusWrapped };
+});
+
+// This gives an informative error message with a stack trace:
+// ✔ [expected fail] plain
+// ℹ REJECTED from ava test.failing("plain"): (Error#2)
+// ℹ Error#2: Transaction 0x123 failed to reach status success
+// ℹ     at assertTxStatusPlain (file:///opt/agoric/agoric-sdk/multichain-testing/test/devex.test.ts:9:7)
+//       at file:///opt/agoric/agoric-sdk/multichain-testing/test/devex.test.ts:31:9
+test.failing('plain', async t => {
+  // @ts-expect-error unknown
+  const { assertTxStatusPlain } = t.context;
+
+  await assertTxStatusPlain('0x123', 'success');
+});
+
+// This loses the error message and the stack trace:
+// ✔ [expected fail] wrapped
+// ℹ REJECTED from ava test.failing("wrapped"): (TestFailure#1)
+// ℹ TestFailure#1: The test has failed
+// ℹ     at Test.saveFirstError (file:///opt/agoric/agoric-sdk/multichain-testing/node_modules/.store/ava-virtual-d28ee69673/package/lib/test.js:410:22)
+//       at Test.failPendingAssertion (file:///opt/agoric/agoric-sdk/multichain-testing/node_modules/.store/ava-virtual-d28ee69673/package/lib/test.js:363:8)
+test.failing('wrapped', async t => {
+  // @ts-expect-error unknown
+  const { assertTxStatusWrapped } = t.context;
+
+  await assertTxStatusWrapped('0x123', 'success');
+});

--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -213,13 +213,10 @@ const makeTestContext = async (t: ExecutionContext) => {
    * Retry until the transaction status is the expected one.
    */
   const assertTxStatus = async (txHash: string, status: string) =>
-    t.notThrowsAsync(
-      common.retryUntilCondition(
-        () => queryTxRecord(txHash),
-        record => record.status === status,
-        `assertTxStatus ${txHash} status is ${status}`,
-      ),
-      `${txHash} status never reached ${status}`,
+    common.retryUntilCondition(
+      () => queryTxRecord(txHash),
+      record => record.status === status,
+      `assertTxStatus ${txHash} status is ${status}`,
     );
 
   const getUsdcDenom = (chainName: string) => {
@@ -241,24 +238,22 @@ const makeTestContext = async (t: ExecutionContext) => {
     eudChain: string,
     mintAmt: bigint,
   ) =>
-    t.notThrowsAsync(async () => {
-      await common.retryUntilCondition(
-        () => queryClient.queryBalance(EUD, getUsdcDenom(eudChain)),
-        ({ balance }) => {
-          if (!balance) return false; // retry
-          const value = BigInt(balance.amount);
-          if (value === 0n) return false; // retry
-          if (value < mintAmt) {
-            throw Error(`fees were deducted: ${value} < ${mintAmt}`);
-          }
-          t.log('forward done', value, 'uusdc');
-          return true;
-        },
-        `${EUD} forward available from fast-usdc`,
-        // this resolves quickly, so _decrease_ the interval so the timing is more apparent
-        { retryIntervalMs: 500, maxRetries: 20 },
-      );
-    });
+    common.retryUntilCondition(
+      () => queryClient.queryBalance(EUD, getUsdcDenom(eudChain)),
+      ({ balance }) => {
+        if (!balance) return false; // retry
+        const value = BigInt(balance.amount);
+        if (value === 0n) return false; // retry
+        if (value < mintAmt) {
+          throw Error(`fees were deducted: ${value} < ${mintAmt}`);
+        }
+        t.log('forward done', value, 'uusdc');
+        return true;
+      },
+      `${EUD} forward available from fast-usdc`,
+      // this resolves quickly, so _decrease_ the interval so the timing is more apparent
+      { retryIntervalMs: 500, maxRetries: 20 },
+    );
 
   return {
     ...common,


### PR DESCRIPTION
_incidental_

## Description
I burned time debugging a failure in https://github.com/Agoric/agoric-sdk/pull/11307 because the output lost the error message and the stack trace. It's particularly costly in multichain-testing because of Starship setup time, how slow the tests are to rerun.

The problem was that `t.notThrowsAsync` called from outside the test function loses the message and stack trace. I've demonstrated this with a `devex.test.ts`. 

I think we're better off eschewing it since awaiting a rejected promise will fail in exactly the same cases.

### * Considerations
no other