### PR TITLE
fix: revise to be compat with symbol flip or not

### DIFF
--- a/packages/SwingSet/test/promises.test.js
+++ b/packages/SwingSet/test/promises.test.js
@@ -259,7 +259,7 @@ test('local promises are rejected by vat upgrade', async t => {
     return awaitRun(kpid);
   };
 
-  const S = Symbol.for('passable');
+  const S = 'passable';
   const watcher = await messageToVat('bootstrap', 'createVat', {
     name: 'watcher',
     bundleCapName: 'watcher',

--- a/packages/internal/test/callback.test.js
+++ b/packages/internal/test/callback.test.js
@@ -50,7 +50,6 @@ test('near function callbacks', t => {
 });
 
 test('near method callbacks', t => {
-  const m2 = Symbol.for('m2');
   const o = {
     /**
      * @param {number} a
@@ -68,7 +67,7 @@ test('near method callbacks', t => {
      * @param {string} c
      * @returns {string}
      */
-    [m2](a, b, c) {
+    m2(a, b, c) {
       return `${a + b}${c}`;
     },
   };
@@ -100,8 +99,13 @@ test('near method callbacks', t => {
   });
 
   /** @type {SyncCallback<(c: string) => string>} */
-  const cb4 = cb.makeSyncMethodCallback(o, m2, 9, 10);
-  t.deepEqual(cb4, { target: o, methodName: m2, bound: [9, 10], isSync: true });
+  const cb4 = cb.makeSyncMethodCallback(o, 'm2', 9, 10);
+  t.deepEqual(cb4, {
+    target: o,
+    methodName: 'm2',
+    bound: [9, 10],
+    isSync: true,
+  });
 
   // @ts-expect-error deliberate: Expected 4 arguments but got 5
   t.is(cb.callSync(cb0, 2, 3, 'go', 'bad'), '5go');
@@ -121,7 +125,6 @@ test('near method callbacks', t => {
 });
 
 test('far method callbacks', async t => {
-  const m2 = Symbol.for('m2');
   const o = Far('MyObject', {
     /**
      * @param {number} a
@@ -139,7 +142,7 @@ test('far method callbacks', async t => {
      * @param {string} c
      * @returns {Promise<string>}
      */
-    [m2]: async (a, b, c) => {
+    m2: async (a, b, c) => {
       return `${a + b}${c}`;
     },
   });
@@ -153,8 +156,8 @@ test('far method callbacks', async t => {
   t.is(await p2r, '19go');
 
   /** @type {Callback<(c: string) => Promise<string>>} */
-  const cbp3 = cb.makeMethodCallback(Promise.resolve(o), m2, 9, 10);
-  t.like(cbp3, { methodName: m2, bound: [9, 10] });
+  const cbp3 = cb.makeMethodCallback(Promise.resolve(o), 'm2', 9, 10);
+  t.like(cbp3, { methodName: 'm2', bound: [9, 10] });
   t.assert(cbp3.target instanceof Promise);
   const p3r = cb.callE(cbp3, 'go');
   t.assert(p3r instanceof Promise);
@@ -236,7 +239,7 @@ test('isCallback', t => {
     'manual method',
   );
   t.true(
-    cb.isCallback({ target: {}, methodName: Symbol.for('foo'), bound: [] }),
+    cb.isCallback({ target: {}, methodName: 'foo', bound: [] }),
     'manual symbol-keyed method',
   );
 

--- a/packages/notifier/test/publish-kit.test.js
+++ b/packages/notifier/test/publish-kit.test.js
@@ -118,7 +118,7 @@ const verifyPublishKit = test.macro(async (t, makePublishKit) => {
   };
 
   const firstCellsP = getLatestPromises();
-  const firstVal = Symbol.for('first');
+  const firstVal = 'first';
   publisher.publish(firstVal);
   firstCellsP.push(...getLatestPromises());
   const firstCells = await Promise.all(firstCellsP);
@@ -130,7 +130,7 @@ const verifyPublishKit = test.macro(async (t, makePublishKit) => {
   const secondCellsP = [subscriber.subscribeAfter(firstPublishCount)];
   const secondVal = { previous: firstVal };
   publisher.publish(secondVal);
-  const thirdVal = Symbol.for('third');
+  const thirdVal = 'third';
   publisher.publish(thirdVal);
   const thirdCellsP = getLatestPromises().slice(0, -1);
   secondCellsP.push(firstCells[0].tail);
@@ -231,7 +231,7 @@ test('durable publish kit rejects non-durable values', async t => {
   t.throws(() => publisher.publish(nonPassable));
   t.throws(() => publisher.finish(nonPassable));
   t.throws(() => publisher.fail(nonPassable));
-  await assertTransmission(t, publishKit, Symbol.for('value'));
+  await assertTransmission(t, publishKit, 'value');
 });
 
 test('durable publish kit upgrade trauma (full-vat integration)', async t => {
@@ -410,7 +410,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
   });
 
   // Verify receipt of a published value from v2.
-  const value3 = Symbol.for('value3');
+  const value3 = 'value3';
   await publish(value3);
   const expectedV2SecondResult = { value: value3, done: false };
   const v2SecondCells = [
@@ -440,7 +440,7 @@ test.failing('durable publish kit upgrade trauma', async t => {
   );
   const kit1 = makeDurablePublishKit();
   const { publisher: pub1, subscriber: sub1 } = kit1;
-  const value = Symbol.for('value');
+  const value = 'value';
   await assertTransmission(t, kit1, value);
   // THEN A MIRACLE OCCURS...
   // @ts-expect-error
@@ -451,7 +451,7 @@ test.failing('durable publish kit upgrade trauma', async t => {
   t.not(sub2, sub1);
   const recoveredCell = await sub2.subscribeAfter();
   t.is(recoveredCell.head.value, value, 'published value must be recovered');
-  const finalValue = Symbol.for('final');
+  const finalValue = 'final';
   await assertTransmission(t, kit2, finalValue, 'finish');
   // @ts-expect-error
   // eslint-disable-next-line no-undef
@@ -482,7 +482,7 @@ const verifyPublishKitTermination = test.macro(
       /** @type {object} */ (config);
 
     const cellsP = [...(await getExtraFinalPromises(publisher, subscriber))];
-    const value = Symbol.for('termination');
+    const value = 'termination';
     publisher[method](value);
     const promiseMapper = method === 'fail' ? invertPromiseSettlement : p => p;
     const results = await Promise.all(
@@ -635,7 +635,7 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   sub2LIFO.unshift(await sub2.subscribeAfter());
   t.deepEqual(sub1FirstAll, [], 'there must be no results before publication');
 
-  const pub1First = Symbol.for('pub1First');
+  const pub1First = 'pub1First';
   pub1.publish(pub1First);
   sub1FirstAll.push(await sub1.subscribeAfter());
   t.is(
@@ -671,7 +671,7 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
     'there must be no future results before another publication',
   );
 
-  const pub1Second = Symbol.for('pub1Second');
+  const pub1Second = 'pub1Second';
   pub1.publish(pub1Second);
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));
@@ -701,7 +701,7 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   assertCells(t, 'second (late)', sub1SecondLateAll, 2n, secondResult);
   t.deepEqual(sub1FinalAll, [], 'there must be no final results before finish');
 
-  const pub1Final = Symbol.for('pub1Final');
+  const pub1Final = 'pub1Final';
   pub1.finish(pub1Final);
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));

--- a/packages/notifier/test/publish-kit.test.js
+++ b/packages/notifier/test/publish-kit.test.js
@@ -329,7 +329,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 
   // Verify receipt of a published value via subscribeAfter
   // and async iterators.
-  const value1 = Symbol.for('value1');
+  const value1 = 'value1';
   await publish(value1);
   const expectedV1FirstResult = { value: value1, done: false };
   const v1FirstCell = await messageToObject(sub1, 'subscribeAfter');
@@ -351,7 +351,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 
   // Verify receipt of a second published value via tail and subscribeAfter
   // and async iterators.
-  const value2 = Symbol.for('value2');
+  const value2 = 'value2';
   await publish(value2);
   const expectedV1SecondResult = { value: value2, done: false };
   await messageToObject(sub1, 'subscribeAfter');

--- a/packages/swingset-liveslots/test/collections.test.js
+++ b/packages/swingset-liveslots/test/collections.test.js
@@ -25,9 +25,6 @@ const something = makeGenericRemotable('something');
 const somethingElse = makeGenericRemotable('something else');
 const somethingMissing = makeGenericRemotable('something missing');
 
-const symbolBozo = Symbol.for('bozo');
-const symbolKrusty = Symbol.for('krusty');
-
 // prettier-ignore
 const primes = [
    2,  3,  5,  7, 11,
@@ -51,8 +48,8 @@ const stuff = [
   [true, 'boolean true'],
   [something, 'remotable object "something"'],
   [somethingElse, 'remotable object "something else"'],
-  [symbolBozo, 'symbol bozo'],
-  [symbolKrusty, 'symbol krusty'],
+  ['bozo', 'symbol bozo'],
+  ['krusty', 'symbol krusty'],
 ];
 
 function m(s) {
@@ -677,7 +674,12 @@ test('map queries', t => {
   t.is(testStore.getSize(M.number()), 3);
   t.deepEqual(Array.from(testStore.keys(47)), [47]);
   t.deepEqual(Array.from(testStore.keys(M.bigint())), [-77n, 1000n]);
-  t.deepEqual(Array.from(testStore.keys(M.string())), ['@#$@#$@#$@', 'hello']);
+  t.deepEqual(Array.from(testStore.keys(M.string())), [
+    '@#$@#$@#$@',
+    'bozo',
+    'hello',
+    'krusty',
+  ]);
   t.deepEqual(Array.from(testStore.keys(M.null())), [null]);
   t.deepEqual(Array.from(testStore.keys(M.boolean())), [false, true]);
   t.deepEqual(Array.from(testStore.keys(M.undefined())), [undefined]);
@@ -685,10 +687,7 @@ test('map queries', t => {
     something,
     somethingElse,
   ]);
-  t.deepEqual(Array.from(testStore.keys(M.symbol())), [
-    symbolBozo,
-    symbolKrusty,
-  ]);
+  t.deepEqual(Array.from(testStore.keys(M.symbol())), []);
   t.deepEqual(Array.from(testStore.keys(M.any())), [
     false,
     true,
@@ -700,10 +699,10 @@ test('map queries', t => {
     something,
     somethingElse,
     '@#$@#$@#$@',
+    'bozo',
     'hello',
+    'krusty',
     null,
-    symbolBozo,
-    symbolKrusty,
     undefined,
   ]);
   t.deepEqual(Array.from(testStore.keys(M.scalar())), [
@@ -717,10 +716,10 @@ test('map queries', t => {
     something,
     somethingElse,
     '@#$@#$@#$@',
+    'bozo',
     'hello',
+    'krusty',
     null,
-    symbolBozo,
-    symbolKrusty,
     undefined,
   ]);
 
@@ -736,7 +735,9 @@ test('map queries', t => {
   ]);
   t.deepEqual(Array.from(testStore.values(M.string())), [
     'string stuff',
+    'symbol bozo',
     'string hello',
+    'symbol krusty',
   ]);
   t.deepEqual(Array.from(testStore.values(M.null())), ['singleton null']);
   t.deepEqual(Array.from(testStore.values(M.boolean())), [
@@ -750,10 +751,7 @@ test('map queries', t => {
     'remotable object "something"',
     'remotable object "something else"',
   ]);
-  t.deepEqual(Array.from(testStore.values(M.symbol())), [
-    'symbol bozo',
-    'symbol krusty',
-  ]);
+  t.deepEqual(Array.from(testStore.values(M.symbol())), []);
   t.deepEqual(Array.from(testStore.values(M.any())), [
     'boolean false',
     'boolean true',
@@ -765,10 +763,10 @@ test('map queries', t => {
     'remotable object "something"',
     'remotable object "something else"',
     'string stuff',
-    'string hello',
-    'singleton null',
     'symbol bozo',
+    'string hello',
     'symbol krusty',
+    'singleton null',
     'singleton undefined',
   ]);
   t.deepEqual(Array.from(testStore.values(M.scalar())), [
@@ -782,10 +780,10 @@ test('map queries', t => {
     'remotable object "something"',
     'remotable object "something else"',
     'string stuff',
-    'string hello',
-    'singleton null',
     'symbol bozo',
+    'string hello',
     'symbol krusty',
+    'singleton null',
     'singleton undefined',
   ]);
 
@@ -801,7 +799,9 @@ test('map queries', t => {
   ]);
   t.deepEqual(Array.from(testStore.entries(M.string())), [
     ['@#$@#$@#$@', 'string stuff'],
+    ['bozo', 'symbol bozo'],
     ['hello', 'string hello'],
+    ['krusty', 'symbol krusty'],
   ]);
   t.deepEqual(Array.from(testStore.entries(M.null())), [
     [null, 'singleton null'],
@@ -817,10 +817,7 @@ test('map queries', t => {
     [something, 'remotable object "something"'],
     [somethingElse, 'remotable object "something else"'],
   ]);
-  t.deepEqual(Array.from(testStore.entries(M.symbol())), [
-    [symbolBozo, 'symbol bozo'],
-    [symbolKrusty, 'symbol krusty'],
-  ]);
+  t.deepEqual(Array.from(testStore.entries(M.symbol())), []);
   t.deepEqual(Array.from(testStore.entries(M.any())), [
     [false, 'boolean false'],
     [true, 'boolean true'],
@@ -832,10 +829,10 @@ test('map queries', t => {
     [something, 'remotable object "something"'],
     [somethingElse, 'remotable object "something else"'],
     ['@#$@#$@#$@', 'string stuff'],
+    ['bozo', 'symbol bozo'],
     ['hello', 'string hello'],
+    ['krusty', 'symbol krusty'],
     [null, 'singleton null'],
-    [symbolBozo, 'symbol bozo'],
-    [symbolKrusty, 'symbol krusty'],
     [undefined, 'singleton undefined'],
   ]);
   t.deepEqual(Array.from(testStore.entries(M.scalar())), [
@@ -849,10 +846,10 @@ test('map queries', t => {
     [something, 'remotable object "something"'],
     [somethingElse, 'remotable object "something else"'],
     ['@#$@#$@#$@', 'string stuff'],
+    ['bozo', 'symbol bozo'],
     ['hello', 'string hello'],
+    ['krusty', 'symbol krusty'],
     [null, 'singleton null'],
-    [symbolBozo, 'symbol bozo'],
-    [symbolKrusty, 'symbol krusty'],
     [undefined, 'singleton undefined'],
   ]);
 });
@@ -866,7 +863,9 @@ test('set queries', t => {
   t.deepEqual(Array.from(testStore.values(M.bigint())), [-77n, 1000n]);
   t.deepEqual(Array.from(testStore.values(M.string())), [
     '@#$@#$@#$@',
+    'bozo',
     'hello',
+    'krusty',
   ]);
   t.deepEqual(Array.from(testStore.values(M.null())), [null]);
   t.deepEqual(Array.from(testStore.values(M.boolean())), [false, true]);
@@ -875,10 +874,7 @@ test('set queries', t => {
     something,
     somethingElse,
   ]);
-  t.deepEqual(Array.from(testStore.values(M.symbol())), [
-    symbolBozo,
-    symbolKrusty,
-  ]);
+  t.deepEqual(Array.from(testStore.values(M.symbol())), []);
   t.deepEqual(Array.from(testStore.values(M.any())), [
     false,
     true,
@@ -890,10 +886,10 @@ test('set queries', t => {
     something,
     somethingElse,
     '@#$@#$@#$@',
+    'bozo',
     'hello',
+    'krusty',
     null,
-    symbolBozo,
-    symbolKrusty,
     undefined,
   ]);
   t.deepEqual(Array.from(testStore.values(M.scalar())), [
@@ -907,10 +903,10 @@ test('set queries', t => {
     something,
     somethingElse,
     '@#$@#$@#$@',
+    'bozo',
     'hello',
+    'krusty',
     null,
-    symbolBozo,
-    symbolKrusty,
     undefined,
   ]);
 });

--- a/packages/swingset-liveslots/test/liveslots.test.js
+++ b/packages/swingset-liveslots/test/liveslots.test.js
@@ -410,7 +410,7 @@ test('liveslots retires result promise IDs after reject', async t => {
 
 test('liveslots vs symbols', async t => {
   const { log, syscall } = buildSyscall();
-  const arbitrarySymbol = Symbol.for('arbitrary');
+  const arbitrarySymbol = 'arbitrary';
 
   function build(_vatPowers) {
     return Far('root', {
@@ -445,7 +445,7 @@ test('liveslots vs symbols', async t => {
 
   // E(root)[arbitrarySymbol]('two')
   const rp2 = 'p-2';
-  await dispatch(makeMessage(rootA, Symbol.for('arbitrary'), ['two'], rp2));
+  await dispatch(makeMessage(rootA, 'arbitrary', ['two'], rp2));
   t.deepEqual(log.shift(), {
     type: 'resolve',
     resolutions: [[rp2, false, kser(['ok', 'arbitrary', 'two'])]],
@@ -464,12 +464,12 @@ test('liveslots vs symbols', async t => {
   matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
-  // root~.sendArbitrary(target) -> send(methodname=Symbol.for('arbitrary')
+  // root~.sendArbitrary(target) -> send(methodname='arbitrary'
   await dispatch(makeMessage(rootA, 'sendArbitrary', [kslot(target)]));
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target,
-    methargs: kser([Symbol.for('arbitrary'), ['arg']]),
+    methargs: kser(['arbitrary', ['arg']]),
     resultSlot: 'p+6',
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p+6' });

--- a/packages/swingset-liveslots/test/virtual-objects/virtualObjectManager.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/virtualObjectManager.test.js
@@ -442,10 +442,8 @@ test('symbol named methods', t => {
       log,
     });
 
-  const IncSym = Symbol.for('incsym');
-
   const symThingBehavior = {
-    [IncSym]({ state }) {
+    IncSym({ state }) {
       state.counter += 1;
       return state.counter;
     },
@@ -487,8 +485,8 @@ test('symbol named methods', t => {
     ['vom.vkind.2.descriptor', '{"kindID":"2","tag":"symthing"}'],
   ]);
 
-  // phase 2: call symbol-named method on thing1
-  t.is(thing1[IncSym](), 1); // [t1-1*]
+  // phase 2
+  t.is(thing1.IncSym(), 1); // [t1-1*]
   t.is(log.shift(), `get vom.${tid}/1 => ${thingVal(0, 'thing-1', 0)}`); // load t1-0
   t.deepEqual(log, []);
   flushStateCache();
@@ -501,8 +499,8 @@ test('symbol named methods', t => {
     ['vom.vkind.2.descriptor', '{"kindID":"2","tag":"symthing"}'],
   ]);
 
-  // phase 3: call symbol-named method on thing2
-  t.is(thing2[IncSym](), 101); // [t2-1*]
+  // phase 3
+  t.is(thing2.IncSym(), 101); // [t2-1*]
   t.is(log.shift(), `get vom.${tid}/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
   t.deepEqual(log, []);
   flushStateCache();

--- a/packages/zoe/test/unitTests/cleanProposal.test.js
+++ b/packages/zoe/test/unitTests/cleanProposal.test.js
@@ -205,15 +205,9 @@ test('cleanProposal - other wrong stuff', t => {
   );
   proposeBad(
     t,
-    { [Symbol.for('what')]: { 'Not Ident': simoleans(1n) } },
+    { what: { 'Not Ident': simoleans(1n) } },
     'nat',
-    /cannot serialize Remotables with non-methods like "Symbol\(what\)" in {}/,
-  );
-  proposeBad(
-    t,
-    { want: { [Symbol.for('S')]: simoleans(1n) } },
-    'nat',
-    /cannot serialize Remotables with non-methods like "Symbol\(S\)" in {}/,
+    '{"what":{"Not Ident":{"brand":"[Alleged: simoleans brand]","value":"[1n]"}}} - Must only have want:, give:, exit: properties: {"what":{"Not Ident":{"brand":"[Alleged: simoleans brand]","value":"[1n]"}}}',
   );
   proposeBad(
     t,


### PR DESCRIPTION
#endo-branch: markm-revert-asyncIterator-handling
linked with https://github.com/endojs/endo/pull/2778


closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/9201 https://github.com/endojs/endo/pull/2778

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
