### PR TITLE
Async flight recorder reads

### DIFF
--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -294,6 +294,7 @@ export const makeSlogSenderFromBuffer = ({ fileHandle, writeCircBuf }) => {
   return Object.assign(writeJSON, {
     forceFlush: async () => {
       await toWrite;
+      await fileHandle.datasync();
     },
     shutdown: async () => {
       const lastWritten = toWrite;

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -233,11 +233,13 @@ export const makeSimpleCircularBuffer = async ({
     assert.equal(bytesRead, firstReadLength, 'Too few bytes read');
 
     if (bytesRead < outbuf.byteLength) {
-      await file.read(outbuf, {
+      const length = outbuf.byteLength - firstReadLength;
+      const { bytesRead: bytesRead2 } = await file.read(outbuf, {
         offset: firstReadLength,
-        length: outbuf.byteLength - firstReadLength,
+        length,
         position: I_ARENA_START,
       });
+      assert.equal(bytesRead2, length, 'Too few bytes read');
     }
   };
 

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -22,7 +22,7 @@ const main = async () => {
     let offset = 0;
     for (;;) {
       const lenBuf = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
-      const { done } = readCircBuf(lenBuf, offset);
+      const { done } = await readCircBuf(lenBuf, offset);
       if (done) {
         break;
       }
@@ -30,7 +30,7 @@ const main = async () => {
       const dv = new DataView(lenBuf.buffer);
       const len = Number(dv.getBigUint64(0));
 
-      const { done: done2, value: buf } = readCircBuf(
+      const { done: done2, value: buf } = await readCircBuf(
         new Uint8Array(len),
         offset,
       );

--- a/packages/telemetry/test/flight-recorder.test.js
+++ b/packages/telemetry/test/flight-recorder.test.js
@@ -55,11 +55,11 @@ const bufferTests = test.macro(
     t.is(fs.readFileSync(tmpFile, { encoding: 'utf8' }).length, BUFFER_SIZE);
 
     const len0 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
-    const { done: done0 } = readCircBuf(len0);
+    const { done: done0 } = await readCircBuf(len0);
     t.false(done0, 'readCircBuf should not be done');
     const dv0 = new DataView(len0.buffer);
     const buf0 = new Uint8Array(Number(dv0.getBigUint64(0)));
-    const { done: done0b } = readCircBuf(buf0, len0.byteLength);
+    const { done: done0b } = await readCircBuf(buf0, len0.byteLength);
     t.false(done0b, 'readCircBuf should not be done');
     const buf0Str = new TextDecoder().decode(buf0);
     t.is(buf0Str, `\n{"type":"start"}`, `start compare failed`);
@@ -78,12 +78,12 @@ const bufferTests = test.macro(
     let offset = 0;
     const len1 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
     for (let i = 490; i < last; i += 1) {
-      const { done: done1 } = readCircBuf(len1, offset);
+      const { done: done1 } = await readCircBuf(len1, offset);
       offset += len1.byteLength;
       t.false(done1, `readCircBuf ${i} should not be done`);
       const dv1 = new DataView(len1.buffer);
       const buf1 = new Uint8Array(Number(dv1.getBigUint64(0)));
-      const { done: done1b } = readCircBuf(buf1, offset);
+      const { done: done1b } = await readCircBuf(buf1, offset);
       offset += buf1.byteLength;
       t.false(done1b, `readCircBuf ${i} should not be done`);
       const buf1Str = new TextDecoder().decode(buf1);
@@ -94,7 +94,7 @@ const bufferTests = test.macro(
       );
     }
 
-    const { done: done2 } = readCircBuf(len1, offset);
+    const { done: done2 } = await readCircBuf(len1, offset);
     t.assert(done2, `readCircBuf ${last} should be done`);
 
     slogSender(null, 'PRE-SERIALIZED');

--- a/packages/telemetry/test/flight-recorder.test.js
+++ b/packages/telemetry/test/flight-recorder.test.js
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import { promisify } from 'node:util';
 import tmp from 'tmp';
 import { test } from './prepare-test-env-ava.js';
 
@@ -13,21 +12,16 @@ const bufferTests = test.macro(
   /**
    *
    * @param {*} t
-   * @param {{makeBuffer: Function}} input
+   * @param {{makeBuffer: typeof makeSimpleCircularBuffer}} input
    */
   async (t, input) => {
     const BUFFER_SIZE = 512;
 
-    const {
-      name: tmpFile,
-      fd,
-      removeCallback,
-    } = tmp.fileSync({ detachDescriptor: true });
-    t.teardown(removeCallback);
-    const fileHandle = /** @type {import('fs/promises').FileHandle} */ ({
-      close: promisify(fs.close.bind(fs, fd)),
+    const { name: tmpFile, removeCallback } = tmp.fileSync({
+      discardDescriptor: true,
     });
-    const { readCircBuf, writeCircBuf } = await input.makeBuffer({
+    t.teardown(removeCallback);
+    const { fileHandle, readCircBuf, writeCircBuf } = await input.makeBuffer({
       circularBufferSize: BUFFER_SIZE,
       circularBufferFilename: tmpFile,
     });


### PR DESCRIPTION
refs: #11428

## Description
Make the flight recorder read async, and fsync data when flushing

### Security Considerations
None

### Scaling Considerations
Mixing sync and async was giving us the worst of both worlds: the overhead of async and promises while also blocking the main thread.

### Documentation Considerations
None

### Testing Considerations
Hard to test the fs impact of this change. Existing tests still pass.

### Upgrade Considerations
Will be part of the next chain software upgrade
