### PR TITLE
feat: ymax deployment in 1 staker vote

### DIFF
--- a/packages/portfolio-contract/src/type-guards-steps.ts
+++ b/packages/portfolio-contract/src/type-guards-steps.ts
@@ -85,7 +85,7 @@ export const makeOfferArgsShapes = (usdcBrand: Brand<'nat'>) => {
     openPortfolio: M.splitRecord(
       {},
       {
-        flow: M.arrayOf(movementDescShape),
+        flow: M.arrayOf(movementDescShape, { arrayLengthLimit: 12 }),
         destinationEVMChain: M.or(...keys(AxelarChain)),
       },
     ) as TypedPattern<OfferArgsFor['openPortfolio']>,

--- a/packages/portfolio-deploy/src/attenuated-deposit.core.js
+++ b/packages/portfolio-deploy/src/attenuated-deposit.core.js
@@ -1,0 +1,43 @@
+/**
+ * @file Get a promise for a deposit facet without
+ * access to all of namesByAddressAdmin.
+ */
+
+import { E } from '@endo/eventual-send';
+
+const trace = (...args) => console.log('---- AttD', ...args);
+
+/**
+ * @import {DepositFacet} from '@agoric/ertp';
+ */
+const depositFacetKey = 'depositFacet';
+
+/**
+ * XXX move this into BootstrapPowers
+ * @typedef {PromiseSpaceOf<{
+ *   getDepositFacet: (addr: string, debugName?: string) => Promise<DepositFacet>
+ * }>} AttenuatedDepositPowers
+ */
+
+/**
+ * @param {BootstrapPowers & AttenuatedDepositPowers} powers
+ */
+export const produceAttenuatedDeposit = powers => {
+  const { namesByAddress, namesByAddressAdmin } = powers.consume;
+  /**
+   *
+   * @param {string} addr
+   * @param {string} [debugName]
+   */
+  const getDepositFacet = async (addr, debugName = 'party') => {
+    trace('reserve nameHub for', debugName, addr);
+    await E(namesByAddressAdmin).reserve(addr);
+    trace('lookup depositFacet for', debugName, addr);
+    const df = await E(namesByAddress).lookup(addr, depositFacetKey);
+    trace('got depositFacet for', debugName, addr);
+    return df;
+  };
+  harden(getDepositFacet);
+
+  powers.produce.getDepositFacet.resolve(getDepositFacet);
+};

--- a/packages/portfolio-deploy/src/chain-info.core.js
+++ b/packages/portfolio-deploy/src/chain-info.core.js
@@ -93,9 +93,16 @@ const publishChainInfoToChainStorage = async (
  */
 
 /**
+ * XXX move this into BootstrapPowers
+ * @typedef {PromiseSpaceOf<{
+ *   chainInfoPublished: unknown
+ * }>} ChainInfoPowers
+ */
+
+/**
  * WARNING: prunes any data that was previously published
  *
- * @param {BootstrapPowers & ChainStoragePresent} powers
+ * @param {BootstrapPowers & ChainStoragePresent & ChainInfoPowers} powers
  * @param {{
  *   options: {
  *     chainInfo?: Record<string, ChainInfo>;
@@ -104,7 +111,10 @@ const publishChainInfoToChainStorage = async (
  * }} config
  */
 export const publishChainInfo = async (
-  { consume: { agoricNames, agoricNamesAdmin, chainStorage } },
+  {
+    consume: { agoricNames, agoricNamesAdmin, chainStorage },
+    produce: { chainInfoPublished },
+  },
   config,
 ) => {
   const { keys } = Object;
@@ -150,6 +160,8 @@ export const publishChainInfo = async (
     trace('@@@registered', name, info);
   }
   trace('@@@conn', ...handledConnections);
+
+  chainInfoPublished.resolve(true);
   trace('publishChainInfo done');
 };
 harden(publishChainInfo);
@@ -162,6 +174,7 @@ export const getManifestForChainInfo = (_u, { options }) => ({
         agoricNamesAdmin: true,
         chainStorage: true,
       },
+      produce: { chainInfoPublished: true },
     },
   },
   options,

--- a/packages/portfolio-deploy/src/portfolio-start.core.js
+++ b/packages/portfolio-deploy/src/portfolio-start.core.js
@@ -17,6 +17,7 @@ import { name, permit } from './portfolio.contract.permit.js';
  * @import {AxelarChainConfigMap} from './axelar-configs.js';
  * @import {EVMContractAddressesMap} from '@aglocal/portfolio-contract/src/type-guards.ts';
  * @import {TypedPattern} from '@agoric/internal';
+ * @import { ChainInfoPowers } from './chain-info.core.js';
  */
 
 const trace = makeTracer(`YMX-Start`, true);
@@ -100,12 +101,15 @@ export const makePrivateArgs = async (
 harden(makePrivateArgs);
 
 /**
- * @param {BootstrapPowers & PortfolioBootPowers} permitted
+ * @param {BootstrapPowers & PortfolioBootPowers & ChainInfoPowers} permitted
  * @param {{ options: LegibleCapData<PortfolioDeployConfig> }} configStruct
  * @returns {Promise<void>}
  */
 export const startPortfolio = async (permitted, configStruct) => {
   trace('startPortfolio', configStruct);
+
+  await permitted.consume.chainInfoPublished;
+
   const { issuer } = permitted;
   const [BLD, USDC, PoC26] = await Promise.all([
     issuer.consume.BLD,

--- a/packages/portfolio-deploy/src/portfolio.contract.permit.js
+++ b/packages/portfolio-deploy/src/portfolio.contract.permit.js
@@ -12,7 +12,7 @@ export const name = /** @type {const} */ ('ymax0');
  */
 export const permit = /** @type {const} */ ({
   produce: { [/** @type {const} */ (`${name}Kit`)]: true },
-  consume: { ...orchPermit },
+  consume: { ...orchPermit, chainInfoPublished: true },
   instance: { produce: { [name]: true } },
   installation: { consume: { [name]: true } },
   brand: {},

--- a/packages/portfolio-deploy/test/portfolio-start.core.test.ts
+++ b/packages/portfolio-deploy/test/portfolio-start.core.test.ts
@@ -28,6 +28,7 @@ import type {
   StartFn,
 } from '../src/portfolio-start.type.ts';
 import { name as contractName } from '../src/portfolio.contract.permit.js';
+import type { ChainInfoPowers } from '../src/chain-info.core.js';
 
 const { entries, keys } = Object;
 
@@ -49,7 +50,8 @@ test('coreEval code without swingset', async t => {
   const log = () => {}; // console.log
   const { produce, consume } = makePromiseSpace({ log });
   const powers = { produce, consume, ...wk } as unknown as BootstrapPowers &
-    PortfolioBootPowers;
+    PortfolioBootPowers &
+    ChainInfoPowers;
   // XXX type of zoe from setUpZoeForTest is any???
   const { zoe: zoeAny, bundleAndInstall } = await setUpZoeForTest();
   const zoe: ZoeService = zoeAny;
@@ -94,6 +96,8 @@ test('coreEval code without swingset', async t => {
     );
     produce.zoe.resolve(zoe);
   }
+
+  produce.chainInfoPublished.resolve(true);
 
   // script from agoric run does this step
   t.log('produce installation using test bundle');


### PR DESCRIPTION
## Description

The ymax core-eval depends on two others: chain-info (directly) and access-token (less directly). This work lets us send them out in one staker vote.

 - ymax deployment awaits chainInfoPublished
 - chore(chain-info.build): default to mainnet chainInfo

Also:

 - feat: limit steps to 12
 - feat: depositFacet awaits provisioning, without namesByAddressAdmin #11613

### Security / Scaling / Upgrade Considerations

nothing new

### Documentation Considerations

It would be awkward to explain separate decisions.

### Testing Considerations

See [Manual testing details](#issuecomment-3076038120) below.
