### PR TITLE
feat: gate YMax PoC access with a token

### DIFF
--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -88,7 +88,7 @@ export const contract = async (
     log: trace,
   });
 
-  const proposalShapes = makeProposalShapes(brands.USDC);
+  const proposalShapes = makeProposalShapes(brands.USDC, brands.Access);
 
   const inertSubscriber: ResolvedPublicTopic<never>['subscriber'] = {
     getUpdateSince() {

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -23,8 +23,8 @@ import {
 import { axelarChainsMap, makeUSDNIBCTraffic } from './mocks.ts';
 import { makeTrader } from './portfolio-actors.ts';
 import {
-  makeIncomingEVMEvent,
   chainInfoFantasyTODO,
+  makeIncomingEVMEvent,
   setupPortfolioTest,
 } from './supports.ts';
 import { makeWallet } from './wallet-offer-tools.ts';
@@ -116,7 +116,7 @@ export const setupTrader = async (t, initial = 10_000) => {
   const trader1 = makeTrader(myWallet, started.instance);
 
   const { ibcBridge } = common.mocks;
-  for (const { msg, ack } of Object.values(makeUSDNIBCTraffic())) {
+  for (const { msg, ack } of values(makeUSDNIBCTraffic())) {
     ibcBridge.addMockAck(msg, ack);
   }
 
@@ -357,11 +357,6 @@ test('open a portfolio with Compound position', async t => {
   const { trader1, common } = await setupTrader(t);
   const { usdc, poc24 } = common.brands;
 
-  const { ibcBridge } = common.mocks;
-  for (const { msg, ack } of Object.values(makeUSDNIBCTraffic())) {
-    ibcBridge.addMockAck(msg, ack);
-  }
-
   const actualP = trader1.openPortfolio(
     t,
     {
@@ -423,11 +418,6 @@ test('open a portfolio with Compound position', async t => {
 test('open portfolio with USDN, Aave positions', async t => {
   const { trader1, common } = await setupTrader(t);
   const { usdc, poc24 } = common.brands;
-
-  const { ibcBridge } = common.mocks;
-  for (const { msg, ack } of Object.values(makeUSDNIBCTraffic())) {
-    ibcBridge.addMockAck(msg, ack);
-  }
 
   const doneP = trader1.openPortfolio(
     t,

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -62,7 +62,8 @@ export {
   makeFakeTransferBridge,
 } from '@agoric/vats/tools/fake-bridge.js';
 
-export const chainInfo = {
+/** TODO: how to address this in production? route thru Osmosis? */
+export const chainInfoFantasyTODO = {
   ...withChainCapabilities(fetchedChainInfo),
   noble: {
     ...withChainCapabilities(fetchedChainInfo).noble,
@@ -135,12 +136,20 @@ export const setupPortfolioTest = async ({
     bootstrap: { agoricNamesAdmin, bankManager },
   } = common;
   const usdc = withAmountUtils(makeIssuerKit('USDC'));
+  const poc24 = withAmountUtils(makeIssuerKit('Poc24'));
   await E(bankManager).addAsset(
     uusdcOnAgoric,
     'USDC',
     'USD Circle Stablecoin',
     usdc.issuerKit,
   );
+  await E(bankManager).addAsset(
+    'upoc24',
+    'Poc24',
+    'Proof of Concept Access',
+    poc24.issuerKit,
+  );
+
   // These mints no longer stay in sync with bankManager.
   // Use pourPayment() for IST.
   const { mint: _i, ...usdcSansMint } = usdc;
@@ -168,7 +177,7 @@ export const setupPortfolioTest = async ({
 
   return {
     ...common,
-    brands: { usdc: usdcSansMint },
+    brands: { usdc: usdcSansMint, poc24 },
     commonPrivateArgs: {
       ...commonPrivateArgs,
       assetInfo,

--- a/packages/portfolio-contract/test/wallet-offer-tools.ts
+++ b/packages/portfolio-contract/test/wallet-offer-tools.ts
@@ -75,16 +75,19 @@ export interface WalletTool {
 }
 
 export const makeWallet = (
-  assets: Record<'USDC', Omit<ReturnType<typeof withAmountUtils>, 'mint'>>,
+  assets: Record<
+    'USDC' | 'Access',
+    Omit<ReturnType<typeof withAmountUtils>, 'mint'>
+  >,
   zoe: ZoeService,
   when,
 ): WalletTool => {
   const purses = {
     USDC: assets.USDC.issuer.makeEmptyPurse(),
+    Access: assets.Access.issuer.makeEmptyPurse(),
   };
 
-  /** @param {Brand} b */
-  const providePurse = b =>
+  const providePurse = (b: Brand) =>
     purses[
       keys(assets).find(k => assets[k].brand === b) || Fail`no purse for ${b}`
     ];

--- a/packages/portfolio-deploy/README.md
+++ b/packages/portfolio-deploy/README.md
@@ -2,6 +2,40 @@
 
 This package contains deployment facilities for the Portfolio contract.
 
+## Deployment (Review)
+
+This package follows the Agoric deployment pattern:
+1. Build contract bundles
+2. Install bundles (requires IST for fees)
+3. Submit CoreEval proposal to governance
+4. Wait for proposal to pass and contract to be instantiated
+
+## Access Token
+
+```sh
+agoric run ./src/access-token-setup.build.js \
+  [--beneficiary=agoric1...]
+```
+
+_beneficiary defaults to gov1_
+
+Then submit the resulting bundles and core-eval as usual.
+
+## Chain Info
+
+```sh
+agoric run src/chain-info.build.js --net=devnet --peer=...
+```
+
+_... IOU; see also branch by Fraz_
+
+## Contract Deployment - DevNet
+
+```
+yarn deploy:devnet
+...IOU some detail; see internal chat...
+```
+
 ## Structure
 
 - `src/portfolio-start.core.ts` - Core evaluation script for contract instantiation
@@ -18,11 +52,3 @@ yarn build
 # Run tests
 yarn test
 ```
-
-## Deployment
-
-This package follows the Agoric deployment pattern:
-1. Build contract bundles
-2. Install bundles (requires IST for fees)
-3. Submit CoreEval proposal to governance
-4. Wait for proposal to pass and contract to be instantiated

--- a/packages/portfolio-deploy/src/access-token-setup.build.js
+++ b/packages/portfolio-deploy/src/access-token-setup.build.js
@@ -1,0 +1,49 @@
+/* global harden */
+/// <reference types="ses" />
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { parseArgs } from 'node:util';
+
+// based on register-interchain-bank-assets.builder.js
+
+/**
+ * @import {ParseArgsConfig} from 'node:util';
+ * @import {CoreEvalBuilder, DeployScriptFunction} from '@agoric/deploy-script-support/src/externalTypes.js';
+ */
+
+/**
+ * @param {*} _
+ * @param {*} options
+ * @satisfies {CoreEvalBuilder}
+ */
+export const defaultProposalBuilder = async (_, options) => {
+  return harden({
+    sourceSpec: './access-token-setup.core.js',
+    getManifestCall: ['getManifestCall', options],
+  });
+};
+
+/** @type {DeployScriptFunction} */
+export default async (homeP, endowments) => {
+  const { scriptArgs } = endowments;
+
+  const {
+    values: { qty: qtyNumeral, beneficiary },
+  } = parseArgs({
+    args: scriptArgs,
+    options: {
+      qty: { type: 'string', default: '50000000' },
+      beneficiary: {
+        type: 'string',
+        default: 'agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce',
+      },
+    },
+  });
+
+  const opts = harden({ qty: Number(qtyNumeral), beneficiary });
+
+  console.log('CONFIG:', opts);
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('eval-access-token-setup', utils =>
+    defaultProposalBuilder(utils, opts),
+  );
+};

--- a/packages/portfolio-deploy/src/access-token-setup.core.js
+++ b/packages/portfolio-deploy/src/access-token-setup.core.js
@@ -122,8 +122,6 @@ export const createPoCAsset = async (
   const brand = await E(issuer).getBrand();
   const amt = harden({ brand, value: BigInt(qty) });
   const supply = await E(mint).mintPayment(amt);
-  await E(depositFacet).receive(supply);
-  trace('sent', amt, 'to', beneficiary);
 
   const kit = /** @type {IssuerKit<'nat'>} */ ({ mint, issuer, brand });
 
@@ -139,6 +137,9 @@ export const createPoCAsset = async (
     // be unique' in provisionPool in testing environments
     E(bankManager).addAsset(denom, issuerName, proposedName, kit),
   ]);
+
+  await E(depositFacet).receive(supply);
+  trace('sent', amt, 'to', beneficiary);
 
   // publish brands and issuers to Bootstrap space for use in proposals
   produceBrands[issuerName].reset();

--- a/packages/portfolio-deploy/src/access-token-setup.core.js
+++ b/packages/portfolio-deploy/src/access-token-setup.core.js
@@ -1,0 +1,186 @@
+/**
+ * @file Core Eval to register PoC access token
+ *
+ * based on register-interchain-bank-assets.js
+ */
+import { AssetKind } from '@agoric/ertp';
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
+
+const { Fail } = assert;
+
+const trace = makeTracer('PoC-CE', true);
+
+/** @import {Board} from '@agoric/vats'; */
+
+const PoCInfo = /** @type {const} */ ({
+  issuerName: 'PoC25',
+  denom: 'upoc25',
+  decimalPlaces: 1,
+});
+harden(PoCInfo);
+
+// vstorage paths under published.
+const BOARD_AUX = 'boardAux';
+
+const marshalData = makeMarshal(_val => Fail`data only`);
+
+/**
+ * Make a storage node for auxiliary data for a value on the board.
+ *
+ * @param {ERef<StorageNode>} chainStorage
+ * @param {string} boardId
+ */
+const makeBoardAuxNode = async (chainStorage, boardId) => {
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  return E(boardAux).makeChildNode(boardId);
+};
+
+/**
+ * see `publishAgoricBrandsDisplayInfo` {@link @agoric/smart-wallet/proposals/upgrade-walletFactory-proposal.js}
+ *
+ * @param {ERef<StorageNode>} chainStorage
+ * @param {ERef<Board>} board
+ * @param {Brand<'nat'>} brand
+ */
+const publishBrandInfo = async (chainStorage, board, brand) => {
+  const [boardId, displayInfo, allegedName] = await Promise.all([
+    E(board).getId(brand),
+    E(brand).getDisplayInfo(),
+    E(brand).getAllegedName(),
+  ]);
+  const node = makeBoardAuxNode(chainStorage, boardId);
+  const aux = marshalData.toCapData(harden({ allegedName, displayInfo }));
+  await E(node).setValue(JSON.stringify(aux));
+};
+
+/**
+ * @param {BootstrapPowers} powers
+ * @param {{ options: { qty: number, beneficiary: string } }} config
+ */
+export const createPoCAsset = async (
+  {
+    consume: {
+      agoricNamesAdmin,
+      bankManager,
+      board,
+      chainStorage,
+      startUpgradable,
+      namesByAddress,
+    },
+    brand: { produce: produceBrands },
+    issuer: { produce: produceIssuers },
+    installation: {
+      consume: { mintHolder },
+    },
+  },
+  { options: { qty, beneficiary } },
+) => {
+  trace(`${createPoCAsset.name} starting...`);
+  trace(PoCInfo);
+  await null;
+  const {
+    denom,
+    decimalPlaces,
+    issuerName,
+    proposedName = issuerName,
+  } = PoCInfo;
+
+  trace('interchainAssetOptions', {
+    denom,
+    decimalPlaces,
+    issuerName,
+    proposedName,
+  });
+  trace('config', { qty, beneficiary });
+
+  // look up *before* starting the mintHolder
+  /** @type {import('@agoric/ertp').DepositFacet} */
+  const depositFacet = await E(namesByAddress).lookup(
+    beneficiary,
+    'depositFacet',
+  );
+
+  const terms = {
+    keyword: issuerName, // "keyword" is a misnomer in mintHolder terms
+    assetKind: AssetKind.NAT,
+    displayInfo: {
+      decimalPlaces,
+      assetKind: AssetKind.NAT,
+    },
+  };
+  const { creatorFacet: mint, publicFacet: issuer } = await E(startUpgradable)({
+    installation: mintHolder,
+    label: issuerName,
+    privateArgs: undefined,
+    terms,
+  });
+
+  /** @type {Brand<'nat'>} */
+  // @ts-expect-error narrow AssetKind
+  const brand = await E(issuer).getBrand();
+  const amt = harden({ brand, value: BigInt(qty) });
+  const supply = await E(mint).mintPayment(amt);
+  await E(depositFacet).receive(supply);
+  trace('sent', amt, 'to', beneficiary);
+
+  const kit = /** @type {IssuerKit<'nat'>} */ ({ mint, issuer, brand });
+
+  /**
+   * `addAssetToVault.js` will register the issuer with the `reserveKit`,
+   * but we don't need to do that here.
+   */
+
+  await Promise.all([
+    E(E(agoricNamesAdmin).lookupAdmin('issuer')).update(issuerName, issuer),
+    E(E(agoricNamesAdmin).lookupAdmin('brand')).update(issuerName, brand),
+    // triggers benign UnhandledPromiseRejection 'Error: keyword "ATOM" must
+    // be unique' in provisionPool in testing environments
+    E(bankManager).addAsset(denom, issuerName, proposedName, kit),
+  ]);
+
+  // publish brands and issuers to Bootstrap space for use in proposals
+  produceBrands[issuerName].reset();
+  produceIssuers[issuerName].reset();
+  produceBrands[issuerName].resolve(brand);
+  produceIssuers[issuerName].resolve(issuer);
+
+  // publish brand info / boardAux for offer legibility
+  await publishBrandInfo(
+    // @ts-expect-error 'Promise<StorageNode | null>' is not assignable to
+    // parameter of type 'ERef<StorageNode>'
+    chainStorage,
+    board,
+    brand,
+  );
+
+  trace(`${createPoCAsset.name} complete`);
+};
+
+/**
+ * @param {unknown} _powers
+ * @param {{ qty: number, beneficiary: string }} options
+ */
+export const getManifestCall = (_powers, options) => {
+  return {
+    manifest: {
+      [createPoCAsset.name]: {
+        consume: {
+          agoricNamesAdmin: true,
+          namesByAddress: true,
+          bankManager: true,
+          board: true,
+          chainStorage: true,
+          startUpgradable: true,
+        },
+        brand: { produce: { PoC25: true } },
+        issuer: { produce: { PoC25: true } },
+        installation: {
+          consume: { mintHolder: true },
+        },
+      },
+    },
+    options,
+  };
+};

--- a/packages/portfolio-deploy/src/portfolio.contract.permit.js
+++ b/packages/portfolio-deploy/src/portfolio.contract.permit.js
@@ -16,6 +16,6 @@ export const permit = /** @type {const} */ ({
   instance: { produce: { [name]: true } },
   installation: { consume: { [name]: true } },
   brand: {},
-  issuer: { consume: { USDC: true } },
+  issuer: { consume: { USDC: true, PoC25: true } },
 });
 harden(permit);

--- a/packages/portfolio-deploy/test/portfolio-start.core.test.ts
+++ b/packages/portfolio-deploy/test/portfolio-start.core.test.ts
@@ -55,7 +55,7 @@ test('coreEval code without swingset', async t => {
   // XXX type of zoe from setUpZoeForTest is any???
   const { zoe: zoeAny, bundleAndInstall } = await setUpZoeForTest();
   const zoe: ZoeService = zoeAny;
-  const { usdc } = common.brands;
+  const { usdc, poc24 } = common.brands;
 
   {
     t.log('produce bootstrap entries from commonSetup()', keys(bootstrap));
@@ -121,7 +121,12 @@ test('coreEval code without swingset', async t => {
   t.is(passStyleOf(instance), 'remotable');
 
   const { vowTools, pourPayment } = utils;
-  const wallet = makeWallet({ USDC: usdc }, zoe, vowTools.when);
+  const { mint: _, ...poc24sansMint } = poc24;
+  const wallet = makeWallet(
+    { USDC: usdc, Access: poc24sansMint },
+    zoe,
+    vowTools.when,
+  );
   await wallet.deposit(await pourPayment(usdc.units(10_000)));
   const silvia = makeTrader(wallet, instance);
   const actualP = silvia.openPortfolio(t, { USDN: usdc.units(3_333) });

--- a/packages/portfolio-deploy/test/portfolio-start.core.test.ts
+++ b/packages/portfolio-deploy/test/portfolio-start.core.test.ts
@@ -73,7 +73,10 @@ test('coreEval code without swingset', async t => {
       }
     }
 
-    for (const [name, { brand, issuer }] of entries({ USDC: usdc })) {
+    for (const [name, { brand, issuer }] of entries({
+      USDC: usdc,
+      PoC25: poc24,
+    })) {
       t.log('produce brand, issuer for', name);
       wk.brand.produce[name].resolve(brand);
       wk.issuer.produce[name].resolve(issuer);


### PR DESCRIPTION
## Description

 - contract
   - add Access to proposal shapes
   - note chainInfoFantasyTODO axelar / noble
   - factor out setupTrader
 - deployment
   - core eval to start `mintHolder` and send supply to a beneficiary

### Security Considerations

In the interest of compatibility with existing clients, the contract fails open if it is run without an `Access` issuer.
Only the closed mode is tested, though.

### Scaling Considerations

This should mitigate scaling considerations to some extent.

### Documentation Considerations

Chain governance is asked to reserve the issuer / brand name **PoC25** for this purpose.

### Testing Considerations

 - unit tests for ProposalShapes expanded
 - `openPortfolio()` calls in contract tests and deployment tests updated
 - deployment test for the mintHolder core eval

### Upgrade Considerations

not yet in prod