### PR TITLE
chore(multichain-testing): Add liquidity in swap pool on noble chain start

### DIFF
--- a/multichain-testing/scripts/create-noble-swap-pool.ts
+++ b/multichain-testing/scripts/create-noble-swap-pool.ts
@@ -283,7 +283,10 @@ Options:
 
   // Add liquidity in pool with uusdc and uusdn
   const args = {
-    amount: { uusdc: '1000000000', uusdn: '1000000000' },
+    amount: {
+      uusdc: `${50_000n * 1_000_000n}`,
+      uusdn: `${50_000n * 1_000_000n}`,
+    },
     slippagePercentage: '5',
     poolId: '0',
   };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/agoric-sdk/issues/11513
refs: https://github.com/Agoric/agoric-sdk/issues/11513

## Description
This PR adds code to add liquidity in swap pool for making `tx swap swap` operation ready. By default when a swap pool is created, it has empty liquidity which throws error while performing swap:
```
Error: rpc error: ... error computing swap routes plan: pool liquidity must be positive
```

The `create-noble-swap-pool.ts` script is updated to add-liquidity after swap pool creation and wait/poll for it's creation (will throw if liquidity not added).

**Changes in genesis:**

1) Added `uusdn` in `genesis` account as initial bank balance.
2) Added `uusdn` denom metadata.
3) Added `uusdn` in bank module supply.


**No Changes `noble-usdn-lab.ts`**:

Changes in `noble-usdn-lab.ts` is already in-progress in a separate [PR](https://github.com/Agoric/agoric-sdk/pull/11516/files) (owned by Dan). I avoided making any duplicate changes in my PR so that there is one source of lab related work and changes. It introduces `whale` account as well (which can be replaced from genesis account for adding liquidity).



**NOTE:** _Tested swap in chain after noble chain started through starship_


<img width="898" alt="image" src="https://github.com/user-attachments/assets/dbb22724-7f1f-4dc9-8c3a-6159e4261110" />


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
