### PR TITLE
chore: cosmos-sdk 0.50 compatibility

### DIFF
--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -16,7 +16,7 @@
     "doctor": "yarn synthetic-chain doctor"
   },
   "dependencies": {
-    "@agoric/synthetic-chain": "^0.5.8"
+    "@agoric/synthetic-chain": "^0.6.1"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/a3p-integration/proposals/f:fast-usdc-cctp/package.json
+++ b/a3p-integration/proposals/f:fast-usdc-cctp/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@agoric/client-utils": "dev",
     "@agoric/fast-usdc": "dev",
-    "@agoric/synthetic-chain": "0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@endo/init": "^1.1.12",
     "agoric": "dev",
     "ava": "^5.3.1"

--- a/a3p-integration/proposals/f:fast-usdc-cctp/yarn.lock
+++ b/a3p-integration/proposals/f:fast-usdc-cctp/yarn.lock
@@ -1089,9 +1089,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -1103,7 +1103,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -6385,7 +6385,7 @@ __metadata:
   dependencies:
     "@agoric/client-utils": "npm:dev"
     "@agoric/fast-usdc": "npm:dev"
-    "@agoric/synthetic-chain": "npm:0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@endo/init": "npm:^1.1.12"
     agoric: "npm:dev"
     ava: "npm:^5.3.1"

--- a/a3p-integration/proposals/g:3-ymax-alpha2/package.json
+++ b/a3p-integration/proposals/g:3-ymax-alpha2/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/client-utils": "dev",
-    "@agoric/synthetic-chain": "0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@endo/far": "^1.1.14",
     "@endo/init": "^1.1.12",
     "@endo/pass-style": "^1.6.3",

--- a/a3p-integration/proposals/g:3-ymax-alpha2/yarn.lock
+++ b/a3p-integration/proposals/g:3-ymax-alpha2/yarn.lock
@@ -686,9 +686,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -700,7 +700,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -5574,7 +5574,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@agoric/client-utils": "npm:dev"
-    "@agoric/synthetic-chain": "npm:0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@endo/far": "npm:^1.1.14"
     "@endo/init": "npm:^1.1.12"
     "@endo/pass-style": "npm:^1.6.3"

--- a/a3p-integration/proposals/g:4-ymax-alpha3/package.json
+++ b/a3p-integration/proposals/g:4-ymax-alpha3/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/client-utils": "dev",
-    "@agoric/synthetic-chain": "^0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@endo/far": "^1.1.14",
     "@endo/init": "^1.1.12",
     "@endo/pass-style": "^1.6.3",

--- a/a3p-integration/proposals/g:4-ymax-alpha3/yarn.lock
+++ b/a3p-integration/proposals/g:4-ymax-alpha3/yarn.lock
@@ -682,9 +682,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -696,7 +696,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -4419,7 +4419,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@agoric/client-utils": "npm:dev"
-    "@agoric/synthetic-chain": "npm:^0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@endo/far": "npm:^1.1.14"
     "@endo/init": "npm:^1.1.12"
     "@endo/pass-style": "npm:^1.6.3"

--- a/a3p-integration/proposals/h:hook-msg-send/package.json
+++ b/a3p-integration/proposals/h:hook-msg-send/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/client-utils": "dev",
-    "@agoric/synthetic-chain": "0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@endo/init": "^1.1.12",
     "agoric": "dev",
     "ava": "^5.3.1"

--- a/a3p-integration/proposals/h:hook-msg-send/yarn.lock
+++ b/a3p-integration/proposals/h:hook-msg-send/yarn.lock
@@ -998,9 +998,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -1012,7 +1012,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -5881,7 +5881,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@agoric/client-utils": "npm:dev"
-    "@agoric/synthetic-chain": "npm:0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@endo/init": "npm:^1.1.12"
     agoric: "npm:dev"
     ava: "npm:^5.3.1"

--- a/a3p-integration/proposals/k:param-change/package.json
+++ b/a3p-integration/proposals/k:param-change/package.json
@@ -9,7 +9,7 @@
     "agops": "yarn --cwd /usr/src/agoric-sdk/ --silent agops"
   },
   "dependencies": {
-    "@agoric/synthetic-chain": "^0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "agoric": "dev"
   },
   "devDependencies": {

--- a/a3p-integration/proposals/k:param-change/yarn.lock
+++ b/a3p-integration/proposals/k:param-change/yarn.lock
@@ -681,9 +681,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -695,7 +695,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -4790,7 +4790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@agoric/synthetic-chain": "npm:^0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     agoric: "npm:dev"
     eslint: "npm:^8.57.0"
     npm-run-all: "npm:^4.1.5"

--- a/a3p-integration/proposals/m:before-upgrade-next/package.json
+++ b/a3p-integration/proposals/m:before-upgrade-next/package.json
@@ -8,7 +8,7 @@
     "@agoric/client-utils": "dev",
     "@agoric/ertp": "dev",
     "@agoric/internal": "dev",
-    "@agoric/synthetic-chain": "^0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@agoric/zoe": "dev",
     "@endo/errors": "^1.2.13",
     "@endo/init": "^1.1.12",

--- a/a3p-integration/proposals/m:before-upgrade-next/yarn.lock
+++ b/a3p-integration/proposals/m:before-upgrade-next/yarn.lock
@@ -992,9 +992,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -1006,7 +1006,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -6419,7 +6419,7 @@ __metadata:
     "@agoric/client-utils": "npm:dev"
     "@agoric/ertp": "npm:dev"
     "@agoric/internal": "npm:dev"
-    "@agoric/synthetic-chain": "npm:^0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@agoric/zoe": "npm:dev"
     "@endo/errors": "npm:^1.2.13"
     "@endo/init": "npm:^1.1.12"

--- a/a3p-integration/proposals/n:upgrade-next/package.json
+++ b/a3p-integration/proposals/n:upgrade-next/package.json
@@ -15,7 +15,7 @@
     "@agoric/client-utils": "dev",
     "@agoric/ertp": "dev",
     "@agoric/internal": "dev",
-    "@agoric/synthetic-chain": "^0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@agoric/zoe": "dev",
     "@endo/errors": "^1.2.13",
     "@endo/init": "^1.1.12",

--- a/a3p-integration/proposals/n:upgrade-next/yarn.lock
+++ b/a3p-integration/proposals/n:upgrade-next/yarn.lock
@@ -992,9 +992,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -1006,7 +1006,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -6237,7 +6237,7 @@ __metadata:
     "@agoric/client-utils": "npm:dev"
     "@agoric/ertp": "npm:dev"
     "@agoric/internal": "npm:dev"
-    "@agoric/synthetic-chain": "npm:^0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@agoric/zoe": "npm:dev"
     "@endo/errors": "npm:^1.2.13"
     "@endo/init": "npm:^1.1.12"

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -19,7 +19,7 @@
     "@agoric/inter-protocol": "dev",
     "@agoric/internal": "dev",
     "@agoric/store": "dev",
-    "@agoric/synthetic-chain": "^0.5.8",
+    "@agoric/synthetic-chain": "^0.6.1",
     "@agoric/zoe": "dev",
     "@cosmjs/stargate": "^0.36.0",
     "@cosmjs/tendermint-rpc": "^0.36.0",

--- a/a3p-integration/proposals/z:acceptance/setup-test.sh
+++ b/a3p-integration/proposals/z:acceptance/setup-test.sh
@@ -12,8 +12,8 @@ CHAIN_ID="$(jq --raw-output '.chain_id' < "$AGORIC_HOME/config/genesis.json")"
 IP_ADDRESS="$(hostname --ip-address)"
 NODE_ID="$(agd tendermint show-node-id)"
 
-LATEST_BLOCK_HEIGHT="$(jq --raw-output '.SyncInfo.latest_block_height' < "$STATUS_FILE")"
-LATEST_BLOCK_HASH="$(jq --raw-output '.SyncInfo.latest_block_hash' < "$STATUS_FILE")"
+LATEST_BLOCK_HEIGHT="$(jq -e --raw-output '.sync_info // .SyncInfo | .latest_block_height' < "$STATUS_FILE")"
+LATEST_BLOCK_HASH="$(jq -e --raw-output '.sync_info // .SyncInfo | .latest_block_hash' < "$STATUS_FILE")"
 
 echo -n "{\"chainName\": \"$CHAIN_ID\", \"rpcAddrs\": [\"$IP_ADDRESS:26657\"], \"gci\": \"$IP_ADDRESS:26657/genesis\", \"peers\":[\"$NODE_ID@$IP_ADDRESS:26656\"], \"seeds\":[], \"trustedBlockInfo\": {\"height\": \"$LATEST_BLOCK_HEIGHT\", \"hash\": \"$LATEST_BLOCK_HASH\"}}" > "$MESSAGE_FILE_PATH"
 

--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -353,9 +353,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@agoric/synthetic-chain@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -367,7 +367,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -4926,7 +4926,7 @@ __metadata:
     "@agoric/inter-protocol": "npm:dev"
     "@agoric/internal": "npm:dev"
     "@agoric/store": "npm:dev"
-    "@agoric/synthetic-chain": "npm:^0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     "@agoric/zoe": "npm:dev"
     "@cosmjs/stargate": "npm:^0.36.0"
     "@cosmjs/tendermint-rpc": "npm:^0.36.0"

--- a/a3p-integration/yarn.lock
+++ b/a3p-integration/yarn.lock
@@ -317,9 +317,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/synthetic-chain@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "@agoric/synthetic-chain@npm:0.5.8"
+"@agoric/synthetic-chain@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@agoric/synthetic-chain@npm:0.6.1"
   dependencies:
     "@agoric/client-utils": "npm:0.1.1-dev-f9483e7.0"
     "@endo/zip": "npm:^1.0.9"
@@ -331,7 +331,7 @@ __metadata:
     tmp: "npm:0.2.3"
   bin:
     synthetic-chain: dist/cli/cli.js
-  checksum: 10c0/cb9c4afdcc4501aa4af3104de9880503ce05285c4de6bb1de55a90dc4f7ed26067622e3bfeb514216b919088a991d8746a8422df335282bfa36809eae6112bf1
+  checksum: 10c0/a53b0b96a43429f9633642e9c51401e08f027afa83fa5735a6100ff8c0ef1a355d19bab289fd7e4fa23f7fdff37ac3d5ca264d814ed7b3d3c1f99394681fafce
   languageName: node
   linkType: hard
 
@@ -4013,7 +4013,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@agoric/synthetic-chain": "npm:^0.5.8"
+    "@agoric/synthetic-chain": "npm:^0.6.1"
     eslint: "npm:^8.57.1"
     npm-run-all: "npm:^4.1.5"
   languageName: unknown

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -413,6 +413,9 @@ const voteLatestProposalAndWait = async ({
     await blockTool.waitForBlock(1, { step: `voting`, on: lastProposalId })
   ) {
     info = await agd.query(['gov', 'proposal', lastProposalId]);
+    if (info.proposal) {
+      info = info.proposal;
+    }
     trace(
       `Waiting for proposal ${lastProposalId} to pass (status=${info.status})`,
     );

--- a/packages/SwingSet/misc-tools/monitor-slog-block-time.py
+++ b/packages/SwingSet/misc-tools/monitor-slog-block-time.py
@@ -99,7 +99,8 @@ def load_genesis_keys(fn):
 def wait_for_block(height):
     while True:
         out = subprocess.check_output(["agd", "status"]).decode()
-        now = int(json.loads(out)["SyncInfo"]["latest_block_height"])
+        status = json.loads(out)
+        now = int(status.get("sync_info", status.get("SyncInfo"))["latest_block_height"])
         if now >= height:
             return
         time.sleep(1)

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -191,7 +191,7 @@ export const pollBlocks = opts => async lookup => {
  * }} opts
  */
 export const pollTx = async (txhash, opts) => {
-  const { execFileSync, rpcAddrs, chainName } = opts;
+  const { execFileSync, rpcAddrs } = opts;
 
   const nodeArgs = [`--node=${rpcAddrs[0]}`];
   const outJson = ['--output', 'json'];
@@ -199,14 +199,7 @@ export const pollTx = async (txhash, opts) => {
   const lookup = async () => {
     const out = execFileSync(
       agdBinary,
-      [
-        'query',
-        'tx',
-        txhash,
-        `--chain-id=${chainName}`,
-        ...nodeArgs,
-        ...outJson,
-      ],
+      ['query', 'tx', txhash, ...nodeArgs, ...outJson],
       { stdio: ['ignore', 'pipe', 'pipe'] },
     );
     // XXX this type is defined in a .proto file somewhere

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -163,9 +163,8 @@ export const pollBlocks = opts => async lookup => {
   for (;;) {
     const sTxt = execFileSync(agdBinary, ['status', ...nodeArgs]);
     const status = JSON.parse(sTxt.toString());
-    const {
-      SyncInfo: { latest_block_time: time, latest_block_height: height },
-    } = status;
+    const { latest_block_time: time, latest_block_height: height } =
+      status.sync_info || status.SyncInfo;
     try {
       // see await null above
       const result = await lookup({ time, height });

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -597,7 +597,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
           'swingset',
           'egress',
           soloAddr,
-          `--chain-id=${CHAIN_ID}`,
           `--node=tcp://${rpcAddr}`,
         ]);
         if (exitStatus) {

--- a/packages/agoric-cli/test/inter-cli.test.js
+++ b/packages/agoric-cli/test/inter-cli.test.js
@@ -159,8 +159,13 @@ const makeProcess = (t, keyring, out) => {
             return addr;
           }
           case 'status': {
+            const syncInfo = {
+              latest_block_time: 123,
+              latest_block_height: 456,
+            };
             return JSON.stringify({
-              SyncInfo: { latest_block_time: 123, latest_block_height: 456 },
+              sync_info: syncInfo,
+              SyncInfo: syncInfo,
             });
           }
           case 'query': {

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -246,7 +246,7 @@ t1-provision-one-with-powers: wait-for-cosmos
 # but we generate it here similarly to how we do in JS.
 fund-provision-pool:
 	PROVISION_POOL=$$($(AGCH) query auth module-account vbank/provision -ojson | \
-	  jq -r .account.base_account.address) && \
+	  jq -e -r '.account | .value // .base_account | .address') && \
 	  $(MAKE) ACCT_ADDR="$$PROVISION_POOL" FUNDS=1000000000ibc/toyusdc fund-acct
 
 fund-acct:

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -229,7 +229,7 @@ t1-provision-one-with-powers: wait-for-cosmos
 	@addrfile=t1/$(BASE_PORT)/cosmos-client-account; \
 		test -f $$addrfile || addrfile=t1/$(BASE_PORT)/ag-cosmos-helper-address; \
 		addr=$$(cat $$addrfile); \
-	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
+	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr || \
 		{ while ! $(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 			bootstrap $$addr $(SOLO_COINS); do sleep 2; done && \
@@ -285,7 +285,7 @@ t1-provision-one: wait-for-cosmos
 	@addrfile=t1/$(BASE_PORT)/cosmos-client-account; \
 		test -f $$addrfile || addrfile=t1/$(BASE_PORT)/ag-cosmos-helper-address; \
 		addr=$$(cat $$addrfile); \
-	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
+	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr || \
 		{ $(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 			bootstrap $$addr $(SOLO_COINS) && \

--- a/packages/deploy-script-support/src/permissioned-deployment.js
+++ b/packages/deploy-script-support/src/permissioned-deployment.js
@@ -87,7 +87,8 @@ export const txFlags = ({
 export const waitForBlock = async (agd, n = 1) => {
   const getHeight = async () => {
     const { stdout } = await agd.exec(['status']);
-    const { latest_block_height: height } = JSON.parse(stdout).SyncInfo;
+    const status = JSON.parse(stdout);
+    const { latest_block_height: height } = status.sync_info || status.SyncInfo;
     return height;
   };
   const initialHeight = await getHeight();

--- a/packages/inter-protocol/Makefile
+++ b/packages/inter-protocol/Makefile
@@ -56,8 +56,8 @@ submit-proposal: $(EVALS) $(DESCRIPTION)
 	  --yes --from=$(KEY) -b sync
 
 gov-q:
-	agd $(CHAIN_OPTS) query gov proposals --output json | \
+	agd query gov proposals --output json | \
 		jq -c '.proposals[] | [if .proposal_id == null then .id else .proposal_id end,.voting_end_time,.status]';
 
 bank-q:
-	agd $(CHAIN_OPTS) query bank balances $(ADDR)
+	agd query bank balances $(ADDR)

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -200,18 +200,16 @@ export async function connectToChain(
 
   let goodRpcHref = rpcHrefs[0];
   const runHelper = (args, stdin = undefined) => {
-    const fullArgs = [
-      ...args,
-      `--chain-id=${chainID}`,
-      `--node=${goodRpcHref}`,
-      `--home=${helperDir}`,
-    ];
+    const fullArgs = [...args, `--node=${goodRpcHref}`, `--home=${helperDir}`];
     console.debug(HELPER, ...fullArgs);
     return new Promise(resolve => {
       const proc = execFile(
         HELPER,
         fullArgs,
-        { maxBuffer: MAX_BUFFER_SIZE },
+        {
+          maxBuffer: MAX_BUFFER_SIZE,
+          env: { ...process.env, AGD_CHAIN_ID: chainID },
+        },
         (_error, stdout, stderr) => {
           resolve({ stdout, stderr });
         },

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -305,7 +305,7 @@ export async function connectToChain(
       };
 
       const subscribeToTxHash = (txHash, cb) => {
-        const txQuery = `tm.event = 'Tx' and tx.hash = '${txHash}'`;
+        const txQuery = `tm.event = 'Tx' AND tx.hash = '${txHash}'`;
 
         const bufHash = decodeHex(txHash);
         const b64Hash = encodeBase64(bufHash);
@@ -328,7 +328,7 @@ export async function connectToChain(
             cb(obj.error);
             return;
           }
-          if (!obj.result) {
+          if (!obj.result || Object.keys(obj.result).length === 0) {
             return;
           }
           let txResult;
@@ -355,7 +355,7 @@ export async function connectToChain(
         // This takes care of BeginBlock/EndBlock events.
         const blockQuery = `tm.event = 'NewBlockHeader' AND storage.path = '${storagePath}'`;
         // We need a separate query for events raised by transactions.
-        const txQuery = `tm.event = 'Tx' and storage.path = '${storagePath}'`;
+        const txQuery = `tm.event = 'Tx' AND storage.path = '${storagePath}'`;
 
         // console.info('subscribeToStorage', blockQuery);
         const blockSubscriptionId = sendRPC('subscribe', { query: blockQuery });
@@ -385,18 +385,14 @@ export async function connectToChain(
         // Query for our initial value.
         setCallback(queryId, obj => {
           // console.info(`got ${storagePath} query`, obj);
-          if (obj.result && obj.result.response && obj.result.response.value) {
+          if (obj.result?.response?.value) {
             // Decode the layers up to the actual storage value.
             const { value: b64JsonStorage, height: heightString } =
               obj.result.response;
             const buf = decodeBase64(b64JsonStorage);
             const { value: storageValue } = QueryDataResponse.decode(buf);
             guardedCb(BigInt(heightString), storageValue);
-          } else if (
-            obj.result &&
-            obj.result.response &&
-            obj.result.response.code === 6
-          ) {
+          } else if (obj.result?.response?.code === 6) {
             // No need to try again, just a missing value that our subscription
             // will pick up.
             const { height: heightString } = obj.result.response;


### PR DESCRIPTION
refs: #11378 

## Description

This PR makes forward compatible changes to agoric-sdk in preparation of the upcoming cosmos-sdk 0.50 upgrade.

- Removing chain-id from agd query
- handle agd query status SyncInfo -> sync_info rename
- handle gov proposal changes
- handle account query changes

All changes are implemented in a backward / forward compatible way.

For `--chain-id` it was simply removed from `agd query` invocations as it is not a required argument in 0.47

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
We will produce a list of known breaking changes in query results and agd cli.

### Testing Considerations
Existing tests on master still pass, and manual+automated testing against 0.50 branch passed as well.

### Upgrade Considerations
Compatibility for future upgrade. No changes in this PR are deployed and are all to surrounding tools.
