### PR TITLE
refactor: factor out USDN / Aave / Compound specific stuff

### DIFF
--- a/packages/portfolio-contract/CONTRIBUTING.md
+++ b/packages/portfolio-contract/CONTRIBUTING.md
@@ -4,13 +4,11 @@ Thanks for your interest in improving YMax! This package is in a proof-of-concep
 
  - `README.md` - user-level description of the contract.
  - `src/`
-    - `portfolio.contract.ts` - contract `start` function
-    - `type-guards.ts` - staic types for the external interface along
-      with (dynamic) pattern guards, aka shapes
-    - `constants.js` - enumerated constants
-    - `portfolio.exo.ts` - durable object for portfolio state
-    - `portfolio.flows.ts` - orchestration flows for opening and
-      managing portfolios
+  - `portfolio.contract.ts` - contract entry point and public facet
+  - `portfolio.{flows,exo}.ts` - orchestration flows and durable state
+  - `pos-{usdn,gmp}.{flows,exo}.ts` - position management for different protocols
+  - `type-guards.ts` - external interface types and validation patterns
+  - `constants.js` - enumerated constants
  - `test/` - tests for contract, flows, etc.
  - `tools/` - utilities exported for use in other packages
 

--- a/packages/portfolio-contract/README.md
+++ b/packages/portfolio-contract/README.md
@@ -4,7 +4,7 @@ A smart contract for managing diversified stablecoin yield portfolios across mul
 
 ## Overview
 
-The YMax Portfolio Contract enables users to create and manage portfolios that deploy stablecoins across different yield-generating protocols. Users can rebalance their positions between USDN (on Agoric), Aave, and Compound (via cross-chain operations).
+The YMax Portfolio Contract enables users to create and manage portfolios that deploy stablecoins across different yield-generating protocols. Users can rebalance their positions between USDN, Aave, and Compound (via cross-chain operations).
 
 ## Parties to the Contract
 
@@ -12,7 +12,7 @@ The YMax Portfolio Contract enables users to create and manage portfolios that d
 - **Create Portfolios**: Open new portfolios by providing USDC, Access tokens, and fees
 - **Fund Positions**: Allocate capital across different yield protocols (USDN, Aave, Compound)
 - **Portfolio Rebalancing**: Execute rebalancing operations by specifying desired asset movements
-- **Multi-chain Operations**: Manage positions across Agoric, Noble, and EVM chains via Axelar GMP
+- **Multi-chain Operations**: Manage positions across Noble and EVM chains
 
 ### The Contract
 - **Portfolio Orchestration**: Manages multiple independent portfolios
@@ -29,7 +29,7 @@ The YMax Portfolio Contract enables users to create and manage portfolios that d
 
 ### Opening a Portfolio
 Users can create a new portfolio by:
-1. Making an `openPortfolio` offer with USDC and fees
+1. Making an `openPortfolio` offer
 2. Specifying initial yield protocol allocations
 3. Receiving a portfolio with rebalancing capabilities
 
@@ -39,4 +39,10 @@ Portfolio holders can:
 - Specify exact amounts to transfer between USDN, Aave, and Compound positions
 - Execute complex cross-chain operations seamlessly through the contract's orchestration
 
+## Client Queries and Offers
 
+For details on making offers and querying vstorage, see
+
+ - `src/type-guards.ts` - types and pattern guards
+ - `test/portfolio-agents.ts` - example client code
+ - `test/snapshots/*.md` - example vstorage data

--- a/packages/portfolio-contract/src/pos-gmp.exo.ts
+++ b/packages/portfolio-contract/src/pos-gmp.exo.ts
@@ -1,0 +1,83 @@
+/**
+ * @file Position state management for Aave, Compound.
+ *
+ * Since Axelar GMP is used in both cases, we use "gmp" in the filename.
+ *
+ * @see {@link prepareGMPPosition}
+ * @see {@link GMPPosition}
+ */
+import type { AccountId, CaipChainId } from '@agoric/orchestration';
+import type { Vow, VowTools } from '@agoric/vow';
+import type { Zone } from '@agoric/zone';
+import type { YieldProtocol } from './constants.js';
+import {
+  recordTransferIn,
+  recordTransferOut,
+  type PublishStatusFn,
+  type TransferStatus,
+} from './portfolio.exo.ts';
+import { makePositionPath } from './type-guards.ts';
+
+export type GMPProtocol = YieldProtocol & ('Aave' | 'Compound');
+
+export const prepareGMPPosition = (
+  zone: Zone,
+  vowTools: VowTools,
+  emptyTransferState: TransferStatus,
+  publishStatus: PublishStatusFn,
+) =>
+  zone.exoClass(
+    'GMP Position',
+    undefined, // interface TODO
+    (
+      portfolioId: number,
+      positionId: number,
+      protocol: GMPProtocol,
+      chainId: CaipChainId,
+    ) => ({
+      portfolioId,
+      positionId,
+      protocol,
+      ...emptyTransferState,
+      chainId,
+      remoteAddressVK: vowTools.makeVowKit<`0x${string}`>(),
+      accountId: undefined as undefined | AccountId,
+    }),
+    {
+      getPositionId() {
+        return this.state.positionId;
+      },
+      getYieldProtocol() {
+        const { protocol } = this.state;
+        return protocol;
+      },
+      getAddress(): Vow<`0x${string}`> {
+        const { remoteAddressVK } = this.state;
+        // TODO: when the vow resolves, publishStatus()
+        return remoteAddressVK.vow;
+      },
+      getChainId() {
+        return this.state.chainId;
+      },
+      recordTransferIn(amount: Amount<'nat'>) {
+        return recordTransferIn(amount, this.state, this.self);
+      },
+      recordTransferOut(amount: Amount<'nat'>) {
+        return recordTransferOut(amount, this.state, this.self);
+      },
+      publishStatus() {
+        const { portfolioId, positionId, protocol, accountId } = this.state;
+        // TODO: typed pattern for GMP status
+        const status = { protocol, accountId };
+        publishStatus(makePositionPath(portfolioId, positionId), status);
+      },
+      resolveAddress(address: `0x${string}`) {
+        const { chainId, remoteAddressVK } = this.state;
+        remoteAddressVK.resolver.resolve(address);
+        this.state.accountId = `${chainId}:${address}`;
+        this.self.publishStatus();
+      },
+    },
+  ); // TODO: satisfies (...args: any[]) => Position
+
+export type GMPPosition = ReturnType<ReturnType<typeof prepareGMPPosition>>;

--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -1,0 +1,466 @@
+/**
+ * @file flows for Aave and Compound protocols on EVM chains
+ *
+ * Since Axelar GMP (General Message Passing) is used in both cases,
+ * we use "gmp" in the filename.
+ *
+ * @see {@link changeGMPPosition}
+ * @see {@link supplyToAave}
+ * @see {@link supplyToCompound}
+ * @see {@link createRemoteEVMAccount}
+ * @see {@link sendTokensViaCCTP}
+ */
+import type { Amount } from '@agoric/ertp';
+import {
+  makeTracer,
+  mustMatch,
+  NonNullish,
+  type TypedPattern,
+} from '@agoric/internal';
+import type { DenomAmount, Orchestrator } from '@agoric/orchestration';
+import {
+  AxelarGMPMessageType,
+  type AxelarGmpOutgoingMemo,
+  type ContractCall,
+} from '@agoric/orchestration/src/axelar-types.js';
+import {
+  buildGMPPayload,
+  gmpAddresses,
+} from '@agoric/orchestration/src/utils/gmp.js';
+import type { AmountKeywordRecord, ZCFSeat } from '@agoric/zoe';
+import { AmountKeywordRecordShape } from '@agoric/zoe/src/typeGuards.js';
+import { assert, throwRedacted as Fail } from '@endo/errors';
+import { M } from '@endo/patterns';
+import type { GuestInterface } from '../../async-flow/src/types.ts';
+import { AxelarChains, type YieldProtocol } from './constants.js';
+import type { PortfolioKit } from './portfolio.exo.ts';
+import {
+  type PortfolioInstanceContext,
+  provideAccountInfo,
+} from './portfolio.flows.ts';
+import type {
+  AxelarChainsMap,
+  OfferArgsFor,
+  OpenPortfolioGive,
+} from './type-guards.ts';
+
+const trace = makeTracer('GMPF');
+const { keys } = Object;
+
+type AxelarChain = keyof typeof AxelarChains; // XXX rename AxelarChains -> AxelarChain
+type BaseGmpArgs = {
+  destinationEVMChain: AxelarChain;
+  keyword: string;
+  amounts: AmountKeywordRecord;
+};
+const GmpCallType = {
+  ContractCall: 1,
+  ContractCallWithToken: 2,
+} as const;
+type GmpCallType = (typeof GmpCallType)[keyof typeof GmpCallType];
+
+export type GmpArgsContractCall = BaseGmpArgs & {
+  destinationAddress: string;
+  type: GmpCallType;
+  contractInvocationData: Array<ContractCall>;
+};
+type GmpArgsTransferAmount = BaseGmpArgs & {
+  transferAmount: bigint;
+};
+type GmpArgsWithdrawAmount = BaseGmpArgs & {
+  withdrawAmount: bigint;
+};
+const ContractCallShape = M.splitRecord({
+  target: M.string(),
+  functionSignature: M.string(),
+  args: M.arrayOf(M.any()),
+});
+const GMPArgsShape: TypedPattern<GmpArgsContractCall> = M.splitRecord({
+  destinationAddress: M.string(),
+  type: M.or(1, 2),
+  destinationEVMChain: M.or(...keys(AxelarChains)),
+  keyword: M.string(),
+  amounts: AmountKeywordRecordShape, // XXX brand should be exactly USDC
+  contractInvocationData: M.arrayOf(ContractCallShape),
+});
+
+export const createRemoteEVMAccount = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  gmpArgs: BaseGmpArgs,
+  kit: GuestInterface<PortfolioKit>,
+  protocol: YieldProtocol,
+) => {
+  const { destinationEVMChain, keyword, amounts: gasAmounts } = gmpArgs;
+  const { contractAddresses } = ctx.axelarChainsMap[destinationEVMChain];
+
+  await sendGmp(
+    orch,
+    ctx,
+    seat,
+    harden({
+      destinationAddress: contractAddresses.factory,
+      destinationEVMChain,
+      type: AxelarGMPMessageType.ContractCall,
+      keyword,
+      amounts: gasAmounts,
+      contractInvocationData: [],
+    }),
+    kit,
+  );
+
+  return kit.reader.getGMPAddress(protocol);
+};
+
+export const sendTokensViaCCTP = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  args: BaseGmpArgs,
+  kit: GuestInterface<PortfolioKit>,
+  protocol: YieldProtocol,
+) => {
+  const { axelarChainsMap, chainHubTools, zoeTools } = ctx;
+  const { keyword, amounts, destinationEVMChain } = args;
+  const amount = amounts[keyword];
+  const denom = NonNullish(chainHubTools.getDenom(amount.brand));
+  const denomAmount: DenomAmount = { denom, value: amount.value };
+
+  const { lca: localAcct } = await provideAccountInfo(orch, 'agoric', kit);
+  const { ica: nobleAccount } = await provideAccountInfo(orch, 'noble', kit);
+
+  trace('localTransfer', amount, 'to local', localAcct.getAddress().value);
+  await zoeTools.localTransfer(seat, localAcct, amounts);
+  try {
+    await localAcct.transfer(nobleAccount.getAddress(), denomAmount);
+    const caipChainId = axelarChainsMap[destinationEVMChain].caip;
+    const remoteAccountAddress = await kit.reader.getGMPAddress(protocol);
+    const destinationAddress = `${caipChainId}:${remoteAccountAddress}`;
+    trace(`CCTP destinationAddress: ${destinationAddress}`);
+
+    try {
+      await nobleAccount.depositForBurn(
+        destinationAddress as `${string}:${string}:${string}`,
+        denomAmount,
+      );
+    } catch (err) {
+      console.error('⚠️ recover to local account.', amount);
+      const nobleAmount: DenomAmount = { denom: 'uusdc', value: amount.value };
+      await nobleAccount.transfer(localAcct.getAddress(), nobleAmount);
+      // TODO: and what if this transfer fails?
+      throw err;
+    }
+  } catch (err) {
+    // TODO: use X from @endo/errors
+    const errorMsg = `⚠️ Noble transfer failed`;
+    console.error(errorMsg, err);
+    await zoeTools.withdrawToSeat(localAcct, seat, amounts);
+    throw new Error(`${errorMsg}: ${err}`);
+  }
+};
+
+export const makeAxelarMemo = (
+  axelarChainsMap: AxelarChainsMap,
+  gmpArgs: GmpArgsContractCall,
+) => {
+  const {
+    contractInvocationData,
+    destinationEVMChain,
+    destinationAddress,
+    keyword,
+    amounts: gasAmounts,
+    type,
+  } = gmpArgs;
+
+  trace(`targets: [${destinationAddress}]`);
+
+  const payload = buildGMPPayload(contractInvocationData);
+  const memo: AxelarGmpOutgoingMemo = {
+    destination_chain: axelarChainsMap[destinationEVMChain].axelarId,
+    destination_address: destinationAddress,
+    payload,
+    type,
+  };
+
+  memo.fee = {
+    amount: String(gasAmounts[keyword].value),
+    recipient: gmpAddresses.AXELAR_GAS,
+  };
+
+  return harden(JSON.stringify(memo));
+};
+harden(makeAxelarMemo);
+
+const sendGmp = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  gmpArgs: GmpArgsContractCall,
+  kit: GuestInterface<PortfolioKit>,
+) => {
+  mustMatch(gmpArgs, GMPArgsShape);
+  const { axelarChainsMap, chainHubTools, zoeTools } = ctx;
+
+  const axelar = await orch.getChain('axelar');
+  const { chainId } = await axelar.getChainInfo();
+
+  const { lca: localAccount } = await provideAccountInfo(orch, 'agoric', kit);
+  const { keyword, amounts: gasAmounts } = gmpArgs;
+  const natAmount = gasAmounts[keyword];
+  const denom = await chainHubTools.getDenom(natAmount.brand);
+  assert(denom, 'denom must be defined');
+  const denomAmount = {
+    denom,
+    value: natAmount.value,
+  };
+
+  try {
+    await zoeTools.localTransfer(seat, localAccount, gasAmounts);
+    const memo = makeAxelarMemo(axelarChainsMap, gmpArgs);
+    await localAccount.transfer(
+      {
+        value: gmpAddresses.AXELAR_GMP,
+        encoding: 'bech32',
+        chainId,
+      },
+      denomAmount,
+      { memo },
+    );
+  } catch (err) {
+    await ctx.zoeTools.withdrawToSeat(localAccount, seat, gasAmounts);
+    throw new Error(`sendGmp failed: ${err}`);
+  }
+};
+
+export const supplyToAave = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  gmpArgs: GmpArgsTransferAmount,
+  kit: GuestInterface<PortfolioKit>,
+) => {
+  const {
+    destinationEVMChain,
+    transferAmount,
+    keyword,
+    amounts: gasAmounts,
+  } = gmpArgs;
+  const { contractAddresses } = ctx.axelarChainsMap[destinationEVMChain];
+  const remoteEVMAddress = await kit.reader.getGMPAddress('Aave');
+
+  await sendGmp(
+    orch,
+    ctx,
+    seat,
+    harden({
+      destinationAddress: remoteEVMAddress,
+      destinationEVMChain,
+      type: AxelarGMPMessageType.ContractCall,
+      keyword,
+      amounts: gasAmounts,
+      contractInvocationData: [
+        {
+          functionSignature: 'approve(address,uint256)',
+          args: [contractAddresses.aavePool, transferAmount],
+          target: contractAddresses.usdc,
+        },
+        {
+          functionSignature: 'supply(address,uint256,address,uint16)',
+          args: [contractAddresses.usdc, transferAmount, remoteEVMAddress, 0],
+          target: contractAddresses.aavePool,
+        },
+      ],
+    }),
+    kit,
+  );
+};
+
+/* c8 ignore start */
+const withdrawFromAave = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  gmpArgs: GmpArgsWithdrawAmount,
+  kit: GuestInterface<PortfolioKit>,
+) => {
+  const {
+    destinationEVMChain,
+    withdrawAmount,
+    keyword,
+    amounts: gasAmounts,
+  } = gmpArgs;
+  const { contractAddresses } = ctx.axelarChainsMap[destinationEVMChain];
+  const remoteEVMAddress = await kit.reader.getGMPAddress('Aave');
+
+  await sendGmp(
+    orch,
+    ctx,
+    seat,
+    harden({
+      destinationAddress: remoteEVMAddress,
+      destinationEVMChain,
+      type: AxelarGMPMessageType.ContractCall,
+      keyword,
+      amounts: gasAmounts,
+      contractInvocationData: [
+        {
+          functionSignature: 'withdraw(address,uint256,address)',
+          args: [contractAddresses.usdc, withdrawAmount, remoteEVMAddress],
+          target: contractAddresses.aavePool,
+        },
+      ],
+    }),
+    kit,
+  );
+};
+/* c8 ignore end */
+
+export const supplyToCompound = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  gmpArgs: GmpArgsTransferAmount,
+  kit: GuestInterface<PortfolioKit>,
+) => {
+  const {
+    destinationEVMChain,
+    transferAmount,
+    keyword,
+    amounts: gasAmounts,
+  } = gmpArgs;
+  const { contractAddresses } = ctx.axelarChainsMap[destinationEVMChain];
+  const remoteEVMAddress = await kit.reader.getGMPAddress('Compound');
+
+  await sendGmp(
+    orch,
+    ctx,
+    seat,
+    harden({
+      destinationAddress: remoteEVMAddress,
+      destinationEVMChain,
+      type: AxelarGMPMessageType.ContractCall,
+      keyword,
+      amounts: gasAmounts,
+      contractInvocationData: [
+        {
+          functionSignature: 'approve(address,uint256)',
+          args: [contractAddresses.compound, transferAmount],
+          target: contractAddresses.usdc,
+        },
+        {
+          functionSignature: 'supply(address,uint256)',
+          args: [contractAddresses.usdc, transferAmount],
+          target: contractAddresses.compound,
+        },
+      ],
+    }),
+    kit,
+  );
+};
+
+/* c8 ignore start */
+const withdrawFromCompound = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  gmpArgs: GmpArgsWithdrawAmount,
+  kit: GuestInterface<PortfolioKit>,
+) => {
+  const {
+    destinationEVMChain,
+    withdrawAmount,
+    keyword,
+    amounts: gasAmounts,
+  } = gmpArgs;
+  const { contractAddresses } = ctx.axelarChainsMap[destinationEVMChain];
+  const remoteEVMAddress = await kit.reader.getGMPAddress('Compound');
+
+  await sendGmp(
+    orch,
+    ctx,
+    seat,
+    harden({
+      destinationAddress: remoteEVMAddress,
+      destinationEVMChain,
+      type: AxelarGMPMessageType.ContractCall,
+      keyword,
+      amounts: gasAmounts,
+      contractInvocationData: [
+        {
+          functionSignature: 'withdraw(address,uint256)',
+          args: [contractAddresses.usdc, withdrawAmount],
+          target: contractAddresses.compound,
+        },
+      ],
+    }),
+    kit,
+  );
+};
+
+export const changeGMPPosition = async (
+  orch: Orchestrator,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  offerArgs: OfferArgsFor['rebalance'],
+  kit,
+  protocol: 'Aave' | 'Compound',
+  give: {} | OpenPortfolioGive,
+) => {
+  const { axelarChainsMap } = ctx;
+  const { destinationEVMChain } = offerArgs;
+
+  (`${protocol}Gmp` in give && `${protocol}Account` in give) ||
+    Fail`Gmp and Account needed for ${protocol}`;
+  if (!destinationEVMChain)
+    throw Fail`destinationEVMChain needed for ${protocol}`;
+  const [gmpKW, accountKW] =
+    protocol === 'Aave'
+      ? ['AaveGmp', 'AaveAccount']
+      : ['CompoundGmp', 'CompoundAccount'];
+
+  const { position: _TODO, isNew } = kit.manager.provideGMPPositionOn(
+    protocol as YieldProtocol,
+    axelarChainsMap[destinationEVMChain].caip,
+  );
+
+  if (isNew) {
+    const gmpArgs = {
+      destinationEVMChain,
+      keyword: accountKW,
+      amounts: { [accountKW]: give[accountKW] },
+    };
+    try {
+      await createRemoteEVMAccount(orch, ctx, seat, gmpArgs, kit, protocol);
+    } catch (err) {
+      console.error('⚠️ initRemoteEVMAccount failed for', protocol, err);
+      seat.fail(err);
+    }
+  }
+
+  const args = {
+    destinationEVMChain,
+    keyword: protocol,
+    amounts: { [protocol]: give[protocol] },
+  };
+  await sendTokensViaCCTP(orch, ctx, seat, args, kit, protocol);
+
+  // Wait before supplying funds to aave - make sure tokens reach the remote EVM account
+  kit.manager.waitKLUDGE(20n);
+
+  const { value: transferAmount } = give[protocol] as Amount<'nat'>;
+  const gmpArgs = {
+    destinationEVMChain,
+    transferAmount,
+    keyword: gmpKW,
+    amounts: { [gmpKW]: give[gmpKW] },
+  };
+  switch (protocol) {
+    case 'Aave':
+      await supplyToAave(orch, ctx, seat, gmpArgs, kit);
+      break;
+    case 'Compound':
+      await supplyToCompound(orch, ctx, seat, gmpArgs, kit);
+      break;
+  }
+};

--- a/packages/portfolio-contract/src/pos-usdn.exo.ts
+++ b/packages/portfolio-contract/src/pos-usdn.exo.ts
@@ -1,0 +1,63 @@
+/**
+ * @file position state management for USDN (Noble Dollar) yield protocol.
+ *
+ * @see {@link prepareUSDNPosition}
+ */
+import type { AccountId } from '@agoric/orchestration';
+import type { Zone } from '@agoric/zone';
+import {
+  recordTransferIn,
+  recordTransferOut,
+  type Position,
+  type PublishStatusFn,
+  type TransferStatus,
+} from './portfolio.exo.ts';
+import { makePositionPath } from './type-guards.ts';
+
+export const prepareUSDNPosition = (
+  zone: Zone,
+  emptyTransferState: TransferStatus,
+  publishStatus: PublishStatusFn,
+) =>
+  zone.exoClass(
+    'USDN Position',
+    undefined, // interface TODO
+    (portfolioId: number, positionId: number, accountId: AccountId) => ({
+      portfolioId,
+      positionId,
+      accountId,
+      ...emptyTransferState,
+    }),
+    {
+      getPositionId() {
+        return this.state.positionId;
+      },
+      getYieldProtocol() {
+        return 'USDN';
+      },
+      publishStatus() {
+        const {
+          portfolioId,
+          positionId,
+          accountId,
+          netTransfers,
+          totalIn,
+          totalOut,
+        } = this.state;
+        // TODO: typed pattern for USDN status
+        publishStatus(makePositionPath(portfolioId, positionId), {
+          protocol: 'USDN',
+          accountId,
+          netTransfers,
+          totalIn,
+          totalOut,
+        });
+      },
+      recordTransferIn(amount: Amount<'nat'>) {
+        return recordTransferIn(amount, this.state, this.self);
+      },
+      recordTransferOut(amount: Amount<'nat'>) {
+        return recordTransferOut(amount, this.state, this.self);
+      },
+    },
+  ) satisfies (...args: any[]) => Position;

--- a/packages/portfolio-contract/src/pos-usdn.flows.ts
+++ b/packages/portfolio-contract/src/pos-usdn.flows.ts
@@ -1,0 +1,151 @@
+/**
+ * @file flows for USDN (Noble Dollar) yield protocol.
+ *
+ * Handles cross-chain operations to swap USDC to USDN and lock it in Noble vaults
+ * for yield generation. Uses IBC transfers and Noble-specific message types.
+ *
+ * @see {@link changeUSDCPosition}
+ */
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
+import { MsgLock } from '@agoric/cosmic-proto/noble/dollar/vaults/v1/tx.js';
+import { MsgSwap } from '@agoric/cosmic-proto/noble/swap/v1/tx.js';
+import { AmountMath, type Amount } from '@agoric/ertp';
+import { makeTracer, NonNullish } from '@agoric/internal';
+import type {
+  CosmosChainAddress,
+  DenomAmount,
+  Orchestrator,
+} from '@agoric/orchestration';
+import { coerceAccountId } from '@agoric/orchestration/src/utils/address.js';
+import type { ZCFSeat } from '@agoric/zoe';
+import type { GuestInterface } from '../../async-flow/src/types.ts';
+import type { PortfolioKit, USDNPosition } from './portfolio.exo.ts';
+import {
+  provideAccountInfo,
+  trackFlow,
+  type LocalAccount,
+  type NobleAccount,
+  type PortfolioInstanceContext,
+} from './portfolio.flows.ts';
+import type { OpenPortfolioGive } from './type-guards.ts';
+// XXX: import { VaultType } from '@agoric/cosmic-proto/dist/codegen/noble/dollar/vaults/v1/vaults';
+
+const { add } = AmountMath;
+const trace = makeTracer('USDNF');
+
+export const makeSwapLockMessages = (
+  nobleAddr: CosmosChainAddress,
+  usdcIn: bigint,
+  {
+    poolId = 0n,
+    denom = 'uusdc',
+    denomTo = 'uusdn',
+    vault = 1, // VaultType.STAKED,
+    usdnOut = undefined as bigint | undefined,
+  } = {},
+) => {
+  const msgSwap = MsgSwap.fromPartial({
+    signer: nobleAddr.value,
+    amount: { denom, amount: `${usdcIn}` },
+    routes: [{ poolId, denomTo }],
+    min: { denom: denomTo, amount: `${usdnOut || usdcIn}` },
+  });
+  if (!usdnOut) {
+    const protoMessages = [Any.toJSON(MsgSwap.toProtoMsg(msgSwap))];
+    return { msgSwap, protoMessages };
+  }
+  const msgLock = MsgLock.fromPartial({
+    signer: nobleAddr.value,
+    vault,
+    amount: `${usdnOut}`,
+  });
+  const protoMessages = [
+    Any.toJSON(MsgSwap.toProtoMsg(msgSwap)),
+    Any.toJSON(MsgLock.toProtoMsg(msgLock)),
+  ];
+  return { msgSwap, msgLock, protoMessages };
+};
+
+export const addToUSDNPosition = async (
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+  lca: LocalAccount,
+  ica: NobleAccount,
+  pos: USDNPosition,
+  reporter: GuestInterface<PortfolioKit['reporter']>,
+  { USDN, NobleFees }: { USDN: Amount<'nat'>; NobleFees?: Amount<'nat'> },
+  usdnOut: bigint = USDN.value,
+) => {
+  const amounts = harden({ USDN, ...(NobleFees ? { NobleFees } : {}) });
+  const denom = NonNullish(ctx.chainHubTools.getDenom(USDN.brand));
+  const volume: DenomAmount = { denom, value: USDN.value };
+  const withFees = NobleFees ? add(USDN, NobleFees) : USDN;
+
+  const nobleAddr = ica.getAddress();
+  await trackFlow(reporter, [
+    {
+      how: 'localTransfer',
+      src: { seat, keyword: 'USDN' },
+      dest: { account: lca },
+      amount: withFees,
+      apply: async () => {
+        await ctx.zoeTools.localTransfer(seat, lca, amounts);
+      },
+      recover: async () => {
+        await ctx.zoeTools.withdrawToSeat(lca, seat, amounts);
+      },
+    },
+    {
+      how: 'IBC transfer',
+      src: { account: lca },
+      dest: { account: ica },
+      amount: withFees,
+      apply: async () => {
+        await lca.transfer(nobleAddr, volume);
+      },
+      recover: async () => {
+        const nobleAmount = { ...volume, denom: 'uusdc' };
+        await ica.transfer(lca.getAddress(), nobleAmount);
+      },
+    },
+    {
+      how: 'Swap, Lock',
+      amount: USDN,
+      src: { account: ica },
+      dest: { pos },
+      apply: async () => {
+        // NOTE: proposalShape guarantees that amount.brand is USDC
+        const { msgSwap, msgLock, protoMessages } = makeSwapLockMessages(
+          nobleAddr,
+          USDN.value,
+          { usdnOut },
+        );
+
+        trace('executing', [msgSwap, msgLock].filter(Boolean));
+        const result = await ica.executeEncodedTx(protoMessages);
+        trace('TODO: decode Swap, Lock result; detect errors', result);
+      },
+      // XXX consider putting withdaw here
+      recover: async () => {},
+    },
+  ]);
+}; // XXX: push down to Orchestration API in NobleMethods, in due course
+
+export const changeUSDCPosition = async (
+  give: OpenPortfolioGive,
+  offerArgs: { usdnOut?: NatValue },
+  orch: Orchestrator,
+  kit,
+  ctx: PortfolioInstanceContext,
+  seat: ZCFSeat,
+) => {
+  assert('USDN' in give && give.USDN); // XXX get rid of this using trackFlow
+  const { USDN, NobleFees } = give;
+  const g = harden({ USDN, NobleFees });
+  const { usdnOut } = offerArgs;
+  const { lca } = await provideAccountInfo(orch, 'agoric', kit);
+  const { ica } = await provideAccountInfo(orch, 'noble', kit);
+  const accountId = coerceAccountId(ica.getAddress());
+  const pos = kit.manager.provideUSDNPosition(accountId);
+  await addToUSDNPosition(ctx, seat, lca, ica, pos, kit.reporter, g, usdnOut);
+};

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -209,6 +209,20 @@ export const portfolioIdOfPath = (path: string | string[]) => {
   return id;
 };
 
+// XXX refactor using AssetMoveDesc
+type FlowStatus = {
+  step: number;
+  how: string;
+  src: string;
+  dest: string;
+  amount: Amount<'nat'>;
+  error?: string;
+};
+type GMPStatusTODO = {
+  protocol: YieldProtocol;
+  accountId: AccountId | undefined;
+};
+
 // XXX relate paths to types a la readPublished()
 export type StatusFor = {
   portfolio: {
@@ -225,15 +239,10 @@ export type StatusFor = {
     totalOut: Amount<'nat'>;
   };
   // XXX refactor using AssetMoveDesc
-  flow: {
-    step: number;
-    how: string;
-    src: string;
-    dest: string;
-    amount: Amount<'nat'>;
-    where?: string;
-    error?: string;
-  };
+  flow:
+    | FlowStatus
+    | (Omit<FlowStatus, 'dest'> & { where: string }) // recovery failed
+    | GMPStatusTODO;
 };
 
 export const PortfolioStatusShape: TypedPattern<StatusFor['portfolio']> =

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -7,9 +7,9 @@ import { gmpAddresses } from '@agoric/orchestration/src/utils/gmp.js';
 import { q } from '@endo/errors';
 import { passStyleOf } from '@endo/far';
 import { matches, mustMatch } from '@endo/patterns';
-import { makeAxelarMemo } from '../src/portfolio.flows.ts';
+import { makeAxelarMemo } from '../src/pos-gmp.flows.ts';
 import { makeProposalShapes } from '../src/type-guards.ts';
-import { type GmpArgsContractCall } from '../src/portfolio.flows.ts';
+import { type GmpArgsContractCall } from '../src/pos-gmp.flows.ts';
 import {
   setupTrader,
   simulateAckTransferToAxelar,

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -29,11 +29,11 @@ import {
   type PortfolioKit,
 } from '../src/portfolio.exo.ts';
 import {
-  makeSwapLockMessages,
   openPortfolio,
   rebalance,
   type PortfolioInstanceContext,
 } from '../src/portfolio.flows.ts';
+import { makeSwapLockMessages } from '../src/pos-usdn.flows.ts';
 import { makeProposalShapes, type ProposalType } from '../src/type-guards.ts';
 import { axelarChainsMapMock } from './mocks.ts';
 import { makeIncomingEVMEvent } from './supports.ts';


### PR DESCRIPTION
## Description

Move code for specific yield protocols to their own files. Aave and Compound have so much in common that we keep them together; since Axelar GMP is used in both cases, we use `gmp` as a shorthand.

### Documentation Considerations

Files with smaller scope are presumably easier to understand.

### Security / Scaling / Testing / Upgrade Considerations

none. pure refactor. Note that other than imports, the tests didn't change at all.
