### PR TITLE
tools: `VBANK_GRAB` in mock bank bridge throws when insufficient funds are detected

### DIFF
--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -233,6 +234,24 @@ func (b *mockBank) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) 
 
 func (b *mockBank) SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
 	b.record(fmt.Sprintf("SendCoinsFromAccountToModule %s %s %s", senderAddr, recipientModule, amt))
+
+	// for each coin in the request, check spendable vs. requested
+	for _, coin := range amt {
+		// mimic GetBalance logic
+		have := b.balances[senderAddr.String()].AmountOf(coin.Denom)
+		spendable := sdk.NewCoin(coin.Denom, have)
+
+		if spendable.IsLT(coin) {
+			// wrap exactly like the real x/bank keeper
+			// https://github.com/agoric-labs/cosmos-sdk/blob/8b2b975304291c51991278734daa2ff5e57fcb83/x/bank/keeper/send.go#L252-L256
+			return sdkerrors.Wrapf(
+				sdkerrors.ErrInsufficientFunds,
+				"spendable balance %s is smaller than %s",
+				spendable, coin,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/packages/orchestration/test/examples/basic-flows.contract.test.ts
+++ b/packages/orchestration/test/examples/basic-flows.contract.test.ts
@@ -211,7 +211,7 @@ test('Deposit, Withdraw errors - LocalOrchAccount', async t => {
     });
     await t.throwsAsync(vt.when(E(withdrawSeat).getOfferResult()), {
       message:
-        'One or more withdrawals failed ["[RangeError: -10 is negative]"]',
+        /^One or more withdrawals failed \["\[Error: cannot grab 10uist coins: spendable balance (0uist)? is smaller than 10uist: insufficient funds\]"\]$/,
     });
     const payouts = await E(withdrawSeat).getPayouts();
     t.deepEqual((await ist.issuer.getAmountOf(payouts.Stable)).value, 0n);


### PR DESCRIPTION
incidental

## Description
- documents `VBANK_GRAB` insufficient funds error in `golang/cosmos/x/vbank/vbank_test.go`
- updates bank bridge in `packages/vats/tools/fake-bridge.js` to throw when insufficient funds are detected

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Improves fidelity of mocks

### Upgrade Considerations
None, test code
