### PR TITLE
Changes to Multichain-Testing to Pass `portfolio-opened` and `usdc-available`

### DIFF
--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -187,5 +187,16 @@ open-with-usdn: deploy-ymax usdc-available ./scripts/ymax-tool.ts
 
 usdc-available: ./scripts/noble-usdn-lab.ts
 	yarn test:ymd test/ymax0 -m usdc-available || \
-	(FAUCET=trader1 NET=starship ./scripts/noble-usdn-lab.ts && \
-	TXFR=9950000 NET=starship ./scripts/noble-usdn-lab.ts)
+	( \
+		FAUCET=trader1 NET=starship ./scripts/noble-usdn-lab.ts && \
+		TXFR=9950000 NET=starship ./scripts/noble-usdn-lab.ts && \
+		( \
+			yarn test:ymd test/ymax0 -m usdc-available || { \
+				sleep 3 && \
+				yarn test:ymd test/ymax0 -m usdc-available || { \
+					sleep 5 && \
+					yarn test:ymd test/ymax0 -m usdc-available; \
+				}; \
+			} \
+		) \
+	)

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -159,15 +159,20 @@ redeploy-ymax: poc-asset agoricNames.chain
 # cf. ymax-tool.ts
 TRADER1=noble18qlqfelxhe7tszqqprm2eqdpzt9s6ry025y3j5
 TRADER1ag=agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl
+TRADER1_MNEMONIC = "cause eight cattle slot course mail more aware vapor slab hobby match"
+
 poc-asset: beneficiary-wallet
 	yarn test:ymd test/ymax0 -m poc-asset || \
 	./scripts/deploy-cli.ts ../packages/portfolio-deploy/src/access-token-setup.build.js \
 		beneficiary=$(TRADER1ag)
 
+# Calling ./scripts/ymax-tool.ts twice to create a smart wallet so that TRADER1
+# can receive the poc tokens
 beneficiary-wallet: ./scripts/ymax-tool.ts
 	yarn test:ymd test/ymax0 -m beneficiary-wallet || \
 	(make ADDR=$(TRADER1ag) fund-wallet && \
-	MNEMONIC="cause eight cattle slot course mail more aware vapor slab hobby match" ./scripts/ymax-tool.ts 0.1 --exit-success)
+	MNEMONIC=$(TRADER1_MNEMONIC) ./scripts/ymax-tool.ts 0.1 --exit-success --skip-poll && \
+	MNEMONIC=$(TRADER1_MNEMONIC) ./scripts/ymax-tool.ts 0.1 --exit-success)
 
 
 agoricNames.chain:
@@ -178,7 +183,7 @@ agoricNames.chain:
 ##
 # Using ymax
 open-with-usdn: deploy-ymax usdc-available ./scripts/ymax-tool.ts
-	./scripts/ymax-tool.ts 1.03
+	(MNEMONIC=$(TRADER1_MNEMONIC) ./scripts/ymax-tool.ts 1.03)
 
 usdc-available: ./scripts/noble-usdn-lab.ts
 	yarn test:ymd test/ymax0 -m usdc-available || \

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -23,10 +23,9 @@ import {
 } from '@cosmjs/proto-signing';
 import { SigningStargateClient, type StdFee } from '@cosmjs/stargate';
 
-/**
- * Generate the usage help message for this tool
- */
-const getUsage = (programName: string): string => `USAGE: ${programName} <volume> [options]
+const getUsage = (
+  programName: string,
+): string => `USAGE: ${programName} <volume> [options]
 Options:
   --skip-poll       Skip polling for offer result
   --exit-success    Exit with success code even if errors occur
@@ -116,7 +115,7 @@ const openPosition = async (
     const status = { result: { transaction: actual } };
     return status;
   }
-  
+
   trace(
     'starting to poll for offer result from block height',
     before.header.height,
@@ -131,7 +130,6 @@ const openPosition = async (
   if ('error' in status) {
     trace('offer failed with error', status.error);
     throw Error(status.error);
-
   }
   trace('offer completed successfully', {
     statusType: 'success',
@@ -154,19 +152,9 @@ const main = async (
   const { values, positionals } = parseArgs({
     args: argv.slice(2),
     options: {
-      'skip-poll': {
-        type: 'boolean',
-        default: false,
-      },
-      'exit-success': {
-        type: 'boolean',
-        default: false,
-      },
-      help: {
-        type: 'boolean',
-        short: 'h',
-        default: false,
-      },
+      'skip-poll': { type: 'boolean', default: false },
+      'exit-success': { type: 'boolean', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
     },
     allowPositionals: true,
   });
@@ -197,7 +185,7 @@ const main = async (
   const client = await connectWithSigner(networkConfig.rpcAddrs[0], signer, {
     registry: new Registry(agoricRegistryTypes),
   });
-  
+
   try {
     // Pass the parsed skipPoll option to openPosition
     await openPosition(volume, {
@@ -220,7 +208,10 @@ const main = async (
 main().catch(err => {
   // Check if this is our special non-error signal for exitSuccess
   if (err && typeof err === 'object' && 'exitSuccess' in err) {
-    console.error('Error occurred but exiting with success code as requested:', err.originalError);
+    console.error(
+      'Error occurred but exiting with success code as requested:',
+      err.originalError,
+    );
     process.exit(0);
   }
 


### PR DESCRIPTION
## Description

Changes in this PR makes the two tests in ymax multichain-testing `'usdc-available'` and `'portfolio-opened'` pass.

refs: 
- #11539
- #11551 

### Security/Scaling/Documentation/Upgrade Considerations
N/A

### Testing:

To Test:

- run multichain-testing with ymax config: `make setup start FILE=config.ymax.yaml`
- run `make deploy-ymax`
- run `make open-with-usdn`
- run `yarn test:ymd test/ymax0/ymax-deploy.test.ts `

