### PR TITLE
feat(solo): Move from RESM to NESM

### DIFF
--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -46,7 +46,6 @@
     "@endo/promise-kit": "^1.1.10",
     "anylogger": "^0.21.0",
     "deterministic-json": "^1.0.5",
-    "esm": "agoric-labs/esm#Agoric-built",
     "express": "^5.0.1",
     "http-proxy-middleware": "^2.0.6",
     "import-meta-resolve": "^4.1.0",

--- a/packages/solo/src/entrypoint.js
+++ b/packages/solo/src/entrypoint.js
@@ -1,10 +1,5 @@
 #! /usr/bin/env node
 
-import '@endo/init/pre-bundle-source.js';
-
-// Needed for legacy plugin support (dapp-oracle, for one).
-import 'esm';
-
 // we need to enable Math.random as a workaround for 'brace-expansion' module
 // (dep chain: temp->glob->minimatch->brace-expansion)
 import '@endo/init/legacy.js';

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -9,8 +9,6 @@ import { promisify } from 'util';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 // import { createHash } from 'crypto';
 
-import createRequire from 'esm';
-
 import anylogger from 'anylogger';
 
 // import connect from 'lotion-connect';
@@ -52,9 +50,6 @@ import { makeHTTPListener } from './web.js';
 import { connectToChain } from './chain-cosmos-sdk.js';
 
 const log = anylogger('start');
-
-// FIXME: Needed for legacy plugins.
-const esmRequire = createRequire(/** @type {any} */ ({}));
 
 let swingSetRunning = false;
 
@@ -138,7 +133,7 @@ const buildSwingset = async (
 
     // TODO: Detect the module type and use the appropriate loader, just like
     // `agoric deploy`.
-    return esmRequire(pluginFile);
+    return import(pluginFile);
   };
 
   const plugin = buildPlugin(pluginDir, importPlugin, queueThunkForKernel);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6289,10 +6289,6 @@ eslint@^9.19.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
-esm@agoric-labs/esm#Agoric-built:
-  version "3.2.25"
-  resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
-
 espree@^10.0.1, espree@^10.1.0, espree@^10.3.0:
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.3.0.tgz#29267cf5b0cb98735b65e64ba07e0ed49d1eed8a"


### PR DESCRIPTION
closes: #4788 
refs: #11363

## Description
This change moves the `solo` from using `node -r esm` to ordinary `node` with dynamic import, obviating a dependency on our fork of `standardthings/esm`.

### Security Considerations
None.

### Scaling Considerations
None.

### Documentation Considerations
None.

### Testing Considerations
None.

### Upgrade Considerations
None.