### PR TITLE
build: esbuild instead of tsc

### DIFF
--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -12,7 +12,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn run -T tsc --build tsconfig.build.json",
+    "build:js": "yarn run -T tsc --build tsconfig.build.json",
+    "build:types": "tsc --project tsconfig.build.json --emitDeclarationOnly",
+    "build": "npm run build:types && npm run build:js",
     "codegen": "scripts/codegen.cjs",
     "prepack": "yarn run -T tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.*ts*' '*.tsbuildinfo'",

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -160,7 +160,9 @@
     "!CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && scripts/minify.cjs",
+    "build:js": "esbuild --platform=neutral --format=esm --outdir=dist src/*.ts src/codegen/**/*.ts",
+    "build:types": "tsc --project tsconfig.build.json --emitDeclarationOnly",
+    "build": "npm run build:types && npm run build:js",
     "clean": "rimraf dist",
     "codegen": "./update-protos.sh && scripts/codegen.cjs",
     "prepare": "npm run build",


### PR DESCRIPTION
*Before*
npm notice package size: 756.7 kB
npm notice unpacked size: 7.9 MB
npm notice total files: 618

*After*
npm notice package size: 244.6 kB
npm notice unpacked size: 3.0 MB
npm notice total files: 207

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #XXXX

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
