### PR TITLE
chore(client-utils): yarn codegen

### DIFF
--- a/packages/client-utils/src/codegen/agoric/lien/genesis.ts
+++ b/packages/client-utils/src/codegen/agoric/lien/genesis.ts
@@ -37,7 +37,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/agoric.lien.GenesisState',
+  typeUrl: '/agoric.lien.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -108,7 +108,7 @@ function createBaseAccountLien(): AccountLien {
   };
 }
 export const AccountLien = {
-  typeUrl: '/agoric.lien.AccountLien',
+  typeUrl: '/agoric.lien.AccountLien' as const,
   encode(
     message: AccountLien,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/lien/lien.ts
+++ b/packages/client-utils/src/codegen/agoric/lien/lien.ts
@@ -29,7 +29,7 @@ function createBaseLien(): Lien {
   };
 }
 export const Lien = {
-  typeUrl: '/agoric.lien.Lien',
+  typeUrl: '/agoric.lien.Lien' as const,
   encode(
     message: Lien,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/swingset/genesis.ts
+++ b/packages/client-utils/src/codegen/agoric/swingset/genesis.ts
@@ -49,7 +49,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/agoric.swingset.GenesisState',
+  typeUrl: '/agoric.swingset.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -165,7 +165,7 @@ function createBaseSwingStoreExportDataEntry(): SwingStoreExportDataEntry {
   };
 }
 export const SwingStoreExportDataEntry = {
-  typeUrl: '/agoric.swingset.SwingStoreExportDataEntry',
+  typeUrl: '/agoric.swingset.SwingStoreExportDataEntry' as const,
   encode(
     message: SwingStoreExportDataEntry,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/swingset/msgs.ts
+++ b/packages/client-utils/src/codegen/agoric/swingset/msgs.ts
@@ -164,7 +164,7 @@ function createBaseMsgDeliverInbound(): MsgDeliverInbound {
   };
 }
 export const MsgDeliverInbound = {
-  typeUrl: '/agoric.swingset.MsgDeliverInbound',
+  typeUrl: '/agoric.swingset.MsgDeliverInbound' as const,
   encode(
     message: MsgDeliverInbound,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -281,7 +281,7 @@ function createBaseMsgDeliverInboundResponse(): MsgDeliverInboundResponse {
   return {};
 }
 export const MsgDeliverInboundResponse = {
-  typeUrl: '/agoric.swingset.MsgDeliverInboundResponse',
+  typeUrl: '/agoric.swingset.MsgDeliverInboundResponse' as const,
   encode(
     _: MsgDeliverInboundResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -343,7 +343,7 @@ function createBaseMsgWalletAction(): MsgWalletAction {
   };
 }
 export const MsgWalletAction = {
-  typeUrl: '/agoric.swingset.MsgWalletAction',
+  typeUrl: '/agoric.swingset.MsgWalletAction' as const,
   encode(
     message: MsgWalletAction,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -417,7 +417,7 @@ function createBaseMsgWalletActionResponse(): MsgWalletActionResponse {
   return {};
 }
 export const MsgWalletActionResponse = {
-  typeUrl: '/agoric.swingset.MsgWalletActionResponse',
+  typeUrl: '/agoric.swingset.MsgWalletActionResponse' as const,
   encode(
     _: MsgWalletActionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -477,7 +477,7 @@ function createBaseMsgWalletSpendAction(): MsgWalletSpendAction {
   };
 }
 export const MsgWalletSpendAction = {
-  typeUrl: '/agoric.swingset.MsgWalletSpendAction',
+  typeUrl: '/agoric.swingset.MsgWalletSpendAction' as const,
   encode(
     message: MsgWalletSpendAction,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -555,7 +555,7 @@ function createBaseMsgWalletSpendActionResponse(): MsgWalletSpendActionResponse 
   return {};
 }
 export const MsgWalletSpendActionResponse = {
-  typeUrl: '/agoric.swingset.MsgWalletSpendActionResponse',
+  typeUrl: '/agoric.swingset.MsgWalletSpendActionResponse' as const,
   encode(
     _: MsgWalletSpendActionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -621,7 +621,7 @@ function createBaseMsgProvision(): MsgProvision {
   };
 }
 export const MsgProvision = {
-  typeUrl: '/agoric.swingset.MsgProvision',
+  typeUrl: '/agoric.swingset.MsgProvision' as const,
   encode(
     message: MsgProvision,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -724,7 +724,7 @@ function createBaseMsgProvisionResponse(): MsgProvisionResponse {
   return {};
 }
 export const MsgProvisionResponse = {
-  typeUrl: '/agoric.swingset.MsgProvisionResponse',
+  typeUrl: '/agoric.swingset.MsgProvisionResponse' as const,
   encode(
     _: MsgProvisionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -782,7 +782,7 @@ function createBaseMsgInstallBundle(): MsgInstallBundle {
   };
 }
 export const MsgInstallBundle = {
-  typeUrl: '/agoric.swingset.MsgInstallBundle',
+  typeUrl: '/agoric.swingset.MsgInstallBundle' as const,
   encode(
     message: MsgInstallBundle,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -889,7 +889,7 @@ function createBaseMsgInstallBundleResponse(): MsgInstallBundleResponse {
   return {};
 }
 export const MsgInstallBundleResponse = {
-  typeUrl: '/agoric.swingset.MsgInstallBundleResponse',
+  typeUrl: '/agoric.swingset.MsgInstallBundleResponse' as const,
   encode(
     _: MsgInstallBundleResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/swingset/query.ts
+++ b/packages/client-utils/src/codegen/agoric/swingset/query.ts
@@ -83,7 +83,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/agoric.swingset.QueryParamsRequest',
+  typeUrl: '/agoric.swingset.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -138,7 +138,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/agoric.swingset.QueryParamsResponse',
+  typeUrl: '/agoric.swingset.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -207,7 +207,7 @@ function createBaseQueryEgressRequest(): QueryEgressRequest {
   };
 }
 export const QueryEgressRequest = {
-  typeUrl: '/agoric.swingset.QueryEgressRequest',
+  typeUrl: '/agoric.swingset.QueryEgressRequest' as const,
   encode(
     message: QueryEgressRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -277,7 +277,7 @@ function createBaseQueryEgressResponse(): QueryEgressResponse {
   };
 }
 export const QueryEgressResponse = {
-  typeUrl: '/agoric.swingset.QueryEgressResponse',
+  typeUrl: '/agoric.swingset.QueryEgressResponse' as const,
   encode(
     message: QueryEgressResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -346,7 +346,7 @@ function createBaseQueryMailboxRequest(): QueryMailboxRequest {
   };
 }
 export const QueryMailboxRequest = {
-  typeUrl: '/agoric.swingset.QueryMailboxRequest',
+  typeUrl: '/agoric.swingset.QueryMailboxRequest' as const,
   encode(
     message: QueryMailboxRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -416,7 +416,7 @@ function createBaseQueryMailboxResponse(): QueryMailboxResponse {
   };
 }
 export const QueryMailboxResponse = {
-  typeUrl: '/agoric.swingset.QueryMailboxResponse',
+  typeUrl: '/agoric.swingset.QueryMailboxResponse' as const,
   encode(
     message: QueryMailboxResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/swingset/swingset.ts
+++ b/packages/client-utils/src/codegen/agoric/swingset/swingset.ts
@@ -269,7 +269,7 @@ function createBaseCoreEvalProposal(): CoreEvalProposal {
   };
 }
 export const CoreEvalProposal = {
-  typeUrl: '/agoric.swingset.CoreEvalProposal',
+  typeUrl: '/agoric.swingset.CoreEvalProposal' as const,
   encode(
     message: CoreEvalProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -357,7 +357,7 @@ function createBaseCoreEval(): CoreEval {
   };
 }
 export const CoreEval = {
-  typeUrl: '/agoric.swingset.CoreEval',
+  typeUrl: '/agoric.swingset.CoreEval' as const,
   encode(
     message: CoreEval,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -434,7 +434,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/agoric.swingset.Params',
+  typeUrl: '/agoric.swingset.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -595,7 +595,7 @@ function createBaseState(): State {
   };
 }
 export const State = {
-  typeUrl: '/agoric.swingset.State',
+  typeUrl: '/agoric.swingset.State' as const,
   encode(
     message: State,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -667,7 +667,7 @@ function createBaseStringBeans(): StringBeans {
   };
 }
 export const StringBeans = {
-  typeUrl: '/agoric.swingset.StringBeans',
+  typeUrl: '/agoric.swingset.StringBeans' as const,
   encode(
     message: StringBeans,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -739,7 +739,7 @@ function createBasePowerFlagFee(): PowerFlagFee {
   };
 }
 export const PowerFlagFee = {
-  typeUrl: '/agoric.swingset.PowerFlagFee',
+  typeUrl: '/agoric.swingset.PowerFlagFee' as const,
   encode(
     message: PowerFlagFee,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -817,7 +817,7 @@ function createBaseQueueSize(): QueueSize {
   };
 }
 export const QueueSize = {
-  typeUrl: '/agoric.swingset.QueueSize',
+  typeUrl: '/agoric.swingset.QueueSize' as const,
   encode(
     message: QueueSize,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -889,7 +889,7 @@ function createBaseUintMapEntry(): UintMapEntry {
   };
 }
 export const UintMapEntry = {
-  typeUrl: '/agoric.swingset.UintMapEntry',
+  typeUrl: '/agoric.swingset.UintMapEntry' as const,
   encode(
     message: UintMapEntry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -962,7 +962,7 @@ function createBaseEgress(): Egress {
   };
 }
 export const Egress = {
-  typeUrl: '/agoric.swingset.Egress',
+  typeUrl: '/agoric.swingset.Egress' as const,
   encode(
     message: Egress,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1054,7 +1054,7 @@ function createBaseSwingStoreArtifact(): SwingStoreArtifact {
   };
 }
 export const SwingStoreArtifact = {
-  typeUrl: '/agoric.swingset.SwingStoreArtifact',
+  typeUrl: '/agoric.swingset.SwingStoreArtifact' as const,
   encode(
     message: SwingStoreArtifact,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vbank/genesis.ts
+++ b/packages/client-utils/src/codegen/agoric/vbank/genesis.ts
@@ -31,7 +31,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/agoric.vbank.GenesisState',
+  typeUrl: '/agoric.vbank.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vbank/query.ts
+++ b/packages/client-utils/src/codegen/agoric/vbank/query.ts
@@ -54,7 +54,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/agoric.vbank.QueryParamsRequest',
+  typeUrl: '/agoric.vbank.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -109,7 +109,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/agoric.vbank.QueryParamsResponse',
+  typeUrl: '/agoric.vbank.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -176,7 +176,7 @@ function createBaseQueryStateRequest(): QueryStateRequest {
   return {};
 }
 export const QueryStateRequest = {
-  typeUrl: '/agoric.vbank.QueryStateRequest',
+  typeUrl: '/agoric.vbank.QueryStateRequest' as const,
   encode(
     _: QueryStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -228,7 +228,7 @@ function createBaseQueryStateResponse(): QueryStateResponse {
   };
 }
 export const QueryStateResponse = {
-  typeUrl: '/agoric.vbank.QueryStateResponse',
+  typeUrl: '/agoric.vbank.QueryStateResponse' as const,
   encode(
     message: QueryStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vbank/vbank.ts
+++ b/packages/client-utils/src/codegen/agoric/vbank/vbank.ts
@@ -79,7 +79,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/agoric.vbank.Params',
+  typeUrl: '/agoric.vbank.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -210,7 +210,7 @@ function createBaseState(): State {
   };
 }
 export const State = {
-  typeUrl: '/agoric.vbank.State',
+  typeUrl: '/agoric.vbank.State' as const,
   encode(
     message: State,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vibc/msgs.ts
+++ b/packages/client-utils/src/codegen/agoric/vibc/msgs.ts
@@ -37,7 +37,7 @@ function createBaseMsgSendPacket(): MsgSendPacket {
   };
 }
 export const MsgSendPacket = {
-  typeUrl: '/agoric.vibc.MsgSendPacket',
+  typeUrl: '/agoric.vibc.MsgSendPacket' as const,
   encode(
     message: MsgSendPacket,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -115,7 +115,7 @@ function createBaseMsgSendPacketResponse(): MsgSendPacketResponse {
   return {};
 }
 export const MsgSendPacketResponse = {
-  typeUrl: '/agoric.vibc.MsgSendPacketResponse',
+  typeUrl: '/agoric.vibc.MsgSendPacketResponse' as const,
   encode(
     _: MsgSendPacketResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vlocalchain/vlocalchain.ts
+++ b/packages/client-utils/src/codegen/agoric/vlocalchain/vlocalchain.ts
@@ -71,7 +71,7 @@ function createBaseCosmosTx(): CosmosTx {
   };
 }
 export const CosmosTx = {
-  typeUrl: '/agoric.vlocalchain.CosmosTx',
+  typeUrl: '/agoric.vlocalchain.CosmosTx' as const,
   encode(
     message: CosmosTx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -141,7 +141,7 @@ function createBaseQueryRequest(): QueryRequest {
   };
 }
 export const QueryRequest = {
-  typeUrl: '/agoric.vlocalchain.QueryRequest',
+  typeUrl: '/agoric.vlocalchain.QueryRequest' as const,
   encode(
     message: QueryRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -227,7 +227,7 @@ function createBaseQueryResponse(): QueryResponse {
   };
 }
 export const QueryResponse = {
-  typeUrl: '/agoric.vlocalchain.QueryResponse',
+  typeUrl: '/agoric.vlocalchain.QueryResponse' as const,
   encode(
     message: QueryResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -317,7 +317,7 @@ function createBaseQueryResponses(): QueryResponses {
   };
 }
 export const QueryResponses = {
-  typeUrl: '/agoric.vlocalchain.QueryResponses',
+  typeUrl: '/agoric.vlocalchain.QueryResponses' as const,
   encode(
     message: QueryResponses,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vstorage/genesis.ts
+++ b/packages/client-utils/src/codegen/agoric/vstorage/genesis.ts
@@ -44,7 +44,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/agoric.vstorage.GenesisState',
+  typeUrl: '/agoric.vstorage.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -113,7 +113,7 @@ function createBaseDataEntry(): DataEntry {
   };
 }
 export const DataEntry = {
-  typeUrl: '/agoric.vstorage.DataEntry',
+  typeUrl: '/agoric.vstorage.DataEntry' as const,
   encode(
     message: DataEntry,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vstorage/query.ts
+++ b/packages/client-utils/src/codegen/agoric/vstorage/query.ts
@@ -124,7 +124,7 @@ function createBaseQueryDataRequest(): QueryDataRequest {
   };
 }
 export const QueryDataRequest = {
-  typeUrl: '/agoric.vstorage.QueryDataRequest',
+  typeUrl: '/agoric.vstorage.QueryDataRequest' as const,
   encode(
     message: QueryDataRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -186,7 +186,7 @@ function createBaseQueryDataResponse(): QueryDataResponse {
   };
 }
 export const QueryDataResponse = {
-  typeUrl: '/agoric.vstorage.QueryDataResponse',
+  typeUrl: '/agoric.vstorage.QueryDataResponse' as const,
   encode(
     message: QueryDataResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -251,7 +251,7 @@ function createBaseQueryCapDataRequest(): QueryCapDataRequest {
   };
 }
 export const QueryCapDataRequest = {
-  typeUrl: '/agoric.vstorage.QueryCapDataRequest',
+  typeUrl: '/agoric.vstorage.QueryCapDataRequest' as const,
   encode(
     message: QueryCapDataRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -347,7 +347,7 @@ function createBaseQueryCapDataResponse(): QueryCapDataResponse {
   };
 }
 export const QueryCapDataResponse = {
-  typeUrl: '/agoric.vstorage.QueryCapDataResponse',
+  typeUrl: '/agoric.vstorage.QueryCapDataResponse' as const,
   encode(
     message: QueryCapDataResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -423,7 +423,7 @@ function createBaseQueryChildrenRequest(): QueryChildrenRequest {
   };
 }
 export const QueryChildrenRequest = {
-  typeUrl: '/agoric.vstorage.QueryChildrenRequest',
+  typeUrl: '/agoric.vstorage.QueryChildrenRequest' as const,
   encode(
     message: QueryChildrenRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -506,7 +506,7 @@ function createBaseQueryChildrenResponse(): QueryChildrenResponse {
   };
 }
 export const QueryChildrenResponse = {
-  typeUrl: '/agoric.vstorage.QueryChildrenResponse',
+  typeUrl: '/agoric.vstorage.QueryChildrenResponse' as const,
   encode(
     message: QueryChildrenResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vstorage/vstorage.ts
+++ b/packages/client-utils/src/codegen/agoric/vstorage/vstorage.ts
@@ -38,7 +38,7 @@ function createBaseData(): Data {
   };
 }
 export const Data = {
-  typeUrl: '/agoric.vstorage.Data',
+  typeUrl: '/agoric.vstorage.Data' as const,
   encode(
     message: Data,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -100,7 +100,7 @@ function createBaseChildren(): Children {
   };
 }
 export const Children = {
-  typeUrl: '/agoric.vstorage.Children',
+  typeUrl: '/agoric.vstorage.Children' as const,
   encode(
     message: Children,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/agoric/vtransfer/genesis.ts
+++ b/packages/client-utils/src/codegen/agoric/vtransfer/genesis.ts
@@ -22,7 +22,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/agoric.vtransfer.GenesisState',
+  typeUrl: '/agoric.vtransfer.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/attester.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/attester.ts
@@ -26,7 +26,7 @@ function createBaseAttester(): Attester {
   };
 }
 export const Attester = {
-  typeUrl: '/circle.cctp.v1.Attester',
+  typeUrl: '/circle.cctp.v1.Attester' as const,
   encode(
     message: Attester,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/burn_message.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/burn_message.ts
@@ -48,7 +48,7 @@ function createBaseBurnMessage(): BurnMessage {
   };
 }
 export const BurnMessage = {
-  typeUrl: '/circle.cctp.v1.BurnMessage',
+  typeUrl: '/circle.cctp.v1.BurnMessage' as const,
   encode(
     message: BurnMessage,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/burning_and_minting_paused.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/burning_and_minting_paused.ts
@@ -26,7 +26,7 @@ function createBaseBurningAndMintingPaused(): BurningAndMintingPaused {
   };
 }
 export const BurningAndMintingPaused = {
-  typeUrl: '/circle.cctp.v1.BurningAndMintingPaused',
+  typeUrl: '/circle.cctp.v1.BurningAndMintingPaused' as const,
   encode(
     message: BurningAndMintingPaused,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/events.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/events.ts
@@ -488,7 +488,7 @@ function createBaseAttesterEnabled(): AttesterEnabled {
   };
 }
 export const AttesterEnabled = {
-  typeUrl: '/circle.cctp.v1.AttesterEnabled',
+  typeUrl: '/circle.cctp.v1.AttesterEnabled' as const,
   encode(
     message: AttesterEnabled,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -550,7 +550,7 @@ function createBaseAttesterDisabled(): AttesterDisabled {
   };
 }
 export const AttesterDisabled = {
-  typeUrl: '/circle.cctp.v1.AttesterDisabled',
+  typeUrl: '/circle.cctp.v1.AttesterDisabled' as const,
   encode(
     message: AttesterDisabled,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -613,7 +613,7 @@ function createBaseSignatureThresholdUpdated(): SignatureThresholdUpdated {
   };
 }
 export const SignatureThresholdUpdated = {
-  typeUrl: '/circle.cctp.v1.SignatureThresholdUpdated',
+  typeUrl: '/circle.cctp.v1.SignatureThresholdUpdated' as const,
   encode(
     message: SignatureThresholdUpdated,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -714,7 +714,7 @@ function createBaseOwnerUpdated(): OwnerUpdated {
   };
 }
 export const OwnerUpdated = {
-  typeUrl: '/circle.cctp.v1.OwnerUpdated',
+  typeUrl: '/circle.cctp.v1.OwnerUpdated' as const,
   encode(
     message: OwnerUpdated,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -789,7 +789,7 @@ function createBaseOwnershipTransferStarted(): OwnershipTransferStarted {
   };
 }
 export const OwnershipTransferStarted = {
-  typeUrl: '/circle.cctp.v1.OwnershipTransferStarted',
+  typeUrl: '/circle.cctp.v1.OwnershipTransferStarted' as const,
   encode(
     message: OwnershipTransferStarted,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -875,7 +875,7 @@ function createBasePauserUpdated(): PauserUpdated {
   };
 }
 export const PauserUpdated = {
-  typeUrl: '/circle.cctp.v1.PauserUpdated',
+  typeUrl: '/circle.cctp.v1.PauserUpdated' as const,
   encode(
     message: PauserUpdated,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -950,7 +950,7 @@ function createBaseAttesterManagerUpdated(): AttesterManagerUpdated {
   };
 }
 export const AttesterManagerUpdated = {
-  typeUrl: '/circle.cctp.v1.AttesterManagerUpdated',
+  typeUrl: '/circle.cctp.v1.AttesterManagerUpdated' as const,
   encode(
     message: AttesterManagerUpdated,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1033,7 +1033,7 @@ function createBaseTokenControllerUpdated(): TokenControllerUpdated {
   };
 }
 export const TokenControllerUpdated = {
-  typeUrl: '/circle.cctp.v1.TokenControllerUpdated',
+  typeUrl: '/circle.cctp.v1.TokenControllerUpdated' as const,
   encode(
     message: TokenControllerUpdated,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1113,7 +1113,7 @@ function createBaseBurningAndMintingPausedEvent(): BurningAndMintingPausedEvent 
   return {};
 }
 export const BurningAndMintingPausedEvent = {
-  typeUrl: '/circle.cctp.v1.BurningAndMintingPausedEvent',
+  typeUrl: '/circle.cctp.v1.BurningAndMintingPausedEvent' as const,
   encode(
     _: BurningAndMintingPausedEvent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1174,7 +1174,7 @@ function createBaseBurningAndMintingUnpausedEvent(): BurningAndMintingUnpausedEv
   return {};
 }
 export const BurningAndMintingUnpausedEvent = {
-  typeUrl: '/circle.cctp.v1.BurningAndMintingUnpausedEvent',
+  typeUrl: '/circle.cctp.v1.BurningAndMintingUnpausedEvent' as const,
   encode(
     _: BurningAndMintingUnpausedEvent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1235,7 +1235,7 @@ function createBaseSendingAndReceivingPausedEvent(): SendingAndReceivingPausedEv
   return {};
 }
 export const SendingAndReceivingPausedEvent = {
-  typeUrl: '/circle.cctp.v1.SendingAndReceivingPausedEvent',
+  typeUrl: '/circle.cctp.v1.SendingAndReceivingPausedEvent' as const,
   encode(
     _: SendingAndReceivingPausedEvent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1296,7 +1296,7 @@ function createBaseSendingAndReceivingUnpausedEvent(): SendingAndReceivingUnpaus
   return {};
 }
 export const SendingAndReceivingUnpausedEvent = {
-  typeUrl: '/circle.cctp.v1.SendingAndReceivingUnpausedEvent',
+  typeUrl: '/circle.cctp.v1.SendingAndReceivingUnpausedEvent' as const,
   encode(
     _: SendingAndReceivingUnpausedEvent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1366,7 +1366,7 @@ function createBaseDepositForBurn(): DepositForBurn {
   };
 }
 export const DepositForBurn = {
-  typeUrl: '/circle.cctp.v1.DepositForBurn',
+  typeUrl: '/circle.cctp.v1.DepositForBurn' as const,
   encode(
     message: DepositForBurn,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1522,7 +1522,7 @@ function createBaseMintAndWithdraw(): MintAndWithdraw {
   };
 }
 export const MintAndWithdraw = {
-  typeUrl: '/circle.cctp.v1.MintAndWithdraw',
+  typeUrl: '/circle.cctp.v1.MintAndWithdraw' as const,
   encode(
     message: MintAndWithdraw,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1611,7 +1611,7 @@ function createBaseTokenPairLinked(): TokenPairLinked {
   };
 }
 export const TokenPairLinked = {
-  typeUrl: '/circle.cctp.v1.TokenPairLinked',
+  typeUrl: '/circle.cctp.v1.TokenPairLinked' as const,
   encode(
     message: TokenPairLinked,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1703,7 +1703,7 @@ function createBaseTokenPairUnlinked(): TokenPairUnlinked {
   };
 }
 export const TokenPairUnlinked = {
-  typeUrl: '/circle.cctp.v1.TokenPairUnlinked',
+  typeUrl: '/circle.cctp.v1.TokenPairUnlinked' as const,
   encode(
     message: TokenPairUnlinked,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1793,7 +1793,7 @@ function createBaseMessageSent(): MessageSent {
   };
 }
 export const MessageSent = {
-  typeUrl: '/circle.cctp.v1.MessageSent',
+  typeUrl: '/circle.cctp.v1.MessageSent' as const,
   encode(
     message: MessageSent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1864,7 +1864,7 @@ function createBaseMessageReceived(): MessageReceived {
   };
 }
 export const MessageReceived = {
-  typeUrl: '/circle.cctp.v1.MessageReceived',
+  typeUrl: '/circle.cctp.v1.MessageReceived' as const,
   encode(
     message: MessageReceived,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1981,7 +1981,7 @@ function createBaseMaxMessageBodySizeUpdated(): MaxMessageBodySizeUpdated {
   };
 }
 export const MaxMessageBodySizeUpdated = {
-  typeUrl: '/circle.cctp.v1.MaxMessageBodySizeUpdated',
+  typeUrl: '/circle.cctp.v1.MaxMessageBodySizeUpdated' as const,
   encode(
     message: MaxMessageBodySizeUpdated,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2064,7 +2064,7 @@ function createBaseRemoteTokenMessengerAdded(): RemoteTokenMessengerAdded {
   };
 }
 export const RemoteTokenMessengerAdded = {
-  typeUrl: '/circle.cctp.v1.RemoteTokenMessengerAdded',
+  typeUrl: '/circle.cctp.v1.RemoteTokenMessengerAdded' as const,
   encode(
     message: RemoteTokenMessengerAdded,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2155,7 +2155,7 @@ function createBaseRemoteTokenMessengerRemoved(): RemoteTokenMessengerRemoved {
   };
 }
 export const RemoteTokenMessengerRemoved = {
-  typeUrl: '/circle.cctp.v1.RemoteTokenMessengerRemoved',
+  typeUrl: '/circle.cctp.v1.RemoteTokenMessengerRemoved' as const,
   encode(
     message: RemoteTokenMessengerRemoved,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2246,7 +2246,7 @@ function createBaseSetBurnLimitPerMessage(): SetBurnLimitPerMessage {
   };
 }
 export const SetBurnLimitPerMessage = {
-  typeUrl: '/circle.cctp.v1.SetBurnLimitPerMessage',
+  typeUrl: '/circle.cctp.v1.SetBurnLimitPerMessage' as const,
   encode(
     message: SetBurnLimitPerMessage,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/genesis.ts
@@ -86,7 +86,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/circle.cctp.v1.GenesisState',
+  typeUrl: '/circle.cctp.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/max_message_body_size.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/max_message_body_size.ts
@@ -26,7 +26,7 @@ function createBaseMaxMessageBodySize(): MaxMessageBodySize {
   };
 }
 export const MaxMessageBodySize = {
-  typeUrl: '/circle.cctp.v1.MaxMessageBodySize',
+  typeUrl: '/circle.cctp.v1.MaxMessageBodySize' as const,
   encode(
     message: MaxMessageBodySize,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/message.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/message.ts
@@ -73,7 +73,7 @@ function createBaseMessage(): Message {
   };
 }
 export const Message = {
-  typeUrl: '/circle.cctp.v1.Message',
+  typeUrl: '/circle.cctp.v1.Message' as const,
   encode(
     message: Message,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/nonce.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/nonce.ts
@@ -35,7 +35,7 @@ function createBaseNonce(): Nonce {
   };
 }
 export const Nonce = {
-  typeUrl: '/circle.cctp.v1.Nonce',
+  typeUrl: '/circle.cctp.v1.Nonce' as const,
   encode(
     message: Nonce,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/per_message_burn_limit.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/per_message_burn_limit.ts
@@ -35,7 +35,7 @@ function createBasePerMessageBurnLimit(): PerMessageBurnLimit {
   };
 }
 export const PerMessageBurnLimit = {
-  typeUrl: '/circle.cctp.v1.PerMessageBurnLimit',
+  typeUrl: '/circle.cctp.v1.PerMessageBurnLimit' as const,
   encode(
     message: PerMessageBurnLimit,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/query.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/query.ts
@@ -692,7 +692,7 @@ function createBaseQueryRolesRequest(): QueryRolesRequest {
   return {};
 }
 export const QueryRolesRequest = {
-  typeUrl: '/circle.cctp.v1.QueryRolesRequest',
+  typeUrl: '/circle.cctp.v1.QueryRolesRequest' as const,
   encode(
     _: QueryRolesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -747,7 +747,7 @@ function createBaseQueryRolesResponse(): QueryRolesResponse {
   };
 }
 export const QueryRolesResponse = {
-  typeUrl: '/circle.cctp.v1.QueryRolesResponse',
+  typeUrl: '/circle.cctp.v1.QueryRolesResponse' as const,
   encode(
     message: QueryRolesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -845,7 +845,7 @@ function createBaseQueryGetAttesterRequest(): QueryGetAttesterRequest {
   };
 }
 export const QueryGetAttesterRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetAttesterRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetAttesterRequest' as const,
   encode(
     message: QueryGetAttesterRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -916,7 +916,7 @@ function createBaseQueryGetAttesterResponse(): QueryGetAttesterResponse {
   };
 }
 export const QueryGetAttesterResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetAttesterResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetAttesterResponse' as const,
   encode(
     message: QueryGetAttesterResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -997,7 +997,7 @@ function createBaseQueryAllAttestersRequest(): QueryAllAttestersRequest {
   };
 }
 export const QueryAllAttestersRequest = {
-  typeUrl: '/circle.cctp.v1.QueryAllAttestersRequest',
+  typeUrl: '/circle.cctp.v1.QueryAllAttestersRequest' as const,
   encode(
     message: QueryAllAttestersRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1079,7 +1079,7 @@ function createBaseQueryAllAttestersResponse(): QueryAllAttestersResponse {
   };
 }
 export const QueryAllAttestersResponse = {
-  typeUrl: '/circle.cctp.v1.QueryAllAttestersResponse',
+  typeUrl: '/circle.cctp.v1.QueryAllAttestersResponse' as const,
   encode(
     message: QueryAllAttestersResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1181,7 +1181,7 @@ function createBaseQueryGetPerMessageBurnLimitRequest(): QueryGetPerMessageBurnL
   };
 }
 export const QueryGetPerMessageBurnLimitRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetPerMessageBurnLimitRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetPerMessageBurnLimitRequest' as const,
   encode(
     message: QueryGetPerMessageBurnLimitRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1254,7 +1254,7 @@ function createBaseQueryGetPerMessageBurnLimitResponse(): QueryGetPerMessageBurn
   };
 }
 export const QueryGetPerMessageBurnLimitResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetPerMessageBurnLimitResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetPerMessageBurnLimitResponse' as const,
   encode(
     message: QueryGetPerMessageBurnLimitResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1341,7 +1341,7 @@ function createBaseQueryAllPerMessageBurnLimitsRequest(): QueryAllPerMessageBurn
   };
 }
 export const QueryAllPerMessageBurnLimitsRequest = {
-  typeUrl: '/circle.cctp.v1.QueryAllPerMessageBurnLimitsRequest',
+  typeUrl: '/circle.cctp.v1.QueryAllPerMessageBurnLimitsRequest' as const,
   encode(
     message: QueryAllPerMessageBurnLimitsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1423,7 +1423,7 @@ function createBaseQueryAllPerMessageBurnLimitsResponse(): QueryAllPerMessageBur
   };
 }
 export const QueryAllPerMessageBurnLimitsResponse = {
-  typeUrl: '/circle.cctp.v1.QueryAllPerMessageBurnLimitsResponse',
+  typeUrl: '/circle.cctp.v1.QueryAllPerMessageBurnLimitsResponse' as const,
   encode(
     message: QueryAllPerMessageBurnLimitsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1525,7 +1525,7 @@ function createBaseQueryGetBurningAndMintingPausedRequest(): QueryGetBurningAndM
   return {};
 }
 export const QueryGetBurningAndMintingPausedRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetBurningAndMintingPausedRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetBurningAndMintingPausedRequest' as const,
   encode(
     _: QueryGetBurningAndMintingPausedRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1588,7 +1588,7 @@ function createBaseQueryGetBurningAndMintingPausedResponse(): QueryGetBurningAnd
   };
 }
 export const QueryGetBurningAndMintingPausedResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetBurningAndMintingPausedResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetBurningAndMintingPausedResponse' as const,
   encode(
     message: QueryGetBurningAndMintingPausedResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1673,7 +1673,8 @@ function createBaseQueryGetSendingAndReceivingMessagesPausedRequest(): QueryGetS
   return {};
 }
 export const QueryGetSendingAndReceivingMessagesPausedRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetSendingAndReceivingMessagesPausedRequest',
+  typeUrl:
+    '/circle.cctp.v1.QueryGetSendingAndReceivingMessagesPausedRequest' as const,
   encode(
     _: QueryGetSendingAndReceivingMessagesPausedRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1748,7 +1749,8 @@ function createBaseQueryGetSendingAndReceivingMessagesPausedResponse(): QueryGet
   };
 }
 export const QueryGetSendingAndReceivingMessagesPausedResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetSendingAndReceivingMessagesPausedResponse',
+  typeUrl:
+    '/circle.cctp.v1.QueryGetSendingAndReceivingMessagesPausedResponse' as const,
   encode(
     message: QueryGetSendingAndReceivingMessagesPausedResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1845,7 +1847,7 @@ function createBaseQueryGetMaxMessageBodySizeRequest(): QueryGetMaxMessageBodySi
   return {};
 }
 export const QueryGetMaxMessageBodySizeRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetMaxMessageBodySizeRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetMaxMessageBodySizeRequest' as const,
   encode(
     _: QueryGetMaxMessageBodySizeRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1908,7 +1910,7 @@ function createBaseQueryGetMaxMessageBodySizeResponse(): QueryGetMaxMessageBodyS
   };
 }
 export const QueryGetMaxMessageBodySizeResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetMaxMessageBodySizeResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetMaxMessageBodySizeResponse' as const,
   encode(
     message: QueryGetMaxMessageBodySizeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1990,7 +1992,7 @@ function createBaseQueryGetNextAvailableNonceRequest(): QueryGetNextAvailableNon
   return {};
 }
 export const QueryGetNextAvailableNonceRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetNextAvailableNonceRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetNextAvailableNonceRequest' as const,
   encode(
     _: QueryGetNextAvailableNonceRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2053,7 +2055,7 @@ function createBaseQueryGetNextAvailableNonceResponse(): QueryGetNextAvailableNo
   };
 }
 export const QueryGetNextAvailableNonceResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetNextAvailableNonceResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetNextAvailableNonceResponse' as const,
   encode(
     message: QueryGetNextAvailableNonceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2128,7 +2130,7 @@ function createBaseQueryGetSignatureThresholdRequest(): QueryGetSignatureThresho
   return {};
 }
 export const QueryGetSignatureThresholdRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetSignatureThresholdRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetSignatureThresholdRequest' as const,
   encode(
     _: QueryGetSignatureThresholdRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2191,7 +2193,7 @@ function createBaseQueryGetSignatureThresholdResponse(): QueryGetSignatureThresh
   };
 }
 export const QueryGetSignatureThresholdResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetSignatureThresholdResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetSignatureThresholdResponse' as const,
   encode(
     message: QueryGetSignatureThresholdResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2276,7 +2278,7 @@ function createBaseQueryGetTokenPairRequest(): QueryGetTokenPairRequest {
   };
 }
 export const QueryGetTokenPairRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetTokenPairRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetTokenPairRequest' as const,
   encode(
     message: QueryGetTokenPairRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2362,7 +2364,7 @@ function createBaseQueryGetTokenPairResponse(): QueryGetTokenPairResponse {
   };
 }
 export const QueryGetTokenPairResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetTokenPairResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetTokenPairResponse' as const,
   encode(
     message: QueryGetTokenPairResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2439,7 +2441,7 @@ function createBaseQueryAllTokenPairsRequest(): QueryAllTokenPairsRequest {
   };
 }
 export const QueryAllTokenPairsRequest = {
-  typeUrl: '/circle.cctp.v1.QueryAllTokenPairsRequest',
+  typeUrl: '/circle.cctp.v1.QueryAllTokenPairsRequest' as const,
   encode(
     message: QueryAllTokenPairsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2521,7 +2523,7 @@ function createBaseQueryAllTokenPairsResponse(): QueryAllTokenPairsResponse {
   };
 }
 export const QueryAllTokenPairsResponse = {
-  typeUrl: '/circle.cctp.v1.QueryAllTokenPairsResponse',
+  typeUrl: '/circle.cctp.v1.QueryAllTokenPairsResponse' as const,
   encode(
     message: QueryAllTokenPairsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2624,7 +2626,7 @@ function createBaseQueryGetUsedNonceRequest(): QueryGetUsedNonceRequest {
   };
 }
 export const QueryGetUsedNonceRequest = {
-  typeUrl: '/circle.cctp.v1.QueryGetUsedNonceRequest',
+  typeUrl: '/circle.cctp.v1.QueryGetUsedNonceRequest' as const,
   encode(
     message: QueryGetUsedNonceRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2713,7 +2715,7 @@ function createBaseQueryGetUsedNonceResponse(): QueryGetUsedNonceResponse {
   };
 }
 export const QueryGetUsedNonceResponse = {
-  typeUrl: '/circle.cctp.v1.QueryGetUsedNonceResponse',
+  typeUrl: '/circle.cctp.v1.QueryGetUsedNonceResponse' as const,
   encode(
     message: QueryGetUsedNonceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2790,7 +2792,7 @@ function createBaseQueryAllUsedNoncesRequest(): QueryAllUsedNoncesRequest {
   };
 }
 export const QueryAllUsedNoncesRequest = {
-  typeUrl: '/circle.cctp.v1.QueryAllUsedNoncesRequest',
+  typeUrl: '/circle.cctp.v1.QueryAllUsedNoncesRequest' as const,
   encode(
     message: QueryAllUsedNoncesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2872,7 +2874,7 @@ function createBaseQueryAllUsedNoncesResponse(): QueryAllUsedNoncesResponse {
   };
 }
 export const QueryAllUsedNoncesResponse = {
-  typeUrl: '/circle.cctp.v1.QueryAllUsedNoncesResponse',
+  typeUrl: '/circle.cctp.v1.QueryAllUsedNoncesResponse' as const,
   encode(
     message: QueryAllUsedNoncesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2974,7 +2976,7 @@ function createBaseQueryRemoteTokenMessengerRequest(): QueryRemoteTokenMessenger
   };
 }
 export const QueryRemoteTokenMessengerRequest = {
-  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengerRequest',
+  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengerRequest' as const,
   encode(
     message: QueryRemoteTokenMessengerRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3048,7 +3050,7 @@ function createBaseQueryRemoteTokenMessengerResponse(): QueryRemoteTokenMessenge
   };
 }
 export const QueryRemoteTokenMessengerResponse = {
-  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengerResponse',
+  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengerResponse' as const,
   encode(
     message: QueryRemoteTokenMessengerResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3136,7 +3138,7 @@ function createBaseQueryRemoteTokenMessengersRequest(): QueryRemoteTokenMessenge
   };
 }
 export const QueryRemoteTokenMessengersRequest = {
-  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengersRequest',
+  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengersRequest' as const,
   encode(
     message: QueryRemoteTokenMessengersRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3218,7 +3220,7 @@ function createBaseQueryRemoteTokenMessengersResponse(): QueryRemoteTokenMesseng
   };
 }
 export const QueryRemoteTokenMessengersResponse = {
-  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengersResponse',
+  typeUrl: '/circle.cctp.v1.QueryRemoteTokenMessengersResponse' as const,
   encode(
     message: QueryRemoteTokenMessengersResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3324,7 +3326,7 @@ function createBaseQueryBurnMessageVersionRequest(): QueryBurnMessageVersionRequ
   return {};
 }
 export const QueryBurnMessageVersionRequest = {
-  typeUrl: '/circle.cctp.v1.QueryBurnMessageVersionRequest',
+  typeUrl: '/circle.cctp.v1.QueryBurnMessageVersionRequest' as const,
   encode(
     _: QueryBurnMessageVersionRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3387,7 +3389,7 @@ function createBaseQueryBurnMessageVersionResponse(): QueryBurnMessageVersionRes
   };
 }
 export const QueryBurnMessageVersionResponse = {
-  typeUrl: '/circle.cctp.v1.QueryBurnMessageVersionResponse',
+  typeUrl: '/circle.cctp.v1.QueryBurnMessageVersionResponse' as const,
   encode(
     message: QueryBurnMessageVersionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3459,7 +3461,7 @@ function createBaseQueryLocalMessageVersionRequest(): QueryLocalMessageVersionRe
   return {};
 }
 export const QueryLocalMessageVersionRequest = {
-  typeUrl: '/circle.cctp.v1.QueryLocalMessageVersionRequest',
+  typeUrl: '/circle.cctp.v1.QueryLocalMessageVersionRequest' as const,
   encode(
     _: QueryLocalMessageVersionRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3522,7 +3524,7 @@ function createBaseQueryLocalMessageVersionResponse(): QueryLocalMessageVersionR
   };
 }
 export const QueryLocalMessageVersionResponse = {
-  typeUrl: '/circle.cctp.v1.QueryLocalMessageVersionResponse',
+  typeUrl: '/circle.cctp.v1.QueryLocalMessageVersionResponse' as const,
   encode(
     message: QueryLocalMessageVersionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3594,7 +3596,7 @@ function createBaseQueryLocalDomainRequest(): QueryLocalDomainRequest {
   return {};
 }
 export const QueryLocalDomainRequest = {
-  typeUrl: '/circle.cctp.v1.QueryLocalDomainRequest',
+  typeUrl: '/circle.cctp.v1.QueryLocalDomainRequest' as const,
   encode(
     _: QueryLocalDomainRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3653,7 +3655,7 @@ function createBaseQueryLocalDomainResponse(): QueryLocalDomainResponse {
   };
 }
 export const QueryLocalDomainResponse = {
-  typeUrl: '/circle.cctp.v1.QueryLocalDomainResponse',
+  typeUrl: '/circle.cctp.v1.QueryLocalDomainResponse' as const,
   encode(
     message: QueryLocalDomainResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/remote_token_messenger.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/remote_token_messenger.ts
@@ -31,7 +31,7 @@ function createBaseRemoteTokenMessenger(): RemoteTokenMessenger {
   };
 }
 export const RemoteTokenMessenger = {
-  typeUrl: '/circle.cctp.v1.RemoteTokenMessenger',
+  typeUrl: '/circle.cctp.v1.RemoteTokenMessenger' as const,
   encode(
     message: RemoteTokenMessenger,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/sending_and_receiving_messages_paused.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/sending_and_receiving_messages_paused.ts
@@ -26,7 +26,7 @@ function createBaseSendingAndReceivingMessagesPaused(): SendingAndReceivingMessa
   };
 }
 export const SendingAndReceivingMessagesPaused = {
-  typeUrl: '/circle.cctp.v1.SendingAndReceivingMessagesPaused',
+  typeUrl: '/circle.cctp.v1.SendingAndReceivingMessagesPaused' as const,
   encode(
     message: SendingAndReceivingMessagesPaused,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/signature_threshold.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/signature_threshold.ts
@@ -28,7 +28,7 @@ function createBaseSignatureThreshold(): SignatureThreshold {
   };
 }
 export const SignatureThreshold = {
-  typeUrl: '/circle.cctp.v1.SignatureThreshold',
+  typeUrl: '/circle.cctp.v1.SignatureThreshold' as const,
   encode(
     message: SignatureThreshold,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/token_pair.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/token_pair.ts
@@ -44,7 +44,7 @@ function createBaseTokenPair(): TokenPair {
   };
 }
 export const TokenPair = {
-  typeUrl: '/circle.cctp.v1.TokenPair',
+  typeUrl: '/circle.cctp.v1.TokenPair' as const,
   encode(
     message: TokenPair,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/circle/cctp/v1/tx.ts
+++ b/packages/client-utils/src/codegen/circle/cctp/v1/tx.ts
@@ -72,7 +72,7 @@ function createBaseMsgDepositForBurn(): MsgDepositForBurn {
   };
 }
 export const MsgDepositForBurn = {
-  typeUrl: '/circle.cctp.v1.MsgDepositForBurn',
+  typeUrl: '/circle.cctp.v1.MsgDepositForBurn' as const,
   encode(
     message: MsgDepositForBurn,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -180,7 +180,7 @@ function createBaseMsgDepositForBurnResponse(): MsgDepositForBurnResponse {
   };
 }
 export const MsgDepositForBurnResponse = {
-  typeUrl: '/circle.cctp.v1.MsgDepositForBurnResponse',
+  typeUrl: '/circle.cctp.v1.MsgDepositForBurnResponse' as const,
   encode(
     message: MsgDepositForBurnResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -262,7 +262,7 @@ function createBaseMsgDepositForBurnWithCaller(): MsgDepositForBurnWithCaller {
   };
 }
 export const MsgDepositForBurnWithCaller = {
-  typeUrl: '/circle.cctp.v1.MsgDepositForBurnWithCaller',
+  typeUrl: '/circle.cctp.v1.MsgDepositForBurnWithCaller' as const,
   encode(
     message: MsgDepositForBurnWithCaller,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -397,7 +397,7 @@ function createBaseMsgDepositForBurnWithCallerResponse(): MsgDepositForBurnWithC
   };
 }
 export const MsgDepositForBurnWithCallerResponse = {
-  typeUrl: '/circle.cctp.v1.MsgDepositForBurnWithCallerResponse',
+  typeUrl: '/circle.cctp.v1.MsgDepositForBurnWithCallerResponse' as const,
   encode(
     message: MsgDepositForBurnWithCallerResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/app/runtime/v1alpha1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/app/runtime/v1alpha1/module.ts
@@ -90,7 +90,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.app.runtime.v1alpha1.Module',
+  typeUrl: '/cosmos.app.runtime.v1alpha1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -248,7 +248,7 @@ function createBaseStoreKeyConfig(): StoreKeyConfig {
   };
 }
 export const StoreKeyConfig = {
-  typeUrl: '/cosmos.app.runtime.v1alpha1.StoreKeyConfig',
+  typeUrl: '/cosmos.app.runtime.v1alpha1.StoreKeyConfig' as const,
   encode(
     message: StoreKeyConfig,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/app/v1alpha1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/app/v1alpha1/module.ts
@@ -120,7 +120,7 @@ function createBaseModuleDescriptor(): ModuleDescriptor {
   };
 }
 export const ModuleDescriptor = {
-  typeUrl: '/cosmos.app.v1alpha1.ModuleDescriptor',
+  typeUrl: '/cosmos.app.v1alpha1.ModuleDescriptor' as const,
   encode(
     message: ModuleDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -223,7 +223,7 @@ function createBasePackageReference(): PackageReference {
   };
 }
 export const PackageReference = {
-  typeUrl: '/cosmos.app.v1alpha1.PackageReference',
+  typeUrl: '/cosmos.app.v1alpha1.PackageReference' as const,
   encode(
     message: PackageReference,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -295,7 +295,7 @@ function createBaseMigrateFromInfo(): MigrateFromInfo {
   };
 }
 export const MigrateFromInfo = {
-  typeUrl: '/cosmos.app.v1alpha1.MigrateFromInfo',
+  typeUrl: '/cosmos.app.v1alpha1.MigrateFromInfo' as const,
   encode(
     message: MigrateFromInfo,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/auth/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/auth/module/v1/module.ts
@@ -48,7 +48,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.auth.module.v1.Module',
+  typeUrl: '/cosmos.auth.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -147,7 +147,7 @@ function createBaseModuleAccountPermission(): ModuleAccountPermission {
   };
 }
 export const ModuleAccountPermission = {
-  typeUrl: '/cosmos.auth.module.v1.ModuleAccountPermission',
+  typeUrl: '/cosmos.auth.module.v1.ModuleAccountPermission' as const,
   encode(
     message: ModuleAccountPermission,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/auth/v1beta1/auth.ts
+++ b/packages/client-utils/src/codegen/cosmos/auth/v1beta1/auth.ts
@@ -103,7 +103,7 @@ function createBaseBaseAccount(): BaseAccount {
   };
 }
 export const BaseAccount = {
-  typeUrl: '/cosmos.auth.v1beta1.BaseAccount',
+  typeUrl: '/cosmos.auth.v1beta1.BaseAccount' as const,
   encode(
     message: BaseAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -210,7 +210,7 @@ function createBaseModuleAccount(): ModuleAccount {
   };
 }
 export const ModuleAccount = {
-  typeUrl: '/cosmos.auth.v1beta1.ModuleAccount',
+  typeUrl: '/cosmos.auth.v1beta1.ModuleAccount' as const,
   encode(
     message: ModuleAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -308,7 +308,7 @@ function createBaseModuleCredential(): ModuleCredential {
   };
 }
 export const ModuleCredential = {
-  typeUrl: '/cosmos.auth.v1beta1.ModuleCredential',
+  typeUrl: '/cosmos.auth.v1beta1.ModuleCredential' as const,
   encode(
     message: ModuleCredential,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -391,7 +391,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/cosmos.auth.v1beta1.Params',
+  typeUrl: '/cosmos.auth.v1beta1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/auth/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/auth/v1beta1/genesis.ts
@@ -27,7 +27,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.auth.v1beta1.GenesisState',
+  typeUrl: '/cosmos.auth.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/auth/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/auth/v1beta1/query.ts
@@ -389,7 +389,7 @@ function createBaseQueryAccountsRequest(): QueryAccountsRequest {
   };
 }
 export const QueryAccountsRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountsRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountsRequest' as const,
   encode(
     message: QueryAccountsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -463,7 +463,7 @@ function createBaseQueryAccountsResponse(): QueryAccountsResponse {
   };
 }
 export const QueryAccountsResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountsResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountsResponse' as const,
   encode(
     message: QueryAccountsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -554,7 +554,7 @@ function createBaseQueryAccountRequest(): QueryAccountRequest {
   };
 }
 export const QueryAccountRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountRequest' as const,
   encode(
     message: QueryAccountRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -619,7 +619,7 @@ function createBaseQueryAccountResponse(): QueryAccountResponse {
   };
 }
 export const QueryAccountResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountResponse' as const,
   encode(
     message: QueryAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -686,7 +686,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -741,7 +741,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -808,7 +808,7 @@ function createBaseQueryModuleAccountsRequest(): QueryModuleAccountsRequest {
   return {};
 }
 export const QueryModuleAccountsRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountsRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountsRequest' as const,
   encode(
     _: QueryModuleAccountsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -869,7 +869,7 @@ function createBaseQueryModuleAccountsResponse(): QueryModuleAccountsResponse {
   };
 }
 export const QueryModuleAccountsResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountsResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountsResponse' as const,
   encode(
     message: QueryModuleAccountsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -948,7 +948,7 @@ function createBaseQueryModuleAccountByNameRequest(): QueryModuleAccountByNameRe
   };
 }
 export const QueryModuleAccountByNameRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountByNameRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountByNameRequest' as const,
   encode(
     message: QueryModuleAccountByNameRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1021,7 +1021,7 @@ function createBaseQueryModuleAccountByNameResponse(): QueryModuleAccountByNameR
   };
 }
 export const QueryModuleAccountByNameResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountByNameResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryModuleAccountByNameResponse' as const,
   encode(
     message: QueryModuleAccountByNameResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1096,7 +1096,7 @@ function createBaseBech32PrefixRequest(): Bech32PrefixRequest {
   return {};
 }
 export const Bech32PrefixRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.Bech32PrefixRequest',
+  typeUrl: '/cosmos.auth.v1beta1.Bech32PrefixRequest' as const,
   encode(
     _: Bech32PrefixRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1151,7 +1151,7 @@ function createBaseBech32PrefixResponse(): Bech32PrefixResponse {
   };
 }
 export const Bech32PrefixResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.Bech32PrefixResponse',
+  typeUrl: '/cosmos.auth.v1beta1.Bech32PrefixResponse' as const,
   encode(
     message: Bech32PrefixResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1219,7 +1219,7 @@ function createBaseAddressBytesToStringRequest(): AddressBytesToStringRequest {
   };
 }
 export const AddressBytesToStringRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.AddressBytesToStringRequest',
+  typeUrl: '/cosmos.auth.v1beta1.AddressBytesToStringRequest' as const,
   encode(
     message: AddressBytesToStringRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1299,7 +1299,7 @@ function createBaseAddressBytesToStringResponse(): AddressBytesToStringResponse 
   };
 }
 export const AddressBytesToStringResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.AddressBytesToStringResponse',
+  typeUrl: '/cosmos.auth.v1beta1.AddressBytesToStringResponse' as const,
   encode(
     message: AddressBytesToStringResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1375,7 +1375,7 @@ function createBaseAddressStringToBytesRequest(): AddressStringToBytesRequest {
   };
 }
 export const AddressStringToBytesRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.AddressStringToBytesRequest',
+  typeUrl: '/cosmos.auth.v1beta1.AddressStringToBytesRequest' as const,
   encode(
     message: AddressStringToBytesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1451,7 +1451,7 @@ function createBaseAddressStringToBytesResponse(): AddressStringToBytesResponse 
   };
 }
 export const AddressStringToBytesResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.AddressStringToBytesResponse',
+  typeUrl: '/cosmos.auth.v1beta1.AddressStringToBytesResponse' as const,
   encode(
     message: AddressStringToBytesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1532,7 +1532,7 @@ function createBaseQueryAccountAddressByIDRequest(): QueryAccountAddressByIDRequ
   };
 }
 export const QueryAccountAddressByIDRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountAddressByIDRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountAddressByIDRequest' as const,
   encode(
     message: QueryAccountAddressByIDRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1623,7 +1623,7 @@ function createBaseQueryAccountAddressByIDResponse(): QueryAccountAddressByIDRes
   };
 }
 export const QueryAccountAddressByIDResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountAddressByIDResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountAddressByIDResponse' as const,
   encode(
     message: QueryAccountAddressByIDResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1699,7 +1699,7 @@ function createBaseQueryAccountInfoRequest(): QueryAccountInfoRequest {
   };
 }
 export const QueryAccountInfoRequest = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountInfoRequest',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountInfoRequest' as const,
   encode(
     message: QueryAccountInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1770,7 +1770,7 @@ function createBaseQueryAccountInfoResponse(): QueryAccountInfoResponse {
   };
 }
 export const QueryAccountInfoResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.QueryAccountInfoResponse',
+  typeUrl: '/cosmos.auth.v1beta1.QueryAccountInfoResponse' as const,
   encode(
     message: QueryAccountInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/auth/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/auth/v1beta1/tx.ts
@@ -56,7 +56,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.auth.v1beta1.MsgUpdateParams',
+  typeUrl: '/cosmos.auth.v1beta1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -129,7 +129,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.auth.v1beta1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.auth.v1beta1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/authz/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/authz/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.authz.module.v1.Module',
+  typeUrl: '/cosmos.authz.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/authz/v1beta1/authz.ts
+++ b/packages/client-utils/src/codegen/cosmos/authz/v1beta1/authz.ts
@@ -94,7 +94,7 @@ function createBaseGenericAuthorization(): GenericAuthorization {
   };
 }
 export const GenericAuthorization = {
-  typeUrl: '/cosmos.authz.v1beta1.GenericAuthorization',
+  typeUrl: '/cosmos.authz.v1beta1.GenericAuthorization' as const,
   encode(
     message: GenericAuthorization,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -160,7 +160,7 @@ function createBaseGrant(): Grant {
   };
 }
 export const Grant = {
-  typeUrl: '/cosmos.authz.v1beta1.Grant',
+  typeUrl: '/cosmos.authz.v1beta1.Grant' as const,
   encode(
     message: Grant,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -248,7 +248,7 @@ function createBaseGrantAuthorization(): GrantAuthorization {
   };
 }
 export const GrantAuthorization = {
-  typeUrl: '/cosmos.authz.v1beta1.GrantAuthorization',
+  typeUrl: '/cosmos.authz.v1beta1.GrantAuthorization' as const,
   encode(
     message: GrantAuthorization,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -354,7 +354,7 @@ function createBaseGrantQueueItem(): GrantQueueItem {
   };
 }
 export const GrantQueueItem = {
-  typeUrl: '/cosmos.authz.v1beta1.GrantQueueItem',
+  typeUrl: '/cosmos.authz.v1beta1.GrantQueueItem' as const,
   encode(
     message: GrantQueueItem,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/authz/v1beta1/event.ts
+++ b/packages/client-utils/src/codegen/cosmos/authz/v1beta1/event.ts
@@ -48,7 +48,7 @@ function createBaseEventGrant(): EventGrant {
   };
 }
 export const EventGrant = {
-  typeUrl: '/cosmos.authz.v1beta1.EventGrant',
+  typeUrl: '/cosmos.authz.v1beta1.EventGrant' as const,
   encode(
     message: EventGrant,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -130,7 +130,7 @@ function createBaseEventRevoke(): EventRevoke {
   };
 }
 export const EventRevoke = {
-  typeUrl: '/cosmos.authz.v1beta1.EventRevoke',
+  typeUrl: '/cosmos.authz.v1beta1.EventRevoke' as const,
   encode(
     message: EventRevoke,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/authz/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/authz/v1beta1/genesis.ts
@@ -20,7 +20,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.authz.v1beta1.GenesisState',
+  typeUrl: '/cosmos.authz.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/authz/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/authz/v1beta1/query.ts
@@ -121,7 +121,7 @@ function createBaseQueryGrantsRequest(): QueryGrantsRequest {
   };
 }
 export const QueryGrantsRequest = {
-  typeUrl: '/cosmos.authz.v1beta1.QueryGrantsRequest',
+  typeUrl: '/cosmos.authz.v1beta1.QueryGrantsRequest' as const,
   encode(
     message: QueryGrantsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -222,7 +222,7 @@ function createBaseQueryGrantsResponse(): QueryGrantsResponse {
   };
 }
 export const QueryGrantsResponse = {
-  typeUrl: '/cosmos.authz.v1beta1.QueryGrantsResponse',
+  typeUrl: '/cosmos.authz.v1beta1.QueryGrantsResponse' as const,
   encode(
     message: QueryGrantsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -314,7 +314,7 @@ function createBaseQueryGranterGrantsRequest(): QueryGranterGrantsRequest {
   };
 }
 export const QueryGranterGrantsRequest = {
-  typeUrl: '/cosmos.authz.v1beta1.QueryGranterGrantsRequest',
+  typeUrl: '/cosmos.authz.v1beta1.QueryGranterGrantsRequest' as const,
   encode(
     message: QueryGranterGrantsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -405,7 +405,7 @@ function createBaseQueryGranterGrantsResponse(): QueryGranterGrantsResponse {
   };
 }
 export const QueryGranterGrantsResponse = {
-  typeUrl: '/cosmos.authz.v1beta1.QueryGranterGrantsResponse',
+  typeUrl: '/cosmos.authz.v1beta1.QueryGranterGrantsResponse' as const,
   encode(
     message: QueryGranterGrantsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -510,7 +510,7 @@ function createBaseQueryGranteeGrantsRequest(): QueryGranteeGrantsRequest {
   };
 }
 export const QueryGranteeGrantsRequest = {
-  typeUrl: '/cosmos.authz.v1beta1.QueryGranteeGrantsRequest',
+  typeUrl: '/cosmos.authz.v1beta1.QueryGranteeGrantsRequest' as const,
   encode(
     message: QueryGranteeGrantsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -601,7 +601,7 @@ function createBaseQueryGranteeGrantsResponse(): QueryGranteeGrantsResponse {
   };
 }
 export const QueryGranteeGrantsResponse = {
-  typeUrl: '/cosmos.authz.v1beta1.QueryGranteeGrantsResponse',
+  typeUrl: '/cosmos.authz.v1beta1.QueryGranteeGrantsResponse' as const,
   encode(
     message: QueryGranteeGrantsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/authz/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/authz/v1beta1/tx.ts
@@ -113,7 +113,7 @@ function createBaseMsgGrant(): MsgGrant {
   };
 }
 export const MsgGrant = {
-  typeUrl: '/cosmos.authz.v1beta1.MsgGrant',
+  typeUrl: '/cosmos.authz.v1beta1.MsgGrant' as const,
   encode(
     message: MsgGrant,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -197,7 +197,7 @@ function createBaseMsgExecResponse(): MsgExecResponse {
   };
 }
 export const MsgExecResponse = {
-  typeUrl: '/cosmos.authz.v1beta1.MsgExecResponse',
+  typeUrl: '/cosmos.authz.v1beta1.MsgExecResponse' as const,
   encode(
     message: MsgExecResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -268,7 +268,7 @@ function createBaseMsgExec(): MsgExec {
   };
 }
 export const MsgExec = {
-  typeUrl: '/cosmos.authz.v1beta1.MsgExec',
+  typeUrl: '/cosmos.authz.v1beta1.MsgExec' as const,
   encode(
     message: MsgExec,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -343,7 +343,7 @@ function createBaseMsgGrantResponse(): MsgGrantResponse {
   return {};
 }
 export const MsgGrantResponse = {
-  typeUrl: '/cosmos.authz.v1beta1.MsgGrantResponse',
+  typeUrl: '/cosmos.authz.v1beta1.MsgGrantResponse' as const,
   encode(
     _: MsgGrantResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -397,7 +397,7 @@ function createBaseMsgRevoke(): MsgRevoke {
   };
 }
 export const MsgRevoke = {
-  typeUrl: '/cosmos.authz.v1beta1.MsgRevoke',
+  typeUrl: '/cosmos.authz.v1beta1.MsgRevoke' as const,
   encode(
     message: MsgRevoke,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -475,7 +475,7 @@ function createBaseMsgRevokeResponse(): MsgRevokeResponse {
   return {};
 }
 export const MsgRevokeResponse = {
-  typeUrl: '/cosmos.authz.v1beta1.MsgRevokeResponse',
+  typeUrl: '/cosmos.authz.v1beta1.MsgRevokeResponse' as const,
   encode(
     _: MsgRevokeResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/bank/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/bank/module/v1/module.ts
@@ -29,7 +29,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.bank.module.v1.Module',
+  typeUrl: '/cosmos.bank.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/bank/v1beta1/authz.ts
+++ b/packages/client-utils/src/codegen/cosmos/bank/v1beta1/authz.ts
@@ -39,7 +39,7 @@ function createBaseSendAuthorization(): SendAuthorization {
   };
 }
 export const SendAuthorization = {
-  typeUrl: '/cosmos.bank.v1beta1.SendAuthorization',
+  typeUrl: '/cosmos.bank.v1beta1.SendAuthorization' as const,
   encode(
     message: SendAuthorization,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/bank/v1beta1/bank.ts
+++ b/packages/client-utils/src/codegen/cosmos/bank/v1beta1/bank.ts
@@ -194,7 +194,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/cosmos.bank.v1beta1.Params',
+  typeUrl: '/cosmos.bank.v1beta1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -278,7 +278,7 @@ function createBaseSendEnabled(): SendEnabled {
   };
 }
 export const SendEnabled = {
-  typeUrl: '/cosmos.bank.v1beta1.SendEnabled',
+  typeUrl: '/cosmos.bank.v1beta1.SendEnabled' as const,
   encode(
     message: SendEnabled,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -350,7 +350,7 @@ function createBaseInput(): Input {
   };
 }
 export const Input = {
-  typeUrl: '/cosmos.bank.v1beta1.Input',
+  typeUrl: '/cosmos.bank.v1beta1.Input' as const,
   encode(
     message: Input,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -428,7 +428,7 @@ function createBaseOutput(): Output {
   };
 }
 export const Output = {
-  typeUrl: '/cosmos.bank.v1beta1.Output',
+  typeUrl: '/cosmos.bank.v1beta1.Output' as const,
   encode(
     message: Output,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -505,7 +505,7 @@ function createBaseSupply(): Supply {
   };
 }
 export const Supply = {
-  typeUrl: '/cosmos.bank.v1beta1.Supply',
+  typeUrl: '/cosmos.bank.v1beta1.Supply' as const,
   encode(
     message: Supply,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -575,7 +575,7 @@ function createBaseDenomUnit(): DenomUnit {
   };
 }
 export const DenomUnit = {
-  typeUrl: '/cosmos.bank.v1beta1.DenomUnit',
+  typeUrl: '/cosmos.bank.v1beta1.DenomUnit' as const,
   encode(
     message: DenomUnit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -669,7 +669,7 @@ function createBaseMetadata(): Metadata {
   };
 }
 export const Metadata = {
-  typeUrl: '/cosmos.bank.v1beta1.Metadata',
+  typeUrl: '/cosmos.bank.v1beta1.Metadata' as const,
   encode(
     message: Metadata,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/bank/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/bank/v1beta1/genesis.ts
@@ -75,7 +75,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.bank.v1beta1.GenesisState',
+  typeUrl: '/cosmos.bank.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -210,7 +210,7 @@ function createBaseBalance(): Balance {
   };
 }
 export const Balance = {
-  typeUrl: '/cosmos.bank.v1beta1.Balance',
+  typeUrl: '/cosmos.bank.v1beta1.Balance' as const,
   encode(
     message: Balance,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/bank/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/bank/v1beta1/query.ts
@@ -482,7 +482,7 @@ function createBaseQueryBalanceRequest(): QueryBalanceRequest {
   };
 }
 export const QueryBalanceRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryBalanceRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryBalanceRequest' as const,
   encode(
     message: QueryBalanceRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -556,7 +556,7 @@ function createBaseQueryBalanceResponse(): QueryBalanceResponse {
   };
 }
 export const QueryBalanceResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryBalanceResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryBalanceResponse' as const,
   encode(
     message: QueryBalanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -630,7 +630,7 @@ function createBaseQueryAllBalancesRequest(): QueryAllBalancesRequest {
   };
 }
 export const QueryAllBalancesRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryAllBalancesRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryAllBalancesRequest' as const,
   encode(
     message: QueryAllBalancesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -719,7 +719,7 @@ function createBaseQueryAllBalancesResponse(): QueryAllBalancesResponse {
   };
 }
 export const QueryAllBalancesResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryAllBalancesResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryAllBalancesResponse' as const,
   encode(
     message: QueryAllBalancesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -821,7 +821,7 @@ function createBaseQuerySpendableBalancesRequest(): QuerySpendableBalancesReques
   };
 }
 export const QuerySpendableBalancesRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalancesRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalancesRequest' as const,
   encode(
     message: QuerySpendableBalancesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -912,7 +912,7 @@ function createBaseQuerySpendableBalancesResponse(): QuerySpendableBalancesRespo
   };
 }
 export const QuerySpendableBalancesResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalancesResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalancesResponse' as const,
   encode(
     message: QuerySpendableBalancesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1014,7 +1014,7 @@ function createBaseQuerySpendableBalanceByDenomRequest(): QuerySpendableBalanceB
   };
 }
 export const QuerySpendableBalanceByDenomRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalanceByDenomRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalanceByDenomRequest' as const,
   encode(
     message: QuerySpendableBalanceByDenomRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1096,7 +1096,7 @@ function createBaseQuerySpendableBalanceByDenomResponse(): QuerySpendableBalance
   };
 }
 export const QuerySpendableBalanceByDenomResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse' as const,
   encode(
     message: QuerySpendableBalanceByDenomResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1177,7 +1177,7 @@ function createBaseQueryTotalSupplyRequest(): QueryTotalSupplyRequest {
   };
 }
 export const QueryTotalSupplyRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryTotalSupplyRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryTotalSupplyRequest' as const,
   encode(
     message: QueryTotalSupplyRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1257,7 +1257,7 @@ function createBaseQueryTotalSupplyResponse(): QueryTotalSupplyResponse {
   };
 }
 export const QueryTotalSupplyResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryTotalSupplyResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryTotalSupplyResponse' as const,
   encode(
     message: QueryTotalSupplyResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1356,7 +1356,7 @@ function createBaseQuerySupplyOfRequest(): QuerySupplyOfRequest {
   };
 }
 export const QuerySupplyOfRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySupplyOfRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySupplyOfRequest' as const,
   encode(
     message: QuerySupplyOfRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1421,7 +1421,7 @@ function createBaseQuerySupplyOfResponse(): QuerySupplyOfResponse {
   };
 }
 export const QuerySupplyOfResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySupplyOfResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySupplyOfResponse' as const,
   encode(
     message: QuerySupplyOfResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1488,7 +1488,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1543,7 +1543,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1612,7 +1612,7 @@ function createBaseQueryDenomsMetadataRequest(): QueryDenomsMetadataRequest {
   };
 }
 export const QueryDenomsMetadataRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryDenomsMetadataRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryDenomsMetadataRequest' as const,
   encode(
     message: QueryDenomsMetadataRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1694,7 +1694,7 @@ function createBaseQueryDenomsMetadataResponse(): QueryDenomsMetadataResponse {
   };
 }
 export const QueryDenomsMetadataResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryDenomsMetadataResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryDenomsMetadataResponse' as const,
   encode(
     message: QueryDenomsMetadataResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1796,7 +1796,7 @@ function createBaseQueryDenomMetadataRequest(): QueryDenomMetadataRequest {
   };
 }
 export const QueryDenomMetadataRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryDenomMetadataRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryDenomMetadataRequest' as const,
   encode(
     message: QueryDenomMetadataRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1869,7 +1869,7 @@ function createBaseQueryDenomMetadataResponse(): QueryDenomMetadataResponse {
   };
 }
 export const QueryDenomMetadataResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryDenomMetadataResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryDenomMetadataResponse' as const,
   encode(
     message: QueryDenomMetadataResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1951,7 +1951,7 @@ function createBaseQueryDenomOwnersRequest(): QueryDenomOwnersRequest {
   };
 }
 export const QueryDenomOwnersRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryDenomOwnersRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QueryDenomOwnersRequest' as const,
   encode(
     message: QueryDenomOwnersRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2040,7 +2040,7 @@ function createBaseDenomOwner(): DenomOwner {
   };
 }
 export const DenomOwner = {
-  typeUrl: '/cosmos.bank.v1beta1.DenomOwner',
+  typeUrl: '/cosmos.bank.v1beta1.DenomOwner' as const,
   encode(
     message: DenomOwner,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2120,7 +2120,7 @@ function createBaseQueryDenomOwnersResponse(): QueryDenomOwnersResponse {
   };
 }
 export const QueryDenomOwnersResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QueryDenomOwnersResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QueryDenomOwnersResponse' as const,
   encode(
     message: QueryDenomOwnersResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2223,7 +2223,7 @@ function createBaseQuerySendEnabledRequest(): QuerySendEnabledRequest {
   };
 }
 export const QuerySendEnabledRequest = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySendEnabledRequest',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySendEnabledRequest' as const,
   encode(
     message: QuerySendEnabledRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2321,7 +2321,7 @@ function createBaseQuerySendEnabledResponse(): QuerySendEnabledResponse {
   };
 }
 export const QuerySendEnabledResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.QuerySendEnabledResponse',
+  typeUrl: '/cosmos.bank.v1beta1.QuerySendEnabledResponse' as const,
   encode(
     message: QuerySendEnabledResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/bank/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/bank/v1beta1/tx.ts
@@ -172,7 +172,7 @@ function createBaseMsgSend(): MsgSend {
   };
 }
 export const MsgSend = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+  typeUrl: '/cosmos.bank.v1beta1.MsgSend' as const,
   encode(
     message: MsgSend,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -257,7 +257,7 @@ function createBaseMsgSendResponse(): MsgSendResponse {
   return {};
 }
 export const MsgSendResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgSendResponse',
+  typeUrl: '/cosmos.bank.v1beta1.MsgSendResponse' as const,
   encode(
     _: MsgSendResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -310,7 +310,7 @@ function createBaseMsgMultiSend(): MsgMultiSend {
   };
 }
 export const MsgMultiSend = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgMultiSend',
+  typeUrl: '/cosmos.bank.v1beta1.MsgMultiSend' as const,
   encode(
     message: MsgMultiSend,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -393,7 +393,7 @@ function createBaseMsgMultiSendResponse(): MsgMultiSendResponse {
   return {};
 }
 export const MsgMultiSendResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgMultiSendResponse',
+  typeUrl: '/cosmos.bank.v1beta1.MsgMultiSendResponse' as const,
   encode(
     _: MsgMultiSendResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -449,7 +449,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgUpdateParams',
+  typeUrl: '/cosmos.bank.v1beta1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -522,7 +522,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.bank.v1beta1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -583,7 +583,7 @@ function createBaseMsgSetSendEnabled(): MsgSetSendEnabled {
   };
 }
 export const MsgSetSendEnabled = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgSetSendEnabled',
+  typeUrl: '/cosmos.bank.v1beta1.MsgSetSendEnabled' as const,
   encode(
     message: MsgSetSendEnabled,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -676,7 +676,7 @@ function createBaseMsgSetSendEnabledResponse(): MsgSetSendEnabledResponse {
   return {};
 }
 export const MsgSetSendEnabledResponse = {
-  typeUrl: '/cosmos.bank.v1beta1.MsgSetSendEnabledResponse',
+  typeUrl: '/cosmos.bank.v1beta1.MsgSetSendEnabledResponse' as const,
   encode(
     _: MsgSetSendEnabledResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/base/abci/v1beta1/abci.ts
+++ b/packages/client-utils/src/codegen/cosmos/base/abci/v1beta1/abci.ts
@@ -303,7 +303,7 @@ function createBaseTxResponse(): TxResponse {
   };
 }
 export const TxResponse = {
-  typeUrl: '/cosmos.base.abci.v1beta1.TxResponse',
+  typeUrl: '/cosmos.base.abci.v1beta1.TxResponse' as const,
   encode(
     message: TxResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -511,7 +511,7 @@ function createBaseABCIMessageLog(): ABCIMessageLog {
   };
 }
 export const ABCIMessageLog = {
-  typeUrl: '/cosmos.base.abci.v1beta1.ABCIMessageLog',
+  typeUrl: '/cosmos.base.abci.v1beta1.ABCIMessageLog' as const,
   encode(
     message: ABCIMessageLog,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -601,7 +601,7 @@ function createBaseStringEvent(): StringEvent {
   };
 }
 export const StringEvent = {
-  typeUrl: '/cosmos.base.abci.v1beta1.StringEvent',
+  typeUrl: '/cosmos.base.abci.v1beta1.StringEvent' as const,
   encode(
     message: StringEvent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -682,7 +682,7 @@ function createBaseAttribute(): Attribute {
   };
 }
 export const Attribute = {
-  typeUrl: '/cosmos.base.abci.v1beta1.Attribute',
+  typeUrl: '/cosmos.base.abci.v1beta1.Attribute' as const,
   encode(
     message: Attribute,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -754,7 +754,7 @@ function createBaseGasInfo(): GasInfo {
   };
 }
 export const GasInfo = {
-  typeUrl: '/cosmos.base.abci.v1beta1.GasInfo',
+  typeUrl: '/cosmos.base.abci.v1beta1.GasInfo' as const,
   encode(
     message: GasInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -840,7 +840,7 @@ function createBaseResult(): Result {
   };
 }
 export const Result = {
-  typeUrl: '/cosmos.base.abci.v1beta1.Result',
+  typeUrl: '/cosmos.base.abci.v1beta1.Result' as const,
   encode(
     message: Result,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -950,7 +950,7 @@ function createBaseSimulationResponse(): SimulationResponse {
   };
 }
 export const SimulationResponse = {
-  typeUrl: '/cosmos.base.abci.v1beta1.SimulationResponse',
+  typeUrl: '/cosmos.base.abci.v1beta1.SimulationResponse' as const,
   encode(
     message: SimulationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1037,7 +1037,7 @@ function createBaseMsgData(): MsgData {
   };
 }
 export const MsgData = {
-  typeUrl: '/cosmos.base.abci.v1beta1.MsgData',
+  typeUrl: '/cosmos.base.abci.v1beta1.MsgData' as const,
   encode(
     message: MsgData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1114,7 +1114,7 @@ function createBaseTxMsgData(): TxMsgData {
   };
 }
 export const TxMsgData = {
-  typeUrl: '/cosmos.base.abci.v1beta1.TxMsgData',
+  typeUrl: '/cosmos.base.abci.v1beta1.TxMsgData' as const,
   encode(
     message: TxMsgData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1205,7 +1205,7 @@ function createBaseSearchTxsResult(): SearchTxsResult {
   };
 }
 export const SearchTxsResult = {
-  typeUrl: '/cosmos.base.abci.v1beta1.SearchTxsResult',
+  typeUrl: '/cosmos.base.abci.v1beta1.SearchTxsResult' as const,
   encode(
     message: SearchTxsResult,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/base/node/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/base/node/v1beta1/query.ts
@@ -26,7 +26,7 @@ function createBaseConfigRequest(): ConfigRequest {
   return {};
 }
 export const ConfigRequest = {
-  typeUrl: '/cosmos.base.node.v1beta1.ConfigRequest',
+  typeUrl: '/cosmos.base.node.v1beta1.ConfigRequest' as const,
   encode(
     _: ConfigRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -78,7 +78,7 @@ function createBaseConfigResponse(): ConfigResponse {
   };
 }
 export const ConfigResponse = {
-  typeUrl: '/cosmos.base.node.v1beta1.ConfigResponse',
+  typeUrl: '/cosmos.base.node.v1beta1.ConfigResponse' as const,
   encode(
     message: ConfigResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/base/query/v1beta1/pagination.ts
+++ b/packages/client-utils/src/codegen/cosmos/base/query/v1beta1/pagination.ts
@@ -114,7 +114,7 @@ function createBasePageRequest(): PageRequest {
   };
 }
 export const PageRequest = {
-  typeUrl: '/cosmos.base.query.v1beta1.PageRequest',
+  typeUrl: '/cosmos.base.query.v1beta1.PageRequest' as const,
   encode(
     message: PageRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -226,7 +226,7 @@ function createBasePageResponse(): PageResponse {
   };
 }
 export const PageResponse = {
-  typeUrl: '/cosmos.base.query.v1beta1.PageResponse',
+  typeUrl: '/cosmos.base.query.v1beta1.PageResponse' as const,
   encode(
     message: PageResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/base/reflection/v2alpha1/reflection.ts
+++ b/packages/client-utils/src/codegen/cosmos/base/reflection/v2alpha1/reflection.ts
@@ -424,7 +424,7 @@ function createBaseAppDescriptor(): AppDescriptor {
   };
 }
 export const AppDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.AppDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.AppDescriptor' as const,
   encode(
     message: AppDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -588,7 +588,7 @@ function createBaseTxDescriptor(): TxDescriptor {
   };
 }
 export const TxDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.TxDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.TxDescriptor' as const,
   encode(
     message: TxDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -667,7 +667,7 @@ function createBaseAuthnDescriptor(): AuthnDescriptor {
   };
 }
 export const AuthnDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.AuthnDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.AuthnDescriptor' as const,
   encode(
     message: AuthnDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -742,7 +742,7 @@ function createBaseSigningModeDescriptor(): SigningModeDescriptor {
   };
 }
 export const SigningModeDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.SigningModeDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.SigningModeDescriptor' as const,
   encode(
     message: SigningModeDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -832,7 +832,7 @@ function createBaseChainDescriptor(): ChainDescriptor {
   };
 }
 export const ChainDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.ChainDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.ChainDescriptor' as const,
   encode(
     message: ChainDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -894,7 +894,7 @@ function createBaseCodecDescriptor(): CodecDescriptor {
   };
 }
 export const CodecDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.CodecDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.CodecDescriptor' as const,
   encode(
     message: CodecDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -969,7 +969,7 @@ function createBaseInterfaceDescriptor(): InterfaceDescriptor {
   };
 }
 export const InterfaceDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.InterfaceDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.InterfaceDescriptor' as const,
   encode(
     message: InterfaceDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1091,7 +1091,8 @@ function createBaseInterfaceImplementerDescriptor(): InterfaceImplementerDescrip
   };
 }
 export const InterfaceImplementerDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.InterfaceImplementerDescriptor',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.InterfaceImplementerDescriptor' as const,
   encode(
     message: InterfaceImplementerDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1176,7 +1177,7 @@ function createBaseInterfaceAcceptingMessageDescriptor(): InterfaceAcceptingMess
 }
 export const InterfaceAcceptingMessageDescriptor = {
   typeUrl:
-    '/cosmos.base.reflection.v2alpha1.InterfaceAcceptingMessageDescriptor',
+    '/cosmos.base.reflection.v2alpha1.InterfaceAcceptingMessageDescriptor' as const,
   encode(
     message: InterfaceAcceptingMessageDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1266,7 +1267,7 @@ function createBaseConfigurationDescriptor(): ConfigurationDescriptor {
   };
 }
 export const ConfigurationDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.ConfigurationDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.ConfigurationDescriptor' as const,
   encode(
     message: ConfigurationDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1341,7 +1342,7 @@ function createBaseMsgDescriptor(): MsgDescriptor {
   };
 }
 export const MsgDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.MsgDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.MsgDescriptor' as const,
   encode(
     message: MsgDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1401,7 +1402,8 @@ function createBaseGetAuthnDescriptorRequest(): GetAuthnDescriptorRequest {
   return {};
 }
 export const GetAuthnDescriptorRequest = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetAuthnDescriptorRequest',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetAuthnDescriptorRequest' as const,
   encode(
     _: GetAuthnDescriptorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1462,7 +1464,8 @@ function createBaseGetAuthnDescriptorResponse(): GetAuthnDescriptorResponse {
   };
 }
 export const GetAuthnDescriptorResponse = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetAuthnDescriptorResponse',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetAuthnDescriptorResponse' as const,
   encode(
     message: GetAuthnDescriptorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1541,7 +1544,8 @@ function createBaseGetChainDescriptorRequest(): GetChainDescriptorRequest {
   return {};
 }
 export const GetChainDescriptorRequest = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetChainDescriptorRequest',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetChainDescriptorRequest' as const,
   encode(
     _: GetChainDescriptorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1602,7 +1606,8 @@ function createBaseGetChainDescriptorResponse(): GetChainDescriptorResponse {
   };
 }
 export const GetChainDescriptorResponse = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetChainDescriptorResponse',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetChainDescriptorResponse' as const,
   encode(
     message: GetChainDescriptorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1681,7 +1686,8 @@ function createBaseGetCodecDescriptorRequest(): GetCodecDescriptorRequest {
   return {};
 }
 export const GetCodecDescriptorRequest = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetCodecDescriptorRequest',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetCodecDescriptorRequest' as const,
   encode(
     _: GetCodecDescriptorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1742,7 +1748,8 @@ function createBaseGetCodecDescriptorResponse(): GetCodecDescriptorResponse {
   };
 }
 export const GetCodecDescriptorResponse = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetCodecDescriptorResponse',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetCodecDescriptorResponse' as const,
   encode(
     message: GetCodecDescriptorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1821,7 +1828,8 @@ function createBaseGetConfigurationDescriptorRequest(): GetConfigurationDescript
   return {};
 }
 export const GetConfigurationDescriptorRequest = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetConfigurationDescriptorRequest',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetConfigurationDescriptorRequest' as const,
   encode(
     _: GetConfigurationDescriptorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1886,7 +1894,7 @@ function createBaseGetConfigurationDescriptorResponse(): GetConfigurationDescrip
 }
 export const GetConfigurationDescriptorResponse = {
   typeUrl:
-    '/cosmos.base.reflection.v2alpha1.GetConfigurationDescriptorResponse',
+    '/cosmos.base.reflection.v2alpha1.GetConfigurationDescriptorResponse' as const,
   encode(
     message: GetConfigurationDescriptorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1972,7 +1980,8 @@ function createBaseGetQueryServicesDescriptorRequest(): GetQueryServicesDescript
   return {};
 }
 export const GetQueryServicesDescriptorRequest = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetQueryServicesDescriptorRequest',
+  typeUrl:
+    '/cosmos.base.reflection.v2alpha1.GetQueryServicesDescriptorRequest' as const,
   encode(
     _: GetQueryServicesDescriptorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2037,7 +2046,7 @@ function createBaseGetQueryServicesDescriptorResponse(): GetQueryServicesDescrip
 }
 export const GetQueryServicesDescriptorResponse = {
   typeUrl:
-    '/cosmos.base.reflection.v2alpha1.GetQueryServicesDescriptorResponse',
+    '/cosmos.base.reflection.v2alpha1.GetQueryServicesDescriptorResponse' as const,
   encode(
     message: GetQueryServicesDescriptorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2123,7 +2132,7 @@ function createBaseGetTxDescriptorRequest(): GetTxDescriptorRequest {
   return {};
 }
 export const GetTxDescriptorRequest = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetTxDescriptorRequest',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.GetTxDescriptorRequest' as const,
   encode(
     _: GetTxDescriptorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2180,7 +2189,7 @@ function createBaseGetTxDescriptorResponse(): GetTxDescriptorResponse {
   };
 }
 export const GetTxDescriptorResponse = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.GetTxDescriptorResponse',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.GetTxDescriptorResponse' as const,
   encode(
     message: GetTxDescriptorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2255,7 +2264,7 @@ function createBaseQueryServicesDescriptor(): QueryServicesDescriptor {
   };
 }
 export const QueryServicesDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.QueryServicesDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.QueryServicesDescriptor' as const,
   encode(
     message: QueryServicesDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2342,7 +2351,7 @@ function createBaseQueryServiceDescriptor(): QueryServiceDescriptor {
   };
 }
 export const QueryServiceDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.QueryServiceDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.QueryServiceDescriptor' as const,
   encode(
     message: QueryServiceDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2439,7 +2448,7 @@ function createBaseQueryMethodDescriptor(): QueryMethodDescriptor {
   };
 }
 export const QueryMethodDescriptor = {
-  typeUrl: '/cosmos.base.reflection.v2alpha1.QueryMethodDescriptor',
+  typeUrl: '/cosmos.base.reflection.v2alpha1.QueryMethodDescriptor' as const,
   encode(
     message: QueryMethodDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/base/v1beta1/coin.ts
+++ b/packages/client-utils/src/codegen/cosmos/base/v1beta1/coin.ts
@@ -82,7 +82,7 @@ function createBaseCoin(): Coin {
   };
 }
 export const Coin = {
-  typeUrl: '/cosmos.base.v1beta1.Coin',
+  typeUrl: '/cosmos.base.v1beta1.Coin' as const,
   encode(
     message: Coin,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -154,7 +154,7 @@ function createBaseDecCoin(): DecCoin {
   };
 }
 export const DecCoin = {
-  typeUrl: '/cosmos.base.v1beta1.DecCoin',
+  typeUrl: '/cosmos.base.v1beta1.DecCoin' as const,
   encode(
     message: DecCoin,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -227,7 +227,7 @@ function createBaseIntProto(): IntProto {
   };
 }
 export const IntProto = {
-  typeUrl: '/cosmos.base.v1beta1.IntProto',
+  typeUrl: '/cosmos.base.v1beta1.IntProto' as const,
   encode(
     message: IntProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -289,7 +289,7 @@ function createBaseDecProto(): DecProto {
   };
 }
 export const DecProto = {
-  typeUrl: '/cosmos.base.v1beta1.DecProto',
+  typeUrl: '/cosmos.base.v1beta1.DecProto' as const,
   encode(
     message: DecProto,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/capability/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/capability/module/v1/module.ts
@@ -24,7 +24,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.capability.module.v1.Module',
+  typeUrl: '/cosmos.capability.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/consensus/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/consensus/module/v1/module.ts
@@ -21,7 +21,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.consensus.module.v1.Module',
+  typeUrl: '/cosmos.consensus.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/consensus/v1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/consensus/v1/query.ts
@@ -35,7 +35,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.consensus.v1.QueryParamsRequest',
+  typeUrl: '/cosmos.consensus.v1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -90,7 +90,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.consensus.v1.QueryParamsResponse',
+  typeUrl: '/cosmos.consensus.v1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/consensus/v1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/consensus/v1/tx.ts
@@ -59,7 +59,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.consensus.v1.MsgUpdateParams',
+  typeUrl: '/cosmos.consensus.v1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -176,7 +176,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.consensus.v1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.consensus.v1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crisis/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/crisis/module/v1/module.ts
@@ -25,7 +25,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.crisis.module.v1.Module',
+  typeUrl: '/cosmos.crisis.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/ed25519/keys.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/ed25519/keys.ts
@@ -52,7 +52,7 @@ function createBasePubKey(): PubKey {
   };
 }
 export const PubKey = {
-  typeUrl: '/cosmos.crypto.ed25519.PubKey',
+  typeUrl: '/cosmos.crypto.ed25519.PubKey' as const,
   encode(
     message: PubKey,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -117,7 +117,7 @@ function createBasePrivKey(): PrivKey {
   };
 }
 export const PrivKey = {
-  typeUrl: '/cosmos.crypto.ed25519.PrivKey',
+  typeUrl: '/cosmos.crypto.ed25519.PrivKey' as const,
   encode(
     message: PrivKey,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/hd/v1/hd.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/hd/v1/hd.ts
@@ -40,7 +40,7 @@ function createBaseBIP44Params(): BIP44Params {
   };
 }
 export const BIP44Params = {
-  typeUrl: '/cosmos.crypto.hd.v1.BIP44Params',
+  typeUrl: '/cosmos.crypto.hd.v1.BIP44Params' as const,
   encode(
     message: BIP44Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/keyring/v1/record.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/keyring/v1/record.ts
@@ -89,7 +89,7 @@ function createBaseRecord(): Record {
   };
 }
 export const Record = {
-  typeUrl: '/cosmos.crypto.keyring.v1.Record',
+  typeUrl: '/cosmos.crypto.keyring.v1.Record' as const,
   encode(
     message: Record,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -232,7 +232,7 @@ function createBaseRecord_Local(): Record_Local {
   };
 }
 export const Record_Local = {
-  typeUrl: '/cosmos.crypto.keyring.v1.Local',
+  typeUrl: '/cosmos.crypto.keyring.v1.Local' as const,
   encode(
     message: Record_Local,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -298,7 +298,7 @@ function createBaseRecord_Ledger(): Record_Ledger {
   };
 }
 export const Record_Ledger = {
-  typeUrl: '/cosmos.crypto.keyring.v1.Ledger',
+  typeUrl: '/cosmos.crypto.keyring.v1.Ledger' as const,
   encode(
     message: Record_Ledger,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -362,7 +362,7 @@ function createBaseRecord_Multi(): Record_Multi {
   return {};
 }
 export const Record_Multi = {
-  typeUrl: '/cosmos.crypto.keyring.v1.Multi',
+  typeUrl: '/cosmos.crypto.keyring.v1.Multi' as const,
   encode(
     _: Record_Multi,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -412,7 +412,7 @@ function createBaseRecord_Offline(): Record_Offline {
   return {};
 }
 export const Record_Offline = {
-  typeUrl: '/cosmos.crypto.keyring.v1.Offline',
+  typeUrl: '/cosmos.crypto.keyring.v1.Offline' as const,
   encode(
     _: Record_Offline,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/multisig/keys.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/multisig/keys.ts
@@ -32,7 +32,7 @@ function createBaseLegacyAminoPubKey(): LegacyAminoPubKey {
   };
 }
 export const LegacyAminoPubKey = {
-  typeUrl: '/cosmos.crypto.multisig.LegacyAminoPubKey',
+  typeUrl: '/cosmos.crypto.multisig.LegacyAminoPubKey' as const,
   encode(
     message: LegacyAminoPubKey,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/multisig/v1beta1/multisig.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/multisig/v1beta1/multisig.ts
@@ -54,7 +54,7 @@ function createBaseMultiSignature(): MultiSignature {
   };
 }
 export const MultiSignature = {
-  typeUrl: '/cosmos.crypto.multisig.v1beta1.MultiSignature',
+  typeUrl: '/cosmos.crypto.multisig.v1beta1.MultiSignature' as const,
   encode(
     message: MultiSignature,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -125,7 +125,7 @@ function createBaseCompactBitArray(): CompactBitArray {
   };
 }
 export const CompactBitArray = {
-  typeUrl: '/cosmos.crypto.multisig.v1beta1.CompactBitArray',
+  typeUrl: '/cosmos.crypto.multisig.v1beta1.CompactBitArray' as const,
   encode(
     message: CompactBitArray,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/secp256k1/keys.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/secp256k1/keys.ts
@@ -46,7 +46,7 @@ function createBasePubKey(): PubKey {
   };
 }
 export const PubKey = {
-  typeUrl: '/cosmos.crypto.secp256k1.PubKey',
+  typeUrl: '/cosmos.crypto.secp256k1.PubKey' as const,
   encode(
     message: PubKey,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -111,7 +111,7 @@ function createBasePrivKey(): PrivKey {
   };
 }
 export const PrivKey = {
-  typeUrl: '/cosmos.crypto.secp256k1.PrivKey',
+  typeUrl: '/cosmos.crypto.secp256k1.PrivKey' as const,
   encode(
     message: PrivKey,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/crypto/secp256r1/keys.ts
+++ b/packages/client-utils/src/codegen/cosmos/crypto/secp256r1/keys.ts
@@ -39,7 +39,7 @@ function createBasePubKey(): PubKey {
   };
 }
 export const PubKey = {
-  typeUrl: '/cosmos.crypto.secp256r1.PubKey',
+  typeUrl: '/cosmos.crypto.secp256r1.PubKey' as const,
   encode(
     message: PubKey,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -104,7 +104,7 @@ function createBasePrivKey(): PrivKey {
   };
 }
 export const PrivKey = {
-  typeUrl: '/cosmos.crypto.secp256r1.PrivKey',
+  typeUrl: '/cosmos.crypto.secp256r1.PrivKey' as const,
   encode(
     message: PrivKey,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/distribution/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/distribution/module/v1/module.ts
@@ -24,7 +24,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.distribution.module.v1.Module',
+  typeUrl: '/cosmos.distribution.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/distribution.ts
+++ b/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/distribution.ts
@@ -308,7 +308,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/cosmos.distribution.v1beta1.Params',
+  typeUrl: '/cosmos.distribution.v1beta1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -425,7 +425,7 @@ function createBaseValidatorHistoricalRewards(): ValidatorHistoricalRewards {
   };
 }
 export const ValidatorHistoricalRewards = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorHistoricalRewards',
+  typeUrl: '/cosmos.distribution.v1beta1.ValidatorHistoricalRewards' as const,
   encode(
     message: ValidatorHistoricalRewards,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -522,7 +522,7 @@ function createBaseValidatorCurrentRewards(): ValidatorCurrentRewards {
   };
 }
 export const ValidatorCurrentRewards = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorCurrentRewards',
+  typeUrl: '/cosmos.distribution.v1beta1.ValidatorCurrentRewards' as const,
   encode(
     message: ValidatorCurrentRewards,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -616,7 +616,8 @@ function createBaseValidatorAccumulatedCommission(): ValidatorAccumulatedCommiss
   };
 }
 export const ValidatorAccumulatedCommission = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorAccumulatedCommission',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.ValidatorAccumulatedCommission' as const,
   encode(
     message: ValidatorAccumulatedCommission,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -698,7 +699,7 @@ function createBaseValidatorOutstandingRewards(): ValidatorOutstandingRewards {
   };
 }
 export const ValidatorOutstandingRewards = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorOutstandingRewards',
+  typeUrl: '/cosmos.distribution.v1beta1.ValidatorOutstandingRewards' as const,
   encode(
     message: ValidatorOutstandingRewards,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -780,7 +781,7 @@ function createBaseValidatorSlashEvent(): ValidatorSlashEvent {
   };
 }
 export const ValidatorSlashEvent = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorSlashEvent',
+  typeUrl: '/cosmos.distribution.v1beta1.ValidatorSlashEvent' as const,
   encode(
     message: ValidatorSlashEvent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -865,7 +866,7 @@ function createBaseValidatorSlashEvents(): ValidatorSlashEvents {
   };
 }
 export const ValidatorSlashEvents = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorSlashEvents',
+  typeUrl: '/cosmos.distribution.v1beta1.ValidatorSlashEvents' as const,
   encode(
     message: ValidatorSlashEvents,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -945,7 +946,7 @@ function createBaseFeePool(): FeePool {
   };
 }
 export const FeePool = {
-  typeUrl: '/cosmos.distribution.v1beta1.FeePool',
+  typeUrl: '/cosmos.distribution.v1beta1.FeePool' as const,
   encode(
     message: FeePool,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1019,7 +1020,7 @@ function createBaseCommunityPoolSpendProposal(): CommunityPoolSpendProposal {
   };
 }
 export const CommunityPoolSpendProposal = {
-  typeUrl: '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal',
+  typeUrl: '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal' as const,
   encode(
     message: CommunityPoolSpendProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1128,7 +1129,7 @@ function createBaseDelegatorStartingInfo(): DelegatorStartingInfo {
   };
 }
 export const DelegatorStartingInfo = {
-  typeUrl: '/cosmos.distribution.v1beta1.DelegatorStartingInfo',
+  typeUrl: '/cosmos.distribution.v1beta1.DelegatorStartingInfo' as const,
   encode(
     message: DelegatorStartingInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1226,7 +1227,7 @@ function createBaseDelegationDelegatorReward(): DelegationDelegatorReward {
   };
 }
 export const DelegationDelegatorReward = {
-  typeUrl: '/cosmos.distribution.v1beta1.DelegationDelegatorReward',
+  typeUrl: '/cosmos.distribution.v1beta1.DelegationDelegatorReward' as const,
   encode(
     message: DelegationDelegatorReward,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1321,7 +1322,8 @@ function createBaseCommunityPoolSpendProposalWithDeposit(): CommunityPoolSpendPr
   };
 }
 export const CommunityPoolSpendProposalWithDeposit = {
-  typeUrl: '/cosmos.distribution.v1beta1.CommunityPoolSpendProposalWithDeposit',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.CommunityPoolSpendProposalWithDeposit' as const,
   encode(
     message: CommunityPoolSpendProposalWithDeposit,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/genesis.ts
@@ -210,7 +210,7 @@ function createBaseDelegatorWithdrawInfo(): DelegatorWithdrawInfo {
   };
 }
 export const DelegatorWithdrawInfo = {
-  typeUrl: '/cosmos.distribution.v1beta1.DelegatorWithdrawInfo',
+  typeUrl: '/cosmos.distribution.v1beta1.DelegatorWithdrawInfo' as const,
   encode(
     message: DelegatorWithdrawInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -291,7 +291,8 @@ function createBaseValidatorOutstandingRewardsRecord(): ValidatorOutstandingRewa
   };
 }
 export const ValidatorOutstandingRewardsRecord = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorOutstandingRewardsRecord',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.ValidatorOutstandingRewardsRecord' as const,
   encode(
     message: ValidatorOutstandingRewardsRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -388,7 +389,8 @@ function createBaseValidatorAccumulatedCommissionRecord(): ValidatorAccumulatedC
   };
 }
 export const ValidatorAccumulatedCommissionRecord = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorAccumulatedCommissionRecord',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.ValidatorAccumulatedCommissionRecord' as const,
   encode(
     message: ValidatorAccumulatedCommissionRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -490,7 +492,8 @@ function createBaseValidatorHistoricalRewardsRecord(): ValidatorHistoricalReward
   };
 }
 export const ValidatorHistoricalRewardsRecord = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorHistoricalRewardsRecord',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.ValidatorHistoricalRewardsRecord' as const,
   encode(
     message: ValidatorHistoricalRewardsRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -605,7 +608,8 @@ function createBaseValidatorCurrentRewardsRecord(): ValidatorCurrentRewardsRecor
   };
 }
 export const ValidatorCurrentRewardsRecord = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorCurrentRewardsRecord',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.ValidatorCurrentRewardsRecord' as const,
   encode(
     message: ValidatorCurrentRewardsRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -706,7 +710,7 @@ function createBaseDelegatorStartingInfoRecord(): DelegatorStartingInfoRecord {
   };
 }
 export const DelegatorStartingInfoRecord = {
-  typeUrl: '/cosmos.distribution.v1beta1.DelegatorStartingInfoRecord',
+  typeUrl: '/cosmos.distribution.v1beta1.DelegatorStartingInfoRecord' as const,
   encode(
     message: DelegatorStartingInfoRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -820,7 +824,7 @@ function createBaseValidatorSlashEventRecord(): ValidatorSlashEventRecord {
   };
 }
 export const ValidatorSlashEventRecord = {
-  typeUrl: '/cosmos.distribution.v1beta1.ValidatorSlashEventRecord',
+  typeUrl: '/cosmos.distribution.v1beta1.ValidatorSlashEventRecord' as const,
   encode(
     message: ValidatorSlashEventRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -959,7 +963,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.distribution.v1beta1.GenesisState',
+  typeUrl: '/cosmos.distribution.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/query.ts
@@ -394,7 +394,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.distribution.v1beta1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -449,7 +449,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.distribution.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -518,7 +518,8 @@ function createBaseQueryValidatorDistributionInfoRequest(): QueryValidatorDistri
   };
 }
 export const QueryValidatorDistributionInfoRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryValidatorDistributionInfoRequest',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryValidatorDistributionInfoRequest' as const,
   encode(
     message: QueryValidatorDistributionInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -598,7 +599,7 @@ function createBaseQueryValidatorDistributionInfoResponse(): QueryValidatorDistr
 }
 export const QueryValidatorDistributionInfoResponse = {
   typeUrl:
-    '/cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse',
+    '/cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse' as const,
   encode(
     message: QueryValidatorDistributionInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -712,7 +713,7 @@ function createBaseQueryValidatorOutstandingRewardsRequest(): QueryValidatorOuts
 }
 export const QueryValidatorOutstandingRewardsRequest = {
   typeUrl:
-    '/cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsRequest',
+    '/cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsRequest' as const,
   encode(
     message: QueryValidatorOutstandingRewardsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -790,7 +791,7 @@ function createBaseQueryValidatorOutstandingRewardsResponse(): QueryValidatorOut
 }
 export const QueryValidatorOutstandingRewardsResponse = {
   typeUrl:
-    '/cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsResponse',
+    '/cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsResponse' as const,
   encode(
     message: QueryValidatorOutstandingRewardsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -878,7 +879,8 @@ function createBaseQueryValidatorCommissionRequest(): QueryValidatorCommissionRe
   };
 }
 export const QueryValidatorCommissionRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryValidatorCommissionRequest',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryValidatorCommissionRequest' as const,
   encode(
     message: QueryValidatorCommissionRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -954,7 +956,8 @@ function createBaseQueryValidatorCommissionResponse(): QueryValidatorCommissionR
   };
 }
 export const QueryValidatorCommissionResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryValidatorCommissionResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryValidatorCommissionResponse' as const,
   encode(
     message: QueryValidatorCommissionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1044,7 +1047,7 @@ function createBaseQueryValidatorSlashesRequest(): QueryValidatorSlashesRequest 
   };
 }
 export const QueryValidatorSlashesRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryValidatorSlashesRequest',
+  typeUrl: '/cosmos.distribution.v1beta1.QueryValidatorSlashesRequest' as const,
   encode(
     message: QueryValidatorSlashesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1168,7 +1171,8 @@ function createBaseQueryValidatorSlashesResponse(): QueryValidatorSlashesRespons
   };
 }
 export const QueryValidatorSlashesResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryValidatorSlashesResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryValidatorSlashesResponse' as const,
   encode(
     message: QueryValidatorSlashesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1273,7 +1277,8 @@ function createBaseQueryDelegationRewardsRequest(): QueryDelegationRewardsReques
   };
 }
 export const QueryDelegationRewardsRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegationRewardsRequest',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegationRewardsRequest' as const,
   encode(
     message: QueryDelegationRewardsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1361,7 +1366,8 @@ function createBaseQueryDelegationRewardsResponse(): QueryDelegationRewardsRespo
   };
 }
 export const QueryDelegationRewardsResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegationRewardsResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegationRewardsResponse' as const,
   encode(
     message: QueryDelegationRewardsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1442,7 +1448,8 @@ function createBaseQueryDelegationTotalRewardsRequest(): QueryDelegationTotalRew
   };
 }
 export const QueryDelegationTotalRewardsRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegationTotalRewardsRequest',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegationTotalRewardsRequest' as const,
   encode(
     message: QueryDelegationTotalRewardsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1520,7 +1527,8 @@ function createBaseQueryDelegationTotalRewardsResponse(): QueryDelegationTotalRe
   };
 }
 export const QueryDelegationTotalRewardsResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegationTotalRewardsResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegationTotalRewardsResponse' as const,
   encode(
     message: QueryDelegationTotalRewardsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1620,7 +1628,8 @@ function createBaseQueryDelegatorValidatorsRequest(): QueryDelegatorValidatorsRe
   };
 }
 export const QueryDelegatorValidatorsRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegatorValidatorsRequest',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegatorValidatorsRequest' as const,
   encode(
     message: QueryDelegatorValidatorsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1696,7 +1705,8 @@ function createBaseQueryDelegatorValidatorsResponse(): QueryDelegatorValidatorsR
   };
 }
 export const QueryDelegatorValidatorsResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegatorValidatorsResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegatorValidatorsResponse' as const,
   encode(
     message: QueryDelegatorValidatorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1775,7 +1785,8 @@ function createBaseQueryDelegatorWithdrawAddressRequest(): QueryDelegatorWithdra
   };
 }
 export const QueryDelegatorWithdrawAddressRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressRequest',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressRequest' as const,
   encode(
     message: QueryDelegatorWithdrawAddressRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1852,7 +1863,8 @@ function createBaseQueryDelegatorWithdrawAddressResponse(): QueryDelegatorWithdr
   };
 }
 export const QueryDelegatorWithdrawAddressResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressResponse' as const,
   encode(
     message: QueryDelegatorWithdrawAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1927,7 +1939,7 @@ function createBaseQueryCommunityPoolRequest(): QueryCommunityPoolRequest {
   return {};
 }
 export const QueryCommunityPoolRequest = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryCommunityPoolRequest',
+  typeUrl: '/cosmos.distribution.v1beta1.QueryCommunityPoolRequest' as const,
   encode(
     _: QueryCommunityPoolRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1988,7 +2000,7 @@ function createBaseQueryCommunityPoolResponse(): QueryCommunityPoolResponse {
   };
 }
 export const QueryCommunityPoolResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.QueryCommunityPoolResponse',
+  typeUrl: '/cosmos.distribution.v1beta1.QueryCommunityPoolResponse' as const,
   encode(
     message: QueryCommunityPoolResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/distribution/v1beta1/tx.ts
@@ -242,7 +242,7 @@ function createBaseMsgSetWithdrawAddress(): MsgSetWithdrawAddress {
   };
 }
 export const MsgSetWithdrawAddress = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgSetWithdrawAddress',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgSetWithdrawAddress' as const,
   encode(
     message: MsgSetWithdrawAddress,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -320,7 +320,8 @@ function createBaseMsgSetWithdrawAddressResponse(): MsgSetWithdrawAddressRespons
   return {};
 }
 export const MsgSetWithdrawAddressResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgSetWithdrawAddressResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.MsgSetWithdrawAddressResponse' as const,
   encode(
     _: MsgSetWithdrawAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -384,7 +385,7 @@ function createBaseMsgWithdrawDelegatorReward(): MsgWithdrawDelegatorReward {
   };
 }
 export const MsgWithdrawDelegatorReward = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward' as const,
   encode(
     message: MsgWithdrawDelegatorReward,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -472,7 +473,8 @@ function createBaseMsgWithdrawDelegatorRewardResponse(): MsgWithdrawDelegatorRew
   };
 }
 export const MsgWithdrawDelegatorRewardResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorRewardResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorRewardResponse' as const,
   encode(
     message: MsgWithdrawDelegatorRewardResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -552,7 +554,8 @@ function createBaseMsgWithdrawValidatorCommission(): MsgWithdrawValidatorCommiss
   };
 }
 export const MsgWithdrawValidatorCommission = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission' as const,
   encode(
     message: MsgWithdrawValidatorCommission,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -629,7 +632,7 @@ function createBaseMsgWithdrawValidatorCommissionResponse(): MsgWithdrawValidato
 }
 export const MsgWithdrawValidatorCommissionResponse = {
   typeUrl:
-    '/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommissionResponse',
+    '/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommissionResponse' as const,
   encode(
     message: MsgWithdrawValidatorCommissionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -710,7 +713,7 @@ function createBaseMsgFundCommunityPool(): MsgFundCommunityPool {
   };
 }
 export const MsgFundCommunityPool = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgFundCommunityPool',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgFundCommunityPool' as const,
   encode(
     message: MsgFundCommunityPool,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -788,7 +791,7 @@ function createBaseMsgFundCommunityPoolResponse(): MsgFundCommunityPoolResponse 
   return {};
 }
 export const MsgFundCommunityPoolResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgFundCommunityPoolResponse',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgFundCommunityPoolResponse' as const,
   encode(
     _: MsgFundCommunityPoolResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -852,7 +855,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgUpdateParams',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -925,7 +928,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -986,7 +989,7 @@ function createBaseMsgCommunityPoolSpend(): MsgCommunityPoolSpend {
   };
 }
 export const MsgCommunityPoolSpend = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgCommunityPoolSpend',
+  typeUrl: '/cosmos.distribution.v1beta1.MsgCommunityPoolSpend' as const,
   encode(
     message: MsgCommunityPoolSpend,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1073,7 +1076,8 @@ function createBaseMsgCommunityPoolSpendResponse(): MsgCommunityPoolSpendRespons
   return {};
 }
 export const MsgCommunityPoolSpendResponse = {
-  typeUrl: '/cosmos.distribution.v1beta1.MsgCommunityPoolSpendResponse',
+  typeUrl:
+    '/cosmos.distribution.v1beta1.MsgCommunityPoolSpendResponse' as const,
   encode(
     _: MsgCommunityPoolSpendResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/evidence/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/evidence/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.evidence.module.v1.Module',
+  typeUrl: '/cosmos.evidence.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/feegrant/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/feegrant/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.feegrant.module.v1.Module',
+  typeUrl: '/cosmos.feegrant.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/feegrant.ts
+++ b/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/feegrant.ts
@@ -121,7 +121,7 @@ function createBaseBasicAllowance(): BasicAllowance {
   };
 }
 export const BasicAllowance = {
-  typeUrl: '/cosmos.feegrant.v1beta1.BasicAllowance',
+  typeUrl: '/cosmos.feegrant.v1beta1.BasicAllowance' as const,
   encode(
     message: BasicAllowance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -210,7 +210,7 @@ function createBasePeriodicAllowance(): PeriodicAllowance {
   };
 }
 export const PeriodicAllowance = {
-  typeUrl: '/cosmos.feegrant.v1beta1.PeriodicAllowance',
+  typeUrl: '/cosmos.feegrant.v1beta1.PeriodicAllowance' as const,
   encode(
     message: PeriodicAllowance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -349,7 +349,7 @@ function createBaseAllowedMsgAllowance(): AllowedMsgAllowance {
   };
 }
 export const AllowedMsgAllowance = {
-  typeUrl: '/cosmos.feegrant.v1beta1.AllowedMsgAllowance',
+  typeUrl: '/cosmos.feegrant.v1beta1.AllowedMsgAllowance' as const,
   encode(
     message: AllowedMsgAllowance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -439,7 +439,7 @@ function createBaseGrant(): Grant {
   };
 }
 export const Grant = {
-  typeUrl: '/cosmos.feegrant.v1beta1.Grant',
+  typeUrl: '/cosmos.feegrant.v1beta1.Grant' as const,
   encode(
     message: Grant,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/genesis.ts
@@ -20,7 +20,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.feegrant.v1beta1.GenesisState',
+  typeUrl: '/cosmos.feegrant.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/query.ts
@@ -123,7 +123,7 @@ function createBaseQueryAllowanceRequest(): QueryAllowanceRequest {
   };
 }
 export const QueryAllowanceRequest = {
-  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowanceRequest',
+  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowanceRequest' as const,
   encode(
     message: QueryAllowanceRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -197,7 +197,7 @@ function createBaseQueryAllowanceResponse(): QueryAllowanceResponse {
   };
 }
 export const QueryAllowanceResponse = {
-  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowanceResponse',
+  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowanceResponse' as const,
   encode(
     message: QueryAllowanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -273,7 +273,7 @@ function createBaseQueryAllowancesRequest(): QueryAllowancesRequest {
   };
 }
 export const QueryAllowancesRequest = {
-  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesRequest',
+  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesRequest' as const,
   encode(
     message: QueryAllowancesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -358,7 +358,7 @@ function createBaseQueryAllowancesResponse(): QueryAllowancesResponse {
   };
 }
 export const QueryAllowancesResponse = {
-  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesResponse',
+  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesResponse' as const,
   encode(
     message: QueryAllowancesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -459,7 +459,7 @@ function createBaseQueryAllowancesByGranterRequest(): QueryAllowancesByGranterRe
   };
 }
 export const QueryAllowancesByGranterRequest = {
-  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesByGranterRequest',
+  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesByGranterRequest' as const,
   encode(
     message: QueryAllowancesByGranterRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -550,7 +550,7 @@ function createBaseQueryAllowancesByGranterResponse(): QueryAllowancesByGranterR
   };
 }
 export const QueryAllowancesByGranterResponse = {
-  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesByGranterResponse',
+  typeUrl: '/cosmos.feegrant.v1beta1.QueryAllowancesByGranterResponse' as const,
   encode(
     message: QueryAllowancesByGranterResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/feegrant/v1beta1/tx.ts
@@ -68,7 +68,7 @@ function createBaseMsgGrantAllowance(): MsgGrantAllowance {
   };
 }
 export const MsgGrantAllowance = {
-  typeUrl: '/cosmos.feegrant.v1beta1.MsgGrantAllowance',
+  typeUrl: '/cosmos.feegrant.v1beta1.MsgGrantAllowance' as const,
   encode(
     message: MsgGrantAllowance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -154,7 +154,7 @@ function createBaseMsgGrantAllowanceResponse(): MsgGrantAllowanceResponse {
   return {};
 }
 export const MsgGrantAllowanceResponse = {
-  typeUrl: '/cosmos.feegrant.v1beta1.MsgGrantAllowanceResponse',
+  typeUrl: '/cosmos.feegrant.v1beta1.MsgGrantAllowanceResponse' as const,
   encode(
     _: MsgGrantAllowanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -216,7 +216,7 @@ function createBaseMsgRevokeAllowance(): MsgRevokeAllowance {
   };
 }
 export const MsgRevokeAllowance = {
-  typeUrl: '/cosmos.feegrant.v1beta1.MsgRevokeAllowance',
+  typeUrl: '/cosmos.feegrant.v1beta1.MsgRevokeAllowance' as const,
   encode(
     message: MsgRevokeAllowance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -288,7 +288,7 @@ function createBaseMsgRevokeAllowanceResponse(): MsgRevokeAllowanceResponse {
   return {};
 }
 export const MsgRevokeAllowanceResponse = {
-  typeUrl: '/cosmos.feegrant.v1beta1.MsgRevokeAllowanceResponse',
+  typeUrl: '/cosmos.feegrant.v1beta1.MsgRevokeAllowanceResponse' as const,
   encode(
     _: MsgRevokeAllowanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/genutil/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/genutil/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.genutil.module.v1.Module',
+  typeUrl: '/cosmos.genutil.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/module/v1/module.ts
@@ -28,7 +28,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.gov.module.v1.Module',
+  typeUrl: '/cosmos.gov.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1/genesis.ts
@@ -84,7 +84,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.gov.v1.GenesisState',
+  typeUrl: '/cosmos.gov.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1/gov.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1/gov.ts
@@ -421,7 +421,7 @@ function createBaseWeightedVoteOption(): WeightedVoteOption {
   };
 }
 export const WeightedVoteOption = {
-  typeUrl: '/cosmos.gov.v1.WeightedVoteOption',
+  typeUrl: '/cosmos.gov.v1.WeightedVoteOption' as const,
   encode(
     message: WeightedVoteOption,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -498,7 +498,7 @@ function createBaseDeposit(): Deposit {
   };
 }
 export const Deposit = {
-  typeUrl: '/cosmos.gov.v1.Deposit',
+  typeUrl: '/cosmos.gov.v1.Deposit' as const,
   encode(
     message: Deposit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -602,7 +602,7 @@ function createBaseProposal(): Proposal {
   };
 }
 export const Proposal = {
-  typeUrl: '/cosmos.gov.v1.Proposal',
+  typeUrl: '/cosmos.gov.v1.Proposal' as const,
   encode(
     message: Proposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -845,7 +845,7 @@ function createBaseTallyResult(): TallyResult {
   };
 }
 export const TallyResult = {
-  typeUrl: '/cosmos.gov.v1.TallyResult',
+  typeUrl: '/cosmos.gov.v1.TallyResult' as const,
   encode(
     message: TallyResult,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -943,7 +943,7 @@ function createBaseVote(): Vote {
   };
 }
 export const Vote = {
-  typeUrl: '/cosmos.gov.v1.Vote',
+  typeUrl: '/cosmos.gov.v1.Vote' as const,
   encode(
     message: Vote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1050,7 +1050,7 @@ function createBaseDepositParams(): DepositParams {
   };
 }
 export const DepositParams = {
-  typeUrl: '/cosmos.gov.v1.DepositParams',
+  typeUrl: '/cosmos.gov.v1.DepositParams' as const,
   encode(
     message: DepositParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1140,7 +1140,7 @@ function createBaseVotingParams(): VotingParams {
   };
 }
 export const VotingParams = {
-  typeUrl: '/cosmos.gov.v1.VotingParams',
+  typeUrl: '/cosmos.gov.v1.VotingParams' as const,
   encode(
     message: VotingParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1212,7 +1212,7 @@ function createBaseTallyParams(): TallyParams {
   };
 }
 export const TallyParams = {
-  typeUrl: '/cosmos.gov.v1.TallyParams',
+  typeUrl: '/cosmos.gov.v1.TallyParams' as const,
   encode(
     message: TallyParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1304,7 +1304,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/cosmos.gov.v1.Params',
+  typeUrl: '/cosmos.gov.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1/query.ts
@@ -310,7 +310,7 @@ function createBaseQueryProposalRequest(): QueryProposalRequest {
   };
 }
 export const QueryProposalRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryProposalRequest',
+  typeUrl: '/cosmos.gov.v1.QueryProposalRequest' as const,
   encode(
     message: QueryProposalRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -381,7 +381,7 @@ function createBaseQueryProposalResponse(): QueryProposalResponse {
   };
 }
 export const QueryProposalResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryProposalResponse',
+  typeUrl: '/cosmos.gov.v1.QueryProposalResponse' as const,
   encode(
     message: QueryProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -457,7 +457,7 @@ function createBaseQueryProposalsRequest(): QueryProposalsRequest {
   };
 }
 export const QueryProposalsRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryProposalsRequest',
+  typeUrl: '/cosmos.gov.v1.QueryProposalsRequest' as const,
   encode(
     message: QueryProposalsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -561,7 +561,7 @@ function createBaseQueryProposalsResponse(): QueryProposalsResponse {
   };
 }
 export const QueryProposalsResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryProposalsResponse',
+  typeUrl: '/cosmos.gov.v1.QueryProposalsResponse' as const,
   encode(
     message: QueryProposalsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -658,7 +658,7 @@ function createBaseQueryVoteRequest(): QueryVoteRequest {
   };
 }
 export const QueryVoteRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryVoteRequest',
+  typeUrl: '/cosmos.gov.v1.QueryVoteRequest' as const,
   encode(
     message: QueryVoteRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -735,7 +735,7 @@ function createBaseQueryVoteResponse(): QueryVoteResponse {
   };
 }
 export const QueryVoteResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryVoteResponse',
+  typeUrl: '/cosmos.gov.v1.QueryVoteResponse' as const,
   encode(
     message: QueryVoteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -802,7 +802,7 @@ function createBaseQueryVotesRequest(): QueryVotesRequest {
   };
 }
 export const QueryVotesRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryVotesRequest',
+  typeUrl: '/cosmos.gov.v1.QueryVotesRequest' as const,
   encode(
     message: QueryVotesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -888,7 +888,7 @@ function createBaseQueryVotesResponse(): QueryVotesResponse {
   };
 }
 export const QueryVotesResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryVotesResponse',
+  typeUrl: '/cosmos.gov.v1.QueryVotesResponse' as const,
   encode(
     message: QueryVotesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -979,7 +979,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   };
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryParamsRequest',
+  typeUrl: '/cosmos.gov.v1.QueryParamsRequest' as const,
   encode(
     message: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1047,7 +1047,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryParamsResponse',
+  typeUrl: '/cosmos.gov.v1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1177,7 +1177,7 @@ function createBaseQueryDepositRequest(): QueryDepositRequest {
   };
 }
 export const QueryDepositRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryDepositRequest',
+  typeUrl: '/cosmos.gov.v1.QueryDepositRequest' as const,
   encode(
     message: QueryDepositRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1257,7 +1257,7 @@ function createBaseQueryDepositResponse(): QueryDepositResponse {
   };
 }
 export const QueryDepositResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryDepositResponse',
+  typeUrl: '/cosmos.gov.v1.QueryDepositResponse' as const,
   encode(
     message: QueryDepositResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1331,7 +1331,7 @@ function createBaseQueryDepositsRequest(): QueryDepositsRequest {
   };
 }
 export const QueryDepositsRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryDepositsRequest',
+  typeUrl: '/cosmos.gov.v1.QueryDepositsRequest' as const,
   encode(
     message: QueryDepositsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1420,7 +1420,7 @@ function createBaseQueryDepositsResponse(): QueryDepositsResponse {
   };
 }
 export const QueryDepositsResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryDepositsResponse',
+  typeUrl: '/cosmos.gov.v1.QueryDepositsResponse' as const,
   encode(
     message: QueryDepositsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1513,7 +1513,7 @@ function createBaseQueryTallyResultRequest(): QueryTallyResultRequest {
   };
 }
 export const QueryTallyResultRequest = {
-  typeUrl: '/cosmos.gov.v1.QueryTallyResultRequest',
+  typeUrl: '/cosmos.gov.v1.QueryTallyResultRequest' as const,
   encode(
     message: QueryTallyResultRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1590,7 +1590,7 @@ function createBaseQueryTallyResultResponse(): QueryTallyResultResponse {
   };
 }
 export const QueryTallyResultResponse = {
-  typeUrl: '/cosmos.gov.v1.QueryTallyResultResponse',
+  typeUrl: '/cosmos.gov.v1.QueryTallyResultResponse' as const,
   encode(
     message: QueryTallyResultResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1/tx.ts
@@ -242,7 +242,7 @@ function createBaseMsgSubmitProposal(): MsgSubmitProposal {
   };
 }
 export const MsgSubmitProposal = {
-  typeUrl: '/cosmos.gov.v1.MsgSubmitProposal',
+  typeUrl: '/cosmos.gov.v1.MsgSubmitProposal' as const,
   encode(
     message: MsgSubmitProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -364,7 +364,7 @@ function createBaseMsgSubmitProposalResponse(): MsgSubmitProposalResponse {
   };
 }
 export const MsgSubmitProposalResponse = {
-  typeUrl: '/cosmos.gov.v1.MsgSubmitProposalResponse',
+  typeUrl: '/cosmos.gov.v1.MsgSubmitProposalResponse' as const,
   encode(
     message: MsgSubmitProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -444,7 +444,7 @@ function createBaseMsgExecLegacyContent(): MsgExecLegacyContent {
   };
 }
 export const MsgExecLegacyContent = {
-  typeUrl: '/cosmos.gov.v1.MsgExecLegacyContent',
+  typeUrl: '/cosmos.gov.v1.MsgExecLegacyContent' as const,
   encode(
     message: MsgExecLegacyContent,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -520,7 +520,7 @@ function createBaseMsgExecLegacyContentResponse(): MsgExecLegacyContentResponse 
   return {};
 }
 export const MsgExecLegacyContentResponse = {
-  typeUrl: '/cosmos.gov.v1.MsgExecLegacyContentResponse',
+  typeUrl: '/cosmos.gov.v1.MsgExecLegacyContentResponse' as const,
   encode(
     _: MsgExecLegacyContentResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -586,7 +586,7 @@ function createBaseMsgVote(): MsgVote {
   };
 }
 export const MsgVote = {
-  typeUrl: '/cosmos.gov.v1.MsgVote',
+  typeUrl: '/cosmos.gov.v1.MsgVote' as const,
   encode(
     message: MsgVote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -680,7 +680,7 @@ function createBaseMsgVoteResponse(): MsgVoteResponse {
   return {};
 }
 export const MsgVoteResponse = {
-  typeUrl: '/cosmos.gov.v1.MsgVoteResponse',
+  typeUrl: '/cosmos.gov.v1.MsgVoteResponse' as const,
   encode(
     _: MsgVoteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -735,7 +735,7 @@ function createBaseMsgVoteWeighted(): MsgVoteWeighted {
   };
 }
 export const MsgVoteWeighted = {
-  typeUrl: '/cosmos.gov.v1.MsgVoteWeighted',
+  typeUrl: '/cosmos.gov.v1.MsgVoteWeighted' as const,
   encode(
     message: MsgVoteWeighted,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -839,7 +839,7 @@ function createBaseMsgVoteWeightedResponse(): MsgVoteWeightedResponse {
   return {};
 }
 export const MsgVoteWeightedResponse = {
-  typeUrl: '/cosmos.gov.v1.MsgVoteWeightedResponse',
+  typeUrl: '/cosmos.gov.v1.MsgVoteWeightedResponse' as const,
   encode(
     _: MsgVoteWeightedResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -900,7 +900,7 @@ function createBaseMsgDeposit(): MsgDeposit {
   };
 }
 export const MsgDeposit = {
-  typeUrl: '/cosmos.gov.v1.MsgDeposit',
+  typeUrl: '/cosmos.gov.v1.MsgDeposit' as const,
   encode(
     message: MsgDeposit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -990,7 +990,7 @@ function createBaseMsgDepositResponse(): MsgDepositResponse {
   return {};
 }
 export const MsgDepositResponse = {
-  typeUrl: '/cosmos.gov.v1.MsgDepositResponse',
+  typeUrl: '/cosmos.gov.v1.MsgDepositResponse' as const,
   encode(
     _: MsgDepositResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1046,7 +1046,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.gov.v1.MsgUpdateParams',
+  typeUrl: '/cosmos.gov.v1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1119,7 +1119,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.gov.v1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.gov.v1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1beta1/genesis.ts
@@ -59,7 +59,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.gov.v1beta1.GenesisState',
+  typeUrl: '/cosmos.gov.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1beta1/gov.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1beta1/gov.ts
@@ -383,7 +383,7 @@ function createBaseWeightedVoteOption(): WeightedVoteOption {
   };
 }
 export const WeightedVoteOption = {
-  typeUrl: '/cosmos.gov.v1beta1.WeightedVoteOption',
+  typeUrl: '/cosmos.gov.v1beta1.WeightedVoteOption' as const,
   encode(
     message: WeightedVoteOption,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -461,7 +461,7 @@ function createBaseTextProposal(): TextProposal {
   };
 }
 export const TextProposal = {
-  typeUrl: '/cosmos.gov.v1beta1.TextProposal',
+  typeUrl: '/cosmos.gov.v1beta1.TextProposal' as const,
   encode(
     message: TextProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -535,7 +535,7 @@ function createBaseDeposit(): Deposit {
   };
 }
 export const Deposit = {
-  typeUrl: '/cosmos.gov.v1beta1.Deposit',
+  typeUrl: '/cosmos.gov.v1beta1.Deposit' as const,
   encode(
     message: Deposit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -635,7 +635,7 @@ function createBaseProposal(): Proposal {
   };
 }
 export const Proposal = {
-  typeUrl: '/cosmos.gov.v1beta1.Proposal',
+  typeUrl: '/cosmos.gov.v1beta1.Proposal' as const,
   encode(
     message: Proposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -843,7 +843,7 @@ function createBaseTallyResult(): TallyResult {
   };
 }
 export const TallyResult = {
-  typeUrl: '/cosmos.gov.v1beta1.TallyResult',
+  typeUrl: '/cosmos.gov.v1beta1.TallyResult' as const,
   encode(
     message: TallyResult,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -935,7 +935,7 @@ function createBaseVote(): Vote {
   };
 }
 export const Vote = {
-  typeUrl: '/cosmos.gov.v1beta1.Vote',
+  typeUrl: '/cosmos.gov.v1beta1.Vote' as const,
   encode(
     message: Vote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1043,7 +1043,7 @@ function createBaseDepositParams(): DepositParams {
   };
 }
 export const DepositParams = {
-  typeUrl: '/cosmos.gov.v1beta1.DepositParams',
+  typeUrl: '/cosmos.gov.v1beta1.DepositParams' as const,
   encode(
     message: DepositParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1133,7 +1133,7 @@ function createBaseVotingParams(): VotingParams {
   };
 }
 export const VotingParams = {
-  typeUrl: '/cosmos.gov.v1beta1.VotingParams',
+  typeUrl: '/cosmos.gov.v1beta1.VotingParams' as const,
   encode(
     message: VotingParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1205,7 +1205,7 @@ function createBaseTallyParams(): TallyParams {
   };
 }
 export const TallyParams = {
-  typeUrl: '/cosmos.gov.v1beta1.TallyParams',
+  typeUrl: '/cosmos.gov.v1beta1.TallyParams' as const,
   encode(
     message: TallyParams,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1beta1/query.ts
@@ -285,7 +285,7 @@ function createBaseQueryProposalRequest(): QueryProposalRequest {
   };
 }
 export const QueryProposalRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryProposalRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryProposalRequest' as const,
   encode(
     message: QueryProposalRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -356,7 +356,7 @@ function createBaseQueryProposalResponse(): QueryProposalResponse {
   };
 }
 export const QueryProposalResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryProposalResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryProposalResponse' as const,
   encode(
     message: QueryProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -432,7 +432,7 @@ function createBaseQueryProposalsRequest(): QueryProposalsRequest {
   };
 }
 export const QueryProposalsRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryProposalsRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryProposalsRequest' as const,
   encode(
     message: QueryProposalsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -536,7 +536,7 @@ function createBaseQueryProposalsResponse(): QueryProposalsResponse {
   };
 }
 export const QueryProposalsResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryProposalsResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryProposalsResponse' as const,
   encode(
     message: QueryProposalsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -633,7 +633,7 @@ function createBaseQueryVoteRequest(): QueryVoteRequest {
   };
 }
 export const QueryVoteRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryVoteRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryVoteRequest' as const,
   encode(
     message: QueryVoteRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -710,7 +710,7 @@ function createBaseQueryVoteResponse(): QueryVoteResponse {
   };
 }
 export const QueryVoteResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryVoteResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryVoteResponse' as const,
   encode(
     message: QueryVoteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -777,7 +777,7 @@ function createBaseQueryVotesRequest(): QueryVotesRequest {
   };
 }
 export const QueryVotesRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryVotesRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryVotesRequest' as const,
   encode(
     message: QueryVotesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -863,7 +863,7 @@ function createBaseQueryVotesResponse(): QueryVotesResponse {
   };
 }
 export const QueryVotesResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryVotesResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryVotesResponse' as const,
   encode(
     message: QueryVotesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -954,7 +954,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   };
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryParamsRequest' as const,
   encode(
     message: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1021,7 +1021,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1138,7 +1138,7 @@ function createBaseQueryDepositRequest(): QueryDepositRequest {
   };
 }
 export const QueryDepositRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryDepositRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryDepositRequest' as const,
   encode(
     message: QueryDepositRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1218,7 +1218,7 @@ function createBaseQueryDepositResponse(): QueryDepositResponse {
   };
 }
 export const QueryDepositResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryDepositResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryDepositResponse' as const,
   encode(
     message: QueryDepositResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1292,7 +1292,7 @@ function createBaseQueryDepositsRequest(): QueryDepositsRequest {
   };
 }
 export const QueryDepositsRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryDepositsRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryDepositsRequest' as const,
   encode(
     message: QueryDepositsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1381,7 +1381,7 @@ function createBaseQueryDepositsResponse(): QueryDepositsResponse {
   };
 }
 export const QueryDepositsResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryDepositsResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryDepositsResponse' as const,
   encode(
     message: QueryDepositsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1474,7 +1474,7 @@ function createBaseQueryTallyResultRequest(): QueryTallyResultRequest {
   };
 }
 export const QueryTallyResultRequest = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryTallyResultRequest',
+  typeUrl: '/cosmos.gov.v1beta1.QueryTallyResultRequest' as const,
   encode(
     message: QueryTallyResultRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1551,7 +1551,7 @@ function createBaseQueryTallyResultResponse(): QueryTallyResultResponse {
   };
 }
 export const QueryTallyResultResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.QueryTallyResultResponse',
+  typeUrl: '/cosmos.gov.v1beta1.QueryTallyResultResponse' as const,
   encode(
     message: QueryTallyResultResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/gov/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/gov/v1beta1/tx.ts
@@ -154,7 +154,7 @@ function createBaseMsgSubmitProposal(): MsgSubmitProposal {
   };
 }
 export const MsgSubmitProposal = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgSubmitProposal',
+  typeUrl: '/cosmos.gov.v1beta1.MsgSubmitProposal' as const,
   encode(
     message: MsgSubmitProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -247,7 +247,7 @@ function createBaseMsgSubmitProposalResponse(): MsgSubmitProposalResponse {
   };
 }
 export const MsgSubmitProposalResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgSubmitProposalResponse',
+  typeUrl: '/cosmos.gov.v1beta1.MsgSubmitProposalResponse' as const,
   encode(
     message: MsgSubmitProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -328,7 +328,7 @@ function createBaseMsgVote(): MsgVote {
   };
 }
 export const MsgVote = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgVote',
+  typeUrl: '/cosmos.gov.v1beta1.MsgVote' as const,
   encode(
     message: MsgVote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -413,7 +413,7 @@ function createBaseMsgVoteResponse(): MsgVoteResponse {
   return {};
 }
 export const MsgVoteResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgVoteResponse',
+  typeUrl: '/cosmos.gov.v1beta1.MsgVoteResponse' as const,
   encode(
     _: MsgVoteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -467,7 +467,7 @@ function createBaseMsgVoteWeighted(): MsgVoteWeighted {
   };
 }
 export const MsgVoteWeighted = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgVoteWeighted',
+  typeUrl: '/cosmos.gov.v1beta1.MsgVoteWeighted' as const,
   encode(
     message: MsgVoteWeighted,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -562,7 +562,7 @@ function createBaseMsgVoteWeightedResponse(): MsgVoteWeightedResponse {
   return {};
 }
 export const MsgVoteWeightedResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgVoteWeightedResponse',
+  typeUrl: '/cosmos.gov.v1beta1.MsgVoteWeightedResponse' as const,
   encode(
     _: MsgVoteWeightedResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -623,7 +623,7 @@ function createBaseMsgDeposit(): MsgDeposit {
   };
 }
 export const MsgDeposit = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgDeposit',
+  typeUrl: '/cosmos.gov.v1beta1.MsgDeposit' as const,
   encode(
     message: MsgDeposit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -713,7 +713,7 @@ function createBaseMsgDepositResponse(): MsgDepositResponse {
   return {};
 }
 export const MsgDepositResponse = {
-  typeUrl: '/cosmos.gov.v1beta1.MsgDepositResponse',
+  typeUrl: '/cosmos.gov.v1beta1.MsgDepositResponse' as const,
   encode(
     _: MsgDepositResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/group/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/group/module/v1/module.ts
@@ -35,7 +35,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.group.module.v1.Module',
+  typeUrl: '/cosmos.group.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/group/v1/events.ts
+++ b/packages/client-utils/src/codegen/cosmos/group/v1/events.ts
@@ -179,7 +179,7 @@ function createBaseEventCreateGroup(): EventCreateGroup {
   };
 }
 export const EventCreateGroup = {
-  typeUrl: '/cosmos.group.v1.EventCreateGroup',
+  typeUrl: '/cosmos.group.v1.EventCreateGroup' as const,
   encode(
     message: EventCreateGroup,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -247,7 +247,7 @@ function createBaseEventUpdateGroup(): EventUpdateGroup {
   };
 }
 export const EventUpdateGroup = {
-  typeUrl: '/cosmos.group.v1.EventUpdateGroup',
+  typeUrl: '/cosmos.group.v1.EventUpdateGroup' as const,
   encode(
     message: EventUpdateGroup,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -315,7 +315,7 @@ function createBaseEventCreateGroupPolicy(): EventCreateGroupPolicy {
   };
 }
 export const EventCreateGroupPolicy = {
-  typeUrl: '/cosmos.group.v1.EventCreateGroupPolicy',
+  typeUrl: '/cosmos.group.v1.EventCreateGroupPolicy' as const,
   encode(
     message: EventCreateGroupPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -382,7 +382,7 @@ function createBaseEventUpdateGroupPolicy(): EventUpdateGroupPolicy {
   };
 }
 export const EventUpdateGroupPolicy = {
-  typeUrl: '/cosmos.group.v1.EventUpdateGroupPolicy',
+  typeUrl: '/cosmos.group.v1.EventUpdateGroupPolicy' as const,
   encode(
     message: EventUpdateGroupPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -449,7 +449,7 @@ function createBaseEventSubmitProposal(): EventSubmitProposal {
   };
 }
 export const EventSubmitProposal = {
-  typeUrl: '/cosmos.group.v1.EventSubmitProposal',
+  typeUrl: '/cosmos.group.v1.EventSubmitProposal' as const,
   encode(
     message: EventSubmitProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -520,7 +520,7 @@ function createBaseEventWithdrawProposal(): EventWithdrawProposal {
   };
 }
 export const EventWithdrawProposal = {
-  typeUrl: '/cosmos.group.v1.EventWithdrawProposal',
+  typeUrl: '/cosmos.group.v1.EventWithdrawProposal' as const,
   encode(
     message: EventWithdrawProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -591,7 +591,7 @@ function createBaseEventVote(): EventVote {
   };
 }
 export const EventVote = {
-  typeUrl: '/cosmos.group.v1.EventVote',
+  typeUrl: '/cosmos.group.v1.EventVote' as const,
   encode(
     message: EventVote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -661,7 +661,7 @@ function createBaseEventExec(): EventExec {
   };
 }
 export const EventExec = {
-  typeUrl: '/cosmos.group.v1.EventExec',
+  typeUrl: '/cosmos.group.v1.EventExec' as const,
   encode(
     message: EventExec,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -751,7 +751,7 @@ function createBaseEventLeaveGroup(): EventLeaveGroup {
   };
 }
 export const EventLeaveGroup = {
-  typeUrl: '/cosmos.group.v1.EventLeaveGroup',
+  typeUrl: '/cosmos.group.v1.EventLeaveGroup' as const,
   encode(
     message: EventLeaveGroup,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -830,7 +830,7 @@ function createBaseEventProposalPruned(): EventProposalPruned {
   };
 }
 export const EventProposalPruned = {
-  typeUrl: '/cosmos.group.v1.EventProposalPruned',
+  typeUrl: '/cosmos.group.v1.EventProposalPruned' as const,
   encode(
     message: EventProposalPruned,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -932,7 +932,7 @@ function createBaseEventTallyError(): EventTallyError {
   };
 }
 export const EventTallyError = {
-  typeUrl: '/cosmos.group.v1.EventTallyError',
+  typeUrl: '/cosmos.group.v1.EventTallyError' as const,
   encode(
     message: EventTallyError,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/group/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/group/v1/genesis.ts
@@ -70,7 +70,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.group.v1.GenesisState',
+  typeUrl: '/cosmos.group.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/group/v1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/group/v1/query.ts
@@ -462,7 +462,7 @@ function createBaseQueryGroupInfoRequest(): QueryGroupInfoRequest {
   };
 }
 export const QueryGroupInfoRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupInfoRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupInfoRequest' as const,
   encode(
     message: QueryGroupInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -533,7 +533,7 @@ function createBaseQueryGroupInfoResponse(): QueryGroupInfoResponse {
   };
 }
 export const QueryGroupInfoResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupInfoResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupInfoResponse' as const,
   encode(
     message: QueryGroupInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -604,7 +604,7 @@ function createBaseQueryGroupPolicyInfoRequest(): QueryGroupPolicyInfoRequest {
   };
 }
 export const QueryGroupPolicyInfoRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupPolicyInfoRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupPolicyInfoRequest' as const,
   encode(
     message: QueryGroupPolicyInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -677,7 +677,7 @@ function createBaseQueryGroupPolicyInfoResponse(): QueryGroupPolicyInfoResponse 
   };
 }
 export const QueryGroupPolicyInfoResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupPolicyInfoResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupPolicyInfoResponse' as const,
   encode(
     message: QueryGroupPolicyInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -759,7 +759,7 @@ function createBaseQueryGroupMembersRequest(): QueryGroupMembersRequest {
   };
 }
 export const QueryGroupMembersRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupMembersRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupMembersRequest' as const,
   encode(
     message: QueryGroupMembersRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -856,7 +856,7 @@ function createBaseQueryGroupMembersResponse(): QueryGroupMembersResponse {
   };
 }
 export const QueryGroupMembersResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupMembersResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupMembersResponse' as const,
   encode(
     message: QueryGroupMembersResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -959,7 +959,7 @@ function createBaseQueryGroupsByAdminRequest(): QueryGroupsByAdminRequest {
   };
 }
 export const QueryGroupsByAdminRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupsByAdminRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupsByAdminRequest' as const,
   encode(
     message: QueryGroupsByAdminRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1050,7 +1050,7 @@ function createBaseQueryGroupsByAdminResponse(): QueryGroupsByAdminResponse {
   };
 }
 export const QueryGroupsByAdminResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupsByAdminResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupsByAdminResponse' as const,
   encode(
     message: QueryGroupsByAdminResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1152,7 +1152,7 @@ function createBaseQueryGroupPoliciesByGroupRequest(): QueryGroupPoliciesByGroup
   };
 }
 export const QueryGroupPoliciesByGroupRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByGroupRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByGroupRequest' as const,
   encode(
     message: QueryGroupPoliciesByGroupRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1249,7 +1249,7 @@ function createBaseQueryGroupPoliciesByGroupResponse(): QueryGroupPoliciesByGrou
   };
 }
 export const QueryGroupPoliciesByGroupResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByGroupResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByGroupResponse' as const,
   encode(
     message: QueryGroupPoliciesByGroupResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1354,7 +1354,7 @@ function createBaseQueryGroupPoliciesByAdminRequest(): QueryGroupPoliciesByAdmin
   };
 }
 export const QueryGroupPoliciesByAdminRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByAdminRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByAdminRequest' as const,
   encode(
     message: QueryGroupPoliciesByAdminRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1445,7 +1445,7 @@ function createBaseQueryGroupPoliciesByAdminResponse(): QueryGroupPoliciesByAdmi
   };
 }
 export const QueryGroupPoliciesByAdminResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByAdminResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupPoliciesByAdminResponse' as const,
   encode(
     message: QueryGroupPoliciesByAdminResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1549,7 +1549,7 @@ function createBaseQueryProposalRequest(): QueryProposalRequest {
   };
 }
 export const QueryProposalRequest = {
-  typeUrl: '/cosmos.group.v1.QueryProposalRequest',
+  typeUrl: '/cosmos.group.v1.QueryProposalRequest' as const,
   encode(
     message: QueryProposalRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1620,7 +1620,7 @@ function createBaseQueryProposalResponse(): QueryProposalResponse {
   };
 }
 export const QueryProposalResponse = {
-  typeUrl: '/cosmos.group.v1.QueryProposalResponse',
+  typeUrl: '/cosmos.group.v1.QueryProposalResponse' as const,
   encode(
     message: QueryProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1694,7 +1694,7 @@ function createBaseQueryProposalsByGroupPolicyRequest(): QueryProposalsByGroupPo
   };
 }
 export const QueryProposalsByGroupPolicyRequest = {
-  typeUrl: '/cosmos.group.v1.QueryProposalsByGroupPolicyRequest',
+  typeUrl: '/cosmos.group.v1.QueryProposalsByGroupPolicyRequest' as const,
   encode(
     message: QueryProposalsByGroupPolicyRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1785,7 +1785,7 @@ function createBaseQueryProposalsByGroupPolicyResponse(): QueryProposalsByGroupP
   };
 }
 export const QueryProposalsByGroupPolicyResponse = {
-  typeUrl: '/cosmos.group.v1.QueryProposalsByGroupPolicyResponse',
+  typeUrl: '/cosmos.group.v1.QueryProposalsByGroupPolicyResponse' as const,
   encode(
     message: QueryProposalsByGroupPolicyResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1888,7 +1888,7 @@ function createBaseQueryVoteByProposalVoterRequest(): QueryVoteByProposalVoterRe
   };
 }
 export const QueryVoteByProposalVoterRequest = {
-  typeUrl: '/cosmos.group.v1.QueryVoteByProposalVoterRequest',
+  typeUrl: '/cosmos.group.v1.QueryVoteByProposalVoterRequest' as const,
   encode(
     message: QueryVoteByProposalVoterRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1976,7 +1976,7 @@ function createBaseQueryVoteByProposalVoterResponse(): QueryVoteByProposalVoterR
   };
 }
 export const QueryVoteByProposalVoterResponse = {
-  typeUrl: '/cosmos.group.v1.QueryVoteByProposalVoterResponse',
+  typeUrl: '/cosmos.group.v1.QueryVoteByProposalVoterResponse' as const,
   encode(
     message: QueryVoteByProposalVoterResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2054,7 +2054,7 @@ function createBaseQueryVotesByProposalRequest(): QueryVotesByProposalRequest {
   };
 }
 export const QueryVotesByProposalRequest = {
-  typeUrl: '/cosmos.group.v1.QueryVotesByProposalRequest',
+  typeUrl: '/cosmos.group.v1.QueryVotesByProposalRequest' as const,
   encode(
     message: QueryVotesByProposalRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2151,7 +2151,7 @@ function createBaseQueryVotesByProposalResponse(): QueryVotesByProposalResponse 
   };
 }
 export const QueryVotesByProposalResponse = {
-  typeUrl: '/cosmos.group.v1.QueryVotesByProposalResponse',
+  typeUrl: '/cosmos.group.v1.QueryVotesByProposalResponse' as const,
   encode(
     message: QueryVotesByProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2251,7 +2251,7 @@ function createBaseQueryVotesByVoterRequest(): QueryVotesByVoterRequest {
   };
 }
 export const QueryVotesByVoterRequest = {
-  typeUrl: '/cosmos.group.v1.QueryVotesByVoterRequest',
+  typeUrl: '/cosmos.group.v1.QueryVotesByVoterRequest' as const,
   encode(
     message: QueryVotesByVoterRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2342,7 +2342,7 @@ function createBaseQueryVotesByVoterResponse(): QueryVotesByVoterResponse {
   };
 }
 export const QueryVotesByVoterResponse = {
-  typeUrl: '/cosmos.group.v1.QueryVotesByVoterResponse',
+  typeUrl: '/cosmos.group.v1.QueryVotesByVoterResponse' as const,
   encode(
     message: QueryVotesByVoterResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2442,7 +2442,7 @@ function createBaseQueryGroupsByMemberRequest(): QueryGroupsByMemberRequest {
   };
 }
 export const QueryGroupsByMemberRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupsByMemberRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupsByMemberRequest' as const,
   encode(
     message: QueryGroupsByMemberRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2533,7 +2533,7 @@ function createBaseQueryGroupsByMemberResponse(): QueryGroupsByMemberResponse {
   };
 }
 export const QueryGroupsByMemberResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupsByMemberResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupsByMemberResponse' as const,
   encode(
     message: QueryGroupsByMemberResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2634,7 +2634,7 @@ function createBaseQueryTallyResultRequest(): QueryTallyResultRequest {
   };
 }
 export const QueryTallyResultRequest = {
-  typeUrl: '/cosmos.group.v1.QueryTallyResultRequest',
+  typeUrl: '/cosmos.group.v1.QueryTallyResultRequest' as const,
   encode(
     message: QueryTallyResultRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2711,7 +2711,7 @@ function createBaseQueryTallyResultResponse(): QueryTallyResultResponse {
   };
 }
 export const QueryTallyResultResponse = {
-  typeUrl: '/cosmos.group.v1.QueryTallyResultResponse',
+  typeUrl: '/cosmos.group.v1.QueryTallyResultResponse' as const,
   encode(
     message: QueryTallyResultResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2792,7 +2792,7 @@ function createBaseQueryGroupsRequest(): QueryGroupsRequest {
   };
 }
 export const QueryGroupsRequest = {
-  typeUrl: '/cosmos.group.v1.QueryGroupsRequest',
+  typeUrl: '/cosmos.group.v1.QueryGroupsRequest' as const,
   encode(
     message: QueryGroupsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2866,7 +2866,7 @@ function createBaseQueryGroupsResponse(): QueryGroupsResponse {
   };
 }
 export const QueryGroupsResponse = {
-  typeUrl: '/cosmos.group.v1.QueryGroupsResponse',
+  typeUrl: '/cosmos.group.v1.QueryGroupsResponse' as const,
   encode(
     message: QueryGroupsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/group/v1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/group/v1/tx.ts
@@ -514,7 +514,7 @@ function createBaseMsgCreateGroup(): MsgCreateGroup {
   };
 }
 export const MsgCreateGroup = {
-  typeUrl: '/cosmos.group.v1.MsgCreateGroup',
+  typeUrl: '/cosmos.group.v1.MsgCreateGroup' as const,
   encode(
     message: MsgCreateGroup,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -603,7 +603,7 @@ function createBaseMsgCreateGroupResponse(): MsgCreateGroupResponse {
   };
 }
 export const MsgCreateGroupResponse = {
-  typeUrl: '/cosmos.group.v1.MsgCreateGroupResponse',
+  typeUrl: '/cosmos.group.v1.MsgCreateGroupResponse' as const,
   encode(
     message: MsgCreateGroupResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -678,7 +678,7 @@ function createBaseMsgUpdateGroupMembers(): MsgUpdateGroupMembers {
   };
 }
 export const MsgUpdateGroupMembers = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMembers',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMembers' as const,
   encode(
     message: MsgUpdateGroupMembers,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -776,7 +776,7 @@ function createBaseMsgUpdateGroupMembersResponse(): MsgUpdateGroupMembersRespons
   return {};
 }
 export const MsgUpdateGroupMembersResponse = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMembersResponse',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMembersResponse' as const,
   encode(
     _: MsgUpdateGroupMembersResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -841,7 +841,7 @@ function createBaseMsgUpdateGroupAdmin(): MsgUpdateGroupAdmin {
   };
 }
 export const MsgUpdateGroupAdmin = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupAdmin',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupAdmin' as const,
   encode(
     message: MsgUpdateGroupAdmin,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -928,7 +928,7 @@ function createBaseMsgUpdateGroupAdminResponse(): MsgUpdateGroupAdminResponse {
   return {};
 }
 export const MsgUpdateGroupAdminResponse = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupAdminResponse',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupAdminResponse' as const,
   encode(
     _: MsgUpdateGroupAdminResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -993,7 +993,7 @@ function createBaseMsgUpdateGroupMetadata(): MsgUpdateGroupMetadata {
   };
 }
 export const MsgUpdateGroupMetadata = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMetadata',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMetadata' as const,
   encode(
     message: MsgUpdateGroupMetadata,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1082,7 +1082,7 @@ function createBaseMsgUpdateGroupMetadataResponse(): MsgUpdateGroupMetadataRespo
   return {};
 }
 export const MsgUpdateGroupMetadataResponse = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMetadataResponse',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupMetadataResponse' as const,
   encode(
     _: MsgUpdateGroupMetadataResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1148,7 +1148,7 @@ function createBaseMsgCreateGroupPolicy(): MsgCreateGroupPolicy {
   };
 }
 export const MsgCreateGroupPolicy = {
-  typeUrl: '/cosmos.group.v1.MsgCreateGroupPolicy',
+  typeUrl: '/cosmos.group.v1.MsgCreateGroupPolicy' as const,
   encode(
     message: MsgCreateGroupPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1254,7 +1254,7 @@ function createBaseMsgCreateGroupPolicyResponse(): MsgCreateGroupPolicyResponse 
   };
 }
 export const MsgCreateGroupPolicyResponse = {
-  typeUrl: '/cosmos.group.v1.MsgCreateGroupPolicyResponse',
+  typeUrl: '/cosmos.group.v1.MsgCreateGroupPolicyResponse' as const,
   encode(
     message: MsgCreateGroupPolicyResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1329,7 +1329,7 @@ function createBaseMsgUpdateGroupPolicyAdmin(): MsgUpdateGroupPolicyAdmin {
   };
 }
 export const MsgUpdateGroupPolicyAdmin = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyAdmin',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyAdmin' as const,
   encode(
     message: MsgUpdateGroupPolicyAdmin,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1421,7 +1421,7 @@ function createBaseMsgUpdateGroupPolicyAdminResponse(): MsgUpdateGroupPolicyAdmi
   return {};
 }
 export const MsgUpdateGroupPolicyAdminResponse = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyAdminResponse',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyAdminResponse' as const,
   encode(
     _: MsgUpdateGroupPolicyAdminResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1489,7 +1489,7 @@ function createBaseMsgCreateGroupWithPolicy(): MsgCreateGroupWithPolicy {
   };
 }
 export const MsgCreateGroupWithPolicy = {
-  typeUrl: '/cosmos.group.v1.MsgCreateGroupWithPolicy',
+  typeUrl: '/cosmos.group.v1.MsgCreateGroupWithPolicy' as const,
   encode(
     message: MsgCreateGroupWithPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1634,7 +1634,7 @@ function createBaseMsgCreateGroupWithPolicyResponse(): MsgCreateGroupWithPolicyR
   };
 }
 export const MsgCreateGroupWithPolicyResponse = {
-  typeUrl: '/cosmos.group.v1.MsgCreateGroupWithPolicyResponse',
+  typeUrl: '/cosmos.group.v1.MsgCreateGroupWithPolicyResponse' as const,
   encode(
     message: MsgCreateGroupWithPolicyResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1727,7 +1727,7 @@ function createBaseMsgUpdateGroupPolicyDecisionPolicy(): MsgUpdateGroupPolicyDec
   };
 }
 export const MsgUpdateGroupPolicyDecisionPolicy = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy' as const,
   encode(
     message: MsgUpdateGroupPolicyDecisionPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1827,7 +1827,8 @@ function createBaseMsgUpdateGroupPolicyDecisionPolicyResponse(): MsgUpdateGroupP
   return {};
 }
 export const MsgUpdateGroupPolicyDecisionPolicyResponse = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicyResponse',
+  typeUrl:
+    '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicyResponse' as const,
   encode(
     _: MsgUpdateGroupPolicyDecisionPolicyResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1893,7 +1894,7 @@ function createBaseMsgUpdateGroupPolicyMetadata(): MsgUpdateGroupPolicyMetadata 
   };
 }
 export const MsgUpdateGroupPolicyMetadata = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyMetadata',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyMetadata' as const,
   encode(
     message: MsgUpdateGroupPolicyMetadata,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1985,7 +1986,7 @@ function createBaseMsgUpdateGroupPolicyMetadataResponse(): MsgUpdateGroupPolicyM
   return {};
 }
 export const MsgUpdateGroupPolicyMetadataResponse = {
-  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyMetadataResponse',
+  typeUrl: '/cosmos.group.v1.MsgUpdateGroupPolicyMetadataResponse' as const,
   encode(
     _: MsgUpdateGroupPolicyMetadataResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2054,7 +2055,7 @@ function createBaseMsgSubmitProposal(): MsgSubmitProposal {
   };
 }
 export const MsgSubmitProposal = {
-  typeUrl: '/cosmos.group.v1.MsgSubmitProposal',
+  typeUrl: '/cosmos.group.v1.MsgSubmitProposal' as const,
   encode(
     message: MsgSubmitProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2185,7 +2186,7 @@ function createBaseMsgSubmitProposalResponse(): MsgSubmitProposalResponse {
   };
 }
 export const MsgSubmitProposalResponse = {
-  typeUrl: '/cosmos.group.v1.MsgSubmitProposalResponse',
+  typeUrl: '/cosmos.group.v1.MsgSubmitProposalResponse' as const,
   encode(
     message: MsgSubmitProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2265,7 +2266,7 @@ function createBaseMsgWithdrawProposal(): MsgWithdrawProposal {
   };
 }
 export const MsgWithdrawProposal = {
-  typeUrl: '/cosmos.group.v1.MsgWithdrawProposal',
+  typeUrl: '/cosmos.group.v1.MsgWithdrawProposal' as const,
   encode(
     message: MsgWithdrawProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2343,7 +2344,7 @@ function createBaseMsgWithdrawProposalResponse(): MsgWithdrawProposalResponse {
   return {};
 }
 export const MsgWithdrawProposalResponse = {
-  typeUrl: '/cosmos.group.v1.MsgWithdrawProposalResponse',
+  typeUrl: '/cosmos.group.v1.MsgWithdrawProposalResponse' as const,
   encode(
     _: MsgWithdrawProposalResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2410,7 +2411,7 @@ function createBaseMsgVote(): MsgVote {
   };
 }
 export const MsgVote = {
-  typeUrl: '/cosmos.group.v1.MsgVote',
+  typeUrl: '/cosmos.group.v1.MsgVote' as const,
   encode(
     message: MsgVote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2513,7 +2514,7 @@ function createBaseMsgVoteResponse(): MsgVoteResponse {
   return {};
 }
 export const MsgVoteResponse = {
-  typeUrl: '/cosmos.group.v1.MsgVoteResponse',
+  typeUrl: '/cosmos.group.v1.MsgVoteResponse' as const,
   encode(
     _: MsgVoteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2566,7 +2567,7 @@ function createBaseMsgExec(): MsgExec {
   };
 }
 export const MsgExec = {
-  typeUrl: '/cosmos.group.v1.MsgExec',
+  typeUrl: '/cosmos.group.v1.MsgExec' as const,
   encode(
     message: MsgExec,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2643,7 +2644,7 @@ function createBaseMsgExecResponse(): MsgExecResponse {
   };
 }
 export const MsgExecResponse = {
-  typeUrl: '/cosmos.group.v1.MsgExecResponse',
+  typeUrl: '/cosmos.group.v1.MsgExecResponse' as const,
   encode(
     message: MsgExecResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2709,7 +2710,7 @@ function createBaseMsgLeaveGroup(): MsgLeaveGroup {
   };
 }
 export const MsgLeaveGroup = {
-  typeUrl: '/cosmos.group.v1.MsgLeaveGroup',
+  typeUrl: '/cosmos.group.v1.MsgLeaveGroup' as const,
   encode(
     message: MsgLeaveGroup,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2784,7 +2785,7 @@ function createBaseMsgLeaveGroupResponse(): MsgLeaveGroupResponse {
   return {};
 }
 export const MsgLeaveGroupResponse = {
-  typeUrl: '/cosmos.group.v1.MsgLeaveGroupResponse',
+  typeUrl: '/cosmos.group.v1.MsgLeaveGroupResponse' as const,
   encode(
     _: MsgLeaveGroupResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/group/v1/types.ts
+++ b/packages/client-utils/src/codegen/cosmos/group/v1/types.ts
@@ -583,7 +583,7 @@ function createBaseMember(): Member {
   };
 }
 export const Member = {
-  typeUrl: '/cosmos.group.v1.Member',
+  typeUrl: '/cosmos.group.v1.Member' as const,
   encode(
     message: Member,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -680,7 +680,7 @@ function createBaseMemberRequest(): MemberRequest {
   };
 }
 export const MemberRequest = {
-  typeUrl: '/cosmos.group.v1.MemberRequest',
+  typeUrl: '/cosmos.group.v1.MemberRequest' as const,
   encode(
     message: MemberRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -761,7 +761,7 @@ function createBaseThresholdDecisionPolicy(): ThresholdDecisionPolicy {
   };
 }
 export const ThresholdDecisionPolicy = {
-  typeUrl: '/cosmos.group.v1.ThresholdDecisionPolicy',
+  typeUrl: '/cosmos.group.v1.ThresholdDecisionPolicy' as const,
   encode(
     message: ThresholdDecisionPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -856,7 +856,7 @@ function createBasePercentageDecisionPolicy(): PercentageDecisionPolicy {
   };
 }
 export const PercentageDecisionPolicy = {
-  typeUrl: '/cosmos.group.v1.PercentageDecisionPolicy',
+  typeUrl: '/cosmos.group.v1.PercentageDecisionPolicy' as const,
   encode(
     message: PercentageDecisionPolicy,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -953,7 +953,7 @@ function createBaseDecisionPolicyWindows(): DecisionPolicyWindows {
   };
 }
 export const DecisionPolicyWindows = {
-  typeUrl: '/cosmos.group.v1.DecisionPolicyWindows',
+  typeUrl: '/cosmos.group.v1.DecisionPolicyWindows' as const,
   encode(
     message: DecisionPolicyWindows,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1052,7 +1052,7 @@ function createBaseGroupInfo(): GroupInfo {
   };
 }
 export const GroupInfo = {
-  typeUrl: '/cosmos.group.v1.GroupInfo',
+  typeUrl: '/cosmos.group.v1.GroupInfo' as const,
   encode(
     message: GroupInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1176,7 +1176,7 @@ function createBaseGroupMember(): GroupMember {
   };
 }
 export const GroupMember = {
-  typeUrl: '/cosmos.group.v1.GroupMember',
+  typeUrl: '/cosmos.group.v1.GroupMember' as const,
   encode(
     message: GroupMember,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1263,7 +1263,7 @@ function createBaseGroupPolicyInfo(): GroupPolicyInfo {
   };
 }
 export const GroupPolicyInfo = {
-  typeUrl: '/cosmos.group.v1.GroupPolicyInfo',
+  typeUrl: '/cosmos.group.v1.GroupPolicyInfo' as const,
   encode(
     message: GroupPolicyInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1418,7 +1418,7 @@ function createBaseProposal(): Proposal {
   };
 }
 export const Proposal = {
-  typeUrl: '/cosmos.group.v1.Proposal',
+  typeUrl: '/cosmos.group.v1.Proposal' as const,
   encode(
     message: Proposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1670,7 +1670,7 @@ function createBaseTallyResult(): TallyResult {
   };
 }
 export const TallyResult = {
-  typeUrl: '/cosmos.group.v1.TallyResult',
+  typeUrl: '/cosmos.group.v1.TallyResult' as const,
   encode(
     message: TallyResult,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1769,7 +1769,7 @@ function createBaseVote(): Vote {
   };
 }
 export const Vote = {
-  typeUrl: '/cosmos.group.v1.Vote',
+  typeUrl: '/cosmos.group.v1.Vote' as const,
   encode(
     message: Vote,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/ics23/v1/proofs.ts
+++ b/packages/client-utils/src/codegen/cosmos/ics23/v1/proofs.ts
@@ -573,7 +573,7 @@ function createBaseExistenceProof(): ExistenceProof {
   };
 }
 export const ExistenceProof = {
-  typeUrl: '/cosmos.ics23.v1.ExistenceProof',
+  typeUrl: '/cosmos.ics23.v1.ExistenceProof' as const,
   encode(
     message: ExistenceProof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -682,7 +682,7 @@ function createBaseNonExistenceProof(): NonExistenceProof {
   };
 }
 export const NonExistenceProof = {
-  typeUrl: '/cosmos.ics23.v1.NonExistenceProof',
+  typeUrl: '/cosmos.ics23.v1.NonExistenceProof' as const,
   encode(
     message: NonExistenceProof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -784,7 +784,7 @@ function createBaseCommitmentProof(): CommitmentProof {
   };
 }
 export const CommitmentProof = {
-  typeUrl: '/cosmos.ics23.v1.CommitmentProof',
+  typeUrl: '/cosmos.ics23.v1.CommitmentProof' as const,
   encode(
     message: CommitmentProof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -918,7 +918,7 @@ function createBaseLeafOp(): LeafOp {
   };
 }
 export const LeafOp = {
-  typeUrl: '/cosmos.ics23.v1.LeafOp',
+  typeUrl: '/cosmos.ics23.v1.LeafOp' as const,
   encode(
     message: LeafOp,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1030,7 +1030,7 @@ function createBaseInnerOp(): InnerOp {
   };
 }
 export const InnerOp = {
-  typeUrl: '/cosmos.ics23.v1.InnerOp',
+  typeUrl: '/cosmos.ics23.v1.InnerOp' as const,
   encode(
     message: InnerOp,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1124,7 +1124,7 @@ function createBaseProofSpec(): ProofSpec {
   };
 }
 export const ProofSpec = {
-  typeUrl: '/cosmos.ics23.v1.ProofSpec',
+  typeUrl: '/cosmos.ics23.v1.ProofSpec' as const,
   encode(
     message: ProofSpec,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1249,7 +1249,7 @@ function createBaseInnerSpec(): InnerSpec {
   };
 }
 export const InnerSpec = {
-  typeUrl: '/cosmos.ics23.v1.InnerSpec',
+  typeUrl: '/cosmos.ics23.v1.InnerSpec' as const,
   encode(
     message: InnerSpec,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1385,7 +1385,7 @@ function createBaseBatchProof(): BatchProof {
   };
 }
 export const BatchProof = {
-  typeUrl: '/cosmos.ics23.v1.BatchProof',
+  typeUrl: '/cosmos.ics23.v1.BatchProof' as const,
   encode(
     message: BatchProof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1456,7 +1456,7 @@ function createBaseBatchEntry(): BatchEntry {
   };
 }
 export const BatchEntry = {
-  typeUrl: '/cosmos.ics23.v1.BatchEntry',
+  typeUrl: '/cosmos.ics23.v1.BatchEntry' as const,
   encode(
     message: BatchEntry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1547,7 +1547,7 @@ function createBaseCompressedBatchProof(): CompressedBatchProof {
   };
 }
 export const CompressedBatchProof = {
-  typeUrl: '/cosmos.ics23.v1.CompressedBatchProof',
+  typeUrl: '/cosmos.ics23.v1.CompressedBatchProof' as const,
   encode(
     message: CompressedBatchProof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1642,7 +1642,7 @@ function createBaseCompressedBatchEntry(): CompressedBatchEntry {
   };
 }
 export const CompressedBatchEntry = {
-  typeUrl: '/cosmos.ics23.v1.CompressedBatchEntry',
+  typeUrl: '/cosmos.ics23.v1.CompressedBatchEntry' as const,
   encode(
     message: CompressedBatchEntry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1747,7 +1747,7 @@ function createBaseCompressedExistenceProof(): CompressedExistenceProof {
   };
 }
 export const CompressedExistenceProof = {
-  typeUrl: '/cosmos.ics23.v1.CompressedExistenceProof',
+  typeUrl: '/cosmos.ics23.v1.CompressedExistenceProof' as const,
   encode(
     message: CompressedExistenceProof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1876,7 +1876,7 @@ function createBaseCompressedNonExistenceProof(): CompressedNonExistenceProof {
   };
 }
 export const CompressedNonExistenceProof = {
-  typeUrl: '/cosmos.ics23.v1.CompressedNonExistenceProof',
+  typeUrl: '/cosmos.ics23.v1.CompressedNonExistenceProof' as const,
   encode(
     message: CompressedNonExistenceProof,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/mint/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/mint/module/v1/module.ts
@@ -24,7 +24,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.mint.module.v1.Module',
+  typeUrl: '/cosmos.mint.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/mint/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/mint/v1beta1/genesis.ts
@@ -31,7 +31,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.mint.v1beta1.GenesisState',
+  typeUrl: '/cosmos.mint.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/mint/v1beta1/mint.ts
+++ b/packages/client-utils/src/codegen/cosmos/mint/v1beta1/mint.ts
@@ -54,7 +54,7 @@ function createBaseMinter(): Minter {
   };
 }
 export const Minter = {
-  typeUrl: '/cosmos.mint.v1beta1.Minter',
+  typeUrl: '/cosmos.mint.v1beta1.Minter' as const,
   encode(
     message: Minter,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -143,7 +143,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/cosmos.mint.v1beta1.Params',
+  typeUrl: '/cosmos.mint.v1beta1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/mint/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/mint/v1beta1/query.ts
@@ -90,7 +90,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.mint.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.mint.v1beta1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -145,7 +145,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.mint.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.mint.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -212,7 +212,7 @@ function createBaseQueryInflationRequest(): QueryInflationRequest {
   return {};
 }
 export const QueryInflationRequest = {
-  typeUrl: '/cosmos.mint.v1beta1.QueryInflationRequest',
+  typeUrl: '/cosmos.mint.v1beta1.QueryInflationRequest' as const,
   encode(
     _: QueryInflationRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -267,7 +267,7 @@ function createBaseQueryInflationResponse(): QueryInflationResponse {
   };
 }
 export const QueryInflationResponse = {
-  typeUrl: '/cosmos.mint.v1beta1.QueryInflationResponse',
+  typeUrl: '/cosmos.mint.v1beta1.QueryInflationResponse' as const,
   encode(
     message: QueryInflationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -337,7 +337,7 @@ function createBaseQueryAnnualProvisionsRequest(): QueryAnnualProvisionsRequest 
   return {};
 }
 export const QueryAnnualProvisionsRequest = {
-  typeUrl: '/cosmos.mint.v1beta1.QueryAnnualProvisionsRequest',
+  typeUrl: '/cosmos.mint.v1beta1.QueryAnnualProvisionsRequest' as const,
   encode(
     _: QueryAnnualProvisionsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -400,7 +400,7 @@ function createBaseQueryAnnualProvisionsResponse(): QueryAnnualProvisionsRespons
   };
 }
 export const QueryAnnualProvisionsResponse = {
-  typeUrl: '/cosmos.mint.v1beta1.QueryAnnualProvisionsResponse',
+  typeUrl: '/cosmos.mint.v1beta1.QueryAnnualProvisionsResponse' as const,
   encode(
     message: QueryAnnualProvisionsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/mint/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/mint/v1beta1/tx.ts
@@ -56,7 +56,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.mint.v1beta1.MsgUpdateParams',
+  typeUrl: '/cosmos.mint.v1beta1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -129,7 +129,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.mint.v1beta1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.mint.v1beta1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/nft/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/nft/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.nft.module.v1.Module',
+  typeUrl: '/cosmos.nft.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/params/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/params/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.params.module.v1.Module',
+  typeUrl: '/cosmos.params.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/params/v1beta1/params.ts
+++ b/packages/client-utils/src/codegen/cosmos/params/v1beta1/params.ts
@@ -48,7 +48,7 @@ function createBaseParameterChangeProposal(): ParameterChangeProposal {
   };
 }
 export const ParameterChangeProposal = {
-  typeUrl: '/cosmos.params.v1beta1.ParameterChangeProposal',
+  typeUrl: '/cosmos.params.v1beta1.ParameterChangeProposal' as const,
   encode(
     message: ParameterChangeProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -149,7 +149,7 @@ function createBaseParamChange(): ParamChange {
   };
 }
 export const ParamChange = {
-  typeUrl: '/cosmos.params.v1beta1.ParamChange',
+  typeUrl: '/cosmos.params.v1beta1.ParamChange' as const,
   encode(
     message: ParamChange,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/params/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/params/v1beta1/query.ts
@@ -103,7 +103,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   };
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.params.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.params.v1beta1.QueryParamsRequest' as const,
   encode(
     message: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -177,7 +177,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.params.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.params.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -248,7 +248,7 @@ function createBaseQuerySubspacesRequest(): QuerySubspacesRequest {
   return {};
 }
 export const QuerySubspacesRequest = {
-  typeUrl: '/cosmos.params.v1beta1.QuerySubspacesRequest',
+  typeUrl: '/cosmos.params.v1beta1.QuerySubspacesRequest' as const,
   encode(
     _: QuerySubspacesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -303,7 +303,7 @@ function createBaseQuerySubspacesResponse(): QuerySubspacesResponse {
   };
 }
 export const QuerySubspacesResponse = {
-  typeUrl: '/cosmos.params.v1beta1.QuerySubspacesResponse',
+  typeUrl: '/cosmos.params.v1beta1.QuerySubspacesResponse' as const,
   encode(
     message: QuerySubspacesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -380,7 +380,7 @@ function createBaseSubspace(): Subspace {
   };
 }
 export const Subspace = {
-  typeUrl: '/cosmos.params.v1beta1.Subspace',
+  typeUrl: '/cosmos.params.v1beta1.Subspace' as const,
   encode(
     message: Subspace,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/reflection/v1/reflection.ts
+++ b/packages/client-utils/src/codegen/cosmos/reflection/v1/reflection.ts
@@ -30,7 +30,7 @@ function createBaseFileDescriptorsRequest(): FileDescriptorsRequest {
   return {};
 }
 export const FileDescriptorsRequest = {
-  typeUrl: '/cosmos.reflection.v1.FileDescriptorsRequest',
+  typeUrl: '/cosmos.reflection.v1.FileDescriptorsRequest' as const,
   encode(
     _: FileDescriptorsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -87,7 +87,7 @@ function createBaseFileDescriptorsResponse(): FileDescriptorsResponse {
   };
 }
 export const FileDescriptorsResponse = {
-  typeUrl: '/cosmos.reflection.v1.FileDescriptorsResponse',
+  typeUrl: '/cosmos.reflection.v1.FileDescriptorsResponse' as const,
   encode(
     message: FileDescriptorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/slashing/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/slashing/module/v1/module.ts
@@ -21,7 +21,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.slashing.module.v1.Module',
+  typeUrl: '/cosmos.slashing.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/staking/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/staking/module/v1/module.ts
@@ -29,7 +29,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.staking.module.v1.Module',
+  typeUrl: '/cosmos.staking.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/staking/v1beta1/authz.ts
+++ b/packages/client-utils/src/codegen/cosmos/staking/v1beta1/authz.ts
@@ -112,7 +112,7 @@ function createBaseStakeAuthorization(): StakeAuthorization {
   };
 }
 export const StakeAuthorization = {
-  typeUrl: '/cosmos.staking.v1beta1.StakeAuthorization',
+  typeUrl: '/cosmos.staking.v1beta1.StakeAuthorization' as const,
   encode(
     message: StakeAuthorization,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -245,7 +245,7 @@ function createBaseStakeAuthorization_Validators(): StakeAuthorization_Validator
   };
 }
 export const StakeAuthorization_Validators = {
-  typeUrl: '/cosmos.staking.v1beta1.Validators',
+  typeUrl: '/cosmos.staking.v1beta1.Validators' as const,
   encode(
     message: StakeAuthorization_Validators,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/staking/v1beta1/genesis.ts
+++ b/packages/client-utils/src/codegen/cosmos/staking/v1beta1/genesis.ts
@@ -84,7 +84,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/cosmos.staking.v1beta1.GenesisState',
+  typeUrl: '/cosmos.staking.v1beta1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -279,7 +279,7 @@ function createBaseLastValidatorPower(): LastValidatorPower {
   };
 }
 export const LastValidatorPower = {
-  typeUrl: '/cosmos.staking.v1beta1.LastValidatorPower',
+  typeUrl: '/cosmos.staking.v1beta1.LastValidatorPower' as const,
   encode(
     message: LastValidatorPower,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/staking/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/staking/v1beta1/query.ts
@@ -546,7 +546,7 @@ function createBaseQueryValidatorsRequest(): QueryValidatorsRequest {
   };
 }
 export const QueryValidatorsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorsRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorsRequest' as const,
   encode(
     message: QueryValidatorsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -631,7 +631,7 @@ function createBaseQueryValidatorsResponse(): QueryValidatorsResponse {
   };
 }
 export const QueryValidatorsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorsResponse' as const,
   encode(
     message: QueryValidatorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -731,7 +731,7 @@ function createBaseQueryValidatorRequest(): QueryValidatorRequest {
   };
 }
 export const QueryValidatorRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorRequest' as const,
   encode(
     message: QueryValidatorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -799,7 +799,7 @@ function createBaseQueryValidatorResponse(): QueryValidatorResponse {
   };
 }
 export const QueryValidatorResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorResponse' as const,
   encode(
     message: QueryValidatorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -875,7 +875,7 @@ function createBaseQueryValidatorDelegationsRequest(): QueryValidatorDelegations
   };
 }
 export const QueryValidatorDelegationsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorDelegationsRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorDelegationsRequest' as const,
   encode(
     message: QueryValidatorDelegationsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -969,7 +969,7 @@ function createBaseQueryValidatorDelegationsResponse(): QueryValidatorDelegation
   };
 }
 export const QueryValidatorDelegationsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorDelegationsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorDelegationsResponse' as const,
   encode(
     message: QueryValidatorDelegationsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1077,7 +1077,8 @@ function createBaseQueryValidatorUnbondingDelegationsRequest(): QueryValidatorUn
   };
 }
 export const QueryValidatorUnbondingDelegationsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsRequest',
+  typeUrl:
+    '/cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsRequest' as const,
   encode(
     message: QueryValidatorUnbondingDelegationsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1172,7 +1173,8 @@ function createBaseQueryValidatorUnbondingDelegationsResponse(): QueryValidatorU
   };
 }
 export const QueryValidatorUnbondingDelegationsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsResponse',
+  typeUrl:
+    '/cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsResponse' as const,
   encode(
     message: QueryValidatorUnbondingDelegationsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1282,7 +1284,7 @@ function createBaseQueryDelegationRequest(): QueryDelegationRequest {
   };
 }
 export const QueryDelegationRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegationRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegationRequest' as const,
   encode(
     message: QueryDelegationRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1364,7 +1366,7 @@ function createBaseQueryDelegationResponse(): QueryDelegationResponse {
   };
 }
 export const QueryDelegationResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegationResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegationResponse' as const,
   encode(
     message: QueryDelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1451,7 +1453,7 @@ function createBaseQueryUnbondingDelegationRequest(): QueryUnbondingDelegationRe
   };
 }
 export const QueryUnbondingDelegationRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryUnbondingDelegationRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryUnbondingDelegationRequest' as const,
   encode(
     message: QueryUnbondingDelegationRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1539,7 +1541,7 @@ function createBaseQueryUnbondingDelegationResponse(): QueryUnbondingDelegationR
   };
 }
 export const QueryUnbondingDelegationResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryUnbondingDelegationResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryUnbondingDelegationResponse' as const,
   encode(
     message: QueryUnbondingDelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1624,7 +1626,7 @@ function createBaseQueryDelegatorDelegationsRequest(): QueryDelegatorDelegations
   };
 }
 export const QueryDelegatorDelegationsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorDelegationsRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorDelegationsRequest' as const,
   encode(
     message: QueryDelegatorDelegationsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1718,7 +1720,7 @@ function createBaseQueryDelegatorDelegationsResponse(): QueryDelegatorDelegation
   };
 }
 export const QueryDelegatorDelegationsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorDelegationsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorDelegationsResponse' as const,
   encode(
     message: QueryDelegatorDelegationsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1826,7 +1828,8 @@ function createBaseQueryDelegatorUnbondingDelegationsRequest(): QueryDelegatorUn
   };
 }
 export const QueryDelegatorUnbondingDelegationsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsRequest',
+  typeUrl:
+    '/cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsRequest' as const,
   encode(
     message: QueryDelegatorUnbondingDelegationsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1921,7 +1924,8 @@ function createBaseQueryDelegatorUnbondingDelegationsResponse(): QueryDelegatorU
   };
 }
 export const QueryDelegatorUnbondingDelegationsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsResponse',
+  typeUrl:
+    '/cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsResponse' as const,
   encode(
     message: QueryDelegatorUnbondingDelegationsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2033,7 +2037,7 @@ function createBaseQueryRedelegationsRequest(): QueryRedelegationsRequest {
   };
 }
 export const QueryRedelegationsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryRedelegationsRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryRedelegationsRequest' as const,
   encode(
     message: QueryRedelegationsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2151,7 +2155,7 @@ function createBaseQueryRedelegationsResponse(): QueryRedelegationsResponse {
   };
 }
 export const QueryRedelegationsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryRedelegationsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryRedelegationsResponse' as const,
   encode(
     message: QueryRedelegationsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2260,7 +2264,7 @@ function createBaseQueryDelegatorValidatorsRequest(): QueryDelegatorValidatorsRe
   };
 }
 export const QueryDelegatorValidatorsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorsRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorsRequest' as const,
   encode(
     message: QueryDelegatorValidatorsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2354,7 +2358,7 @@ function createBaseQueryDelegatorValidatorsResponse(): QueryDelegatorValidatorsR
   };
 }
 export const QueryDelegatorValidatorsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorsResponse' as const,
   encode(
     message: QueryDelegatorValidatorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2457,7 +2461,7 @@ function createBaseQueryDelegatorValidatorRequest(): QueryDelegatorValidatorRequ
   };
 }
 export const QueryDelegatorValidatorRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorRequest' as const,
   encode(
     message: QueryDelegatorValidatorRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2545,7 +2549,7 @@ function createBaseQueryDelegatorValidatorResponse(): QueryDelegatorValidatorRes
   };
 }
 export const QueryDelegatorValidatorResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryDelegatorValidatorResponse' as const,
   encode(
     message: QueryDelegatorValidatorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2626,7 +2630,7 @@ function createBaseQueryHistoricalInfoRequest(): QueryHistoricalInfoRequest {
   };
 }
 export const QueryHistoricalInfoRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryHistoricalInfoRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryHistoricalInfoRequest' as const,
   encode(
     message: QueryHistoricalInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2705,7 +2709,7 @@ function createBaseQueryHistoricalInfoResponse(): QueryHistoricalInfoResponse {
   };
 }
 export const QueryHistoricalInfoResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryHistoricalInfoResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryHistoricalInfoResponse' as const,
   encode(
     message: QueryHistoricalInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2784,7 +2788,7 @@ function createBaseQueryPoolRequest(): QueryPoolRequest {
   return {};
 }
 export const QueryPoolRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryPoolRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryPoolRequest' as const,
   encode(
     _: QueryPoolRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2836,7 +2840,7 @@ function createBaseQueryPoolResponse(): QueryPoolResponse {
   };
 }
 export const QueryPoolResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryPoolResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryPoolResponse' as const,
   encode(
     message: QueryPoolResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2900,7 +2904,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryParamsRequest',
+  typeUrl: '/cosmos.staking.v1beta1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2955,7 +2959,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.QueryParamsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/staking/v1beta1/staking.ts
+++ b/packages/client-utils/src/codegen/cosmos/staking/v1beta1/staking.ts
@@ -625,7 +625,7 @@ function createBaseHistoricalInfo(): HistoricalInfo {
   };
 }
 export const HistoricalInfo = {
-  typeUrl: '/cosmos.staking.v1beta1.HistoricalInfo',
+  typeUrl: '/cosmos.staking.v1beta1.HistoricalInfo' as const,
   encode(
     message: HistoricalInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -710,7 +710,7 @@ function createBaseCommissionRates(): CommissionRates {
   };
 }
 export const CommissionRates = {
-  typeUrl: '/cosmos.staking.v1beta1.CommissionRates',
+  typeUrl: '/cosmos.staking.v1beta1.CommissionRates' as const,
   encode(
     message: CommissionRates,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -801,7 +801,7 @@ function createBaseCommission(): Commission {
   };
 }
 export const Commission = {
-  typeUrl: '/cosmos.staking.v1beta1.Commission',
+  typeUrl: '/cosmos.staking.v1beta1.Commission' as const,
   encode(
     message: Commission,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -896,7 +896,7 @@ function createBaseDescription(): Description {
   };
 }
 export const Description = {
-  typeUrl: '/cosmos.staking.v1beta1.Description',
+  typeUrl: '/cosmos.staking.v1beta1.Description' as const,
   encode(
     message: Description,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1009,7 +1009,7 @@ function createBaseValidator(): Validator {
   };
 }
 export const Validator = {
-  typeUrl: '/cosmos.staking.v1beta1.Validator',
+  typeUrl: '/cosmos.staking.v1beta1.Validator' as const,
   encode(
     message: Validator,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1263,7 +1263,7 @@ function createBaseValAddresses(): ValAddresses {
   };
 }
 export const ValAddresses = {
-  typeUrl: '/cosmos.staking.v1beta1.ValAddresses',
+  typeUrl: '/cosmos.staking.v1beta1.ValAddresses' as const,
   encode(
     message: ValAddresses,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1332,7 +1332,7 @@ function createBaseDVPair(): DVPair {
   };
 }
 export const DVPair = {
-  typeUrl: '/cosmos.staking.v1beta1.DVPair',
+  typeUrl: '/cosmos.staking.v1beta1.DVPair' as const,
   encode(
     message: DVPair,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1409,7 +1409,7 @@ function createBaseDVPairs(): DVPairs {
   };
 }
 export const DVPairs = {
-  typeUrl: '/cosmos.staking.v1beta1.DVPairs',
+  typeUrl: '/cosmos.staking.v1beta1.DVPairs' as const,
   encode(
     message: DVPairs,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1479,7 +1479,7 @@ function createBaseDVVTriplet(): DVVTriplet {
   };
 }
 export const DVVTriplet = {
-  typeUrl: '/cosmos.staking.v1beta1.DVVTriplet',
+  typeUrl: '/cosmos.staking.v1beta1.DVVTriplet' as const,
   encode(
     message: DVVTriplet,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1568,7 +1568,7 @@ function createBaseDVVTriplets(): DVVTriplets {
   };
 }
 export const DVVTriplets = {
-  typeUrl: '/cosmos.staking.v1beta1.DVVTriplets',
+  typeUrl: '/cosmos.staking.v1beta1.DVVTriplets' as const,
   encode(
     message: DVVTriplets,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1641,7 +1641,7 @@ function createBaseDelegation(): Delegation {
   };
 }
 export const Delegation = {
-  typeUrl: '/cosmos.staking.v1beta1.Delegation',
+  typeUrl: '/cosmos.staking.v1beta1.Delegation' as const,
   encode(
     message: Delegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1731,7 +1731,7 @@ function createBaseUnbondingDelegation(): UnbondingDelegation {
   };
 }
 export const UnbondingDelegation = {
-  typeUrl: '/cosmos.staking.v1beta1.UnbondingDelegation',
+  typeUrl: '/cosmos.staking.v1beta1.UnbondingDelegation' as const,
   encode(
     message: UnbondingDelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1836,7 +1836,7 @@ function createBaseUnbondingDelegationEntry(): UnbondingDelegationEntry {
   };
 }
 export const UnbondingDelegationEntry = {
-  typeUrl: '/cosmos.staking.v1beta1.UnbondingDelegationEntry',
+  typeUrl: '/cosmos.staking.v1beta1.UnbondingDelegationEntry' as const,
   encode(
     message: UnbondingDelegationEntry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1994,7 +1994,7 @@ function createBaseRedelegationEntry(): RedelegationEntry {
   };
 }
 export const RedelegationEntry = {
-  typeUrl: '/cosmos.staking.v1beta1.RedelegationEntry',
+  typeUrl: '/cosmos.staking.v1beta1.RedelegationEntry' as const,
   encode(
     message: RedelegationEntry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2144,7 +2144,7 @@ function createBaseRedelegation(): Redelegation {
   };
 }
 export const Redelegation = {
-  typeUrl: '/cosmos.staking.v1beta1.Redelegation',
+  typeUrl: '/cosmos.staking.v1beta1.Redelegation' as const,
   encode(
     message: Redelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2258,7 +2258,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/cosmos.staking.v1beta1.Params',
+  typeUrl: '/cosmos.staking.v1beta1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2389,7 +2389,7 @@ function createBaseDelegationResponse(): DelegationResponse {
   };
 }
 export const DelegationResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.DelegationResponse',
+  typeUrl: '/cosmos.staking.v1beta1.DelegationResponse' as const,
   encode(
     message: DelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2480,7 +2480,7 @@ function createBaseRedelegationEntryResponse(): RedelegationEntryResponse {
   };
 }
 export const RedelegationEntryResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.RedelegationEntryResponse',
+  typeUrl: '/cosmos.staking.v1beta1.RedelegationEntryResponse' as const,
   encode(
     message: RedelegationEntryResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2578,7 +2578,7 @@ function createBaseRedelegationResponse(): RedelegationResponse {
   };
 }
 export const RedelegationResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.RedelegationResponse',
+  typeUrl: '/cosmos.staking.v1beta1.RedelegationResponse' as const,
   encode(
     message: RedelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2675,7 +2675,7 @@ function createBasePool(): Pool {
   };
 }
 export const Pool = {
-  typeUrl: '/cosmos.staking.v1beta1.Pool',
+  typeUrl: '/cosmos.staking.v1beta1.Pool' as const,
   encode(
     message: Pool,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2752,7 +2752,7 @@ function createBaseValidatorUpdates(): ValidatorUpdates {
   };
 }
 export const ValidatorUpdates = {
-  typeUrl: '/cosmos.staking.v1beta1.ValidatorUpdates',
+  typeUrl: '/cosmos.staking.v1beta1.ValidatorUpdates' as const,
   encode(
     message: ValidatorUpdates,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/staking/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/staking/v1beta1/tx.ts
@@ -283,7 +283,7 @@ function createBaseMsgCreateValidator(): MsgCreateValidator {
   };
 }
 export const MsgCreateValidator = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgCreateValidator',
+  typeUrl: '/cosmos.staking.v1beta1.MsgCreateValidator' as const,
   encode(
     message: MsgCreateValidator,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -439,7 +439,7 @@ function createBaseMsgCreateValidatorResponse(): MsgCreateValidatorResponse {
   return {};
 }
 export const MsgCreateValidatorResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgCreateValidatorResponse',
+  typeUrl: '/cosmos.staking.v1beta1.MsgCreateValidatorResponse' as const,
   encode(
     _: MsgCreateValidatorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -503,7 +503,7 @@ function createBaseMsgEditValidator(): MsgEditValidator {
   };
 }
 export const MsgEditValidator = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgEditValidator',
+  typeUrl: '/cosmos.staking.v1beta1.MsgEditValidator' as const,
   encode(
     message: MsgEditValidator,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -615,7 +615,7 @@ function createBaseMsgEditValidatorResponse(): MsgEditValidatorResponse {
   return {};
 }
 export const MsgEditValidatorResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgEditValidatorResponse',
+  typeUrl: '/cosmos.staking.v1beta1.MsgEditValidatorResponse' as const,
   encode(
     _: MsgEditValidatorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -676,7 +676,7 @@ function createBaseMsgDelegate(): MsgDelegate {
   };
 }
 export const MsgDelegate = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+  typeUrl: '/cosmos.staking.v1beta1.MsgDelegate' as const,
   encode(
     message: MsgDelegate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -764,7 +764,7 @@ function createBaseMsgDelegateResponse(): MsgDelegateResponse {
   return {};
 }
 export const MsgDelegateResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgDelegateResponse',
+  typeUrl: '/cosmos.staking.v1beta1.MsgDelegateResponse' as const,
   encode(
     _: MsgDelegateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -822,7 +822,7 @@ function createBaseMsgBeginRedelegate(): MsgBeginRedelegate {
   };
 }
 export const MsgBeginRedelegate = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegate',
+  typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegate' as const,
   encode(
     message: MsgBeginRedelegate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -927,7 +927,7 @@ function createBaseMsgBeginRedelegateResponse(): MsgBeginRedelegateResponse {
   };
 }
 export const MsgBeginRedelegateResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegateResponse',
+  typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegateResponse' as const,
   encode(
     message: MsgBeginRedelegateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1013,7 +1013,7 @@ function createBaseMsgUndelegate(): MsgUndelegate {
   };
 }
 export const MsgUndelegate = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgUndelegate',
+  typeUrl: '/cosmos.staking.v1beta1.MsgUndelegate' as const,
   encode(
     message: MsgUndelegate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1103,7 +1103,7 @@ function createBaseMsgUndelegateResponse(): MsgUndelegateResponse {
   };
 }
 export const MsgUndelegateResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgUndelegateResponse',
+  typeUrl: '/cosmos.staking.v1beta1.MsgUndelegateResponse' as const,
   encode(
     message: MsgUndelegateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1182,7 +1182,7 @@ function createBaseMsgCancelUnbondingDelegation(): MsgCancelUnbondingDelegation 
   };
 }
 export const MsgCancelUnbondingDelegation = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation',
+  typeUrl: '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation' as const,
   encode(
     message: MsgCancelUnbondingDelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1296,7 +1296,8 @@ function createBaseMsgCancelUnbondingDelegationResponse(): MsgCancelUnbondingDel
   return {};
 }
 export const MsgCancelUnbondingDelegationResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegationResponse',
+  typeUrl:
+    '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegationResponse' as const,
   encode(
     _: MsgCancelUnbondingDelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1360,7 +1361,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgUpdateParams',
+  typeUrl: '/cosmos.staking.v1beta1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1433,7 +1434,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/cosmos.staking.v1beta1.MsgUpdateParamsResponse',
+  typeUrl: '/cosmos.staking.v1beta1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/tx/config/v1/config.ts
+++ b/packages/client-utils/src/codegen/cosmos/tx/config/v1/config.ts
@@ -31,7 +31,7 @@ function createBaseConfig(): Config {
   };
 }
 export const Config = {
-  typeUrl: '/cosmos.tx.config.v1.Config',
+  typeUrl: '/cosmos.tx.config.v1.Config' as const,
   encode(
     message: Config,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/tx/signing/v1beta1/signing.ts
+++ b/packages/client-utils/src/codegen/cosmos/tx/signing/v1beta1/signing.ts
@@ -210,7 +210,7 @@ function createBaseSignatureDescriptors(): SignatureDescriptors {
   };
 }
 export const SignatureDescriptors = {
-  typeUrl: '/cosmos.tx.signing.v1beta1.SignatureDescriptors',
+  typeUrl: '/cosmos.tx.signing.v1beta1.SignatureDescriptors' as const,
   encode(
     message: SignatureDescriptors,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -288,7 +288,7 @@ function createBaseSignatureDescriptor(): SignatureDescriptor {
   };
 }
 export const SignatureDescriptor = {
-  typeUrl: '/cosmos.tx.signing.v1beta1.SignatureDescriptor',
+  typeUrl: '/cosmos.tx.signing.v1beta1.SignatureDescriptor' as const,
   encode(
     message: SignatureDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -400,7 +400,7 @@ function createBaseSignatureDescriptor_Data(): SignatureDescriptor_Data {
   };
 }
 export const SignatureDescriptor_Data = {
-  typeUrl: '/cosmos.tx.signing.v1beta1.Data',
+  typeUrl: '/cosmos.tx.signing.v1beta1.Data' as const,
   encode(
     message: SignatureDescriptor_Data,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -511,7 +511,7 @@ function createBaseSignatureDescriptor_Data_Single(): SignatureDescriptor_Data_S
   };
 }
 export const SignatureDescriptor_Data_Single = {
-  typeUrl: '/cosmos.tx.signing.v1beta1.Single',
+  typeUrl: '/cosmos.tx.signing.v1beta1.Single' as const,
   encode(
     message: SignatureDescriptor_Data_Single,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -599,7 +599,7 @@ function createBaseSignatureDescriptor_Data_Multi(): SignatureDescriptor_Data_Mu
   };
 }
 export const SignatureDescriptor_Data_Multi = {
-  typeUrl: '/cosmos.tx.signing.v1beta1.Multi',
+  typeUrl: '/cosmos.tx.signing.v1beta1.Multi' as const,
   encode(
     message: SignatureDescriptor_Data_Multi,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/tx/v1beta1/service.ts
+++ b/packages/client-utils/src/codegen/cosmos/tx/v1beta1/service.ts
@@ -565,7 +565,7 @@ function createBaseGetTxsEventRequest(): GetTxsEventRequest {
   };
 }
 export const GetTxsEventRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.GetTxsEventRequest',
+  typeUrl: '/cosmos.tx.v1beta1.GetTxsEventRequest' as const,
   encode(
     message: GetTxsEventRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -692,7 +692,7 @@ function createBaseGetTxsEventResponse(): GetTxsEventResponse {
   };
 }
 export const GetTxsEventResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.GetTxsEventResponse',
+  typeUrl: '/cosmos.tx.v1beta1.GetTxsEventResponse' as const,
   encode(
     message: GetTxsEventResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -815,7 +815,7 @@ function createBaseBroadcastTxRequest(): BroadcastTxRequest {
   };
 }
 export const BroadcastTxRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.BroadcastTxRequest',
+  typeUrl: '/cosmos.tx.v1beta1.BroadcastTxRequest' as const,
   encode(
     message: BroadcastTxRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -895,7 +895,7 @@ function createBaseBroadcastTxResponse(): BroadcastTxResponse {
   };
 }
 export const BroadcastTxResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.BroadcastTxResponse',
+  typeUrl: '/cosmos.tx.v1beta1.BroadcastTxResponse' as const,
   encode(
     message: BroadcastTxResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -969,7 +969,7 @@ function createBaseSimulateRequest(): SimulateRequest {
   };
 }
 export const SimulateRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.SimulateRequest',
+  typeUrl: '/cosmos.tx.v1beta1.SimulateRequest' as const,
   encode(
     message: SimulateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1050,7 +1050,7 @@ function createBaseSimulateResponse(): SimulateResponse {
   };
 }
 export const SimulateResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.SimulateResponse',
+  typeUrl: '/cosmos.tx.v1beta1.SimulateResponse' as const,
   encode(
     message: SimulateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1133,7 +1133,7 @@ function createBaseGetTxRequest(): GetTxRequest {
   };
 }
 export const GetTxRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.GetTxRequest',
+  typeUrl: '/cosmos.tx.v1beta1.GetTxRequest' as const,
   encode(
     message: GetTxRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1196,7 +1196,7 @@ function createBaseGetTxResponse(): GetTxResponse {
   };
 }
 export const GetTxResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.GetTxResponse',
+  typeUrl: '/cosmos.tx.v1beta1.GetTxResponse' as const,
   encode(
     message: GetTxResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1280,7 +1280,7 @@ function createBaseGetBlockWithTxsRequest(): GetBlockWithTxsRequest {
   };
 }
 export const GetBlockWithTxsRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.GetBlockWithTxsRequest',
+  typeUrl: '/cosmos.tx.v1beta1.GetBlockWithTxsRequest' as const,
   encode(
     message: GetBlockWithTxsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1373,7 +1373,7 @@ function createBaseGetBlockWithTxsResponse(): GetBlockWithTxsResponse {
   };
 }
 export const GetBlockWithTxsResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.GetBlockWithTxsResponse',
+  typeUrl: '/cosmos.tx.v1beta1.GetBlockWithTxsResponse' as const,
   encode(
     message: GetBlockWithTxsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1500,7 +1500,7 @@ function createBaseTxDecodeRequest(): TxDecodeRequest {
   };
 }
 export const TxDecodeRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.TxDecodeRequest',
+  typeUrl: '/cosmos.tx.v1beta1.TxDecodeRequest' as const,
   encode(
     message: TxDecodeRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1567,7 +1567,7 @@ function createBaseTxDecodeResponse(): TxDecodeResponse {
   };
 }
 export const TxDecodeResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.TxDecodeResponse',
+  typeUrl: '/cosmos.tx.v1beta1.TxDecodeResponse' as const,
   encode(
     message: TxDecodeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1633,7 +1633,7 @@ function createBaseTxEncodeRequest(): TxEncodeRequest {
   };
 }
 export const TxEncodeRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.TxEncodeRequest',
+  typeUrl: '/cosmos.tx.v1beta1.TxEncodeRequest' as const,
   encode(
     message: TxEncodeRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1699,7 +1699,7 @@ function createBaseTxEncodeResponse(): TxEncodeResponse {
   };
 }
 export const TxEncodeResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.TxEncodeResponse',
+  typeUrl: '/cosmos.tx.v1beta1.TxEncodeResponse' as const,
   encode(
     message: TxEncodeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1766,7 +1766,7 @@ function createBaseTxEncodeAminoRequest(): TxEncodeAminoRequest {
   };
 }
 export const TxEncodeAminoRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.TxEncodeAminoRequest',
+  typeUrl: '/cosmos.tx.v1beta1.TxEncodeAminoRequest' as const,
   encode(
     message: TxEncodeAminoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1831,7 +1831,7 @@ function createBaseTxEncodeAminoResponse(): TxEncodeAminoResponse {
   };
 }
 export const TxEncodeAminoResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.TxEncodeAminoResponse',
+  typeUrl: '/cosmos.tx.v1beta1.TxEncodeAminoResponse' as const,
   encode(
     message: TxEncodeAminoResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1903,7 +1903,7 @@ function createBaseTxDecodeAminoRequest(): TxDecodeAminoRequest {
   };
 }
 export const TxDecodeAminoRequest = {
-  typeUrl: '/cosmos.tx.v1beta1.TxDecodeAminoRequest',
+  typeUrl: '/cosmos.tx.v1beta1.TxDecodeAminoRequest' as const,
   encode(
     message: TxDecodeAminoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1975,7 +1975,7 @@ function createBaseTxDecodeAminoResponse(): TxDecodeAminoResponse {
   };
 }
 export const TxDecodeAminoResponse = {
-  typeUrl: '/cosmos.tx.v1beta1.TxDecodeAminoResponse',
+  typeUrl: '/cosmos.tx.v1beta1.TxDecodeAminoResponse' as const,
   encode(
     message: TxDecodeAminoResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/tx/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/tx/v1beta1/tx.ts
@@ -465,7 +465,7 @@ function createBaseTx(): Tx {
   };
 }
 export const Tx = {
-  typeUrl: '/cosmos.tx.v1beta1.Tx',
+  typeUrl: '/cosmos.tx.v1beta1.Tx' as const,
   encode(
     message: Tx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -567,7 +567,7 @@ function createBaseTxRaw(): TxRaw {
   };
 }
 export const TxRaw = {
-  typeUrl: '/cosmos.tx.v1beta1.TxRaw',
+  typeUrl: '/cosmos.tx.v1beta1.TxRaw' as const,
   encode(
     message: TxRaw,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -670,7 +670,7 @@ function createBaseSignDoc(): SignDoc {
   };
 }
 export const SignDoc = {
-  typeUrl: '/cosmos.tx.v1beta1.SignDoc',
+  typeUrl: '/cosmos.tx.v1beta1.SignDoc' as const,
   encode(
     message: SignDoc,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -782,7 +782,7 @@ function createBaseSignDocDirectAux(): SignDocDirectAux {
   };
 }
 export const SignDocDirectAux = {
-  typeUrl: '/cosmos.tx.v1beta1.SignDocDirectAux',
+  typeUrl: '/cosmos.tx.v1beta1.SignDocDirectAux' as const,
   encode(
     message: SignDocDirectAux,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -922,7 +922,7 @@ function createBaseTxBody(): TxBody {
   };
 }
 export const TxBody = {
-  typeUrl: '/cosmos.tx.v1beta1.TxBody',
+  typeUrl: '/cosmos.tx.v1beta1.TxBody' as const,
   encode(
     message: TxBody,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1056,7 +1056,7 @@ function createBaseAuthInfo(): AuthInfo {
   };
 }
 export const AuthInfo = {
-  typeUrl: '/cosmos.tx.v1beta1.AuthInfo',
+  typeUrl: '/cosmos.tx.v1beta1.AuthInfo' as const,
   encode(
     message: AuthInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1155,7 +1155,7 @@ function createBaseSignerInfo(): SignerInfo {
   };
 }
 export const SignerInfo = {
-  typeUrl: '/cosmos.tx.v1beta1.SignerInfo',
+  typeUrl: '/cosmos.tx.v1beta1.SignerInfo' as const,
   encode(
     message: SignerInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1258,7 +1258,7 @@ function createBaseModeInfo(): ModeInfo {
   };
 }
 export const ModeInfo = {
-  typeUrl: '/cosmos.tx.v1beta1.ModeInfo',
+  typeUrl: '/cosmos.tx.v1beta1.ModeInfo' as const,
   encode(
     message: ModeInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1345,7 +1345,7 @@ function createBaseModeInfo_Single(): ModeInfo_Single {
   };
 }
 export const ModeInfo_Single = {
-  typeUrl: '/cosmos.tx.v1beta1.Single',
+  typeUrl: '/cosmos.tx.v1beta1.Single' as const,
   encode(
     message: ModeInfo_Single,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1408,7 +1408,7 @@ function createBaseModeInfo_Multi(): ModeInfo_Multi {
   };
 }
 export const ModeInfo_Multi = {
-  typeUrl: '/cosmos.tx.v1beta1.Multi',
+  typeUrl: '/cosmos.tx.v1beta1.Multi' as const,
   encode(
     message: ModeInfo_Multi,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1502,7 +1502,7 @@ function createBaseFee(): Fee {
   };
 }
 export const Fee = {
-  typeUrl: '/cosmos.tx.v1beta1.Fee',
+  typeUrl: '/cosmos.tx.v1beta1.Fee' as const,
   encode(
     message: Fee,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1604,7 +1604,7 @@ function createBaseTip(): Tip {
   };
 }
 export const Tip = {
-  typeUrl: '/cosmos.tx.v1beta1.Tip',
+  typeUrl: '/cosmos.tx.v1beta1.Tip' as const,
   encode(
     message: Tip,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1684,7 +1684,7 @@ function createBaseAuxSignerData(): AuxSignerData {
   };
 }
 export const AuxSignerData = {
-  typeUrl: '/cosmos.tx.v1beta1.AuxSignerData',
+  typeUrl: '/cosmos.tx.v1beta1.AuxSignerData' as const,
   encode(
     message: AuxSignerData,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/upgrade/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/upgrade/module/v1/module.ts
@@ -21,7 +21,7 @@ function createBaseModule(): Module {
   };
 }
 export const Module = {
-  typeUrl: '/cosmos.upgrade.module.v1.Module',
+  typeUrl: '/cosmos.upgrade.module.v1.Module' as const,
   encode(
     message: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/upgrade/v1beta1/query.ts
+++ b/packages/client-utils/src/codegen/cosmos/upgrade/v1beta1/query.ts
@@ -216,7 +216,7 @@ function createBaseQueryCurrentPlanRequest(): QueryCurrentPlanRequest {
   return {};
 }
 export const QueryCurrentPlanRequest = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryCurrentPlanRequest',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryCurrentPlanRequest' as const,
   encode(
     _: QueryCurrentPlanRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -275,7 +275,7 @@ function createBaseQueryCurrentPlanResponse(): QueryCurrentPlanResponse {
   };
 }
 export const QueryCurrentPlanResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryCurrentPlanResponse',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryCurrentPlanResponse' as const,
   encode(
     message: QueryCurrentPlanResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -352,7 +352,7 @@ function createBaseQueryAppliedPlanRequest(): QueryAppliedPlanRequest {
   };
 }
 export const QueryAppliedPlanRequest = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryAppliedPlanRequest',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryAppliedPlanRequest' as const,
   encode(
     message: QueryAppliedPlanRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -423,7 +423,7 @@ function createBaseQueryAppliedPlanResponse(): QueryAppliedPlanResponse {
   };
 }
 export const QueryAppliedPlanResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryAppliedPlanResponse',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryAppliedPlanResponse' as const,
   encode(
     message: QueryAppliedPlanResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -502,7 +502,8 @@ function createBaseQueryUpgradedConsensusStateRequest(): QueryUpgradedConsensusS
   };
 }
 export const QueryUpgradedConsensusStateRequest = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateRequest',
+  typeUrl:
+    '/cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateRequest' as const,
   encode(
     message: QueryUpgradedConsensusStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -581,7 +582,8 @@ function createBaseQueryUpgradedConsensusStateResponse(): QueryUpgradedConsensus
   };
 }
 export const QueryUpgradedConsensusStateResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateResponse',
+  typeUrl:
+    '/cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateResponse' as const,
   encode(
     message: QueryUpgradedConsensusStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -662,7 +664,7 @@ function createBaseQueryModuleVersionsRequest(): QueryModuleVersionsRequest {
   };
 }
 export const QueryModuleVersionsRequest = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryModuleVersionsRequest',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryModuleVersionsRequest' as const,
   encode(
     message: QueryModuleVersionsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -735,7 +737,7 @@ function createBaseQueryModuleVersionsResponse(): QueryModuleVersionsResponse {
   };
 }
 export const QueryModuleVersionsResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryModuleVersionsResponse',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryModuleVersionsResponse' as const,
   encode(
     message: QueryModuleVersionsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -817,7 +819,7 @@ function createBaseQueryAuthorityRequest(): QueryAuthorityRequest {
   return {};
 }
 export const QueryAuthorityRequest = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryAuthorityRequest',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryAuthorityRequest' as const,
   encode(
     _: QueryAuthorityRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -872,7 +874,7 @@ function createBaseQueryAuthorityResponse(): QueryAuthorityResponse {
   };
 }
 export const QueryAuthorityResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.QueryAuthorityResponse',
+  typeUrl: '/cosmos.upgrade.v1beta1.QueryAuthorityResponse' as const,
   encode(
     message: QueryAuthorityResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/upgrade/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/upgrade/v1beta1/tx.ts
@@ -87,7 +87,7 @@ function createBaseMsgSoftwareUpgrade(): MsgSoftwareUpgrade {
   };
 }
 export const MsgSoftwareUpgrade = {
-  typeUrl: '/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade',
+  typeUrl: '/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade' as const,
   encode(
     message: MsgSoftwareUpgrade,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -163,7 +163,7 @@ function createBaseMsgSoftwareUpgradeResponse(): MsgSoftwareUpgradeResponse {
   return {};
 }
 export const MsgSoftwareUpgradeResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.MsgSoftwareUpgradeResponse',
+  typeUrl: '/cosmos.upgrade.v1beta1.MsgSoftwareUpgradeResponse' as const,
   encode(
     _: MsgSoftwareUpgradeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -224,7 +224,7 @@ function createBaseMsgCancelUpgrade(): MsgCancelUpgrade {
   };
 }
 export const MsgCancelUpgrade = {
-  typeUrl: '/cosmos.upgrade.v1beta1.MsgCancelUpgrade',
+  typeUrl: '/cosmos.upgrade.v1beta1.MsgCancelUpgrade' as const,
   encode(
     message: MsgCancelUpgrade,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -284,7 +284,7 @@ function createBaseMsgCancelUpgradeResponse(): MsgCancelUpgradeResponse {
   return {};
 }
 export const MsgCancelUpgradeResponse = {
-  typeUrl: '/cosmos.upgrade.v1beta1.MsgCancelUpgradeResponse',
+  typeUrl: '/cosmos.upgrade.v1beta1.MsgCancelUpgradeResponse' as const,
   encode(
     _: MsgCancelUpgradeResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/upgrade/v1beta1/upgrade.ts
+++ b/packages/client-utils/src/codegen/cosmos/upgrade/v1beta1/upgrade.ts
@@ -148,7 +148,7 @@ function createBasePlan(): Plan {
   };
 }
 export const Plan = {
-  typeUrl: '/cosmos.upgrade.v1beta1.Plan',
+  typeUrl: '/cosmos.upgrade.v1beta1.Plan' as const,
   encode(
     message: Plan,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -270,7 +270,7 @@ function createBaseSoftwareUpgradeProposal(): SoftwareUpgradeProposal {
   };
 }
 export const SoftwareUpgradeProposal = {
-  typeUrl: '/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal',
+  typeUrl: '/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal' as const,
   encode(
     message: SoftwareUpgradeProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -365,7 +365,7 @@ function createBaseCancelSoftwareUpgradeProposal(): CancelSoftwareUpgradeProposa
   };
 }
 export const CancelSoftwareUpgradeProposal = {
-  typeUrl: '/cosmos.upgrade.v1beta1.CancelSoftwareUpgradeProposal',
+  typeUrl: '/cosmos.upgrade.v1beta1.CancelSoftwareUpgradeProposal' as const,
   encode(
     message: CancelSoftwareUpgradeProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -449,7 +449,7 @@ function createBaseModuleVersion(): ModuleVersion {
   };
 }
 export const ModuleVersion = {
-  typeUrl: '/cosmos.upgrade.v1beta1.ModuleVersion',
+  typeUrl: '/cosmos.upgrade.v1beta1.ModuleVersion' as const,
   encode(
     message: ModuleVersion,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/vesting/module/v1/module.ts
+++ b/packages/client-utils/src/codegen/cosmos/vesting/module/v1/module.ts
@@ -13,7 +13,7 @@ function createBaseModule(): Module {
   return {};
 }
 export const Module = {
-  typeUrl: '/cosmos.vesting.module.v1.Module',
+  typeUrl: '/cosmos.vesting.module.v1.Module' as const,
   encode(
     _: Module,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/vesting/v1beta1/tx.ts
+++ b/packages/client-utils/src/codegen/cosmos/vesting/v1beta1/tx.ts
@@ -248,7 +248,7 @@ function createBaseMsgCreateVestingAccount(): MsgCreateVestingAccount {
   };
 }
 export const MsgCreateVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateVestingAccount' as const,
   encode(
     message: MsgCreateVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -366,7 +366,7 @@ function createBaseMsgCreateVestingAccountResponse(): MsgCreateVestingAccountRes
   return {};
 }
 export const MsgCreateVestingAccountResponse = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateVestingAccountResponse',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateVestingAccountResponse' as const,
   encode(
     _: MsgCreateVestingAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -431,7 +431,7 @@ function createBaseMsgCreatePermanentLockedAccount(): MsgCreatePermanentLockedAc
   };
 }
 export const MsgCreatePermanentLockedAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccount' as const,
   encode(
     message: MsgCreatePermanentLockedAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -527,7 +527,8 @@ function createBaseMsgCreatePermanentLockedAccountResponse(): MsgCreatePermanent
   return {};
 }
 export const MsgCreatePermanentLockedAccountResponse = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccountResponse',
+  typeUrl:
+    '/cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccountResponse' as const,
   encode(
     _: MsgCreatePermanentLockedAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -595,7 +596,7 @@ function createBaseMsgCreatePeriodicVestingAccount(): MsgCreatePeriodicVestingAc
   };
 }
 export const MsgCreatePeriodicVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccount' as const,
   encode(
     message: MsgCreatePeriodicVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -718,7 +719,8 @@ function createBaseMsgCreatePeriodicVestingAccountResponse(): MsgCreatePeriodicV
   return {};
 }
 export const MsgCreatePeriodicVestingAccountResponse = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccountResponse',
+  typeUrl:
+    '/cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccountResponse' as const,
   encode(
     _: MsgCreatePeriodicVestingAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -787,7 +789,7 @@ function createBaseMsgCreateClawbackVestingAccount(): MsgCreateClawbackVestingAc
   };
 }
 export const MsgCreateClawbackVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateClawbackVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateClawbackVestingAccount' as const,
   encode(
     message: MsgCreateClawbackVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -928,7 +930,8 @@ function createBaseMsgCreateClawbackVestingAccountResponse(): MsgCreateClawbackV
   return {};
 }
 export const MsgCreateClawbackVestingAccountResponse = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgCreateClawbackVestingAccountResponse',
+  typeUrl:
+    '/cosmos.vesting.v1beta1.MsgCreateClawbackVestingAccountResponse' as const,
   encode(
     _: MsgCreateClawbackVestingAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -994,7 +997,7 @@ function createBaseMsgClawback(): MsgClawback {
   };
 }
 export const MsgClawback = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgClawback',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgClawback' as const,
   encode(
     message: MsgClawback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1076,7 +1079,7 @@ function createBaseMsgClawbackResponse(): MsgClawbackResponse {
   return {};
 }
 export const MsgClawbackResponse = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgClawbackResponse',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgClawbackResponse' as const,
   encode(
     _: MsgClawbackResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1131,7 +1134,7 @@ function createBaseMsgReturnGrants(): MsgReturnGrants {
   };
 }
 export const MsgReturnGrants = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgReturnGrants',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgReturnGrants' as const,
   encode(
     message: MsgReturnGrants,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1191,7 +1194,7 @@ function createBaseMsgReturnGrantsResponse(): MsgReturnGrantsResponse {
   return {};
 }
 export const MsgReturnGrantsResponse = {
-  typeUrl: '/cosmos.vesting.v1beta1.MsgReturnGrantsResponse',
+  typeUrl: '/cosmos.vesting.v1beta1.MsgReturnGrantsResponse' as const,
   encode(
     _: MsgReturnGrantsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos/vesting/v1beta1/vesting.ts
+++ b/packages/client-utils/src/codegen/cosmos/vesting/v1beta1/vesting.ts
@@ -189,7 +189,7 @@ function createBaseBaseVestingAccount(): BaseVestingAccount {
   };
 }
 export const BaseVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.BaseVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.BaseVestingAccount' as const,
   encode(
     message: BaseVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -335,7 +335,7 @@ function createBaseContinuousVestingAccount(): ContinuousVestingAccount {
   };
 }
 export const ContinuousVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.ContinuousVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.ContinuousVestingAccount' as const,
   encode(
     message: ContinuousVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -438,7 +438,7 @@ function createBaseDelayedVestingAccount(): DelayedVestingAccount {
   };
 }
 export const DelayedVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.DelayedVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.DelayedVestingAccount' as const,
   encode(
     message: DelayedVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -519,7 +519,7 @@ function createBasePeriod(): Period {
   };
 }
 export const Period = {
-  typeUrl: '/cosmos.vesting.v1beta1.Period',
+  typeUrl: '/cosmos.vesting.v1beta1.Period' as const,
   encode(
     message: Period,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -604,7 +604,7 @@ function createBasePeriodicVestingAccount(): PeriodicVestingAccount {
   };
 }
 export const PeriodicVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.PeriodicVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.PeriodicVestingAccount' as const,
   encode(
     message: PeriodicVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -719,7 +719,7 @@ function createBasePermanentLockedAccount(): PermanentLockedAccount {
   };
 }
 export const PermanentLockedAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.PermanentLockedAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.PermanentLockedAccount' as const,
   encode(
     message: PermanentLockedAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -805,7 +805,7 @@ function createBaseClawbackVestingAccount(): ClawbackVestingAccount {
   };
 }
 export const ClawbackVestingAccount = {
-  typeUrl: '/cosmos.vesting.v1beta1.ClawbackVestingAccount',
+  typeUrl: '/cosmos.vesting.v1beta1.ClawbackVestingAccount' as const,
   encode(
     message: ClawbackVestingAccount,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/cosmos_proto/cosmos.ts
+++ b/packages/client-utils/src/codegen/cosmos_proto/cosmos.ts
@@ -125,7 +125,7 @@ function createBaseInterfaceDescriptor(): InterfaceDescriptor {
   };
 }
 export const InterfaceDescriptor = {
-  typeUrl: '/cosmos_proto.InterfaceDescriptor',
+  typeUrl: '/cosmos_proto.InterfaceDescriptor' as const,
   encode(
     message: InterfaceDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -202,7 +202,7 @@ function createBaseScalarDescriptor(): ScalarDescriptor {
   };
 }
 export const ScalarDescriptor = {
-  typeUrl: '/cosmos_proto.ScalarDescriptor',
+  typeUrl: '/cosmos_proto.ScalarDescriptor' as const,
   encode(
     message: ScalarDescriptor,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/google/api/http.ts
+++ b/packages/client-utils/src/codegen/google/api/http.ts
@@ -677,7 +677,7 @@ function createBaseHttp(): Http {
   };
 }
 export const Http = {
-  typeUrl: '/google.api.Http',
+  typeUrl: '/google.api.Http' as const,
   encode(
     message: Http,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -767,7 +767,7 @@ function createBaseHttpRule(): HttpRule {
   };
 }
 export const HttpRule = {
-  typeUrl: '/google.api.HttpRule',
+  typeUrl: '/google.api.HttpRule' as const,
   encode(
     message: HttpRule,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -936,7 +936,7 @@ function createBaseCustomHttpPattern(): CustomHttpPattern {
   };
 }
 export const CustomHttpPattern = {
-  typeUrl: '/google.api.CustomHttpPattern',
+  typeUrl: '/google.api.CustomHttpPattern' as const,
   encode(
     message: CustomHttpPattern,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/google/protobuf/any.ts
+++ b/packages/client-utils/src/codegen/google/protobuf/any.ts
@@ -224,7 +224,7 @@ function createBaseAny(): Any {
   };
 }
 export const Any = {
-  typeUrl: '/google.protobuf.Any',
+  typeUrl: '/google.protobuf.Any' as const,
   encode(
     message: Any,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/google/protobuf/descriptor.ts
+++ b/packages/client-utils/src/codegen/google/protobuf/descriptor.ts
@@ -1411,7 +1411,7 @@ function createBaseFileDescriptorSet(): FileDescriptorSet {
   };
 }
 export const FileDescriptorSet = {
-  typeUrl: '/google.protobuf.FileDescriptorSet',
+  typeUrl: '/google.protobuf.FileDescriptorSet' as const,
   encode(
     message: FileDescriptorSet,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1495,7 +1495,7 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
   };
 }
 export const FileDescriptorProto = {
-  typeUrl: '/google.protobuf.FileDescriptorProto',
+  typeUrl: '/google.protobuf.FileDescriptorProto' as const,
   encode(
     message: FileDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1770,7 +1770,7 @@ function createBaseDescriptorProto(): DescriptorProto {
   };
 }
 export const DescriptorProto = {
-  typeUrl: '/google.protobuf.DescriptorProto',
+  typeUrl: '/google.protobuf.DescriptorProto' as const,
   encode(
     message: DescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2020,7 +2020,7 @@ function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRa
   };
 }
 export const DescriptorProto_ExtensionRange = {
-  typeUrl: '/google.protobuf.ExtensionRange',
+  typeUrl: '/google.protobuf.ExtensionRange' as const,
   encode(
     message: DescriptorProto_ExtensionRange,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2126,7 +2126,7 @@ function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRang
   };
 }
 export const DescriptorProto_ReservedRange = {
-  typeUrl: '/google.protobuf.ReservedRange',
+  typeUrl: '/google.protobuf.ReservedRange' as const,
   encode(
     message: DescriptorProto_ReservedRange,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2208,7 +2208,7 @@ function createBaseExtensionRangeOptions(): ExtensionRangeOptions {
   };
 }
 export const ExtensionRangeOptions = {
-  typeUrl: '/google.protobuf.ExtensionRangeOptions',
+  typeUrl: '/google.protobuf.ExtensionRangeOptions' as const,
   encode(
     message: ExtensionRangeOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2297,7 +2297,7 @@ function createBaseFieldDescriptorProto(): FieldDescriptorProto {
   };
 }
 export const FieldDescriptorProto = {
-  typeUrl: '/google.protobuf.FieldDescriptorProto',
+  typeUrl: '/google.protobuf.FieldDescriptorProto' as const,
   encode(
     message: FieldDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2462,7 +2462,7 @@ function createBaseOneofDescriptorProto(): OneofDescriptorProto {
   };
 }
 export const OneofDescriptorProto = {
-  typeUrl: '/google.protobuf.OneofDescriptorProto',
+  typeUrl: '/google.protobuf.OneofDescriptorProto' as const,
   encode(
     message: OneofDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2548,7 +2548,7 @@ function createBaseEnumDescriptorProto(): EnumDescriptorProto {
   };
 }
 export const EnumDescriptorProto = {
-  typeUrl: '/google.protobuf.EnumDescriptorProto',
+  typeUrl: '/google.protobuf.EnumDescriptorProto' as const,
   encode(
     message: EnumDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2696,7 +2696,7 @@ function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_
   };
 }
 export const EnumDescriptorProto_EnumReservedRange = {
-  typeUrl: '/google.protobuf.EnumReservedRange',
+  typeUrl: '/google.protobuf.EnumReservedRange' as const,
   encode(
     message: EnumDescriptorProto_EnumReservedRange,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2780,7 +2780,7 @@ function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
   };
 }
 export const EnumValueDescriptorProto = {
-  typeUrl: '/google.protobuf.EnumValueDescriptorProto',
+  typeUrl: '/google.protobuf.EnumValueDescriptorProto' as const,
   encode(
     message: EnumValueDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2884,7 +2884,7 @@ function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
   };
 }
 export const ServiceDescriptorProto = {
-  typeUrl: '/google.protobuf.ServiceDescriptorProto',
+  typeUrl: '/google.protobuf.ServiceDescriptorProto' as const,
   encode(
     message: ServiceDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2993,7 +2993,7 @@ function createBaseMethodDescriptorProto(): MethodDescriptorProto {
   };
 }
 export const MethodDescriptorProto = {
-  typeUrl: '/google.protobuf.MethodDescriptorProto',
+  typeUrl: '/google.protobuf.MethodDescriptorProto' as const,
   encode(
     message: MethodDescriptorProto,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3137,7 +3137,7 @@ function createBaseFileOptions(): FileOptions {
   };
 }
 export const FileOptions = {
-  typeUrl: '/google.protobuf.FileOptions',
+  typeUrl: '/google.protobuf.FileOptions' as const,
   encode(
     message: FileOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3447,7 +3447,7 @@ function createBaseMessageOptions(): MessageOptions {
   };
 }
 export const MessageOptions = {
-  typeUrl: '/google.protobuf.MessageOptions',
+  typeUrl: '/google.protobuf.MessageOptions' as const,
   encode(
     message: MessageOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3573,7 +3573,7 @@ function createBaseFieldOptions(): FieldOptions {
   };
 }
 export const FieldOptions = {
-  typeUrl: '/google.protobuf.FieldOptions',
+  typeUrl: '/google.protobuf.FieldOptions' as const,
   encode(
     message: FieldOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3710,7 +3710,7 @@ function createBaseOneofOptions(): OneofOptions {
   };
 }
 export const OneofOptions = {
-  typeUrl: '/google.protobuf.OneofOptions',
+  typeUrl: '/google.protobuf.OneofOptions' as const,
   encode(
     message: OneofOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3789,7 +3789,7 @@ function createBaseEnumOptions(): EnumOptions {
   };
 }
 export const EnumOptions = {
-  typeUrl: '/google.protobuf.EnumOptions',
+  typeUrl: '/google.protobuf.EnumOptions' as const,
   encode(
     message: EnumOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3885,7 +3885,7 @@ function createBaseEnumValueOptions(): EnumValueOptions {
   };
 }
 export const EnumValueOptions = {
-  typeUrl: '/google.protobuf.EnumValueOptions',
+  typeUrl: '/google.protobuf.EnumValueOptions' as const,
   encode(
     message: EnumValueOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3972,7 +3972,7 @@ function createBaseServiceOptions(): ServiceOptions {
   };
 }
 export const ServiceOptions = {
-  typeUrl: '/google.protobuf.ServiceOptions',
+  typeUrl: '/google.protobuf.ServiceOptions' as const,
   encode(
     message: ServiceOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4060,7 +4060,7 @@ function createBaseMethodOptions(): MethodOptions {
   };
 }
 export const MethodOptions = {
-  typeUrl: '/google.protobuf.MethodOptions',
+  typeUrl: '/google.protobuf.MethodOptions' as const,
   encode(
     message: MethodOptions,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4166,7 +4166,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
   };
 }
 export const UninterpretedOption = {
-  typeUrl: '/google.protobuf.UninterpretedOption',
+  typeUrl: '/google.protobuf.UninterpretedOption' as const,
   encode(
     message: UninterpretedOption,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4330,7 +4330,7 @@ function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart 
   };
 }
 export const UninterpretedOption_NamePart = {
-  typeUrl: '/google.protobuf.NamePart',
+  typeUrl: '/google.protobuf.NamePart' as const,
   encode(
     message: UninterpretedOption_NamePart,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4415,7 +4415,7 @@ function createBaseSourceCodeInfo(): SourceCodeInfo {
   };
 }
 export const SourceCodeInfo = {
-  typeUrl: '/google.protobuf.SourceCodeInfo',
+  typeUrl: '/google.protobuf.SourceCodeInfo' as const,
   encode(
     message: SourceCodeInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4492,7 +4492,7 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
   };
 }
 export const SourceCodeInfo_Location = {
-  typeUrl: '/google.protobuf.Location',
+  typeUrl: '/google.protobuf.Location' as const,
   encode(
     message: SourceCodeInfo_Location,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4642,7 +4642,7 @@ function createBaseGeneratedCodeInfo(): GeneratedCodeInfo {
   };
 }
 export const GeneratedCodeInfo = {
-  typeUrl: '/google.protobuf.GeneratedCodeInfo',
+  typeUrl: '/google.protobuf.GeneratedCodeInfo' as const,
   encode(
     message: GeneratedCodeInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4725,7 +4725,7 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
   };
 }
 export const GeneratedCodeInfo_Annotation = {
-  typeUrl: '/google.protobuf.Annotation',
+  typeUrl: '/google.protobuf.Annotation' as const,
   encode(
     message: GeneratedCodeInfo_Annotation,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/google/protobuf/duration.ts
+++ b/packages/client-utils/src/codegen/google/protobuf/duration.ts
@@ -154,7 +154,7 @@ function createBaseDuration(): Duration {
   };
 }
 export const Duration = {
-  typeUrl: '/google.protobuf.Duration',
+  typeUrl: '/google.protobuf.Duration' as const,
   encode(
     message: Duration,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/google/protobuf/empty.ts
+++ b/packages/client-utils/src/codegen/google/protobuf/empty.ts
@@ -33,7 +33,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 export const Empty = {
-  typeUrl: '/google.protobuf.Empty',
+  typeUrl: '/google.protobuf.Empty' as const,
   encode(_: Empty, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
     return writer;
   },

--- a/packages/client-utils/src/codegen/google/protobuf/timestamp.ts
+++ b/packages/client-utils/src/codegen/google/protobuf/timestamp.ts
@@ -200,7 +200,7 @@ function createBaseTimestamp(): Timestamp {
   };
 }
 export const Timestamp = {
-  typeUrl: '/google.protobuf.Timestamp',
+  typeUrl: '/google.protobuf.Timestamp' as const,
   encode(
     message: Timestamp,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/controller/v1/controller.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/controller/v1/controller.ts
@@ -27,7 +27,8 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/ibc.applications.interchain_accounts.controller.v1.Params',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.controller.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/controller/v1/query.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/controller/v1/query.ts
@@ -58,7 +58,7 @@ function createBaseQueryInterchainAccountRequest(): QueryInterchainAccountReques
 }
 export const QueryInterchainAccountRequest = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.QueryInterchainAccountRequest',
+    '/ibc.applications.interchain_accounts.controller.v1.QueryInterchainAccountRequest' as const,
   encode(
     message: QueryInterchainAccountRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -145,7 +145,7 @@ function createBaseQueryInterchainAccountResponse(): QueryInterchainAccountRespo
 }
 export const QueryInterchainAccountResponse = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.QueryInterchainAccountResponse',
+    '/ibc.applications.interchain_accounts.controller.v1.QueryInterchainAccountResponse' as const,
   encode(
     message: QueryInterchainAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -218,7 +218,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
 }
 export const QueryParamsRequest = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.QueryParamsRequest',
+    '/ibc.applications.interchain_accounts.controller.v1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -275,7 +275,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
 }
 export const QueryParamsResponse = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.QueryParamsResponse',
+    '/ibc.applications.interchain_accounts.controller.v1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/controller/v1/tx.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/controller/v1/tx.ts
@@ -87,7 +87,7 @@ function createBaseMsgRegisterInterchainAccount(): MsgRegisterInterchainAccount 
 }
 export const MsgRegisterInterchainAccount = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccount',
+    '/ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccount' as const,
   encode(
     message: MsgRegisterInterchainAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -194,7 +194,7 @@ function createBaseMsgRegisterInterchainAccountResponse(): MsgRegisterInterchain
 }
 export const MsgRegisterInterchainAccountResponse = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccountResponse',
+    '/ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccountResponse' as const,
   encode(
     message: MsgRegisterInterchainAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -280,7 +280,8 @@ function createBaseMsgSendTx(): MsgSendTx {
   };
 }
 export const MsgSendTx = {
-  typeUrl: '/ibc.applications.interchain_accounts.controller.v1.MsgSendTx',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.controller.v1.MsgSendTx' as const,
   encode(
     message: MsgSendTx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -393,7 +394,7 @@ function createBaseMsgSendTxResponse(): MsgSendTxResponse {
 }
 export const MsgSendTxResponse = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.controller.v1.MsgSendTxResponse',
+    '/ibc.applications.interchain_accounts.controller.v1.MsgSendTxResponse' as const,
   encode(
     message: MsgSendTxResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/genesis/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/genesis/v1/genesis.ts
@@ -103,7 +103,8 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/ibc.applications.interchain_accounts.genesis.v1.GenesisState',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.genesis.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -207,7 +208,7 @@ function createBaseControllerGenesisState(): ControllerGenesisState {
 }
 export const ControllerGenesisState = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.genesis.v1.ControllerGenesisState',
+    '/ibc.applications.interchain_accounts.genesis.v1.ControllerGenesisState' as const,
   encode(
     message: ControllerGenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -345,7 +346,8 @@ function createBaseHostGenesisState(): HostGenesisState {
   };
 }
 export const HostGenesisState = {
-  typeUrl: '/ibc.applications.interchain_accounts.genesis.v1.HostGenesisState',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.genesis.v1.HostGenesisState' as const,
   encode(
     message: HostGenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -472,7 +474,8 @@ function createBaseActiveChannel(): ActiveChannel {
   };
 }
 export const ActiveChannel = {
-  typeUrl: '/ibc.applications.interchain_accounts.genesis.v1.ActiveChannel',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.genesis.v1.ActiveChannel' as const,
   encode(
     message: ActiveChannel,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -570,7 +573,7 @@ function createBaseRegisteredInterchainAccount(): RegisteredInterchainAccount {
 }
 export const RegisteredInterchainAccount = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.genesis.v1.RegisteredInterchainAccount',
+    '/ibc.applications.interchain_accounts.genesis.v1.RegisteredInterchainAccount' as const,
   encode(
     message: RegisteredInterchainAccount,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/host/v1/host.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/host/v1/host.ts
@@ -61,7 +61,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/ibc.applications.interchain_accounts.host.v1.Params',
+  typeUrl: '/ibc.applications.interchain_accounts.host.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -142,7 +142,8 @@ function createBaseQueryRequest(): QueryRequest {
   };
 }
 export const QueryRequest = {
-  typeUrl: '/ibc.applications.interchain_accounts.host.v1.QueryRequest',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.host.v1.QueryRequest' as const,
   encode(
     message: QueryRequest,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/host/v1/query.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/host/v1/query.ts
@@ -28,7 +28,8 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/ibc.applications.interchain_accounts.host.v1.QueryParamsRequest',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.host.v1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -84,7 +85,8 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/ibc.applications.interchain_accounts.host.v1.QueryParamsResponse',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.host.v1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/host/v1/tx.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/host/v1/tx.ts
@@ -44,7 +44,8 @@ function createBaseMsgModuleQuerySafe(): MsgModuleQuerySafe {
   };
 }
 export const MsgModuleQuerySafe = {
-  typeUrl: '/ibc.applications.interchain_accounts.host.v1.MsgModuleQuerySafe',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.host.v1.MsgModuleQuerySafe' as const,
   encode(
     message: MsgModuleQuerySafe,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -130,7 +131,7 @@ function createBaseMsgModuleQuerySafeResponse(): MsgModuleQuerySafeResponse {
 }
 export const MsgModuleQuerySafeResponse = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.host.v1.MsgModuleQuerySafeResponse',
+    '/ibc.applications.interchain_accounts.host.v1.MsgModuleQuerySafeResponse' as const,
   encode(
     message: MsgModuleQuerySafeResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/v1/account.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/v1/account.ts
@@ -27,7 +27,8 @@ function createBaseInterchainAccount(): InterchainAccount {
   };
 }
 export const InterchainAccount = {
-  typeUrl: '/ibc.applications.interchain_accounts.v1.InterchainAccount',
+  typeUrl:
+    '/ibc.applications.interchain_accounts.v1.InterchainAccount' as const,
   encode(
     message: InterchainAccount,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/v1/metadata.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/v1/metadata.ts
@@ -50,7 +50,7 @@ function createBaseMetadata(): Metadata {
   };
 }
 export const Metadata = {
-  typeUrl: '/ibc.applications.interchain_accounts.v1.Metadata',
+  typeUrl: '/ibc.applications.interchain_accounts.v1.Metadata' as const,
   encode(
     message: Metadata,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/v1/packet.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/interchain_accounts/v1/packet.ts
@@ -79,7 +79,7 @@ function createBaseInterchainAccountPacketData(): InterchainAccountPacketData {
 }
 export const InterchainAccountPacketData = {
   typeUrl:
-    '/ibc.applications.interchain_accounts.v1.InterchainAccountPacketData',
+    '/ibc.applications.interchain_accounts.v1.InterchainAccountPacketData' as const,
   encode(
     message: InterchainAccountPacketData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -176,7 +176,7 @@ function createBaseCosmosTx(): CosmosTx {
   };
 }
 export const CosmosTx = {
-  typeUrl: '/ibc.applications.interchain_accounts.v1.CosmosTx',
+  typeUrl: '/ibc.applications.interchain_accounts.v1.CosmosTx' as const,
   encode(
     message: CosmosTx,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/transfer/v1/authz.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/transfer/v1/authz.ts
@@ -63,7 +63,7 @@ function createBaseAllocation(): Allocation {
   };
 }
 export const Allocation = {
-  typeUrl: '/ibc.applications.transfer.v1.Allocation',
+  typeUrl: '/ibc.applications.transfer.v1.Allocation' as const,
   encode(
     message: Allocation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -184,7 +184,7 @@ function createBaseTransferAuthorization(): TransferAuthorization {
   };
 }
 export const TransferAuthorization = {
-  typeUrl: '/ibc.applications.transfer.v1.TransferAuthorization',
+  typeUrl: '/ibc.applications.transfer.v1.TransferAuthorization' as const,
   encode(
     message: TransferAuthorization,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/transfer/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/transfer/v1/genesis.ts
@@ -43,7 +43,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/ibc.applications.transfer.v1.GenesisState',
+  typeUrl: '/ibc.applications.transfer.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/transfer/v1/query.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/transfer/v1/query.ts
@@ -215,7 +215,7 @@ function createBaseQueryDenomTraceRequest(): QueryDenomTraceRequest {
   };
 }
 export const QueryDenomTraceRequest = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTraceRequest',
+  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTraceRequest' as const,
   encode(
     message: QueryDenomTraceRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -282,7 +282,7 @@ function createBaseQueryDenomTraceResponse(): QueryDenomTraceResponse {
   };
 }
 export const QueryDenomTraceResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTraceResponse',
+  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTraceResponse' as const,
   encode(
     message: QueryDenomTraceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -361,7 +361,7 @@ function createBaseQueryDenomTracesRequest(): QueryDenomTracesRequest {
   };
 }
 export const QueryDenomTracesRequest = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTracesRequest',
+  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTracesRequest' as const,
   encode(
     message: QueryDenomTracesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -441,7 +441,7 @@ function createBaseQueryDenomTracesResponse(): QueryDenomTracesResponse {
   };
 }
 export const QueryDenomTracesResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTracesResponse',
+  typeUrl: '/ibc.applications.transfer.v1.QueryDenomTracesResponse' as const,
   encode(
     message: QueryDenomTracesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -541,7 +541,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryParamsRequest',
+  typeUrl: '/ibc.applications.transfer.v1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -596,7 +596,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryParamsResponse',
+  typeUrl: '/ibc.applications.transfer.v1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -665,7 +665,7 @@ function createBaseQueryDenomHashRequest(): QueryDenomHashRequest {
   };
 }
 export const QueryDenomHashRequest = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryDenomHashRequest',
+  typeUrl: '/ibc.applications.transfer.v1.QueryDenomHashRequest' as const,
   encode(
     message: QueryDenomHashRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -730,7 +730,7 @@ function createBaseQueryDenomHashResponse(): QueryDenomHashResponse {
   };
 }
 export const QueryDenomHashResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryDenomHashResponse',
+  typeUrl: '/ibc.applications.transfer.v1.QueryDenomHashResponse' as const,
   encode(
     message: QueryDenomHashResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -798,7 +798,7 @@ function createBaseQueryEscrowAddressRequest(): QueryEscrowAddressRequest {
   };
 }
 export const QueryEscrowAddressRequest = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryEscrowAddressRequest',
+  typeUrl: '/ibc.applications.transfer.v1.QueryEscrowAddressRequest' as const,
   encode(
     message: QueryEscrowAddressRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -880,7 +880,7 @@ function createBaseQueryEscrowAddressResponse(): QueryEscrowAddressResponse {
   };
 }
 export const QueryEscrowAddressResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryEscrowAddressResponse',
+  typeUrl: '/ibc.applications.transfer.v1.QueryEscrowAddressResponse' as const,
   encode(
     message: QueryEscrowAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -956,7 +956,8 @@ function createBaseQueryTotalEscrowForDenomRequest(): QueryTotalEscrowForDenomRe
   };
 }
 export const QueryTotalEscrowForDenomRequest = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryTotalEscrowForDenomRequest',
+  typeUrl:
+    '/ibc.applications.transfer.v1.QueryTotalEscrowForDenomRequest' as const,
   encode(
     message: QueryTotalEscrowForDenomRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1029,7 +1030,8 @@ function createBaseQueryTotalEscrowForDenomResponse(): QueryTotalEscrowForDenomR
   };
 }
 export const QueryTotalEscrowForDenomResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.QueryTotalEscrowForDenomResponse',
+  typeUrl:
+    '/ibc.applications.transfer.v1.QueryTotalEscrowForDenomResponse' as const,
   encode(
     message: QueryTotalEscrowForDenomResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/transfer/v1/transfer.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/transfer/v1/transfer.ts
@@ -66,7 +66,7 @@ function createBaseDenomTrace(): DenomTrace {
   };
 }
 export const DenomTrace = {
-  typeUrl: '/ibc.applications.transfer.v1.DenomTrace',
+  typeUrl: '/ibc.applications.transfer.v1.DenomTrace' as const,
   encode(
     message: DenomTrace,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -138,7 +138,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/ibc.applications.transfer.v1.Params',
+  typeUrl: '/ibc.applications.transfer.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/transfer/v1/tx.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/transfer/v1/tx.ts
@@ -81,7 +81,7 @@ function createBaseMsgTransfer(): MsgTransfer {
   };
 }
 export const MsgTransfer = {
-  typeUrl: '/ibc.applications.transfer.v1.MsgTransfer',
+  typeUrl: '/ibc.applications.transfer.v1.MsgTransfer' as const,
   encode(
     message: MsgTransfer,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -229,7 +229,7 @@ function createBaseMsgTransferResponse(): MsgTransferResponse {
   };
 }
 export const MsgTransferResponse = {
-  typeUrl: '/ibc.applications.transfer.v1.MsgTransferResponse',
+  typeUrl: '/ibc.applications.transfer.v1.MsgTransferResponse' as const,
   encode(
     message: MsgTransferResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/applications/transfer/v2/packet.ts
+++ b/packages/client-utils/src/codegen/ibc/applications/transfer/v2/packet.ts
@@ -45,7 +45,7 @@ function createBaseFungibleTokenPacketData(): FungibleTokenPacketData {
   };
 }
 export const FungibleTokenPacketData = {
-  typeUrl: '/ibc.applications.transfer.v2.FungibleTokenPacketData',
+  typeUrl: '/ibc.applications.transfer.v2.FungibleTokenPacketData' as const,
   encode(
     message: FungibleTokenPacketData,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/channel/v1/channel.ts
+++ b/packages/client-utils/src/codegen/ibc/core/channel/v1/channel.ts
@@ -342,7 +342,7 @@ function createBaseChannel(): Channel {
   };
 }
 export const Channel = {
-  typeUrl: '/ibc.core.channel.v1.Channel',
+  typeUrl: '/ibc.core.channel.v1.Channel' as const,
   encode(
     message: Channel,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -464,7 +464,7 @@ function createBaseIdentifiedChannel(): IdentifiedChannel {
   };
 }
 export const IdentifiedChannel = {
-  typeUrl: '/ibc.core.channel.v1.IdentifiedChannel',
+  typeUrl: '/ibc.core.channel.v1.IdentifiedChannel' as const,
   encode(
     message: IdentifiedChannel,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -599,7 +599,7 @@ function createBaseCounterparty(): Counterparty {
   };
 }
 export const Counterparty = {
-  typeUrl: '/ibc.core.channel.v1.Counterparty',
+  typeUrl: '/ibc.core.channel.v1.Counterparty' as const,
   encode(
     message: Counterparty,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -677,7 +677,7 @@ function createBasePacket(): Packet {
   };
 }
 export const Packet = {
-  typeUrl: '/ibc.core.channel.v1.Packet',
+  typeUrl: '/ibc.core.channel.v1.Packet' as const,
   encode(
     message: Packet,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -841,7 +841,7 @@ function createBasePacketState(): PacketState {
   };
 }
 export const PacketState = {
-  typeUrl: '/ibc.core.channel.v1.PacketState',
+  typeUrl: '/ibc.core.channel.v1.PacketState' as const,
   encode(
     message: PacketState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -943,7 +943,7 @@ function createBasePacketId(): PacketId {
   };
 }
 export const PacketId = {
-  typeUrl: '/ibc.core.channel.v1.PacketId',
+  typeUrl: '/ibc.core.channel.v1.PacketId' as const,
   encode(
     message: PacketId,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1030,7 +1030,7 @@ function createBaseAcknowledgement(): Acknowledgement {
   };
 }
 export const Acknowledgement = {
-  typeUrl: '/ibc.core.channel.v1.Acknowledgement',
+  typeUrl: '/ibc.core.channel.v1.Acknowledgement' as const,
   encode(
     message: Acknowledgement,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/channel/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/ibc/core/channel/v1/genesis.ts
@@ -70,7 +70,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/ibc.core.channel.v1.GenesisState',
+  typeUrl: '/ibc.core.channel.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -279,7 +279,7 @@ function createBasePacketSequence(): PacketSequence {
   };
 }
 export const PacketSequence = {
-  typeUrl: '/ibc.core.channel.v1.PacketSequence',
+  typeUrl: '/ibc.core.channel.v1.PacketSequence' as const,
   encode(
     message: PacketSequence,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/channel/v1/query.ts
+++ b/packages/client-utils/src/codegen/ibc/core/channel/v1/query.ts
@@ -655,7 +655,7 @@ function createBaseQueryChannelRequest(): QueryChannelRequest {
   };
 }
 export const QueryChannelRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelRequest' as const,
   encode(
     message: QueryChannelRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -731,7 +731,7 @@ function createBaseQueryChannelResponse(): QueryChannelResponse {
   };
 }
 export const QueryChannelResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelResponse' as const,
   encode(
     message: QueryChannelResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -835,7 +835,7 @@ function createBaseQueryChannelsRequest(): QueryChannelsRequest {
   };
 }
 export const QueryChannelsRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelsRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelsRequest' as const,
   encode(
     message: QueryChannelsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -910,7 +910,7 @@ function createBaseQueryChannelsResponse(): QueryChannelsResponse {
   };
 }
 export const QueryChannelsResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelsResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelsResponse' as const,
   encode(
     message: QueryChannelsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1020,7 +1020,7 @@ function createBaseQueryConnectionChannelsRequest(): QueryConnectionChannelsRequ
   };
 }
 export const QueryConnectionChannelsRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryConnectionChannelsRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryConnectionChannelsRequest' as const,
   encode(
     message: QueryConnectionChannelsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1112,7 +1112,7 @@ function createBaseQueryConnectionChannelsResponse(): QueryConnectionChannelsRes
   };
 }
 export const QueryConnectionChannelsResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryConnectionChannelsResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryConnectionChannelsResponse' as const,
   encode(
     message: QueryConnectionChannelsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1230,7 +1230,7 @@ function createBaseQueryChannelClientStateRequest(): QueryChannelClientStateRequ
   };
 }
 export const QueryChannelClientStateRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelClientStateRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelClientStateRequest' as const,
   encode(
     message: QueryChannelClientStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1314,7 +1314,7 @@ function createBaseQueryChannelClientStateResponse(): QueryChannelClientStateRes
   };
 }
 export const QueryChannelClientStateResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelClientStateResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelClientStateResponse' as const,
   encode(
     message: QueryChannelClientStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1436,7 +1436,7 @@ function createBaseQueryChannelConsensusStateRequest(): QueryChannelConsensusSta
   };
 }
 export const QueryChannelConsensusStateRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelConsensusStateRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelConsensusStateRequest' as const,
   encode(
     message: QueryChannelConsensusStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1551,7 +1551,7 @@ function createBaseQueryChannelConsensusStateResponse(): QueryChannelConsensusSt
   };
 }
 export const QueryChannelConsensusStateResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryChannelConsensusStateResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryChannelConsensusStateResponse' as const,
   encode(
     message: QueryChannelConsensusStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1674,7 +1674,7 @@ function createBaseQueryPacketCommitmentRequest(): QueryPacketCommitmentRequest 
   };
 }
 export const QueryPacketCommitmentRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentRequest' as const,
   encode(
     message: QueryPacketCommitmentRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1773,7 +1773,7 @@ function createBaseQueryPacketCommitmentResponse(): QueryPacketCommitmentRespons
   };
 }
 export const QueryPacketCommitmentResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentResponse' as const,
   encode(
     message: QueryPacketCommitmentResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1886,7 +1886,7 @@ function createBaseQueryPacketCommitmentsRequest(): QueryPacketCommitmentsReques
   };
 }
 export const QueryPacketCommitmentsRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentsRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentsRequest' as const,
   encode(
     message: QueryPacketCommitmentsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1987,7 +1987,7 @@ function createBaseQueryPacketCommitmentsResponse(): QueryPacketCommitmentsRespo
   };
 }
 export const QueryPacketCommitmentsResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentsResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketCommitmentsResponse' as const,
   encode(
     message: QueryPacketCommitmentsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2104,7 +2104,7 @@ function createBaseQueryPacketReceiptRequest(): QueryPacketReceiptRequest {
   };
 }
 export const QueryPacketReceiptRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketReceiptRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketReceiptRequest' as const,
   encode(
     message: QueryPacketReceiptRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2203,7 +2203,7 @@ function createBaseQueryPacketReceiptResponse(): QueryPacketReceiptResponse {
   };
 }
 export const QueryPacketReceiptResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketReceiptResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketReceiptResponse' as const,
   encode(
     message: QueryPacketReceiptResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2309,7 +2309,7 @@ function createBaseQueryPacketAcknowledgementRequest(): QueryPacketAcknowledgeme
   };
 }
 export const QueryPacketAcknowledgementRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementRequest' as const,
   encode(
     message: QueryPacketAcknowledgementRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2408,7 +2408,7 @@ function createBaseQueryPacketAcknowledgementResponse(): QueryPacketAcknowledgem
   };
 }
 export const QueryPacketAcknowledgementResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementResponse' as const,
   encode(
     message: QueryPacketAcknowledgementResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2522,7 +2522,7 @@ function createBaseQueryPacketAcknowledgementsRequest(): QueryPacketAcknowledgem
   };
 }
 export const QueryPacketAcknowledgementsRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementsRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementsRequest' as const,
   encode(
     message: QueryPacketAcknowledgementsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2652,7 +2652,7 @@ function createBaseQueryPacketAcknowledgementsResponse(): QueryPacketAcknowledge
   };
 }
 export const QueryPacketAcknowledgementsResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementsResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryPacketAcknowledgementsResponse' as const,
   encode(
     message: QueryPacketAcknowledgementsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2771,7 +2771,7 @@ function createBaseQueryUnreceivedPacketsRequest(): QueryUnreceivedPacketsReques
   };
 }
 export const QueryUnreceivedPacketsRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedPacketsRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedPacketsRequest' as const,
   encode(
     message: QueryUnreceivedPacketsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2883,7 +2883,7 @@ function createBaseQueryUnreceivedPacketsResponse(): QueryUnreceivedPacketsRespo
   };
 }
 export const QueryUnreceivedPacketsResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedPacketsResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedPacketsResponse' as const,
   encode(
     message: QueryUnreceivedPacketsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2986,7 +2986,7 @@ function createBaseQueryUnreceivedAcksRequest(): QueryUnreceivedAcksRequest {
   };
 }
 export const QueryUnreceivedAcksRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedAcksRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedAcksRequest' as const,
   encode(
     message: QueryUnreceivedAcksRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3096,7 +3096,7 @@ function createBaseQueryUnreceivedAcksResponse(): QueryUnreceivedAcksResponse {
   };
 }
 export const QueryUnreceivedAcksResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedAcksResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryUnreceivedAcksResponse' as const,
   encode(
     message: QueryUnreceivedAcksResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3198,7 +3198,7 @@ function createBaseQueryNextSequenceReceiveRequest(): QueryNextSequenceReceiveRe
   };
 }
 export const QueryNextSequenceReceiveRequest = {
-  typeUrl: '/ibc.core.channel.v1.QueryNextSequenceReceiveRequest',
+  typeUrl: '/ibc.core.channel.v1.QueryNextSequenceReceiveRequest' as const,
   encode(
     message: QueryNextSequenceReceiveRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3282,7 +3282,7 @@ function createBaseQueryNextSequenceReceiveResponse(): QueryNextSequenceReceiveR
   };
 }
 export const QueryNextSequenceReceiveResponse = {
-  typeUrl: '/ibc.core.channel.v1.QueryNextSequenceReceiveResponse',
+  typeUrl: '/ibc.core.channel.v1.QueryNextSequenceReceiveResponse' as const,
   encode(
     message: QueryNextSequenceReceiveResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/channel/v1/tx.ts
+++ b/packages/client-utils/src/codegen/ibc/core/channel/v1/tx.ts
@@ -422,7 +422,7 @@ function createBaseMsgChannelOpenInit(): MsgChannelOpenInit {
   };
 }
 export const MsgChannelOpenInit = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenInit',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenInit' as const,
   encode(
     message: MsgChannelOpenInit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -514,7 +514,7 @@ function createBaseMsgChannelOpenInitResponse(): MsgChannelOpenInitResponse {
   };
 }
 export const MsgChannelOpenInitResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenInitResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenInitResponse' as const,
   encode(
     message: MsgChannelOpenInitResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -602,7 +602,7 @@ function createBaseMsgChannelOpenTry(): MsgChannelOpenTry {
   };
 }
 export const MsgChannelOpenTry = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenTry',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenTry' as const,
   encode(
     message: MsgChannelOpenTry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -746,7 +746,7 @@ function createBaseMsgChannelOpenTryResponse(): MsgChannelOpenTryResponse {
   };
 }
 export const MsgChannelOpenTryResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenTryResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenTryResponse' as const,
   encode(
     message: MsgChannelOpenTryResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -834,7 +834,7 @@ function createBaseMsgChannelOpenAck(): MsgChannelOpenAck {
   };
 }
 export const MsgChannelOpenAck = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenAck',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenAck' as const,
   encode(
     message: MsgChannelOpenAck,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -967,7 +967,7 @@ function createBaseMsgChannelOpenAckResponse(): MsgChannelOpenAckResponse {
   return {};
 }
 export const MsgChannelOpenAckResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenAckResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenAckResponse' as const,
   encode(
     _: MsgChannelOpenAckResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1032,7 +1032,7 @@ function createBaseMsgChannelOpenConfirm(): MsgChannelOpenConfirm {
   };
 }
 export const MsgChannelOpenConfirm = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenConfirm',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenConfirm' as const,
   encode(
     message: MsgChannelOpenConfirm,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1144,7 +1144,7 @@ function createBaseMsgChannelOpenConfirmResponse(): MsgChannelOpenConfirmRespons
   return {};
 }
 export const MsgChannelOpenConfirmResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenConfirmResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelOpenConfirmResponse' as const,
   encode(
     _: MsgChannelOpenConfirmResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1209,7 +1209,7 @@ function createBaseMsgChannelCloseInit(): MsgChannelCloseInit {
   };
 }
 export const MsgChannelCloseInit = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseInit',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseInit' as const,
   encode(
     message: MsgChannelCloseInit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1290,7 +1290,7 @@ function createBaseMsgChannelCloseInitResponse(): MsgChannelCloseInitResponse {
   return {};
 }
 export const MsgChannelCloseInitResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseInitResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseInitResponse' as const,
   encode(
     _: MsgChannelCloseInitResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1357,7 +1357,7 @@ function createBaseMsgChannelCloseConfirm(): MsgChannelCloseConfirm {
   };
 }
 export const MsgChannelCloseConfirm = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseConfirm',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseConfirm' as const,
   encode(
     message: MsgChannelCloseConfirm,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1471,7 +1471,7 @@ function createBaseMsgChannelCloseConfirmResponse(): MsgChannelCloseConfirmRespo
   return {};
 }
 export const MsgChannelCloseConfirmResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseConfirmResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgChannelCloseConfirmResponse' as const,
   encode(
     _: MsgChannelCloseConfirmResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1537,7 +1537,7 @@ function createBaseMsgRecvPacket(): MsgRecvPacket {
   };
 }
 export const MsgRecvPacket = {
-  typeUrl: '/ibc.core.channel.v1.MsgRecvPacket',
+  typeUrl: '/ibc.core.channel.v1.MsgRecvPacket' as const,
   encode(
     message: MsgRecvPacket,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1645,7 +1645,7 @@ function createBaseMsgRecvPacketResponse(): MsgRecvPacketResponse {
   };
 }
 export const MsgRecvPacketResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgRecvPacketResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgRecvPacketResponse' as const,
   encode(
     message: MsgRecvPacketResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1717,7 +1717,7 @@ function createBaseMsgTimeout(): MsgTimeout {
   };
 }
 export const MsgTimeout = {
-  typeUrl: '/ibc.core.channel.v1.MsgTimeout',
+  typeUrl: '/ibc.core.channel.v1.MsgTimeout' as const,
   encode(
     message: MsgTimeout,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1842,7 +1842,7 @@ function createBaseMsgTimeoutResponse(): MsgTimeoutResponse {
   };
 }
 export const MsgTimeoutResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgTimeoutResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgTimeoutResponse' as const,
   encode(
     message: MsgTimeoutResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1915,7 +1915,7 @@ function createBaseMsgTimeoutOnClose(): MsgTimeoutOnClose {
   };
 }
 export const MsgTimeoutOnClose = {
-  typeUrl: '/ibc.core.channel.v1.MsgTimeoutOnClose',
+  typeUrl: '/ibc.core.channel.v1.MsgTimeoutOnClose' as const,
   encode(
     message: MsgTimeoutOnClose,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2056,7 +2056,7 @@ function createBaseMsgTimeoutOnCloseResponse(): MsgTimeoutOnCloseResponse {
   };
 }
 export const MsgTimeoutOnCloseResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgTimeoutOnCloseResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgTimeoutOnCloseResponse' as const,
   encode(
     message: MsgTimeoutOnCloseResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2136,7 +2136,7 @@ function createBaseMsgAcknowledgement(): MsgAcknowledgement {
   };
 }
 export const MsgAcknowledgement = {
-  typeUrl: '/ibc.core.channel.v1.MsgAcknowledgement',
+  typeUrl: '/ibc.core.channel.v1.MsgAcknowledgement' as const,
   encode(
     message: MsgAcknowledgement,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2263,7 +2263,7 @@ function createBaseMsgAcknowledgementResponse(): MsgAcknowledgementResponse {
   };
 }
 export const MsgAcknowledgementResponse = {
-  typeUrl: '/ibc.core.channel.v1.MsgAcknowledgementResponse',
+  typeUrl: '/ibc.core.channel.v1.MsgAcknowledgementResponse' as const,
   encode(
     message: MsgAcknowledgementResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/client/v1/client.ts
+++ b/packages/client-utils/src/codegen/ibc/core/client/v1/client.ts
@@ -202,7 +202,7 @@ function createBaseIdentifiedClientState(): IdentifiedClientState {
   };
 }
 export const IdentifiedClientState = {
-  typeUrl: '/ibc.core.client.v1.IdentifiedClientState',
+  typeUrl: '/ibc.core.client.v1.IdentifiedClientState' as const,
   encode(
     message: IdentifiedClientState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -285,7 +285,7 @@ function createBaseConsensusStateWithHeight(): ConsensusStateWithHeight {
   };
 }
 export const ConsensusStateWithHeight = {
-  typeUrl: '/ibc.core.client.v1.ConsensusStateWithHeight',
+  typeUrl: '/ibc.core.client.v1.ConsensusStateWithHeight' as const,
   encode(
     message: ConsensusStateWithHeight,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -380,7 +380,7 @@ function createBaseClientConsensusStates(): ClientConsensusStates {
   };
 }
 export const ClientConsensusStates = {
-  typeUrl: '/ibc.core.client.v1.ClientConsensusStates',
+  typeUrl: '/ibc.core.client.v1.ClientConsensusStates' as const,
   encode(
     message: ClientConsensusStates,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -472,7 +472,7 @@ function createBaseClientUpdateProposal(): ClientUpdateProposal {
   };
 }
 export const ClientUpdateProposal = {
-  typeUrl: '/ibc.core.client.v1.ClientUpdateProposal',
+  typeUrl: '/ibc.core.client.v1.ClientUpdateProposal' as const,
   encode(
     message: ClientUpdateProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -574,7 +574,7 @@ function createBaseUpgradeProposal(): UpgradeProposal {
   };
 }
 export const UpgradeProposal = {
-  typeUrl: '/ibc.core.client.v1.UpgradeProposal',
+  typeUrl: '/ibc.core.client.v1.UpgradeProposal' as const,
   encode(
     message: UpgradeProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -681,7 +681,7 @@ function createBaseHeight(): Height {
   };
 }
 export const Height = {
-  typeUrl: '/ibc.core.client.v1.Height',
+  typeUrl: '/ibc.core.client.v1.Height' as const,
   encode(
     message: Height,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -764,7 +764,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/ibc.core.client.v1.Params',
+  typeUrl: '/ibc.core.client.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/client/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/ibc/core/client/v1/genesis.ts
@@ -92,7 +92,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/ibc.core.client.v1.GenesisState',
+  typeUrl: '/ibc.core.client.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -256,7 +256,7 @@ function createBaseGenesisMetadata(): GenesisMetadata {
   };
 }
 export const GenesisMetadata = {
-  typeUrl: '/ibc.core.client.v1.GenesisMetadata',
+  typeUrl: '/ibc.core.client.v1.GenesisMetadata' as const,
   encode(
     message: GenesisMetadata,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -336,7 +336,7 @@ function createBaseIdentifiedGenesisMetadata(): IdentifiedGenesisMetadata {
   };
 }
 export const IdentifiedGenesisMetadata = {
-  typeUrl: '/ibc.core.client.v1.IdentifiedGenesisMetadata',
+  typeUrl: '/ibc.core.client.v1.IdentifiedGenesisMetadata' as const,
   encode(
     message: IdentifiedGenesisMetadata,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/client/v1/query.ts
+++ b/packages/client-utils/src/codegen/ibc/core/client/v1/query.ts
@@ -396,7 +396,7 @@ function createBaseQueryClientStateRequest(): QueryClientStateRequest {
   };
 }
 export const QueryClientStateRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryClientStateRequest',
+  typeUrl: '/ibc.core.client.v1.QueryClientStateRequest' as const,
   encode(
     message: QueryClientStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -469,7 +469,7 @@ function createBaseQueryClientStateResponse(): QueryClientStateResponse {
   };
 }
 export const QueryClientStateResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryClientStateResponse',
+  typeUrl: '/ibc.core.client.v1.QueryClientStateResponse' as const,
   encode(
     message: QueryClientStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -581,7 +581,7 @@ function createBaseQueryClientStatesRequest(): QueryClientStatesRequest {
   };
 }
 export const QueryClientStatesRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryClientStatesRequest',
+  typeUrl: '/ibc.core.client.v1.QueryClientStatesRequest' as const,
   encode(
     message: QueryClientStatesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -663,7 +663,7 @@ function createBaseQueryClientStatesResponse(): QueryClientStatesResponse {
   };
 }
 export const QueryClientStatesResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryClientStatesResponse',
+  typeUrl: '/ibc.core.client.v1.QueryClientStatesResponse' as const,
   encode(
     message: QueryClientStatesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -770,7 +770,7 @@ function createBaseQueryConsensusStateRequest(): QueryConsensusStateRequest {
   };
 }
 export const QueryConsensusStateRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryConsensusStateRequest',
+  typeUrl: '/ibc.core.client.v1.QueryConsensusStateRequest' as const,
   encode(
     message: QueryConsensusStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -887,7 +887,7 @@ function createBaseQueryConsensusStateResponse(): QueryConsensusStateResponse {
   };
 }
 export const QueryConsensusStateResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryConsensusStateResponse',
+  typeUrl: '/ibc.core.client.v1.QueryConsensusStateResponse' as const,
   encode(
     message: QueryConsensusStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1000,7 +1000,7 @@ function createBaseQueryConsensusStatesRequest(): QueryConsensusStatesRequest {
   };
 }
 export const QueryConsensusStatesRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryConsensusStatesRequest',
+  typeUrl: '/ibc.core.client.v1.QueryConsensusStatesRequest' as const,
   encode(
     message: QueryConsensusStatesRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1091,7 +1091,7 @@ function createBaseQueryConsensusStatesResponse(): QueryConsensusStatesResponse 
   };
 }
 export const QueryConsensusStatesResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryConsensusStatesResponse',
+  typeUrl: '/ibc.core.client.v1.QueryConsensusStatesResponse' as const,
   encode(
     message: QueryConsensusStatesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1200,7 +1200,7 @@ function createBaseQueryConsensusStateHeightsRequest(): QueryConsensusStateHeigh
   };
 }
 export const QueryConsensusStateHeightsRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryConsensusStateHeightsRequest',
+  typeUrl: '/ibc.core.client.v1.QueryConsensusStateHeightsRequest' as const,
   encode(
     message: QueryConsensusStateHeightsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1291,7 +1291,7 @@ function createBaseQueryConsensusStateHeightsResponse(): QueryConsensusStateHeig
   };
 }
 export const QueryConsensusStateHeightsResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryConsensusStateHeightsResponse',
+  typeUrl: '/ibc.core.client.v1.QueryConsensusStateHeightsResponse' as const,
   encode(
     message: QueryConsensusStateHeightsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1395,7 +1395,7 @@ function createBaseQueryClientStatusRequest(): QueryClientStatusRequest {
   };
 }
 export const QueryClientStatusRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryClientStatusRequest',
+  typeUrl: '/ibc.core.client.v1.QueryClientStatusRequest' as const,
   encode(
     message: QueryClientStatusRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1468,7 +1468,7 @@ function createBaseQueryClientStatusResponse(): QueryClientStatusResponse {
   };
 }
 export const QueryClientStatusResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryClientStatusResponse',
+  typeUrl: '/ibc.core.client.v1.QueryClientStatusResponse' as const,
   encode(
     message: QueryClientStatusResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1539,7 +1539,7 @@ function createBaseQueryClientParamsRequest(): QueryClientParamsRequest {
   return {};
 }
 export const QueryClientParamsRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryClientParamsRequest',
+  typeUrl: '/ibc.core.client.v1.QueryClientParamsRequest' as const,
   encode(
     _: QueryClientParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1598,7 +1598,7 @@ function createBaseQueryClientParamsResponse(): QueryClientParamsResponse {
   };
 }
 export const QueryClientParamsResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryClientParamsResponse',
+  typeUrl: '/ibc.core.client.v1.QueryClientParamsResponse' as const,
   encode(
     message: QueryClientParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1673,7 +1673,7 @@ function createBaseQueryUpgradedClientStateRequest(): QueryUpgradedClientStateRe
   return {};
 }
 export const QueryUpgradedClientStateRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryUpgradedClientStateRequest',
+  typeUrl: '/ibc.core.client.v1.QueryUpgradedClientStateRequest' as const,
   encode(
     _: QueryUpgradedClientStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1736,7 +1736,7 @@ function createBaseQueryUpgradedClientStateResponse(): QueryUpgradedClientStateR
   };
 }
 export const QueryUpgradedClientStateResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryUpgradedClientStateResponse',
+  typeUrl: '/ibc.core.client.v1.QueryUpgradedClientStateResponse' as const,
   encode(
     message: QueryUpgradedClientStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1819,7 +1819,7 @@ function createBaseQueryUpgradedConsensusStateRequest(): QueryUpgradedConsensusS
   return {};
 }
 export const QueryUpgradedConsensusStateRequest = {
-  typeUrl: '/ibc.core.client.v1.QueryUpgradedConsensusStateRequest',
+  typeUrl: '/ibc.core.client.v1.QueryUpgradedConsensusStateRequest' as const,
   encode(
     _: QueryUpgradedConsensusStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1882,7 +1882,7 @@ function createBaseQueryUpgradedConsensusStateResponse(): QueryUpgradedConsensus
   };
 }
 export const QueryUpgradedConsensusStateResponse = {
-  typeUrl: '/ibc.core.client.v1.QueryUpgradedConsensusStateResponse',
+  typeUrl: '/ibc.core.client.v1.QueryUpgradedConsensusStateResponse' as const,
   encode(
     message: QueryUpgradedConsensusStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/client/v1/tx.ts
+++ b/packages/client-utils/src/codegen/ibc/core/client/v1/tx.ts
@@ -168,7 +168,7 @@ function createBaseMsgCreateClient(): MsgCreateClient {
   };
 }
 export const MsgCreateClient = {
-  typeUrl: '/ibc.core.client.v1.MsgCreateClient',
+  typeUrl: '/ibc.core.client.v1.MsgCreateClient' as const,
   encode(
     message: MsgCreateClient,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -262,7 +262,7 @@ function createBaseMsgCreateClientResponse(): MsgCreateClientResponse {
   return {};
 }
 export const MsgCreateClientResponse = {
-  typeUrl: '/ibc.core.client.v1.MsgCreateClientResponse',
+  typeUrl: '/ibc.core.client.v1.MsgCreateClientResponse' as const,
   encode(
     _: MsgCreateClientResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -323,7 +323,7 @@ function createBaseMsgUpdateClient(): MsgUpdateClient {
   };
 }
 export const MsgUpdateClient = {
-  typeUrl: '/ibc.core.client.v1.MsgUpdateClient',
+  typeUrl: '/ibc.core.client.v1.MsgUpdateClient' as const,
   encode(
     message: MsgUpdateClient,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -409,7 +409,7 @@ function createBaseMsgUpdateClientResponse(): MsgUpdateClientResponse {
   return {};
 }
 export const MsgUpdateClientResponse = {
-  typeUrl: '/ibc.core.client.v1.MsgUpdateClientResponse',
+  typeUrl: '/ibc.core.client.v1.MsgUpdateClientResponse' as const,
   encode(
     _: MsgUpdateClientResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -473,7 +473,7 @@ function createBaseMsgUpgradeClient(): MsgUpgradeClient {
   };
 }
 export const MsgUpgradeClient = {
-  typeUrl: '/ibc.core.client.v1.MsgUpgradeClient',
+  typeUrl: '/ibc.core.client.v1.MsgUpgradeClient' as const,
   encode(
     message: MsgUpgradeClient,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -609,7 +609,7 @@ function createBaseMsgUpgradeClientResponse(): MsgUpgradeClientResponse {
   return {};
 }
 export const MsgUpgradeClientResponse = {
-  typeUrl: '/ibc.core.client.v1.MsgUpgradeClientResponse',
+  typeUrl: '/ibc.core.client.v1.MsgUpgradeClientResponse' as const,
   encode(
     _: MsgUpgradeClientResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -670,7 +670,7 @@ function createBaseMsgSubmitMisbehaviour(): MsgSubmitMisbehaviour {
   };
 }
 export const MsgSubmitMisbehaviour = {
-  typeUrl: '/ibc.core.client.v1.MsgSubmitMisbehaviour',
+  typeUrl: '/ibc.core.client.v1.MsgSubmitMisbehaviour' as const,
   encode(
     message: MsgSubmitMisbehaviour,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -759,7 +759,7 @@ function createBaseMsgSubmitMisbehaviourResponse(): MsgSubmitMisbehaviourRespons
   return {};
 }
 export const MsgSubmitMisbehaviourResponse = {
-  typeUrl: '/ibc.core.client.v1.MsgSubmitMisbehaviourResponse',
+  typeUrl: '/ibc.core.client.v1.MsgSubmitMisbehaviourResponse' as const,
   encode(
     _: MsgSubmitMisbehaviourResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/commitment/v1/commitment.ts
+++ b/packages/client-utils/src/codegen/ibc/core/commitment/v1/commitment.ts
@@ -96,7 +96,7 @@ function createBaseMerkleRoot(): MerkleRoot {
   };
 }
 export const MerkleRoot = {
-  typeUrl: '/ibc.core.commitment.v1.MerkleRoot',
+  typeUrl: '/ibc.core.commitment.v1.MerkleRoot' as const,
   encode(
     message: MerkleRoot,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -163,7 +163,7 @@ function createBaseMerklePrefix(): MerklePrefix {
   };
 }
 export const MerklePrefix = {
-  typeUrl: '/ibc.core.commitment.v1.MerklePrefix',
+  typeUrl: '/ibc.core.commitment.v1.MerklePrefix' as const,
   encode(
     message: MerklePrefix,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -230,7 +230,7 @@ function createBaseMerklePath(): MerklePath {
   };
 }
 export const MerklePath = {
-  typeUrl: '/ibc.core.commitment.v1.MerklePath',
+  typeUrl: '/ibc.core.commitment.v1.MerklePath' as const,
   encode(
     message: MerklePath,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -298,7 +298,7 @@ function createBaseMerkleProof(): MerkleProof {
   };
 }
 export const MerkleProof = {
-  typeUrl: '/ibc.core.commitment.v1.MerkleProof',
+  typeUrl: '/ibc.core.commitment.v1.MerkleProof' as const,
   encode(
     message: MerkleProof,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/connection/v1/connection.ts
+++ b/packages/client-utils/src/codegen/ibc/core/connection/v1/connection.ts
@@ -242,7 +242,7 @@ function createBaseConnectionEnd(): ConnectionEnd {
   };
 }
 export const ConnectionEnd = {
-  typeUrl: '/ibc.core.connection.v1.ConnectionEnd',
+  typeUrl: '/ibc.core.connection.v1.ConnectionEnd' as const,
   encode(
     message: ConnectionEnd,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -370,7 +370,7 @@ function createBaseIdentifiedConnection(): IdentifiedConnection {
   };
 }
 export const IdentifiedConnection = {
-  typeUrl: '/ibc.core.connection.v1.IdentifiedConnection',
+  typeUrl: '/ibc.core.connection.v1.IdentifiedConnection' as const,
   encode(
     message: IdentifiedConnection,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -507,7 +507,7 @@ function createBaseCounterparty(): Counterparty {
   };
 }
 export const Counterparty = {
-  typeUrl: '/ibc.core.connection.v1.Counterparty',
+  typeUrl: '/ibc.core.connection.v1.Counterparty' as const,
   encode(
     message: Counterparty,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -598,7 +598,7 @@ function createBaseClientPaths(): ClientPaths {
   };
 }
 export const ClientPaths = {
-  typeUrl: '/ibc.core.connection.v1.ClientPaths',
+  typeUrl: '/ibc.core.connection.v1.ClientPaths' as const,
   encode(
     message: ClientPaths,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -667,7 +667,7 @@ function createBaseConnectionPaths(): ConnectionPaths {
   };
 }
 export const ConnectionPaths = {
-  typeUrl: '/ibc.core.connection.v1.ConnectionPaths',
+  typeUrl: '/ibc.core.connection.v1.ConnectionPaths' as const,
   encode(
     message: ConnectionPaths,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -745,7 +745,7 @@ function createBaseVersion(): Version {
   };
 }
 export const Version = {
-  typeUrl: '/ibc.core.connection.v1.Version',
+  typeUrl: '/ibc.core.connection.v1.Version' as const,
   encode(
     message: Version,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -822,7 +822,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/ibc.core.connection.v1.Params',
+  typeUrl: '/ibc.core.connection.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/connection/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/ibc/core/connection/v1/genesis.ts
@@ -38,7 +38,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/ibc.core.connection.v1.GenesisState',
+  typeUrl: '/ibc.core.connection.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/connection/v1/query.ts
+++ b/packages/client-utils/src/codegen/ibc/core/connection/v1/query.ts
@@ -280,7 +280,7 @@ function createBaseQueryConnectionRequest(): QueryConnectionRequest {
   };
 }
 export const QueryConnectionRequest = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionRequest',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionRequest' as const,
   encode(
     message: QueryConnectionRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -352,7 +352,7 @@ function createBaseQueryConnectionResponse(): QueryConnectionResponse {
   };
 }
 export const QueryConnectionResponse = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionResponse',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionResponse' as const,
   encode(
     message: QueryConnectionResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -465,7 +465,7 @@ function createBaseQueryConnectionsRequest(): QueryConnectionsRequest {
   };
 }
 export const QueryConnectionsRequest = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionsRequest',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionsRequest' as const,
   encode(
     message: QueryConnectionsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -546,7 +546,7 @@ function createBaseQueryConnectionsResponse(): QueryConnectionsResponse {
   };
 }
 export const QueryConnectionsResponse = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionsResponse',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionsResponse' as const,
   encode(
     message: QueryConnectionsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -663,7 +663,7 @@ function createBaseQueryClientConnectionsRequest(): QueryClientConnectionsReques
   };
 }
 export const QueryClientConnectionsRequest = {
-  typeUrl: '/ibc.core.connection.v1.QueryClientConnectionsRequest',
+  typeUrl: '/ibc.core.connection.v1.QueryClientConnectionsRequest' as const,
   encode(
     message: QueryClientConnectionsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -738,7 +738,7 @@ function createBaseQueryClientConnectionsResponse(): QueryClientConnectionsRespo
   };
 }
 export const QueryClientConnectionsResponse = {
-  typeUrl: '/ibc.core.connection.v1.QueryClientConnectionsResponse',
+  typeUrl: '/ibc.core.connection.v1.QueryClientConnectionsResponse' as const,
   encode(
     message: QueryClientConnectionsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -848,7 +848,7 @@ function createBaseQueryConnectionClientStateRequest(): QueryConnectionClientSta
   };
 }
 export const QueryConnectionClientStateRequest = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionClientStateRequest',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionClientStateRequest' as const,
   encode(
     message: QueryConnectionClientStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -926,7 +926,8 @@ function createBaseQueryConnectionClientStateResponse(): QueryConnectionClientSt
   };
 }
 export const QueryConnectionClientStateResponse = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionClientStateResponse',
+  typeUrl:
+    '/ibc.core.connection.v1.QueryConnectionClientStateResponse' as const,
   encode(
     message: QueryConnectionClientStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1047,7 +1048,8 @@ function createBaseQueryConnectionConsensusStateRequest(): QueryConnectionConsen
   };
 }
 export const QueryConnectionConsensusStateRequest = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionConsensusStateRequest',
+  typeUrl:
+    '/ibc.core.connection.v1.QueryConnectionConsensusStateRequest' as const,
   encode(
     message: QueryConnectionConsensusStateRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1156,7 +1158,8 @@ function createBaseQueryConnectionConsensusStateResponse(): QueryConnectionConse
   };
 }
 export const QueryConnectionConsensusStateResponse = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionConsensusStateResponse',
+  typeUrl:
+    '/ibc.core.connection.v1.QueryConnectionConsensusStateResponse' as const,
   encode(
     message: QueryConnectionConsensusStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1275,7 +1278,7 @@ function createBaseQueryConnectionParamsRequest(): QueryConnectionParamsRequest 
   return {};
 }
 export const QueryConnectionParamsRequest = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionParamsRequest',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionParamsRequest' as const,
   encode(
     _: QueryConnectionParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1338,7 +1341,7 @@ function createBaseQueryConnectionParamsResponse(): QueryConnectionParamsRespons
   };
 }
 export const QueryConnectionParamsResponse = {
-  typeUrl: '/ibc.core.connection.v1.QueryConnectionParamsResponse',
+  typeUrl: '/ibc.core.connection.v1.QueryConnectionParamsResponse' as const,
   encode(
     message: QueryConnectionParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/core/connection/v1/tx.ts
+++ b/packages/client-utils/src/codegen/ibc/core/connection/v1/tx.ts
@@ -224,7 +224,7 @@ function createBaseMsgConnectionOpenInit(): MsgConnectionOpenInit {
   };
 }
 export const MsgConnectionOpenInit = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenInit',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenInit' as const,
   encode(
     message: MsgConnectionOpenInit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -348,7 +348,7 @@ function createBaseMsgConnectionOpenInitResponse(): MsgConnectionOpenInitRespons
   return {};
 }
 export const MsgConnectionOpenInitResponse = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenInitResponse',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenInitResponse' as const,
   encode(
     _: MsgConnectionOpenInitResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -423,7 +423,7 @@ function createBaseMsgConnectionOpenTry(): MsgConnectionOpenTry {
   };
 }
 export const MsgConnectionOpenTry = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenTry',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenTry' as const,
   encode(
     message: MsgConnectionOpenTry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -676,7 +676,7 @@ function createBaseMsgConnectionOpenTryResponse(): MsgConnectionOpenTryResponse 
   return {};
 }
 export const MsgConnectionOpenTryResponse = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenTryResponse',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenTryResponse' as const,
   encode(
     _: MsgConnectionOpenTryResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -749,7 +749,7 @@ function createBaseMsgConnectionOpenAck(): MsgConnectionOpenAck {
   };
 }
 export const MsgConnectionOpenAck = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenAck',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenAck' as const,
   encode(
     message: MsgConnectionOpenAck,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -967,7 +967,7 @@ function createBaseMsgConnectionOpenAckResponse(): MsgConnectionOpenAckResponse 
   return {};
 }
 export const MsgConnectionOpenAckResponse = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenAckResponse',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenAckResponse' as const,
   encode(
     _: MsgConnectionOpenAckResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1033,7 +1033,7 @@ function createBaseMsgConnectionOpenConfirm(): MsgConnectionOpenConfirm {
   };
 }
 export const MsgConnectionOpenConfirm = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenConfirm',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenConfirm' as const,
   encode(
     message: MsgConnectionOpenConfirm,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1147,7 +1147,7 @@ function createBaseMsgConnectionOpenConfirmResponse(): MsgConnectionOpenConfirmR
   return {};
 }
 export const MsgConnectionOpenConfirmResponse = {
-  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenConfirmResponse',
+  typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenConfirmResponse' as const,
   encode(
     _: MsgConnectionOpenConfirmResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/lightclients/localhost/v1/localhost.ts
+++ b/packages/client-utils/src/codegen/ibc/lightclients/localhost/v1/localhost.ts
@@ -32,7 +32,7 @@ function createBaseClientState(): ClientState {
   };
 }
 export const ClientState = {
-  typeUrl: '/ibc.lightclients.localhost.v1.ClientState',
+  typeUrl: '/ibc.lightclients.localhost.v1.ClientState' as const,
   encode(
     message: ClientState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/lightclients/localhost/v2/localhost.ts
+++ b/packages/client-utils/src/codegen/ibc/lightclients/localhost/v2/localhost.ts
@@ -22,7 +22,7 @@ function createBaseClientState(): ClientState {
   };
 }
 export const ClientState = {
-  typeUrl: '/ibc.lightclients.localhost.v2.ClientState',
+  typeUrl: '/ibc.lightclients.localhost.v2.ClientState' as const,
   encode(
     message: ClientState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/lightclients/solomachine/v1/solomachine.ts
+++ b/packages/client-utils/src/codegen/ibc/lightclients/solomachine/v1/solomachine.ts
@@ -454,7 +454,7 @@ function createBaseClientState(): ClientState {
   };
 }
 export const ClientState = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.ClientState',
+  typeUrl: '/ibc.lightclients.solomachine.v1.ClientState' as const,
   encode(
     message: ClientState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -574,7 +574,7 @@ function createBaseConsensusState(): ConsensusState {
   };
 }
 export const ConsensusState = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.ConsensusState',
+  typeUrl: '/ibc.lightclients.solomachine.v1.ConsensusState' as const,
   encode(
     message: ConsensusState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -673,7 +673,7 @@ function createBaseHeader(): Header {
   };
 }
 export const Header = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.Header',
+  typeUrl: '/ibc.lightclients.solomachine.v1.Header' as const,
   encode(
     message: Header,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -802,7 +802,7 @@ function createBaseMisbehaviour(): Misbehaviour {
   };
 }
 export const Misbehaviour = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.Misbehaviour',
+  typeUrl: '/ibc.lightclients.solomachine.v1.Misbehaviour' as const,
   encode(
     message: Misbehaviour,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -928,7 +928,7 @@ function createBaseSignatureAndData(): SignatureAndData {
   };
 }
 export const SignatureAndData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.SignatureAndData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.SignatureAndData' as const,
   encode(
     message: SignatureAndData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1035,7 +1035,7 @@ function createBaseTimestampedSignatureData(): TimestampedSignatureData {
   };
 }
 export const TimestampedSignatureData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.TimestampedSignatureData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.TimestampedSignatureData' as const,
   encode(
     message: TimestampedSignatureData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1134,7 +1134,7 @@ function createBaseSignBytes(): SignBytes {
   };
 }
 export const SignBytes = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.SignBytes',
+  typeUrl: '/ibc.lightclients.solomachine.v1.SignBytes' as const,
   encode(
     message: SignBytes,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1252,7 +1252,7 @@ function createBaseHeaderData(): HeaderData {
   };
 }
 export const HeaderData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.HeaderData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.HeaderData' as const,
   encode(
     message: HeaderData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1335,7 +1335,7 @@ function createBaseClientStateData(): ClientStateData {
   };
 }
 export const ClientStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.ClientStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.ClientStateData' as const,
   encode(
     message: ClientStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1420,7 +1420,7 @@ function createBaseConsensusStateData(): ConsensusStateData {
   };
 }
 export const ConsensusStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.ConsensusStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.ConsensusStateData' as const,
   encode(
     message: ConsensusStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1508,7 +1508,7 @@ function createBaseConnectionStateData(): ConnectionStateData {
   };
 }
 export const ConnectionStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.ConnectionStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.ConnectionStateData' as const,
   encode(
     message: ConnectionStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1599,7 +1599,7 @@ function createBaseChannelStateData(): ChannelStateData {
   };
 }
 export const ChannelStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.ChannelStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.ChannelStateData' as const,
   encode(
     message: ChannelStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1684,7 +1684,7 @@ function createBasePacketCommitmentData(): PacketCommitmentData {
   };
 }
 export const PacketCommitmentData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.PacketCommitmentData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.PacketCommitmentData' as const,
   encode(
     message: PacketCommitmentData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1771,7 +1771,8 @@ function createBasePacketAcknowledgementData(): PacketAcknowledgementData {
   };
 }
 export const PacketAcknowledgementData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.PacketAcknowledgementData',
+  typeUrl:
+    '/ibc.lightclients.solomachine.v1.PacketAcknowledgementData' as const,
   encode(
     message: PacketAcknowledgementData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1865,7 +1866,7 @@ function createBasePacketReceiptAbsenceData(): PacketReceiptAbsenceData {
   };
 }
 export const PacketReceiptAbsenceData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.PacketReceiptAbsenceData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.PacketReceiptAbsenceData' as const,
   encode(
     message: PacketReceiptAbsenceData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1944,7 +1945,7 @@ function createBaseNextSequenceRecvData(): NextSequenceRecvData {
   };
 }
 export const NextSequenceRecvData = {
-  typeUrl: '/ibc.lightclients.solomachine.v1.NextSequenceRecvData',
+  typeUrl: '/ibc.lightclients.solomachine.v1.NextSequenceRecvData' as const,
   encode(
     message: NextSequenceRecvData,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/lightclients/solomachine/v2/solomachine.ts
+++ b/packages/client-utils/src/codegen/ibc/lightclients/solomachine/v2/solomachine.ts
@@ -454,7 +454,7 @@ function createBaseClientState(): ClientState {
   };
 }
 export const ClientState = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.ClientState',
+  typeUrl: '/ibc.lightclients.solomachine.v2.ClientState' as const,
   encode(
     message: ClientState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -568,7 +568,7 @@ function createBaseConsensusState(): ConsensusState {
   };
 }
 export const ConsensusState = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.ConsensusState',
+  typeUrl: '/ibc.lightclients.solomachine.v2.ConsensusState' as const,
   encode(
     message: ConsensusState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -667,7 +667,7 @@ function createBaseHeader(): Header {
   };
 }
 export const Header = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.Header',
+  typeUrl: '/ibc.lightclients.solomachine.v2.Header' as const,
   encode(
     message: Header,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -796,7 +796,7 @@ function createBaseMisbehaviour(): Misbehaviour {
   };
 }
 export const Misbehaviour = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.Misbehaviour',
+  typeUrl: '/ibc.lightclients.solomachine.v2.Misbehaviour' as const,
   encode(
     message: Misbehaviour,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -922,7 +922,7 @@ function createBaseSignatureAndData(): SignatureAndData {
   };
 }
 export const SignatureAndData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.SignatureAndData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.SignatureAndData' as const,
   encode(
     message: SignatureAndData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1029,7 +1029,7 @@ function createBaseTimestampedSignatureData(): TimestampedSignatureData {
   };
 }
 export const TimestampedSignatureData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.TimestampedSignatureData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.TimestampedSignatureData' as const,
   encode(
     message: TimestampedSignatureData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1128,7 +1128,7 @@ function createBaseSignBytes(): SignBytes {
   };
 }
 export const SignBytes = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.SignBytes',
+  typeUrl: '/ibc.lightclients.solomachine.v2.SignBytes' as const,
   encode(
     message: SignBytes,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1246,7 +1246,7 @@ function createBaseHeaderData(): HeaderData {
   };
 }
 export const HeaderData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.HeaderData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.HeaderData' as const,
   encode(
     message: HeaderData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1329,7 +1329,7 @@ function createBaseClientStateData(): ClientStateData {
   };
 }
 export const ClientStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.ClientStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.ClientStateData' as const,
   encode(
     message: ClientStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1414,7 +1414,7 @@ function createBaseConsensusStateData(): ConsensusStateData {
   };
 }
 export const ConsensusStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.ConsensusStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.ConsensusStateData' as const,
   encode(
     message: ConsensusStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1502,7 +1502,7 @@ function createBaseConnectionStateData(): ConnectionStateData {
   };
 }
 export const ConnectionStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.ConnectionStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.ConnectionStateData' as const,
   encode(
     message: ConnectionStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1593,7 +1593,7 @@ function createBaseChannelStateData(): ChannelStateData {
   };
 }
 export const ChannelStateData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.ChannelStateData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.ChannelStateData' as const,
   encode(
     message: ChannelStateData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1678,7 +1678,7 @@ function createBasePacketCommitmentData(): PacketCommitmentData {
   };
 }
 export const PacketCommitmentData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.PacketCommitmentData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.PacketCommitmentData' as const,
   encode(
     message: PacketCommitmentData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1765,7 +1765,8 @@ function createBasePacketAcknowledgementData(): PacketAcknowledgementData {
   };
 }
 export const PacketAcknowledgementData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.PacketAcknowledgementData',
+  typeUrl:
+    '/ibc.lightclients.solomachine.v2.PacketAcknowledgementData' as const,
   encode(
     message: PacketAcknowledgementData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1859,7 +1860,7 @@ function createBasePacketReceiptAbsenceData(): PacketReceiptAbsenceData {
   };
 }
 export const PacketReceiptAbsenceData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.PacketReceiptAbsenceData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.PacketReceiptAbsenceData' as const,
   encode(
     message: PacketReceiptAbsenceData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1938,7 +1939,7 @@ function createBaseNextSequenceRecvData(): NextSequenceRecvData {
   };
 }
 export const NextSequenceRecvData = {
-  typeUrl: '/ibc.lightclients.solomachine.v2.NextSequenceRecvData',
+  typeUrl: '/ibc.lightclients.solomachine.v2.NextSequenceRecvData' as const,
   encode(
     message: NextSequenceRecvData,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/lightclients/solomachine/v3/solomachine.ts
+++ b/packages/client-utils/src/codegen/ibc/lightclients/solomachine/v3/solomachine.ts
@@ -192,7 +192,7 @@ function createBaseClientState(): ClientState {
   };
 }
 export const ClientState = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.ClientState',
+  typeUrl: '/ibc.lightclients.solomachine.v3.ClientState' as const,
   encode(
     message: ClientState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -294,7 +294,7 @@ function createBaseConsensusState(): ConsensusState {
   };
 }
 export const ConsensusState = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.ConsensusState',
+  typeUrl: '/ibc.lightclients.solomachine.v3.ConsensusState' as const,
   encode(
     message: ConsensusState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -392,7 +392,7 @@ function createBaseHeader(): Header {
   };
 }
 export const Header = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.Header',
+  typeUrl: '/ibc.lightclients.solomachine.v3.Header' as const,
   encode(
     message: Header,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -505,7 +505,7 @@ function createBaseMisbehaviour(): Misbehaviour {
   };
 }
 export const Misbehaviour = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.Misbehaviour',
+  typeUrl: '/ibc.lightclients.solomachine.v3.Misbehaviour' as const,
   encode(
     message: Misbehaviour,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -622,7 +622,7 @@ function createBaseSignatureAndData(): SignatureAndData {
   };
 }
 export const SignatureAndData = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.SignatureAndData',
+  typeUrl: '/ibc.lightclients.solomachine.v3.SignatureAndData' as const,
   encode(
     message: SignatureAndData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -733,7 +733,7 @@ function createBaseTimestampedSignatureData(): TimestampedSignatureData {
   };
 }
 export const TimestampedSignatureData = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.TimestampedSignatureData',
+  typeUrl: '/ibc.lightclients.solomachine.v3.TimestampedSignatureData' as const,
   encode(
     message: TimestampedSignatureData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -832,7 +832,7 @@ function createBaseSignBytes(): SignBytes {
   };
 }
 export const SignBytes = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.SignBytes',
+  typeUrl: '/ibc.lightclients.solomachine.v3.SignBytes' as const,
   encode(
     message: SignBytes,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -954,7 +954,7 @@ function createBaseHeaderData(): HeaderData {
   };
 }
 export const HeaderData = {
-  typeUrl: '/ibc.lightclients.solomachine.v3.HeaderData',
+  typeUrl: '/ibc.lightclients.solomachine.v3.HeaderData' as const,
   encode(
     message: HeaderData,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/ibc/lightclients/tendermint/v1/tendermint.ts
+++ b/packages/client-utils/src/codegen/ibc/lightclients/tendermint/v1/tendermint.ts
@@ -221,7 +221,7 @@ function createBaseClientState(): ClientState {
   };
 }
 export const ClientState = {
-  typeUrl: '/ibc.lightclients.tendermint.v1.ClientState',
+  typeUrl: '/ibc.lightclients.tendermint.v1.ClientState' as const,
   encode(
     message: ClientState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -451,7 +451,7 @@ function createBaseConsensusState(): ConsensusState {
   };
 }
 export const ConsensusState = {
-  typeUrl: '/ibc.lightclients.tendermint.v1.ConsensusState',
+  typeUrl: '/ibc.lightclients.tendermint.v1.ConsensusState' as const,
   encode(
     message: ConsensusState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -550,7 +550,7 @@ function createBaseMisbehaviour(): Misbehaviour {
   };
 }
 export const Misbehaviour = {
-  typeUrl: '/ibc.lightclients.tendermint.v1.Misbehaviour',
+  typeUrl: '/ibc.lightclients.tendermint.v1.Misbehaviour' as const,
   encode(
     message: Misbehaviour,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -649,7 +649,7 @@ function createBaseHeader(): Header {
   };
 }
 export const Header = {
-  typeUrl: '/ibc.lightclients.tendermint.v1.Header',
+  typeUrl: '/ibc.lightclients.tendermint.v1.Header' as const,
   encode(
     message: Header,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -784,7 +784,7 @@ function createBaseFraction(): Fraction {
   };
 }
 export const Fraction = {
-  typeUrl: '/ibc.lightclients.tendermint.v1.Fraction',
+  typeUrl: '/ibc.lightclients.tendermint.v1.Fraction' as const,
   encode(
     message: Fraction,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/icq/v1/genesis.ts
+++ b/packages/client-utils/src/codegen/icq/v1/genesis.ts
@@ -24,7 +24,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/icq.v1.GenesisState',
+  typeUrl: '/icq.v1.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/icq/v1/icq.ts
+++ b/packages/client-utils/src/codegen/icq/v1/icq.ts
@@ -25,7 +25,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/icq.v1.Params',
+  typeUrl: '/icq.v1.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/icq/v1/packet.ts
+++ b/packages/client-utils/src/codegen/icq/v1/packet.ts
@@ -68,7 +68,7 @@ function createBaseInterchainQueryPacketData(): InterchainQueryPacketData {
   };
 }
 export const InterchainQueryPacketData = {
-  typeUrl: '/icq.v1.InterchainQueryPacketData',
+  typeUrl: '/icq.v1.InterchainQueryPacketData' as const,
   encode(
     message: InterchainQueryPacketData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -155,7 +155,7 @@ function createBaseInterchainQueryPacketAck(): InterchainQueryPacketAck {
   };
 }
 export const InterchainQueryPacketAck = {
-  typeUrl: '/icq.v1.InterchainQueryPacketAck',
+  typeUrl: '/icq.v1.InterchainQueryPacketAck' as const,
   encode(
     message: InterchainQueryPacketAck,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -233,7 +233,7 @@ function createBaseCosmosQuery(): CosmosQuery {
   };
 }
 export const CosmosQuery = {
-  typeUrl: '/icq.v1.CosmosQuery',
+  typeUrl: '/icq.v1.CosmosQuery' as const,
   encode(
     message: CosmosQuery,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -304,7 +304,7 @@ function createBaseCosmosResponse(): CosmosResponse {
   };
 }
 export const CosmosResponse = {
-  typeUrl: '/icq.v1.CosmosResponse',
+  typeUrl: '/icq.v1.CosmosResponse' as const,
   encode(
     message: CosmosResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/icq/v1/query.ts
+++ b/packages/client-utils/src/codegen/icq/v1/query.ts
@@ -28,7 +28,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/icq.v1.QueryParamsRequest',
+  typeUrl: '/icq.v1.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -83,7 +83,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/icq.v1.QueryParamsResponse',
+  typeUrl: '/icq.v1.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/icq/v1/tx.ts
+++ b/packages/client-utils/src/codegen/icq/v1/tx.ts
@@ -56,7 +56,7 @@ function createBaseMsgUpdateParams(): MsgUpdateParams {
   };
 }
 export const MsgUpdateParams = {
-  typeUrl: '/icq.v1.MsgUpdateParams',
+  typeUrl: '/icq.v1.MsgUpdateParams' as const,
   encode(
     message: MsgUpdateParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -129,7 +129,7 @@ function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
   return {};
 }
 export const MsgUpdateParamsResponse = {
-  typeUrl: '/icq.v1.MsgUpdateParamsResponse',
+  typeUrl: '/icq.v1.MsgUpdateParamsResponse' as const,
   encode(
     _: MsgUpdateParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/noble/dollar/vaults/v1/tx.ts
+++ b/packages/client-utils/src/codegen/noble/dollar/vaults/v1/tx.ts
@@ -88,7 +88,7 @@ function createBaseMsgLock(): MsgLock {
   };
 }
 export const MsgLock = {
-  typeUrl: '/noble.dollar.vaults.v1.MsgLock',
+  typeUrl: '/noble.dollar.vaults.v1.MsgLock' as const,
   encode(
     message: MsgLock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -166,7 +166,7 @@ function createBaseMsgLockResponse(): MsgLockResponse {
   return {};
 }
 export const MsgLockResponse = {
-  typeUrl: '/noble.dollar.vaults.v1.MsgLockResponse',
+  typeUrl: '/noble.dollar.vaults.v1.MsgLockResponse' as const,
   encode(
     _: MsgLockResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -220,7 +220,7 @@ function createBaseMsgUnlock(): MsgUnlock {
   };
 }
 export const MsgUnlock = {
-  typeUrl: '/noble.dollar.vaults.v1.MsgUnlock',
+  typeUrl: '/noble.dollar.vaults.v1.MsgUnlock' as const,
   encode(
     message: MsgUnlock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -298,7 +298,7 @@ function createBaseMsgUnlockResponse(): MsgUnlockResponse {
   return {};
 }
 export const MsgUnlockResponse = {
-  typeUrl: '/noble.dollar.vaults.v1.MsgUnlockResponse',
+  typeUrl: '/noble.dollar.vaults.v1.MsgUnlockResponse' as const,
   encode(
     _: MsgUnlockResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -351,7 +351,7 @@ function createBaseMsgSetPausedState(): MsgSetPausedState {
   };
 }
 export const MsgSetPausedState = {
-  typeUrl: '/noble.dollar.vaults.v1.MsgSetPausedState',
+  typeUrl: '/noble.dollar.vaults.v1.MsgSetPausedState' as const,
   encode(
     message: MsgSetPausedState,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -421,7 +421,7 @@ function createBaseMsgSetPausedStateResponse(): MsgSetPausedStateResponse {
   return {};
 }
 export const MsgSetPausedStateResponse = {
-  typeUrl: '/noble.dollar.vaults.v1.MsgSetPausedStateResponse',
+  typeUrl: '/noble.dollar.vaults.v1.MsgSetPausedStateResponse' as const,
   encode(
     _: MsgSetPausedStateResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/noble/dollar/vaults/v1/vaults.ts
+++ b/packages/client-utils/src/codegen/noble/dollar/vaults/v1/vaults.ts
@@ -184,7 +184,7 @@ function createBaseReward(): Reward {
   };
 }
 export const Reward = {
-  typeUrl: '/noble.dollar.vaults.v1.Reward',
+  typeUrl: '/noble.dollar.vaults.v1.Reward' as const,
   encode(
     message: Reward,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -271,7 +271,7 @@ function createBasePosition(): Position {
   };
 }
 export const Position = {
-  typeUrl: '/noble.dollar.vaults.v1.Position',
+  typeUrl: '/noble.dollar.vaults.v1.Position' as const,
   encode(
     message: Position,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -369,7 +369,7 @@ function createBasePositionRewards(): PositionRewards {
   };
 }
 export const PositionRewards = {
-  typeUrl: '/noble.dollar.vaults.v1.PositionRewards',
+  typeUrl: '/noble.dollar.vaults.v1.PositionRewards' as const,
   encode(
     message: PositionRewards,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -448,7 +448,7 @@ function createBasePositionEntry(): PositionEntry {
   };
 }
 export const PositionEntry = {
-  typeUrl: '/noble.dollar.vaults.v1.PositionEntry',
+  typeUrl: '/noble.dollar.vaults.v1.PositionEntry' as const,
   encode(
     message: PositionEntry,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -572,7 +572,7 @@ function createBaseStats(): Stats {
   };
 }
 export const Stats = {
-  typeUrl: '/noble.dollar.vaults.v1.Stats',
+  typeUrl: '/noble.dollar.vaults.v1.Stats' as const,
   encode(
     message: Stats,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/noble/swap/v1/swap.ts
+++ b/packages/client-utils/src/codegen/noble/swap/v1/swap.ts
@@ -44,7 +44,7 @@ function createBaseRoute(): Route {
   };
 }
 export const Route = {
-  typeUrl: '/noble.swap.v1.Route',
+  typeUrl: '/noble.swap.v1.Route' as const,
   encode(
     message: Route,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -124,7 +124,7 @@ function createBaseSwap(): Swap {
   };
 }
 export const Swap = {
-  typeUrl: '/noble.swap.v1.Swap',
+  typeUrl: '/noble.swap.v1.Swap' as const,
   encode(
     message: Swap,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/noble/swap/v1/tx.ts
+++ b/packages/client-utils/src/codegen/noble/swap/v1/tx.ts
@@ -188,7 +188,7 @@ function createBaseMsgWithdrawProtocolFees(): MsgWithdrawProtocolFees {
   };
 }
 export const MsgWithdrawProtocolFees = {
-  typeUrl: '/noble.swap.v1.MsgWithdrawProtocolFees',
+  typeUrl: '/noble.swap.v1.MsgWithdrawProtocolFees' as const,
   encode(
     message: MsgWithdrawProtocolFees,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -266,7 +266,7 @@ function createBaseMsgWithdrawProtocolFeesResponse(): MsgWithdrawProtocolFeesRes
   return {};
 }
 export const MsgWithdrawProtocolFeesResponse = {
-  typeUrl: '/noble.swap.v1.MsgWithdrawProtocolFeesResponse',
+  typeUrl: '/noble.swap.v1.MsgWithdrawProtocolFeesResponse' as const,
   encode(
     _: MsgWithdrawProtocolFeesResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -329,7 +329,7 @@ function createBaseMsgWithdrawRewards(): MsgWithdrawRewards {
   };
 }
 export const MsgWithdrawRewards = {
-  typeUrl: '/noble.swap.v1.MsgWithdrawRewards',
+  typeUrl: '/noble.swap.v1.MsgWithdrawRewards' as const,
   encode(
     message: MsgWithdrawRewards,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -394,7 +394,7 @@ function createBaseMsgWithdrawRewardsResponse(): MsgWithdrawRewardsResponse {
   };
 }
 export const MsgWithdrawRewardsResponse = {
-  typeUrl: '/noble.swap.v1.MsgWithdrawRewardsResponse',
+  typeUrl: '/noble.swap.v1.MsgWithdrawRewardsResponse' as const,
   encode(
     message: MsgWithdrawRewardsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -476,7 +476,7 @@ function createBaseMsgSwap(): MsgSwap {
   };
 }
 export const MsgSwap = {
-  typeUrl: '/noble.swap.v1.MsgSwap',
+  typeUrl: '/noble.swap.v1.MsgSwap' as const,
   encode(
     message: MsgSwap,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -580,7 +580,7 @@ function createBaseMsgSwapResponse(): MsgSwapResponse {
   };
 }
 export const MsgSwapResponse = {
-  typeUrl: '/noble.swap.v1.MsgSwapResponse',
+  typeUrl: '/noble.swap.v1.MsgSwapResponse' as const,
   encode(
     message: MsgSwapResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -662,7 +662,7 @@ function createBaseMsgPauseByAlgorithm(): MsgPauseByAlgorithm {
   };
 }
 export const MsgPauseByAlgorithm = {
-  typeUrl: '/noble.swap.v1.MsgPauseByAlgorithm',
+  typeUrl: '/noble.swap.v1.MsgPauseByAlgorithm' as const,
   encode(
     message: MsgPauseByAlgorithm,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -739,7 +739,7 @@ function createBaseMsgPauseByAlgorithmResponse(): MsgPauseByAlgorithmResponse {
   };
 }
 export const MsgPauseByAlgorithmResponse = {
-  typeUrl: '/noble.swap.v1.MsgPauseByAlgorithmResponse',
+  typeUrl: '/noble.swap.v1.MsgPauseByAlgorithmResponse' as const,
   encode(
     message: MsgPauseByAlgorithmResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -831,7 +831,7 @@ function createBaseMsgPauseByPoolIds(): MsgPauseByPoolIds {
   };
 }
 export const MsgPauseByPoolIds = {
-  typeUrl: '/noble.swap.v1.MsgPauseByPoolIds',
+  typeUrl: '/noble.swap.v1.MsgPauseByPoolIds' as const,
   encode(
     message: MsgPauseByPoolIds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -917,7 +917,7 @@ function createBaseMsgPauseByPoolIdsResponse(): MsgPauseByPoolIdsResponse {
   };
 }
 export const MsgPauseByPoolIdsResponse = {
-  typeUrl: '/noble.swap.v1.MsgPauseByPoolIdsResponse',
+  typeUrl: '/noble.swap.v1.MsgPauseByPoolIdsResponse' as const,
   encode(
     message: MsgPauseByPoolIdsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1009,7 +1009,7 @@ function createBaseMsgUnpauseByAlgorithm(): MsgUnpauseByAlgorithm {
   };
 }
 export const MsgUnpauseByAlgorithm = {
-  typeUrl: '/noble.swap.v1.MsgUnpauseByAlgorithm',
+  typeUrl: '/noble.swap.v1.MsgUnpauseByAlgorithm' as const,
   encode(
     message: MsgUnpauseByAlgorithm,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1086,7 +1086,7 @@ function createBaseMsgUnpauseByAlgorithmResponse(): MsgUnpauseByAlgorithmRespons
   };
 }
 export const MsgUnpauseByAlgorithmResponse = {
-  typeUrl: '/noble.swap.v1.MsgUnpauseByAlgorithmResponse',
+  typeUrl: '/noble.swap.v1.MsgUnpauseByAlgorithmResponse' as const,
   encode(
     message: MsgUnpauseByAlgorithmResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1178,7 +1178,7 @@ function createBaseMsgUnpauseByPoolIds(): MsgUnpauseByPoolIds {
   };
 }
 export const MsgUnpauseByPoolIds = {
-  typeUrl: '/noble.swap.v1.MsgUnpauseByPoolIds',
+  typeUrl: '/noble.swap.v1.MsgUnpauseByPoolIds' as const,
   encode(
     message: MsgUnpauseByPoolIds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1267,7 +1267,7 @@ function createBaseMsgUnpauseByPoolIdsResponse(): MsgUnpauseByPoolIdsResponse {
   };
 }
 export const MsgUnpauseByPoolIdsResponse = {
-  typeUrl: '/noble.swap.v1.MsgUnpauseByPoolIdsResponse',
+  typeUrl: '/noble.swap.v1.MsgUnpauseByPoolIdsResponse' as const,
   encode(
     message: MsgUnpauseByPoolIdsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/epochs/genesis.ts
+++ b/packages/client-utils/src/codegen/stride/epochs/genesis.ts
@@ -56,7 +56,7 @@ function createBaseEpochInfo(): EpochInfo {
   };
 }
 export const EpochInfo = {
-  typeUrl: '/stride.epochs.EpochInfo',
+  typeUrl: '/stride.epochs.EpochInfo' as const,
   encode(
     message: EpochInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -219,7 +219,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/stride.epochs.GenesisState',
+  typeUrl: '/stride.epochs.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/epochs/query.ts
+++ b/packages/client-utils/src/codegen/stride/epochs/query.ts
@@ -77,7 +77,7 @@ function createBaseQueryEpochsInfoRequest(): QueryEpochsInfoRequest {
   };
 }
 export const QueryEpochsInfoRequest = {
-  typeUrl: '/stride.epochs.QueryEpochsInfoRequest',
+  typeUrl: '/stride.epochs.QueryEpochsInfoRequest' as const,
   encode(
     message: QueryEpochsInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -153,7 +153,7 @@ function createBaseQueryEpochsInfoResponse(): QueryEpochsInfoResponse {
   };
 }
 export const QueryEpochsInfoResponse = {
-  typeUrl: '/stride.epochs.QueryEpochsInfoResponse',
+  typeUrl: '/stride.epochs.QueryEpochsInfoResponse' as const,
   encode(
     message: QueryEpochsInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -252,7 +252,7 @@ function createBaseQueryCurrentEpochRequest(): QueryCurrentEpochRequest {
   };
 }
 export const QueryCurrentEpochRequest = {
-  typeUrl: '/stride.epochs.QueryCurrentEpochRequest',
+  typeUrl: '/stride.epochs.QueryCurrentEpochRequest' as const,
   encode(
     message: QueryCurrentEpochRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -325,7 +325,7 @@ function createBaseQueryCurrentEpochResponse(): QueryCurrentEpochResponse {
   };
 }
 export const QueryCurrentEpochResponse = {
-  typeUrl: '/stride.epochs.QueryCurrentEpochResponse',
+  typeUrl: '/stride.epochs.QueryCurrentEpochResponse' as const,
   encode(
     message: QueryCurrentEpochResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -404,7 +404,7 @@ function createBaseQueryEpochInfoRequest(): QueryEpochInfoRequest {
   };
 }
 export const QueryEpochInfoRequest = {
-  typeUrl: '/stride.epochs.QueryEpochInfoRequest',
+  typeUrl: '/stride.epochs.QueryEpochInfoRequest' as const,
   encode(
     message: QueryEpochInfoRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -469,7 +469,7 @@ function createBaseQueryEpochInfoResponse(): QueryEpochInfoResponse {
   };
 }
 export const QueryEpochInfoResponse = {
-  typeUrl: '/stride.epochs.QueryEpochInfoResponse',
+  typeUrl: '/stride.epochs.QueryEpochInfoResponse' as const,
   encode(
     message: QueryEpochInfoResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/records/callbacks.ts
+++ b/packages/client-utils/src/codegen/stride/records/callbacks.ts
@@ -29,7 +29,7 @@ function createBaseTransferCallback(): TransferCallback {
   };
 }
 export const TransferCallback = {
-  typeUrl: '/stride.records.TransferCallback',
+  typeUrl: '/stride.records.TransferCallback' as const,
   encode(
     message: TransferCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -97,7 +97,7 @@ function createBaseTransferLSMTokenCallback(): TransferLSMTokenCallback {
   };
 }
 export const TransferLSMTokenCallback = {
-  typeUrl: '/stride.records.TransferLSMTokenCallback',
+  typeUrl: '/stride.records.TransferLSMTokenCallback' as const,
   encode(
     message: TransferLSMTokenCallback,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/records/genesis.ts
+++ b/packages/client-utils/src/codegen/stride/records/genesis.ts
@@ -52,7 +52,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/stride.records.GenesisState',
+  typeUrl: '/stride.records.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/records/params.ts
+++ b/packages/client-utils/src/codegen/stride/records/params.ts
@@ -13,7 +13,7 @@ function createBaseParams(): Params {
   return {};
 }
 export const Params = {
-  typeUrl: '/stride.records.Params',
+  typeUrl: '/stride.records.Params' as const,
   encode(
     _: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/records/query.ts
+++ b/packages/client-utils/src/codegen/stride/records/query.ts
@@ -268,7 +268,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/stride.records.QueryParamsRequest',
+  typeUrl: '/stride.records.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -323,7 +323,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/stride.records.QueryParamsResponse',
+  typeUrl: '/stride.records.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -392,7 +392,7 @@ function createBaseQueryGetDepositRecordRequest(): QueryGetDepositRecordRequest 
   };
 }
 export const QueryGetDepositRecordRequest = {
-  typeUrl: '/stride.records.QueryGetDepositRecordRequest',
+  typeUrl: '/stride.records.QueryGetDepositRecordRequest' as const,
   encode(
     message: QueryGetDepositRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -468,7 +468,7 @@ function createBaseQueryGetDepositRecordResponse(): QueryGetDepositRecordRespons
   };
 }
 export const QueryGetDepositRecordResponse = {
-  typeUrl: '/stride.records.QueryGetDepositRecordResponse',
+  typeUrl: '/stride.records.QueryGetDepositRecordResponse' as const,
   encode(
     message: QueryGetDepositRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -552,7 +552,7 @@ function createBaseQueryAllDepositRecordRequest(): QueryAllDepositRecordRequest 
   };
 }
 export const QueryAllDepositRecordRequest = {
-  typeUrl: '/stride.records.QueryAllDepositRecordRequest',
+  typeUrl: '/stride.records.QueryAllDepositRecordRequest' as const,
   encode(
     message: QueryAllDepositRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -634,7 +634,7 @@ function createBaseQueryAllDepositRecordResponse(): QueryAllDepositRecordRespons
   };
 }
 export const QueryAllDepositRecordResponse = {
-  typeUrl: '/stride.records.QueryAllDepositRecordResponse',
+  typeUrl: '/stride.records.QueryAllDepositRecordResponse' as const,
   encode(
     message: QueryAllDepositRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -738,7 +738,7 @@ function createBaseQueryDepositRecordByHostRequest(): QueryDepositRecordByHostRe
   };
 }
 export const QueryDepositRecordByHostRequest = {
-  typeUrl: '/stride.records.QueryDepositRecordByHostRequest',
+  typeUrl: '/stride.records.QueryDepositRecordByHostRequest' as const,
   encode(
     message: QueryDepositRecordByHostRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -811,7 +811,7 @@ function createBaseQueryDepositRecordByHostResponse(): QueryDepositRecordByHostR
   };
 }
 export const QueryDepositRecordByHostResponse = {
-  typeUrl: '/stride.records.QueryDepositRecordByHostResponse',
+  typeUrl: '/stride.records.QueryDepositRecordByHostResponse' as const,
   encode(
     message: QueryDepositRecordByHostResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -895,7 +895,7 @@ function createBaseQueryGetUserRedemptionRecordRequest(): QueryGetUserRedemption
   };
 }
 export const QueryGetUserRedemptionRecordRequest = {
-  typeUrl: '/stride.records.QueryGetUserRedemptionRecordRequest',
+  typeUrl: '/stride.records.QueryGetUserRedemptionRecordRequest' as const,
   encode(
     message: QueryGetUserRedemptionRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -968,7 +968,7 @@ function createBaseQueryGetUserRedemptionRecordResponse(): QueryGetUserRedemptio
   };
 }
 export const QueryGetUserRedemptionRecordResponse = {
-  typeUrl: '/stride.records.QueryGetUserRedemptionRecordResponse',
+  typeUrl: '/stride.records.QueryGetUserRedemptionRecordResponse' as const,
   encode(
     message: QueryGetUserRedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1056,7 +1056,7 @@ function createBaseQueryAllUserRedemptionRecordRequest(): QueryAllUserRedemption
   };
 }
 export const QueryAllUserRedemptionRecordRequest = {
-  typeUrl: '/stride.records.QueryAllUserRedemptionRecordRequest',
+  typeUrl: '/stride.records.QueryAllUserRedemptionRecordRequest' as const,
   encode(
     message: QueryAllUserRedemptionRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1138,7 +1138,7 @@ function createBaseQueryAllUserRedemptionRecordResponse(): QueryAllUserRedemptio
   };
 }
 export const QueryAllUserRedemptionRecordResponse = {
-  typeUrl: '/stride.records.QueryAllUserRedemptionRecordResponse',
+  typeUrl: '/stride.records.QueryAllUserRedemptionRecordResponse' as const,
   encode(
     message: QueryAllUserRedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1250,7 +1250,8 @@ function createBaseQueryAllUserRedemptionRecordForUserRequest(): QueryAllUserRed
   };
 }
 export const QueryAllUserRedemptionRecordForUserRequest = {
-  typeUrl: '/stride.records.QueryAllUserRedemptionRecordForUserRequest',
+  typeUrl:
+    '/stride.records.QueryAllUserRedemptionRecordForUserRequest' as const,
   encode(
     message: QueryAllUserRedemptionRecordForUserRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1377,7 +1378,8 @@ function createBaseQueryAllUserRedemptionRecordForUserResponse(): QueryAllUserRe
   };
 }
 export const QueryAllUserRedemptionRecordForUserResponse = {
-  typeUrl: '/stride.records.QueryAllUserRedemptionRecordForUserResponse',
+  typeUrl:
+    '/stride.records.QueryAllUserRedemptionRecordForUserResponse' as const,
   encode(
     message: QueryAllUserRedemptionRecordForUserResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1486,7 +1488,7 @@ function createBaseQueryGetEpochUnbondingRecordRequest(): QueryGetEpochUnbonding
   };
 }
 export const QueryGetEpochUnbondingRecordRequest = {
-  typeUrl: '/stride.records.QueryGetEpochUnbondingRecordRequest',
+  typeUrl: '/stride.records.QueryGetEpochUnbondingRecordRequest' as const,
   encode(
     message: QueryGetEpochUnbondingRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1565,7 +1567,7 @@ function createBaseQueryGetEpochUnbondingRecordResponse(): QueryGetEpochUnbondin
   };
 }
 export const QueryGetEpochUnbondingRecordResponse = {
-  typeUrl: '/stride.records.QueryGetEpochUnbondingRecordResponse',
+  typeUrl: '/stride.records.QueryGetEpochUnbondingRecordResponse' as const,
   encode(
     message: QueryGetEpochUnbondingRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1653,7 +1655,7 @@ function createBaseQueryAllEpochUnbondingRecordRequest(): QueryAllEpochUnbonding
   };
 }
 export const QueryAllEpochUnbondingRecordRequest = {
-  typeUrl: '/stride.records.QueryAllEpochUnbondingRecordRequest',
+  typeUrl: '/stride.records.QueryAllEpochUnbondingRecordRequest' as const,
   encode(
     message: QueryAllEpochUnbondingRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1735,7 +1737,7 @@ function createBaseQueryAllEpochUnbondingRecordResponse(): QueryAllEpochUnbondin
   };
 }
 export const QueryAllEpochUnbondingRecordResponse = {
-  typeUrl: '/stride.records.QueryAllEpochUnbondingRecordResponse',
+  typeUrl: '/stride.records.QueryAllEpochUnbondingRecordResponse' as const,
   encode(
     message: QueryAllEpochUnbondingRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1844,7 +1846,7 @@ function createBaseQueryLSMDepositRequest(): QueryLSMDepositRequest {
   };
 }
 export const QueryLSMDepositRequest = {
-  typeUrl: '/stride.records.QueryLSMDepositRequest',
+  typeUrl: '/stride.records.QueryLSMDepositRequest' as const,
   encode(
     message: QueryLSMDepositRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1920,7 +1922,7 @@ function createBaseQueryLSMDepositResponse(): QueryLSMDepositResponse {
   };
 }
 export const QueryLSMDepositResponse = {
-  typeUrl: '/stride.records.QueryLSMDepositResponse',
+  typeUrl: '/stride.records.QueryLSMDepositResponse' as const,
   encode(
     message: QueryLSMDepositResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2004,7 +2006,7 @@ function createBaseQueryLSMDepositsRequest(): QueryLSMDepositsRequest {
   };
 }
 export const QueryLSMDepositsRequest = {
-  typeUrl: '/stride.records.QueryLSMDepositsRequest',
+  typeUrl: '/stride.records.QueryLSMDepositsRequest' as const,
   encode(
     message: QueryLSMDepositsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2096,7 +2098,7 @@ function createBaseQueryLSMDepositsResponse(): QueryLSMDepositsResponse {
   };
 }
 export const QueryLSMDepositsResponse = {
-  typeUrl: '/stride.records.QueryLSMDepositsResponse',
+  typeUrl: '/stride.records.QueryLSMDepositsResponse' as const,
   encode(
     message: QueryLSMDepositsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/records/records.ts
+++ b/packages/client-utils/src/codegen/stride/records/records.ts
@@ -349,7 +349,7 @@ function createBaseUserRedemptionRecord(): UserRedemptionRecord {
   };
 }
 export const UserRedemptionRecord = {
-  typeUrl: '/stride.records.UserRedemptionRecord',
+  typeUrl: '/stride.records.UserRedemptionRecord' as const,
   encode(
     message: UserRedemptionRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -499,7 +499,7 @@ function createBaseDepositRecord(): DepositRecord {
   };
 }
 export const DepositRecord = {
-  typeUrl: '/stride.records.DepositRecord',
+  typeUrl: '/stride.records.DepositRecord' as const,
   encode(
     message: DepositRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -661,7 +661,7 @@ function createBaseHostZoneUnbonding(): HostZoneUnbonding {
   };
 }
 export const HostZoneUnbonding = {
-  typeUrl: '/stride.records.HostZoneUnbonding',
+  typeUrl: '/stride.records.HostZoneUnbonding' as const,
   encode(
     message: HostZoneUnbonding,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -854,7 +854,7 @@ function createBaseEpochUnbondingRecord(): EpochUnbondingRecord {
   };
 }
 export const EpochUnbondingRecord = {
-  typeUrl: '/stride.records.EpochUnbondingRecord',
+  typeUrl: '/stride.records.EpochUnbondingRecord' as const,
   encode(
     message: EpochUnbondingRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -956,7 +956,7 @@ function createBaseLSMTokenDeposit(): LSMTokenDeposit {
   };
 }
 export const LSMTokenDeposit = {
-  typeUrl: '/stride.records.LSMTokenDeposit',
+  typeUrl: '/stride.records.LSMTokenDeposit' as const,
   encode(
     message: LSMTokenDeposit,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakedym/genesis.ts
+++ b/packages/client-utils/src/codegen/stride/stakedym/genesis.ts
@@ -72,7 +72,7 @@ function createBaseParams(): Params {
   return {};
 }
 export const Params = {
-  typeUrl: '/stride.stakedym.Params',
+  typeUrl: '/stride.stakedym.Params' as const,
   encode(
     _: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -126,7 +126,7 @@ function createBaseTransferInProgressRecordIds(): TransferInProgressRecordIds {
   };
 }
 export const TransferInProgressRecordIds = {
-  typeUrl: '/stride.stakedym.TransferInProgressRecordIds',
+  typeUrl: '/stride.stakedym.TransferInProgressRecordIds' as const,
   encode(
     message: TransferInProgressRecordIds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -235,7 +235,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/stride.stakedym.GenesisState',
+  typeUrl: '/stride.stakedym.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakedym/query.ts
+++ b/packages/client-utils/src/codegen/stride/stakedym/query.ts
@@ -175,7 +175,7 @@ function createBaseQueryHostZoneRequest(): QueryHostZoneRequest {
   return {};
 }
 export const QueryHostZoneRequest = {
-  typeUrl: '/stride.stakedym.QueryHostZoneRequest',
+  typeUrl: '/stride.stakedym.QueryHostZoneRequest' as const,
   encode(
     _: QueryHostZoneRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -230,7 +230,7 @@ function createBaseQueryHostZoneResponse(): QueryHostZoneResponse {
   };
 }
 export const QueryHostZoneResponse = {
-  typeUrl: '/stride.stakedym.QueryHostZoneResponse',
+  typeUrl: '/stride.stakedym.QueryHostZoneResponse' as const,
   encode(
     message: QueryHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -303,7 +303,7 @@ function createBaseQueryDelegationRecordsRequest(): QueryDelegationRecordsReques
   };
 }
 export const QueryDelegationRecordsRequest = {
-  typeUrl: '/stride.stakedym.QueryDelegationRecordsRequest',
+  typeUrl: '/stride.stakedym.QueryDelegationRecordsRequest' as const,
   encode(
     message: QueryDelegationRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -379,7 +379,7 @@ function createBaseQueryDelegationRecordsResponse(): QueryDelegationRecordsRespo
   };
 }
 export const QueryDelegationRecordsResponse = {
-  typeUrl: '/stride.stakedym.QueryDelegationRecordsResponse',
+  typeUrl: '/stride.stakedym.QueryDelegationRecordsResponse' as const,
   encode(
     message: QueryDelegationRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -463,7 +463,7 @@ function createBaseQueryUnbondingRecordsRequest(): QueryUnbondingRecordsRequest 
   };
 }
 export const QueryUnbondingRecordsRequest = {
-  typeUrl: '/stride.stakedym.QueryUnbondingRecordsRequest',
+  typeUrl: '/stride.stakedym.QueryUnbondingRecordsRequest' as const,
   encode(
     message: QueryUnbondingRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -539,7 +539,7 @@ function createBaseQueryUnbondingRecordsResponse(): QueryUnbondingRecordsRespons
   };
 }
 export const QueryUnbondingRecordsResponse = {
-  typeUrl: '/stride.stakedym.QueryUnbondingRecordsResponse',
+  typeUrl: '/stride.stakedym.QueryUnbondingRecordsResponse' as const,
   encode(
     message: QueryUnbondingRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -624,7 +624,7 @@ function createBaseQueryRedemptionRecordRequest(): QueryRedemptionRecordRequest 
   };
 }
 export const QueryRedemptionRecordRequest = {
-  typeUrl: '/stride.stakedym.QueryRedemptionRecordRequest',
+  typeUrl: '/stride.stakedym.QueryRedemptionRecordRequest' as const,
   encode(
     message: QueryRedemptionRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -715,7 +715,7 @@ function createBaseQueryRedemptionRecordResponse(): QueryRedemptionRecordRespons
   };
 }
 export const QueryRedemptionRecordResponse = {
-  typeUrl: '/stride.stakedym.QueryRedemptionRecordResponse',
+  typeUrl: '/stride.stakedym.QueryRedemptionRecordResponse' as const,
   encode(
     message: QueryRedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -805,7 +805,7 @@ function createBaseQueryRedemptionRecordsRequest(): QueryRedemptionRecordsReques
   };
 }
 export const QueryRedemptionRecordsRequest = {
-  typeUrl: '/stride.stakedym.QueryRedemptionRecordsRequest',
+  typeUrl: '/stride.stakedym.QueryRedemptionRecordsRequest' as const,
   encode(
     message: QueryRedemptionRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -914,7 +914,7 @@ function createBaseQueryRedemptionRecordsResponse(): QueryRedemptionRecordsRespo
   };
 }
 export const QueryRedemptionRecordsResponse = {
-  typeUrl: '/stride.stakedym.QueryRedemptionRecordsResponse',
+  typeUrl: '/stride.stakedym.QueryRedemptionRecordsResponse' as const,
   encode(
     message: QueryRedemptionRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1022,7 +1022,7 @@ function createBaseQuerySlashRecordsRequest(): QuerySlashRecordsRequest {
   return {};
 }
 export const QuerySlashRecordsRequest = {
-  typeUrl: '/stride.stakedym.QuerySlashRecordsRequest',
+  typeUrl: '/stride.stakedym.QuerySlashRecordsRequest' as const,
   encode(
     _: QuerySlashRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1081,7 +1081,7 @@ function createBaseQuerySlashRecordsResponse(): QuerySlashRecordsResponse {
   };
 }
 export const QuerySlashRecordsResponse = {
-  typeUrl: '/stride.stakedym.QuerySlashRecordsResponse',
+  typeUrl: '/stride.stakedym.QuerySlashRecordsResponse' as const,
   encode(
     message: QuerySlashRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1166,7 +1166,7 @@ function createBaseRedemptionRecordResponse(): RedemptionRecordResponse {
   };
 }
 export const RedemptionRecordResponse = {
-  typeUrl: '/stride.stakedym.RedemptionRecordResponse',
+  typeUrl: '/stride.stakedym.RedemptionRecordResponse' as const,
   encode(
     message: RedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakedym/stakedym.ts
+++ b/packages/client-utils/src/codegen/stride/stakedym/stakedym.ts
@@ -358,7 +358,7 @@ function createBaseHostZone(): HostZone {
   };
 }
 export const HostZone = {
-  typeUrl: '/stride.stakedym.HostZone',
+  typeUrl: '/stride.stakedym.HostZone' as const,
   encode(
     message: HostZone,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -688,7 +688,7 @@ function createBaseDelegationRecord(): DelegationRecord {
   };
 }
 export const DelegationRecord = {
-  typeUrl: '/stride.stakedym.DelegationRecord',
+  typeUrl: '/stride.stakedym.DelegationRecord' as const,
   encode(
     message: DelegationRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -792,7 +792,7 @@ function createBaseUnbondingRecord(): UnbondingRecord {
   };
 }
 export const UnbondingRecord = {
-  typeUrl: '/stride.stakedym.UnbondingRecord',
+  typeUrl: '/stride.stakedym.UnbondingRecord' as const,
   encode(
     message: UnbondingRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -940,7 +940,7 @@ function createBaseRedemptionRecord(): RedemptionRecord {
   };
 }
 export const RedemptionRecord = {
-  typeUrl: '/stride.stakedym.RedemptionRecord',
+  typeUrl: '/stride.stakedym.RedemptionRecord' as const,
   encode(
     message: RedemptionRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1047,7 +1047,7 @@ function createBaseSlashRecord(): SlashRecord {
   };
 }
 export const SlashRecord = {
-  typeUrl: '/stride.stakedym.SlashRecord',
+  typeUrl: '/stride.stakedym.SlashRecord' as const,
   encode(
     message: SlashRecord,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakedym/tx.ts
+++ b/packages/client-utils/src/codegen/stride/stakedym/tx.ts
@@ -334,7 +334,7 @@ function createBaseMsgLiquidStake(): MsgLiquidStake {
   };
 }
 export const MsgLiquidStake = {
-  typeUrl: '/stride.stakedym.MsgLiquidStake',
+  typeUrl: '/stride.stakedym.MsgLiquidStake' as const,
   encode(
     message: MsgLiquidStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -408,7 +408,7 @@ function createBaseMsgLiquidStakeResponse(): MsgLiquidStakeResponse {
   };
 }
 export const MsgLiquidStakeResponse = {
-  typeUrl: '/stride.stakedym.MsgLiquidStakeResponse',
+  typeUrl: '/stride.stakedym.MsgLiquidStakeResponse' as const,
   encode(
     message: MsgLiquidStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -484,7 +484,7 @@ function createBaseMsgRedeemStake(): MsgRedeemStake {
   };
 }
 export const MsgRedeemStake = {
-  typeUrl: '/stride.stakedym.MsgRedeemStake',
+  typeUrl: '/stride.stakedym.MsgRedeemStake' as const,
   encode(
     message: MsgRedeemStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -558,7 +558,7 @@ function createBaseMsgRedeemStakeResponse(): MsgRedeemStakeResponse {
   };
 }
 export const MsgRedeemStakeResponse = {
-  typeUrl: '/stride.stakedym.MsgRedeemStakeResponse',
+  typeUrl: '/stride.stakedym.MsgRedeemStakeResponse' as const,
   encode(
     message: MsgRedeemStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -635,7 +635,7 @@ function createBaseMsgConfirmDelegation(): MsgConfirmDelegation {
   };
 }
 export const MsgConfirmDelegation = {
-  typeUrl: '/stride.stakedym.MsgConfirmDelegation',
+  typeUrl: '/stride.stakedym.MsgConfirmDelegation' as const,
   encode(
     message: MsgConfirmDelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -722,7 +722,7 @@ function createBaseMsgConfirmDelegationResponse(): MsgConfirmDelegationResponse 
   return {};
 }
 export const MsgConfirmDelegationResponse = {
-  typeUrl: '/stride.stakedym.MsgConfirmDelegationResponse',
+  typeUrl: '/stride.stakedym.MsgConfirmDelegationResponse' as const,
   encode(
     _: MsgConfirmDelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -787,7 +787,7 @@ function createBaseMsgConfirmUndelegation(): MsgConfirmUndelegation {
   };
 }
 export const MsgConfirmUndelegation = {
-  typeUrl: '/stride.stakedym.MsgConfirmUndelegation',
+  typeUrl: '/stride.stakedym.MsgConfirmUndelegation' as const,
   encode(
     message: MsgConfirmUndelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -876,7 +876,7 @@ function createBaseMsgConfirmUndelegationResponse(): MsgConfirmUndelegationRespo
   return {};
 }
 export const MsgConfirmUndelegationResponse = {
-  typeUrl: '/stride.stakedym.MsgConfirmUndelegationResponse',
+  typeUrl: '/stride.stakedym.MsgConfirmUndelegationResponse' as const,
   encode(
     _: MsgConfirmUndelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -941,7 +941,7 @@ function createBaseMsgConfirmUnbondedTokenSweep(): MsgConfirmUnbondedTokenSweep 
   };
 }
 export const MsgConfirmUnbondedTokenSweep = {
-  typeUrl: '/stride.stakedym.MsgConfirmUnbondedTokenSweep',
+  typeUrl: '/stride.stakedym.MsgConfirmUnbondedTokenSweep' as const,
   encode(
     message: MsgConfirmUnbondedTokenSweep,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1036,7 +1036,7 @@ function createBaseMsgConfirmUnbondedTokenSweepResponse(): MsgConfirmUnbondedTok
   return {};
 }
 export const MsgConfirmUnbondedTokenSweepResponse = {
-  typeUrl: '/stride.stakedym.MsgConfirmUnbondedTokenSweepResponse',
+  typeUrl: '/stride.stakedym.MsgConfirmUnbondedTokenSweepResponse' as const,
   encode(
     _: MsgConfirmUnbondedTokenSweepResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1101,7 +1101,7 @@ function createBaseMsgAdjustDelegatedBalance(): MsgAdjustDelegatedBalance {
   };
 }
 export const MsgAdjustDelegatedBalance = {
-  typeUrl: '/stride.stakedym.MsgAdjustDelegatedBalance',
+  typeUrl: '/stride.stakedym.MsgAdjustDelegatedBalance' as const,
   encode(
     message: MsgAdjustDelegatedBalance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1196,7 +1196,7 @@ function createBaseMsgAdjustDelegatedBalanceResponse(): MsgAdjustDelegatedBalanc
   return {};
 }
 export const MsgAdjustDelegatedBalanceResponse = {
-  typeUrl: '/stride.stakedym.MsgAdjustDelegatedBalanceResponse',
+  typeUrl: '/stride.stakedym.MsgAdjustDelegatedBalanceResponse' as const,
   encode(
     _: MsgAdjustDelegatedBalanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1261,7 +1261,7 @@ function createBaseMsgUpdateInnerRedemptionRateBounds(): MsgUpdateInnerRedemptio
   };
 }
 export const MsgUpdateInnerRedemptionRateBounds = {
-  typeUrl: '/stride.stakedym.MsgUpdateInnerRedemptionRateBounds',
+  typeUrl: '/stride.stakedym.MsgUpdateInnerRedemptionRateBounds' as const,
   encode(
     message: MsgUpdateInnerRedemptionRateBounds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1370,7 +1370,8 @@ function createBaseMsgUpdateInnerRedemptionRateBoundsResponse(): MsgUpdateInnerR
   return {};
 }
 export const MsgUpdateInnerRedemptionRateBoundsResponse = {
-  typeUrl: '/stride.stakedym.MsgUpdateInnerRedemptionRateBoundsResponse',
+  typeUrl:
+    '/stride.stakedym.MsgUpdateInnerRedemptionRateBoundsResponse' as const,
   encode(
     _: MsgUpdateInnerRedemptionRateBoundsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1434,7 +1435,7 @@ function createBaseMsgResumeHostZone(): MsgResumeHostZone {
   };
 }
 export const MsgResumeHostZone = {
-  typeUrl: '/stride.stakedym.MsgResumeHostZone',
+  typeUrl: '/stride.stakedym.MsgResumeHostZone' as const,
   encode(
     message: MsgResumeHostZone,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1494,7 +1495,7 @@ function createBaseMsgResumeHostZoneResponse(): MsgResumeHostZoneResponse {
   return {};
 }
 export const MsgResumeHostZoneResponse = {
-  typeUrl: '/stride.stakedym.MsgResumeHostZoneResponse',
+  typeUrl: '/stride.stakedym.MsgResumeHostZoneResponse' as const,
   encode(
     _: MsgResumeHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1555,7 +1556,7 @@ function createBaseMsgRefreshRedemptionRate(): MsgRefreshRedemptionRate {
   };
 }
 export const MsgRefreshRedemptionRate = {
-  typeUrl: '/stride.stakedym.MsgRefreshRedemptionRate',
+  typeUrl: '/stride.stakedym.MsgRefreshRedemptionRate' as const,
   encode(
     message: MsgRefreshRedemptionRate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1626,7 +1627,7 @@ function createBaseMsgRefreshRedemptionRateResponse(): MsgRefreshRedemptionRateR
   return {};
 }
 export const MsgRefreshRedemptionRateResponse = {
-  typeUrl: '/stride.stakedym.MsgRefreshRedemptionRateResponse',
+  typeUrl: '/stride.stakedym.MsgRefreshRedemptionRateResponse' as const,
   encode(
     _: MsgRefreshRedemptionRateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1690,7 +1691,7 @@ function createBaseMsgOverwriteDelegationRecord(): MsgOverwriteDelegationRecord 
   };
 }
 export const MsgOverwriteDelegationRecord = {
-  typeUrl: '/stride.stakedym.MsgOverwriteDelegationRecord',
+  typeUrl: '/stride.stakedym.MsgOverwriteDelegationRecord' as const,
   encode(
     message: MsgOverwriteDelegationRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1784,7 +1785,7 @@ function createBaseMsgOverwriteDelegationRecordResponse(): MsgOverwriteDelegatio
   return {};
 }
 export const MsgOverwriteDelegationRecordResponse = {
-  typeUrl: '/stride.stakedym.MsgOverwriteDelegationRecordResponse',
+  typeUrl: '/stride.stakedym.MsgOverwriteDelegationRecordResponse' as const,
   encode(
     _: MsgOverwriteDelegationRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1848,7 +1849,7 @@ function createBaseMsgOverwriteUnbondingRecord(): MsgOverwriteUnbondingRecord {
   };
 }
 export const MsgOverwriteUnbondingRecord = {
-  typeUrl: '/stride.stakedym.MsgOverwriteUnbondingRecord',
+  typeUrl: '/stride.stakedym.MsgOverwriteUnbondingRecord' as const,
   encode(
     message: MsgOverwriteUnbondingRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1942,7 +1943,7 @@ function createBaseMsgOverwriteUnbondingRecordResponse(): MsgOverwriteUnbondingR
   return {};
 }
 export const MsgOverwriteUnbondingRecordResponse = {
-  typeUrl: '/stride.stakedym.MsgOverwriteUnbondingRecordResponse',
+  typeUrl: '/stride.stakedym.MsgOverwriteUnbondingRecordResponse' as const,
   encode(
     _: MsgOverwriteUnbondingRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2006,7 +2007,7 @@ function createBaseMsgOverwriteRedemptionRecord(): MsgOverwriteRedemptionRecord 
   };
 }
 export const MsgOverwriteRedemptionRecord = {
-  typeUrl: '/stride.stakedym.MsgOverwriteRedemptionRecord',
+  typeUrl: '/stride.stakedym.MsgOverwriteRedemptionRecord' as const,
   encode(
     message: MsgOverwriteRedemptionRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2100,7 +2101,7 @@ function createBaseMsgOverwriteRedemptionRecordResponse(): MsgOverwriteRedemptio
   return {};
 }
 export const MsgOverwriteRedemptionRecordResponse = {
-  typeUrl: '/stride.stakedym.MsgOverwriteRedemptionRecordResponse',
+  typeUrl: '/stride.stakedym.MsgOverwriteRedemptionRecordResponse' as const,
   encode(
     _: MsgOverwriteRedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2164,7 +2165,7 @@ function createBaseMsgSetOperatorAddress(): MsgSetOperatorAddress {
   };
 }
 export const MsgSetOperatorAddress = {
-  typeUrl: '/stride.stakedym.MsgSetOperatorAddress',
+  typeUrl: '/stride.stakedym.MsgSetOperatorAddress' as const,
   encode(
     message: MsgSetOperatorAddress,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2236,7 +2237,7 @@ function createBaseMsgSetOperatorAddressResponse(): MsgSetOperatorAddressRespons
   return {};
 }
 export const MsgSetOperatorAddressResponse = {
-  typeUrl: '/stride.stakedym.MsgSetOperatorAddressResponse',
+  typeUrl: '/stride.stakedym.MsgSetOperatorAddressResponse' as const,
   encode(
     _: MsgSetOperatorAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/address_unbonding.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/address_unbonding.ts
@@ -36,7 +36,7 @@ function createBaseAddressUnbonding(): AddressUnbonding {
   };
 }
 export const AddressUnbonding = {
-  typeUrl: '/stride.stakeibc.AddressUnbonding',
+  typeUrl: '/stride.stakeibc.AddressUnbonding' as const,
   encode(
     message: AddressUnbonding,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/callbacks.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/callbacks.ts
@@ -206,7 +206,7 @@ function createBaseSplitDelegation(): SplitDelegation {
   };
 }
 export const SplitDelegation = {
-  typeUrl: '/stride.stakeibc.SplitDelegation',
+  typeUrl: '/stride.stakeibc.SplitDelegation' as const,
   encode(
     message: SplitDelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -278,7 +278,7 @@ function createBaseSplitUndelegation(): SplitUndelegation {
   };
 }
 export const SplitUndelegation = {
-  typeUrl: '/stride.stakeibc.SplitUndelegation',
+  typeUrl: '/stride.stakeibc.SplitUndelegation' as const,
   encode(
     message: SplitUndelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -354,7 +354,7 @@ function createBaseDelegateCallback(): DelegateCallback {
   };
 }
 export const DelegateCallback = {
-  typeUrl: '/stride.stakeibc.DelegateCallback',
+  typeUrl: '/stride.stakeibc.DelegateCallback' as const,
   encode(
     message: DelegateCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -453,7 +453,7 @@ function createBaseClaimCallback(): ClaimCallback {
   };
 }
 export const ClaimCallback = {
-  typeUrl: '/stride.stakeibc.ClaimCallback',
+  typeUrl: '/stride.stakeibc.ClaimCallback' as const,
   encode(
     message: ClaimCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -543,7 +543,7 @@ function createBaseReinvestCallback(): ReinvestCallback {
   };
 }
 export const ReinvestCallback = {
-  typeUrl: '/stride.stakeibc.ReinvestCallback',
+  typeUrl: '/stride.stakeibc.ReinvestCallback' as const,
   encode(
     message: ReinvestCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -624,7 +624,7 @@ function createBaseUndelegateCallback(): UndelegateCallback {
   };
 }
 export const UndelegateCallback = {
-  typeUrl: '/stride.stakeibc.UndelegateCallback',
+  typeUrl: '/stride.stakeibc.UndelegateCallback' as const,
   encode(
     message: UndelegateCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -740,7 +740,7 @@ function createBaseRedemptionCallback(): RedemptionCallback {
   };
 }
 export const RedemptionCallback = {
-  typeUrl: '/stride.stakeibc.RedemptionCallback',
+  typeUrl: '/stride.stakeibc.RedemptionCallback' as const,
   encode(
     message: RedemptionCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -834,7 +834,7 @@ function createBaseRebalancing(): Rebalancing {
   };
 }
 export const Rebalancing = {
-  typeUrl: '/stride.stakeibc.Rebalancing',
+  typeUrl: '/stride.stakeibc.Rebalancing' as const,
   encode(
     message: Rebalancing,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -921,7 +921,7 @@ function createBaseRebalanceCallback(): RebalanceCallback {
   };
 }
 export const RebalanceCallback = {
-  typeUrl: '/stride.stakeibc.RebalanceCallback',
+  typeUrl: '/stride.stakeibc.RebalanceCallback' as const,
   encode(
     message: RebalanceCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1003,7 +1003,7 @@ function createBaseDetokenizeSharesCallback(): DetokenizeSharesCallback {
   };
 }
 export const DetokenizeSharesCallback = {
-  typeUrl: '/stride.stakeibc.DetokenizeSharesCallback',
+  typeUrl: '/stride.stakeibc.DetokenizeSharesCallback' as const,
   encode(
     message: DetokenizeSharesCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1089,7 +1089,7 @@ function createBaseLSMLiquidStake(): LSMLiquidStake {
   };
 }
 export const LSMLiquidStake = {
-  typeUrl: '/stride.stakeibc.LSMLiquidStake',
+  typeUrl: '/stride.stakeibc.LSMLiquidStake' as const,
   encode(
     message: LSMLiquidStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1196,7 +1196,7 @@ function createBaseValidatorSharesToTokensQueryCallback(): ValidatorSharesToToke
   };
 }
 export const ValidatorSharesToTokensQueryCallback = {
-  typeUrl: '/stride.stakeibc.ValidatorSharesToTokensQueryCallback',
+  typeUrl: '/stride.stakeibc.ValidatorSharesToTokensQueryCallback' as const,
   encode(
     message: ValidatorSharesToTokensQueryCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1283,7 +1283,7 @@ function createBaseDelegatorSharesQueryCallback(): DelegatorSharesQueryCallback 
   };
 }
 export const DelegatorSharesQueryCallback = {
-  typeUrl: '/stride.stakeibc.DelegatorSharesQueryCallback',
+  typeUrl: '/stride.stakeibc.DelegatorSharesQueryCallback' as const,
   encode(
     message: DelegatorSharesQueryCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1361,7 +1361,7 @@ function createBaseCommunityPoolBalanceQueryCallback(): CommunityPoolBalanceQuer
   };
 }
 export const CommunityPoolBalanceQueryCallback = {
-  typeUrl: '/stride.stakeibc.CommunityPoolBalanceQueryCallback',
+  typeUrl: '/stride.stakeibc.CommunityPoolBalanceQueryCallback' as const,
   encode(
     message: CommunityPoolBalanceQueryCallback,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1447,7 +1447,7 @@ function createBaseTradeRouteCallback(): TradeRouteCallback {
   };
 }
 export const TradeRouteCallback = {
-  typeUrl: '/stride.stakeibc.TradeRouteCallback',
+  typeUrl: '/stride.stakeibc.TradeRouteCallback' as const,
   encode(
     message: TradeRouteCallback,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/epoch_tracker.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/epoch_tracker.ts
@@ -27,7 +27,7 @@ function createBaseEpochTracker(): EpochTracker {
   };
 }
 export const EpochTracker = {
-  typeUrl: '/stride.stakeibc.EpochTracker',
+  typeUrl: '/stride.stakeibc.EpochTracker' as const,
   encode(
     message: EpochTracker,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/genesis.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/genesis.ts
@@ -36,7 +36,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/stride.stakeibc.GenesisState',
+  typeUrl: '/stride.stakeibc.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/gov.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/gov.ts
@@ -49,7 +49,7 @@ function createBaseAddValidatorsProposal(): AddValidatorsProposal {
   };
 }
 export const AddValidatorsProposal = {
-  typeUrl: '/stride.stakeibc.AddValidatorsProposal',
+  typeUrl: '/stride.stakeibc.AddValidatorsProposal' as const,
   encode(
     message: AddValidatorsProposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -164,7 +164,7 @@ function createBaseToggleLSMProposal(): ToggleLSMProposal {
   };
 }
 export const ToggleLSMProposal = {
-  typeUrl: '/stride.stakeibc.ToggleLSMProposal',
+  typeUrl: '/stride.stakeibc.ToggleLSMProposal' as const,
   encode(
     message: ToggleLSMProposal,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/host_zone.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/host_zone.ts
@@ -170,7 +170,7 @@ function createBaseCommunityPoolRebate(): CommunityPoolRebate {
   };
 }
 export const CommunityPoolRebate = {
-  typeUrl: '/stride.stakeibc.CommunityPoolRebate',
+  typeUrl: '/stride.stakeibc.CommunityPoolRebate' as const,
   encode(
     message: CommunityPoolRebate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -281,7 +281,7 @@ function createBaseHostZone(): HostZone {
   };
 }
 export const HostZone = {
-  typeUrl: '/stride.stakeibc.HostZone',
+  typeUrl: '/stride.stakeibc.HostZone' as const,
   encode(
     message: HostZone,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/ica_account.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/ica_account.ts
@@ -94,7 +94,7 @@ function createBaseICAAccount(): ICAAccount {
   };
 }
 export const ICAAccount = {
-  typeUrl: '/stride.stakeibc.ICAAccount',
+  typeUrl: '/stride.stakeibc.ICAAccount' as const,
   encode(
     message: ICAAccount,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/packet.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/packet.ts
@@ -24,7 +24,7 @@ function createBaseStakeibcPacketData(): StakeibcPacketData {
   };
 }
 export const StakeibcPacketData = {
-  typeUrl: '/stride.stakeibc.StakeibcPacketData',
+  typeUrl: '/stride.stakeibc.StakeibcPacketData' as const,
   encode(
     message: StakeibcPacketData,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -91,7 +91,7 @@ function createBaseNoData(): NoData {
   return {};
 }
 export const NoData = {
-  typeUrl: '/stride.stakeibc.NoData',
+  typeUrl: '/stride.stakeibc.NoData' as const,
   encode(
     _: NoData,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/params.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/params.ts
@@ -72,7 +72,7 @@ function createBaseParams(): Params {
   };
 }
 export const Params = {
-  typeUrl: '/stride.stakeibc.Params',
+  typeUrl: '/stride.stakeibc.Params' as const,
   encode(
     message: Params,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/query.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/query.ts
@@ -259,7 +259,7 @@ function createBaseQueryInterchainAccountFromAddressRequest(): QueryInterchainAc
   };
 }
 export const QueryInterchainAccountFromAddressRequest = {
-  typeUrl: '/stride.stakeibc.QueryInterchainAccountFromAddressRequest',
+  typeUrl: '/stride.stakeibc.QueryInterchainAccountFromAddressRequest' as const,
   encode(
     message: QueryInterchainAccountFromAddressRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -344,7 +344,8 @@ function createBaseQueryInterchainAccountFromAddressResponse(): QueryInterchainA
   };
 }
 export const QueryInterchainAccountFromAddressResponse = {
-  typeUrl: '/stride.stakeibc.QueryInterchainAccountFromAddressResponse',
+  typeUrl:
+    '/stride.stakeibc.QueryInterchainAccountFromAddressResponse' as const,
   encode(
     message: QueryInterchainAccountFromAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -418,7 +419,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
   return {};
 }
 export const QueryParamsRequest = {
-  typeUrl: '/stride.stakeibc.QueryParamsRequest',
+  typeUrl: '/stride.stakeibc.QueryParamsRequest' as const,
   encode(
     _: QueryParamsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -473,7 +474,7 @@ function createBaseQueryParamsResponse(): QueryParamsResponse {
   };
 }
 export const QueryParamsResponse = {
-  typeUrl: '/stride.stakeibc.QueryParamsResponse',
+  typeUrl: '/stride.stakeibc.QueryParamsResponse' as const,
   encode(
     message: QueryParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -542,7 +543,7 @@ function createBaseQueryGetValidatorsRequest(): QueryGetValidatorsRequest {
   };
 }
 export const QueryGetValidatorsRequest = {
-  typeUrl: '/stride.stakeibc.QueryGetValidatorsRequest',
+  typeUrl: '/stride.stakeibc.QueryGetValidatorsRequest' as const,
   encode(
     message: QueryGetValidatorsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -615,7 +616,7 @@ function createBaseQueryGetValidatorsResponse(): QueryGetValidatorsResponse {
   };
 }
 export const QueryGetValidatorsResponse = {
-  typeUrl: '/stride.stakeibc.QueryGetValidatorsResponse',
+  typeUrl: '/stride.stakeibc.QueryGetValidatorsResponse' as const,
   encode(
     message: QueryGetValidatorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -697,7 +698,7 @@ function createBaseQueryGetHostZoneRequest(): QueryGetHostZoneRequest {
   };
 }
 export const QueryGetHostZoneRequest = {
-  typeUrl: '/stride.stakeibc.QueryGetHostZoneRequest',
+  typeUrl: '/stride.stakeibc.QueryGetHostZoneRequest' as const,
   encode(
     message: QueryGetHostZoneRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -768,7 +769,7 @@ function createBaseQueryGetHostZoneResponse(): QueryGetHostZoneResponse {
   };
 }
 export const QueryGetHostZoneResponse = {
-  typeUrl: '/stride.stakeibc.QueryGetHostZoneResponse',
+  typeUrl: '/stride.stakeibc.QueryGetHostZoneResponse' as const,
   encode(
     message: QueryGetHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -849,7 +850,7 @@ function createBaseQueryAllHostZoneRequest(): QueryAllHostZoneRequest {
   };
 }
 export const QueryAllHostZoneRequest = {
-  typeUrl: '/stride.stakeibc.QueryAllHostZoneRequest',
+  typeUrl: '/stride.stakeibc.QueryAllHostZoneRequest' as const,
   encode(
     message: QueryAllHostZoneRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -929,7 +930,7 @@ function createBaseQueryAllHostZoneResponse(): QueryAllHostZoneResponse {
   };
 }
 export const QueryAllHostZoneResponse = {
-  typeUrl: '/stride.stakeibc.QueryAllHostZoneResponse',
+  typeUrl: '/stride.stakeibc.QueryAllHostZoneResponse' as const,
   encode(
     message: QueryAllHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1030,7 +1031,7 @@ function createBaseQueryModuleAddressRequest(): QueryModuleAddressRequest {
   };
 }
 export const QueryModuleAddressRequest = {
-  typeUrl: '/stride.stakeibc.QueryModuleAddressRequest',
+  typeUrl: '/stride.stakeibc.QueryModuleAddressRequest' as const,
   encode(
     message: QueryModuleAddressRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1103,7 +1104,7 @@ function createBaseQueryModuleAddressResponse(): QueryModuleAddressResponse {
   };
 }
 export const QueryModuleAddressResponse = {
-  typeUrl: '/stride.stakeibc.QueryModuleAddressResponse',
+  typeUrl: '/stride.stakeibc.QueryModuleAddressResponse' as const,
   encode(
     message: QueryModuleAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1176,7 +1177,7 @@ function createBaseQueryGetEpochTrackerRequest(): QueryGetEpochTrackerRequest {
   };
 }
 export const QueryGetEpochTrackerRequest = {
-  typeUrl: '/stride.stakeibc.QueryGetEpochTrackerRequest',
+  typeUrl: '/stride.stakeibc.QueryGetEpochTrackerRequest' as const,
   encode(
     message: QueryGetEpochTrackerRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1252,7 +1253,7 @@ function createBaseQueryGetEpochTrackerResponse(): QueryGetEpochTrackerResponse 
   };
 }
 export const QueryGetEpochTrackerResponse = {
-  typeUrl: '/stride.stakeibc.QueryGetEpochTrackerResponse',
+  typeUrl: '/stride.stakeibc.QueryGetEpochTrackerResponse' as const,
   encode(
     message: QueryGetEpochTrackerResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1334,7 +1335,7 @@ function createBaseQueryAllEpochTrackerRequest(): QueryAllEpochTrackerRequest {
   return {};
 }
 export const QueryAllEpochTrackerRequest = {
-  typeUrl: '/stride.stakeibc.QueryAllEpochTrackerRequest',
+  typeUrl: '/stride.stakeibc.QueryAllEpochTrackerRequest' as const,
   encode(
     _: QueryAllEpochTrackerRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1397,7 +1398,7 @@ function createBaseQueryAllEpochTrackerResponse(): QueryAllEpochTrackerResponse 
   };
 }
 export const QueryAllEpochTrackerResponse = {
-  typeUrl: '/stride.stakeibc.QueryAllEpochTrackerResponse',
+  typeUrl: '/stride.stakeibc.QueryAllEpochTrackerResponse' as const,
   encode(
     message: QueryAllEpochTrackerResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1482,7 +1483,7 @@ function createBaseQueryGetNextPacketSequenceRequest(): QueryGetNextPacketSequen
   };
 }
 export const QueryGetNextPacketSequenceRequest = {
-  typeUrl: '/stride.stakeibc.QueryGetNextPacketSequenceRequest',
+  typeUrl: '/stride.stakeibc.QueryGetNextPacketSequenceRequest' as const,
   encode(
     message: QueryGetNextPacketSequenceRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1564,7 +1565,7 @@ function createBaseQueryGetNextPacketSequenceResponse(): QueryGetNextPacketSeque
   };
 }
 export const QueryGetNextPacketSequenceResponse = {
-  typeUrl: '/stride.stakeibc.QueryGetNextPacketSequenceResponse',
+  typeUrl: '/stride.stakeibc.QueryGetNextPacketSequenceResponse' as const,
   encode(
     message: QueryGetNextPacketSequenceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1643,7 +1644,7 @@ function createBaseQueryAddressUnbondings(): QueryAddressUnbondings {
   };
 }
 export const QueryAddressUnbondings = {
-  typeUrl: '/stride.stakeibc.QueryAddressUnbondings',
+  typeUrl: '/stride.stakeibc.QueryAddressUnbondings' as const,
   encode(
     message: QueryAddressUnbondings,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1710,7 +1711,7 @@ function createBaseQueryAddressUnbondingsResponse(): QueryAddressUnbondingsRespo
   };
 }
 export const QueryAddressUnbondingsResponse = {
-  typeUrl: '/stride.stakeibc.QueryAddressUnbondingsResponse',
+  typeUrl: '/stride.stakeibc.QueryAddressUnbondingsResponse' as const,
   encode(
     message: QueryAddressUnbondingsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1792,7 +1793,7 @@ function createBaseQueryAllTradeRoutes(): QueryAllTradeRoutes {
   return {};
 }
 export const QueryAllTradeRoutes = {
-  typeUrl: '/stride.stakeibc.QueryAllTradeRoutes',
+  typeUrl: '/stride.stakeibc.QueryAllTradeRoutes' as const,
   encode(
     _: QueryAllTradeRoutes,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1847,7 +1848,7 @@ function createBaseQueryAllTradeRoutesResponse(): QueryAllTradeRoutesResponse {
   };
 }
 export const QueryAllTradeRoutesResponse = {
-  typeUrl: '/stride.stakeibc.QueryAllTradeRoutesResponse',
+  typeUrl: '/stride.stakeibc.QueryAllTradeRoutesResponse' as const,
   encode(
     message: QueryAllTradeRoutesResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/trade_route.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/trade_route.ts
@@ -160,7 +160,7 @@ function createBaseTradeConfig(): TradeConfig {
   };
 }
 export const TradeConfig = {
-  typeUrl: '/stride.stakeibc.TradeConfig',
+  typeUrl: '/stride.stakeibc.TradeConfig' as const,
   encode(
     message: TradeConfig,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -315,7 +315,7 @@ function createBaseTradeRoute(): TradeRoute {
   };
 }
 export const TradeRoute = {
-  typeUrl: '/stride.stakeibc.TradeRoute',
+  typeUrl: '/stride.stakeibc.TradeRoute' as const,
   encode(
     message: TradeRoute,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/tx.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/tx.ts
@@ -712,7 +712,7 @@ function createBaseMsgUpdateInnerRedemptionRateBounds(): MsgUpdateInnerRedemptio
   };
 }
 export const MsgUpdateInnerRedemptionRateBounds = {
-  typeUrl: '/stride.stakeibc.MsgUpdateInnerRedemptionRateBounds',
+  typeUrl: '/stride.stakeibc.MsgUpdateInnerRedemptionRateBounds' as const,
   encode(
     message: MsgUpdateInnerRedemptionRateBounds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -830,7 +830,8 @@ function createBaseMsgUpdateInnerRedemptionRateBoundsResponse(): MsgUpdateInnerR
   return {};
 }
 export const MsgUpdateInnerRedemptionRateBoundsResponse = {
-  typeUrl: '/stride.stakeibc.MsgUpdateInnerRedemptionRateBoundsResponse',
+  typeUrl:
+    '/stride.stakeibc.MsgUpdateInnerRedemptionRateBoundsResponse' as const,
   encode(
     _: MsgUpdateInnerRedemptionRateBoundsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -896,7 +897,7 @@ function createBaseMsgLiquidStake(): MsgLiquidStake {
   };
 }
 export const MsgLiquidStake = {
-  typeUrl: '/stride.stakeibc.MsgLiquidStake',
+  typeUrl: '/stride.stakeibc.MsgLiquidStake' as const,
   encode(
     message: MsgLiquidStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -976,7 +977,7 @@ function createBaseMsgLiquidStakeResponse(): MsgLiquidStakeResponse {
   };
 }
 export const MsgLiquidStakeResponse = {
-  typeUrl: '/stride.stakeibc.MsgLiquidStakeResponse',
+  typeUrl: '/stride.stakeibc.MsgLiquidStakeResponse' as const,
   encode(
     message: MsgLiquidStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1053,7 +1054,7 @@ function createBaseMsgLSMLiquidStake(): MsgLSMLiquidStake {
   };
 }
 export const MsgLSMLiquidStake = {
-  typeUrl: '/stride.stakeibc.MsgLSMLiquidStake',
+  typeUrl: '/stride.stakeibc.MsgLSMLiquidStake' as const,
   encode(
     message: MsgLSMLiquidStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1136,7 +1137,7 @@ function createBaseMsgLSMLiquidStakeResponse(): MsgLSMLiquidStakeResponse {
   };
 }
 export const MsgLSMLiquidStakeResponse = {
-  typeUrl: '/stride.stakeibc.MsgLSMLiquidStakeResponse',
+  typeUrl: '/stride.stakeibc.MsgLSMLiquidStakeResponse' as const,
   encode(
     message: MsgLSMLiquidStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1215,7 +1216,7 @@ function createBaseMsgClearBalance(): MsgClearBalance {
   };
 }
 export const MsgClearBalance = {
-  typeUrl: '/stride.stakeibc.MsgClearBalance',
+  typeUrl: '/stride.stakeibc.MsgClearBalance' as const,
   encode(
     message: MsgClearBalance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1302,7 +1303,7 @@ function createBaseMsgClearBalanceResponse(): MsgClearBalanceResponse {
   return {};
 }
 export const MsgClearBalanceResponse = {
-  typeUrl: '/stride.stakeibc.MsgClearBalanceResponse',
+  typeUrl: '/stride.stakeibc.MsgClearBalanceResponse' as const,
   encode(
     _: MsgClearBalanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1364,7 +1365,7 @@ function createBaseMsgRedeemStake(): MsgRedeemStake {
   };
 }
 export const MsgRedeemStake = {
-  typeUrl: '/stride.stakeibc.MsgRedeemStake',
+  typeUrl: '/stride.stakeibc.MsgRedeemStake' as const,
   encode(
     message: MsgRedeemStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1451,7 +1452,7 @@ function createBaseMsgRedeemStakeResponse(): MsgRedeemStakeResponse {
   return {};
 }
 export const MsgRedeemStakeResponse = {
-  typeUrl: '/stride.stakeibc.MsgRedeemStakeResponse',
+  typeUrl: '/stride.stakeibc.MsgRedeemStakeResponse' as const,
   encode(
     _: MsgRedeemStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1519,7 +1520,7 @@ function createBaseMsgRegisterHostZone(): MsgRegisterHostZone {
   };
 }
 export const MsgRegisterHostZone = {
-  typeUrl: '/stride.stakeibc.MsgRegisterHostZone',
+  typeUrl: '/stride.stakeibc.MsgRegisterHostZone' as const,
   encode(
     message: MsgRegisterHostZone,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1728,7 +1729,7 @@ function createBaseMsgRegisterHostZoneResponse(): MsgRegisterHostZoneResponse {
   return {};
 }
 export const MsgRegisterHostZoneResponse = {
-  typeUrl: '/stride.stakeibc.MsgRegisterHostZoneResponse',
+  typeUrl: '/stride.stakeibc.MsgRegisterHostZoneResponse' as const,
   encode(
     _: MsgRegisterHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1794,7 +1795,7 @@ function createBaseMsgClaimUndelegatedTokens(): MsgClaimUndelegatedTokens {
   };
 }
 export const MsgClaimUndelegatedTokens = {
-  typeUrl: '/stride.stakeibc.MsgClaimUndelegatedTokens',
+  typeUrl: '/stride.stakeibc.MsgClaimUndelegatedTokens' as const,
   encode(
     message: MsgClaimUndelegatedTokens,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1896,7 +1897,7 @@ function createBaseMsgClaimUndelegatedTokensResponse(): MsgClaimUndelegatedToken
   return {};
 }
 export const MsgClaimUndelegatedTokensResponse = {
-  typeUrl: '/stride.stakeibc.MsgClaimUndelegatedTokensResponse',
+  typeUrl: '/stride.stakeibc.MsgClaimUndelegatedTokensResponse' as const,
   encode(
     _: MsgClaimUndelegatedTokensResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1961,7 +1962,7 @@ function createBaseMsgRebalanceValidators(): MsgRebalanceValidators {
   };
 }
 export const MsgRebalanceValidators = {
-  typeUrl: '/stride.stakeibc.MsgRebalanceValidators',
+  typeUrl: '/stride.stakeibc.MsgRebalanceValidators' as const,
   encode(
     message: MsgRebalanceValidators,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2050,7 +2051,7 @@ function createBaseMsgRebalanceValidatorsResponse(): MsgRebalanceValidatorsRespo
   return {};
 }
 export const MsgRebalanceValidatorsResponse = {
-  typeUrl: '/stride.stakeibc.MsgRebalanceValidatorsResponse',
+  typeUrl: '/stride.stakeibc.MsgRebalanceValidatorsResponse' as const,
   encode(
     _: MsgRebalanceValidatorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2115,7 +2116,7 @@ function createBaseMsgAddValidators(): MsgAddValidators {
   };
 }
 export const MsgAddValidators = {
-  typeUrl: '/stride.stakeibc.MsgAddValidators',
+  typeUrl: '/stride.stakeibc.MsgAddValidators' as const,
   encode(
     message: MsgAddValidators,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2202,7 +2203,7 @@ function createBaseMsgAddValidatorsResponse(): MsgAddValidatorsResponse {
   return {};
 }
 export const MsgAddValidatorsResponse = {
-  typeUrl: '/stride.stakeibc.MsgAddValidatorsResponse',
+  typeUrl: '/stride.stakeibc.MsgAddValidatorsResponse' as const,
   encode(
     _: MsgAddValidatorsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2262,7 +2263,7 @@ function createBaseValidatorWeight(): ValidatorWeight {
   };
 }
 export const ValidatorWeight = {
-  typeUrl: '/stride.stakeibc.ValidatorWeight',
+  typeUrl: '/stride.stakeibc.ValidatorWeight' as const,
   encode(
     message: ValidatorWeight,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2341,7 +2342,7 @@ function createBaseMsgChangeValidatorWeights(): MsgChangeValidatorWeights {
   };
 }
 export const MsgChangeValidatorWeights = {
-  typeUrl: '/stride.stakeibc.MsgChangeValidatorWeights',
+  typeUrl: '/stride.stakeibc.MsgChangeValidatorWeights' as const,
   encode(
     message: MsgChangeValidatorWeights,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2441,7 +2442,7 @@ function createBaseMsgChangeValidatorWeightsResponse(): MsgChangeValidatorWeight
   return {};
 }
 export const MsgChangeValidatorWeightsResponse = {
-  typeUrl: '/stride.stakeibc.MsgChangeValidatorWeightsResponse',
+  typeUrl: '/stride.stakeibc.MsgChangeValidatorWeightsResponse' as const,
   encode(
     _: MsgChangeValidatorWeightsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2506,7 +2507,7 @@ function createBaseMsgDeleteValidator(): MsgDeleteValidator {
   };
 }
 export const MsgDeleteValidator = {
-  typeUrl: '/stride.stakeibc.MsgDeleteValidator',
+  typeUrl: '/stride.stakeibc.MsgDeleteValidator' as const,
   encode(
     message: MsgDeleteValidator,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2587,7 +2588,7 @@ function createBaseMsgDeleteValidatorResponse(): MsgDeleteValidatorResponse {
   return {};
 }
 export const MsgDeleteValidatorResponse = {
-  typeUrl: '/stride.stakeibc.MsgDeleteValidatorResponse',
+  typeUrl: '/stride.stakeibc.MsgDeleteValidatorResponse' as const,
   encode(
     _: MsgDeleteValidatorResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2651,7 +2652,7 @@ function createBaseMsgRestoreInterchainAccount(): MsgRestoreInterchainAccount {
   };
 }
 export const MsgRestoreInterchainAccount = {
-  typeUrl: '/stride.stakeibc.MsgRestoreInterchainAccount',
+  typeUrl: '/stride.stakeibc.MsgRestoreInterchainAccount' as const,
   encode(
     message: MsgRestoreInterchainAccount,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2755,7 +2756,7 @@ function createBaseMsgRestoreInterchainAccountResponse(): MsgRestoreInterchainAc
   return {};
 }
 export const MsgRestoreInterchainAccountResponse = {
-  typeUrl: '/stride.stakeibc.MsgRestoreInterchainAccountResponse',
+  typeUrl: '/stride.stakeibc.MsgRestoreInterchainAccountResponse' as const,
   encode(
     _: MsgRestoreInterchainAccountResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2819,7 +2820,7 @@ function createBaseMsgCloseDelegationChannel(): MsgCloseDelegationChannel {
   };
 }
 export const MsgCloseDelegationChannel = {
-  typeUrl: '/stride.stakeibc.MsgCloseDelegationChannel',
+  typeUrl: '/stride.stakeibc.MsgCloseDelegationChannel' as const,
   encode(
     message: MsgCloseDelegationChannel,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2899,7 +2900,7 @@ function createBaseMsgCloseDelegationChannelResponse(): MsgCloseDelegationChanne
   return {};
 }
 export const MsgCloseDelegationChannelResponse = {
-  typeUrl: '/stride.stakeibc.MsgCloseDelegationChannelResponse',
+  typeUrl: '/stride.stakeibc.MsgCloseDelegationChannelResponse' as const,
   encode(
     _: MsgCloseDelegationChannelResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2964,7 +2965,7 @@ function createBaseMsgUpdateValidatorSharesExchRate(): MsgUpdateValidatorSharesE
   };
 }
 export const MsgUpdateValidatorSharesExchRate = {
-  typeUrl: '/stride.stakeibc.MsgUpdateValidatorSharesExchRate',
+  typeUrl: '/stride.stakeibc.MsgUpdateValidatorSharesExchRate' as const,
   encode(
     message: MsgUpdateValidatorSharesExchRate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3053,7 +3054,7 @@ function createBaseMsgUpdateValidatorSharesExchRateResponse(): MsgUpdateValidato
   return {};
 }
 export const MsgUpdateValidatorSharesExchRateResponse = {
-  typeUrl: '/stride.stakeibc.MsgUpdateValidatorSharesExchRateResponse',
+  typeUrl: '/stride.stakeibc.MsgUpdateValidatorSharesExchRateResponse' as const,
   encode(
     _: MsgUpdateValidatorSharesExchRateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3118,7 +3119,7 @@ function createBaseMsgCalibrateDelegation(): MsgCalibrateDelegation {
   };
 }
 export const MsgCalibrateDelegation = {
-  typeUrl: '/stride.stakeibc.MsgCalibrateDelegation',
+  typeUrl: '/stride.stakeibc.MsgCalibrateDelegation' as const,
   encode(
     message: MsgCalibrateDelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3201,7 +3202,7 @@ function createBaseMsgCalibrateDelegationResponse(): MsgCalibrateDelegationRespo
   return {};
 }
 export const MsgCalibrateDelegationResponse = {
-  typeUrl: '/stride.stakeibc.MsgCalibrateDelegationResponse',
+  typeUrl: '/stride.stakeibc.MsgCalibrateDelegationResponse' as const,
   encode(
     _: MsgCalibrateDelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3265,7 +3266,7 @@ function createBaseMsgResumeHostZone(): MsgResumeHostZone {
   };
 }
 export const MsgResumeHostZone = {
-  typeUrl: '/stride.stakeibc.MsgResumeHostZone',
+  typeUrl: '/stride.stakeibc.MsgResumeHostZone' as const,
   encode(
     message: MsgResumeHostZone,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3334,7 +3335,7 @@ function createBaseMsgResumeHostZoneResponse(): MsgResumeHostZoneResponse {
   return {};
 }
 export const MsgResumeHostZoneResponse = {
-  typeUrl: '/stride.stakeibc.MsgResumeHostZoneResponse',
+  typeUrl: '/stride.stakeibc.MsgResumeHostZoneResponse' as const,
   encode(
     _: MsgResumeHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3411,7 +3412,7 @@ function createBaseMsgCreateTradeRoute(): MsgCreateTradeRoute {
   };
 }
 export const MsgCreateTradeRoute = {
-  typeUrl: '/stride.stakeibc.MsgCreateTradeRoute',
+  typeUrl: '/stride.stakeibc.MsgCreateTradeRoute' as const,
   encode(
     message: MsgCreateTradeRoute,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3675,7 +3676,7 @@ function createBaseMsgCreateTradeRouteResponse(): MsgCreateTradeRouteResponse {
   return {};
 }
 export const MsgCreateTradeRouteResponse = {
-  typeUrl: '/stride.stakeibc.MsgCreateTradeRouteResponse',
+  typeUrl: '/stride.stakeibc.MsgCreateTradeRouteResponse' as const,
   encode(
     _: MsgCreateTradeRouteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3740,7 +3741,7 @@ function createBaseMsgDeleteTradeRoute(): MsgDeleteTradeRoute {
   };
 }
 export const MsgDeleteTradeRoute = {
-  typeUrl: '/stride.stakeibc.MsgDeleteTradeRoute',
+  typeUrl: '/stride.stakeibc.MsgDeleteTradeRoute' as const,
   encode(
     message: MsgDeleteTradeRoute,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3822,7 +3823,7 @@ function createBaseMsgDeleteTradeRouteResponse(): MsgDeleteTradeRouteResponse {
   return {};
 }
 export const MsgDeleteTradeRouteResponse = {
-  typeUrl: '/stride.stakeibc.MsgDeleteTradeRouteResponse',
+  typeUrl: '/stride.stakeibc.MsgDeleteTradeRouteResponse' as const,
   encode(
     _: MsgDeleteTradeRouteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -3892,7 +3893,7 @@ function createBaseMsgUpdateTradeRoute(): MsgUpdateTradeRoute {
   };
 }
 export const MsgUpdateTradeRoute = {
-  typeUrl: '/stride.stakeibc.MsgUpdateTradeRoute',
+  typeUrl: '/stride.stakeibc.MsgUpdateTradeRoute' as const,
   encode(
     message: MsgUpdateTradeRoute,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4037,7 +4038,7 @@ function createBaseMsgUpdateTradeRouteResponse(): MsgUpdateTradeRouteResponse {
   return {};
 }
 export const MsgUpdateTradeRouteResponse = {
-  typeUrl: '/stride.stakeibc.MsgUpdateTradeRouteResponse',
+  typeUrl: '/stride.stakeibc.MsgUpdateTradeRouteResponse' as const,
   encode(
     _: MsgUpdateTradeRouteResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4103,7 +4104,7 @@ function createBaseMsgSetCommunityPoolRebate(): MsgSetCommunityPoolRebate {
   };
 }
 export const MsgSetCommunityPoolRebate = {
-  typeUrl: '/stride.stakeibc.MsgSetCommunityPoolRebate',
+  typeUrl: '/stride.stakeibc.MsgSetCommunityPoolRebate' as const,
   encode(
     message: MsgSetCommunityPoolRebate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4209,7 +4210,7 @@ function createBaseMsgSetCommunityPoolRebateResponse(): MsgSetCommunityPoolRebat
   return {};
 }
 export const MsgSetCommunityPoolRebateResponse = {
-  typeUrl: '/stride.stakeibc.MsgSetCommunityPoolRebateResponse',
+  typeUrl: '/stride.stakeibc.MsgSetCommunityPoolRebateResponse' as const,
   encode(
     _: MsgSetCommunityPoolRebateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4276,7 +4277,7 @@ function createBaseMsgToggleTradeController(): MsgToggleTradeController {
   };
 }
 export const MsgToggleTradeController = {
-  typeUrl: '/stride.stakeibc.MsgToggleTradeController',
+  typeUrl: '/stride.stakeibc.MsgToggleTradeController' as const,
   encode(
     message: MsgToggleTradeController,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4388,7 +4389,7 @@ function createBaseMsgToggleTradeControllerResponse(): MsgToggleTradeControllerR
   return {};
 }
 export const MsgToggleTradeControllerResponse = {
-  typeUrl: '/stride.stakeibc.MsgToggleTradeControllerResponse',
+  typeUrl: '/stride.stakeibc.MsgToggleTradeControllerResponse' as const,
   encode(
     _: MsgToggleTradeControllerResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4453,7 +4454,7 @@ function createBaseMsgUpdateHostZoneParams(): MsgUpdateHostZoneParams {
   };
 }
 export const MsgUpdateHostZoneParams = {
-  typeUrl: '/stride.stakeibc.MsgUpdateHostZoneParams',
+  typeUrl: '/stride.stakeibc.MsgUpdateHostZoneParams' as const,
   encode(
     message: MsgUpdateHostZoneParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -4549,7 +4550,7 @@ function createBaseMsgUpdateHostZoneParamsResponse(): MsgUpdateHostZoneParamsRes
   return {};
 }
 export const MsgUpdateHostZoneParamsResponse = {
-  typeUrl: '/stride.stakeibc.MsgUpdateHostZoneParamsResponse',
+  typeUrl: '/stride.stakeibc.MsgUpdateHostZoneParamsResponse' as const,
   encode(
     _: MsgUpdateHostZoneParamsResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/stakeibc/validator.ts
+++ b/packages/client-utils/src/codegen/stride/stakeibc/validator.ts
@@ -43,7 +43,7 @@ function createBaseValidator(): Validator {
   };
 }
 export const Validator = {
-  typeUrl: '/stride.stakeibc.Validator',
+  typeUrl: '/stride.stakeibc.Validator' as const,
   encode(
     message: Validator,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/staketia/genesis.ts
+++ b/packages/client-utils/src/codegen/stride/staketia/genesis.ts
@@ -72,7 +72,7 @@ function createBaseParams(): Params {
   return {};
 }
 export const Params = {
-  typeUrl: '/stride.staketia.Params',
+  typeUrl: '/stride.staketia.Params' as const,
   encode(
     _: Params,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -126,7 +126,7 @@ function createBaseTransferInProgressRecordIds(): TransferInProgressRecordIds {
   };
 }
 export const TransferInProgressRecordIds = {
-  typeUrl: '/stride.staketia.TransferInProgressRecordIds',
+  typeUrl: '/stride.staketia.TransferInProgressRecordIds' as const,
   encode(
     message: TransferInProgressRecordIds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -235,7 +235,7 @@ function createBaseGenesisState(): GenesisState {
   };
 }
 export const GenesisState = {
-  typeUrl: '/stride.staketia.GenesisState',
+  typeUrl: '/stride.staketia.GenesisState' as const,
   encode(
     message: GenesisState,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/staketia/query.ts
+++ b/packages/client-utils/src/codegen/stride/staketia/query.ts
@@ -175,7 +175,7 @@ function createBaseQueryHostZoneRequest(): QueryHostZoneRequest {
   return {};
 }
 export const QueryHostZoneRequest = {
-  typeUrl: '/stride.staketia.QueryHostZoneRequest',
+  typeUrl: '/stride.staketia.QueryHostZoneRequest' as const,
   encode(
     _: QueryHostZoneRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -230,7 +230,7 @@ function createBaseQueryHostZoneResponse(): QueryHostZoneResponse {
   };
 }
 export const QueryHostZoneResponse = {
-  typeUrl: '/stride.staketia.QueryHostZoneResponse',
+  typeUrl: '/stride.staketia.QueryHostZoneResponse' as const,
   encode(
     message: QueryHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -303,7 +303,7 @@ function createBaseQueryDelegationRecordsRequest(): QueryDelegationRecordsReques
   };
 }
 export const QueryDelegationRecordsRequest = {
-  typeUrl: '/stride.staketia.QueryDelegationRecordsRequest',
+  typeUrl: '/stride.staketia.QueryDelegationRecordsRequest' as const,
   encode(
     message: QueryDelegationRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -379,7 +379,7 @@ function createBaseQueryDelegationRecordsResponse(): QueryDelegationRecordsRespo
   };
 }
 export const QueryDelegationRecordsResponse = {
-  typeUrl: '/stride.staketia.QueryDelegationRecordsResponse',
+  typeUrl: '/stride.staketia.QueryDelegationRecordsResponse' as const,
   encode(
     message: QueryDelegationRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -463,7 +463,7 @@ function createBaseQueryUnbondingRecordsRequest(): QueryUnbondingRecordsRequest 
   };
 }
 export const QueryUnbondingRecordsRequest = {
-  typeUrl: '/stride.staketia.QueryUnbondingRecordsRequest',
+  typeUrl: '/stride.staketia.QueryUnbondingRecordsRequest' as const,
   encode(
     message: QueryUnbondingRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -539,7 +539,7 @@ function createBaseQueryUnbondingRecordsResponse(): QueryUnbondingRecordsRespons
   };
 }
 export const QueryUnbondingRecordsResponse = {
-  typeUrl: '/stride.staketia.QueryUnbondingRecordsResponse',
+  typeUrl: '/stride.staketia.QueryUnbondingRecordsResponse' as const,
   encode(
     message: QueryUnbondingRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -624,7 +624,7 @@ function createBaseQueryRedemptionRecordRequest(): QueryRedemptionRecordRequest 
   };
 }
 export const QueryRedemptionRecordRequest = {
-  typeUrl: '/stride.staketia.QueryRedemptionRecordRequest',
+  typeUrl: '/stride.staketia.QueryRedemptionRecordRequest' as const,
   encode(
     message: QueryRedemptionRecordRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -715,7 +715,7 @@ function createBaseQueryRedemptionRecordResponse(): QueryRedemptionRecordRespons
   };
 }
 export const QueryRedemptionRecordResponse = {
-  typeUrl: '/stride.staketia.QueryRedemptionRecordResponse',
+  typeUrl: '/stride.staketia.QueryRedemptionRecordResponse' as const,
   encode(
     message: QueryRedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -805,7 +805,7 @@ function createBaseQueryRedemptionRecordsRequest(): QueryRedemptionRecordsReques
   };
 }
 export const QueryRedemptionRecordsRequest = {
-  typeUrl: '/stride.staketia.QueryRedemptionRecordsRequest',
+  typeUrl: '/stride.staketia.QueryRedemptionRecordsRequest' as const,
   encode(
     message: QueryRedemptionRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -914,7 +914,7 @@ function createBaseQueryRedemptionRecordsResponse(): QueryRedemptionRecordsRespo
   };
 }
 export const QueryRedemptionRecordsResponse = {
-  typeUrl: '/stride.staketia.QueryRedemptionRecordsResponse',
+  typeUrl: '/stride.staketia.QueryRedemptionRecordsResponse' as const,
   encode(
     message: QueryRedemptionRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1022,7 +1022,7 @@ function createBaseQuerySlashRecordsRequest(): QuerySlashRecordsRequest {
   return {};
 }
 export const QuerySlashRecordsRequest = {
-  typeUrl: '/stride.staketia.QuerySlashRecordsRequest',
+  typeUrl: '/stride.staketia.QuerySlashRecordsRequest' as const,
   encode(
     _: QuerySlashRecordsRequest,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1081,7 +1081,7 @@ function createBaseQuerySlashRecordsResponse(): QuerySlashRecordsResponse {
   };
 }
 export const QuerySlashRecordsResponse = {
-  typeUrl: '/stride.staketia.QuerySlashRecordsResponse',
+  typeUrl: '/stride.staketia.QuerySlashRecordsResponse' as const,
   encode(
     message: QuerySlashRecordsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1166,7 +1166,7 @@ function createBaseRedemptionRecordResponse(): RedemptionRecordResponse {
   };
 }
 export const RedemptionRecordResponse = {
-  typeUrl: '/stride.staketia.RedemptionRecordResponse',
+  typeUrl: '/stride.staketia.RedemptionRecordResponse' as const,
   encode(
     message: RedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/staketia/staketia.ts
+++ b/packages/client-utils/src/codegen/stride/staketia/staketia.ts
@@ -333,7 +333,7 @@ function createBaseHostZone(): HostZone {
   };
 }
 export const HostZone = {
-  typeUrl: '/stride.staketia.HostZone',
+  typeUrl: '/stride.staketia.HostZone' as const,
   encode(
     message: HostZone,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -557,7 +557,7 @@ function createBaseDelegationRecord(): DelegationRecord {
   };
 }
 export const DelegationRecord = {
-  typeUrl: '/stride.staketia.DelegationRecord',
+  typeUrl: '/stride.staketia.DelegationRecord' as const,
   encode(
     message: DelegationRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -661,7 +661,7 @@ function createBaseUnbondingRecord(): UnbondingRecord {
   };
 }
 export const UnbondingRecord = {
-  typeUrl: '/stride.staketia.UnbondingRecord',
+  typeUrl: '/stride.staketia.UnbondingRecord' as const,
   encode(
     message: UnbondingRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -809,7 +809,7 @@ function createBaseRedemptionRecord(): RedemptionRecord {
   };
 }
 export const RedemptionRecord = {
-  typeUrl: '/stride.staketia.RedemptionRecord',
+  typeUrl: '/stride.staketia.RedemptionRecord' as const,
   encode(
     message: RedemptionRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -916,7 +916,7 @@ function createBaseSlashRecord(): SlashRecord {
   };
 }
 export const SlashRecord = {
-  typeUrl: '/stride.staketia.SlashRecord',
+  typeUrl: '/stride.staketia.SlashRecord' as const,
   encode(
     message: SlashRecord,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/stride/staketia/tx.ts
+++ b/packages/client-utils/src/codegen/stride/staketia/tx.ts
@@ -350,7 +350,7 @@ function createBaseMsgLiquidStake(): MsgLiquidStake {
   };
 }
 export const MsgLiquidStake = {
-  typeUrl: '/stride.staketia.MsgLiquidStake',
+  typeUrl: '/stride.staketia.MsgLiquidStake' as const,
   encode(
     message: MsgLiquidStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -424,7 +424,7 @@ function createBaseMsgLiquidStakeResponse(): MsgLiquidStakeResponse {
   };
 }
 export const MsgLiquidStakeResponse = {
-  typeUrl: '/stride.staketia.MsgLiquidStakeResponse',
+  typeUrl: '/stride.staketia.MsgLiquidStakeResponse' as const,
   encode(
     message: MsgLiquidStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -501,7 +501,7 @@ function createBaseMsgRedeemStake(): MsgRedeemStake {
   };
 }
 export const MsgRedeemStake = {
-  typeUrl: '/stride.staketia.MsgRedeemStake',
+  typeUrl: '/stride.staketia.MsgRedeemStake' as const,
   encode(
     message: MsgRedeemStake,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -584,7 +584,7 @@ function createBaseMsgRedeemStakeResponse(): MsgRedeemStakeResponse {
   };
 }
 export const MsgRedeemStakeResponse = {
-  typeUrl: '/stride.staketia.MsgRedeemStakeResponse',
+  typeUrl: '/stride.staketia.MsgRedeemStakeResponse' as const,
   encode(
     message: MsgRedeemStakeResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -661,7 +661,7 @@ function createBaseMsgConfirmDelegation(): MsgConfirmDelegation {
   };
 }
 export const MsgConfirmDelegation = {
-  typeUrl: '/stride.staketia.MsgConfirmDelegation',
+  typeUrl: '/stride.staketia.MsgConfirmDelegation' as const,
   encode(
     message: MsgConfirmDelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -748,7 +748,7 @@ function createBaseMsgConfirmDelegationResponse(): MsgConfirmDelegationResponse 
   return {};
 }
 export const MsgConfirmDelegationResponse = {
-  typeUrl: '/stride.staketia.MsgConfirmDelegationResponse',
+  typeUrl: '/stride.staketia.MsgConfirmDelegationResponse' as const,
   encode(
     _: MsgConfirmDelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -813,7 +813,7 @@ function createBaseMsgConfirmUndelegation(): MsgConfirmUndelegation {
   };
 }
 export const MsgConfirmUndelegation = {
-  typeUrl: '/stride.staketia.MsgConfirmUndelegation',
+  typeUrl: '/stride.staketia.MsgConfirmUndelegation' as const,
   encode(
     message: MsgConfirmUndelegation,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -902,7 +902,7 @@ function createBaseMsgConfirmUndelegationResponse(): MsgConfirmUndelegationRespo
   return {};
 }
 export const MsgConfirmUndelegationResponse = {
-  typeUrl: '/stride.staketia.MsgConfirmUndelegationResponse',
+  typeUrl: '/stride.staketia.MsgConfirmUndelegationResponse' as const,
   encode(
     _: MsgConfirmUndelegationResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -967,7 +967,7 @@ function createBaseMsgConfirmUnbondedTokenSweep(): MsgConfirmUnbondedTokenSweep 
   };
 }
 export const MsgConfirmUnbondedTokenSweep = {
-  typeUrl: '/stride.staketia.MsgConfirmUnbondedTokenSweep',
+  typeUrl: '/stride.staketia.MsgConfirmUnbondedTokenSweep' as const,
   encode(
     message: MsgConfirmUnbondedTokenSweep,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1062,7 +1062,7 @@ function createBaseMsgConfirmUnbondedTokenSweepResponse(): MsgConfirmUnbondedTok
   return {};
 }
 export const MsgConfirmUnbondedTokenSweepResponse = {
-  typeUrl: '/stride.staketia.MsgConfirmUnbondedTokenSweepResponse',
+  typeUrl: '/stride.staketia.MsgConfirmUnbondedTokenSweepResponse' as const,
   encode(
     _: MsgConfirmUnbondedTokenSweepResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1127,7 +1127,7 @@ function createBaseMsgAdjustDelegatedBalance(): MsgAdjustDelegatedBalance {
   };
 }
 export const MsgAdjustDelegatedBalance = {
-  typeUrl: '/stride.staketia.MsgAdjustDelegatedBalance',
+  typeUrl: '/stride.staketia.MsgAdjustDelegatedBalance' as const,
   encode(
     message: MsgAdjustDelegatedBalance,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1222,7 +1222,7 @@ function createBaseMsgAdjustDelegatedBalanceResponse(): MsgAdjustDelegatedBalanc
   return {};
 }
 export const MsgAdjustDelegatedBalanceResponse = {
-  typeUrl: '/stride.staketia.MsgAdjustDelegatedBalanceResponse',
+  typeUrl: '/stride.staketia.MsgAdjustDelegatedBalanceResponse' as const,
   encode(
     _: MsgAdjustDelegatedBalanceResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1287,7 +1287,7 @@ function createBaseMsgUpdateInnerRedemptionRateBounds(): MsgUpdateInnerRedemptio
   };
 }
 export const MsgUpdateInnerRedemptionRateBounds = {
-  typeUrl: '/stride.staketia.MsgUpdateInnerRedemptionRateBounds',
+  typeUrl: '/stride.staketia.MsgUpdateInnerRedemptionRateBounds' as const,
   encode(
     message: MsgUpdateInnerRedemptionRateBounds,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1396,7 +1396,8 @@ function createBaseMsgUpdateInnerRedemptionRateBoundsResponse(): MsgUpdateInnerR
   return {};
 }
 export const MsgUpdateInnerRedemptionRateBoundsResponse = {
-  typeUrl: '/stride.staketia.MsgUpdateInnerRedemptionRateBoundsResponse',
+  typeUrl:
+    '/stride.staketia.MsgUpdateInnerRedemptionRateBoundsResponse' as const,
   encode(
     _: MsgUpdateInnerRedemptionRateBoundsResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1460,7 +1461,7 @@ function createBaseMsgResumeHostZone(): MsgResumeHostZone {
   };
 }
 export const MsgResumeHostZone = {
-  typeUrl: '/stride.staketia.MsgResumeHostZone',
+  typeUrl: '/stride.staketia.MsgResumeHostZone' as const,
   encode(
     message: MsgResumeHostZone,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1520,7 +1521,7 @@ function createBaseMsgResumeHostZoneResponse(): MsgResumeHostZoneResponse {
   return {};
 }
 export const MsgResumeHostZoneResponse = {
-  typeUrl: '/stride.staketia.MsgResumeHostZoneResponse',
+  typeUrl: '/stride.staketia.MsgResumeHostZoneResponse' as const,
   encode(
     _: MsgResumeHostZoneResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1581,7 +1582,7 @@ function createBaseMsgRefreshRedemptionRate(): MsgRefreshRedemptionRate {
   };
 }
 export const MsgRefreshRedemptionRate = {
-  typeUrl: '/stride.staketia.MsgRefreshRedemptionRate',
+  typeUrl: '/stride.staketia.MsgRefreshRedemptionRate' as const,
   encode(
     message: MsgRefreshRedemptionRate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1652,7 +1653,7 @@ function createBaseMsgRefreshRedemptionRateResponse(): MsgRefreshRedemptionRateR
   return {};
 }
 export const MsgRefreshRedemptionRateResponse = {
-  typeUrl: '/stride.staketia.MsgRefreshRedemptionRateResponse',
+  typeUrl: '/stride.staketia.MsgRefreshRedemptionRateResponse' as const,
   encode(
     _: MsgRefreshRedemptionRateResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1716,7 +1717,7 @@ function createBaseMsgOverwriteDelegationRecord(): MsgOverwriteDelegationRecord 
   };
 }
 export const MsgOverwriteDelegationRecord = {
-  typeUrl: '/stride.staketia.MsgOverwriteDelegationRecord',
+  typeUrl: '/stride.staketia.MsgOverwriteDelegationRecord' as const,
   encode(
     message: MsgOverwriteDelegationRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1810,7 +1811,7 @@ function createBaseMsgOverwriteDelegationRecordResponse(): MsgOverwriteDelegatio
   return {};
 }
 export const MsgOverwriteDelegationRecordResponse = {
-  typeUrl: '/stride.staketia.MsgOverwriteDelegationRecordResponse',
+  typeUrl: '/stride.staketia.MsgOverwriteDelegationRecordResponse' as const,
   encode(
     _: MsgOverwriteDelegationRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1874,7 +1875,7 @@ function createBaseMsgOverwriteUnbondingRecord(): MsgOverwriteUnbondingRecord {
   };
 }
 export const MsgOverwriteUnbondingRecord = {
-  typeUrl: '/stride.staketia.MsgOverwriteUnbondingRecord',
+  typeUrl: '/stride.staketia.MsgOverwriteUnbondingRecord' as const,
   encode(
     message: MsgOverwriteUnbondingRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1968,7 +1969,7 @@ function createBaseMsgOverwriteUnbondingRecordResponse(): MsgOverwriteUnbondingR
   return {};
 }
 export const MsgOverwriteUnbondingRecordResponse = {
-  typeUrl: '/stride.staketia.MsgOverwriteUnbondingRecordResponse',
+  typeUrl: '/stride.staketia.MsgOverwriteUnbondingRecordResponse' as const,
   encode(
     _: MsgOverwriteUnbondingRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2032,7 +2033,7 @@ function createBaseMsgOverwriteRedemptionRecord(): MsgOverwriteRedemptionRecord 
   };
 }
 export const MsgOverwriteRedemptionRecord = {
-  typeUrl: '/stride.staketia.MsgOverwriteRedemptionRecord',
+  typeUrl: '/stride.staketia.MsgOverwriteRedemptionRecord' as const,
   encode(
     message: MsgOverwriteRedemptionRecord,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2126,7 +2127,7 @@ function createBaseMsgOverwriteRedemptionRecordResponse(): MsgOverwriteRedemptio
   return {};
 }
 export const MsgOverwriteRedemptionRecordResponse = {
-  typeUrl: '/stride.staketia.MsgOverwriteRedemptionRecordResponse',
+  typeUrl: '/stride.staketia.MsgOverwriteRedemptionRecordResponse' as const,
   encode(
     _: MsgOverwriteRedemptionRecordResponse,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2190,7 +2191,7 @@ function createBaseMsgSetOperatorAddress(): MsgSetOperatorAddress {
   };
 }
 export const MsgSetOperatorAddress = {
-  typeUrl: '/stride.staketia.MsgSetOperatorAddress',
+  typeUrl: '/stride.staketia.MsgSetOperatorAddress' as const,
   encode(
     message: MsgSetOperatorAddress,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2262,7 +2263,7 @@ function createBaseMsgSetOperatorAddressResponse(): MsgSetOperatorAddressRespons
   return {};
 }
 export const MsgSetOperatorAddressResponse = {
-  typeUrl: '/stride.staketia.MsgSetOperatorAddressResponse',
+  typeUrl: '/stride.staketia.MsgSetOperatorAddressResponse' as const,
   encode(
     _: MsgSetOperatorAddressResponse,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/abci/types.ts
+++ b/packages/client-utils/src/codegen/tendermint/abci/types.ts
@@ -688,7 +688,7 @@ function createBaseRequestQuery(): RequestQuery {
   };
 }
 export const RequestQuery = {
-  typeUrl: '/tendermint.abci.RequestQuery',
+  typeUrl: '/tendermint.abci.RequestQuery' as const,
   encode(
     message: RequestQuery,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -791,7 +791,7 @@ function createBaseRequestBeginBlock(): RequestBeginBlock {
   };
 }
 export const RequestBeginBlock = {
-  typeUrl: '/tendermint.abci.RequestBeginBlock',
+  typeUrl: '/tendermint.abci.RequestBeginBlock' as const,
   encode(
     message: RequestBeginBlock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -915,7 +915,7 @@ function createBaseRequestCheckTx(): RequestCheckTx {
   };
 }
 export const RequestCheckTx = {
-  typeUrl: '/tendermint.abci.RequestCheckTx',
+  typeUrl: '/tendermint.abci.RequestCheckTx' as const,
   encode(
     message: RequestCheckTx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -989,7 +989,7 @@ function createBaseRequestDeliverTx(): RequestDeliverTx {
   };
 }
 export const RequestDeliverTx = {
-  typeUrl: '/tendermint.abci.RequestDeliverTx',
+  typeUrl: '/tendermint.abci.RequestDeliverTx' as const,
   encode(
     message: RequestDeliverTx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1054,7 +1054,7 @@ function createBaseRequestEndBlock(): RequestEndBlock {
   };
 }
 export const RequestEndBlock = {
-  typeUrl: '/tendermint.abci.RequestEndBlock',
+  typeUrl: '/tendermint.abci.RequestEndBlock' as const,
   encode(
     message: RequestEndBlock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1120,7 +1120,7 @@ function createBaseRequestCommit(): RequestCommit {
   return {};
 }
 export const RequestCommit = {
-  typeUrl: '/tendermint.abci.RequestCommit',
+  typeUrl: '/tendermint.abci.RequestCommit' as const,
   encode(
     _: RequestCommit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1180,7 +1180,7 @@ function createBaseResponseQuery(): ResponseQuery {
   };
 }
 export const ResponseQuery = {
-  typeUrl: '/tendermint.abci.ResponseQuery',
+  typeUrl: '/tendermint.abci.ResponseQuery' as const,
   encode(
     message: ResponseQuery,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1340,7 +1340,7 @@ function createBaseResponseBeginBlock(): ResponseBeginBlock {
   };
 }
 export const ResponseBeginBlock = {
-  typeUrl: '/tendermint.abci.ResponseBeginBlock',
+  typeUrl: '/tendermint.abci.ResponseBeginBlock' as const,
   encode(
     message: ResponseBeginBlock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1418,7 +1418,7 @@ function createBaseResponseCheckTx(): ResponseCheckTx {
   };
 }
 export const ResponseCheckTx = {
-  typeUrl: '/tendermint.abci.ResponseCheckTx',
+  typeUrl: '/tendermint.abci.ResponseCheckTx' as const,
   encode(
     message: ResponseCheckTx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1573,7 +1573,7 @@ function createBaseResponseDeliverTx(): ResponseDeliverTx {
   };
 }
 export const ResponseDeliverTx = {
-  typeUrl: '/tendermint.abci.ResponseDeliverTx',
+  typeUrl: '/tendermint.abci.ResponseDeliverTx' as const,
   encode(
     message: ResponseDeliverTx,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1723,7 +1723,7 @@ function createBaseResponseEndBlock(): ResponseEndBlock {
   };
 }
 export const ResponseEndBlock = {
-  typeUrl: '/tendermint.abci.ResponseEndBlock',
+  typeUrl: '/tendermint.abci.ResponseEndBlock' as const,
   encode(
     message: ResponseEndBlock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1836,7 +1836,7 @@ function createBaseResponseCommit(): ResponseCommit {
   };
 }
 export const ResponseCommit = {
-  typeUrl: '/tendermint.abci.ResponseCommit',
+  typeUrl: '/tendermint.abci.ResponseCommit' as const,
   encode(
     message: ResponseCommit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1919,7 +1919,7 @@ function createBaseLastCommitInfo(): LastCommitInfo {
   };
 }
 export const LastCommitInfo = {
-  typeUrl: '/tendermint.abci.LastCommitInfo',
+  typeUrl: '/tendermint.abci.LastCommitInfo' as const,
   encode(
     message: LastCommitInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1997,7 +1997,7 @@ function createBaseEvent(): Event {
   };
 }
 export const Event = {
-  typeUrl: '/tendermint.abci.Event',
+  typeUrl: '/tendermint.abci.Event' as const,
   encode(
     message: Event,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2081,7 +2081,7 @@ function createBaseEventAttribute(): EventAttribute {
   };
 }
 export const EventAttribute = {
-  typeUrl: '/tendermint.abci.EventAttribute',
+  typeUrl: '/tendermint.abci.EventAttribute' as const,
   encode(
     message: EventAttribute,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2172,7 +2172,7 @@ function createBaseTxResult(): TxResult {
   };
 }
 export const TxResult = {
-  typeUrl: '/tendermint.abci.TxResult',
+  typeUrl: '/tendermint.abci.TxResult' as const,
   encode(
     message: TxResult,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2282,7 +2282,7 @@ function createBaseValidator(): Validator {
   };
 }
 export const Validator = {
-  typeUrl: '/tendermint.abci.Validator',
+  typeUrl: '/tendermint.abci.Validator' as const,
   encode(
     message: Validator,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2363,7 +2363,7 @@ function createBaseValidatorUpdate(): ValidatorUpdate {
   };
 }
 export const ValidatorUpdate = {
-  typeUrl: '/tendermint.abci.ValidatorUpdate',
+  typeUrl: '/tendermint.abci.ValidatorUpdate' as const,
   encode(
     message: ValidatorUpdate,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2447,7 +2447,7 @@ function createBaseVoteInfo(): VoteInfo {
   };
 }
 export const VoteInfo = {
-  typeUrl: '/tendermint.abci.VoteInfo',
+  typeUrl: '/tendermint.abci.VoteInfo' as const,
   encode(
     message: VoteInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -2533,7 +2533,7 @@ function createBaseEvidence(): Evidence {
   };
 }
 export const Evidence = {
-  typeUrl: '/tendermint.abci.Evidence',
+  typeUrl: '/tendermint.abci.Evidence' as const,
   encode(
     message: Evidence,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/crypto/keys.ts
+++ b/packages/client-utils/src/codegen/tendermint/crypto/keys.ts
@@ -25,7 +25,7 @@ function createBasePublicKey(): PublicKey {
   };
 }
 export const PublicKey = {
-  typeUrl: '/tendermint.crypto.PublicKey',
+  typeUrl: '/tendermint.crypto.PublicKey' as const,
   encode(
     message: PublicKey,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/crypto/proof.ts
+++ b/packages/client-utils/src/codegen/tendermint/crypto/proof.ts
@@ -93,7 +93,7 @@ function createBaseProof(): Proof {
   };
 }
 export const Proof = {
-  typeUrl: '/tendermint.crypto.Proof',
+  typeUrl: '/tendermint.crypto.Proof' as const,
   encode(
     message: Proof,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -204,7 +204,7 @@ function createBaseValueOp(): ValueOp {
   };
 }
 export const ValueOp = {
-  typeUrl: '/tendermint.crypto.ValueOp',
+  typeUrl: '/tendermint.crypto.ValueOp' as const,
   encode(
     message: ValueOp,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -284,7 +284,7 @@ function createBaseDominoOp(): DominoOp {
   };
 }
 export const DominoOp = {
-  typeUrl: '/tendermint.crypto.DominoOp',
+  typeUrl: '/tendermint.crypto.DominoOp' as const,
   encode(
     message: DominoOp,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -366,7 +366,7 @@ function createBaseProofOp(): ProofOp {
   };
 }
 export const ProofOp = {
-  typeUrl: '/tendermint.crypto.ProofOp',
+  typeUrl: '/tendermint.crypto.ProofOp' as const,
   encode(
     message: ProofOp,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -454,7 +454,7 @@ function createBaseProofOps(): ProofOps {
   };
 }
 export const ProofOps = {
-  typeUrl: '/tendermint.crypto.ProofOps',
+  typeUrl: '/tendermint.crypto.ProofOps' as const,
   encode(
     message: ProofOps,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/libs/bits/types.ts
+++ b/packages/client-utils/src/codegen/tendermint/libs/bits/types.ts
@@ -21,7 +21,7 @@ function createBaseBitArray(): BitArray {
   };
 }
 export const BitArray = {
-  typeUrl: '/tendermint.libs.bits.BitArray',
+  typeUrl: '/tendermint.libs.bits.BitArray' as const,
   encode(
     message: BitArray,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/p2p/types.ts
+++ b/packages/client-utils/src/codegen/tendermint/p2p/types.ts
@@ -76,7 +76,7 @@ function createBaseNetAddress(): NetAddress {
   };
 }
 export const NetAddress = {
-  typeUrl: '/tendermint.p2p.NetAddress',
+  typeUrl: '/tendermint.p2p.NetAddress' as const,
   encode(
     message: NetAddress,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -158,7 +158,7 @@ function createBaseProtocolVersion(): ProtocolVersion {
   };
 }
 export const ProtocolVersion = {
-  typeUrl: '/tendermint.p2p.ProtocolVersion',
+  typeUrl: '/tendermint.p2p.ProtocolVersion' as const,
   encode(
     message: ProtocolVersion,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -257,7 +257,7 @@ function createBaseDefaultNodeInfo(): DefaultNodeInfo {
   };
 }
 export const DefaultNodeInfo = {
-  typeUrl: '/tendermint.p2p.DefaultNodeInfo',
+  typeUrl: '/tendermint.p2p.DefaultNodeInfo' as const,
   encode(
     message: DefaultNodeInfo,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -416,7 +416,7 @@ function createBaseDefaultNodeInfoOther(): DefaultNodeInfoOther {
   };
 }
 export const DefaultNodeInfoOther = {
-  typeUrl: '/tendermint.p2p.DefaultNodeInfoOther',
+  typeUrl: '/tendermint.p2p.DefaultNodeInfoOther' as const,
   encode(
     message: DefaultNodeInfoOther,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/types/block.ts
+++ b/packages/client-utils/src/codegen/tendermint/types/block.ts
@@ -36,7 +36,7 @@ function createBaseBlock(): Block {
   };
 }
 export const Block = {
-  typeUrl: '/tendermint.types.Block',
+  typeUrl: '/tendermint.types.Block' as const,
   encode(
     message: Block,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/types/evidence.ts
+++ b/packages/client-utils/src/codegen/tendermint/types/evidence.ts
@@ -82,7 +82,7 @@ function createBaseEvidence(): Evidence {
   };
 }
 export const Evidence = {
-  typeUrl: '/tendermint.types.Evidence',
+  typeUrl: '/tendermint.types.Evidence' as const,
   encode(
     message: Evidence,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -189,7 +189,7 @@ function createBaseDuplicateVoteEvidence(): DuplicateVoteEvidence {
   };
 }
 export const DuplicateVoteEvidence = {
-  typeUrl: '/tendermint.types.DuplicateVoteEvidence',
+  typeUrl: '/tendermint.types.DuplicateVoteEvidence' as const,
   encode(
     message: DuplicateVoteEvidence,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -322,7 +322,7 @@ function createBaseLightClientAttackEvidence(): LightClientAttackEvidence {
   };
 }
 export const LightClientAttackEvidence = {
-  typeUrl: '/tendermint.types.LightClientAttackEvidence',
+  typeUrl: '/tendermint.types.LightClientAttackEvidence' as const,
   encode(
     message: LightClientAttackEvidence,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -473,7 +473,7 @@ function createBaseEvidenceList(): EvidenceList {
   };
 }
 export const EvidenceList = {
-  typeUrl: '/tendermint.types.EvidenceList',
+  typeUrl: '/tendermint.types.EvidenceList' as const,
   encode(
     message: EvidenceList,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/types/params.ts
+++ b/packages/client-utils/src/codegen/tendermint/types/params.ts
@@ -155,7 +155,7 @@ function createBaseConsensusParams(): ConsensusParams {
   };
 }
 export const ConsensusParams = {
-  typeUrl: '/tendermint.types.ConsensusParams',
+  typeUrl: '/tendermint.types.ConsensusParams' as const,
   encode(
     message: ConsensusParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -284,7 +284,7 @@ function createBaseBlockParams(): BlockParams {
   };
 }
 export const BlockParams = {
-  typeUrl: '/tendermint.types.BlockParams',
+  typeUrl: '/tendermint.types.BlockParams' as const,
   encode(
     message: BlockParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -384,7 +384,7 @@ function createBaseEvidenceParams(): EvidenceParams {
   };
 }
 export const EvidenceParams = {
-  typeUrl: '/tendermint.types.EvidenceParams',
+  typeUrl: '/tendermint.types.EvidenceParams' as const,
   encode(
     message: EvidenceParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -487,7 +487,7 @@ function createBaseValidatorParams(): ValidatorParams {
   };
 }
 export const ValidatorParams = {
-  typeUrl: '/tendermint.types.ValidatorParams',
+  typeUrl: '/tendermint.types.ValidatorParams' as const,
   encode(
     message: ValidatorParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -555,7 +555,7 @@ function createBaseVersionParams(): VersionParams {
   };
 }
 export const VersionParams = {
-  typeUrl: '/tendermint.types.VersionParams',
+  typeUrl: '/tendermint.types.VersionParams' as const,
   encode(
     message: VersionParams,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -624,7 +624,7 @@ function createBaseHashedParams(): HashedParams {
   };
 }
 export const HashedParams = {
-  typeUrl: '/tendermint.types.HashedParams',
+  typeUrl: '/tendermint.types.HashedParams' as const,
   encode(
     message: HashedParams,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/types/types.ts
+++ b/packages/client-utils/src/codegen/tendermint/types/types.ts
@@ -363,7 +363,7 @@ function createBasePartSetHeader(): PartSetHeader {
   };
 }
 export const PartSetHeader = {
-  typeUrl: '/tendermint.types.PartSetHeader',
+  typeUrl: '/tendermint.types.PartSetHeader' as const,
   encode(
     message: PartSetHeader,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -441,7 +441,7 @@ function createBasePart(): Part {
   };
 }
 export const Part = {
-  typeUrl: '/tendermint.types.Part',
+  typeUrl: '/tendermint.types.Part' as const,
   encode(
     message: Part,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -531,7 +531,7 @@ function createBaseBlockID(): BlockID {
   };
 }
 export const BlockID = {
-  typeUrl: '/tendermint.types.BlockID',
+  typeUrl: '/tendermint.types.BlockID' as const,
   encode(
     message: BlockID,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -631,7 +631,7 @@ function createBaseHeader(): Header {
   };
 }
 export const Header = {
-  typeUrl: '/tendermint.types.Header',
+  typeUrl: '/tendermint.types.Header' as const,
   encode(
     message: Header,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -895,7 +895,7 @@ function createBaseData(): Data {
   };
 }
 export const Data = {
-  typeUrl: '/tendermint.types.Data',
+  typeUrl: '/tendermint.types.Data' as const,
   encode(
     message: Data,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -972,7 +972,7 @@ function createBaseVote(): Vote {
   };
 }
 export const Vote = {
-  typeUrl: '/tendermint.types.Vote',
+  typeUrl: '/tendermint.types.Vote' as const,
   encode(
     message: Vote,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1136,7 +1136,7 @@ function createBaseCommit(): Commit {
   };
 }
 export const Commit = {
-  typeUrl: '/tendermint.types.Commit',
+  typeUrl: '/tendermint.types.Commit' as const,
   encode(
     message: Commit,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1251,7 +1251,7 @@ function createBaseCommitSig(): CommitSig {
   };
 }
 export const CommitSig = {
-  typeUrl: '/tendermint.types.CommitSig',
+  typeUrl: '/tendermint.types.CommitSig' as const,
   encode(
     message: CommitSig,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1367,7 +1367,7 @@ function createBaseProposal(): Proposal {
   };
 }
 export const Proposal = {
-  typeUrl: '/tendermint.types.Proposal',
+  typeUrl: '/tendermint.types.Proposal' as const,
   encode(
     message: Proposal,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1511,7 +1511,7 @@ function createBaseSignedHeader(): SignedHeader {
   };
 }
 export const SignedHeader = {
-  typeUrl: '/tendermint.types.SignedHeader',
+  typeUrl: '/tendermint.types.SignedHeader' as const,
   encode(
     message: SignedHeader,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1591,7 +1591,7 @@ function createBaseLightBlock(): LightBlock {
   };
 }
 export const LightBlock = {
-  typeUrl: '/tendermint.types.LightBlock',
+  typeUrl: '/tendermint.types.LightBlock' as const,
   encode(
     message: LightBlock,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1687,7 +1687,7 @@ function createBaseBlockMeta(): BlockMeta {
   };
 }
 export const BlockMeta = {
-  typeUrl: '/tendermint.types.BlockMeta',
+  typeUrl: '/tendermint.types.BlockMeta' as const,
   encode(
     message: BlockMeta,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -1802,7 +1802,7 @@ function createBaseTxProof(): TxProof {
   };
 }
 export const TxProof = {
-  typeUrl: '/tendermint.types.TxProof',
+  typeUrl: '/tendermint.types.TxProof' as const,
   encode(
     message: TxProof,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/types/validator.ts
+++ b/packages/client-utils/src/codegen/tendermint/types/validator.ts
@@ -55,7 +55,7 @@ function createBaseValidatorSet(): ValidatorSet {
   };
 }
 export const ValidatorSet = {
-  typeUrl: '/tendermint.types.ValidatorSet',
+  typeUrl: '/tendermint.types.ValidatorSet' as const,
   encode(
     message: ValidatorSet,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -163,7 +163,7 @@ function createBaseValidator(): Validator {
   };
 }
 export const Validator = {
-  typeUrl: '/tendermint.types.Validator',
+  typeUrl: '/tendermint.types.Validator' as const,
   encode(
     message: Validator,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -280,7 +280,7 @@ function createBaseSimpleValidator(): SimpleValidator {
   };
 }
 export const SimpleValidator = {
-  typeUrl: '/tendermint.types.SimpleValidator',
+  typeUrl: '/tendermint.types.SimpleValidator' as const,
   encode(
     message: SimpleValidator,
     writer: BinaryWriter = BinaryWriter.create(),

--- a/packages/client-utils/src/codegen/tendermint/version/types.ts
+++ b/packages/client-utils/src/codegen/tendermint/version/types.ts
@@ -53,7 +53,7 @@ function createBaseApp(): App {
   };
 }
 export const App = {
-  typeUrl: '/tendermint.version.App',
+  typeUrl: '/tendermint.version.App' as const,
   encode(
     message: App,
     writer: BinaryWriter = BinaryWriter.create(),
@@ -131,7 +131,7 @@ function createBaseConsensus(): Consensus {
   };
 }
 export const Consensus = {
-  typeUrl: '/tendermint.version.Consensus',
+  typeUrl: '/tendermint.version.Consensus' as const,
   encode(
     message: Consensus,
     writer: BinaryWriter = BinaryWriter.create(),


### PR DESCRIPTION
refs: #11593 #10409 #11763

## Description

#11593 changed the cosmos proto codegen, and regenerated `cosmic-proto`, but since #10409 we also have codegen in `client-utils`, and it isn't DRY yet (#11763)

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
Wondering which Maintainers file we need to update for this

### Testing Considerations
Like https://github.com/Agoric/agoric-sdk/pull/11783 mentions, we should have some CI test catching out of date codegen

### Upgrade Considerations
None
