### PR TITLE
Close transcript span synchronously

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -223,7 +223,7 @@ export const makeQueueStorage = (call, queuePath) => {
  * @param {typeof process.env} [options.env]
  * @param {Pick<import('fs'), 'createWriteStream' | 'mkdirSync' | 'renameSync'>} options.fs
  * @param {Pick<import('path'), 'join' | 'resolve'>} options.path
- * @param {import('tmp')} [options.tmp] required to support vatSnapshotArchiveDir/vatTranscriptArchiveDir
+ * @param {import('tmp')} options.tmp required to support vatSnapshotArchiveDir/vatTranscriptArchiveDir
  * @param {ReturnType<typeof makeProcessValue>} [options.processValue]
  * @param {() => Promise<void>} [options.readyForCommit]
  * @param {{

--- a/packages/cosmic-swingset/tools/test-kit.js
+++ b/packages/cosmic-swingset/tools/test-kit.js
@@ -253,6 +253,7 @@ export const makeCosmicSwingsetTestKit = async (
     env,
     fs,
     path: nativePath,
+    tmp,
     testingOverrides: {
       debugName,
       slogSender,

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -31,6 +31,8 @@
   },
   "devDependencies": {
     "@endo/init": "^1.1.12",
+    "@endo/promise-kit": "^1.1.13",
+    "@endo/stream": "^1.2.13",
     "@types/better-sqlite3": "^7.6.13",
     "ava": "^5.3.0",
     "c8": "^10.1.3",

--- a/packages/swing-store/test/transcriptStore.test.js
+++ b/packages/swing-store/test/transcriptStore.test.js
@@ -1,0 +1,178 @@
+// @ts-check
+import test from 'ava';
+
+import sqlite3 from 'better-sqlite3';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeQueue } from '@endo/stream';
+
+import { makeTranscriptStore } from '../src/transcriptStore.js';
+
+/**
+ * @import {AsyncQueue} from '@endo/stream';
+ * @import {PromiseKit} from '@endo/promise-kit';
+ */
+
+function makeExportLog() {
+  const exportLog = [];
+  return {
+    noteExport(key, value) {
+      exportLog.push([key, value]);
+    },
+    getLog() {
+      return exportLog.splice(0);
+    },
+  };
+}
+
+/**
+ * @typedef {{name: string; entries: Uint8Array[]}} TranscriptArtifact
+ */
+
+/**
+ * A test kit that consumes the transcript archive entries on demand
+ */
+function makeArchiveTranscript() {
+  /** @type {AsyncQueue<(transcriptArtifact: TranscriptArtifact) => void>} */
+  const queue = makeQueue();
+
+  return {
+    archiveTranscript: async (name, rawEntries) => {
+      const resolve = await queue.get();
+      // TODO: use Array.fromAsync once we're on Node 22
+      const entries = [];
+      for await (const entry of rawEntries) {
+        entries.push(entry);
+      }
+      resolve({ name, entries });
+    },
+    getTranscriptArtifact: () => {
+      /** @type {PromiseKit<TranscriptArtifact>} */
+      const { resolve, promise } = makePromiseKit();
+      queue.put(resolve);
+      return promise;
+    },
+  };
+}
+
+function ensureTxn() {}
+
+const closeSpanMacro = test.macro(async (t, useArchiver) => {
+  const db = sqlite3(':memory:');
+  const exportLog = makeExportLog();
+  const { archiveTranscript, getTranscriptArtifact } = useArchiver
+    ? makeArchiveTranscript()
+    : {};
+  const store = makeTranscriptStore(db, ensureTxn, exportLog.noteExport, {
+    keepTranscripts: false,
+    archiveTranscript,
+  });
+
+  const vatID = 'v1';
+
+  await null;
+
+  store.initTranscript(vatID);
+  store.addItem(vatID, 'foo');
+  store.addItem(vatID, 'bar');
+
+  t.deepEqual(exportLog.getLog(), [
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":0,"endPos":0,"hash":"43e6be43a3a34d60c0ebeb8498b5849b094fc20fc68483a7aeb3624fa10f79f6","isCurrent":1,"incarnation":0}',
+    ],
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":0,"endPos":1,"hash":"3a676f1da91fe6da8268853f21e64e3366da45811b830f9d92f39d4c01d69291","isCurrent":1,"incarnation":0}',
+    ],
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":0,"endPos":2,"hash":"92bf47a2498333897b80e299e6248c3a9f180a68d9f8ced4d1408956afc48e55","isCurrent":1,"incarnation":0}',
+    ],
+  ]);
+
+  const spanRolloverResult = store.rolloverSpan(vatID);
+
+  t.deepEqual(exportLog.getLog(), [
+    [
+      'transcript.v1.0',
+      '{"vatID":"v1","startPos":0,"endPos":2,"hash":"92bf47a2498333897b80e299e6248c3a9f180a68d9f8ced4d1408956afc48e55","isCurrent":0,"incarnation":0}',
+    ],
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":2,"endPos":2,"hash":"43e6be43a3a34d60c0ebeb8498b5849b094fc20fc68483a7aeb3624fa10f79f6","isCurrent":1,"incarnation":0}',
+    ],
+  ]);
+
+  if (useArchiver) {
+    t.deepEqual(await getTranscriptArtifact?.(), {
+      name: 'transcript.v1.0.2',
+      entries: [Buffer.from('foo\n'), Buffer.from('bar\n')],
+    });
+  }
+
+  await spanRolloverResult;
+
+  t.deepEqual(exportLog.getLog(), []);
+
+  store.addItem(vatID, 'foo');
+  const incarnationRolloverResult = store.rolloverIncarnation(vatID);
+
+  t.deepEqual(exportLog.getLog(), [
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":2,"endPos":3,"hash":"3a676f1da91fe6da8268853f21e64e3366da45811b830f9d92f39d4c01d69291","isCurrent":1,"incarnation":0}',
+    ],
+    [
+      'transcript.v1.2',
+      '{"vatID":"v1","startPos":2,"endPos":3,"hash":"3a676f1da91fe6da8268853f21e64e3366da45811b830f9d92f39d4c01d69291","isCurrent":0,"incarnation":0}',
+    ],
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":3,"endPos":3,"hash":"43e6be43a3a34d60c0ebeb8498b5849b094fc20fc68483a7aeb3624fa10f79f6","isCurrent":1,"incarnation":1}',
+    ],
+  ]);
+
+  if (useArchiver) {
+    t.deepEqual(await getTranscriptArtifact?.(), {
+      name: 'transcript.v1.2.3',
+      entries: [Buffer.from('foo\n')],
+    });
+  }
+
+  await incarnationRolloverResult;
+
+  t.deepEqual(exportLog.getLog(), []);
+
+  store.addItem(vatID, 'foo');
+  const stopResult = store.stopUsingTranscript(vatID);
+
+  t.deepEqual(exportLog.getLog(), [
+    [
+      'transcript.v1.current',
+      '{"vatID":"v1","startPos":3,"endPos":4,"hash":"3a676f1da91fe6da8268853f21e64e3366da45811b830f9d92f39d4c01d69291","isCurrent":1,"incarnation":1}',
+    ],
+    [
+      'transcript.v1.3',
+      '{"vatID":"v1","startPos":3,"endPos":4,"hash":"3a676f1da91fe6da8268853f21e64e3366da45811b830f9d92f39d4c01d69291","isCurrent":0,"incarnation":1}',
+    ],
+    ['transcript.v1.current', undefined],
+  ]);
+
+  if (useArchiver) {
+    t.deepEqual(await getTranscriptArtifact?.(), {
+      name: 'transcript.v1.3.4',
+      entries: [Buffer.from('foo\n')],
+    });
+  }
+
+  await stopResult;
+
+  t.deepEqual(exportLog.getLog(), []);
+});
+
+test('span close operations are sync (with archiver)', closeSpanMacro, true);
+test(
+  'span close operations are sync (without archiver)',
+  closeSpanMacro,
+  false,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,6 +1052,8 @@ __metadata:
     "@endo/errors": "npm:^1.2.13"
     "@endo/init": "npm:^1.1.12"
     "@endo/nat": "npm:^5.1.3"
+    "@endo/promise-kit": "npm:^1.1.13"
+    "@endo/stream": "npm:^1.2.13"
     "@types/better-sqlite3": "npm:^7.6.13"
     ava: "npm:^5.3.0"
     better-sqlite3: "npm:^10.1.0"


### PR DESCRIPTION
closes: #11642

## Description
The vat termination triggered in u21 revealed a latent bug in the way transcript archiving integrates with span rollover.

This PR does the least intrusive change updating only the implementation of the transcript store to guarantee that all store operations are synchronous even for the methods that are async because of the archiver's integration.

### Security Considerations
We previously released Zalgo by assuming some async operation was mostly sync, and it worked fine because of the low number of ticks the callee took, except when the archiver was enabled. This is taming Zalgo a little bit. In a perfect world we would change the signature of these async transcript store APIs into sync functions returning a nested promise for the deferred part, making the sync part explicit, and legal to rely upon.

### Scaling Considerations
None

### Documentation Considerations
Comment added in JSDoc with sync guarantees

### Testing Considerations
Added test for the sync guarantees.

Reproduced the original issue in a manual test of the code before fix: with the addition of an `await new Promise(resolve => setImmediate(resolve));` between the call to the APIs triggering span close and the log check (simulating the numerous `await` in the callers), the test with archiver disabled passes, but fails with the archiver enabled.

### Upgrade Considerations
None, this is not consensus affecting (running this patch on my u21 archiving follower).
