### PR TITLE
eslint perf improvements

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,5 @@
 import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import prettier from 'eslint-plugin-prettier';
 import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -94,7 +93,6 @@ export default [
   {
     plugins: {
       '@typescript-eslint': typescriptEslint,
-      prettier,
       'require-extensions': fixupPluginRules(requireExtensions),
     },
 
@@ -176,7 +174,6 @@ export default [
         },
       ],
 
-      'prettier/prettier': 'warn',
       'no-use-before-define': 'off',
     },
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-github": "^5.1.6",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsdoc": "^52.0.2",
-    "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-require-extensions": "^0.1.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.5.3",

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -65,9 +65,14 @@ module.exports = {
 
     'github/array-foreach': 'warn',
 
-    // it doesn't support exports maps https://github.com/import-js/eslint-plugin-import/issues/1810
-    // and most of our code is covered by tsc which does
-    'import/no-unresolved': 'off',
+    // Covered faster by TS
+    // https://typescript-eslint.io/troubleshooting/typed-linting/performance/#eslint-plugin-import
+    'import/named': 'off',
+    'import/namespace': 'off',
+    'import/default': 'off',
+    'import/no-named-as-default-member': 'off',
+    'import/no-unresolved': 'off', // Plus no-unresolved doesn't support exports maps https://github.com/import-js/eslint-plugin-import/issues/1810
+
     'import/prefer-default-export': 'off',
 
     'jsdoc/no-multi-asterisks': ['warn', { allowWhitespace: true }],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-github": "^5.1.4",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^46.4.3",
-    "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.4.2",
     "typescript-eslint": "^8.17.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,7 +589,6 @@ __metadata:
     eslint-plugin-github: ^5.1.4
     eslint-plugin-import: ^2.25.3
     eslint-plugin-jsdoc: ^46.4.3
-    eslint-plugin-prettier: ^5.0.0
     prettier: ^3.4.2
     typescript-eslint: ^8.17.0
   languageName: unknown
@@ -895,7 +894,6 @@ __metadata:
     eslint-plugin-github: "npm:^5.1.6"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jsdoc: "npm:^52.0.2"
-    eslint-plugin-prettier: "npm:^5.2.6"
     eslint-plugin-require-extensions: "npm:^0.1.3"
     npm-run-all: "npm:^4.1.5"
     prettier: "npm:^3.5.3"
@@ -9216,7 +9214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^5.2.1, eslint-plugin-prettier@npm:^5.2.6":
+"eslint-plugin-prettier@npm:^5.2.1":
   version: 5.2.6
   resolution: "eslint-plugin-prettier@npm:5.2.6"
   dependencies:


### PR DESCRIPTION
closes: #4339

## Description
Speed up linting by removing eslint-plugin-prettier

35% reduction in `yarn lint:eslint` testing on my laptop ([data](https://github.com/Agoric/agoric-sdk/pull/11703/commits/c6972884757887070295ffcca2bf0f794bc5d74c))

## CI impact (lint-primary, minutes)

**Before**
[21.07](https://github.com/Agoric/agoric-sdk/actions/runs/16733507335/job/47367299173)

**After**
[20.38](https://github.com/Agoric/agoric-sdk/actions/runs/16733458240/job/47367128023?pr=11703)


### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations
This does impact DX for some developers if they rely on `lint-fix` to format their code. Instead they should have their editor auto-save as Prettier. `scripts/configure-vscode.sh` will do that.

### Testing Considerations
CI

### Upgrade Considerations
n/a