### PR TITLE
test(portfolio-contract): no need to bundle

### DIFF
--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -8,17 +8,14 @@ import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { E, passStyleOf } from '@endo/far';
 import { M, mustMatch } from '@endo/patterns';
 import type { ExecutionContext } from 'ava';
-import { createRequire } from 'module';
+import * as contractExports from '../src/portfolio.contract.ts';
 import { makeUSDNIBCTraffic } from './mocks.ts';
 import { makeTrader } from './portfolio-actors.ts';
 import { setupPortfolioTest } from './supports.ts';
 import { makeWallet } from './wallet-offer-tools.ts';
 
-const nodeRequire = createRequire(import.meta.url);
-
 const contractName = 'ymax0';
-const contractFile = nodeRequire.resolve('../src/portfolio.contract.ts');
-type StartFn = typeof import('../src/portfolio.contract.ts').start;
+type StartFn = typeof contractExports.start;
 
 /** from https://www.mintscan.io/noble explorer */
 const explored = [
@@ -55,7 +52,7 @@ const deploy = async (t: ExecutionContext) => {
   t.log('contract deployment', contractName);
 
   const installation: Installation<StartFn> =
-    await bundleAndInstall(contractFile);
+    await bundleAndInstall(contractExports);
   t.is(passStyleOf(installation), 'remotable');
 
   const { usdc } = common.brands;


### PR DESCRIPTION
incidental

## Description / Testing Considerations

use `contractExports` in contract test to reduce running time from 6.7sec to 562ms

### Security / Scaling / Documentation / Upgrade Considerations

n/a