### PR TITLE
feat(portfolio-planner): Cleanup engine.ts

### DIFF
--- a/packages/portfolio-planner/package.json
+++ b/packages/portfolio-planner/package.json
@@ -48,6 +48,7 @@
     "@cosmjs/stargate": "^0.34.0",
     "@endo/errors": "^1.2.13",
     "@endo/init": "^1.1.12",
+    "@endo/lockdown": "^1.0.18",
     "@endo/nat": "^5.1.3",
     "@endo/pass-style": "^1.6.3",
     "@endo/promise-kit": "^1.1.13",

--- a/packages/portfolio-planner/package.json
+++ b/packages/portfolio-planner/package.json
@@ -49,6 +49,7 @@
     "@endo/errors": "^1.2.13",
     "@endo/init": "^1.1.12",
     "@endo/nat": "^5.1.3",
+    "@endo/pass-style": "^1.6.3",
     "@endo/promise-kit": "^1.1.13",
     "dotenv": "^17.2.1",
     "json-rpc-2.0": "^1.7.1",

--- a/packages/portfolio-planner/src/engine.ts
+++ b/packages/portfolio-planner/src/engine.ts
@@ -337,6 +337,12 @@ export const startEngine = async ({
         ),
       );
 
+      const vbankAssets = new Map(
+        depositAddrsWithActivity.size
+          ? await vstorageKit.readPublished('agoricNames.vbankAsset')
+          : undefined,
+      );
+
       // Respond to deposits.
       const portfolioOps = await Promise.all(
         [...depositAddrsWithActivity.entries()].map(
@@ -353,11 +359,7 @@ export const startEngine = async ({
             }
             const { denom, amount: balanceValue } = balances[0];
 
-            // TODO: Cache brands as they are mapped.
-            const vbankAssets = await vstorageKit.readPublished(
-              'agoricNames.vbankAsset',
-            );
-            const brand = new Map(vbankAssets).get(denom)?.brand as
+            const brand = vbankAssets.get(denom)?.brand as
               | undefined
               | Brand<'nat'>;
             if (!brand) throw Fail`no brand found for denom ${q(denom)}`;

--- a/packages/portfolio-planner/src/engine.ts
+++ b/packages/portfolio-planner/src/engine.ts
@@ -6,10 +6,11 @@ import { Nat } from '@endo/nat';
 import { PortfolioStatusShapeExt } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import { AmountMath } from '@agoric/ertp';
 import type { SigningStargateClient } from '@cosmjs/stargate';
-import type { BridgeAction } from '@agoric/smart-wallet/src/smartWallet.js';
+import type { InvokeAction } from '@agoric/smart-wallet/src/smartWallet.js';
 import { mustMatch } from '@agoric/internal';
 import { StreamCellShape } from '@agoric/internal/src/lib-chainStorage.js';
 import { fromUniqueEntries } from '@agoric/internal/src/ses-utils.js';
+import type { StatusFor } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import type { VstorageKit, SmartWalletKit } from '@agoric/client-utils';
 import type { Bech32Address } from '@agoric/orchestration';
 import type { CosmosRPCClient } from './cosmos-rpc.ts';
@@ -41,19 +42,50 @@ const encodedKeyToPath = (key: string) => {
   return path;
 };
 
+/**
+ * Determine whether a dot-separated path starts with a sequence of path
+ * components.
+ */
+const vstoragePathStartsWith = (path: string, prefix: string) =>
+  path === prefix ||
+  path.startsWith(prefix.endsWith('.') ? prefix : `${prefix}.`);
+
 const stripPrefix = (prefix: string, str: string) => {
-  str.startsWith(prefix) || Fail`${str} is missing prefix ${prefix}`;
+  str.startsWith(prefix) || Fail`${str} is missing prefix ${q(prefix)}`;
   return str.slice(prefix.length);
 };
 
+/**
+ * Parse input as JSON, or handle an error (for e.g. substituting a default or
+ * applying a more specific message).
+ */
 const tryJsonParse = (json: string, replaceErr?: (err?: Error) => unknown) => {
   try {
     return JSON.parse(json);
   } catch (err) {
     if (!replaceErr) throw err;
-    return replaceErr(err);
+    try {
+      return replaceErr(err);
+    } catch (newErr) {
+      if (!newErr.cause) assert.note(newErr, err.message);
+      throw newErr;
+    }
   }
 };
+
+/**
+ * Map the elements of an array to new values, skipping elements for which the
+ * mapping results in either `undefined` or `false`.
+ */
+const partialMap = <T, U>(
+  arr: T[],
+  mapOrDrop: (value: T, index?: number, arr?: T[]) => U | undefined | false,
+): U[] =>
+  arr.flatMap((el, i, arrArg) => {
+    const result = mapOrDrop(el, i, arrArg);
+    if (result === undefined || result === false) return [];
+    return [result];
+  });
 
 type IO = {
   rpc: CosmosRPCClient;
@@ -160,21 +192,22 @@ export const startEngine = async ({
 
   // TODO: verify consumption of paginated data.
   const portfolioKeys = await vstorageKit.vstorage.keys(VSTORAGE_PATH_PREFIX);
-  const portfolioAddressEntries = await Promise.all(
-    portfolioKeys.map(async key => {
+  const portfolioAddressRecords = await Promise.all(
+    portfolioKeys.map(async portfolioKey => {
       const status = await vstorageKit.readPublished(
-        `${stripPrefix('published.', VSTORAGE_PATH_PREFIX)}.${key}`,
+        `${stripPrefix('published.', VSTORAGE_PATH_PREFIX)}.${portfolioKey}`,
       );
-      mustMatch(status, PortfolioStatusShapeExt, key);
+      mustMatch(status, PortfolioStatusShapeExt, portfolioKey);
       const { depositAddress } = status;
-      if (!depositAddress) return undefined;
-      return [key, depositAddress] as [string, Bech32Address];
+      if (!depositAddress) return;
+      return { portfolioKey, depositAddress };
     }),
   );
   const portfolioKeyForDepositAddr = new Map(
-    portfolioAddressEntries.flatMap(entry =>
-      entry ? [entry.toReversed()] : [],
-    ) as [Bech32Address, string][],
+    partialMap(
+      portfolioAddressRecords,
+      record => record && [record.depositAddress, record.portfolioKey],
+    ),
   );
 
   try {
@@ -197,43 +230,34 @@ export const startEngine = async ({
       }
 
       // Capture vstorage updates.
-      const eventRecords = Object.entries(respData).flatMap(
-        ([key, value]: [string, any]) => {
-          // We care about result_begin_block/result_end_block/etc.
-          if (!key.startsWith('result_')) return [];
-          if (!value?.events) {
-            console.warn('missing events', type, key);
-            return [];
-          }
-          return value.events as CosmosEvent[];
-        },
-      );
-      const portfolioVstorageEvents = eventRecords.flatMap(eventRecord => {
+      const eventRecords = Object.entries(respData).flatMap(([key, value]) => {
+        // We care about result_begin_block/result_end_block/etc.
+        if (!key.startsWith('result_')) return [];
+        const events = (value as any)?.events;
+        if (!events) console.warn('missing events', type, key);
+        return events ?? [];
+      }) as CosmosEvent[];
+      const portfolioVstorageEvents = partialMap(eventRecords, eventRecord => {
         const { type: eventType, attributes: attrRecords } = eventRecord;
         // Filter for vstorage state_change events.
         // cf. golang/cosmos/types/events.go
-        if (eventType !== 'state_change') return [];
+        if (eventType !== 'state_change') return;
         const attributes = fromUniqueEntries(
           attrRecords?.map(({ key, value }) => [key, value]) || [],
         );
-        if (attributes.store !== 'vstorage') return [];
+        if (attributes.store !== 'vstorage') return;
 
         // Require attributes "key" and "value".
         if (attributes.key === undefined || attributes.value === undefined) {
           console.error('vstorage state_change missing "key" and/or "value"');
-          return [];
+          return;
         }
 
         // Filter for ymax portfolio paths.
         const path = encodedKeyToPath(attributes.key);
-        if (
-          path !== VSTORAGE_PATH_PREFIX &&
-          !path.startsWith(`${VSTORAGE_PATH_PREFIX}.`)
-        ) {
-          return [];
-        }
+        if (!vstoragePathStartsWith(path, VSTORAGE_PATH_PREFIX)) return;
 
-        return [{ path, value: attributes.value }];
+        return { path, value: attributes.value };
       });
 
       // Detect new portfolios.
@@ -243,18 +267,19 @@ export const startEngine = async ({
           _err =>
             Fail`non-JSON value at vstorage path ${q(path)}: ${vstorageValue}`,
         );
-        harden(streamCell);
-        mustMatch(streamCell, StreamCellShape);
+        mustMatch(harden(streamCell), StreamCellShape);
         if (path === VSTORAGE_PATH_PREFIX) {
           for (let i = 0; i < streamCell.values.length; i += 1) {
-            const strValue = streamCell.values[i] as string;
+            const strValue = streamCell.values[i];
             const value = tryJsonParse(
               // @ts-expect-error use `undefined` to force an error for non-string input
               typeof strValue === 'string' ? strValue : undefined,
               _err =>
                 Fail`non-JSON StreamCell value for ${q(path)} index ${q(i)}: ${strValue}`,
             );
-            const portfoliosData = vstorageKit.marshaller.fromCapData(value);
+            const portfoliosData = vstorageKit.marshaller.fromCapData(
+              value,
+            ) as StatusFor['portfolios'];
             if (portfoliosData.addPortfolio) {
               const key = portfoliosData.addPortfolio;
               console.warn('Detected new portfolio', key);
@@ -264,10 +289,9 @@ export const startEngine = async ({
               );
               mustMatch(status, PortfolioStatusShapeExt, key);
               const { depositAddress } = status;
-              if (depositAddress) {
-                portfolioKeyForDepositAddr.set(depositAddress, key);
-                console.warn('Added new portfolio', key, depositAddress);
-              }
+              if (!depositAddress) continue;
+              portfolioKeyForDepositAddr.set(depositAddress, key);
+              console.warn('Added new portfolio', key, depositAddress);
             }
           }
         }
@@ -284,10 +308,9 @@ export const startEngine = async ({
         ]),
       ];
       const depositAddrsWithActivity = new Map(
-        [...addrsWithActivity].flatMap(addr => {
+        partialMap(addrsWithActivity, addr => {
           const portfolioKey = portfolioKeyForDepositAddr.get(addr);
-          if (!portfolioKey) return [];
-          return [[addr, portfolioKey]] as [[Bech32Address, string]];
+          return portfolioKey ? [addr, portfolioKey] : undefined;
         }),
       );
 
@@ -364,26 +387,20 @@ export const startEngine = async ({
         ),
       );
 
-      for await (const portfolioOp of portfolioOps) {
-        if (!portfolioOp) continue;
-
-        const { portfolioId, steps } = portfolioOp;
-
-        const action: BridgeAction = harden({
+      for (const { portfolioId, steps } of portfolioOps.filter(x => !!x)) {
+        const action: InvokeAction = harden({
           method: 'invokeItem',
           name: 'planner',
           steps: [{ method: 'submit', args: [portfolioId, steps] }],
         });
 
         console.log('submitting action', action);
-
         const result = await submitAction(action, {
           stargateClient,
           walletKit,
           skipPoll: true,
           address: plannerAddress,
         });
-
         console.log('result', result);
       }
     }

--- a/packages/portfolio-planner/src/entrypoint.js
+++ b/packages/portfolio-planner/src/entrypoint.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env -S node --import ts-blank-space/register
 /* global globalThis */
 
 // We need some pre-lockdown shimming.

--- a/packages/portfolio-planner/src/entrypoint.js
+++ b/packages/portfolio-planner/src/entrypoint.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S node --import ts-blank-space/register
 /* global globalThis */
+/* eslint-env node */
 
 // We need some pre-lockdown shimming.
 import '@endo/init/pre-remoting.js';

--- a/packages/portfolio-planner/src/shims.cjs
+++ b/packages/portfolio-planner/src/shims.cjs
@@ -11,8 +11,3 @@ if (!Promise.withResolvers) {
     return { promise, resolve, reject };
   };
 }
-
-if (typeof WebSocket === 'undefined') {
-  globalThis.WebSocket = require('ws').WebSocket;
-  // globalThis.WebSocket = require('websocket').w3cwebsocket;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,6 +265,7 @@ __metadata:
     "@cosmjs/stargate": "npm:^0.34.0"
     "@endo/errors": "npm:^1.2.13"
     "@endo/init": "npm:^1.1.12"
+    "@endo/lockdown": "npm:^1.0.18"
     "@endo/nat": "npm:^5.1.3"
     "@endo/pass-style": "npm:^1.6.3"
     "@endo/promise-kit": "npm:^1.1.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,7 @@ __metadata:
     "@endo/errors": "npm:^1.2.13"
     "@endo/init": "npm:^1.1.12"
     "@endo/nat": "npm:^5.1.3"
+    "@endo/pass-style": "npm:^1.6.3"
     "@endo/promise-kit": "npm:^1.1.13"
     "@types/node": "npm:^22.10.2"
     "@types/ws": "npm:^8"


### PR DESCRIPTION
## Description
A handful of commits from work started in transit, mostly adding and taking advantage of utility functions that ultimately belong in supporting libraries.

### Security Considerations
This refactoring should not affect any security posture.

### Scaling Considerations
Rather than a slow `for await` or aggressive `Promise.all` over potentially large collections, this PR introduces a new `makeWorkPool` helper for bounded concurrency, which should improve behavior in those cases. It also includes once-per-block caching of `vbankAssets`.

### Documentation Considerations
The new helpers include doc comments and explanatory inline comments.

### Testing Considerations
In line with the rest of the work jam, testing is deferred for integration with the master branch.

### Upgrade Considerations
portfolio-planner is stateless off-chain code that can be restarted at any time.