### PR TITLE
docs(portfolio-contract): Commit Messages w.r.t. Last Release

### DIFF
--- a/packages/portfolio-contract/CHANGELOG.md
+++ b/packages/portfolio-contract/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.
+
+## [0.1.0-alpha] - 2024-07-15
+
+### Features
+
+- Initial portfolio contract implementation for diversified stablecoin yield management
+- Support for multiple yield protocols (USDN, Aave, Compound)
+- Cross-chain portfolio rebalancing via Noble and Axelar GMP
+- Portfolio position tracking and flow logging to vstorage
+- Continuing invitations for ongoing portfolio management
+- Build system with governance proposal generation
+- Access token setup for portfolio permissions
+
+### Notes
+- This is a proof-of-concept alpha release
+- Contract name: `ymax0`
+- Commit: [`f741807`](https://github.com/Agoric/agoric-sdk/commit/f741807aff5929acabc007380c4a057882a35147)
+
+[0.1.0-alpha]: https://github.com/Agoric/agoric-sdk/releases/tag/ymax-v0.1-alpha

--- a/packages/portfolio-contract/CONTRIBUTING.md
+++ b/packages/portfolio-contract/CONTRIBUTING.md
@@ -25,6 +25,19 @@ Our [unit testing conventions](https://github.com/Agoric/agoric-sdk/wiki/agoric-
 
 While [tooling to enforce consistent import ordering #7403](https://github.com/Agoric/agoric-sdk/issues/7403) is not yet in place, please use **Organize Imports** regularly.
 
+## Commit Messages w.r.t. Last Release
+
+Note [use of Conventional Commits in agoric-sdk](https://github.com/Agoric/agoric-sdk/wiki/Conventional-Commits). In particular:
+
+ - `feat:` for **user-visible** (or: client-visible) features
+ - `fix:` for **bugs present in [the previous release](./CHANGELOG.md)**
+
+Adding a new function without wiring it all the way out to the contract interface so that it works in a user story is a `chore`, not a `feat`.
+
+If something wonky was added to master _since the last release_, cleaning it up is perhaps a `chore` or `refactor`, but not a `fix`.
+
+Between `docs`, `test`, and `chore`, the distinction has less impact. Salt to taste.
+
 ## Deployment is out of scope
 
 The `@aglocal/portfolio-deploy` package takes care of deployment. It depends on this package.


### PR DESCRIPTION
## Description

An LLM was spitting out nonsense such as `feat: fix TypeScript type definitions...`. Is it a `feat` or a `fix`? pick one!?

I could have just pointed it at [Conventional Commits in agoric-sdk](https://github.com/Agoric/agoric-sdk/wiki/Conventional-Commits), but while I was at it, I wrote up my preference for how to use **fix** and **feat**. Shall we adopt it?