### PR TITLE
Reproducible docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,14 @@ packages/stat-logger
 **/*.egg-info
 **/swingset-kernel-state
 **/.cache
+**/.pnp.*
+**/.yarn/*
+!**/.yarn/patches
+!**/.yarn/plugins
+!**/.yarn/releases
+!**/.yarn/sdks
+!**/.yarn/versions
+**/.DS_Store
 **/_agstate
 .vagrant
 endo-sha.txt

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -128,7 +128,6 @@ RUN ln -s /usr/src/agoric-sdk/golang/cosmos/build/agd /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/solo/bin/ag-solo /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/agoric-cli/bin/agoric /usr/local/bin/
-COPY --link . lib/ag-solo/
 
 ARG GIT_REVISION=unknown
 RUN echo "$GIT_REVISION" > /usr/src/agoric-sdk/packages/solo/public/git-revision.txt
@@ -138,7 +137,6 @@ RUN ln -sf /data /agoric
 RUN ln -sf /data/solo /usr/src/agoric-sdk/packages/cosmic-swingset/solo
 RUN ln -sf /data/chains /usr/src/agoric-sdk/packages/cosmic-swingset/chains
 
-COPY --link scripts agoric-sdk/scripts
 RUN /usr/src/agoric-sdk/scripts/smoketest-binaries.sh
 
 # By default, run the daemon with specified arguments.


### PR DESCRIPTION
incidental 

refs: https://github.com/Agoric/agoric-sdk/pull/11342

## Description
Excludes local yarn files from assets copied into docker image
Remove `/usr/src/lib/ag-solo` that was unused because it unexpectedly contained a copy of the whole SDK

### Security Considerations
Reproducible builds

### Scaling Considerations
Better caching for builds

### Documentation Considerations
None? The `lib/ag-solo` was likely not used. Only old mentions circa 2019

### Testing Considerations
Locally tested, expecting coverage from CI integration testing

### Upgrade Considerations
None
