### PR TITLE
Update portfolio.exo.ts

### DIFF
--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -61,7 +61,7 @@ const PositionShape = M.splitRecord({}); // TODO
 const KeeperI = M.interface('keeper', {
   add: M.call(
     TypeShape,
-    M.or(ChainShape),
+    ChainShape,
     M.remotable('OrchestrationAccount'),
   ).returns(M.number()),
   getPositions: M.call(TypeShape, ChainShape).returns(M.arrayOf(PositionShape)),


### PR DESCRIPTION
`M.or()` accidently appears twice in the arg 1 shape match.

In devnet logs I see:
`SwingSet: ls: v154: Error#6: In "add" method of (Portfolio keeper): arg 1: (a string) - Must match one of ["[match:or]"]`