### PR TITLE
fix lint commands

### DIFF
--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -14,8 +14,8 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
-    "lint:types": "tsc",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "yarn run -T eslint .",
+    "lint:types": "yarn run -T tsc"
   },
   "exports": {
     ".": "./index.js"

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -20,8 +20,8 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
-    "lint:types": "tsc",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "yarn run -T eslint .",
+    "lint:types": "yarn run -T tsc"
   },
   "devDependencies": {
     "ava": "^5.3.0",

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -154,8 +154,8 @@
     "prepare": "npm run build",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
-    "lint:types": "tsc",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "yarn run -T eslint .",
+    "lint:types": "yarn run -T tsc",
     "test": "ava",
     "test:xs": "exit 0",
     "test:live": "yarn build && scripts/test-live.js"

--- a/packages/create-dapp/package.json
+++ b/packages/create-dapp/package.json
@@ -14,8 +14,8 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
-    "lint:types": "tsc",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "yarn run -T eslint .",
+    "lint:types": "yarn run -T tsc"
   },
   "devDependencies": {
     "ava": "^5.3.0",

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -16,10 +16,10 @@
     "test": "ava",
     "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "exit 0",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
-    "lint:types": "tsc",
-    "lint:eslint": "eslint .",
-    "lint-fix": "yarn lint:eslint --fix"
+    "lint:eslint": "yarn run -T eslint .",
+    "lint:types": "yarn run -T tsc"
   },
   "repository": {
     "type": "git",

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -16,8 +16,8 @@
     "test:xs:ci": "npm run test:xs",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
-    "lint:eslint": "eslint .",
-    "lint:types": "tsc"
+    "lint:eslint": "yarn run -T eslint .",
+    "lint:types": "yarn run -T tsc"
   },
   "dependencies": {
     "@agoric/base-zone": "^0.1.0",


### PR DESCRIPTION
refs: #9945

## Description
 #9945 lost some updates in rebasing

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
searched for `eslint": "eslint` to find all the leftovers that were missing `-T`.

ran `yarn lint` locally in these packages

### Upgrade Considerations
n/a
