### PR TITLE
refactor: use `*passableSymbolForName` instead of `Symbol`

### DIFF
--- a/packages/SwingSet/test/promises.test.js
+++ b/packages/SwingSet/test/promises.test.js
@@ -259,7 +259,7 @@ test('local promises are rejected by vat upgrade', async t => {
     return awaitRun(kpid);
   };
 
-  const S = Symbol.for('passable');
+  const S = passableSymbolForName('passable');
   const watcher = await messageToVat('bootstrap', 'createVat', {
     name: 'watcher',
     bundleCapName: 'watcher',

--- a/packages/casting/test/fake-rpc-server.js
+++ b/packages/casting/test/fake-rpc-server.js
@@ -236,8 +236,8 @@ export const jsonPairs = harden([
   ['{"@qclass":"bigint","digits":"9007199254740993"}', '9007199254740993n'],
   ['{"@qclass":"symbol","name":"@@asyncIterator"}', 'Symbol.asyncIterator'],
   ['{"@qclass":"symbol","name":"@@match"}', 'Symbol.match'],
-  ['{"@qclass":"symbol","name":"foo"}', 'Symbol.for("foo")'],
-  ['{"@qclass":"symbol","name":"@@@@foo"}', 'Symbol.for("@@foo")'],
+  ['{"@qclass":"symbol","name":"foo"}', 'passableSymbolForName("foo")'],
+  ['{"@qclass":"symbol","name":"@@@@foo"}', 'passableSymbolForName("@@@@foo")'],
 
   // Arrays and objects
   ['[{"@qclass":"undefined"}]', '[undefined]'],

--- a/packages/client-utils/src/sync-tools.js
+++ b/packages/client-utils/src/sync-tools.js
@@ -67,7 +67,7 @@ export const retryUntilCondition = async (
 
   await null; // separate sync prologue
 
-  const timedOut = Symbol('timed out');
+  const timedOut = unpassableSymbolForName('timed out');
   let retries = 0;
   /** @type {Promise | undefined } */
   let resultP;

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -40,6 +40,7 @@
     "@endo/init": "^1.1.12",
     "@endo/marshal": "^1.8.0",
     "@endo/nat": "^5.1.3",
+    "@endo/pass-style": "^1.6.3",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",
     "@iarna/toml": "^2.2.3",

--- a/packages/cosmic-swingset/src/helpers/bufferedStorage.js
+++ b/packages/cosmic-swingset/src/helpers/bufferedStorage.js
@@ -302,8 +302,8 @@ export function makeBufferedStorage(kvStore, listeners = {}) {
 export const makeReadCachingStorage = kvStore => {
   // In addition to the wrapping write buffer, keep a simple cache of
   // read values for has and get.
-  const deleted = Symbol('deleted');
-  const undef = Symbol('undefined');
+  const deleted = unpassableSymbolForName('deleted');
+  const undef = unpassableSymbolForName('undefined');
   /** @typedef {(typeof deleted) | (typeof undef)} ReadCacheSentinel */
   /** @type {Map<string, T | ReadCacheSentinel>} */
   let cache;

--- a/packages/cosmic-swingset/test/export-storage.test.ts
+++ b/packages/cosmic-swingset/test/export-storage.test.ts
@@ -1,11 +1,13 @@
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
+
+import { unpassableSymbolForName } from '@endo/pass-style';
 import { exportStorage } from '../src/export-storage.js';
 
 const test = anyTest as TestFn;
 
 // Export this binding when used by other modules.
-const TestDataKey = Symbol('TestDataKey');
+const TestDataKey = unpassableSymbolForName('TestDataKey');
 
 // Create a local alias, then
 //  - regex replace '\._\b' with '[_]'

--- a/packages/import-manager/test/unitTests/badImports.js
+++ b/packages/import-manager/test/unitTests/badImports.js
@@ -6,7 +6,7 @@ import { listIsEmpty, numIsEmpty } from './valueOps.js';
 function makeBadImportManager() {
   const mgr = importManager();
   const obj = { numIsEmpty };
-  const fooSym = Symbol('foo');
+  const fooSym = unpassableSymbolForName('foo');
   obj[fooSym] = listIsEmpty;
   return mgr.addExports(obj);
 }

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -38,7 +38,7 @@ import {
 
 const trace = makeTracer('VFDriver');
 
-export const AT_NEXT = Symbol('AT_NEXT');
+export const AT_NEXT = unpassableSymbolForName('AT_NEXT');
 
 export const BASIS_POINTS = 10000n;
 

--- a/packages/internal/test/callback.test.js
+++ b/packages/internal/test/callback.test.js
@@ -50,7 +50,7 @@ test('near function callbacks', t => {
 });
 
 test('near method callbacks', t => {
-  const m2 = Symbol.for('m2');
+  const m2 = passableSymbolForName('m2');
   const o = {
     /**
      * @param {number} a
@@ -121,7 +121,7 @@ test('near method callbacks', t => {
 });
 
 test('far method callbacks', async t => {
-  const m2 = Symbol.for('m2');
+  const m2 = passableSymbolForName('m2');
   const o = Far('MyObject', {
     /**
      * @param {number} a
@@ -236,7 +236,7 @@ test('isCallback', t => {
     'manual method',
   );
   t.true(
-    cb.isCallback({ target: {}, methodName: Symbol.for('foo'), bound: [] }),
+    cb.isCallback({ target: {}, methodName: passableSymbolForName('foo'), bound: [] }),
     'manual symbol-keyed method',
   );
 
@@ -249,7 +249,7 @@ test('isCallback', t => {
     'non-object target',
   );
   t.false(
-    cb.isCallback({ target: {}, methodName: Symbol('foo'), bound: [] }),
+    cb.isCallback({ target: {}, methodName: unpassableSymbolForName('foo'), bound: [] }),
     'unique symbol method name',
   );
   t.false(cb.isCallback({ target: {}, bound: {} }), 'non-array bound args');

--- a/packages/internal/test/storage-test-utils.test.js
+++ b/packages/internal/test/storage-test-utils.test.js
@@ -29,7 +29,7 @@ test('makeFakeStorageKit', async t => {
       boolean: true,
       null: null,
       undefined,
-      symbol: Symbol('foo'),
+      symbol: unpassableSymbolForName('foo'),
       array: ['foo'],
       object: {
         toString() {

--- a/packages/internal/test/utils.test.js
+++ b/packages/internal/test/utils.test.js
@@ -45,8 +45,8 @@ const arbString = fc.oneof(
 const arbKey = fc.oneof(
   fastShrink,
   arbString,
-  arbString.map(s => Symbol(s)),
-  arbString.map(s => Symbol.for(s)),
+  arbString.map(s => unpassableSymbolForName(s)),
+  arbString.map(s => passableSymbolForName(s)),
 );
 const arbPrimitive = fc.oneof(
   fastShrink,
@@ -332,7 +332,7 @@ const { value: arbShallow } = fc.letrec(tie => ({
       arbGoodCase.filter(({ specimen }) => hasObjectType(specimen)),
     ]),
     async (t, { specimen, permit }) => {
-      const tag = Symbol('transformed');
+      const tag = unpassableSymbolForName('transformed');
 
       let mutationCallCount = 0;
       const mutatedAttenuation = attenuate(specimen, permit, obj => {
@@ -522,7 +522,7 @@ test('makeMeasureSeconds', async t => {
   const mockNow = () => times.shift();
   const measureSeconds = makeMeasureSeconds(mockNow);
 
-  const unique = Symbol('unique');
+  const unique = unpassableSymbolForName('unique');
   const output = await measureSeconds(async () => unique);
   t.deepEqual(output, { result: unique, duration: 1.0005 });
   t.deepEqual(times, [NaN]);

--- a/packages/notifier/test/marshal-corpus.js
+++ b/packages/notifier/test/marshal-corpus.js
@@ -26,8 +26,8 @@ export const jsonPairs = harden([
   ['{"@qclass":"bigint","digits":"9007199254740993"}', '9007199254740993n'],
   ['{"@qclass":"symbol","name":"@@asyncIterator"}', 'Symbol.asyncIterator'],
   ['{"@qclass":"symbol","name":"@@match"}', 'Symbol.match'],
-  ['{"@qclass":"symbol","name":"foo"}', 'Symbol.for("foo")'],
-  ['{"@qclass":"symbol","name":"@@@@foo"}', 'Symbol.for("@@foo")'],
+  ['{"@qclass":"symbol","name":"foo"}', 'passableSymbolForName("foo")'],
+  ['{"@qclass":"symbol","name":"@@@@foo"}', 'passableSymbolForName("@@@@foo")'],
 
   // Arrays and objects
   ['[{"@qclass":"undefined"}]', '[undefined]'],

--- a/packages/notifier/test/publish-kit.test.js
+++ b/packages/notifier/test/publish-kit.test.js
@@ -118,7 +118,7 @@ const verifyPublishKit = test.macro(async (t, makePublishKit) => {
   };
 
   const firstCellsP = getLatestPromises();
-  const firstVal = Symbol.for('first');
+  const firstVal = passableSymbolForName('first');
   publisher.publish(firstVal);
   firstCellsP.push(...getLatestPromises());
   const firstCells = await Promise.all(firstCellsP);
@@ -130,7 +130,7 @@ const verifyPublishKit = test.macro(async (t, makePublishKit) => {
   const secondCellsP = [subscriber.subscribeAfter(firstPublishCount)];
   const secondVal = { previous: firstVal };
   publisher.publish(secondVal);
-  const thirdVal = Symbol.for('third');
+  const thirdVal = passableSymbolForName('third');
   publisher.publish(thirdVal);
   const thirdCellsP = getLatestPromises().slice(0, -1);
   secondCellsP.push(firstCells[0].tail);
@@ -192,7 +192,7 @@ const verifySubscribeAfter = test.macro(async (t, makePublishKit) => {
   const { publisher, subscriber } = /** @type {MakePublishKit} */ (
     makePublishKit
   )();
-  for (const badCount of [1n, 0, '', false, Symbol('symbol'), {}]) {
+  for (const badCount of [1n, 0, '', false, unpassableSymbolForName('symbol'), {}]) {
     t.throws(
       // @ts-expect-error deliberate invalid arguments for testing
       () => subscriber.subscribeAfter(badCount),
@@ -215,7 +215,7 @@ for (const [type, maker] of Object.entries(makers)) {
 
 test('publish kit allows non-durable values', async t => {
   const publishKit = makePublishKit();
-  const nonPassable = { [Symbol('key')]: Symbol('value'), method() {} };
+  const nonPassable = { [unpassableSymbolForName('key')]: unpassableSymbolForName('value'), method() {} };
   await assertTransmission(t, publishKit, nonPassable);
   await assertTransmission(t, publishKit, nonPassable, 'finish');
   await assertTransmission(t, makePublishKit(), nonPassable, 'fail');
@@ -227,11 +227,11 @@ test('durable publish kit rejects non-durable values', async t => {
   );
   const publishKit = makeDurablePublishKit();
   const { publisher } = publishKit;
-  const nonPassable = { [Symbol('key')]: Symbol('value') };
+  const nonPassable = { [unpassableSymbolForName('key')]: unpassableSymbolForName('value') };
   t.throws(() => publisher.publish(nonPassable));
   t.throws(() => publisher.finish(nonPassable));
   t.throws(() => publisher.fail(nonPassable));
-  await assertTransmission(t, publishKit, Symbol.for('value'));
+  await assertTransmission(t, publishKit, passableSymbolForName('value'));
 });
 
 test('durable publish kit upgrade trauma (full-vat integration)', async t => {
@@ -329,7 +329,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 
   // Verify receipt of a published value via subscribeAfter
   // and async iterators.
-  const value1 = Symbol.for('value1');
+  const value1 = passableSymbolForName('value1');
   await publish(value1);
   const expectedV1FirstResult = { value: value1, done: false };
   const v1FirstCell = await messageToObject(sub1, 'subscribeAfter');
@@ -351,7 +351,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 
   // Verify receipt of a second published value via tail and subscribeAfter
   // and async iterators.
-  const value2 = Symbol.for('value2');
+  const value2 = passableSymbolForName('value2');
   await publish(value2);
   const expectedV1SecondResult = { value: value2, done: false };
   await messageToObject(sub1, 'subscribeAfter');
@@ -410,7 +410,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
   });
 
   // Verify receipt of a published value from v2.
-  const value3 = Symbol.for('value3');
+  const value3 = passableSymbolForName('value3');
   await publish(value3);
   const expectedV2SecondResult = { value: value3, done: false };
   const v2SecondCells = [
@@ -440,7 +440,7 @@ test.failing('durable publish kit upgrade trauma', async t => {
   );
   const kit1 = makeDurablePublishKit();
   const { publisher: pub1, subscriber: sub1 } = kit1;
-  const value = Symbol.for('value');
+  const value = passableSymbolForName('value');
   await assertTransmission(t, kit1, value);
   // THEN A MIRACLE OCCURS...
   // @ts-expect-error
@@ -451,7 +451,7 @@ test.failing('durable publish kit upgrade trauma', async t => {
   t.not(sub2, sub1);
   const recoveredCell = await sub2.subscribeAfter();
   t.is(recoveredCell.head.value, value, 'published value must be recovered');
-  const finalValue = Symbol.for('final');
+  const finalValue = passableSymbolForName('final');
   await assertTransmission(t, kit2, finalValue, 'finish');
   // @ts-expect-error
   // eslint-disable-next-line no-undef
@@ -482,7 +482,7 @@ const verifyPublishKitTermination = test.macro(
       /** @type {object} */ (config);
 
     const cellsP = [...(await getExtraFinalPromises(publisher, subscriber))];
-    const value = Symbol.for('termination');
+    const value = passableSymbolForName('termination');
     publisher[method](value);
     const promiseMapper = method === 'fail' ? invertPromiseSettlement : p => p;
     const results = await Promise.all(
@@ -635,7 +635,7 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   sub2LIFO.unshift(await sub2.subscribeAfter());
   t.deepEqual(sub1FirstAll, [], 'there must be no results before publication');
 
-  const pub1First = Symbol.for('pub1First');
+  const pub1First = passableSymbolForName('pub1First');
   pub1.publish(pub1First);
   sub1FirstAll.push(await sub1.subscribeAfter());
   t.is(
@@ -671,7 +671,7 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
     'there must be no future results before another publication',
   );
 
-  const pub1Second = Symbol.for('pub1Second');
+  const pub1Second = passableSymbolForName('pub1Second');
   pub1.publish(pub1Second);
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));
@@ -701,7 +701,7 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   assertCells(t, 'second (late)', sub1SecondLateAll, 2n, secondResult);
   t.deepEqual(sub1FinalAll, [], 'there must be no final results before finish');
 
-  const pub1Final = Symbol.for('pub1Final');
+  const pub1Final = passableSymbolForName('pub1Final');
   pub1.finish(pub1Final);
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));

--- a/packages/swingset-liveslots/test/collections.test.js
+++ b/packages/swingset-liveslots/test/collections.test.js
@@ -25,8 +25,8 @@ const something = makeGenericRemotable('something');
 const somethingElse = makeGenericRemotable('something else');
 const somethingMissing = makeGenericRemotable('something missing');
 
-const symbolBozo = Symbol.for('bozo');
-const symbolKrusty = Symbol.for('krusty');
+const symbolBozo = passableSymbolForName('bozo');
+const symbolKrusty = passableSymbolForName('krusty');
 
 // prettier-ignore
 const primes = [

--- a/packages/swingset-liveslots/test/facetiousness.test.js
+++ b/packages/swingset-liveslots/test/facetiousness.test.js
@@ -43,7 +43,7 @@ const brokenMixed2 = harden({
 });
 
 const brokenSymbolNamedFacet1 = harden({
-  [Symbol.for('resetter')]: {
+  [passableSymbolForName('resetter')]: {
     reset: ({ state }) => (state.count = 0),
   },
 });
@@ -52,13 +52,13 @@ const brokenSymbolNamedFacet2 = harden({
   incrementer: {
     increment: ({ state }) => (state.count += 1),
   },
-  [Symbol.for('resetter')]: {
+  [passableSymbolForName('resetter')]: {
     reset: ({ state }) => (state.count = 0),
   },
 });
 
 const brokenSymbolNamedFacet3 = harden({
-  [Symbol.for('resetter')]: {
+  [passableSymbolForName('resetter')]: {
     reset: ({ state }) => (state.count = 0),
   },
   incrementer: {

--- a/packages/swingset-liveslots/test/liveslots.test.js
+++ b/packages/swingset-liveslots/test/liveslots.test.js
@@ -410,7 +410,7 @@ test('liveslots retires result promise IDs after reject', async t => {
 
 test('liveslots vs symbols', async t => {
   const { log, syscall } = buildSyscall();
-  const arbitrarySymbol = Symbol.for('arbitrary');
+  const arbitrarySymbol = passableSymbolForName('arbitrary');
 
   function build(_vatPowers) {
     return Far('root', {
@@ -445,7 +445,7 @@ test('liveslots vs symbols', async t => {
 
   // E(root)[arbitrarySymbol]('two')
   const rp2 = 'p-2';
-  await dispatch(makeMessage(rootA, Symbol.for('arbitrary'), ['two'], rp2));
+  await dispatch(makeMessage(rootA, passableSymbolForName('arbitrary'), ['two'], rp2));
   t.deepEqual(log.shift(), {
     type: 'resolve',
     resolutions: [[rp2, false, kser(['ok', 'arbitrary', 'two'])]],
@@ -464,12 +464,12 @@ test('liveslots vs symbols', async t => {
   matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
-  // root~.sendArbitrary(target) -> send(methodname=Symbol.for('arbitrary')
+  // root~.sendArbitrary(target) -> send(methodname=passableSymbolForName('arbitrary')
   await dispatch(makeMessage(rootA, 'sendArbitrary', [kslot(target)]));
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target,
-    methargs: kser([Symbol.for('arbitrary'), ['arg']]),
+    methargs: kser([passableSymbolForName('arbitrary'), ['arg']]),
     resultSlot: 'p+6',
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p+6' });

--- a/packages/swingset-liveslots/test/virtual-objects/virtualObjectManager.test.js
+++ b/packages/swingset-liveslots/test/virtual-objects/virtualObjectManager.test.js
@@ -442,7 +442,7 @@ test('symbol named methods', t => {
       log,
     });
 
-  const IncSym = Symbol.for('incsym');
+  const IncSym = passableSymbolForName('incsym');
 
   const symThingBehavior = {
     [IncSym]({ state }) {

--- a/packages/vats/test/dump.test.js
+++ b/packages/vats/test/dump.test.js
@@ -15,7 +15,7 @@ test('dump: the @erights challenge', t => {
     undefined,
     'undefined',
     URIError('wut?'),
-    [33n, Symbol('foo'), Symbol.for('bar'), Symbol.asyncIterator],
+    [33n, unpassableSymbolForName('foo'), passableSymbolForName('bar'), Symbol.asyncIterator],
     {
       NaN,
       Infinity,
@@ -27,7 +27,7 @@ test('dump: the @erights challenge', t => {
   ];
   t.is(
     dump(challenges),
-    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,Symbol(foo),Symbol(bar),Symbol(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":[Object Tagged]{[Symbol(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}},{}]',
+    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,unpassableSymbolForName(foo),unpassableSymbolForName(bar),unpassableSymbolForName(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":[Object Tagged]{[unpassableSymbolForName(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}},{}]',
   );
   t.is(
     dump(challenges, 2),
@@ -41,9 +41,9 @@ test('dump: the @erights challenge', t => {
   [URIError: wut?],
   [
     33n,
-    Symbol(foo),
-    Symbol(bar),
-    Symbol(Symbol.asyncIterator)
+    unpassableSymbolForName(foo),
+    unpassableSymbolForName(bar),
+    unpassableSymbolForName(Symbol.asyncIterator)
   ],
   {
     "NaN": NaN,
@@ -53,7 +53,7 @@ test('dump: the @erights challenge', t => {
   18014398509481984,
   {
     "superTagged": [Object Tagged] {
-      [Symbol(Symbol.toStringTag)]: "Tagged"
+      [unpassableSymbolForName(Symbol.toStringTag)]: "Tagged"
     },
     "subTagged": [Object Tagged] {},
     "subTaggedNonEmpty": [Object Tagged] {

--- a/packages/vats/test/repl.test.js
+++ b/packages/vats/test/repl.test.js
@@ -86,11 +86,11 @@ test('repl: Symbols', t => {
 
   let histnum = 0;
   const exprDisplays = ['asyncIterator', 'toStringTag', 'hasInstance'].map(
-    name => [`Symbol.${name}`, `Symbol(Symbol.${name})`],
+    name => [`Symbol.${name}`, `unpassableSymbolForName(Symbol.${name})`],
   );
   exprDisplays.push(
-    [`Symbol.for('foo')`, `Symbol(foo)`],
-    [`Symbol('foo')`, `Symbol(foo)`],
+    [`passableSymbolForName('foo')`, `unpassableSymbolForName(foo)`],
+    [`unpassableSymbolForName('foo')`, `unpassableSymbolForName(foo)`],
   );
   for (const [expr, display] of exprDisplays) {
     t.deepEqual(doEval(histnum, expr), {});

--- a/packages/zoe/test/unitTests/cleanProposal.test.js
+++ b/packages/zoe/test/unitTests/cleanProposal.test.js
@@ -205,13 +205,13 @@ test('cleanProposal - other wrong stuff', t => {
   );
   proposeBad(
     t,
-    { [Symbol.for('what')]: { 'Not Ident': simoleans(1n) } },
+    { [passableSymbolForName('what')]: { 'Not Ident': simoleans(1n) } },
     'nat',
     /cannot serialize Remotables with non-methods like "Symbol\(what\)" in {}/,
   );
   proposeBad(
     t,
-    { want: { [Symbol.for('S')]: simoleans(1n) } },
+    { want: { [passableSymbolForName('S')]: simoleans(1n) } },
     'nat',
     /cannot serialize Remotables with non-methods like "Symbol\(S\)" in {}/,
   );


### PR DESCRIPTION
#endo-branch: markm-only-string-named-methods

Assumes https://github.com/endojs/endo/pull/2792

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2792

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
