### PR TITLE
ci(restore-node): fix caching problems

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -133,9 +133,19 @@ runs:
       shell: bash
       run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
 
-    # Before setup-node because that action runs `yarn cache dir`. See https://github.com/actions/setup-node/issues/480#issuecomment-1915448139
-    - run: corepack enable
-      shell: bash
+    # Set up for Corepack before trying to cache yarn. See
+    # https://github.com/actions/setup-node/issues/899#issuecomment-1828798029.
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.set-node-version.outputs.NODE_VERSION }}
+
+    # Before setup-node because that action tries to discover the cache directory.
+    # See https://github.com/actions/setup-node/issues/480#issuecomment-1915448139
+    - shell: bash
+      run: |
+        set -ex
+        corepack enable
+        mkdir -p "$(yarn config get cacheFolder)"
 
     - uses: actions/setup-node@v4
       with:
@@ -143,6 +153,9 @@ runs:
         cache: yarn
         cache-dependency-path: |
           ${{ inputs.path }}/yarn.lock
+          ${{ inputs.path }}/a3p-integration/yarn.lock
+          ${{ inputs.path }}/a3p-integration/proposals/*/yarn.lock
+          ${{ inputs.path }}/multichain-testing/yarn.lock
           ${{ inputs.path }}/endo-sha.txt
 
     - uses: kenchan0130/actions-system-info@master


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This is a tiny PR that may fix [a caching failure discovered in CI](https://github.com/Agoric/agoric-sdk/actions/runs/16103776211/job/45436346738?pr=11571#step:11:12) on several Agoric/agoric-sdk branches.

Here’s the error, in case the above URL is expired:

![image](https://github.com/user-attachments/assets/c23ab216-7bd0-4b35-8189-dcbad2aed137)

<details><summary>And some text around the Error since the screenshot isn't easy to search for:
</summary>

```
Post run /./.github/actions/restore-node
Post job cleanup.
Post job cleanup.
+ cd .
+ ignore_dirty_yarn_lock=false
++ git status --porcelain
+ changes=
+ '[' false = true ']'
+ '[' -n '' ']'
Post job cleanup.
Cache hit occurred on the primary key Linux-X64-24.04-node-22-built-0-74323d7bb088cb02ca74849be983097db5d9cab2-NOPE, not saving cache.
Post job cleanup.
Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
Post job cleanup.
```

</details> 

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
n/a

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
n/a

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
n/a

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
n/a