### PR TITLE
ci(nix-check): reenable magic-nix-cache

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -25,15 +25,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Provide cache@v1 proxy for magic-nix-cache's benefit
-        if: ${{ env.USE_MAGIC_NIX_CACHE }}
-        uses: jashandeep-sohi/action-cache-api-shim@master
-
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Enable Nix cache via GitHub's cache@v1
-        if: ${{ env.USE_MAGIC_NIX_CACHE }}
+      - name: Enable Nix cache via GitHub's cache-action
         uses: DeterminateSystems/magic-nix-cache-action@v8
         with:
           use-flakehub: false


### PR DESCRIPTION
refs: #11417

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
https://github.com/jashandeep-sohi/action-cache-api-shim/issues/19 indicates that the magic-nix-cache support works again (without the shim), and so it can be reenabled!

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
CI has less reliance on network services, as more dependencies are cached within CI.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Better CI performance.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
n/a

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
CI will show if there are failures.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
n/a