### PR TITLE
feat(agoric-cli): Add `--verbose` option to `agops perf satisfaction`

### DIFF
--- a/packages/agoric-cli/src/commands/perf.js
+++ b/packages/agoric-cli/src/commands/perf.js
@@ -51,6 +51,7 @@ export const makePerfCommand = logger => {
       'address literal or name',
       normalizeAddress,
     )
+    .option('--verbose')
     .action(async function (opts) {
       const sharedOpts = perf.opts();
       logger.warn({ sharedOpts, opts });
@@ -102,7 +103,11 @@ export const makePerfCommand = logger => {
       if (sharedOpts.home) {
         cmd.push(`--home=${sharedOpts.home}`);
       }
-      execSwingsetTransaction(cmd, { from: opts.from, ...networkConfig });
+      execSwingsetTransaction(cmd, {
+        from: opts.from,
+        verbose: opts.verbose,
+        ...networkConfig,
+      });
     });
 
   return perf;


### PR DESCRIPTION
## Description
Extracted from #11373

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
This supports more useful output for debugging tests, particularly those in a3p-integration.

### Upgrade Considerations
n/a