### PR TITLE
feat: import / export kernel DB should support compressed artifacts

### DIFF
--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -184,7 +184,6 @@ func ExportGenesis(
 			eventHandler,
 			keeper.SwingStoreExportOptions{
 				ArtifactMode:   artifactMode,
-				Compressed:     true,
 				ExportDataMode: exportDataMode,
 			},
 		)

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -129,6 +129,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, swingStoreExportsHandler *SwingStore
 	err = swingStoreExportsHandler.RestoreExport(
 		keeper.SwingStoreExportProvider{
 			BlockHeight:         snapshotHeight,
+			Compressed:          artifactProvider.Compressed,
 			GetExportDataReader: getExportDataReader,
 			ReadNextArtifact:    artifactProvider.ReadNextArtifact,
 		},
@@ -222,6 +223,7 @@ func (eventHandler swingStoreGenesisEventHandler) OnExportRetrieved(provider kee
 	artifactsEnded := false
 
 	artifactsProvider := keeper.SwingStoreExportProvider{
+		Compressed: provider.Compressed,
 		GetExportDataReader: func() (agoric.KVEntryReader, error) {
 			exportDataIterator := eventHandler.swingStore.Iterator(nil, nil)
 			kvReader := agoric.NewKVIteratorReader(exportDataIterator)

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -183,6 +183,7 @@ func ExportGenesis(
 			eventHandler,
 			keeper.SwingStoreExportOptions{
 				ArtifactMode:   artifactMode,
+				Compressed:     true,
 				ExportDataMode: exportDataMode,
 			},
 		)

--- a/golang/cosmos/x/swingset/keeper/extension_snapshotter.go
+++ b/golang/cosmos/x/swingset/keeper/extension_snapshotter.go
@@ -124,10 +124,15 @@ func (snapshotter *ExtensionSnapshotter) InitiateSnapshot(height int64) error {
 
 	blockHeight := uint64(height)
 
-	return snapshotter.swingStoreExportsHandler.InitiateExport(blockHeight, snapshotter, SwingStoreExportOptions{
-		ArtifactMode:   SwingStoreArtifactModeOperational,
-		ExportDataMode: SwingStoreExportDataModeSkip,
-	})
+	return snapshotter.swingStoreExportsHandler.InitiateExport(
+		blockHeight,
+		snapshotter,
+		SwingStoreExportOptions{
+			ArtifactMode:   SwingStoreArtifactModeOperational,
+			Compressed:     false,
+			ExportDataMode: SwingStoreExportDataModeSkip,
+		},
+	)
 }
 
 // OnExportStarted performs the actual cosmos state-sync app snapshot.

--- a/golang/cosmos/x/swingset/keeper/swing_store_exports_handler.go
+++ b/golang/cosmos/x/swingset/keeper/swing_store_exports_handler.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	sdkioerrors "cosmossdk.io/errors"
 	agoric "github.com/Agoric/agoric-sdk/golang/cosmos/types"
@@ -86,12 +85,14 @@ import (
 // for the "export data" (described in the godoc for exportDataFilename), and
 // for the opaque artifacts of the export.
 type exportManifest struct {
-	// BlockHeight is the block height of the manifest.
-	BlockHeight uint64 `json:"blockHeight,omitempty"`
-	// Data is the filename of the export data.
-	Data string `json:"data,omitempty"`
 	// Artifacts is the list of [artifact name, file name] pairs.
 	Artifacts [][2]string `json:"artifacts"`
+	// BlockHeight is the block height of the manifest.
+	BlockHeight uint64 `json:"blockHeight,omitempty"`
+	// Indicates wether the manifest has compressed artifacts
+	Compressed bool `json:"compressed,omitempty"`
+	// Data is the filename of the export data.
+	Data string `json:"data,omitempty"`
 }
 
 // ExportManifestFilename is the manifest filename which must be synchronized with the JS export/import tooling
@@ -227,13 +228,14 @@ type SwingStoreRestoreOptions struct {
 }
 
 type swingStoreImportOptions struct {
+	// ArtifactMode is a copy of SwingStoreRestoreOptions.ArtifactMode
+	ArtifactMode string `json:"artifactMode,omitempty"`
+	Compressed   bool   `json:"compressed"`
+	// ExportDataMode is a copy of SwingStoreRestoreOptions.ExportDataMode
+	ExportDataMode string `json:"exportDataMode,omitempty"`
 	// ExportDir is the directory created by RestoreExport that JS swing-store
 	// should import from.
 	ExportDir string `json:"exportDir"`
-	// ArtifactMode is a copy of SwingStoreRestoreOptions.ArtifactMode
-	ArtifactMode string `json:"artifactMode,omitempty"`
-	// ExportDataMode is a copy of SwingStoreRestoreOptions.ExportDataMode
-	ExportDataMode string `json:"exportDataMode,omitempty"`
 }
 
 var disallowedArtifactNameChar = regexp.MustCompile(`[^-_.a-zA-Z0-9]`)
@@ -241,7 +243,7 @@ var disallowedArtifactNameChar = regexp.MustCompile(`[^-_.a-zA-Z0-9]`)
 // sanitizeArtifactName searches a string for all characters
 // other than ASCII alphanumerics, hyphens, underscores, and dots,
 // and replaces each of them with a hyphen.
-func sanitizeArtifactFileName(name string) string {
+func sanitizeArtifactName(name string) string {
 	return disallowedArtifactNameChar.ReplaceAllString(name, "-")
 }
 
@@ -403,6 +405,8 @@ func checkNotActive() error {
 type SwingStoreExportProvider struct {
 	// BlockHeight is the block height of the SwingStore export.
 	BlockHeight uint64
+	// Indicates wether the provided artifacts will be compressed
+	Compressed bool
 	// GetExportDataReader returns a KVEntryReader for the "export data" of the
 	// SwingStore export, or nil if the "export data" is not part of this export.
 	GetExportDataReader func() (agoric.KVEntryReader, error)
@@ -712,13 +716,18 @@ func OpenSwingStoreExportDirectory(exportDir string) (SwingStoreExportProvider, 
 		if artifactName == UntrustedExportDataArtifactName {
 			return artifact, fmt.Errorf("unexpected export artifact name %s", artifactName)
 		}
-		artifact.Name = fileName
+		artifact.Name = artifactName
 		artifact.Data, err = os.ReadFile(filepath.Join(exportDir, fileName))
 
 		return artifact, err
 	}
 
-	return SwingStoreExportProvider{BlockHeight: manifest.BlockHeight, GetExportDataReader: getExportDataReader, ReadNextArtifact: readNextArtifact}, nil
+	return SwingStoreExportProvider{
+		BlockHeight:         manifest.BlockHeight,
+		Compressed:          manifest.Compressed,
+		GetExportDataReader: getExportDataReader,
+		ReadNextArtifact:    readNextArtifact,
+	}, nil
 }
 
 // RestoreExport restores the JS swing-store using previously exported data and artifacts.
@@ -767,14 +776,15 @@ func (exportsHandler SwingStoreExportsHandler) RestoreExport(provider SwingStore
 	exportsHandler.logger.Info("restoring swing-store", "exportDir", exportDir, "height", blockHeight)
 
 	action := &swingStoreRestoreExportAction{
-		Type:        swingStoreExportActionType,
+		Args: [1]swingStoreImportOptions{{
+			ArtifactMode:   restoreOptions.ArtifactMode,
+			Compressed:     provider.Compressed,
+			ExportDataMode: restoreOptions.ExportDataMode,
+			ExportDir:      exportDir,
+		}},
 		BlockHeight: blockHeight,
 		Request:     restoreRequest,
-		Args: [1]swingStoreImportOptions{{
-			ExportDir:      exportDir,
-			ArtifactMode:   restoreOptions.ArtifactMode,
-			ExportDataMode: restoreOptions.ExportDataMode,
-		}},
+		Type:        swingStoreExportActionType,
 	}
 
 	_, err = exportsHandler.blockingSend(action, true)
@@ -807,6 +817,7 @@ func WriteSwingStoreExportToDirectory(provider SwingStoreExportProvider, exportD
 
 	manifest := exportManifest{
 		BlockHeight: provider.BlockHeight,
+		Compressed:  provider.Compressed,
 	}
 
 	exportDataReader, err := provider.GetExportDataReader()
@@ -856,13 +867,17 @@ func WriteSwingStoreExportToDirectory(provider SwingStoreExportProvider, exportD
 			// any non letters-digits-hyphen-underscore-dot by a hyphen, and
 			// prefixing with an incremented id.
 			// The filename is not used for any purpose in the import logic.
-			filename := artifact.Name
-			artifactName := strings.TrimSuffix(
-				sanitizeArtifactFileName(filename),
-				filepath.Ext(filename),
+			filename := fmt.Sprintf(
+				"%d-%s",
+				len(manifest.Artifacts),
+				sanitizeArtifactName(artifact.Name),
 			)
-			filename = fmt.Sprintf("%d-%s", len(manifest.Artifacts), filename)
-			manifest.Artifacts = append(manifest.Artifacts, [2]string{artifactName, filename})
+
+			if provider.Compressed {
+				filename = fmt.Sprintf("%s.gz", filename)
+			}
+
+			manifest.Artifacts = append(manifest.Artifacts, [2]string{artifact.Name, filename})
 			err = writeExportFile(filename, artifact.Data)
 		} else {
 			// Pseudo artifact containing untrusted export data which may have been

--- a/golang/cosmos/x/swingset/keeper/swing_store_exports_handler.go
+++ b/golang/cosmos/x/swingset/keeper/swing_store_exports_handler.go
@@ -125,10 +125,10 @@ const swingStoreExportActionType = "SWING_STORE_EXPORT"
 const initiateRequest = "initiate"
 
 type swingStoreInitiateExportAction struct {
-	Args        [1]SwingStoreExportOptions `json:"args"`
-	BlockHeight uint64                     `json:"blockHeight,omitempty"` // empty if no blockHeight requested (latest)
-	Request     string                     `json:"request"`               // "initiate"
 	Type        string                     `json:"type"`                  // "SWING_STORE_EXPORT"
+	Request     string                     `json:"request"`               // "initiate"
+	BlockHeight uint64                     `json:"blockHeight,omitempty"` // empty if no blockHeight requested (latest)
+	Args        [1]SwingStoreExportOptions `json:"args"`
 }
 
 // retrieveRequest is the request type for retrieving an initiated export
@@ -204,7 +204,6 @@ type SwingStoreExportOptions struct {
 	// (None, Operational, Replay, Archival, Debug).
 	// See packages/cosmic-swingset/src/export-kernel-db.js initiateSwingStoreExport
 	ArtifactMode string `json:"artifactMode,omitempty"`
-	Compressed   bool   `json:"compressed"`
 	// ExportDataMode selects whether to include "export data" in the swing-store
 	// export or not. Use the value SwingStoreExportDataModeSkip or
 	// SwingStoreExportDataModeAll. If "skip", the reader returned by
@@ -533,10 +532,10 @@ func (exportsHandler SwingStoreExportsHandler) InitiateExport(
 		}()
 
 		initiateAction := &swingStoreInitiateExportAction{
-			Args:        [1]SwingStoreExportOptions{exportOptions},
+			Type:        swingStoreExportActionType,
 			BlockHeight: blockHeight,
 			Request:     initiateRequest,
-			Type:        swingStoreExportActionType,
+			Args:        [1]SwingStoreExportOptions{exportOptions},
 		}
 
 		// blockingSend for SWING_STORE_EXPORT action is safe to call from a goroutine

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -656,6 +656,16 @@ export default async function main(
     await exportData?.cleanup?.();
   }
 
+  /**
+   * @param {number} blockHeight
+   * @param {string} request
+   * @param {Array<{
+   *  artifactMode: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['artifactMode'];
+   *  compressed: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['compressed'];
+   *  exportDataMode: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['exportDataMode'];
+   *  exportDir: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['exportDir'];
+   * }>} requestArgs
+   */
   async function handleSwingStoreExport(blockHeight, request, requestArgs) {
     await null;
     switch (request) {

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -661,7 +661,7 @@ export default async function main(
    * @param {string} request
    * @param {Array<{
    *  artifactMode: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['artifactMode'];
-   *  compressed: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['compressed'];
+   *  compressed: boolean;
    *  exportDataMode: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['exportDataMode'];
    *  exportDir: import("@agoric/cosmic-swingset/src/export-kernel-db.js").StateSyncExporterOptions['exportDir'];
    * }>} requestArgs

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -112,12 +112,11 @@ export const checkExportDataMode = (mode, isImport = false) => {
 
 /**
  * @typedef {object} StateSyncExporterOptions
- * @property {SwingStoreArtifactMode} [artifactMode] the level of artifacts to include in the export
- * @property {number} [blockHeight] block height to check for
- * @property {boolean} compressed wether the generated artificats should be compressed or not
- * @property {SwingStoreExportDataMode} [exportDataMode] include a synthetic artifact for the export data in the export
- * @property {string} exportDir the directory in which to place the exported artifacts and manifest
  * @property {string} stateDir the directory containing the SwingStore to export
+ * @property {string} exportDir the directory in which to place the exported artifacts and manifest
+ * @property {number} [blockHeight] block height to check for
+ * @property {SwingStoreArtifactMode} [artifactMode] the level of artifacts to include in the export
+ * @property {SwingStoreExportDataMode} [exportDataMode] include a synthetic artifact for the export data in the export
  */
 
 /**
@@ -151,14 +150,7 @@ export const validateExporterOptions = options => {
  * @returns {StateSyncExporter}
  */
 export const initiateSwingStoreExport = (
-  {
-    artifactMode,
-    blockHeight,
-    compressed,
-    exportDataMode,
-    exportDir,
-    stateDir,
-  },
+  { stateDir, exportDir, blockHeight, artifactMode, exportDataMode },
   {
     fs: { open, writeFile },
     pathResolve,
@@ -188,7 +180,7 @@ export const initiateSwingStoreExport = (
 
     const swingStoreExporter = makeExporter(stateDir, {
       artifactMode: effectiveArtifactMode,
-      compressed,
+      compressed: true,
     });
     cleanup.push(async () => swingStoreExporter.close());
 
@@ -213,7 +205,7 @@ export const initiateSwingStoreExport = (
       artifactMode: artifactMode || effectiveArtifactMode,
       artifacts: [],
       blockHeight: savedBlockHeight,
-      compressed,
+      compressed: true,
     };
 
     if (exportDataMode === 'all') {
@@ -349,14 +341,11 @@ export const main = async (
 
   const exporter = initiateSwingStoreExport(
     {
-      artifactMode,
-      blockHeight: checkBlockHeight,
-      compressed: !!processValue.getBoolean({
-        flagName: 'compressed',
-      }),
-      exportDataMode,
-      exportDir,
       stateDir,
+      exportDir,
+      blockHeight: checkBlockHeight,
+      artifactMode,
+      exportDataMode,
     },
     {
       fs,
@@ -397,24 +386,10 @@ export const main = async (
  * @returns {StateSyncExporter}
  */
 export const spawnSwingStoreExport = (
-  {
-    artifactMode,
-    blockHeight,
-    compressed,
-    exportDataMode,
-    exportDir,
-    stateDir,
-  },
+  { stateDir, exportDir, blockHeight, artifactMode, exportDataMode },
   { fork, verbose },
 ) => {
-  const args = [
-    '--compressed',
-    String(compressed),
-    '--export-dir',
-    exportDir,
-    '--state-dir',
-    stateDir,
-  ];
+  const args = ['--state-dir', stateDir, '--export-dir', exportDir];
 
   if (blockHeight !== undefined) {
     args.push('--check-block-height', String(blockHeight));

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -232,15 +232,13 @@ export const initiateSwingStoreExport = (
 
     if (artifactMode !== 'none') {
       for await (const artifactName of swingStoreExporter.getArtifactNames()) {
-        let artifactFileName = artifactName;
-        if (compressed) artifactFileName += '.gz';
         abortIfStopped();
         log?.(`Writing artifact: ${artifactName}`);
         const artifactData = swingStoreExporter.getArtifact(artifactName);
         // Use artifactName as the file name as we trust swingStore to generate
         // artifact names that are valid file names.
-        await writeFile(pathResolve(exportDir, artifactFileName), artifactData);
-        manifest.artifacts.push([artifactName, artifactFileName]);
+        await writeFile(pathResolve(exportDir, artifactName), artifactData);
+        manifest.artifacts.push([artifactName, artifactName]);
       }
     }
 

--- a/packages/swing-store/src/kvStore.js
+++ b/packages/swing-store/src/kvStore.js
@@ -5,7 +5,7 @@ import { Fail } from '@endo/errors';
  * @typedef {{
  *   has: (key: string) => boolean,
  *   get: (key: string) => string | undefined,
- *   getExportData: () => IterableIterator<import('./exporter').KVPair>
+ *   getExportData: () => IterableIterator<import('./exporter.js').KVPair>
  *   getNextKey: (previousKey: string) => string | undefined,
  *   set: (key: string, value: string, bypassHash?: boolean ) => void,
  *   delete: (key: string) => void,


### PR DESCRIPTION
closes: #8448

## Description
This PR adds support for compressing/decompressing artifacts in `agd export`, `agd snapshots export` and state sync flows
The reduction in swing-store export size tested on a local chain for `1000` blocks using `decentral-core-config.json` bootstrap config is `80%` (`41 MB` compared to `209 MB`)
For more details, refere to the linked issue

### Security Considerations
None

### Scaling Considerations
None of the flows blocks the main process. `agd export` and `agd snapshots export` are offline processes and state sync snapshot creation flow runs in a go routine. Though this do result in increased CPU usage temporarily.

### Documentation Considerations
None

### Testing Considerations
Our existing tests already test for both state sync restoration and re starting the node by using snapshot created from `agd snapshots export` so the change should be good as long as the CI pass

### Upgrade Considerations
None
