### PR TITLE
fix(client-utils): Vstorage client utility misreports values in non-chronological order

### DIFF
--- a/packages/client-utils/src/vstorage.js
+++ b/packages/client-utils/src/vstorage.js
@@ -96,6 +96,7 @@ export const makeVStorage = ({ fetch }, config) => {
     const rpc = kindToRpc[kind];
     const codec = codecs[rpc];
 
+    /** @type {Awaited<ReturnType<typeof getVstorageJson>>} */
     let data;
     try {
       data = await getVstorageJson(path, { kind, height });
@@ -167,14 +168,12 @@ export const makeVStorage = ({ fetch }, config) => {
       let blockHeight;
       await null;
       do {
-        // console.debug('READING', { blockHeight });
         let values;
         try {
           ({ blockHeight, values } = await vstorage.readAt(
             path,
             blockHeight === undefined ? undefined : Number(blockHeight) - 1,
           ));
-          // console.debug('readAt returned', { blockHeight });
         } catch (err) {
           if (
             // CosmosSDK ErrInvalidRequest with particular message text;
@@ -190,9 +189,7 @@ export const makeVStorage = ({ fetch }, config) => {
           }
           throw err;
         }
-        parts.push(values);
-        // console.debug('PUSHED', values);
-        // console.debug('NEW', { blockHeight, minHeight });
+        parts.push(values.reverse());
         if (minHeight && Number(blockHeight) <= Number(minHeight)) break;
       } while (Number(blockHeight) > 0);
       return /** @type {string[]} */ (parts.flat());

--- a/packages/client-utils/src/vstorage.js
+++ b/packages/client-utils/src/vstorage.js
@@ -168,12 +168,14 @@ export const makeVStorage = ({ fetch }, config) => {
       let blockHeight;
       await null;
       do {
+        // console.debug('READING', { blockHeight });
         let values;
         try {
           ({ blockHeight, values } = await vstorage.readAt(
             path,
             blockHeight === undefined ? undefined : Number(blockHeight) - 1,
           ));
+          // console.debug('readAt returned', { blockHeight });
         } catch (err) {
           if (
             // CosmosSDK ErrInvalidRequest with particular message text;
@@ -190,6 +192,8 @@ export const makeVStorage = ({ fetch }, config) => {
           throw err;
         }
         parts.push(values.reverse());
+        // console.debug('PUSHED', values);
+        // console.debug('NEW', { blockHeight, minHeight });
         if (minHeight && Number(blockHeight) <= Number(minHeight)) break;
       } while (Number(blockHeight) > 0);
       return /** @type {string[]} */ (parts.flat());

--- a/packages/client-utils/test/vstorage.test.js
+++ b/packages/client-utils/test/vstorage.test.js
@@ -3,16 +3,16 @@
 import test from 'ava';
 import { makeVStorage } from '../src/vstorage.js';
 
-const makeTestConfig = () => ({
+const testConfig = {
   chainName: 'test-chain',
   rpcAddrs: ['http://localhost:26657'],
-});
+};
 
 /** @type {any} */
 const fetch = () => Promise.resolve({});
 
 test('readFully can be used without instance binding', async t => {
-  const vstorage = makeVStorage({ fetch }, makeTestConfig());
+  const vstorage = makeVStorage({ fetch }, testConfig);
   const { readFully } = vstorage;
 
   // Mock implementation to avoid actual network calls
@@ -35,6 +35,8 @@ test('storage history should be in chronological order', async t => {
       ])
       .flat();
 
+  const generateRandomNumber = () => Math.ceil(Math.random() * 10);
+
   /**
    * @param {number} maximumHeight
    * @param {number} minimumHeight
@@ -48,9 +50,10 @@ test('storage history should be in chronological order', async t => {
       ],
     }));
 
-  const maximumHeight = 9; // randomly choosen, could be replaced by Math.rand
-  const minimumHeight = 3; // randomly choosen, could be replaced by Math.rand
+  const minimumHeight = generateRandomNumber();
   const storagePathName = 'published.test';
+
+  const maximumHeight = generateRandomNumber() + minimumHeight;
 
   const responses = generateResponses(maximumHeight, minimumHeight);
 
@@ -62,7 +65,7 @@ test('storage history should be in chronological order', async t => {
     {},
   );
 
-  const vstorageKit = makeVStorage({ fetch }, makeTestConfig());
+  const vstorageKit = makeVStorage({ fetch }, testConfig);
 
   /**
    * @param {string} path


### PR DESCRIPTION
closes: #11614

## Description
The `readFully` function doesn't respect the order of the updates which happen within a single block
This can create problem in case there are more than one block history requested as there is no way to know which one is the latest without fetching the latest block data separately

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
The added test should pass

### Upgrade Considerations
None
