### PR TITLE
refactor(base-zone): attenuator and revocable share common code

### DIFF
--- a/packages/base-zone/src/prepare-attenuator.js
+++ b/packages/base-zone/src/prepare-attenuator.js
@@ -1,6 +1,7 @@
 import { Fail, q } from '@endo/errors';
 import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 import { M } from '@endo/patterns';
+import { makeHeapZone } from './heap.js';
 
 // This attenuator implementation is just a simplification of the
 // revocable kit implementation in prepare-revocable.js. The revocable kit
@@ -20,16 +21,51 @@ import { M } from '@endo/patterns';
 // in a testcase at `prepare-attenuator.test.js`
 
 /**
+ * @param {string} wrapperKindName
+ * @param {PropertyKey[]} uMethodNames
+ * @param {Record<PropertyKey, (...args: any[]) => any>} [extraMethods]
+ */
+export const wrapperMethods = (
+  wrapperKindName,
+  uMethodNames,
+  extraMethods = {},
+) =>
+  harden({
+    ...fromUniqueEntries(
+      uMethodNames.map(name => [
+        name,
+        {
+          // Use concise method syntax for exo methods
+          [name](...args) {
+            // @ts-expect-error normal exo-this typing confusion
+            const { underlying } = this.state;
+
+            // Because attenuators still support someone adding `selfRevoke`
+            // as an `extraMethod`, this test is still useful. See the
+            // testcase in `prepare-attenuator.test.js`.
+            underlying !== undefined || Fail`${q(wrapperKindName)} revoked`;
+
+            return underlying[name](...args);
+          },
+          // @ts-expect-error using possible symbol as index type
+        }[name],
+      ]),
+    ),
+    ...extraMethods,
+  });
+harden(wrapperMethods);
+
+/**
  * @template [U=any]
  * @callback MakeAttenuator
  * @param {U} underlying
- * @returns {U}
+ * @returns {Partial<U>}
  */
 
 /**
  * @template [U=any]
  * @typedef {object} AttenuatorThis
- * @property {U} self
+ * @property {Partial<U>} self
  * @property {{ underlying: U }} state
  */
 
@@ -40,14 +76,14 @@ import { M } from '@endo/patterns';
  *   The `interfaceName` of the underlying interface guard.
  *   Defaults to the `uKindName`.
  * @property {Record<
- *   string|symbol,
+ *   PropertyKey,
  *   import('@endo/patterns').MethodGuard
  * >} [extraMethodGuards]
  * For guarding the `extraMethods`, if you include them below. These appear
  * only on the synthesized interface guard for the attenuator, and
  * do not necessarily correspond to any method of the underlying.
  * @property {Record<
- *   string|symbol,
+ *   PropertyKey,
  *   (this: AttenuatorThis<U>, ...args: any[]) => any
  * >} [extraMethods]
  * Extra methods adding behavior only to the attenuator, and
@@ -62,7 +98,7 @@ import { M } from '@endo/patterns';
  * @param {import('@agoric/base-zone').Zone} zone
  * @param {string} uKindName
  *   The `kindName` of the underlying exo class
- * @param {(string|symbol)[]} uMethodNames
+ * @param {PropertyKey[]} uMethodNames
  *   The method names of the underlying exo class that should be represented
  *   by transparently-forwarding methods of the attenuator.
  * @param {AttenuatorOptions<U>} [options]
@@ -76,17 +112,13 @@ export const prepareAttenuatorMaker = (
 ) => {
   const {
     uInterfaceName = uKindName,
-    extraMethodGuards = undefined,
-    extraMethods = undefined,
+    extraMethodGuards = {},
+    extraMethods = {},
   } = options;
   const AttenuatorI = M.interface(
     `${uInterfaceName}_attenuator`,
-    {
-      ...extraMethodGuards,
-    },
-    {
-      defaultGuards: 'raw',
-    },
+    extraMethodGuards,
+    { defaultGuards: 'raw' },
   );
 
   const attenuatorKindName = `${uKindName}_attenuator`;
@@ -94,38 +126,45 @@ export const prepareAttenuatorMaker = (
   return zone.exoClass(
     attenuatorKindName,
     AttenuatorI,
-    underlying => ({
-      underlying,
-    }),
+    underlying => ({ underlying }),
+    wrapperMethods(attenuatorKindName, uMethodNames, extraMethods),
     {
-      ...fromUniqueEntries(
-        uMethodNames.map(name => [
-          name,
-          {
-            // Use concise method syntax for exo methods
-            [name](...args) {
-              // @ts-expect-error normal exo-this typing confusion
-              const { underlying } = this.state;
-
-              // Because attenuators still support someone adding `selfRevoke`
-              // as an `extraMethod`, this test is still useful. See the
-              // testcase in `prepare-attenuator.test.js`.
-              underlying !== undefined ||
-                Fail`${q(attenuatorKindName)} revoked`;
-
-              return underlying[name](...args);
-            },
-            // @ts-expect-error using possible symbol as index type
-          }[name],
-        ]),
-      ),
-      ...extraMethods,
-    },
-    {
-      stateShape: {
-        underlying: M.opt(M.remotable('underlying')),
-      },
+      stateShape: { underlying: M.opt(M.remotable('underlying')) },
     },
   );
 };
 harden(prepareAttenuatorMaker);
+
+const PrefixedKindNameRE = /(alleged: |DebugName: )(.*)/;
+
+/**
+ * A convenience above `prepareAttenuatorMaker` for doing a singleton
+ * ephemeral attenuator, i.e., a new attenuator instance (and hidden class)
+ * that is allocated in the heap zone, and therefore ephemeral. The underlying
+ * can be durable or not, with no conflict with the attenuator being
+ * ephemeral. The price of this convenience is the allocation of the hidden
+ * class and wrapper methods per `attenuateOne` call, i.e., per attenuator
+ * instance.
+ *
+ * @template {any} U
+ * @param {U} underlying
+ * @param {PropertyKey[]} uMethodNames
+ * @param {AttenuatorOptions<U>} [options]
+ * @returns {Partial<U>}
+ */
+export const attenuateOne = (underlying, uMethodNames, options = undefined) => {
+  const heapZone = makeHeapZone();
+  let uKindName = underlying[Symbol.toStringTag] || 'Underlying';
+  const match = PrefixedKindNameRE.exec(uKindName);
+  if (match) {
+    uKindName = match[2];
+  }
+  const makeAttenuator = prepareAttenuatorMaker(
+    heapZone,
+    uKindName,
+    uMethodNames,
+    options,
+  );
+  return makeAttenuator(underlying);
+};
+harden(attenuateOne);

--- a/packages/base-zone/src/prepare-attenuator.js
+++ b/packages/base-zone/src/prepare-attenuator.js
@@ -98,7 +98,7 @@ harden(wrapperMethods);
  * @param {import('@agoric/base-zone').Zone} zone
  * @param {string} uKindName
  *   The `kindName` of the underlying exo class
- * @param {PropertyKey[]} uMethodNames
+ * @param {(keyof U)[]} uMethodNames
  *   The method names of the underlying exo class that should be represented
  *   by transparently-forwarding methods of the attenuator.
  * @param {AttenuatorOptions<U>} [options]
@@ -148,7 +148,7 @@ const PrefixedKindNameRE = /(alleged: |DebugName: )(.*)/;
  *
  * @template {any} U
  * @param {U} underlying
- * @param {PropertyKey[]} uMethodNames
+ * @param {(keyof U)[]} uMethodNames
  * @param {AttenuatorOptions<U>} [options]
  * @returns {Partial<U>}
  */

--- a/packages/base-zone/test/prepare-attenuator.test.js
+++ b/packages/base-zone/test/prepare-attenuator.test.js
@@ -87,6 +87,8 @@ test('test revoke defineVirtualExoClassKit', t => {
           if (state.underlying === undefined) {
             return false;
           }
+          // @ts-expect-error Setting this to `undefined` is purposely outside
+          // the type system.
           state.underlying = undefined;
           return true;
         },

--- a/packages/zoe/src/contractSupport/prepare-ownable.js
+++ b/packages/zoe/src/contractSupport/prepare-ownable.js
@@ -38,7 +38,7 @@ const TransferProposalShape = M.splitRecord({
  *   The method names of the underlying exo class that should be represented
  *   by transparently-forwarding methods of the wrapping ownable object.
  * @param {OwnableOptions} [options]
- * @returns {<U>(underlying: U) => Pick<U, MN[number]> & {makeTransferInvitation: () => Invitation<U>}}
+ * @returns {<U>(underlying: U) => Partial<U> & {makeTransferInvitation: () => Invitation<U>}}
  */
 export const prepareOwnable = (
   zone,
@@ -94,6 +94,10 @@ export const prepareOwnable = (
   );
 
   const makeOwnable = underlying => makeRevocable(underlying);
+  // Using at-ts-ignore rather than at-ts-expect-error because the vscode
+  // ts server says it is an error but `yarn lint` says it is not.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Return type is more precise than revocable supports
   return harden(makeOwnable);
 };
 harden(prepareOwnable);

--- a/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
+++ b/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
@@ -37,14 +37,10 @@ test('zoe - ownable-counter contract', async t => {
     'c1-ownable-counter',
   );
 
-  await t.throwsAsync(
-    // @ts-expect-error method of underlying that ownable doesn't allow
-    E(firstCounter).toBeAttenuated(),
-    {
-      message:
-        'target has no method "toBeAttenuated", has ["__getInterfaceGuard__","__getMethodNames__","getInvitationCustomDetails","incr","makeTransferInvitation"]',
-    },
-  );
+  await t.throwsAsync(E(firstCounter).toBeAttenuated(), {
+    message:
+      'target has no method "toBeAttenuated", has ["__getInterfaceGuard__","__getMethodNames__","getInvitationCustomDetails","incr","makeTransferInvitation"]',
+  });
 
   // the following tests could invoke `firstCounter` and `viewCounter`
   // synchronously. But we don't in order to better model the user


### PR DESCRIPTION

closes: #XXXX
refs: #11332 

## Description

Attenuator and Revocable have similar code. This PR abstracts out their common core so that can both reuse it.

This PR also adds an `attenuateOne` as a convenience above `prepareAttenuatorMaker` for doing a singleton ephemeral attenuator. IOW, a new attenuator instance (and hidden class) that is allocated in the heap zone, and therefore ephemeral. The underlying can be durable or not, with no conflict with the attenuator being ephemeral. 

#11332 already has a first use of `attenuateOne`. It's predecessor (TODO link) used the less convenient `prepareAttenuatorMaker` instead. At least on this first example, both seem to work.

### Security Considerations

Attenuation helps POLA which helps security. Making attenuation simpler will encourage its use.

### Scaling Considerations

The price of the `attenuateOne` convenience is the allocation of the hidden class and wrapper methods per `attenuateOne` call, i.e., per attenuator instance.

If you want to avoid these extra costs, use `prepareAttenuatorMaker`.

### Documentation Considerations

Needs documentation

### Testing Considerations

- [ ] test the `attenuateOne` convenience itself. The rest is tested, and this refactoring did not affect the tests.

### Upgrade Considerations

`attenuateOne` creates an ephemeral attenuator, whose identity therefore cannot survive an upgrade. If you need a durable attenuator, i.e., one with a continuing identity, use `prepareAttenuatorMaker`.