### PR TITLE
test(multichain): deploy, use ymax0

### DIFF
--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -174,3 +174,13 @@ agoricNames.chain:
 	yarn test:main test/ymax0 -m chain-info || \
 	./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/chain-info.build.js \
 		  net=local peer=noble:connection-0:channel-0:uusdc
+
+##
+# Using ymax
+open-with-usdn: deploy-ymax usdc-available ./scripts/ymax-tool.ts
+	./scripts/ymax-tool.ts 1.01
+
+usdc-available: ./scripts/noble-usdn-lab.ts
+	yarn test:main test/ymax0 -m usdc-available || \
+	(FAUCET=trader1 NET=starship ./scripts/noble-usdn-lab.ts && \
+	TXFR=9950000 NET=starship ./scripts/noble-usdn-lab.ts)

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -100,7 +100,7 @@ register-bank-assets:
 		assets="$$(scripts/make-bank-asset-info.ts)"
 
 ADDR=agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce
-COIN=1000000000uist
+COIN=1000000000uist,25000000ubld
 
 fund-wallet:
 	kubectl exec -i agoriclocal-genesis-0 -c validator -- agd tx bank send faucet $(ADDR) $(COIN) -y -b block
@@ -136,3 +136,41 @@ start: sstart fund-provision-pool register-bank-assets create-noble-swap-pool
 .PHONY: sstart
 sstart:
 	$(STARSHIP) start
+
+##
+# YMax testing for https://github.com/Agoric/agoric-sdk/issues/11536
+
+deploy-ymax: poc-asset agoricNames.chain
+	yarn test:main test/ymax0 -m ymax-deployed || \
+	( 	(cd ../packages/portfolio-deploy; yarn build) && \
+		./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/portfolio.build.js)
+
+redeploy-ymax: poc-asset agoricNames.chain
+	date -u
+	(cd ../packages/portfolio-deploy; yarn build)
+	time ./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/portfolio.build.js
+	@echo
+	@echo
+	@echo ======= DEPLOY AGAIN to address the "old code" issue
+	date -u
+	time ./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/portfolio.build.js
+	date -u
+
+# cf. ymax-tool.ts
+TRADER1=noble18qlqfelxhe7tszqqprm2eqdpzt9s6ry025y3j5
+TRADER1ag=agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl
+poc-asset: beneficiary-wallet
+	yarn test:main test/ymax0 -m poc-asset || \
+	./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/access-token-setup.build.js \
+		beneficiary=$(TRADER1ag)
+
+beneficiary-wallet: ./scripts/ymax-tool.ts
+	yarn test:main test/ymax0 -m beneficiary-wallet || \
+	(make ADDR=$(TRADER1ag) fund-wallet && \
+	./scripts/ymax-tool.ts 0.1 --exit-success)
+
+
+agoricNames.chain:
+	yarn test:main test/ymax0 -m chain-info || \
+	./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/chain-info.build.js \
+		  net=local peer=noble:connection-0:channel-0:uusdc

--- a/multichain-testing/ava.rest.config.js
+++ b/multichain-testing/ava.rest.config.js
@@ -14,5 +14,6 @@ export default {
     '!test/queries/**/*.test.*',
     '!test/staking/**/*.test.*',
     '!test/xcs-swap-anything/**/*.test.*',
+    '!test/ymax0/**/*.test.*',
   ],
 };

--- a/multichain-testing/ava.ymd.config.js
+++ b/multichain-testing/ava.ymd.config.js
@@ -1,0 +1,8 @@
+/** @file YMax deploy-check tests */
+import mainConfig from './ava.config.js';
+
+export default {
+  ...mainConfig,
+  files: ['test/ymax0/**/*.test.ts'],
+  timeout: '300s',
+};

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -10,6 +10,7 @@
     "test:fast-usdc": "ava --config ava.fusdc.config.js",
     "test:queries": "ava --config ava.queries.config.js",
     "test:staking": "ava --config ava.staking.config.js",
+    "test:ymd": "ava --config ava.ymd.config.js",
     "test:xcs": "ava --config ava.xcs.config.js"
   },
   "packageManager": "yarn@4.9.1",

--- a/multichain-testing/scripts/noble-usdn-lab.ts
+++ b/multichain-testing/scripts/noble-usdn-lab.ts
@@ -37,6 +37,7 @@ import { makeQueryClient } from '../tools/query.ts';
 import { makeSwapLockMessages } from '@aglocal/portfolio-contract/src/portfolio.flows.ts';
 import { MsgSwap } from '@agoric/cosmic-proto/noble/swap/v1/tx.js';
 import { MsgLock } from '@agoric/cosmic-proto/noble/dollar/vaults/v1/tx.js';
+import starshipChainInfo from '../starship-chain-info.js';
 
 const [poolId, denom, denomTo] = [0, 'uusdc' as const, 'uusdn' as const]; // cf. .flows.ts
 
@@ -45,6 +46,7 @@ const keyring1 = {
     mnemonic:
       'cause eight cattle slot course mail more aware vapor slab hobby match',
     address: 'noble18qlqfelxhe7tszqqprm2eqdpzt9s6ry025y3j5',
+    // agoric address: agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl
   },
   whale: {
     mnemonic:
@@ -61,10 +63,9 @@ type Who = keyof typeof keyring1;
 
 const configs = {
   starship: {
+    ...starshipChainInfo,
     noble: {
-      // XXX should get these from starship registry
-      // meanwhile, see config.ymax.yml
-      chainId: 'noblelocal',
+      ...starshipChainInfo.noble,
       rpc: 'http://localhost:26654',
       api: 'http://localhost:1314',
     },
@@ -333,6 +334,7 @@ const main = async ({
       { connectWithSigner },
     );
     console.log(tx);
+    console.log('XXX check for arrival on agoric not automated');
   }
   if (env.POOL) {
     throw Error('does not work; needs to use authority exec');

--- a/multichain-testing/scripts/noble-usdn-lab.ts
+++ b/multichain-testing/scripts/noble-usdn-lab.ts
@@ -24,14 +24,21 @@ import '@endo/init';
 import { MsgTransfer } from '@agoric/cosmic-proto/ibc/applications/transfer/v1/tx.js';
 import type { StdFee } from '@cosmjs/amino';
 import { stringToPath } from '@cosmjs/crypto';
-import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import {
+  DirectSecp256k1HdWallet,
+  Registry,
+  type GeneratedType,
+} from '@cosmjs/proto-signing';
 import { SigningStargateClient } from '@cosmjs/stargate';
 import { $ } from 'execa';
 import { ConfigContext, useChain, useRegistry } from 'starshipjs';
 import { DEFAULT_TIMEOUT_NS } from '../tools/ibc-transfer.ts';
 import { makeQueryClient } from '../tools/query.ts';
+import { makeSwapLockMessages } from '@aglocal/portfolio-contract/src/portfolio.flows.ts';
+import { MsgSwap } from '@agoric/cosmic-proto/noble/swap/v1/tx.js';
+import { MsgLock } from '@agoric/cosmic-proto/noble/dollar/vaults/v1/tx.js';
 
-const [poolId, denom, denomTo] = [0, 'uusdc', 'uusdn']; // cf. .flows.ts
+const [poolId, denom, denomTo] = [0, 'uusdc' as const, 'uusdn' as const]; // cf. .flows.ts
 
 const keyring1 = {
   trader1: {
@@ -245,6 +252,58 @@ const lockUSDN = async (
   console.log({ txhash, url: `${config.noble.explorer}/tx/${txhash}` });
 };
 
+const nobleRegistryTypes: [string, GeneratedType][] = [
+  [MsgSwap.typeUrl, MsgSwap as GeneratedType],
+  [MsgLock.typeUrl, MsgLock as GeneratedType],
+];
+
+const swapAndLock = async (
+  amount: bigint,
+  config: typeof configs.testnet,
+  {
+    connectWithSigner,
+  }: { connectWithSigner: typeof SigningStargateClient.connectWithSigner },
+  memo = 'noble-usdn-lab',
+) => {
+  const [nobleWallet] = await Promise.all(
+    [{ prefix: 'noble' }].map(opts => makeWallet('trader1', opts)),
+  );
+  const [{ address: signer }] = await nobleWallet.getAccounts();
+
+  const { chainId } = config.noble;
+
+  const usdnOut = (amount * 99n) / 100n; // XXX should query
+  const { msgSwap, msgLock, protoMessages } = makeSwapLockMessages(
+    { value: signer as `${string}1${string}`, chainId, encoding: 'bech32' },
+    amount,
+    {
+      usdnOut,
+    },
+  );
+
+  const defaultGas = 2_000_000n;
+  const fee: StdFee = {
+    amount: [{ denom, amount: `${2_000_000}` }],
+    gas: `${defaultGas * 10n}`,
+  };
+
+  const clientN = await connectWithSigner(config.noble.rpc, nobleWallet, {
+    registry: new Registry(nobleRegistryTypes),
+  });
+  console.log('swap, lock', signer, [msgSwap, msgLock], fee);
+  console.log(protoMessages);
+  const tx = await clientN.signAndBroadcast(
+    signer,
+    [
+      { typeUrl: MsgSwap.typeUrl, value: msgSwap },
+      { typeUrl: MsgLock.typeUrl, value: msgLock },
+    ],
+    fee,
+    memo,
+  );
+  return tx;
+};
+
 const main = async ({
   env = process.env,
   configFile = 'config.ymax.yaml',
@@ -289,6 +348,14 @@ const main = async ({
   }
   if (env.LOCK) {
     await lockUSDN(BigInt(env.LOCK), config, $v);
+  }
+  if (env.SWAPLOCK) {
+    const tx = await swapAndLock(
+      BigInt(env.SWAPLOCK),
+      configs[env.NET || 'testnet'],
+      { connectWithSigner },
+    );
+    console.log(tx);
   }
 };
 

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -4,12 +4,16 @@
  */
 import '@endo/init';
 
-import { fetchNetworkConfig, makeSmartWalletKit } from '@agoric/client-utils';
+import {
+  fetchEnvNetworkConfig,
+  makeSmartWalletKit,
+} from '@agoric/client-utils';
 import { MsgWalletSpendAction } from '@agoric/cosmic-proto/agoric/swingset/msgs.js';
 import { AmountMath } from '@agoric/ertp';
 import { multiplyBy, parseRatio } from '@agoric/ertp/src/ratio.js';
 import { makeTracer } from '@agoric/internal';
 import type { BridgeAction } from '@agoric/smart-wallet/src/smartWallet.js';
+import { stringToPath } from '@cosmjs/crypto';
 import { fromBech32 } from '@cosmjs/encoding';
 import {
   DirectSecp256k1HdWallet,
@@ -17,7 +21,6 @@ import {
   type GeneratedType,
 } from '@cosmjs/proto-signing';
 import { SigningStargateClient, type StdFee } from '@cosmjs/stargate';
-import { stringToPath } from '@cosmjs/crypto';
 
 const toAccAddress = (address: string): Uint8Array => {
   return fromBech32(address).data;
@@ -72,6 +75,7 @@ const openPosition = async (
         callPipe: [['makeOpenPortfolioInvitation']],
       },
       proposal: { give },
+      offerArgs: {}, // TODO: should be optional
     },
   });
 
@@ -118,7 +122,7 @@ const main = async (
 
   const delay = ms =>
     new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
-  const networkConfig = await fetchNetworkConfig('devnet', { fetch });
+  const networkConfig = await fetchEnvNetworkConfig({ env, fetch });
   const walletKit = await makeSmartWalletKit({ fetch, delay }, networkConfig);
   const signer = await DirectSecp256k1HdWallet.fromMnemonic(MNEMONIC, {
     prefix: 'agoric',

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -58,10 +58,12 @@ const openPosition = async (
   },
 ) => {
   const brand = fromEntries(await walletKit.readPublished('agoricNames.brand'));
-  const { USDC } = brand as Record<string, Brand<'nat'>>;
+  const { USDC, PoC25 } = brand as Record<string, Brand<'nat'>>;
 
   const give = {
     USDN: multiplyBy(make(USDC, 1_000_000n), parseRatio(volume, USDC)),
+    NobleFees: make(USDC, 20_000n),
+    Access: make(PoC25, 1n),
   };
 
   trace('opening portfolio', give);
@@ -75,7 +77,7 @@ const openPosition = async (
         callPipe: [['makeOpenPortfolioInvitation']],
       },
       proposal: { give },
-      offerArgs: {}, // TODO: should be optional
+      offerArgs: {}, // without usdnOut: swap only
     },
   });
 

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -68,7 +68,7 @@ const openPosition = async (
   const action: BridgeAction = harden({
     method: 'executeOffer',
     offer: {
-      id: `open-${now()}`,
+      id: `open-${new Date(now()).toISOString()}`,
       invitationSpec: {
         source: 'agoricContract',
         instancePath: ['ymax0'],

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -103,6 +103,7 @@ const openPosition = async (
     before.header.height,
   );
   trace('status', status);
+  if ('error' in status) throw Error(status.error);
   return status;
 };
 
@@ -138,5 +139,6 @@ const main = async (
 // TODO: use endo-exec so we can unit test the above
 main().catch(err => {
   console.error(err);
-  process.exit(1);
+  const code = '--exit-success' in process.argv ? 0 : 1;
+  process.exit(code);
 });

--- a/multichain-testing/test/ymax0/ymax-deploy.test.ts
+++ b/multichain-testing/test/ymax0/ymax-deploy.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @file check whether things are already deployed
+ */
+import anyTest from '@endo/ses-ava/prepare-endo.js';
+
+import { LOCAL_CONFIG, makeVstorageKit } from '@agoric/client-utils';
+import {
+  denomHash,
+  type CosmosChainInfo,
+  type IBCConnectionInfo,
+} from '@agoric/orchestration';
+import type { TestFn } from 'ava';
+
+// cf. ymax-tool
+const trader1ag = 'agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl';
+// cf. config.ymax.yml
+const agoricRest = 'http://localhost:1317';
+
+const test = anyTest as TestFn<Awaited<ReturnType<typeof makeTestContext>>>;
+
+test.before(async t => (t.context = await makeTestContext(t)));
+
+const makeTestContext = async t => {
+  const vstorageClient = makeVstorageKit({ fetch }, LOCAL_CONFIG);
+
+  return { fetch: globalThis.fetch, vstorageClient };
+};
+
+test('chain-info', async t => {
+  const { vstorageClient: vsc } = t.context;
+  const { vstorage: vs } = vsc;
+
+  const kinds = await vs.keys('published.agoricNames');
+  t.log('keys(agoricNames).length:', kinds.length);
+  t.true(kinds.includes('chain'));
+  t.true(kinds.includes('chainConnection'));
+
+  const chainNames = await vs.keys('published.agoricNames.chain');
+  t.log('chains:', chainNames.join(','));
+  t.true(chainNames.includes('agoric'), 'agoric chain present');
+  t.true(chainNames.includes('noble'), 'noble chain present');
+  const chainInfo = fromEntries(
+    await Promise.all(
+      chainNames.map(async n => [
+        n,
+        await vsc.readPublished(`agoricNames.chain.${n}`),
+      ]),
+    ),
+  ) as Record<string, CosmosChainInfo>;
+  const { agoric, noble } = chainInfo;
+
+  const conns = await vs.keys('published.agoricNames.chainConnection');
+  t.log('connections:', conns.join(','));
+  const toNoble = `${agoric.chainId}_${noble.chainId}`;
+  t.true(conns.includes(toNoble), 'agoric->noble present');
+
+  const id = it => it.getBoardId();
+  const { transferChannel } = (await vsc.readPublished(
+    `agoricNames.chainConnection.${toNoble}`,
+  )) as IBCConnectionInfo;
+  const path = {
+    port: 'transfer',
+    channelId: transferChannel.counterPartyChannelId,
+    denom: 'uusdc',
+  };
+  const denom = `ibc/${denomHash(path)}`;
+  t.log('USDC on agoric:', path, denom);
+  const asset = fromEntries(await vsc.readPublished('agoricNames.vbankAsset'));
+  const { [denom]: USDC } = asset;
+  t.is(USDC.issuerName, 'USDC');
+  t.log('E(bank).getId(vbank.${denom}.brand):', id(USDC.brand));
+});
+
+const { fromEntries, keys, values } = Object;
+
+test('beneficiary-wallet', async t => {
+  const { vstorage: vs } = t.context.vstorageClient;
+  const w = await vs.keys('published.wallet');
+  t.log(trader1ag);
+  t.true(w.includes(trader1ag));
+});
+
+test('poc-asset', async t => {
+  const { vstorageClient: vsc } = t.context;
+  await null;
+
+  const id = it => it.getBoardId();
+  const issuer = fromEntries(await vsc.readPublished('agoricNames.issuer'));
+  t.log('issuer names:', keys(issuer).join(','));
+  const brand = fromEntries(await vsc.readPublished('agoricNames.brand'));
+  t.log('brand names:', keys(brand).join(','));
+  const asset = fromEntries(await vsc.readPublished('agoricNames.vbankAsset'));
+  const { upoc25 } = asset;
+  t.truthy(asset.upoc25);
+  t.log('E(bank).getId(vbank.upoc25.brand):', id(upoc25.brand));
+  t.true('PoC25' in brand);
+  t.true('PoC25' in issuer);
+  t.is(id(brand.PoC25), id(asset.upoc25.brand));
+});
+
+test('ymax-deployed', async t => {
+  const { vstorageClient: vsc } = t.context;
+
+  const instance = fromEntries(await vsc.readPublished('agoricNames.instance'));
+  t.true('ymax0' in instance);
+  const id = it => it.getBoardId();
+  t.log('ymax0 instance boardId:', id(instance.ymax0));
+});
+
+test('usdc-available', async t => {
+  const { fetch } = t.context;
+
+  const { balances } = await fetch(
+    `${agoricRest}/cosmos/bank/v1beta1/balances/${trader1ag}`,
+  ).then(r => r.json());
+  const byDenom = fromEntries(balances.map(b => [b.denom, BigInt(b.amount)]));
+  t.log('balances:', byDenom);
+
+  const channelId = 'channel-0';
+  const path = { channelId, denom: 'uusdc' };
+  const denom = `ibc/${denomHash(path)}`;
+  t.true(denom in byDenom);
+  t.log('balance', byDenom[denom]);
+  t.true(byDenom[denom] >= 1_000_000n);
+});

--- a/packages/client-utils/src/marshalTables.js
+++ b/packages/client-utils/src/marshalTables.js
@@ -1,4 +1,3 @@
-// @ts-check
 /**
  * @file marshal tools for vstorage clients
  *
@@ -56,7 +55,6 @@ const makeTranslationTable = (makeSlot, makeVal) => {
     slotToVal.set(slot, val);
     return val;
   };
-  // eslint-disable-next-line no-undef
   return harden({ convertValToSlot, convertSlotToVal });
 };
 

--- a/packages/client-utils/src/smart-wallet-kit.js
+++ b/packages/client-utils/src/smart-wallet-kit.js
@@ -17,14 +17,20 @@ import { makeAgoricNames, makeVstorageKit } from './vstorage-kit.js';
  * @param {object} root0
  * @param {typeof globalThis.fetch} root0.fetch
  * @param {(ms: number) => Promise<void>} root0.delay
+ * @param {boolean} [root0.names]
  * @param {MinimalNetworkConfig} networkConfig
  */
-export const makeSmartWalletKit = async ({ fetch, delay }, networkConfig) => {
+export const makeSmartWalletKit = async (
+  { fetch, delay, names = true },
+  networkConfig,
+) => {
   const vsk = makeVstorageKit({ fetch }, networkConfig);
 
   const client = await makeStargateClient(networkConfig, { fetch });
 
-  const agoricNames = await makeAgoricNames(vsk.fromBoard, vsk.vstorage);
+  const agoricNames = await (names
+    ? makeAgoricNames(vsk.fromBoard, vsk.vstorage)
+    : /** @type {import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes} */ ({}));
 
   /**
    * @param {string} from

--- a/packages/client-utils/src/types.ts
+++ b/packages/client-utils/src/types.ts
@@ -1,7 +1,7 @@
 // @file types for the client-utils package
 // NB: this doesn't follow best practices for TS in JS because this package will likely soon be written in TS
 
-import type { Brand } from '@agoric/ertp';
+import type { Brand, Issuer } from '@agoric/ertp';
 import type {
   ContractRecord,
   FeeConfig,
@@ -20,6 +20,7 @@ import type {
   CurrentWalletRecord,
   UpdateRecord,
 } from '@agoric/smart-wallet/src/smartWallet.js';
+import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import type { Instance } from '@agoric/zoe/src/zoeService/types.js';
 
 // For static string key types. String template matching has to be in the ternary below.
@@ -29,6 +30,8 @@ type PublishedTypeMap = {
   'vaultFactory.metrics': VaultDirectorMetrics;
   'agoricNames.instance': Array<[string, Instance]>;
   'agoricNames.brand': Array<[string, Brand]>;
+  'agoricNames.issuer': Array<[string, Issuer]>;
+  'agoricNames.vbankAsset': Array<[string, AssetInfo]>;
   fastUsdc: ContractRecord;
   'fastUsdc.feeConfig': FeeConfig;
   'fastUsdc.poolMetrics': PoolMetrics;

--- a/packages/portfolio-deploy/src/access-token-setup.core.js
+++ b/packages/portfolio-deploy/src/access-token-setup.core.js
@@ -138,6 +138,11 @@ export const createPoCAsset = async (
     E(bankManager).addAsset(denom, issuerName, proposedName, kit),
   ]);
 
+  const slots = {
+    issuer: await E(board).getId(issuer),
+    brand: await E(board).getId(brand),
+  };
+  trace(issuerName, slots, 'for', { brand, issuer });
   await E(depositFacet).receive(supply);
   trace('sent', amt, 'to', beneficiary);
 

--- a/packages/portfolio-deploy/src/chain-info.core.js
+++ b/packages/portfolio-deploy/src/chain-info.core.js
@@ -131,7 +131,9 @@ export const publishChainInfo = async (
     const node = E(agoricNamesNode).makeChildNode(kind);
     // XXX setValue('') deletes a vstorage key (right?)
     await Promise.all(
-      oldKeys.map(k => E(E(node).makeChildNode(k)).setValue('')),
+      oldKeys.map(k =>
+        E(E(node).makeChildNode(k, { sequence: false })).setValue(''),
+      ),
     );
   }
 

--- a/packages/portfolio-deploy/src/orch.start.js
+++ b/packages/portfolio-deploy/src/orch.start.js
@@ -136,6 +136,14 @@ export const startOrchContract = async (
 
   const { startUpgradable } = consume;
   const installation = await installationP;
+
+  const [installationId, bundleId] = await Promise.all([
+    E(board).getId(installation),
+    E(zoe).getBundleIDFromInstallation(installation),
+  ]);
+
+  trace('startUpgradable', { installationId, bundleId });
+
   const kit = await E(startUpgradable)({
     label: name,
     installation,
@@ -153,19 +161,18 @@ export const startOrchContract = async (
   produceInstance.reset();
   produceInstance.resolve(instance);
 
-  const [installationId, instanceId, terms, bundleId] = await Promise.all([
+  const [instanceId, terms] = await Promise.all([
     E(board).getId(instance),
-    E(board).getId(installation),
     E(zoe).getTerms(instance),
-    E(zoe).getBundleIDFromInstallation(installation),
   ]);
 
   trace(
-    'startOrchContract done',
-    name,
-    { instanceId, installationId, bundleId },
-    terms,
-    objectMap(fullKit, it => passStyleOf(it)),
+    ...[
+      ['startOrchContract done', name],
+      ['getId(instance):', instanceId],
+      ['terms:', terms],
+      [objectMap(fullKit, it => passStyleOf(it))],
+    ].flat(),
   );
   return { config, kit: fullKit };
 };

--- a/packages/portfolio-deploy/src/portfolio.build.js
+++ b/packages/portfolio-deploy/src/portfolio.build.js
@@ -34,7 +34,7 @@ const defaultProposalBuilder = async (
 const build = async (homeP, endowments) => {
   const { writeCoreEval } = await makeHelpers(homeP, endowments);
   // TODO: unit test agreement with startPortfolio.name
-  await writeCoreEval('startPortfolio', defaultProposalBuilder);
+  await writeCoreEval('eval-ymax0', defaultProposalBuilder);
 };
 
 export default build;


### PR DESCRIPTION
stacked on #11538
refs:
 - #11538
 - #11536
 - #11456
 - #10491

## Description / Testing Considerations

In an attempt to diagnose #11536, I worked with @michaelfig on deploying in `multichain-testing`. I kept getting the prereqs out of order, forcing me to `make stop` / `make start` over and over. I finally got `make deploy-ymax` working:

```
deploy-ymax
├── poc-asset
│   └── beneficiary-wallet
│       └── ./scripts/ymax-tool.ts
└── agoricNames.chain
```

`./scripts/ymax-tool.ts` is used, before ymax is deployed, to provision a smart-wallet for the beneficiary.

To actually open a portfolio, not only do you need `deploy-ymax`, but you have to tap the faucet on `noblelocal` and do an IBC transfer some USDC to `agoriclocal`. All that is automated too:

```
open-with-usdn
├── deploy-ymax
│   ├── poc-asset
│   │   └── beneficiary-wallet
│   │       └── ./scripts/ymax-tool.ts
│   └── agoricNames.chain
├── usdc-available
│   └── ./scripts/noble-usdn-lab.ts
└── ./scripts/ymax-tool.ts
```

The `Makefile` is mixed with `ymax-deploy.test.ts` to make it idempotent: before doing each step, we test whether it's already done. The tests use `t.log(...)` for handy stuff like board IDs of the instance and various brands.

Also misc stuff in `portfolio-deploy`:

 - use `{ sequence: false }` when clearing old chain info
 - use eval-* for generated core eval files
 - boardIds for installation / instance were flipped in logs

### Security / Scaling / Upgrade Considerations

n/a

### Documentation Considerations

should some of the above go in a `multichain-testing/test/ymax0/README.md`? or is the `Makefile` clear enough as is?
