### PR TITLE
feat(portfolio-contract): deposit more to same allocation

### DIFF
--- a/packages/portfolio-contract/src/planner.exo.ts
+++ b/packages/portfolio-contract/src/planner.exo.ts
@@ -1,15 +1,35 @@
-import type { Zone } from '@agoric/zone';
-import type { MovementDesc } from './type-guards-steps.ts';
 import { makeTracer } from '@agoric/internal';
+import { type Vow } from '@agoric/vow';
+import type { Zone } from '@agoric/zone';
+import type { MovementDesc, OfferArgsFor } from './type-guards-steps.ts';
+import type { PortfolioKit } from './portfolio.exo.ts';
 
 const iterfaceTODO = undefined;
 
 const trace = makeTracer('PPLN');
 
-export const preparePlanner = (zone: Zone) => {
+export const preparePlanner = (
+  zone: Zone,
+  {
+    rebalance,
+    zcf,
+    getPortfolio,
+  }: {
+    rebalance: (
+      seat: ZCFSeat,
+      offerArgs: OfferArgsFor['rebalance'],
+      kit: unknown, // XXX avoid circular reference
+    ) => Vow<any>; // XXX HostForGuest???
+    zcf: ZCF;
+    getPortfolio: (id: number) => PortfolioKit;
+  },
+) => {
   return zone.exoClass('Planner', iterfaceTODO, () => ({}), {
-    submit(portfolioId: number, plan: MovementDesc[]) {
-      trace({ portfolioId, plan });
+    submit(portfolioId: number, plan: MovementDesc[]): Vow<void> {
+      trace('TODO: vet plan', { portfolioId, plan });
+      const { zcfSeat: emptySeat } = zcf.makeEmptySeatKit();
+      const pKit = getPortfolio(portfolioId);
+      return rebalance(emptySeat, { flow: plan }, pKit);
     },
   });
 };

--- a/packages/portfolio-contract/src/planner.exo.ts
+++ b/packages/portfolio-contract/src/planner.exo.ts
@@ -1,0 +1,15 @@
+import type { Zone } from '@agoric/zone';
+import type { MovementDesc } from './type-guards-steps.ts';
+import { makeTracer } from '@agoric/internal';
+
+const iterfaceTODO = undefined;
+
+const trace = makeTracer('PPLN');
+
+export const preparePlanner = (zone: Zone) => {
+  return zone.exoClass('Planner', iterfaceTODO, () => ({}), {
+    submit(portfolioId: number, plan: MovementDesc[]) {
+      trace({ portfolioId, plan });
+    },
+  });
+};

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -44,6 +44,7 @@ import {
   type OfferArgsFor,
   type ProposalType,
 } from './type-guards.ts';
+import { preparePlanner } from './planner.exo.ts';
 
 const trace = makeTracer('PortC');
 const { fromEntries, keys } = Object;
@@ -320,7 +321,22 @@ export const contract = async (
     },
   });
 
-  return { publicFacet };
+  const makePlanner = preparePlanner(zone.subZone('planner'));
+
+  const creatorFacet = zone.exo('PortfolioAdmin', interfaceTODO, {
+    makePlannerInvitation() {
+      return zcf.makeInvitation(
+        seat => {
+          seat.exit();
+          return makePlanner();
+        },
+        'planner',
+        undefined,
+      );
+    },
+  });
+
+  return { creatorFacet, publicFacet };
 };
 harden(contract);
 

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -321,7 +321,12 @@ export const contract = async (
     },
   });
 
-  const makePlanner = preparePlanner(zone.subZone('planner'));
+  const getPortfolio = (id: number) => portfolios.get(id);
+  const makePlanner = preparePlanner(zone.subZone('planner'), {
+    zcf,
+    rebalance,
+    getPortfolio,
+  });
 
   const creatorFacet = zone.exo('PortfolioAdmin', interfaceTODO, {
     makePlannerInvitation() {

--- a/packages/portfolio-contract/src/resolver.exo.ts
+++ b/packages/portfolio-contract/src/resolver.exo.ts
@@ -1,0 +1,7 @@
+import type { Zone } from '@agoric/zone';
+
+const iterfaceTODO = undefined;
+
+export const prepareResolver = (zone: Zone) => {
+  return zone.exoClass('Resolver', iterfaceTODO, () => ({}), {});
+};

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -86,7 +86,12 @@ const deploy = async (t: ExecutionContext) => {
       }),
     ),
   );
-  return { common, zoe, started, timerService };
+  return {
+    common: { ...common, utils: { ...common.utils, bundleAndInstall } },
+    zoe,
+    started,
+    timerService,
+  };
 };
 
 export const setupTrader = async (t, initial = 10_000) => {

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -13,6 +13,7 @@ import fetchedChainInfo from '@agoric/orchestration/src/fetched-chain-info.js';
 import { setupOrchestrationTest } from '@agoric/orchestration/tools/contract-tests.ts';
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.ts';
 import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
+import { makeNameHubKit } from '@agoric/vats';
 import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { E } from '@endo/far';
@@ -238,8 +239,16 @@ export const setupPortfolioTest = async ({
   const { poolMetricsNode: _p, ...commonPrivateArgs } =
     common.commonPrivateArgs;
 
+  const { nameHub: namesByAddress, nameAdmin: namesByAddressAdmin } =
+    makeNameHubKit();
+  const bootstrap = {
+    ...common.bootstrap,
+    namesByAddress,
+    namesByAddressAdmin,
+  };
   return {
     ...common,
+    bootstrap,
     brands: { usdc: usdcSansMint, poc26, bld },
     commonPrivateArgs: {
       ...commonPrivateArgs,

--- a/packages/portfolio-contract/tools/agents-mock.ts
+++ b/packages/portfolio-contract/tools/agents-mock.ts
@@ -1,0 +1,67 @@
+import type { VStorage, VstorageKit } from '@agoric/client-utils';
+import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
+import type { SmartWallet } from '@agoric/smart-wallet/src/smartWallet';
+import type { start as startYMax } from '../src/portfolio.contract.js';
+
+import { E } from '@endo/far';
+import type { MovementDesc } from '../src/type-guards-steps.js';
+
+const getCapDataStructure = cell => {
+  const { body, slots } = JSON.parse(cell);
+  const structure = JSON.parse(body.replace(/^#/, ''));
+  return { structure, slots };
+};
+
+export const fakePlanner = (
+  wallet: SmartWallet,
+  instance: Instance<typeof startYMax>,
+  readAt: VStorage['readAt'],
+) => {
+  const offersP = E(wallet).getOffersFacet();
+  const redeem = async () => {
+    await E(offersP).executeOffer({
+      id: 'redeem-1',
+      invitationSpec: {
+        source: 'purse',
+        instance,
+        description: 'planner',
+      },
+      proposal: {},
+      after: { saveAs: 'planner' },
+    });
+  };
+
+  const invokeP = E(wallet).getInvokeFacet();
+  const submit1 = async () => {
+    const portfolioId = 1;
+    const plan: MovementDesc[] = [];
+    await E(invokeP).invokeItem('planner', {
+      method: 'submit',
+      args: [portfolioId, plan],
+    });
+  };
+
+  return harden({ redeem, submit1 });
+};
+
+export const makeResolver = (
+  wallet: SmartWallet,
+  instance: Instance<typeof startYMax>,
+  readAt: VStorage['readAt'],
+) => {
+  const offersP = E(wallet).getOffersFacet();
+  const redeem = async () => {
+    await E(offersP).executeOffer({
+      id: 'redeem-1',
+      invitationSpec: {
+        source: 'purse',
+        description: 'resolver',
+        instance,
+      },
+      proposal: {},
+      after: { saveAs: 'priceSetter' },
+    });
+  };
+
+  return harden({ redeem });
+};

--- a/packages/portfolio-deploy/src/portfolio.build.js
+++ b/packages/portfolio-deploy/src/portfolio.build.js
@@ -24,6 +24,7 @@ const isValidAddr = addr => {
 const options = {
   net: { type: 'string' },
   replace: { type: 'string' },
+  planner: { type: 'string', default: 'agoric1TODOmainnetplannerAddress' },
 };
 
 /**
@@ -70,6 +71,7 @@ const build = async (homeP, endowments) => {
       gmpAddresses: {
         ...gmpAddresses.mainnet,
       },
+      plannerAddress: flags.planner,
       oldBoardId: boardId || '',
     },
     testnet: {
@@ -77,6 +79,7 @@ const build = async (homeP, endowments) => {
       gmpAddresses: {
         ...gmpAddresses.testnet,
       },
+      plannerAddress: flags.planner,
       oldBoardId: boardId || '',
     },
   });

--- a/packages/portfolio-deploy/src/portfolio.contract.permit.js
+++ b/packages/portfolio-deploy/src/portfolio.contract.permit.js
@@ -14,6 +14,7 @@ export const permit = /** @type {const} */ ({
   produce: { [/** @type {const} */ (`${name}Kit`)]: true },
   consume: {
     ...orchPermit,
+    namesByAddress: true,
     chainInfoPublished: true,
     [/** @type {const} */ (`${name}Kit`)]: true,
   },

--- a/packages/portfolio-deploy/test/portfolio-start.core.test.ts
+++ b/packages/portfolio-deploy/test/portfolio-start.core.test.ts
@@ -108,8 +108,13 @@ test('coreEval code without swingset', async t => {
     await bundleAndInstall(contractExports),
   );
 
+  const plannerAddress = 'agoric1planner';
   const options = toExternalConfig(
-    harden({ axelarConfig, gmpAddresses } as PortfolioDeployConfig),
+    harden({
+      axelarConfig,
+      gmpAddresses,
+      plannerAddress,
+    } as PortfolioDeployConfig),
     {},
     portfolioDeployConfigShape,
   );


### PR DESCRIPTION
## Description

- [x] split out facet
- [x] deploy support for EE
   - [x] builder arg for addr
   - [x] core eval invitation maker/distributor

landed separately:
- [x] #11688
- [x] #11690

postponed:
- wait for resolver for CCTP etc.

stacked on:
 - #11672

For context, see: 4. deposit-triggered distribution in [DESIGN-BETA.md](https://github.com/Agoric/agoric-sdk/blob/master/packages/portfolio-contract/DESIGN-BETA.md)

### Security Considerations

 - planner facet can get access to any portfolio
 - vetting submitted plans is TODO

### Scaling Considerations

not much

### Documentation Considerations

see also DESIGN-BETA.md

### Testing Considerations

deploy test for planner invitation fails for lack of a smart wallet

### Upgrade Considerations

functionality depends on an upgrade to smartWallet; cf. #11672
