### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,6 +39,9 @@ shared:
       - base=master
       - label=automerge:squash
 
+merge_queue:
+  max_parallel_checks: 1
+
 priority_rules:
   - name: high_priority
     conditions:


### PR DESCRIPTION
Recently mergify changed the default parallel checks, which [broke landing squash PRs](https://github.com/Agoric/agoric-sdk/pull/11583/checks?check_run_id=47144991594), and created some spurious ["merge queue" PRs](https://github.com/Agoric/agoric-sdk/pulls?q=is%3Apr+is%3Aclosed+%22merge+queue%22) for these parallel checks.

This restores the former default of 1 up-to-date PR landing at a time.

This change has been made by @mhofman from the Mergify config editor.