### PR TITLE
fix(portfolio-contract): don't make new storage nodes on each update

### DIFF
--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -186,15 +186,21 @@ export const preparePortfolioKit = (
     usdcBrand: Brand<'nat'>;
   },
 ) => {
-  const makePathNode = (path: string[]) => {
-    let node = portfoliosNode;
-    for (const segment of path) {
-      node = E(node).makeChildNode(segment);
-    }
+  // Ephemeral node cache
+  // XXX collecting flow nodes is TBD
+  const nodes = new Map<string, ERef<StorageNode>>();
+  const providePathNode = (segments: string[]): ERef<StorageNode> => {
+    if (segments.length === 0) return portfoliosNode;
+    const path = segments.join('.');
+    if (nodes.has(path)) return nodes.get(path)!;
+    const parent = providePathNode(segments.slice(0, -1));
+    const node = E(parent).makeChildNode(segments.at(-1)!);
+    nodes.set(path, node);
     return node;
   };
+
   const publishStatus: PublishStatusFn = (path, status): void => {
-    const node = makePathNode(path);
+    const node = providePathNode(path);
     // Don't await, just writing to vstorage.
     void E.when(E(marshaller).toCapData(status), capData =>
       E(node).setValue(JSON.stringify(capData)),
@@ -345,7 +351,7 @@ export const preparePortfolioKit = (
         },
         getStoragePath() {
           const { portfolioId } = this.state;
-          const node = makePathNode(makePortfolioPath(portfolioId));
+          const node = providePathNode(makePortfolioPath(portfolioId));
           return vowTools.asVow(() => E(node).getPath());
         },
         getPortfolioId() {
@@ -384,6 +390,7 @@ export const preparePortfolioKit = (
           this.facets.reporter.publishStatus();
           return nextFlowId;
         },
+        // XXX collecting flow nodes is TBD
         publishFlowStatus(id: number, status: StatusFor['flow']) {
           const { portfolioId } = this.state;
           publishStatus(makeFlowPath(portfolioId, id), status);

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -1,0 +1,73 @@
+/** @file tests for PortfolioKit exo */
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { preparePortfolioKit } from '../src/portfolio.exo.ts';
+import { makeHeapZone } from '@agoric/zone';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
+import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+
+const { brand: USDC } = makeIssuerKit('USDC');
+
+test('portfolio exo caches storage nodes', async t => {
+  const zone = makeHeapZone();
+  const board = makeFakeBoard();
+  const marshaller = board.getReadonlyMarshaller();
+
+  // count each time we makeChildNode(...)
+  let nodeQty = 0;
+  const makeMockNode = (here: string) => {
+    nodeQty += 1;
+    t.log(nodeQty, here);
+    const node = harden({
+      makeChildNode: (name: string) => makeMockNode(`${here}.${name}`),
+      setValue: _x => {},
+    }) as unknown as StorageNode;
+    return node;
+  };
+
+  const makePortfolioKit = preparePortfolioKit(zone, {
+    portfoliosNode: makeMockNode('published.ymax0.portfolios'),
+    marshaller,
+    usdcBrand: USDC,
+    // rest are not used
+    zcf: null as any,
+    axelarIds: null as any,
+    vowTools: null as any,
+    timer: null as any,
+    chainHubTools: null as any,
+    rebalance: null as any,
+    rebalanceFromTransfer: null as any,
+    proposalShapes: null as any,
+    offerArgsShapes: null as any,
+  });
+  await eventLoopIteration(); // wait for vstorage writes to settle
+  t.is(nodeQty, 1, '1 root node for all portfolios');
+
+  const { reporter, manager } = makePortfolioKit({ portfolioId: 123 });
+  reporter.publishStatus();
+  reporter.publishStatus();
+  await eventLoopIteration();
+  t.is(nodeQty, 2, 'root + portfolio');
+
+  reporter.allocateFlowId();
+  const amount = AmountMath.make(USDC, 123n);
+  const flowStatus = {
+    step: 1,
+    amount,
+    src: '@noble',
+    dest: 'USDN',
+    how: 'USDN',
+  };
+  reporter.publishFlowStatus(1, flowStatus);
+  reporter.publishFlowStatus(1, { ...flowStatus, step: 2 });
+  await eventLoopIteration();
+  t.is(nodeQty, 4, 'root, portfolio, flows, flow1');
+
+  const acctId = 'cosmos:noble-1:noble1xyz';
+  const pos = manager.providePosition('USDN', 'USDN', acctId);
+  pos.publishStatus();
+  pos.publishStatus();
+  await eventLoopIteration();
+  t.is(nodeQty, 6, 'root, portfolio, flows, flow1, positions, position1');
+});


### PR DESCRIPTION
## Description

Cache (promises for) storage nodes in an ephemeral map.

As we see in the [viz for devnet tx/8CD4F...](https://devnet.explorer.agoric.net/agoric/causeway?blockHeight=2350157&runId=bridge-2350157-8CD4FA07EEDC009AB03D0E026B015FC755C74BC2E8F1C3C8FABA3F09A90019D6-0), ymax (like [Fast USDC](https://github.com/Agoric/agoric-sdk/blob/69b365d0861f0c7fda58d8f499ef6885f7f0a254/packages/fast-usdc-contract/src/exos/status-manager.ts#L160-L163)) created new storage nodes whenever it needed to write to chain storage. In this 23 July tx, we create the `portfolio1` node 4x:

<img width="1044" height="252" alt="image" src="https://github.com/user-attachments/assets/c9593481-6c25-4fa4-87c1-33072da69d0f" />

### Security / Documentation / Testing / Upgrade Considerations

Largely unremarkable. Not externally visible. No change to exo state. A test to count node creations fails without this fix.

### Scaling Considerations

In the previous design, storage nodes could be collected immediately after use. In this design, we reduce cross-vat work at update time, but we increase long-term storage of nodes.

Collecting flow nodes is TBD.
