### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,6 +55,7 @@ queue_rules:
     merge_conditions: *merge-conditions
     merge_method: merge
     update_method: rebase
+    autosquash: true
 
   - name: merge
     commit_message_template: *commit-message-template

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,43 +1,43 @@
 # Linear queue for the main branch.
 shared:
-    commit_message_template: &commit-message-template |-
-      {{ title }} (#{{ number }})
+  commit_message_template: &commit-message-template |-
+    {{ title }} (#{{ number }})
 
-      {{ body | trim }}
-    queue_conditions: &queue-conditions
-      - base=master
-      - or:
-          - check-pending=integration-test-result
-          - check-success=integration-test-result
-          - label=bypass:integration
-      - check-success=breakage
-    merge_conditions: &merge-conditions
-      - base=master
-      # Rebase PRs with fixup commits are allowed to enter the merge queue but 
-      # should not be allowed to merge if there are leftover fixup commits after rebase
-      - or:
-          - label=bypass:linear-history
-          - check-success=no-fixup-commits
-          - check-skipped=no-fixup-commits
-      # Require integration tests before merging only
-      - or:
-          - label=bypass:integration
-          - check-success=integration-test-result
-    pr_queue_merge_conditions: &pr-queue-merge-conditions
-      - base=master
-      - label=automerge:no-update
-      - or:
-          - '#commits-behind=0'
-          - label=bypass:linear-history
-    pr_queue_rebase_conditions: &pr-queue-rebase-conditions
-      - base=master
-      - label=automerge:rebase
-      - or:
-          - '#commits-behind>0'
-          - linear-history
-    pr_queue_squash_conditions: &pr-queue-squash-conditions
-      - base=master
-      - label=automerge:squash
+    {{ body | trim }}
+  queue_conditions: &queue-conditions
+    - base=master
+    - or:
+        - check-pending=integration-test-result
+        - check-success=integration-test-result
+        - label=bypass:integration
+    - check-success=breakage
+  merge_conditions: &merge-conditions
+    - base=master
+    # Rebase PRs with fixup commits are allowed to enter the merge queue but
+    # should not be allowed to merge if there are leftover fixup commits after rebase
+    - or:
+        - label=bypass:linear-history
+        - check-success=no-fixup-commits
+        - check-skipped=no-fixup-commits
+    # Require integration tests before merging only
+    - or:
+        - label=bypass:integration
+        - check-success=integration-test-result
+  pr_queue_merge_conditions: &pr-queue-merge-conditions
+    - base=master
+    - label=automerge:no-update
+    - or:
+        - '#commits-behind=0'
+        - label=bypass:linear-history
+  pr_queue_rebase_conditions: &pr-queue-rebase-conditions
+    - base=master
+    - label=automerge:rebase
+    - or:
+        - '#commits-behind>0'
+        - linear-history
+  pr_queue_squash_conditions: &pr-queue-squash-conditions
+    - base=master
+    - label=automerge:squash
 
 merge_queue:
   max_parallel_checks: 1
@@ -90,8 +90,8 @@ pull_request_rules:
       - label=automerge:rebase
       - '#commits-behind=0'
       - or:
-        - -linear-history
-        - check-failure=no-fixup-commits
+          - -linear-history
+          - check-failure=no-fixup-commits
       - -draft
     actions:
       rebase:


### PR DESCRIPTION
https://github.com/Agoric/agoric-sdk/pull/11771 was added to the merge queue when the [branch](https://github.com/Agoric/agoric-sdk/activity?ref=mz/upgrade-50-remove-chain-id) was not up-to-date (commit 810c360). The PR was embarked and immediately rebased (I believe matching our "rebase updates then merge to master" PR rules). The rebase (commit f7ea37b) did not autosquash the `fixup!` commit, so our [`no-fixup-commits` check failed](https://github.com/Agoric/agoric-sdk/actions/runs/17222402412/job/48860410528#step:3:12) and the PR was disembarked. 

At that point I think our "rebase and autosquash" PR rule kicked in and autosquashed the PR (commit 3298152), and it ultimately landed. However if another PR was waiting in the merge queue, it'd have moved ahead, and the PR that got disembarked would have had to go another round of rebase.

According to the doc, `autosquash` is a merge queue rule that needs to be explicitly set (not sure how it ever worked before).