### PR TITLE
chore(portfolio-deploy): shrink aux bundle from 2,268K to 708K

### DIFF
--- a/packages/portfolio-deploy/src/chain-name-service.js
+++ b/packages/portfolio-deploy/src/chain-name-service.js
@@ -1,4 +1,4 @@
-import { denomHash } from '@agoric/orchestration';
+import { denomHash } from '@agoric/orchestration/src/utils/denomHash.js';
 
 /**
  * @import {IBCChannelID, NameAdmin} from '@agoric/vats';


### PR DESCRIPTION
import less of orchestration pkg

### Upgrade Considerations

This does make the bundle we use for multichain-testing etc. differ from the one on chain.