### PR TITLE
reimburse OpCo

### DIFF
--- a/multichain-testing/README.md
+++ b/multichain-testing/README.md
@@ -41,6 +41,8 @@ You can start everything with a single command:
 
 ```sh
 make start
+# or for testing with Fast USDC
+make start FILE=config.fusdc.yaml
 ```
 
 This command will:
@@ -65,7 +67,7 @@ make wait-for-pods
 make port-forward
 
 # set up Agoric testing environment
-make fund-provision-pool override-chain-registry register-bank-assets
+make fund-provision-pool register-bank-assets
 ```
 
 If you get an error like "connection refused", you need to wait longer, until all the pods are Running.

--- a/multichain-testing/test/README.md
+++ b/multichain-testing/test/README.md
@@ -5,6 +5,8 @@ Runs agoric, cosmoshub, and osmosis with hermes relayers.
 ```sh
 # start starship with default configuration
 make start
+# or for Fast USDC
+make start FILE=config.fusdc.yaml
 ```
 
 ## Run Tests

--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -320,6 +320,9 @@ const advanceAndSettleScenario = test.macro({
       vstorageClient,
     } = t.context;
 
+    const { encumberedBalance: balanceBeforeBurn } =
+      await fastLPQ(vstorageClient).metrics();
+
     // EUD wallet on the specified chain
     const eudWallet = await createWallet(
       useChain(eudChain).chain.bech32_prefix,
@@ -403,8 +406,8 @@ const advanceAndSettleScenario = test.macro({
     await retryUntilCondition(
       () => fastLPQ(vstorageClient).metrics(),
       ({ encumberedBalance }) =>
-        encumberedBalance && isEmpty(encumberedBalance),
-      'encumberedBalance returns to 0',
+        AmountMath.isEqual(encumberedBalance, balanceBeforeBurn),
+      'encumberedBalance returns to original value',
     );
 
     // retry until status is reached
@@ -485,13 +488,6 @@ test.serial('Ethereum destination', async t => {
 
   // Verify disbursement succeeds
   nobleTools.mockCctpMint(mintAmt, userForwardingAddr);
-  await retryUntilCondition(
-    () => fastLPQ(vstorageClient).metrics(),
-    ({ encumberedBalance }) =>
-      AmountMath.isEqual(encumberedBalance, balanceBeforeBurn),
-    'encumberedBalance returns to original value',
-  );
-
   await retryUntilCondition(
     () => fastLPQ(vstorageClient).metrics(),
     ({ encumberedBalance }) =>

--- a/packages/boot/test/bootstrapTests/liquidation-concurrent-1.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-concurrent-1.test.ts
@@ -117,7 +117,7 @@ const setups = {
   STARS: starsSetup,
 };
 
-const atomOutcome = /** @type {const} */ {
+const atomOutcome = {
   bids: [
     {
       payouts: {
@@ -168,7 +168,7 @@ const atomOutcome = /** @type {const} */ {
   ],
 };
 
-const starsOutcome = /** @type {const} */ {
+const starsOutcome = {
   bids: [
     {
       payouts: {
@@ -310,7 +310,6 @@ test('concurrent flow 1', async t => {
 
   for (const { collateralBrandKey, managerIndex } of cases) {
     // check nothing liquidating yet
-    /** @type {import('@agoric/inter-protocol/src/auction/scheduler.js').ScheduleNotification} */
     t.is(liveSchedule.activeStartTime, null);
     t.like(readLatest(metricsPaths[managerIndex]), {
       numActiveVaults: setups[collateralBrandKey].vaults.length,

--- a/packages/boot/test/bootstrapTests/liquidation-concurrent-2b.test.ts
+++ b/packages/boot/test/bootstrapTests/liquidation-concurrent-2b.test.ts
@@ -63,7 +63,7 @@ const atomSetup = {
   },
 };
 
-const starsSetup = /** @type {const} */ {
+const starsSetup = {
   vaults: [
     {
       atom: 15,
@@ -105,14 +105,14 @@ const starsSetup = /** @type {const} */ {
       debt: 236.675,
     },
   },
-};
+} as const;
 
 const setups = {
   ATOM: atomSetup,
   STARS: starsSetup,
 };
 
-const atomOutcome = /** @type {const} */ {
+const atomOutcome = {
   bids: [
     {
       payouts: {
@@ -146,9 +146,9 @@ const atomOutcome = /** @type {const} */ {
       locked: 0,
     },
   ],
-};
+} as const;
 
-const starsOutcome = /** @type {const} */ {
+const starsOutcome = {
   bids: [
     {
       payouts: {
@@ -182,7 +182,7 @@ const starsOutcome = /** @type {const} */ {
       locked: 0,
     },
   ],
-};
+} as const;
 
 const outcomes = {
   ATOM: atomOutcome,
@@ -271,7 +271,6 @@ test.serial(
 
     for (const { collateralBrandKey, managerIndex } of cases) {
       // check nothing liquidating yet
-      /** @type {import('@agoric/inter-protocol/src/auction/scheduler.js').ScheduleNotification} */
       t.is(liveSchedule.activeStartTime, null);
       t.like(readLatest(metricsPaths[managerIndex]), {
         numActiveVaults: setups[collateralBrandKey].vaults.length,

--- a/packages/boot/tools/liquidation.ts
+++ b/packages/boot/tools/liquidation.ts
@@ -416,7 +416,6 @@ const addSTARsCollateral = async (
   t.log({ bridgeMessage });
 
   const { EV } = t.context.runUtils;
-  /** @type {ERef<import('@agoric/vats/src/types.js').BridgeHandler>} */
   const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
     'coreEvalBridgeHandler',
   );

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -903,8 +903,7 @@ export const makeSwingsetHarness = ({
     xsnapComputron: computronCost,
   },
 } = {}) => {
-  /** @type {ReturnType<typeof computronCounter> | undefined} */
-  let policy;
+  let policy: ReturnType<typeof computronCounter> | undefined;
   let policyEnabled = false;
 
   const meter = harden({

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -28,7 +28,10 @@ import { initSwingStore } from '@agoric/swing-store';
 import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
 import { makeSlogSender } from '@agoric/telemetry';
 import { TimeMath, type Timestamp } from '@agoric/time';
-import { fakeLocalChainBridgeTxMsgHandler } from '@agoric/vats/tools/fake-bridge.js';
+import {
+  fakeLocalChainBridgeQueryHandler,
+  fakeLocalChainBridgeTxMsgHandler,
+} from '@agoric/vats/tools/fake-bridge.js';
 import { Fail } from '@endo/errors';
 
 import type { Amount, Brand } from '@agoric/ertp';
@@ -678,6 +681,18 @@ export const makeSwingsetTestKit = async (
         return obj.messages.map(message =>
           fakeLocalChainBridgeTxMsgHandler(message, lcaSequenceNonce),
         );
+      }
+      case `${BridgeId.VLOCALCHAIN}:VLOCALCHAIN_QUERY_MANY`: {
+        console.warn(
+          'SwingsetTestKit bridgeOutbound faking VLOCALCHAIN_QUERY_MANY response for',
+          obj,
+        );
+        lcaSequenceNonce += 1;
+        const result = obj.messages.map(message =>
+          fakeLocalChainBridgeQueryHandler(message),
+        );
+        console.warn('      VLOCALCHAIN_QUERY_MANY result', result);
+        return result;
       }
       default: {
         throw Error(`FIXME missing support for ${bridgeId}: ${obj.type}`);

--- a/packages/fast-usdc-contract/test/contract-setup.ts
+++ b/packages/fast-usdc-contract/test/contract-setup.ts
@@ -177,7 +177,7 @@ export const makeTestContext = async (t: ExecutionContext) => {
   const accountsData = common.bootstrap.storage.data.get(ROOT_STORAGE_PATH);
   const { settlementAccount, poolAccount } = JSON.parse(
     JSON.parse(accountsData!).values[0],
-  );
+  ) as Record<string, string>;
   t.is(settlementAccount, 'agoric1qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc09z0g');
   t.is(poolAccount, 'agoric1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp7zqht');
   const mint = async (e: CctpTxEvidence): Promise<NatAmount> => {

--- a/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
+++ b/packages/fast-usdc-contract/test/fast-usdc.contract.test.ts
@@ -768,3 +768,37 @@ test.serial('mint received while ADVANCING', async t => {
     { split, status: 'DISBURSED' },
   ]);
 });
+
+// The bridge messages are all mocked so this isn't testing real balances,
+// but at least it tests that the call resolves and returns the right shape.
+test.serial('sendFromSettlementAccount', async t => {
+  const {
+    startKit: { creatorFacet },
+    common: {
+      brands: { usdc },
+    },
+  } = t.context;
+
+  const recipient = 'cosmos:agoric-3:agoric1recipient123';
+  const amount = usdc.units(1_000);
+
+  // Perform the reimbursement
+  const balances = await E(creatorFacet).sendFromSettlementAccount(
+    recipient,
+    amount,
+  );
+  t.deepEqual(
+    balances,
+    {
+      before: [
+        { denom: 'ubld', value: 10n },
+        { denom: 'uist', value: 10n },
+      ],
+      after: [
+        { denom: 'ubld', value: 10n },
+        { denom: 'uist', value: 10n },
+      ],
+    },
+    'reimbursement has mocked data in the right shape',
+  );
+});

--- a/packages/fast-usdc-contract/test/supports.ts
+++ b/packages/fast-usdc-contract/test/supports.ts
@@ -1,18 +1,4 @@
 import { makeIssuerKit } from '@agoric/ertp';
-import {
-  denomHash,
-  type CosmosChainInfo,
-  type Denom,
-} from '@agoric/orchestration';
-import { type DenomDetail } from '@agoric/orchestration/src/exos/chain-hub.js';
-import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
-import { setupOrchestrationTest } from '@agoric/orchestration/tools/contract-tests.ts';
-import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
-import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
-import { type Zone } from '@agoric/zone';
-import { makeDurableZone } from '@agoric/zone/durable.js';
-import { E } from '@endo/far';
-import type { ExecutionContext } from 'ava';
 import type {
   CctpTxEvidence,
   FeeConfig,
@@ -22,6 +8,21 @@ import {
   makeFeeTools,
   type RepayAmountKWR,
 } from '@agoric/fast-usdc/src/utils/fees.js';
+import {
+  denomHash,
+  type CosmosChainInfo,
+  type Denom,
+} from '@agoric/orchestration';
+import { type DenomDetail } from '@agoric/orchestration/src/exos/chain-hub.js';
+import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
+import { setupOrchestrationTest } from '@agoric/orchestration/tools/contract-tests.ts';
+import { reincarnate } from '@agoric/swingset-liveslots/tools/setup-vat-data.js';
+import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import { type Zone } from '@agoric/zone';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+import { E } from '@endo/far';
+import type { ExecutionContext } from 'ava';
 import { makeTestFeeConfig } from './mocks.js';
 
 export {
@@ -93,14 +94,14 @@ export const setupFastUsdcTest = async ({
   const { mint: _i, ...usdcSansMint } = usdc;
   await E(E(agoricNamesAdmin).lookupAdmin('vbankAsset')).update(
     uusdcOnAgoric,
-    /** @type {AssetInfo} */ harden({
+    harden({
       brand: usdc.brand,
       issuer: usdc.issuer,
       issuerName: 'USDC',
       denom: 'uusdc',
       proposedName: 'USDC',
-      displayInfo: { IOU: true },
-    }),
+      displayInfo: { assetKind: 'nat', IOU: true },
+    }) as AssetInfo,
   );
 
   const assetInfo: [Denom, DenomDetail & { brandKey?: string }][] = harden([

--- a/packages/fast-usdc-deploy/scripts/check-forward-fails.ts
+++ b/packages/fast-usdc-deploy/scripts/check-forward-fails.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+/* eslint-env node */
+
+// Adapted from https://gist.github.com/0xpatrickdev/56e91f6318352832efa0977cfd98d188/550b9d70e5a859d25f43c0080c5ca6dd126d205a
+const formatUSDC = x => Number(x) / 1_000_000;
+
+const run = async () => {
+  // copied from chrome network tools. manually changed pageSize to 50
+  const txsRes = await fetch(
+    'https://api.subquery.network/sq/agoric-labs/internal',
+    {
+      headers: {
+        accept: 'application/graphql-response+json, application/json',
+        'content-type': 'application/json',
+      },
+      body: '{"query":"\\n  query TransactionsQuery(\\n    $after: Cursor\\n    $pageSize: Int\\n    $statusFilter: FastUsdcTransactionStatus\\n    $orderBy: [FastUsdcTransactionsOrderBy!]\\n  ) {\\n    \\n  _metadata {\\n    lastProcessedHeight\\n    indexerHealthy\\n    lastProcessedTimestamp\\n  }\\n\\n    fastUsdcTransactions(\\n      first: $pageSize\\n      after: $after\\n      orderBy: $orderBy\\n      filter: { status: { equalTo: $statusFilter } }\\n    ) {\\n      \\n  totalCount\\n  pageInfo {\\n    endCursor\\n    hasNextPage\\n  }\\n  edges {\\n    node {\\n      id\\n      sourceAddress\\n      eud\\n      usdcAmount\\n      status\\n      statusHeight\\n      heightObserved\\n      heightAdvanced\\n      heightDisbursed\\n      contractFee\\n      poolFee\\n      sourceBlockTimestamp\\n      timeObserved\\n      timeAdvanced\\n      timeDisbursed\\n      risksIdentified\\n      sourceChainId\\n    }\\n  }\\n\\n    }\\n  }\\n","variables":{"after":"","pageSize":50,"orderBy":["TIME_OBSERVED_DESC"],"statusFilter":"FORWARD_FAILED"},"operationName":"TransactionsQuery"}',
+      method: 'POST',
+    },
+  );
+  if (txsRes.status !== 200)
+    throw Error(`Got status code ${txsRes.status} for Subquery`);
+
+  const { data } = await txsRes.json();
+  console.log('data', data);
+
+  const { totalCount, edges } = data.fastUsdcTransactions;
+  console.log(`Found ${totalCount} FORWARD_FAILED transactions.`);
+
+  const amounts = edges.map(e => BigInt(e.node.usdcAmount));
+  console.log('amounts', amounts);
+  console.log('$ amounts', amounts.map(formatUSDC));
+  const totalAmount = edges.reduce(
+    (acc, e) => acc + BigInt(e.node.usdcAmount),
+    0n,
+  );
+  console.log(
+    `Totaling ${totalAmount} usdcAmount (${formatUSDC(totalAmount)}).`,
+  );
+
+  const settlementAccount =
+    'agoric1j9l00dxy08zqr53unr8kkk54n0lllgvfxrmfh43hp5p67el34lkq0hhxdt';
+  const usdcDenom =
+    'ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9';
+  const rpcUrl = 'https://main.api.agoric.net';
+  const balanceQueryPath = `/cosmos/bank/v1beta1/balances/`;
+
+  const balanceQueryRes = await fetch(
+    `${rpcUrl}${balanceQueryPath}${settlementAccount}`,
+  );
+
+  if (balanceQueryRes.status !== 200)
+    throw Error(`Got status code ${balanceQueryRes.status} for Balance Query`);
+
+  const { balances } = await balanceQueryRes.json();
+  const usdcBalance = BigInt(balances.find(x => x.denom === usdcDenom)?.amount);
+  console.log(
+    `Settlement Account has ${usdcBalance} USDC (${formatUSDC(usdcBalance)}).`,
+  );
+
+  const remaining = usdcBalance - totalAmount;
+
+  console.log(
+    `Repaying ${totalCount} transactions for (${formatUSDC(totalAmount)}) would result in ${remaining} (${formatUSDC(remaining)}) left in the Settlement Account`,
+  );
+
+  const pollMetricsFetch = await fetch(
+    'https://main-a.rpc.agoric.net/abci_query?path=%22/agoric.vstorage.Query/Data%22&data=0x0a1e7075626c69736865642e66617374557364632e706f6f6c4d657472696373&height=0',
+    {
+      headers: { accept: '*/*' },
+      method: 'GET',
+    },
+  );
+  if (pollMetricsFetch.status !== 200)
+    throw Error(
+      `Got status code ${pollMetricsFetch.status} for Pool Metrics Query`,
+    );
+  const { result } = await pollMetricsFetch.json();
+  if (result?.response?.code !== 0) throw Error(`Did not get code 0 ${result}`);
+  const fromB64 = atob(result.response.value);
+  // avoid parsing cap data here
+  const matches = fromB64.match(/encumberedBalance.*?(\d{10,})/);
+  if (!matches || matches.length < 2) {
+    throw new Error(`Unable to parse encumbered balance from ${fromB64}`);
+  }
+  const encumberedBalance = BigInt(matches[1]);
+  console.log(
+    'encumberedBalance',
+    encumberedBalance,
+    formatUSDC(encumberedBalance),
+  );
+  const encumberedAfter = encumberedBalance - totalAmount;
+  console.log(
+    `Repaying ${totalAmount} (${formatUSDC(totalAmount)}) would result in ${encumberedAfter} ${formatUSDC(encumberedAfter)} encumbered balance`,
+  );
+  if (encumberedAfter < 0n) {
+    console.warn(
+      `🚨 encumberedAfter is negative ${encumberedAfter} ${formatUSDC(encumberedAfter)}`,
+    );
+  }
+};
+
+run().then(console.log).catch(console.error);

--- a/packages/fast-usdc-deploy/src/reimburse-opco.build.js
+++ b/packages/fast-usdc-deploy/src/reimburse-opco.build.js
@@ -1,0 +1,63 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { AmountMath } from '@agoric/ertp';
+import { multiplyBy, parseRatio } from '@agoric/ertp/src/ratio.js';
+import { Far } from '@endo/far';
+import { parseArgs } from 'node:util';
+import { getManifestForReimburseOpCo } from './reimburse-opco.core.js';
+import { toExternalConfig } from './utils/config-marshal.js';
+
+/**
+ * @import {CoreEvalBuilder, DeployScriptFunction} from '@agoric/deploy-script-support/src/externalTypes.js'
+ * @import {ReimbursementTerms} from './reimburse-opco.core.js'
+ */
+
+const usage = 'Use: --destinationAddress <address> --principal <amount>';
+
+const xVatCtx = /** @type {const} */ ({
+  /** @type {Brand<'nat'>} */
+  USDC: Far('USDC Brand'),
+});
+const { USDC } = xVatCtx;
+const USDC_DECIMALS = 6n;
+const unit = AmountMath.make(USDC, 10n ** USDC_DECIMALS);
+
+/**
+ * @param {unknown} _utils
+ * @param {ReimbursementTerms} terms
+ * @satisfies {CoreEvalBuilder}
+ */
+const reimbursementProposalBuilder = async (_utils, terms) => {
+  return harden({
+    sourceSpec: './reimburse-opco.core.js',
+    /** @type {[string, Parameters<typeof getManifestForReimburseOpCo>[1]]} */
+    getManifestCall: [
+      getManifestForReimburseOpCo.name,
+      { options: toExternalConfig(harden({ terms }), xVatCtx) },
+    ],
+  });
+};
+
+/** @type {DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  const {
+    values: { destinationAddress, principal },
+  } = parseArgs({
+    args: endowments.scriptArgs,
+    options: {
+      destinationAddress: { type: 'string' },
+      principal: { type: 'string' },
+    },
+  });
+  assert(destinationAddress && principal, usage);
+
+  /** @type {ReimbursementTerms} */
+  const feeTerms = {
+    // @ts-expect-error Bech32Address expected
+    destinationAddress,
+    principal: multiplyBy(unit, parseRatio(principal, USDC)),
+  };
+  await writeCoreEval('eval-reimburse-opco', utils =>
+    reimbursementProposalBuilder(utils, feeTerms),
+  );
+};

--- a/packages/fast-usdc-deploy/src/reimburse-opco.core.js
+++ b/packages/fast-usdc-deploy/src/reimburse-opco.core.js
@@ -1,0 +1,64 @@
+/** @file core eval module to collect fees. */
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+import { fromExternalConfig } from './utils/config-marshal.js';
+
+/**
+ * @import {Amount, Brand, DepositFacet, Ratio} from '@agoric/ertp';
+ * @import {FastUSDCCorePowers} from './start-fast-usdc.core.js';
+ * @import {CopyRecord} from '@endo/pass-style'
+ * @import {BootstrapManifestPermit} from '@agoric/vats/src/core/lib-boot.js'
+ * @import {LegibleCapData} from './utils/config-marshal.js'
+ */
+
+/**
+ * @typedef {{ destinationAddress: import('@agoric/orchestration').Bech32Address, principal: Amount<'nat'>} &
+ *  CopyRecord
+ * } ReimbursementTerms
+ */
+
+const issUSDC = 'USDC'; // issuer name
+
+const trace = makeTracer('RUCF', true);
+
+/**
+ * @param {BootstrapPowers & FastUSDCCorePowers } permittedPowers
+ * @param {{ options: LegibleCapData<{ terms: ReimbursementTerms}> }} config
+ */
+export const reimburseOpCo = async (permittedPowers, config) => {
+  trace('reimburseOpCo...', config.options);
+
+  const { agoricNames } = permittedPowers.consume;
+  /** @type {Brand<'nat'>} */
+  const usdcBrand = await E(agoricNames).lookup('brand', issUSDC);
+  /** @type {{ terms: ReimbursementTerms}} */
+  const { terms } = fromExternalConfig(config.options, {
+    USDC: usdcBrand,
+  });
+
+  const { creatorFacet } = await permittedPowers.consume.fastUsdcKit;
+  await E(creatorFacet).sendFromSettlementAccount(
+    terms.destinationAddress,
+    terms.principal,
+  );
+  trace('done');
+};
+harden(reimburseOpCo);
+
+/** @satisfies {BootstrapManifestPermit} */
+const permit = {
+  consume: {
+    fastUsdcKit: true,
+    agoricNames: true,
+    namesByAddress: true,
+    zoe: true,
+  },
+};
+
+/**
+ * @param {unknown} _utils
+ * @param {Parameters<typeof reimburseOpCo>[1]} config
+ */
+export const getManifestForReimburseOpCo = (_utils, { options }) => {
+  return { manifest: { [reimburseOpCo.name]: permit }, options };
+};

--- a/packages/fast-usdc-deploy/src/upgrade-evm-dests.core.js
+++ b/packages/fast-usdc-deploy/src/upgrade-evm-dests.core.js
@@ -157,6 +157,7 @@ export const upgradeEvmDests = async (
     await E(creatorFacet).registerChain(chainName, {
       ...info,
       // for backwards compatibility with `CosmosChainInfoShapeV1` which expects a `chainId`
+      // @ts-expect-error no longer expected
       chainId: `${info.namespace}:${info.reference}`,
     });
   }

--- a/packages/fast-usdc-deploy/test/chain-impact.test.ts
+++ b/packages/fast-usdc-deploy/test/chain-impact.test.ts
@@ -220,8 +220,7 @@ test.serial('iterate simulation several times', async t => {
   harness.resetRunPolicy(); // never mind computrons from bootstrap
   const snapStore = swingStore.internal.snapStore as unknown as SnapStoreDebug;
 
-  /** @type {Record<string, number>} */
-  let previousReapPos = harden({});
+  let previousReapPos = harden({}) as Record<string, number>;
 
   async function doCleanupAndSnapshot(id) {
     slogSender?.({ type: 'cleanup-begin', id });

--- a/packages/fast-usdc-deploy/test/fast-usdc.test.ts
+++ b/packages/fast-usdc-deploy/test/fast-usdc.test.ts
@@ -31,6 +31,7 @@ import {
   buildVTransferEvent,
 } from '@agoric/orchestration/tools/ibc-mocks.js';
 import { Fail } from '@endo/errors';
+import type { ForwardInfo } from '@agoric/orchestration';
 import { configurations } from '../src/utils/deploy-config.js';
 import {
   makeWalletFactoryContext,
@@ -691,18 +692,18 @@ test.serial('minted before observed; forward path', async t => {
       destinationChannel: nobleToAgoricChannel,
       sequence: '4', // XXX brittle, abstract from tests
       amount: evidence.tx.amount,
-      memo: JSON.stringify(
-        /** @type {ForwardInfo} */
-        {
-          forward: {
-            receiver: recipientAddress,
-            port: 'transfer',
-            channel:
-              fetchedChainInfo.noble.connections['agoric-3'].transferChannel
-                .channelId,
-          },
+      memo: JSON.stringify({
+        forward: {
+          receiver: recipientAddress,
+          port: 'transfer',
+          channel:
+            fetchedChainInfo.noble.connections['agoric-3'].transferChannel
+              .channelId,
         },
-      ),
+      } as Omit<ForwardInfo, 'forward'> & {
+        // ignored in test
+        forward: Omit<ForwardInfo['forward'], 'timeout' | 'retries'>;
+      }),
     }),
   );
   await eventLoopIteration();
@@ -1003,18 +1004,18 @@ test.serial('forward timeout', async t => {
 
   // Simulate timeout of the outgoing forward transfer
   const firstForward = 6n; // XXX brittle, depends on IBC of previous tests
-  const forwardMemo = JSON.stringify(
-    /** @type {ForwardInfo} */
-    {
-      forward: {
-        receiver: recipientAddress,
-        port: 'transfer',
-        channel:
-          fetchedChainInfo.noble.connections['agoric-3'].transferChannel
-            .channelId,
-      },
+  const forwardMemo = JSON.stringify({
+    forward: {
+      receiver: recipientAddress,
+      port: 'transfer',
+      channel:
+        fetchedChainInfo.noble.connections['agoric-3'].transferChannel
+          .channelId,
     },
-  );
+  } as Omit<ForwardInfo, 'forward'> & {
+    // ignored in test
+    forward: Omit<ForwardInfo['forward'], 'timeout' | 'retries'>;
+  });
 
   const successfulForwardEvent = buildVTransferEvent({
     sender: settlementAccount,

--- a/packages/orchestration/test/examples/send-cctp.test.ts
+++ b/packages/orchestration/test/examples/send-cctp.test.ts
@@ -7,6 +7,7 @@ import type { IBCMethod } from '@agoric/vats';
 import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { E } from '@endo/far';
+import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import type {
   CosmosChainInfo,
   IBCConnectionInfo,
@@ -111,14 +112,14 @@ const registerUSDC = async ({ bankManager, agoricNamesAdmin }) => {
   });
   await E(E(agoricNamesAdmin).lookupAdmin('vbankAsset')).update(
     denom,
-    /** @type {AssetInfo} */ harden({
+    harden({
       brand,
       issuer,
       issuerName,
       denom,
       proposedName,
-      displayInfo: { IOU: true },
-    }),
+      displayInfo: { assetKind: 'nat', IOU: true },
+    }) as AssetInfo,
   );
 
   return harden({ ...usdcKit, denom });

--- a/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
+++ b/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
@@ -16,8 +16,7 @@ test('portfolio holder kit behaviors', async t => {
    * mock zcf that echos back the offer description
    */
   const mockZcf = Far('MockZCF', {
-    /** @type {ZCF['makeInvitation']} */
-    makeInvitation: (offerHandler, description, ..._rest) => {
+    makeInvitation: (offerHandler: OfferHandler, description: string) => {
       t.is(typeof offerHandler, 'function');
       const p = new Promise(resolve => resolve(description));
       return p;

--- a/packages/orchestration/test/network-fakes.ts
+++ b/packages/orchestration/test/network-fakes.ts
@@ -172,13 +172,11 @@ export const makeFakeIBCBridge = (
    * accounts.
    * XXX teach this about IBCConnections and store sequence on a
    * per-channel basis.
-   * @type {bigint}
    */
   let ibcSequenceNonce = 0n;
   /**
    * The number of channels created. Currently used as a proxy to increment
    * fake account addresses and channels.
-   * @type {nubmer}
    */
   let channelCount = 0;
   let icaAccountCount = 0;
@@ -192,7 +190,6 @@ export const makeFakeIBCBridge = (
 
   /**
    * Packet byte string map of requests to responses
-   * @type {Record<string, string>}
    */
   let mockAckMap = defaultMockAckMap;
   let bridgeEvents: BridgeEvents = [];

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -24,6 +24,7 @@ import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeHeapZone } from '@agoric/zone';
 import { E } from '@endo/far';
 import type { ExecutionContext } from 'ava';
+import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import { withChainCapabilities } from '../src/chain-capabilities.js';
 import { registerKnownChains } from '../src/chain-info.js';
 import type { Bech32Address } from '../src/cosmos-api.js';
@@ -72,25 +73,25 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
   await makeWellKnownSpaces(agoricNamesAdmin, t.log, ['vbankAsset']);
   await E(E(agoricNamesAdmin).lookupAdmin('vbankAsset')).update(
     'uist',
-    /** @type {AssetInfo} */ harden({
+    harden({
       brand: ist.brand,
       issuer: ist.issuer,
       issuerName: 'IST',
       denom: 'uist',
       proposedName: 'IST',
-      displayInfo: { IOU: true },
-    }),
+      displayInfo: { assetKind: 'nat', IOU: true },
+    }) as AssetInfo,
   );
   await E(E(agoricNamesAdmin).lookupAdmin('vbankAsset')).update(
     'ubld',
-    /** @type {AssetInfo} */ harden({
+    harden({
       brand: bld.brand,
       issuer: bld.issuer,
       issuerName: 'BLD',
       denom: 'ubld',
       proposedName: 'BLD',
-      displayInfo: { IOU: true },
-    }),
+      displayInfo: { assetKind: 'nat', IOU: true },
+    }) as AssetInfo,
   );
 
   const vowTools = prepareSwingsetVowTools(rootZone.subZone('vows'));


### PR DESCRIPTION
closes: https://github.com/Agoric/agoric-private/issues/307

## Description
Add a feature to fast usdc contract creatorFacet to send send funds from the `settlementAccount`. 
Add a core-eval and builder that does so. We'll use this to reimburse OpCo for the transactions it paid for when FORWARD_FAILED didn't reach the end users.

Also cleans up tests and types.

### Security Considerations

This exposes a method on creatorFacet that can drain the settlementAccount. Presently only BLD stakers are able to make such code execute on Mainnet. The proposal to them will detail why the amount in the proposal is valid.

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
This includes a script that can help with determining the correct value. The correct value and destination of out of scope of this work though.

### Upgrade Considerations
The feature will go out in the CCTP GTM release. That same proposal could include the reimbursement call, or it could be made separately. TBD