### PR TITLE
docs(MAINTAINERS.md): Add a task to update cosmos/chain-registry

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -352,6 +352,11 @@ to pass and for reviewer approval.
   with the proposal directory's **package.json** `agoricProposal` updated to include `releaseNotes`
   and `upgradeInfo` matching the mainnet proposal.
 
+- [ ] Open a [cosmos/chain-registry](https://github.com/cosmos/chain-registry) PR to document the
+  new version in both
+  [agoric/chain.json](https://github.com/cosmos/chain-registry/blob/master/agoric/chain.json) and
+  [agoric/versions.json](https://github.com/cosmos/chain-registry/blob/master/agoric/versions.json).
+
 ## More subtlety
 
 To get help for the command-line options that will affect these commands, use:


### PR DESCRIPTION
## Description
This is already mentioned in internal documents, but should be in the canonical maintainer's guide.