### PR TITLE
refactor: use shorter failure idiom

### DIFF
--- a/packages/ERTP/test/swingsetTests/basicFunctionality/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/bootstrap.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { assert, X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import { Far } from '@endo/marshal';
 import { makeIssuerKit, AmountMath } from '../../../src/index.js';
 
@@ -24,7 +24,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return testBasicFunctionality(aliceMaker);
         }
         default: {
-          assert.fail(X`unrecognized argument value ${arg0}`);
+          Fail`unrecognized argument value ${arg0}`;
         }
       }
     },

--- a/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { assert, X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import { Far } from '@endo/marshal';
 import { makeIssuerKit, AmountMath } from '../../../src/index.js';
 
@@ -23,7 +23,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return testSplitPayments(aliceMaker);
         }
         default: {
-          assert.fail(X`unrecognized argument value ${arg0}`);
+          Fail`unrecognized argument value ${arg0}`;
         }
       }
     },

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import { assert, X } from '@endo/errors';
+import { assert, Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { showPurseBalance, setupIssuers } from '../helpers.js';
@@ -78,7 +78,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       .getOfferResult()
       .then(
         o => log(`Successful refund: ${o}`),
-        e => assert(false, X`Expected swap outcome to succeed ${e}`),
+        e => Fail`Expected swap outcome to succeed ${e}`,
       );
     const newPurse = await E(moolaIssuer).makeEmptyPurse();
     const swapMoolaPayout = await E(secondSeat).getPayout('Asset');
@@ -130,7 +130,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
               return log(`Swap outcome is an invitation (${val}).`);
             });
         },
-        e => assert(false, X`expected outcome not to resolve yet ${e}`),
+        e => Fail`expected outcome not to resolve yet ${e}`,
       );
     await logCounter(log, publicFacet);
 
@@ -183,7 +183,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       .getOfferResult()
       .then(
         o => log(`outcome correctly resolves: "${o}"`),
-        e => assert(false, X`expected outcome to succeed ${e}`),
+        e => Fail`expected outcome to succeed ${e}`,
       );
     const moolaSwapTwoPayout = await E(swapSeatTwo).getPayout('Asset');
     const simoleanSwapTwoPayout = await E(swapSeatTwo).getPayout('Price');
@@ -399,7 +399,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
           return doSadTermination();
         }
         default: {
-          assert.fail(X`testName ${testName} not recognized`);
+          Fail`testName ${testName} not recognized`;
         }
       }
     },

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/bootstrap-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/bootstrap-coveredCall-service-upgrade.js
@@ -1,4 +1,4 @@
-import { q, X } from '@endo/errors';
+import { q, Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
@@ -55,9 +55,7 @@ const depositPayout = (seat, keyword, purse, expectedAmount) => {
     })
     .then(depositAmount => {
       AmountMath.isEqual(depositAmount, expectedAmount) ||
-        assert.fail(
-          X`amounts don't match: ${q(depositAmount)}, ${q(expectedAmount)}`,
-        );
+        Fail`amounts don't match: ${q(depositAmount)}, ${q(expectedAmount)}`;
     });
 };
 

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -69,9 +69,9 @@ export const start = async (zcf, _privateArgs, instanceBaggage) => {
     );
     const sellSeatExitRule = sellSeat.getProposal().exit;
     if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
-      // TypeScript confused about `||` control flow so use `if` instead
+      // TypeScript confused about `||` control flow so use `if/throw` instead
       // https://github.com/microsoft/TypeScript/issues/50739
-      Fail`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`;
+      throw Fail`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`;
     }
     const exerciseOption = makeExerciser(sellSeat);
     const customDetails = harden({

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,4 +1,4 @@
-import { X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import { M, mustMatch } from '@agoric/store';
 import { prepareExoClass, prepareExo } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
@@ -71,9 +71,7 @@ export const start = async (zcf, _privateArgs, instanceBaggage) => {
     if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
       // TypeScript confused about `||` control flow so use `if` instead
       // https://github.com/microsoft/TypeScript/issues/50739
-      assert.fail(
-        X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
-      );
+      Fail`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`;
     }
     const exerciseOption = makeExerciser(sellSeat);
     const customDetails = harden({

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -1,4 +1,4 @@
-import { assert, X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
@@ -605,7 +605,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           return doShutdownAutoswap();
         }
         default: {
-          assert.fail(X`testName ${testName} not recognized`);
+          Fail`testName ${testName} not recognized`;
         }
       }
     },

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -1,4 +1,4 @@
-import { assert, X } from '@endo/errors';
+import { assert, X, Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { keyEQ } from '@agoric/store';
@@ -29,11 +29,11 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Bob ensures it's the contract he expects
       installations.automaticRefund === installation ||
-        assert.fail(X`should be the expected automaticRefund`);
+        Fail`should be the expected automaticRefund`;
       issuerKeywordRecord.Contribution1 === moolaIssuer ||
-        assert.fail(X`The first issuer should be the moola issuer`);
+        Fail`The first issuer should be the moola issuer`;
       issuerKeywordRecord.Contribution2 === simoleanIssuer ||
-        assert.fail(X`The second issuer should be the simolean issuer`);
+        Fail`The second issuer should be the simolean issuer`;
 
       // 1. Bob escrows his offer
       const bobProposal = harden({
@@ -85,8 +85,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(typeof customDetails === 'object');
 
       assert(installation === installations.coveredCall, X`wrong installation`);
-      optionValue[0].description === 'exerciseOption' ||
-        assert.fail(X`wrong invitation`);
+      optionValue[0].description === 'exerciseOption' || Fail`wrong invitation`;
       assert(
         AmountMath.isEqual(
           customDetails.underlyingAssets.UnderlyingAsset,
@@ -103,9 +102,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(customDetails.timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
       UnderlyingAsset === moolaIssuer ||
-        assert.fail(X`The underlying asset issuer should be the moola issuer`);
+        Fail`The underlying asset issuer should be the moola issuer`;
       StrikePrice === simoleanIssuer ||
-        assert.fail(X`The strike price issuer should be the simolean issuer`);
+        Fail`The strike price issuer should be the simolean issuer`;
 
       const bobPayments = { StrikePrice: simoleanPayment };
       // Bob escrows
@@ -147,8 +146,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(typeof customDetails === 'object');
 
       assert(installation === installations.coveredCall, X`wrong installation`);
-      optionValue[0].description === 'exerciseOption' ||
-        assert.fail(X`wrong invitation`);
+      optionValue[0].description === 'exerciseOption' || Fail`wrong invitation`;
       assert(
         AmountMath.isEqual(
           customDetails.underlyingAssets.UnderlyingAsset,
@@ -166,9 +164,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(customDetails.expirationDate === 100n, X`wrong expiration date`);
       assert(customDetails.timeAuthority === timer, X`wrong timer`);
       UnderlyingAsset === moolaIssuer ||
-        assert.fail(X`The underlyingAsset issuer should be the moola issuer`);
+        Fail`The underlyingAsset issuer should be the moola issuer`;
       StrikePrice === simoleanIssuer ||
-        assert.fail(X`The strikePrice issuer should be the simolean issuer`);
+        Fail`The strikePrice issuer should be the simolean issuer`;
 
       // Let's imagine that Bob wants to create a swap to trade this
       // invitation for bucks. He wants to invitation Dave as the
@@ -221,7 +219,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: invitationValue } =
         await E(invitationIssuer).getAmountOf(exclInvitation);
       installation === installations.secondPriceAuction ||
-        assert.fail(X`wrong installation`);
+        Fail`wrong installation`;
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -279,9 +277,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`issuers were not as expected`,
       );
       keyEQ(invitationValue[0].customDetails?.asset, moola(3n)) ||
-        assert.fail(X`Alice made a different offer than expected`);
+        Fail`Alice made a different offer than expected`;
       keyEQ(invitationValue[0].customDetails?.price, simoleans(7n)) ||
-        assert.fail(X`Alice made a different offer than expected`);
+        Fail`Alice made a different offer than expected`;
 
       const proposal = harden({
         want: { Asset: moola(3n) },
@@ -315,12 +313,11 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         invitation,
       );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      installation === installations.simpleExchange ||
-        assert.fail(X`wrong installation`);
+      installation === installations.simpleExchange || Fail`wrong installation`;
       issuerKeywordRecord.Asset === moolaIssuer ||
-        assert.fail(X`The first issuer should be the moola issuer`);
+        Fail`The first issuer should be the moola issuer`;
       issuerKeywordRecord.Price === simoleanIssuer ||
-        assert.fail(X`The second issuer should be the simolean issuer`);
+        Fail`The second issuer should be the simolean issuer`;
 
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(3n) },
@@ -354,12 +351,11 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      installation === installations.simpleExchange ||
-        assert.fail(X`wrong installation`);
+      installation === installations.simpleExchange || Fail`wrong installation`;
       issuerKeywordRecord.Asset === moolaIssuer ||
-        assert.fail(X`The first issuer should be the moola issuer`);
+        Fail`The first issuer should be the moola issuer`;
       issuerKeywordRecord.Price === simoleanIssuer ||
-        assert.fail(X`The second issuer should be the simolean issuer`);
+        Fail`The second issuer should be the simolean issuer`;
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(m) },
         give: { Price: simoleans(s) },

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -1,4 +1,4 @@
-import { assert, X } from '@endo/errors';
+import { assert, X, Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { keyEQ } from '@agoric/store';
@@ -26,7 +26,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       const { value: invitationValue } =
         await E(invitationIssuer).getAmountOf(invitation);
       installation === installations.secondPriceAuction ||
-        assert.fail(X`wrong installation`);
+        Fail`wrong installation`;
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -27,7 +27,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: invitationValue } =
         await E(invitationIssuer).getAmountOf(exclInvitation);
       installation === installations.secondPriceAuction ||
-        assert.fail(X`wrong installation`);
+        Fail`wrong installation`;
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -1,4 +1,4 @@
-import { assert, X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
@@ -56,7 +56,7 @@ const start = async zcf => {
       assertProposalShape(bountySeat, feeProposal);
       const feeAmount = bountySeat.getCurrentAllocation().Fee;
       AmountMath.isGTE(feeAmount, fee) ||
-        assert.fail(X`Fee was required to be at least ${fee}`);
+        Fail`Fee was required to be at least ${fee}`;
 
       // The funder gets the fee regardless of the outcome.
       atomicTransfer(zcf, bountySeat, funderSeat, {

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import { X, q } from '@endo/errors';
+import { Fail, q } from '@endo/errors';
 import { Far } from '@endo/marshal';
 import { makeScalarMapStore } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
@@ -39,7 +39,7 @@ const start = zcf => {
   const assertResponse = response => {
     response === 'NO' ||
       response === 'YES' ||
-      assert.fail(X`the answer ${q(response)} was not 'YES' or 'NO'`);
+      Fail`the answer ${q(response)} was not 'YES' or 'NO'`;
     // Throw an error if the response is not valid, but do not
     // exit the seat. We should allow the voter to recast their vote.
   };

--- a/packages/zoe/test/unitTests/contracts/oracle.test.js
+++ b/packages/zoe/test/unitTests/contracts/oracle.test.js
@@ -2,7 +2,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import path from 'path';
 
-import { assert, X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import bundleSource from '@endo/bundle-source';
 import { Far } from '@endo/marshal';
 import { E } from '@endo/eventual-send';
@@ -65,7 +65,7 @@ test.before(
           if (query.kind === 'Paid') {
             requiredFee = feeAmount;
             AmountMath.isGTE(fee, requiredFee) ||
-              assert.fail(X`Minimum fee of ${feeAmount} not met; have ${fee}`);
+              Fail`Minimum fee of ${feeAmount} not met; have ${fee}`;
           }
           const reply = { pong: query };
           return harden({ reply, requiredFee });

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -1,4 +1,4 @@
-import { X } from '@endo/errors';
+import { Fail } from '@endo/errors';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
@@ -44,9 +44,7 @@ const start = zcf => {
         // Ensure that the amount of pixels that we want to color is
         // covered by what is actually escrowed.
         AmountMath.isGTE(escrowedAmount, amountToColor) ||
-          assert.fail(
-            X`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
-          );
+          Fail`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`;
 
         // Pretend to color
         return `successfully colored ${amountToColor.value} pixels ${color}`;


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2852

## Description


Whenever we say, for example, 
```js
assert.fail(X`...`)
```
we should instead say
```js
Fail`...`
```

This PR is a refactor doing exactly this.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations

All the changes were in tests

### Upgrade Considerations
none