### PR TITLE
test(cosmic-swingset): Implement subprocess-based retries for metrics comparison

### DIFF
--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -55,7 +55,8 @@
     "@agoric/kmarshal": "^0.1.0",
     "ava": "^5.3.0",
     "better-sqlite3": "^10.1.0",
-    "c8": "^10.1.3"
+    "c8": "^10.1.3",
+    "execa": "^9.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cosmic-swingset/test/prometheus.test.ts
+++ b/packages/cosmic-swingset/test/prometheus.test.ts
@@ -1,5 +1,7 @@
-import type { TestFn } from 'ava';
+import type { TestFn, Implementation } from 'ava';
 import anyTest from 'ava';
+import { fileURLToPath } from 'node:url';
+import { execa } from 'execa';
 
 import { q, Fail } from '@endo/errors';
 
@@ -20,7 +22,43 @@ import { makeCosmicSwingsetTestKit } from '../tools/test-kit.js';
 
 const test = anyTest as TestFn;
 
-avaRetry(test, 'Prometheus metric definitions', async t => {
+let tryCount = 0;
+const { IS_SUBPROCESS_RETRY } = process.env;
+const testPrometheusMetrics = async t => {
+  await null;
+
+  // @opentelemetry/sdk-metrics keeps too much internal state to support simple
+  // retries, so instead we spawn a subprocess. Fortunately, this kludge will go
+  // away when metrics collection is fully extracted from swingset and the
+  // kernel: https://github.com/Agoric/agoric-sdk/issues/11405
+  if (tryCount) {
+    if (IS_SUBPROCESS_RETRY) throw Error('Unexpected retry within subprocess');
+    tryCount += 1;
+    console.log('\nRetrying in subprocess...');
+    const self = fileURLToPath(import.meta.url);
+    let child: undefined | ReturnType<typeof execa>;
+    let childOk = false;
+    try {
+      child = execa({
+        shell: true,
+        env: { IS_SUBPROCESS_RETRY: 'true' },
+        stdout: 'inherit',
+        stderr: 'inherit',
+        timeout: 2 * 60_000, // 2 minutes
+      })`yarn test ${self}`;
+      // Inspired by media type multipart/* common syntax:
+      // https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1
+      console.log(`--subprocess ${child.pid}`);
+      await child;
+      childOk = true;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-empty
+    } catch (_err) {}
+    if (child) console.log(`\n--subprocess ${child.pid}--\n`);
+    t.true(childOk, 'subprocess retry');
+    return;
+  }
+  tryCount += 1;
+
   // Enable both direct and slog-based Prometheus export.
   const OTEL_EXPORTER_PROMETHEUS_PORT = '12345';
   const SLOGSENDER_AGENT_OTEL_EXPORTER_PROMETHEUS_PORT = '12346';
@@ -124,28 +162,34 @@ avaRetry(test, 'Prometheus metric definitions', async t => {
   t.log(`compared ${slogMetrics.keys.length} keys`);
 
   let comparisonCount = 0;
+  const isRetry = !!IS_SUBPROCESS_RETRY;
   const fuzzinessOverrides = new Map([
     // Directly-produced "swingset_crank_processing_time" includes kvStore
     // lookups in `getNextMessageAndProcessor` for dequeueing messages.
     ['swingset_crank_processing_time_sum', [50, '%']],
 
-    // Memory measurements vary based on when they are captured.
-    ['heapStats_external_memory', [50, '%']],
-    ['heapStats_malloced_memory', [50, '%']],
-    ['heapStats_peak_malloced_memory', [50, '%']],
-    ['heapStats_total_available_size', [20, '%']],
-    ['heapStats_total_global_handles_size', [20, '%']],
-    ['heapStats_total_heap_size', [20, '%']],
-    ['heapStats_total_heap_size_executable', [20, '%']],
-    ['heapStats_total_physical_size', [20, '%']],
-    ['heapStats_used_global_handles_size', [20, '%']],
-    ['heapStats_used_heap_size', [20, '%']],
-    ['memoryUsage_arrayBuffers', [20, '%']],
-    ['memoryUsage_external', [20, '%']],
-    ['memoryUsage_heapTotal', [20, '%']],
-    ['memoryUsage_heapUsed', [20, '%']],
-    ['memoryUsage_rss', [20, '%']],
-  ]) as TotalMap<string, [number, string]>;
+    // Memory measurements vary based on when they are captured, and are
+    // ultimately ignorable (albeit with logging).
+    ['heapStats_external_memory', [50, '%', isRetry]],
+    ['heapStats_malloced_memory', [50, '%', isRetry]],
+    ['heapStats_peak_malloced_memory', [50, '%', isRetry]],
+    ['heapStats_total_available_size', [20, '%', isRetry]],
+    ['heapStats_total_global_handles_size', [20, '%', isRetry]],
+    ['heapStats_total_heap_size', [20, '%', isRetry]],
+    ['heapStats_total_heap_size_executable', [20, '%', isRetry]],
+    ['heapStats_total_physical_size', [20, '%', isRetry]],
+    ['heapStats_used_global_handles_size', [20, '%', isRetry]],
+    ['heapStats_used_heap_size', [20, '%', isRetry]],
+    ['memoryUsage_arrayBuffers', [20, '%', isRetry]],
+    ['memoryUsage_external', [20, '%', isRetry]],
+    ['memoryUsage_heapTotal', [20, '%', isRetry]],
+    ['memoryUsage_heapUsed', [20, '%', isRetry]],
+    ['memoryUsage_rss', [20, '%', isRetry]],
+  ]) as TotalMap<string, [number, unit: string, ignorable?: boolean]>;
+
+  // blockLagSeconds isn't reliable under retry.
+  if (isRetry) fuzzinessOverrides.set('blockLagSeconds_sum', [0.5, 's', true]);
+
   for (const directEntry of directMetrics.comparableData.entries()) {
     const [nameAndLabels, directValue] = directEntry;
     const [name] = nameAndLabels.match(leadingPrometheusNameRegExp) || [];
@@ -157,17 +201,19 @@ avaRetry(test, 'Prometheus metric definitions', async t => {
       `slog metrics must include ${q(nameAndLabels)}`,
     );
     comparisonCount += 1;
-    const [fuzziness, unit] = (() => {
+    const [fuzziness, unit, ignorable] = (() => {
       if (fuzzinessOverrides.has(name)) return fuzzinessOverrides.get(name);
 
-      // Default to 100 milliseconds of wiggle room for timing data.
+      // Default to 100 milliseconds of wiggle room for timing data, but expand
+      // that to 500 under subprocess retry (where the greater load can widen
+      // discrepancies).
       const baseName = name.replace(/_sum$/, '');
       const meta =
         HISTOGRAM_METRICS[baseName] || BLOCK_HISTOGRAM_METRICS[baseName];
       // eslint-disable-next-line no-shadow
       const unit = meta?.unit;
-      if (unit === 'ms') return [100, unit];
-      if (unit === 's') return [0.1, unit];
+      if (unit === 'ms') return [isRetry ? 500 : 100, unit];
+      if (unit === 's') return [isRetry ? 0.5 : 0.1, unit];
 
       return [0];
     })();
@@ -176,15 +222,33 @@ avaRetry(test, 'Prometheus metric definitions', async t => {
       t.is(slogValue, directValue, msg);
     } else {
       const msg = `${q(nameAndLabels)} values must be within ${fuzziness} ${unit} - direct ${directValue} vs. slog ${slogValue}`;
+      let flaky: Implementation<[]>;
       if (unit === '%') {
         const smaller = Math.min(slogValue, directValue);
         const bigger = Math.max(slogValue, directValue);
-        t.true((1 - smaller / bigger) * 100 <= fuzziness, msg);
+        flaky = tt => {
+          tt.true((1 - smaller / bigger) * 100 <= fuzziness, msg);
+        };
       } else {
-        t.true(Math.abs(slogValue - directValue) <= fuzziness, msg);
+        flaky = tt => {
+          tt.true(Math.abs(slogValue - directValue) <= fuzziness, msg);
+        };
+      }
+      const maybe = await t.try(flaky);
+      if (maybe.passed || !ignorable) {
+        maybe.commit();
+      } else {
+        t.log(msg);
+        maybe.discard();
       }
     }
   }
   t.truthy(comparisonCount);
   t.log(`compared ${comparisonCount} values`);
-});
+};
+
+if (!IS_SUBPROCESS_RETRY) {
+  avaRetry(test, 'Prometheus metric definitions', testPrometheusMetrics);
+} else {
+  test('Prometheus metric definitions', testPrometheusMetrics);
+}

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -27,6 +27,7 @@
     "@endo/errors": "^1.2.10",
     "@endo/init": "^1.1.9",
     "@endo/marshal": "^1.6.4",
+    "@endo/promise-kit": "^1.1.10",
     "@endo/stream": "^1.2.10",
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/api-logs": "0.57.1",

--- a/packages/telemetry/src/otel-metrics.js
+++ b/packages/telemetry/src/otel-metrics.js
@@ -10,7 +10,8 @@ import {
 } from '@agoric/internal/src/metrics.js';
 
 /**
- * @import {MeterProvider, MetricOptions, ObservableCounter, ObservableUpDownCounter} from '@opentelemetry/api';
+ * @import {MetricOptions, ObservableCounter, ObservableUpDownCounter} from '@opentelemetry/api';
+ * @import {MeterProvider} from '@opentelemetry/sdk-metrics';
  * @import {TotalMap} from '@agoric/internal';
  */
 
@@ -21,6 +22,10 @@ export const makeSlogSender = async (opts = /** @type {any} */ ({})) => {
   const { otelMeterName, otelMeterProvider } = opts;
   if (!otelMeterName) throw Fail`OTel meter name is required`;
   if (!otelMeterProvider) return;
+
+  const shutdown = async () => {
+    await otelMeterProvider.shutdown();
+  };
 
   const otelMeter = otelMeterProvider.getMeter(otelMeterName);
 
@@ -218,6 +223,7 @@ export const makeSlogSender = async (opts = /** @type {any} */ ({})) => {
     }
   };
   return Object.assign(slogSender, {
+    shutdown,
     usesJsonObject: false,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,6 +1070,7 @@ __metadata:
     "@endo/init": "npm:^1.1.9"
     "@endo/lockdown": "npm:^1.0.15"
     "@endo/marshal": "npm:^1.6.4"
+    "@endo/promise-kit": "npm:^1.1.10"
     "@endo/ses-ava": "npm:^1.2.10"
     "@endo/stream": "npm:^1.2.10"
     "@opentelemetry/api": "npm:~1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,6 +420,7 @@ __metadata:
     better-sqlite3: "npm:^10.1.0"
     c8: "npm:^10.1.3"
     deterministic-json: "npm:^1.0.5"
+    execa: "npm:^9.5.2"
     import-meta-resolve: "npm:^4.1.0"
     ses: "npm:^1.12.0"
     tmp: "npm:^0.2.1"


### PR DESCRIPTION
`@opentelemetry/sdk-metrics` keeps too much internal state to support simple
retries, so instead we spawn a subprocess. Fortunately, this kludge will go
away when metrics collection is fully extracted from swingset and the
kernel: #11405

Fixes #11175
Ref #11392

## Description

The first commit extends shutdown logic for slog-sender-pipe and otel-metrics, which I hoped was the root cause of flakiness here [narrator: "it wasn't"].

The second commit updates packages/cosmic-swingset/test/prometheus.test.ts with a kludgy bit of code that uses the current test implementation for the first try, but then on any subsequent try it instead spawns a `yarn test $SELF` subprocess with an IS_SUBPROCESS_RETRY environment variable, echoes the combined stdout/stderr from that subprocess, and asserts a successful exit status. That subprocess does not perform any retries of its own, and furthermore expands comparison fuzziness for metrics that are particularly susceptible to divergence, especially under what seems to be increased load in the subprocess (_logging failure messages for those metrics rather than actually failing their assertions_).

Fortunately, the latter code should be short-lived (cf. #11405).

### Security Considerations
None known.

### Scaling Considerations
Shutdown may be slower, but that's better than misbehavior from impatience.

### Documentation Considerations
n/a

### Upgrade Considerations
Nothing special is needed, and CI fully covers the expected testing/validation.