### PR TITLE
feat: prune old ymax0 vstorage nodes (builder, core-eval)

### DIFF
--- a/packages/portfolio-deploy/src/vstorage-prune.build.js
+++ b/packages/portfolio-deploy/src/vstorage-prune.build.js
@@ -1,0 +1,113 @@
+/**
+ * @file enumerate [vstorage][vsmod] keys under `published.ymax` that are
+ * older than the ymax0 instance in published.agoricNames.instance
+ *
+ * Motivation: each time we deploy to devnet, portfolios and such from
+ * earlier deployments remain in vstorage, confusing clients.
+ *
+ * [vsmod]: https://github.com/Agoric/agoric-sdk/blob/ymax-v0.1-alpha/golang/cosmos/x/vstorage/README.md
+ */
+/* global globalThis */
+import { fetchEnvNetworkConfig, makeVStorage } from '@agoric/client-utils';
+import { makeHelpers } from '@agoric/deploy-script-support';
+import { NonNullish } from '@agoric/internal';
+import { Fail } from '@endo/errors';
+import { getManifestForPruneVStorage } from './vstorage-prune.core.js';
+
+const sourceSpec = './vstorage-prune.core.js';
+
+/**
+ * @import { StreamCell } from '@agoric/internal/src/lib-chainStorage.js';
+ * @import { VStorage } from '@agoric/client-utils';
+ * @import {CoreEvalBuilder, DeployScriptFunction} from '@agoric/deploy-script-support/src/externalTypes.js';
+ * @import {PruneOpts} from './vstorage-prune.core';
+ */
+
+/**
+ * @param {unknown} _utils
+ * @param {PruneOpts} pruneOpts
+ * @satisfies {CoreEvalBuilder}
+ */
+export const defaultProposalBuilder = async (_utils, pruneOpts) =>
+  harden({
+    sourceSpec,
+    getManifestCall: [getManifestForPruneVStorage.name, { options: pruneOpts }],
+  });
+
+/**
+ * @param {VStorage} vs
+ * @param {string} start
+ */
+async function* depthFirst(vs, start) {
+  /** @param {string} current */
+  async function* visit(current) {
+    const children = await vs.keys(current);
+    for (const child of children) {
+      yield* visit(`${current}.${child}`);
+    }
+    yield current;
+  }
+
+  yield* visit(start);
+}
+
+/** @param {VStorage} vs */
+const findOutdated = async vs => {
+  const verbose = false; // XXX cli flag
+  const debug = verbose ? console.debug : () => {};
+
+  /** @param {string} path */
+  const getHeightLast = async path => {
+    debug('read', path);
+    // const raw = await vs.readStorage(path);
+    // console.debug({ path, raw });
+
+    const { blockHeight, values } = /** @type {StreamCell<'string'>} */ (
+      await vs.readAt(path)
+    );
+    return { blockHeight: Number(blockHeight), last: values.at(-1) };
+  };
+
+  const { blockHeight: t0, last } = await getHeightLast(
+    'published.agoricNames.instance',
+  );
+  (last && last.includes('ymax0')) || Fail`no ymax0 instance`;
+  console.error('published.agoricNames.instance blockHeight', t0);
+
+  /** @type {PruneOpts['toPrune']} */
+  const toPrune = {};
+
+  const noData = ['.portfolios', '.flows', '.positions'];
+  for await (const path of depthFirst(vs, 'published.ymax0.portfolios')) {
+    if (noData.some(tail => path.endsWith(tail))) continue;
+    const { blockHeight: age } = await getHeightLast(path);
+    const ok = age >= t0;
+    debug({ path, age, t0, ok });
+    if (!ok) {
+      const parts = path.split('.');
+      const child = NonNullish(parts.at(-1));
+      const parent = parts.slice(0, -1).join('.');
+      if (!(parent in toPrune)) {
+        toPrune[parent] = [];
+      }
+      toPrune[parent].push(child);
+    }
+  }
+  return harden(toPrune);
+};
+
+/** @type {DeployScriptFunction} */
+export default async (
+  homeP,
+  endowments,
+  { fetch = globalThis.fetch, env = process.env } = {},
+) => {
+  const config = await fetchEnvNetworkConfig({ env, fetch });
+  const vs = makeVStorage({ fetch }, config);
+  const toPrune = await findOutdated(vs);
+
+  const { writeCoreEval } = await makeHelpers(homeP, endowments);
+  await writeCoreEval('eval-vstorage-prune', utils =>
+    defaultProposalBuilder(utils, harden({ toPrune })),
+  );
+};

--- a/packages/portfolio-deploy/src/vstorage-prune.core.js
+++ b/packages/portfolio-deploy/src/vstorage-prune.core.js
@@ -1,0 +1,70 @@
+/**
+ * @file core eval to prune (presumably outdated) vstorage nodes.
+ *
+ * Use `vstorage-prune.build.js` to configure which nodes to prune.
+ */
+
+/**
+ * @import {ChainStoragePresent} from './chain-info.core'
+ */
+
+import { makeTracer, zip } from '@agoric/internal';
+import { E } from '@endo/eventual-send';
+
+const trace = makeTracer('VSP');
+
+/**
+ * @typedef {{
+ *   toPrune: Record<string, string[]>
+ * }} PruneOpts
+ */
+
+/**
+ * @param {BootstrapPowers & ChainStoragePresent} permitted
+ * @param {{options: PruneOpts}} config
+ */
+export const pruneVStorage = async (permitted, { options }) => {
+  const { toPrune } = options;
+  trace('toPrune', toPrune);
+  const { chainStorage } = permitted.consume;
+
+  /** @param {string[]} path */
+  const makePathNode = path => {
+    let node = chainStorage;
+    for (const segment of path) {
+      node = E(node).makeChildNode(segment);
+    }
+    return node;
+  };
+
+  await null;
+  for (const [parent, children] of Object.entries(toPrune)) {
+    const segments = parent.replace(/^published\./, '').split('.');
+    const parentNode = makePathNode(segments);
+    trace('pruning', parent, children);
+    // on failure, trace rather than aborting the whole job
+    const results = await Promise.allSettled(
+      children.map(k =>
+        E(E(parentNode).makeChildNode(k, { sequence: false })).setValue(''),
+      ),
+    );
+    for (const [child, result] of zip(children, results)) {
+      if (result.status === 'rejected') {
+        trace('rejected:', parent, child, result.reason);
+      }
+    }
+  }
+  trace('done');
+};
+harden(pruneVStorage);
+
+export const getManifestForPruneVStorage = (_u, { options }) => ({
+  manifest: {
+    [pruneVStorage.name]: {
+      consume: {
+        chainStorage: true,
+      },
+    },
+  },
+  options,
+});


### PR DESCRIPTION
## Description

builder `@file` comment:
> enumerate [vstorage][vsmod] keys under `published.ymax` that are
> older than the `ymax0` instance in `published.agoricNames.instance`
> 
> Motivation: each time we deploy to devnet, portfolios and such from
> earlier deployments remain in vstorage, confusing clients.
> 
> [vsmod]: https://github.com/Agoric/agoric-sdk/blob/ymax-v0.1-alpha/golang/cosmos/x/vstorage/README.md

core eval `@file` comment:
> core eval to prune (presumably outdated) vstorage nodes.

limitation: the builder assumes the last update to `.agoricNames.instance` was to update `ymax0`.
postponed: iterate back until the `ymax0` boardId changes

### Security Considerations

`chainStorage` is a capability to scribble all over vstorage; reviewers should confirm that it's only used as directed.

pruning vstorage reduces confusion, which generally aids security

### Scaling Considerations

There's a loop, but it's over data that's fixed at voting time.

### Documentation / Testing Considerations

not much, given that its intended usage is for devnet

It worked as designed in [proposal 223](https://devnet.explorer.agoric.net/agoric/gov/223).

### Upgrade Considerations

This is sort of a work-around for the fact that we don't (yet) upgrade the ymax contract; we replace it with a new instance.
