### PR TITLE
feat(agoric-cli): Remove support for -r esm contract scripts

### DIFF
--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -1407,7 +1407,6 @@ __metadata:
     chalk: "npm:^5.2.0"
     commander: "npm:^12.1.0"
     deterministic-json: "npm:^1.0.5"
-    esm: "agoric-labs/esm#Agoric-built"
     inquirer: "npm:^8.2.2"
     opener: "npm:^1.5.2"
     tmp: "npm:^0.2.1"
@@ -2578,13 +2577,6 @@ __metadata:
   bin:
     eslint: bin/eslint.js
   checksum: 10c0/1fd31533086c1b72f86770a4d9d7058ee8b4643fd1cfd10c7aac1ecb8725698e88352a87805cf4b2ce890aa35947df4b4da9655fb7fdfa60dbb448a43f6ebcf1
-  languageName: node
-  linkType: hard
-
-"esm@agoric-labs/esm#Agoric-built":
-  version: 3.2.25
-  resolution: "esm@https://github.com/agoric-labs/esm.git#commit=3603726ad4636b2f865f463188fcaade6375638e"
-  checksum: 10c0/fc1e112a3a681e7b4152d4f5c76dd5aa9e30496d2020490ffa0fb61aaf57d1e12dae0c1074fdd2e0f08949ab2df7e00e750262356781f072e4119955ee10b754
   languageName: node
   linkType: hard
 

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -75,7 +75,6 @@
     "chalk": "^5.2.0",
     "commander": "^12.1.0",
     "deterministic-json": "^1.0.5",
-    "esm": "agoric-labs/esm#Agoric-built",
     "inquirer": "^8.2.2",
     "opener": "^1.5.2",
     "tmp": "^0.2.1",

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -3,8 +3,6 @@
 // @ts-check
 // @jessie-check
 
-import '@endo/init/pre.js';
-
 import '@endo/init';
 
 import { E } from '@endo/far';

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -2,8 +2,6 @@
 /* eslint-env node */
 // @jessie-check
 
-import '@endo/init/pre.js';
-import 'esm';
 import '@endo/init/legacy.js';
 
 import path from 'path';

--- a/packages/agoric-cli/src/scripts.js
+++ b/packages/agoric-cli/src/scripts.js
@@ -2,15 +2,11 @@
 /* eslint-env node */
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/captp';
-import { search as readContainingPackageDescriptor } from '@endo/compartment-mapper';
 
-import createEsmRequire from 'esm';
 import { createRequire } from 'module';
 import path from 'path';
-import url from 'url';
 
 const require = createRequire(import.meta.url);
-const esmRequire = createEsmRequire(/** @type {NodeModule} */ ({}));
 
 const PATH_SEP_RE = new RegExp(`${path.sep.replace(/\\/g, '\\\\')}`, 'g');
 
@@ -133,31 +129,8 @@ export { bootPlugin } from ${JSON.stringify(absPath)};
       // Use a dynamic import to load the deploy script.
       // It is unconfined.
 
-      // Use Node.js ESM support if package.json of template says "type":
-      // "module".
-      const read = async location => fs.readFile(url.fileURLToPath(location));
-      const { packageDescriptorText } = await readContainingPackageDescriptor(
-        read,
-        url.pathToFileURL(moduleFile).href,
-      ).catch(cause => {
-        throw Error(
-          `Expected a package.json beside deploy script ${moduleFile}, ${cause}`,
-          { cause },
-        );
-      });
-      const packageDescriptor = JSON.parse(packageDescriptorText);
-      const nativeEsm = packageDescriptor.type === 'module';
-      console.log(
-        `Deploy script will run with ${
-          nativeEsm ? 'Node.js ESM' : 'standardthings/esm emulation'
-        }`,
-      );
-
       const modulePath = pathResolve(moduleFile);
-      let mainNS = await (nativeEsm && import(modulePath));
-      if (!mainNS) {
-        mainNS = esmRequire(modulePath);
-      }
+      const mainNS = await import(modulePath);
 
       const allEndowments = harden({
         home: bootP,

--- a/packages/agoric-cli/test/main.test.js
+++ b/packages/agoric-cli/test/main.test.js
@@ -1,6 +1,4 @@
 /* global globalThis */
-import '@endo/init/pre.js';
-import 'esm';
 import '@endo/init/debug.js';
 import test from 'ava';
 import fs from 'fs';


### PR DESCRIPTION
closes: #11361 
refs: #4788 

## Description
Withdraws legacy support for `node -r esm` contract deployment scripts. All contract deployment scripts going forward are imported using the host Node.js dynamic import.

### Security Considerations
No change in insecurity. Deploy scripts are not confined.

### Scaling Considerations
None.

### Documentation Considerations
We might want to post a celebration that we can now use modern JavaScript syntax like nullish coalescing and default chaining operators.

### Testing Considerations
We did not have adequate coverage over the `-r esm` behavior and so no tests needed to be removed.

### Upgrade Considerations
This should not affect any modern contracts. It may require some old contracts to upgrade their deployment infrastructure.
This change has been a long time coming because we had longitudinal tests that ran before our current chain in continuous integration. See https://github.com/Agoric/testnet-load-generator/issues/125