### PR TITLE
lint unused vars in .ts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -276,6 +276,13 @@ export default [
       'jsdoc/require-param': 'off',
       'jsdoc/require-param-type': 'off',
       'no-undef': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   {
@@ -283,6 +290,12 @@ export default [
 
     rules: {
       'no-redeclare': 'off',
+    },
+  },
+  {
+    files: ['**/*.test-d.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   ...compat

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
     "typescript": "~5.8.2",
-    "typescript-eslint": "^8.26.0"
+    "typescript-eslint": "^8.31.0"
   },
   "resolutions": {
     "**/protobufjs": "^7.2.6",
     "**/@types/estree": "^1.0.0",
-    "@endo/eslint-plugin/typescript-eslint": "^8.26.0"
+    "@endo/eslint-plugin/typescript-eslint": "^8.31.0"
   },
   "engines": {
     "node": "^18.12 || ^20.9"

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,7 +21,7 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.9",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",
     "@types/yargs-parser": "^21.0.0"

--- a/packages/async-flow/src/types.ts
+++ b/packages/async-flow/src/types.ts
@@ -68,7 +68,7 @@ export type GuestInterface<T> = {
     ? (...args: Parameters<T[K]>) => Promise<R>
     : T[K] extends HostAsyncFuncWrapper
       ? GuestOf<T[K]>
-      : T[K] extends (...args: any[]) => infer R
+      : T[K] extends (...args: any[]) => any
         ? T[K]
         : T[K] extends object
           ? GuestInterface<T[K]>

--- a/packages/boot/test/bootstrapTests/liquidation-1.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-1.test.ts
@@ -2,16 +2,15 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { NonNullish } from '@agoric/internal';
-import process from 'process';
 import type { ExecutionContext, TestFn } from 'ava';
-import type { ScheduleNotification } from '@agoric/inter-protocol/src/auction/scheduler.js';
+import process from 'process';
 import {
   ensureVaultCollateral,
-  type LiquidationTestContext,
   likePayouts,
   makeLiquidationTestContext,
   scale6,
   type LiquidationSetup,
+  type LiquidationTestContext,
 } from '../../tools/liquidation.js';
 
 const test = anyTest as TestFn<LiquidationTestContext>;
@@ -145,7 +144,6 @@ const checkFlow1 = async (
     advanceTimeTo,
     check,
     priceFeedDrivers,
-    readLatest,
     readPublished,
     walletFactoryDriver,
     setupVaults,

--- a/packages/boot/test/bootstrapTests/liquidation-2b.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-2b.test.ts
@@ -10,7 +10,6 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { NonNullish } from '@agoric/internal';
 import type { TestFn } from 'ava';
-import type { ScheduleNotification } from '@agoric/inter-protocol/src/auction/scheduler.js';
 import {
   type LiquidationSetup,
   type LiquidationTestContext,
@@ -131,7 +130,6 @@ test.serial('scenario: Flow 2b', async t => {
     advanceTimeTo,
     check,
     priceFeedDrivers,
-    readLatest,
     readPublished,
     setupVaults,
     placeBids,

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -5,9 +5,6 @@ import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 import type { TestFn } from 'ava';
 import { createRequire } from 'module';
 
-import type { Baggage } from '@agoric/swingset-liveslots';
-import { M, makeScalarBigMapStore } from '@agoric/vat-data';
-import { makeDurableZone } from '@agoric/zone/durable.js';
 import { makeSwingsetTestKit } from '../../tools/supports.js';
 
 const { entries, assign } = Object;
@@ -22,12 +19,6 @@ const asset = {
 
 export const makeTestContext = async t => {
   console.time('DefaultTestContext');
-
-  const baggage = makeScalarBigMapStore('baggage', {
-    keyShape: M.string(),
-    durable: true,
-  }) as Baggage;
-  const zone = makeDurableZone(baggage);
 
   const bundleDir = 'bundles';
   const bundleCache = await makeNodeBundleCache(
@@ -163,7 +154,7 @@ test.serial('upgrade at many points in network API flow', async t => {
       t.is(ack, `got ${label}`, `${label} expected echo`);
       return [label, { ...opts, ack }];
     },
-    closeConnection: async ([label, opts]) => {
+    closeConnection: async ([_label, opts]) => {
       await EV(opts.client).close();
     },
   });

--- a/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
+++ b/packages/boot/test/bootstrapTests/price-feed-replace.test.ts
@@ -87,7 +87,6 @@ test.serial('setupVaults; run updatePriceFeeds proposals', async t => {
   const priceFeedBuilder =
     '@agoric/builders/scripts/inter-protocol/updatePriceFeeds.js';
   t.log('building', priceFeedBuilder);
-  const brandName = collateralBrandKey;
 
   const { ATOM } = agoricNamesRemotes.brand;
   ATOM || Fail`ATOM missing from agoricNames`;

--- a/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
+++ b/packages/boot/test/bootstrapTests/updateUpgradedVaultParams.test.ts
@@ -71,10 +71,6 @@ test.after.always(t => {
   return t.context.shutdown && t.context.shutdown();
 });
 
-const outcome = {
-  bids: [{ payouts: { Bid: 0, Collateral: 1.800828 } }],
-};
-
 test('restart vaultFactory, change params', async t => {
   const { runUtils, gd, agoricNamesRemotes } = t.context;
   const { EV } = runUtils;

--- a/packages/boot/test/bootstrapTests/upgradeAPI.test.ts
+++ b/packages/boot/test/bootstrapTests/upgradeAPI.test.ts
@@ -186,7 +186,6 @@ test.serial(`verify API governance`, async t => {
   } = t.context;
   const {
     governorFacets: { creatorFacet, instance },
-    voteCounterInstallation: vci,
   } = facets;
 
   const { EV } = runUtils;
@@ -253,14 +252,12 @@ test.serial(`verify API governance`, async t => {
 });
 
 test.serial(`upgrade`, async t => {
-  const { runUtils, facets, governanceDriver, advanceTimeBy } = t.context;
+  const { runUtils, facets } = t.context;
   const {
     governorFacets: { creatorFacet },
-    voteCounterInstallation: vci,
     contract2SHA,
     poserInvitation2,
   } = facets;
-  const committee = governanceDriver.ecMembers;
 
   const { EV } = runUtils;
   const af = await EV(creatorFacet).getAdminFacet();
@@ -283,8 +280,7 @@ test.serial(`verify API governance post-upgrade`, async t => {
     governedContract,
   } = t.context;
   const {
-    governorFacets: { creatorFacet, instance },
-    voteCounterInstallation: vci,
+    governorFacets: { creatorFacet },
   } = facets;
 
   const { EV } = runUtils;

--- a/packages/boot/test/bootstrapTests/vats-restart.test.ts
+++ b/packages/boot/test/bootstrapTests/vats-restart.test.ts
@@ -98,7 +98,7 @@ test.serial('make IBC callbacks before upgrade', async t => {
 });
 
 test.serial('run restart-vats proposal', async t => {
-  const { controller, buildProposal, evalProposal } = t.context;
+  const { buildProposal, evalProposal } = t.context;
 
   t.log('building proposal');
   await evalProposal(

--- a/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-upgrade.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * @file Bootstrap test integration vaults with smart-wallet. The tests in this
  *   file are NOT independent; a single `test.before()` handler creates shared
@@ -6,16 +7,16 @@
  */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { Fail } from '@endo/errors';
-import { NonNullish } from '@agoric/internal';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { Far, makeMarshal } from '@endo/marshal';
 import { SECONDS_PER_YEAR } from '@agoric/inter-protocol/src/interest.js';
-import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
-import type { ExecutionContext, TestFn } from 'ava';
+import { NonNullish } from '@agoric/internal';
 import type { FakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
+import { Fail } from '@endo/errors';
+import { Far, makeMarshal } from '@endo/marshal';
+import type { ExecutionContext, TestFn } from 'ava';
 import { makeWalletFactoryDriver } from '../../tools/drivers.js';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';
@@ -33,7 +34,7 @@ const makeDefaultTestContext = async (
     storage,
   });
 
-  const { readLatest, readPublished, runUtils } = swingsetTestKit;
+  const { readPublished, runUtils } = swingsetTestKit;
   ({ storage } = swingsetTestKit);
   const { EV } = runUtils;
   logTiming && console.timeLog('DefaultTestContext', 'swingsetTestKit');

--- a/packages/boot/test/orchestration/orchestration.test.ts
+++ b/packages/boot/test/orchestration/orchestration.test.ts
@@ -59,7 +59,6 @@ test.skip('stakeOsmo - queries', async t => {
     buildProposal,
     evalProposal,
     runUtils: { EV },
-    harness,
   } = t.context;
   await evalProposal(
     buildProposal('@agoric/builders/scripts/orchestration/init-stakeOsmo.js', [
@@ -224,7 +223,6 @@ test.serial('basic-flows', async t => {
   const {
     buildProposal,
     evalProposal,
-    agoricNamesRemotes,
     readPublished,
     bridgeUtils: { flushInboundQueue, runInbound },
   } = t.context;

--- a/packages/boot/test/orchestration/vat-orchestration.test.ts
+++ b/packages/boot/test/orchestration/vat-orchestration.test.ts
@@ -193,7 +193,6 @@ test.skip('Query connection can be created', async t => {
     runUtils: { EV },
   } = t.context;
 
-  type Powers = { orchestration: CosmosInterchainService };
   const contract = async ({ orchestration }) => {
     const connection =
       await EV(orchestration).provideICQConnection('connection-0');
@@ -219,7 +218,6 @@ test.skip('Query connection can send a query', async t => {
     runUtils: { EV },
   } = t.context;
 
-  type Powers = { orchestration: CosmosInterchainService };
   const contract = async ({ orchestration }) => {
     const queryConnection =
       await EV(orchestration).provideICQConnection('connection-0');

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -1,33 +1,29 @@
-import { Fail } from '@endo/errors';
 import { type Amount } from '@agoric/ertp';
-import { NonNullish } from '@agoric/internal';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { SECONDS_PER_MINUTE } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
-import {
-  slotToBoardRemote,
-  unmarshalFromVstorage,
-} from '@agoric/internal/src/marshal.js';
+import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
+import { NonNullish } from '@agoric/internal';
+import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
 import {
   type FakeStorageKit,
   slotToRemotable,
 } from '@agoric/internal/src/storage-test-utils.js';
-import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
+import { Fail } from '@endo/errors';
 
-import {
-  type AgoricNamesRemotes,
-  boardSlottingMarshaller,
-} from '@agoric/vats/tools/board-utils.js';
+import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type {
   CurrentWalletRecord,
   SmartWallet,
   UpdateRecord,
 } from '@agoric/smart-wallet/src/smartWallet.js';
-import type { WalletFactoryStartResult } from '@agoric/vats/src/core/startWalletFactory.js';
-import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
-import type { TimerService } from '@agoric/time';
 import type { OfferMaker } from '@agoric/smart-wallet/src/types.js';
 import type { RunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
-import { makeMarshal } from '@endo/marshal';
+import type { TimerService } from '@agoric/time';
+import type { WalletFactoryStartResult } from '@agoric/vats/src/core/startWalletFactory.js';
+import {
+  type AgoricNamesRemotes,
+  boardSlottingMarshaller,
+} from '@agoric/vats/tools/board-utils.js';
 import type { InvitationDetails } from '@agoric/zoe';
 import type { SwingsetTestKit } from './supports.js';
 
@@ -221,8 +217,6 @@ export const makeGovernanceDriver = async (
   const { EV } = testKit.runUtils;
   const charterMembershipId = 'charterMembership';
   const committeeMembershipId = 'committeeMembership';
-
-  const { fromCapData } = makeMarshal(undefined, slotToBoardRemote);
 
   const chainTimerService: ERef<TimerService> =
     await EV.vat('bootstrap').consumeItem('chainTimerService');

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -107,7 +107,7 @@ export const makeLiquidationTestKit = async ({
     price: number;
   }) => {
     const managerPath = `vaultFactory.managers.manager${managerIndex}`;
-    const { advanceTimeBy, readLatest, readPublished } = swingsetTestKit;
+    const { advanceTimeBy, readPublished } = swingsetTestKit;
 
     await null;
     if (!priceFeedDrivers[collateralBrandKey]) {

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -455,7 +455,7 @@ export const makeSwingsetTestKit = async (
     let data;
     try {
       data = unmarshalFromVstorage(storage.data, path, fromCapData, -1);
-    } catch (e) {
+    } catch {
       // fall back to regular JSON
       const raw = storage.getValues(path).at(-1);
       assert(raw, `No data found for ${path}`);
@@ -985,7 +985,7 @@ export const fetchCoreEvalRelease = async (
 
       return { bundles, evals: [{ js_code: script, json_permits: permit }] };
     }
-  } catch (error) {
+  } catch {
     console.warn(
       `Plan file not found at ${planUrl}. Falling back to direct artifact detection.`,
     );

--- a/packages/cosmic-swingset/test/inquisitor.test.ts
+++ b/packages/cosmic-swingset/test/inquisitor.test.ts
@@ -1,12 +1,12 @@
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
 
-import { q, Fail } from '@endo/errors';
+import { Fail, q } from '@endo/errors';
 
 import { BridgeId, VBankAccount } from '@agoric/internal';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 
-import { makeHelpers, type Helpers } from '../tools/inquisitor.mjs';
+import { makeHelpers } from '../tools/inquisitor.mjs';
 import { makeCosmicSwingsetTestKit } from '../tools/test-kit.js';
 
 const test = anyTest as TestFn;

--- a/packages/cosmic-swingset/test/provision-smartwallet.test.ts
+++ b/packages/cosmic-swingset/test/provision-smartwallet.test.ts
@@ -2,9 +2,9 @@ import type { TestFn } from 'ava';
 import anyTest from 'ava';
 
 // Use ambient authority only in test.before()
-import { spawn as ambientSpawn, type ChildProcess } from 'child_process';
-import * as ambientPath from 'path';
+import { spawn as ambientSpawn } from 'child_process';
 import * as ambientFs from 'fs';
+import * as ambientPath from 'path';
 
 import { VBankAccount } from '@agoric/internal';
 import { makeScenario2, makeWalletTool, pspawn } from './scenario2.js';

--- a/packages/fast-usdc-contract/src/exos/advancer.ts
+++ b/packages/fast-usdc-contract/src/exos/advancer.ts
@@ -283,7 +283,7 @@ export const prepareAdvancerKit = (
           return asVow(() => {
             const { poolAccount, settlementAddress } = this.state;
             const { tmpSeat, ...vowContext } = ctx;
-            const { destination, advanceAmount, ...detail } = vowContext;
+            const { destination, advanceAmount } = vowContext;
             tmpSeat.exit();
             const amount = harden({
               denom: usdc.denom,
@@ -391,7 +391,7 @@ export const prepareAdvancerKit = (
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
         onFulfilled(result: undefined, ctx: AdvancerVowCtx) {
-          const { advanceAmount, destination, ...detail } = ctx;
+          const { advanceAmount, destination } = ctx;
           // assets are on noble, transfer to dest.
           const intermediaryAccount = getNobleICA();
           const amount = harden({
@@ -401,7 +401,7 @@ export const prepareAdvancerKit = (
           const burn = intermediaryAccount.depositForBurn(destination, amount);
           return watch(burn, this.facets.transferHandler, ctx);
         },
-        onRejected(error: Error, ctx: AdvancerVowCtx) {
+        onRejected(error: Error, _ctx: AdvancerVowCtx) {
           log('🚨 CCTP transfer failed', error);
           // FIXME really handle, with tests
         },

--- a/packages/fast-usdc-contract/src/exos/settler.ts
+++ b/packages/fast-usdc-contract/src/exos/settler.ts
@@ -27,7 +27,7 @@ import { fromOnly } from '@agoric/zoe/src/contractSupport/index.js';
 
 import type { HostInterface, HostOf } from '@agoric/async-flow';
 import type { FungibleTokenPacketData } from '@agoric/cosmic-proto/ibc/applications/transfer/v2/packet.js';
-import type { Amount, Brand, NatAmount, NatValue } from '@agoric/ertp';
+import type { Amount, Brand, NatAmount } from '@agoric/ertp';
 import type {
   CctpTxEvidence,
   EvmHash,
@@ -37,14 +37,11 @@ import type {
 } from '@agoric/fast-usdc/src/types.js';
 import type {
   AccountId,
-  AccountIdArg,
   Bech32Address,
   ChainHub,
-  CosmosChainAddress,
   Denom,
   OrchestrationAccount,
 } from '@agoric/orchestration';
-import { parseAccountId } from '@agoric/orchestration/src/utils/address.js';
 import type { WithdrawToSeat } from '@agoric/orchestration/src/utils/zoe-tools.js';
 import { mustMatch, type MapStore } from '@agoric/store';
 import type { IBCChannelID, IBCPacket, VTransferIBCEvent } from '@agoric/vats';
@@ -52,7 +49,6 @@ import type { TargetRegistration } from '@agoric/vats/src/bridge-target.js';
 import type { Vow, VowTools } from '@agoric/vow';
 import type { ZCF } from '@agoric/zoe/src/zoeService/zoe.js';
 import type { Zone } from '@agoric/zone';
-import { makeSupportsCctp } from '../utils/cctp.ts';
 import { asMultiset } from '../utils/store.ts';
 import type { LiquidityPoolKit } from './liquidity-pool.js';
 import type { StatusManager } from './status-manager.js';
@@ -67,7 +63,7 @@ const decodeEventPacket = (
   let tx: FungibleTokenPacketData;
   try {
     tx = JSON.parse(atob(data));
-  } catch (e) {
+  } catch {
     return { error: ['could not parse packet data', data] };
   }
 
@@ -85,14 +81,14 @@ const decodeEventPacket = (
     mustMatch(decoded, AddressHookShape);
 
     ({ EUD } = decoded.query);
-  } catch (e) {
+  } catch {
     return { error: ['no query params', tx.receiver] };
   }
 
   let amount: bigint;
   try {
     amount = BigInt(tx.amount);
-  } catch (e) {
+  } catch {
     return { error: ['invalid amount', tx.amount] };
   }
 
@@ -432,7 +428,7 @@ export const prepareSettler = (
           const dest: AccountId | null = (() => {
             try {
               return chainHub.resolveAccountId(EUD);
-            } catch (e) {
+            } catch {
               log(
                 '⚠️ forward not attempted',
                 'unresolvable destination',

--- a/packages/fast-usdc-contract/src/exos/status-manager.ts
+++ b/packages/fast-usdc-contract/src/exos/status-manager.ts
@@ -18,7 +18,6 @@ import type {
   TransactionRecord,
 } from '@agoric/fast-usdc/src/types.js';
 import type { RepayAmountKWR } from '@agoric/fast-usdc/src/utils/fees.js';
-import { makeTracer } from '@agoric/internal';
 import type {
   Marshaller,
   StorageNode,
@@ -71,16 +70,11 @@ export const stateShape = harden({
  * and `Settler`.
  *
  * XXX consider separate facets for `Advancing` and `Settling` capabilities.
- * @param zone
- * @param txnsNode
- * @param root0
- * @param root0.marshaller
- * @param root0.log
  */
 export const prepareStatusManager = (
   zone: Zone,
   txnsNode: ERef<StorageNode>,
-  { marshaller, log = makeTracer('StatusManager', true) }: StatusManagerPowers,
+  { marshaller }: StatusManagerPowers,
 ) => {
   /**
    * Keyed by a tuple of the Noble Forwarding Account and amount.

--- a/packages/fast-usdc-contract/src/utils/cctp.ts
+++ b/packages/fast-usdc-contract/src/utils/cctp.ts
@@ -7,7 +7,7 @@ export const makeSupportsCctp = (chainHub: ChainHub) => (dest: AccountId) => {
   try {
     const ci = chainHub.getChainInfoByChainId(`${namespace}:${reference}`);
     return typeof ci.cctpDestinationDomain === 'number';
-  } catch (e) {
+  } catch {
     return false;
   }
 };

--- a/packages/fast-usdc-contract/src/utils/zoe.ts
+++ b/packages/fast-usdc-contract/src/utils/zoe.ts
@@ -1,5 +1,5 @@
 import { makeTracer } from '@agoric/internal';
-import type { Invitation, ZCF } from '@agoric/zoe/src/zoeService/zoe.js';
+import type { ZCF } from '@agoric/zoe/src/zoeService/zoe.js';
 
 const trace = makeTracer('ZoeUtils');
 

--- a/packages/fast-usdc-contract/test/exos/settler.test.ts
+++ b/packages/fast-usdc-contract/test/exos/settler.test.ts
@@ -209,8 +209,7 @@ const makeTestContext = async t => {
        */
       observeLate: (evidence?: CctpTxEvidence) => {
         const cctpTxEvidence = makeEvidence(evidence);
-        const { destination, forwardingAddress, fullAmount, txHash } =
-          makeNotifyInfo(cctpTxEvidence);
+        const { destination } = makeNotifyInfo(cctpTxEvidence);
         notifier.checkMintedEarly(cctpTxEvidence, destination);
         return cctpTxEvidence;
       },
@@ -571,9 +570,6 @@ test('Settlement for unknown transaction (minted early)', async t => {
 
 test('Multiple minted early transactions with same address and amount', async t => {
   const {
-    common: {
-      brands: { usdc },
-    },
     makeSettler,
     defaultSettlerParams,
     repayer,
@@ -808,7 +804,6 @@ test('Settlement for Advancing transaction (advance fails)', async t => {
 
 test('slow path, and forward fails (terminal state)', async t => {
   const {
-    common,
     makeSettler,
     defaultSettlerParams,
     repayer,
@@ -817,7 +812,6 @@ test('slow path, and forward fails (terminal state)', async t => {
     accounts,
     storage,
   } = t.context;
-  const { usdc } = common.brands;
 
   const settler = makeSettler({
     repayer,
@@ -1124,7 +1118,6 @@ test('forward not attempted: unresolvable destination', async t => {
 
 test('forward not attempted: unsupported destination', async t => {
   const {
-    common,
     makeSettler,
     statusManager,
     defaultSettlerParams,
@@ -1135,7 +1128,6 @@ test('forward not attempted: unsupported destination', async t => {
     inspectLogs,
     storage,
   } = t.context;
-  const { usdc } = common.brands;
 
   const settler = makeSettler({
     repayer,

--- a/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
@@ -618,7 +618,6 @@ test.serial('Contract skips advance when risks identified', async t => {
       utils: { transmitTransferAck },
     },
     evm: { cctp, txPub },
-    startKit: { metricsSub },
     bridges: { snapshot, since },
     mint,
   } = t.context;
@@ -758,9 +757,6 @@ test.todo(
 
 test.serial('STORY03: see accounting metrics', async t => {
   const {
-    common: {
-      brands: { usdc },
-    },
     startKit: { metricsSub },
   } = t.context;
   const { value: metrics } = await E(metricsSub).getUpdateSince();
@@ -827,12 +823,7 @@ test.serial('With 250 available, 3 race to get ~100', async t => {
 });
 
 test.serial('STORY05(cont): LPs withdraw all liquidity', async t => {
-  const {
-    sync,
-    common: {
-      brands: { usdc },
-    },
-  } = t.context;
+  const { sync } = t.context;
 
   const lp = await sync.lp.promise;
   const [a, b] = await Promise.all([
@@ -856,7 +847,7 @@ test.serial('withdraw all liquidity while ADVANCING', async t => {
     },
     evm: { cctp, txPub },
     mint,
-    startKit: { zoe, instance, metricsSub },
+    startKit: { zoe, instance },
   } = t.context;
 
   const usdcPurse = purseOf(usdc.issuer, utils);

--- a/packages/fast-usdc-contract/test/mocks.ts
+++ b/packages/fast-usdc-contract/test/mocks.ts
@@ -1,21 +1,21 @@
 import type { HostInterface } from '@agoric/async-flow';
 import type { Brand, Issuer, Payment } from '@agoric/ertp';
+import { makeRatio } from '@agoric/ertp/src/ratio.js';
+import type { FeeConfig, LogFn } from '@agoric/fast-usdc/src/types.js';
 import type {
   CosmosChainAddress,
   DenomAmount,
   OrchestrationAccount,
 } from '@agoric/orchestration';
 import type { VowTools } from '@agoric/vow';
-import { makeRatio } from '@agoric/ertp/src/ratio.js';
 import type { AmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import type { Zone } from '@agoric/zone';
-import type { FeeConfig, LogFn } from '@agoric/fast-usdc/src/types.js';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export const prepareMockOrchAccounts = (
   zone: Zone,
   {
-    vowTools: { makeVowKit, asVow },
+    vowTools: { asVow },
     log,
     usdc,
   }: {

--- a/packages/fast-usdc-contract/test/supports.ts
+++ b/packages/fast-usdc-contract/test/supports.ts
@@ -290,8 +290,6 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
   };
 };
 
-export const makeDefaultContext = <SF>(contract: Installation<SF>) => {};
-
 /**
  * Reincarnate without relaxDurabilityRules and provide a durable zone in the incarnation.
  * @param key

--- a/packages/fast-usdc-contract/test/supports.ts
+++ b/packages/fast-usdc-contract/test/supports.ts
@@ -1,4 +1,6 @@
 import { makeIssuerKit } from '@agoric/ertp';
+import { CosmosChainInfoShapeV1 } from '@agoric/fast-usdc/src/type-guards.js';
+import type { ChainHubChainInfo } from '@agoric/fast-usdc/src/types.js';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import {
   defaultSerializer,
@@ -11,6 +13,7 @@ import {
   type CosmosChainInfo,
   type Denom,
 } from '@agoric/orchestration';
+import cctpChainInfo from '@agoric/orchestration/src/cctp-chain-info.js';
 import { registerKnownChains } from '@agoric/orchestration/src/chain-info.js';
 import {
   makeChainHub,
@@ -34,17 +37,13 @@ import {
   makeFakeTransferBridge,
 } from '@agoric/vats/tools/fake-bridge.js';
 import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
-import type { Installation } from '@agoric/zoe/src/zoeService/utils.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeHeapZone, type Zone } from '@agoric/zone';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 import { E } from '@endo/far';
-import type { ExecutionContext } from 'ava';
-import cctpChainInfo from '@agoric/orchestration/src/cctp-chain-info.js';
 import { objectMap } from '@endo/patterns';
-import type { ChainHubChainInfo } from '@agoric/fast-usdc/src/types.js';
-import { CosmosChainInfoShapeV1 } from '@agoric/fast-usdc/src/type-guards.js';
+import type { ExecutionContext } from 'ava';
 import { makeTestFeeConfig } from './mocks.js';
 
 export {

--- a/packages/fast-usdc-deploy/test/fast-usdc.test.ts
+++ b/packages/fast-usdc-deploy/test/fast-usdc.test.ts
@@ -14,11 +14,10 @@ import {
 } from '@agoric/cosmic-proto/circle/cctp/v1/tx.js';
 import { AmountMath } from '@agoric/ertp';
 import { makeRatio } from '@agoric/ertp/src/ratio.js';
-import type { CctpTxEvidence, FeeConfig } from '@agoric/fast-usdc';
+import type { CctpTxEvidence } from '@agoric/fast-usdc';
 import { Offers } from '@agoric/fast-usdc/src/clientSupport.js';
 import { MockCctpTxEvidences } from '@agoric/fast-usdc/tools/mock-evidence.js';
 import { BridgeId, NonNullish } from '@agoric/internal';
-import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
 import {
   defaultSerializer,
   documentStorageSchema,
@@ -32,7 +31,6 @@ import {
   buildVTransferEvent,
 } from '@agoric/orchestration/tools/ibc-mocks.js';
 import { Fail } from '@endo/errors';
-import { makeMarshal } from '@endo/marshal';
 import { configurations } from '../src/utils/deploy-config.js';
 import {
   makeWalletFactoryContext,
@@ -634,9 +632,7 @@ test.serial('distributes fees per BLD staker decision', async t => {
 
 test.serial('skips usdc advance when risks identified', async t => {
   const { walletFactoryDriver: wfd, readPublished, storage } = t.context;
-  const oracles = await Promise.all(
-    oracleAddrs.map(addr => wfd.provideSmartWallet(addr)),
-  );
+  await Promise.all(oracleAddrs.map(addr => wfd.provideSmartWallet(addr)));
 
   const EUD = 'dydx1riskyeud';
   const { settlementAccount } = readPublished('fastUsdc');

--- a/packages/fast-usdc-deploy/test/fu-sim-iter.ts
+++ b/packages/fast-usdc-deploy/test/fu-sim-iter.ts
@@ -283,7 +283,6 @@ const makeIBCChannel = (
 export const makeSimulation = (ctx: WalletFactoryTestContext) => {
   const cctp = makeCctp(ctx, nobleAgoricChannelId, 'channel-62');
   const toNoble = makeIBCChannel(ctx.bridgeUtils, 'channel-62');
-  const fromNoble = 'channel-21';
   const oracles = Object.entries(configurations.MAINNET.oracles).map(
     ([name, addr]) => makeTxOracle(ctx, name, addr),
   );

--- a/packages/fast-usdc/src/types.ts
+++ b/packages/fast-usdc/src/types.ts
@@ -1,17 +1,17 @@
+import type { Amount } from '@agoric/ertp';
 import type {
   AccountId,
-  CosmosChainAddress,
+  BaseChainInfo,
   Bech32Address,
+  CaipChainId,
+  CosmosChainAddress,
   CosmosChainInfo,
   Denom,
   DenomDetail,
-  BaseChainInfo,
   KnownNamespace,
-  CaipChainId,
 } from '@agoric/orchestration';
 import type { IBCChannelID } from '@agoric/vats';
-import type { Amount } from '@agoric/ertp';
-import type { CopyRecord, Passable } from '@endo/pass-style';
+import type { CopyRecord } from '@endo/pass-style';
 import type { PendingTxStatus, TxStatus } from './constants.js';
 import type { RepayAmountKWR } from './utils/fees.js';
 

--- a/packages/fast-usdc/test/pool-share-math.test.ts
+++ b/packages/fast-usdc/test/pool-share-math.test.ts
@@ -183,7 +183,6 @@ test('withdrawal offer overestimates value of share', t => {
 test('withdrawal during advance can fail', t => {
   const { PoolShares, USDC } = brands;
   const state0 = makeParity(USDC, PoolShares);
-  const emptyShares = makeEmpty(PoolShares);
 
   const pDep = {
     give: { USDC: make(USDC, 100n) },
@@ -209,13 +208,8 @@ const scaleAmount = (frac: number, amount: Amount<'nat'>) => {
   return multiplyBy(amount, asRatio);
 };
 
-// ack: https://stackoverflow.com/a/2901298/7963
-const numberWithCommas = x =>
-  x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-
 const logAmt = amt => [
   Number(amt.value),
-  //   numberWithCommas(Number(amt.value)),
   amt.brand
     .toString()
     .replace(/^\[object Alleged:/, '')

--- a/packages/fast-usdc/test/type-guards.test.ts
+++ b/packages/fast-usdc/test/type-guards.test.ts
@@ -1,7 +1,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { M, mustMatch } from '@endo/patterns';
-import { TxStatus, PendingTxStatus } from '../src/constants.js';
+import { mustMatch } from '@endo/patterns';
+import { PendingTxStatus, TxStatus } from '../src/constants.js';
 import {
   CctpTxEvidenceShape,
   ChainPolicyShape,

--- a/packages/fast-usdc/tools/mock-evidence.ts
+++ b/packages/fast-usdc/tools/mock-evidence.ts
@@ -2,18 +2,15 @@ import { encodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
 import type { Bech32Address, CosmosChainAddress } from '@agoric/orchestration';
 import type { CctpTxEvidence, EvmAddress } from '../src/types.js';
 
-const mockScenarios = [
-  'AGORIC_PLUS_OSMO',
-  'AGORIC_PLUS_DYDX',
-  'AGORIC_PLUS_AGORIC',
-  'AGORIC_NO_PARAMS',
-  'AGORIC_UNKNOWN_EUD',
-  'AGORIC_PLUS_ETHEREUM',
-  'AGORIC_PLUS_NOBLE',
-  'AGORIC_PLUS_NOBLE_B32EUD',
-] as const;
-
-export type MockScenario = (typeof mockScenarios)[number];
+export type MockScenario =
+  | 'AGORIC_PLUS_OSMO'
+  | 'AGORIC_PLUS_DYDX'
+  | 'AGORIC_PLUS_AGORIC'
+  | 'AGORIC_NO_PARAMS'
+  | 'AGORIC_UNKNOWN_EUD'
+  | 'AGORIC_PLUS_ETHEREUM'
+  | 'AGORIC_PLUS_NOBLE'
+  | 'AGORIC_PLUS_NOBLE_B32EUD';
 
 export const Senders = {
   default: '0xDefaultFakeEthereumAddress',

--- a/packages/internal/test/ts-erasureSyntaxOnly.ts
+++ b/packages/internal/test/ts-erasureSyntaxOnly.ts
@@ -4,7 +4,7 @@
 // https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option
 
 // @ts-expect-error ts(1294) This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
-enum Foo {
+export enum Foo {
   A = 1,
   B = 2,
   C = 3,

--- a/packages/orchestration/src/cosmos-api.ts
+++ b/packages/orchestration/src/cosmos-api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- fails to notice the @see uses */
 import type { AnyJson, JsonSafe, TypedJson } from '@agoric/cosmic-proto';
 import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import type {

--- a/packages/orchestration/src/ethereum-api.ts
+++ b/packages/orchestration/src/ethereum-api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- fails to notice the @see uses */
 import type { BaseChainInfo } from './orchestration-api.ts';
 
 /**

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -4,6 +4,7 @@
  * - should remain relatively stable.
  */
 import type { Amount, Brand, NatAmount } from '@agoric/ertp/src/types.js';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- fails to notice the @see uses
 import type { CurrentWalletRecord } from '@agoric/smart-wallet/src/smartWallet.js';
 import type { Timestamp } from '@agoric/time';
 import type { QueryManyFn } from '@agoric/vats/src/localchain.js';

--- a/packages/orchestration/test/cosmos-interchain-service.test.ts
+++ b/packages/orchestration/test/cosmos-interchain-service.test.ts
@@ -1,4 +1,5 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
 import { toRequestQueryJson } from '@agoric/cosmic-proto';
 import {
   QueryBalanceRequest,
@@ -9,18 +10,17 @@ import {
   MsgDelegateResponse,
 } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
-import { matches } from '@endo/patterns';
-import { heapVowE as E } from '@agoric/vow/vat.js';
-import { decodeBase64 } from '@endo/base64';
-import type { LocalIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
 import { getMethodNames } from '@agoric/internal';
-import type { Port } from '@agoric/network';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import type { IBCMethod } from '@agoric/vats';
-import { commonSetup } from './supports.js';
+import type { LocalIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
+import { decodeBase64 } from '@endo/base64';
+import { matches } from '@endo/patterns';
 import { CosmosChainAddressShape } from '../src/typeGuards.js';
 import { tryDecodeResponse } from '../src/utils/cosmos.js';
 import { buildChannelCloseConfirmEvent } from '../tools/ibc-mocks.js';
+import { commonSetup } from './supports.js';
 
 const CHAIN_ID = 'cosmoshub-99';
 const HOST_CONNECTION_ID = 'connection-0';
@@ -275,7 +275,7 @@ test.serial(
     t.is(bridgeDowncalls0.length, 2, 'bridge received 2 downcalls');
 
     // get channelInfo from `channelOpenAck` event
-    const { event, ...channelInfo } = bridgeEvents0[0];
+    const { event: _, ...channelInfo } = bridgeEvents0[0];
     // simulate channel closing from remote chain
     await E(ibcBridge).fromBridge(buildChannelCloseConfirmEvent(channelInfo));
     await eventLoopIteration();

--- a/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
+++ b/packages/orchestration/test/examples/auto-stake-it.contract.test.ts
@@ -1,20 +1,17 @@
+import { MsgDelegateResponse } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import type { IBCEvent } from '@agoric/vats';
+import { heapVowE } from '@agoric/vow/vat.js';
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E } from '@endo/far';
-import { heapVowE } from '@agoric/vow/vat.js';
-import path from 'path';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { MsgDelegateResponse } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
-import type { IBCEvent } from '@agoric/vats';
-import { commonSetup } from '../supports.js';
 import {
   buildMsgResponseString,
   buildVTransferEvent,
 } from '../../tools/ibc-mocks.js';
+import { commonSetup } from '../supports.js';
 
 import * as contractExports from '../../src/examples/auto-stake-it.contract.js';
-
-const dirname = path.dirname(new URL(import.meta.url).pathname);
 
 const contractName = 'auto-stake-it';
 type StartFn = typeof contractExports.start;

--- a/packages/orchestration/test/examples/basic-flows.contract.test.ts
+++ b/packages/orchestration/test/examples/basic-flows.contract.test.ts
@@ -1,16 +1,16 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import type { TestFn } from 'ava';
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
-import { E, getInterfaceOf, type EReturn } from '@endo/far';
-import path from 'path';
+
 import { makeIssuerKit } from '@agoric/ertp';
+import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import {
-  type AmountUtils,
   withAmountUtils,
+  type AmountUtils,
 } from '@agoric/zoe/tools/test-utils.js';
-import { commonSetup } from '../supports.js';
+import { E, getInterfaceOf, type EReturn } from '@endo/far';
+import type { TestFn } from 'ava';
 import * as contractExports from '../../src/examples/basic-flows.contract.js';
+import { commonSetup } from '../supports.js';
 
 const contractName = 'basic-flows';
 type StartFn = typeof contractExports.start;

--- a/packages/orchestration/test/examples/send-anywhere.test.ts
+++ b/packages/orchestration/test/examples/send-anywhere.test.ts
@@ -1,30 +1,19 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E } from '@endo/far';
-import path from 'path';
-import { mustMatch } from '@endo/patterns';
 import { makeIssuerKit } from '@agoric/ertp';
-import {
-  eventLoopIteration,
-  inspectMapStore,
-} from '@agoric/internal/src/testing-utils.js';
-import { makeExpectUnhandledRejection } from '@agoric/internal/src/lib-nodejs/ava-unhandled-rejection.js';
-import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
+import { inspectMapStore } from '@agoric/internal/src/testing-utils.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import { E } from '@endo/far';
+import { mustMatch } from '@endo/patterns';
+import { registerChain } from '../../src/chain-info.js';
 import type {
   CosmosChainInfo,
   IBCConnectionInfo,
 } from '../../src/cosmos-api.js';
-import { commonSetup } from '../supports.js';
-import { SingleNatAmountRecord } from '../../src/examples/send-anywhere.contract.js';
-import { registerChain } from '../../src/chain-info.js';
 import * as contractExports from '../../src/examples/send-anywhere.contract.js';
-
-const expectUnhandled = makeExpectUnhandledRejection({
-  test,
-  importMetaUrl: import.meta.url,
-});
+import { SingleNatAmountRecord } from '../../src/examples/send-anywhere.contract.js';
+import { commonSetup } from '../supports.js';
 
 const contractName = 'sendAnywhere';
 type StartFn = typeof contractExports.start;
@@ -443,7 +432,6 @@ test('rejects multi-asset send', async t => {
     brands: { ist, bld },
     utils: { pourPayment },
   } = await commonSetup(t);
-  const vt = bootstrap.vowTools;
 
   const { zoe, bundleAndInstall } = await setUpZoeForTest();
 
@@ -527,7 +515,7 @@ test('send to Noble', async t => {
   }
 
   const usdcKit = withAmountUtils(makeIssuerKit('USDC'));
-  const orchKit = await E(zoe).startInstance(
+  await E(zoe).startInstance(
     installation,
     { Stable: ist.issuer, USDC: usdcKit.issuer },
     {},

--- a/packages/orchestration/test/examples/send-cctp.test.ts
+++ b/packages/orchestration/test/examples/send-cctp.test.ts
@@ -1,23 +1,22 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E } from '@endo/far';
-import { makeIssuerKit } from '@agoric/ertp';
-import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
-import type { IBCMethod } from '@agoric/vats';
-import path from 'path';
 import { MsgDepositForBurn } from '@agoric/cosmic-proto/circle/cctp/v1/tx.js';
+import { makeIssuerKit } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import type { IBCMethod } from '@agoric/vats';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import { E } from '@endo/far';
 import type {
   CosmosChainInfo,
   IBCConnectionInfo,
 } from '../../src/cosmos-api.js';
-import { commonSetup } from '../supports.js';
-import { denomHash } from '../../src/utils/denomHash.js';
-import type { DenomDetail } from '../../src/types.js';
-import fetchedChainInfo from '../../src/fetched-chain-info.js';
-import { parseOutgoingTxPacket } from '../../tools/ibc-mocks.js';
 import * as contractExports from '../../src/examples/send-anywhere.contract.js';
+import fetchedChainInfo from '../../src/fetched-chain-info.js';
+import type { DenomDetail } from '../../src/types.js';
+import { denomHash } from '../../src/utils/denomHash.js';
+import { parseOutgoingTxPacket } from '../../tools/ibc-mocks.js';
+import { commonSetup } from '../supports.js';
 
 const contractName = 'sendAnywhere';
 type StartFn = typeof contractExports.start;

--- a/packages/orchestration/test/examples/stake-bld.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-bld.contract.test.ts
@@ -44,7 +44,7 @@ test('makeAccount, deposit, withdraw', async t => {
     commonPrivateArgs: { marshaller },
     utils,
   } = await commonSetup(t);
-  const { publicFacet, zoe } = await startContract({
+  const { publicFacet } = await startContract({
     ...bootstrap,
     bld,
     marshaller,
@@ -55,9 +55,7 @@ test('makeAccount, deposit, withdraw', async t => {
   t.truthy(account, 'account is returned');
 
   t.log('deposit 100 bld to account');
-  const depositResp = await E(account).deposit(
-    await utils.pourPayment(bld.units(100)),
-  );
+  await E(account).deposit(await utils.pourPayment(bld.units(100)));
   t.deepEqual(await E(account).getBalance('ubld'), {
     denom: 'ubld',
     value: bld.units(100).value,
@@ -146,7 +144,6 @@ test('makeAccountInvitationMaker', async t => {
     bootstrap,
     brands: { bld },
     commonPrivateArgs: { marshaller },
-    utils,
   } = await commonSetup(t);
   const { publicFacet, zoe } = await startContract({
     ...bootstrap,

--- a/packages/orchestration/test/examples/stake-ica.contract.test.ts
+++ b/packages/orchestration/test/examples/stake-ica.contract.test.ts
@@ -4,7 +4,6 @@ import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import type { Installation } from '@agoric/zoe/src/zoeService/utils.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import path from 'path';
 import type { CosmosChainInfo } from '../../src/cosmos-api.js';
 import { type StakeIcaTerms } from '../../src/examples/stake-ica.contract.js';
 import fetchedChainInfo from '../../src/fetched-chain-info.js';

--- a/packages/orchestration/test/examples/staking-combinations.test.ts
+++ b/packages/orchestration/test/examples/staking-combinations.test.ts
@@ -1,32 +1,21 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import {
-  eventLoopIteration,
-  inspectMapStore,
-} from '@agoric/internal/src/testing-utils.js';
-import { makeExpectUnhandledRejection } from '@agoric/internal/src/lib-nodejs/ava-unhandled-rejection.js';
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E } from '@endo/far';
-import path from 'path';
-import {
   MsgTransfer,
   MsgTransferResponse,
 } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
+import { inspectMapStore } from '@agoric/internal/src/testing-utils.js';
 import type { IBCMethod } from '@agoric/vats';
 import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
-import { protoMsgMocks, UNBOND_PERIOD_SECONDS } from '../ibc-mocks.js';
-import { commonSetup } from '../supports.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { E } from '@endo/far';
+import * as contractExports from '../../src/examples/staking-combinations.contract.js';
 import {
   buildMsgResponseString,
-  buildVTransferEvent,
   parseOutgoingTxPacket,
 } from '../../tools/ibc-mocks.js';
-import * as contractExports from '../../src/examples/staking-combinations.contract.js';
-
-const expectUnhandled = makeExpectUnhandledRejection({
-  test,
-  importMetaUrl: import.meta.url,
-});
+import { protoMsgMocks, UNBOND_PERIOD_SECONDS } from '../ibc-mocks.js';
+import { commonSetup } from '../supports.js';
 
 type StartFn = typeof contractExports.start;
 
@@ -34,7 +23,7 @@ test('start', async t => {
   const {
     bootstrap: { timer, vowTools: vt },
     brands: { bld },
-    mocks: { ibcBridge, transferBridge },
+    mocks: { ibcBridge },
     utils: { inspectDibcBridge, pourPayment, transmitVTransferEvent },
     commonPrivateArgs,
   } = await commonSetup(t);

--- a/packages/orchestration/test/examples/swap.contract.test.ts
+++ b/packages/orchestration/test/examples/swap.contract.test.ts
@@ -3,9 +3,8 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { LOCALCHAIN_DEFAULT_ADDRESS } from '@agoric/vats/tools/fake-bridge.js';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E } from '@endo/far';
-import path from 'path';
-import { commonSetup } from '../supports.js';
 import * as contractExports from '../../src/examples/swap.contract.js';
+import { commonSetup } from '../supports.js';
 
 type StartFn = typeof contractExports.start;
 

--- a/packages/orchestration/test/examples/unbond.contract.test.ts
+++ b/packages/orchestration/test/examples/unbond.contract.test.ts
@@ -1,19 +1,18 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { E } from '@endo/far';
-import path from 'path';
-import { inspectMapStore } from '@agoric/internal/src/testing-utils.js';
+import { QueryBalanceResponse } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
 import { QueryDelegatorDelegationsResponse } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/query.js';
 import { MsgUndelegateResponse } from '@agoric/cosmic-proto/cosmos/staking/v1beta1/tx.js';
 import { MsgTransferResponse } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
-import { QueryBalanceResponse } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
-import { commonSetup } from '../supports.js';
+import { inspectMapStore } from '@agoric/internal/src/testing-utils.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { E } from '@endo/far';
+import * as contractExports from '../../src/examples/unbond.contract.js';
 import {
   buildMsgResponseString,
   buildQueryResponseString,
 } from '../../tools/ibc-mocks.js';
-import * as contractExports from '../../src/examples/unbond.contract.js';
+import { commonSetup } from '../supports.js';
 
 type StartFn = typeof contractExports.start;
 

--- a/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
+++ b/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
@@ -317,7 +317,7 @@ test('no asset info', t => {
 
 const knownChainsSansConns = objectMap(
   withChainCapabilities(knownChains),
-  ({ connections, ...rest }) => rest,
+  ({ connections: _, ...rest }) => rest,
 );
 
 test('no connection info single hop', t => {

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -6,6 +6,7 @@ import { makeNameHubKit, type IBCChannelID } from '@agoric/vats';
 import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { E } from '@endo/far';
+import cctpChainInfo from '../../src/cctp-chain-info.js';
 import {
   registerChainAssets,
   registerKnownChains,
@@ -19,8 +20,6 @@ import { makeChainHub, registerAssets } from '../../src/exos/chain-hub.js';
 import knownChains from '../../src/fetched-chain-info.js';
 import { assets as assetFixture } from '../assets.fixture.js';
 import { provideFreshRootZone } from '../durability.js';
-import cctpChainInfo from '../../src/cctp-chain-info.js';
-import type { BaseChainInfo } from '../../src/orchestration-api.js';
 
 // fresh state for each test
 const setup = () => {
@@ -450,7 +449,7 @@ test('updateAsset updates existing asset and brand mappings', t => {
 });
 
 test('updateAsset errors appropriately', t => {
-  const { chainHub, zone } = setup();
+  const { chainHub } = setup();
 
   // Register chains
   chainHub.registerChain('agoric', {

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -2,7 +2,6 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { makeExpectUnhandledRejection } from '@agoric/internal/src/lib-nodejs/ava-unhandled-rejection.js';
 import type { TargetApp } from '@agoric/vats/src/bridge-target.js';
 import {
   LOCALCHAIN_QUERY_ALL_BALANCES_RESPONSE,
@@ -10,26 +9,21 @@ import {
 } from '@agoric/vats/tools/fake-bridge.js';
 import { heapVowE as VE } from '@agoric/vow/vat.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import type { IBCMsgTransferOptions } from '../../src/cosmos-api.js';
+import { PFM_RECEIVER } from '../../src/exos/chain-hub.js';
+import fetchedChainInfo from '../../src/fetched-chain-info.js';
 import type {
-  CosmosChainAddress,
   AmountArg,
+  CosmosChainAddress,
   DenomAmount,
 } from '../../src/orchestration-api.js';
+import { assetOn } from '../../src/utils/asset.js';
 import { maxClockSkew } from '../../src/utils/cosmos.js';
 import { NANOSECONDS_PER_SECOND } from '../../src/utils/time.js';
 import { buildVTransferEvent } from '../../tools/ibc-mocks.js';
 import { UNBOND_PERIOD_SECONDS } from '../ibc-mocks.js';
 import { commonSetup } from '../supports.js';
 import { prepareMakeTestLOAKit } from './make-test-loa-kit.js';
-import fetchedChainInfo from '../../src/fetched-chain-info.js';
-import type { IBCMsgTransferOptions } from '../../src/cosmos-api.js';
-import { PFM_RECEIVER } from '../../src/exos/chain-hub.js';
-import { assetOn } from '../../src/utils/asset.js';
-
-const expectUnhandled = makeExpectUnhandledRejection({
-  test,
-  importMetaUrl: import.meta.url,
-});
 
 test('deposit, withdraw', async t => {
   const common = await commonSetup(t);

--- a/packages/orchestration/test/exos/make-test-loa-kit.ts
+++ b/packages/orchestration/test/exos/make-test-loa-kit.ts
@@ -19,7 +19,6 @@ export const prepareMakeTestLOAKit = (
     bootstrap,
     commonPrivateArgs: { marshaller },
     facadeServices: { chainHub },
-    utils,
   }: EReturn<typeof commonSetup>,
   { zcf = Far('MockZCF', {}) } = {},
 ) => {

--- a/packages/orchestration/test/facade-durability.test.ts
+++ b/packages/orchestration/test/facade-durability.test.ts
@@ -7,8 +7,8 @@ import fetchedChainInfo from '../src/fetched-chain-info.js'; // Refresh with scr
 import type { Chain } from '../src/orchestration-api.js';
 import { denomHash } from '../src/utils/denomHash.js';
 import { provideOrchestration } from '../src/utils/start-helper.js';
+import { provideFreshRootZone } from './durability.js';
 import { commonSetup } from './supports.js';
-import { provideDurableZone, provideFreshRootZone } from './durability.js';
 
 const test = anyTest;
 
@@ -261,13 +261,13 @@ test('asset / denom info', async t => {
     baseDenom: 'utoken2',
   });
 
-  const missingGetChain = orchestrate('missing getChain', {}, async orc => {
-    const actual = orc.getDenomInfo(
+  const missingGetChain = orchestrate('missing getChain', {}, async orc =>
+    orc.getDenomInfo(
       'utoken2',
       // @ts-expect-error 'mock' not a KnownChain
       'anotherChain',
-    );
-  });
+    ),
+  );
 
   await t.throwsAsync(vt.when(missingGetChain()), {
     message: 'use getChain("anotherChain") before getDenomInfo("utoken2")',

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -36,7 +36,7 @@ test.beforeEach(async t => {
 });
 
 test('calls between flows', async t => {
-  const { vt, orchestrateAll, zcf } = t.context;
+  const { vt, orchestrateAll } = t.context;
 
   const flows = {
     outer(orch, ctx, ...recipients) {
@@ -47,7 +47,7 @@ test('calls between flows', async t => {
     },
   } as Record<string, OrchestrationFlow<any>>;
 
-  const { outer, outer2, inner } = orchestrateAll(flows, {
+  const { outer, inner } = orchestrateAll(flows, {
     peerFlows: flows,
   });
 
@@ -56,7 +56,7 @@ test('calls between flows', async t => {
 });
 
 test('context mapping individual flows', async t => {
-  const { vt, orchestrateAll, zcf } = t.context;
+  const { vt, orchestrateAll } = t.context;
 
   const flows = {
     outer(orch, ctx, ...recipients) {

--- a/packages/orchestration/test/fixtures/query-flows.contract.test.ts
+++ b/packages/orchestration/test/fixtures/query-flows.contract.test.ts
@@ -1,9 +1,5 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import type { TestFn } from 'ava';
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
-import { E, type EReturn } from '@endo/far';
-import path from 'path';
+
 import {
   type JsonSafe,
   toRequestQueryJson,
@@ -16,18 +12,22 @@ import {
   QueryBalanceResponse,
 } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
 import type { ResponseQuery } from '@agoric/cosmic-proto/tendermint/abci/types.js';
-import { decodeBase64 } from '@endo/base64';
 import {
   LOCALCHAIN_DEFAULT_ADDRESS,
   LOCALCHAIN_QUERY_ALL_BALANCES_RESPONSE,
 } from '@agoric/vats/tools/fake-bridge.js';
-import { commonSetup } from '../supports.js';
-import { defaultMockAckMap } from '../ibc-mocks.js';
+import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { decodeBase64 } from '@endo/base64';
+import { E, type EReturn } from '@endo/far';
+import type { TestFn } from 'ava';
+import * as contractExports from '../../src/fixtures/query-flows.contract.js';
 import {
   buildQueryPacketString,
   buildQueryResponseString,
 } from '../../tools/ibc-mocks.js';
-import * as contractExports from '../../src/fixtures/query-flows.contract.js';
+import { defaultMockAckMap } from '../ibc-mocks.js';
+import { commonSetup } from '../supports.js';
 
 const contractName = 'query-flows';
 type StartFn = typeof contractExports.start;

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -1,3 +1,4 @@
+import type { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
 import { makeIssuerKit } from '@agoric/ertp';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
@@ -18,23 +19,21 @@ import {
   makeFakeTransferBridge,
 } from '@agoric/vats/tools/fake-bridge.js';
 import { prepareSwingsetVowTools } from '@agoric/vow/vat.js';
-import type { Installation } from '@agoric/zoe/src/zoeService/utils.js';
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import type { ExecutionContext } from 'ava';
-import type { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
+import { withChainCapabilities } from '../src/chain-capabilities.js';
 import { registerKnownChains } from '../src/chain-info.js';
+import type { Bech32Address } from '../src/cosmos-api.js';
 import { makeChainHub } from '../src/exos/chain-hub.js';
 import { prepareCosmosInterchainService } from '../src/exos/cosmos-interchain-service.js';
 import fetchedChainInfo from '../src/fetched-chain-info.js';
+import { assetOn } from '../src/utils/asset.js';
+import { registerChainsAndAssets } from '../src/utils/chain-hub-helper.js';
 import { buildVTransferEvent } from '../tools/ibc-mocks.js';
 import { setupFakeNetwork } from './network-fakes.js';
-import { withChainCapabilities } from '../src/chain-capabilities.js';
-import { registerChainsAndAssets } from '../src/utils/chain-hub-helper.js';
-import { assetOn } from '../src/utils/asset.js';
-import type { Bech32Address } from '../src/cosmos-api.js';
 
 export {
   makeFakeLocalchainBridge,

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -299,5 +299,3 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
     },
   };
 };
-
-export const makeDefaultContext = <SF>(contract: Installation<SF>) => {};

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -253,7 +253,7 @@ const cctpFixture = [
 
 const mintRecipientMacro = test.macro({
   title(txt = '', { accountId, mintRecipient: _ }) {
-    return `CCTP mintRecipient: ${accountId.slice(0, 24)}...`;
+    return `${txt} CCTP mintRecipient: ${accountId.slice(0, 24)}...`;
   },
   exec(t, { accountId, mintRecipient }) {
     const actual = accountIdTo32Bytes(accountId);

--- a/packages/orchestration/test/utils/time.test.ts
+++ b/packages/orchestration/test/utils/time.test.ts
@@ -1,6 +1,6 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
 import { buildZoeManualTimer } from '@agoric/zoe/tools/manualTimer.js';
-import { TimeMath } from '@agoric/time';
 import {
   makeTimestampHelper,
   NANOSECONDS_PER_SECOND,

--- a/packages/orchestration/test/utils/zcf-tools.test.ts
+++ b/packages/orchestration/test/utils/zcf-tools.test.ts
@@ -2,6 +2,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit } from '@agoric/ertp';
 import { prepareSwingsetVowTools } from '@agoric/vow';
+import type { ZCF } from '@agoric/zoe';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { makeHeapZone } from '@agoric/zone';
@@ -9,7 +10,6 @@ import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
 import { E, Far, type EReturn } from '@endo/far';
 import type { TestFn } from 'ava';
 import { createRequire } from 'node:module';
-import type { ZCF } from '@agoric/zoe';
 import { makeZcfTools } from '../../src/utils/zcf-tools.js';
 
 const nodeRequire = createRequire(import.meta.url);
@@ -19,9 +19,7 @@ const makeTestContext = async () => {
   let testJig;
   const setJig = jig => (testJig = jig);
   const fakeVatAdmin = makeFakeVatAdmin(setJig);
-  const { zoeService: zoe, feeMintAccess } = makeZoeKitForTest(
-    fakeVatAdmin.admin,
-  );
+  const { zoeService: zoe } = makeZoeKitForTest(fakeVatAdmin.admin);
 
   const bundleCache = await makeNodeBundleCache('bundles', {}, s => import(s));
   const contractBundle = await bundleCache.load(contractEntry);
@@ -59,7 +57,7 @@ test('unchanged: atomicRearrange(), assertUniqueKeyword()', async t => {
 test('changed: makeInvitation: watch promise', async t => {
   const { zoe, zcfTools, vt } = t.context;
 
-  const handler = Far('Trade', { handle: seat => {} });
+  const handler = Far('Trade', { handle: _seat => {} });
   const toTradeVow = zcfTools.makeInvitation(handler, 'trade');
 
   const toTrade = await vt.when(toTradeVow);

--- a/packages/smart-wallet/src/types.ts
+++ b/packages/smart-wallet/src/types.ts
@@ -5,14 +5,13 @@
  * Downside is it can't reference any ambient types, which most of agoric-sdk type are presently.
  */
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- fails to notice the @see uses
 import type { agoric } from '@agoric/cosmic-proto/agoric/bundle.js';
-import type { AgoricNamesRemotes } from '@agoric/vats/tools/board-utils.js';
-import type { PublicTopic } from '@agoric/zoe/src/contractSupport/topics.js';
 import type { Payment } from '@agoric/ertp';
+import type { AgoricNamesRemotes } from '@agoric/vats/tools/board-utils.js';
 import type { InvitationDetails } from '@agoric/zoe';
+import type { PublicTopic } from '@agoric/zoe/src/contractSupport/topics.js';
 import type { OfferSpec } from './offers.js';
-
-declare const CapDataShape: unique symbol;
 
 // Match the type in Zoe, which can't be imported because it's ambient.
 // This omits the parameters that aren't used in this module.

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@endo/init": "^1.1.9",
-    "@types/better-sqlite3": "^7.6.9",
+    "@types/better-sqlite3": "^7.6.13",
     "ava": "^5.3.0",
     "c8": "^10.1.3",
     "tmp": "^0.2.1"

--- a/packages/vats/src/types.ts
+++ b/packages/vats/src/types.ts
@@ -1,11 +1,12 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- fails to notice the @see uses */
+import type { JsonSafe } from '@agoric/cosmic-proto';
 import type { FungibleTokenPacketData } from '@agoric/cosmic-proto/ibc/applications/transfer/v2/packet.js';
+import type { PacketSDKType } from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
 import type { BridgeId, Remote } from '@agoric/internal';
 import type { Bytes } from '@agoric/network';
 import type { Guarded } from '@endo/exo';
-import type { PacketSDKType } from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
-import type { JsonSafe } from '@agoric/cosmic-proto';
-import type { LocalChainAccount } from './localchain.js';
 import type { TargetApp } from './bridge-target.js';
+import type { LocalChainAccount } from './localchain.js';
 
 export type Board = ReturnType<
   ReturnType<typeof import('./lib-board.js').prepareBoardKit>

--- a/packages/zoe/src/types.ts
+++ b/packages/zoe/src/types.ts
@@ -1,12 +1,5 @@
-import type {
-  Issuer,
-  Brand,
-  AssetKind,
-  DisplayInfo,
-  AnyAmount,
-} from '@agoric/ertp';
+import type { Brand, Issuer } from '@agoric/ertp';
 import type { RemotableObject } from '@endo/pass-style';
-import type { Key } from '@endo/patterns';
 
 /**
  * Alias for RemotableObject

--- a/scripts/configure-vscode.sh
+++ b/scripts/configure-vscode.sh
@@ -34,6 +34,7 @@ cat > .vscode/settings.json.new << \EOF || die "Could not write settings.json"
     { "rule": "prettier/*", "severity": "off" },
     // Error in CI but a common state while coding in IDE
     { "rule": "no-unused-vars", "severity": "warn" },
+    { "rule": "@typescript-eslint/no-unused-vars", "severity": "warn" },
     // Imports are auto-fixed on save
     { "rule": "import/newline-after-import", "severity": "off" },
     { "rule": "import/order", "severity": "off" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,62 +3841,62 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@8.26.0", "@typescript-eslint/eslint-plugin@^8.0.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz#7e880faf91f89471c30c141951e15f0eb3a0599e"
-  integrity sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==
+"@typescript-eslint/eslint-plugin@8.31.0", "@typescript-eslint/eslint-plugin@^8.0.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.0.tgz#ef3ece95406a80026f82a19a2984c1e375981711"
+  integrity sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.26.0"
-    "@typescript-eslint/type-utils" "8.26.0"
-    "@typescript-eslint/utils" "8.26.0"
-    "@typescript-eslint/visitor-keys" "8.26.0"
+    "@typescript-eslint/scope-manager" "8.31.0"
+    "@typescript-eslint/type-utils" "8.31.0"
+    "@typescript-eslint/utils" "8.31.0"
+    "@typescript-eslint/visitor-keys" "8.31.0"
     graphemer "^1.4.0"
     ignore "^5.3.1"
     natural-compare "^1.4.0"
     ts-api-utils "^2.0.1"
 
-"@typescript-eslint/parser@8.26.0", "@typescript-eslint/parser@^8.0.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.26.0.tgz#9b4d2198e89f64fb81e83167eedd89a827d843a9"
-  integrity sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==
+"@typescript-eslint/parser@8.31.0", "@typescript-eslint/parser@^8.0.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.31.0.tgz#5ec28823d06dd20ed5f67b61224823f12ccde095"
+  integrity sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.26.0"
-    "@typescript-eslint/types" "8.26.0"
-    "@typescript-eslint/typescript-estree" "8.26.0"
-    "@typescript-eslint/visitor-keys" "8.26.0"
+    "@typescript-eslint/scope-manager" "8.31.0"
+    "@typescript-eslint/types" "8.31.0"
+    "@typescript-eslint/typescript-estree" "8.31.0"
+    "@typescript-eslint/visitor-keys" "8.31.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@8.26.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz#b06623fad54a3a77fadab5f652ef75ed3780b545"
-  integrity sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==
+"@typescript-eslint/scope-manager@8.31.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz#48c7f7d729ea038e36cae0ff511e48c2412fb11c"
+  integrity sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==
   dependencies:
-    "@typescript-eslint/types" "8.26.0"
-    "@typescript-eslint/visitor-keys" "8.26.0"
+    "@typescript-eslint/types" "8.31.0"
+    "@typescript-eslint/visitor-keys" "8.31.0"
 
-"@typescript-eslint/type-utils@8.26.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz#9ee8cc98184b5f66326578de9c097edc89da6f68"
-  integrity sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==
+"@typescript-eslint/type-utils@8.31.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.31.0.tgz#01536a993fae23e2def885b006aaa991cbfbe9e7"
+  integrity sha512-DJ1N1GdjI7IS7uRlzJuEDCgDQix3ZVYVtgeWEyhyn4iaoitpMBX6Ndd488mXSx0xah/cONAkEaYyylDyAeHMHg==
   dependencies:
-    "@typescript-eslint/typescript-estree" "8.26.0"
-    "@typescript-eslint/utils" "8.26.0"
+    "@typescript-eslint/typescript-estree" "8.31.0"
+    "@typescript-eslint/utils" "8.31.0"
     debug "^4.3.4"
     ts-api-utils "^2.0.1"
 
-"@typescript-eslint/types@8.26.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.26.0.tgz#c4e93a8faf3a38a8d8adb007dc7834f1c89ee7bf"
-  integrity sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==
+"@typescript-eslint/types@8.31.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.31.0.tgz#c48e20ec47a43b72747714f49ea9f7b38a4fa6c1"
+  integrity sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==
 
-"@typescript-eslint/typescript-estree@8.26.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz#128972172005a7376e34ed2ecba4e29363b0cad1"
-  integrity sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==
+"@typescript-eslint/typescript-estree@8.31.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz#9c7f84eff6ad23d63cf086c6e93af571cd561270"
+  integrity sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==
   dependencies:
-    "@typescript-eslint/types" "8.26.0"
-    "@typescript-eslint/visitor-keys" "8.26.0"
+    "@typescript-eslint/types" "8.31.0"
+    "@typescript-eslint/visitor-keys" "8.31.0"
     debug "^4.3.4"
     fast-glob "^3.3.2"
     is-glob "^4.0.3"
@@ -3904,22 +3904,22 @@
     semver "^7.6.0"
     ts-api-utils "^2.0.1"
 
-"@typescript-eslint/utils@8.26.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.26.0.tgz#845d20ed8378a5594e6445f54e53b972aee7b3e6"
-  integrity sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==
+"@typescript-eslint/utils@8.31.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.31.0.tgz#6fb52471a29fdd16fc253d568c5ad4b048f78ba4"
+  integrity sha512-qi6uPLt9cjTFxAb1zGNgTob4x9ur7xC6mHQJ8GwEzGMGE9tYniublmJaowOJ9V2jUzxrltTPfdG2nKlWsq0+Ww==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "8.26.0"
-    "@typescript-eslint/types" "8.26.0"
-    "@typescript-eslint/typescript-estree" "8.26.0"
+    "@typescript-eslint/scope-manager" "8.31.0"
+    "@typescript-eslint/types" "8.31.0"
+    "@typescript-eslint/typescript-estree" "8.31.0"
 
-"@typescript-eslint/visitor-keys@8.26.0":
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz#a4876216756c69130ea958df3b77222c2ad95290"
-  integrity sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==
+"@typescript-eslint/visitor-keys@8.31.0":
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz#9a1a97ed16c60d4d1e7399b41c11a6d94ebc1ce5"
+  integrity sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==
   dependencies:
-    "@typescript-eslint/types" "8.26.0"
+    "@typescript-eslint/types" "8.31.0"
     eslint-visitor-keys "^4.2.0"
 
 "@yarnpkg/lockfile@^1.1.0":
@@ -12020,14 +12020,14 @@ typedoc@^0.26.7:
     shiki "^1.16.2"
     yaml "^2.5.1"
 
-typescript-eslint@^7.3.1, typescript-eslint@^8.14.0, typescript-eslint@^8.26.0:
-  version "8.26.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.26.0.tgz#f44cafdaa6edc99e3612b33b791eb77a56286320"
-  integrity sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==
+typescript-eslint@^7.3.1, typescript-eslint@^8.14.0, typescript-eslint@^8.31.0:
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.31.0.tgz#955e2e81011afbc11db3abd5f1d073a4b12e1270"
+  integrity sha512-u+93F0sB0An8WEAPtwxVhFby573E8ckdjwUUQUj9QA4v8JAvgtoDdIyYR3XFwFHq2W1KJ1AurwJCO+w+Y1ixyQ==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "8.26.0"
-    "@typescript-eslint/parser" "8.26.0"
-    "@typescript-eslint/utils" "8.26.0"
+    "@typescript-eslint/eslint-plugin" "8.31.0"
+    "@typescript-eslint/parser" "8.31.0"
+    "@typescript-eslint/utils" "8.31.0"
 
 "typescript@5.1.6 - 5.7.x":
   version "5.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,10 +3525,10 @@
   resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-5.4.5.tgz#a7c11d3a97ddfa201f831f4e4270a169a87f7655"
   integrity sha512-saiCxzHRhUrRxQV2JhH580aQUZiKQUXI38FcAcikcfOomAil4G4lxT0RfrrKywoAYP/rqAdYXYmNRLppcd+hQQ==
 
-"@types/better-sqlite3@^7.6.9":
-  version "7.6.9"
-  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.9.tgz#4bff3eb7c5eaaae26f8099606c69279146561c50"
-  integrity sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==
+"@types/better-sqlite3@^7.6.13":
+  version "7.6.13"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz#a72387f00d2f53cab699e63f2e2c05453cf953f0"
+  integrity sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
_incidental_

## Description
`.ts` files have different lint rules and were neglecting to lint unused vars.

This adds a rule for that and corrects the violations.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
none

### Upgrade Considerations
n/a