### PR TITLE
docs(orchestration): getBalances @throws when prohibited by chain

### DIFF
--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -235,10 +235,18 @@ export interface OrchestrationAccountCommon {
    */
   getAddress: () => CosmosChainAddress;
 
-  /** @returns an array of amounts for every balance in the account. */
+  /**
+   * @returns an array of amounts for every balance in the account.
+   *
+   * @throws when prohibited (see `icqEnabled` in {@link CosmosChainInfo})
+   */
   getBalances: () => Promise<DenomAmount[]>;
 
-  /** @returns the balance of a specific denom for the account. */
+  /**
+   * @returns the balance of a specific denom for the account.
+   *
+   * @throws when prohibited (see `icqEnabled` in {@link CosmosChainInfo})
+   */
   getBalance: (denom: DenomArg) => Promise<DenomAmount>;
 
   /**


### PR DESCRIPTION
refs:
 - #10004
 - #9757

## Description / Documentation Considerations

document that `getBalance` and `getBalances` only work on some chains

### Security / Scaling / Upgrade Considerations

n/a

### Testing Considerations

already tested

