### PR TITLE
ci(proto): act on `proto:breakage` label in `proto.yml`

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -41,9 +41,28 @@ jobs:
             **/**.proto
             **/buf*.yaml
       - name: check-breakage
-        run: make proto-check-breaking PR_TARGET_REPO=https://github.com/${{ github.repository }}.git PR_TARGET_BRANCH=${{ github.base_ref }}
-        working-directory: golang/cosmos
         if: env.GIT_DIFF
+        run: |
+          make proto-check-breaking PR_TARGET_REPO="$REPO" PR_TARGET_BRANCH="$BRANCH"
+          status=$?
+          if [ $status -eq 0 ]; then
+            if [ "$EXPECT_BREAKAGE" = "true" ]; then
+              echo "Expected breakage, but got no breakage."
+              exit 1
+            fi
+            echo "As expected, no breakage was detected."
+          elif [ "$EXPECT_BREAKAGE" == "true" ]; then
+            echo "Expected breakage, and got it."
+            exit 0
+          else
+            echo "Unexpected breakage detected."
+          fi
+          exit $status
+        working-directory: golang/cosmos
+        env:
+          REPO: https://github.com/${{ github.repository }}.git
+          BRANCH: ${{ github.base_ref}}
+          EXPECT_BREAKAGE: ${{ contains( github.event.pull_request.labels.*.name, 'proto:expect-breakage') }}
   up-to-date:
     runs-on: ubuntu-latest
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,13 +10,7 @@ shared:
           - check-pending=integration-test-result
           - check-success=integration-test-result
           - label=bypass:integration
-      - or:
-          - and: # breakage succeeds like we thought
-              - check-success=breakage
-              - -label=proto:expect-breakage
-          - and: # breakage fails like we thought
-              - check-failure=breakage
-              - label=proto:expect-breakage
+      - check-success=breakage
     merge_conditions: &merge-conditions
       - base=master
       # Rebase PRs with fixup commits are allowed to enter the merge queue but 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #11414 

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Simplifies mergify logic. Extracted from dee5db6f12a6a454a2eac086e825325727ffb1d7

Tests on a mergify-experiment fork:

Case: [check is not breaking but breakage is expected](https://github.com/mujahidkay/mergify-experiements/pull/4) (by adding label)
Result: proto workflow fails. mergify does NOT rightfully put the PR on the queue


Case: [check is breaking and breakage is expected](https://github.com/mujahidkay/mergify-experiements/pull/3/)
Result: proto workflow passes. mergify queues the PR to be merged and merges it
([this](https://github.com/mujahidkay/mergify-experiements/pull/3/commits/480f32a471f4337c75f9fa8200620e9e2833dbf3) tests the condition where breakage occurs but no label is added to expect it)

Case: [check is breaking and breakage is not expected](https://github.com/mujahidkay/mergify-experiements/pull/5)
Result: proto workflow fails. mergify doesn't put the PR on queue

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
None

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
verified via mergify-experiments.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
None