### PR TITLE
feat(ymax-planner): Require direct vstorage read block height to be at or after the triggering event

### DIFF
--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -28,7 +28,8 @@ import * as cb from './callback.js';
 /**
  * @template [T=unknown]
  * @typedef StreamCell
- * @property {string} blockHeight decimal representation of a natural number
+ * @property {string} blockHeight corresponding with the write of `values`
+ *   (decimal representation of a natural number)
  * @property {T[]} values
  */
 

--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -5,6 +5,12 @@ const MAX_SUBSCRIPTIONS = 5;
 const hasOwnProperties = (obj: unknown) =>
   typeof obj === 'object' && obj !== null && Reflect.ownKeys(obj).length > 0;
 
+/** cf. https://docs.cometbft.com/v1.0/explanation/core/subscription */
+export type SubscriptionResponse = {
+  type: string;
+  value: Record<string, unknown>;
+};
+
 export class CosmosRPCClient extends JSONRPCClient {
   #subscriptions: Map<
     number,
@@ -95,7 +101,7 @@ export class CosmosRPCClient extends JSONRPCClient {
    */
   async *subscribeAll(queries: string[]): AsyncGenerator<{
     query: string;
-    data: { type: string; value: Record<string, unknown> };
+    data: SubscriptionResponse;
     events?: Record<string, unknown>;
   }> {
     const newQueries = new Set(queries);

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -17,7 +17,7 @@ import { isPrimitive } from '@endo/pass-style';
 import { makePromiseKit, type PromiseKit } from '@endo/promise-kit';
 import { inspect } from 'node:util';
 import type { CosmosRestClient } from './cosmos-rest-client.ts';
-import type { CosmosRPCClient } from './cosmos-rpc.ts';
+import type { CosmosRPCClient, SubscriptionResponse } from './cosmos-rpc.ts';
 import { handleDeposit } from './plan-deposit.ts';
 import type { SpectrumClient } from './spectrum-client.ts';
 import {
@@ -32,10 +32,26 @@ const { isInteger } = Number;
 
 const sink = () => {};
 
+const STALE = 'STALE';
+
+const throwErrorCode = <Code extends string = string>(
+  message: string,
+  code: Code,
+): never => {
+  const err = Error(message);
+  Object.defineProperty(err, 'code', { value: code, enumerable: true });
+  throw err;
+};
+
 type CosmosEvent = {
   type: string;
   attributes?: Array<{ key: string; value: string }>;
 };
+
+type EventRecord = { blockHeight: bigint } & (
+  | { type: 'kvstore'; event: CosmosEvent }
+  | { type: 'transfer'; address: Bech32Address }
+);
 
 export const PORTFOLIOS_PATH_PREFIX = 'published.ymax0.portfolios';
 export const PENDING_TX_PATH_PREFIX = 'published.ymax0.pendingTxs';
@@ -283,13 +299,23 @@ type Powers = {
 };
 
 const processPortfolioEvents = async (
-  portfolioEvents: Array<{ path: string; value: string }>,
+  portfolioEvents: Array<{
+    path: string;
+    value: string;
+    eventRecord: EventRecord;
+  }>,
+  blockHeight: bigint,
   marshaller: SigningSmartWalletKit['marshaller'],
-  query: SigningSmartWalletKit['query'],
+  readAndDecodeStreamCellValue: (
+    vstoragePath: string,
+    options?: { minBlockHeight?: bigint; retries?: number },
+  ) => any,
   portfolioKeyForDepositAddr: Map<Bech32Address, string>,
+  deferrals: EventRecord[],
 ) => {
   await null;
-  for (const { path, value: cellJson } of portfolioEvents) {
+  for (const portfolioEvent of portfolioEvents) {
+    const { path, value: cellJson, eventRecord } = portfolioEvent;
     const streamCell = tryJsonParse(
       cellJson,
       _err => Fail`non-JSON value at vstorage path ${q(path)}: ${cellJson}`,
@@ -310,14 +336,24 @@ const processPortfolioEvents = async (
         if (portfoliosData.addPortfolio) {
           const key = portfoliosData.addPortfolio;
           console.warn('Detected new portfolio', key);
-          const status = await query.readPublished(
-            `${stripPrefix('published.', PORTFOLIOS_PATH_PREFIX)}.${key}`,
-          );
-          mustMatch(status, PortfolioStatusShapeExt, key);
-          const { depositAddress } = status;
-          if (!depositAddress) continue;
-          portfolioKeyForDepositAddr.set(depositAddress, key);
-          console.warn('Added new portfolio', key, depositAddress);
+          try {
+            const status = await readAndDecodeStreamCellValue(
+              `${PORTFOLIOS_PATH_PREFIX}.${key}`,
+              { minBlockHeight: eventRecord.blockHeight, retries: 4 },
+            );
+            mustMatch(status, PortfolioStatusShapeExt, key);
+            const { depositAddress } = status;
+            if (!depositAddress) continue;
+            portfolioKeyForDepositAddr.set(depositAddress, key);
+            console.warn('Added new portfolio', key, depositAddress);
+          } catch (err) {
+            if (err.code !== STALE) throw err;
+            console.error(
+              `Deferring addPortfolio of age ${blockHeight - eventRecord.blockHeight} block(s)`,
+              eventRecord,
+            );
+            deferrals.push(eventRecord);
+          }
         }
       }
     }
@@ -429,6 +465,56 @@ export const startEngine = async (
 ) => {
   await null;
   const { query, marshaller } = signingSmartWalletKit;
+  /**
+   * Read from a vstorage path, requiring the data to be a StreamCell of
+   * CapData-encoded values and returning the decoding of the final one.
+   * UNTIL https://github.com/Agoric/agoric-sdk/pull/11630
+   */
+  const readAndDecodeStreamCellValue = async (
+    vstoragePath: string,
+    {
+      minBlockHeight = 0n,
+      retries = 0,
+    }: { minBlockHeight?: bigint; retries?: number } = {},
+  ) => {
+    await null;
+    let finalErr: undefined | Error;
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      let values: string[];
+      try {
+        const { blockHeight, result } = await query.vstorage.readStorageMeta(
+          vstoragePath,
+          { kind: 'data' } as const,
+        );
+        if (typeof blockHeight !== 'bigint') {
+          throw Fail`blockHeight ${blockHeight} must be a bigint`;
+        }
+        if (blockHeight < minBlockHeight) {
+          throwErrorCode(`old blockHeight ${blockHeight}`, STALE);
+        }
+        const streamCellJson = result.value;
+        const streamCell = tryJsonParse(
+          streamCellJson,
+          _err =>
+            Fail`non-JSON value at vstorage path ${q(vstoragePath)}: ${streamCellJson}`,
+        );
+        mustMatch(harden(streamCell), StreamCellShape);
+        // We have suitably fresh data; any further errors should propagate.
+        values = streamCell.values;
+      } catch (err) {
+        if (err.code || !finalErr) finalErr = err;
+        continue;
+      }
+      const strValue = values.at(-1) as string;
+      const lastValueCapData = tryJsonParse(
+        strValue,
+        _err =>
+          Fail`non-JSON StreamCell value for ${q(vstoragePath)} index ${q(values.length - 1)}: ${strValue}`,
+      );
+      return marshaller.fromCapData(lastValueCapData);
+    }
+    throw finalErr;
+  };
 
   const chainStatus = await rpc.request('status', {});
   console.warn('agoric chain status', chainStatus);
@@ -496,6 +582,27 @@ export const startEngine = async (
     throw Fail`Could not find vbankAsset for ${q(depositIbcDenom)}`;
   }
 
+  const deferrals = [] as EventRecord[];
+
+  const blockHeightFromSubscriptionResponse = (resp: SubscriptionResponse) => {
+    const { type: respType, value: respData } = resp;
+    switch (respType) {
+      case 'tendermint/event/NewBlockHeader':
+        return BigInt((respData.header as any).height);
+      case 'tendermint/event/Tx':
+        return BigInt((respData.TxResult as any).height);
+      default: {
+        console.error(
+          `Attempting to read block height from unexpected response type ${respType}`,
+          respData,
+        );
+        const obj = Object.values(respData)[0];
+        // @ts-expect-error
+        return BigInt(obj.height ?? obj.blockHeight ?? obj.block_height);
+      }
+    }
+  };
+
   // To avoid data gaps, establish subscriptions before gathering initial state.
   const subscriptionFilters = [
     // vstorage events are in BEGIN_BLOCK/END_BLOCK activity
@@ -509,7 +616,9 @@ export const startEngine = async (
     Fail`Unexpected ready signal ${firstResult}`;
   // console.log('subscribed to events', subscriptionFilters);
 
-  // TODO: verify consumption of paginated data.
+  // TODO: Verify consumption of paginated data.
+  // TODO: Retry when data is associated with a block height lower than that of
+  //       the first result from `responses`.
   const portfolioKeys = await query.vstorage.keys(PORTFOLIOS_PATH_PREFIX);
   const portfolioKeyForDepositAddr = new Map() as Map<Bech32Address, string>;
   await makeWorkPool(portfolioKeys, undefined, async portfolioKey => {
@@ -520,6 +629,13 @@ export const startEngine = async (
     const { depositAddress } = status;
     if (!depositAddress) return;
     portfolioKeyForDepositAddr.set(depositAddress, portfolioKey);
+    // TODO: Use the block height associated with portfolioKey.
+    // https://github.com/Agoric/agoric-sdk/pull/11630
+    deferrals.push({
+      blockHeight: 0n,
+      type: 'transfer' as const,
+      address: depositAddress,
+    });
   }).done;
 
   const pendingTxKeys = await query.vstorage.keys(PENDING_TX_PATH_PREFIX);
@@ -567,16 +683,31 @@ export const startEngine = async (
       continue;
     }
 
+    const respHeight = blockHeightFromSubscriptionResponse(resp);
+
     // Capture vstorage updates.
-    const eventRecords = Object.entries(respData).flatMap(([key, value]) => {
+    const oldEventRecords = deferrals.splice(0).filter(deferral => {
+      if (deferral.type === 'kvstore') return true;
+      deferrals.push(deferral);
+      return false;
+    }) as Array<EventRecord & { type: 'kvstore' }>;
+    const newEvents = Object.entries(respData).flatMap(([key, value]) => {
       // We care about result_begin_block/result_end_block/etc.
       if (!key.startsWith('result_')) return [];
       const events = (value as any)?.events;
       if (!events) console.warn('missing events', respType, key);
       return events ?? [];
     }) as CosmosEvent[];
+    const eventRecords = [
+      ...oldEventRecords,
+      ...newEvents.map(event => ({
+        blockHeight: respHeight,
+        type: 'kvstore' as const,
+        event,
+      })),
+    ];
     const vstorageEvents = partialMap(eventRecords, eventRecord => {
-      const { type: eventType, attributes: attrRecords } = eventRecord;
+      const { type: eventType, attributes: attrRecords } = eventRecord.event;
       // Filter for vstorage state_change events.
       // cf. golang/cosmos/types/events.go
       if (eventType !== 'state_change') return;
@@ -595,13 +726,21 @@ export const startEngine = async (
       const path = encodedKeyToPath(attributes.key);
 
       if (vstoragePathStartsWith(path, PORTFOLIOS_PATH_PREFIX)) {
-        return { type: 'portfolio' as const, path, value: attributes.value };
+        return {
+          type: 'portfolio' as const,
+          path,
+          value: attributes.value,
+          eventRecord,
+        };
       }
       if (vstoragePathStartsWith(path, PENDING_TX_PATH_PREFIX)) {
-        return { type: 'pendingTx' as const, path, value: attributes.value };
+        return {
+          type: 'pendingTx' as const,
+          path,
+          value: attributes.value,
+          eventRecord,
+        };
       }
-
-      return;
     });
 
     const portfolioEvents = vstorageEvents.filter(
@@ -614,9 +753,11 @@ export const startEngine = async (
     // Detect new portfolios.
     await processPortfolioEvents(
       portfolioEvents,
+      respHeight,
       marshaller,
-      query,
+      readAndDecodeStreamCellValue,
       portfolioKeyForDepositAddr,
+      deferrals,
     );
 
     await processPendingTxEvents(
@@ -626,7 +767,12 @@ export const startEngine = async (
     );
 
     // Detect activity against portfolio deposit addresses.
-    const addrsWithActivity: Bech32Address[] = [
+    const oldAddrActivity = deferrals.splice(0).filter(deferral => {
+      if (deferral.type === 'transfer') return true;
+      deferrals.push(deferral);
+      return false;
+    }) as Array<EventRecord & { type: 'transfer' }>;
+    const newActiveAddresses: Bech32Address[] = [
       ...new Set([
         ...((eventRollups['coin_received.receiver'] as Bech32Address[]) || []),
         ...((eventRollups['coin_spent.spender'] as Bech32Address[]) || []),
@@ -634,15 +780,28 @@ export const startEngine = async (
         ...((eventRollups['transfer.sender'] as Bech32Address[]) || []),
       ]),
     ];
+    const addrsWithActivity = [
+      ...oldAddrActivity,
+      ...newActiveAddresses.map(address => ({
+        blockHeight: respHeight,
+        type: 'transfer' as const,
+        address,
+      })),
+    ];
     const depositAddrsWithActivity = new Map(
-      partialMap(addrsWithActivity, addr => {
+      partialMap(addrsWithActivity, eventRecord => {
+        const { address: addr } = eventRecord;
         const portfolioKey = portfolioKeyForDepositAddr.get(addr);
-        return portfolioKey ? [addr, portfolioKey] : undefined;
+        return portfolioKey ? [addr, { portfolioKey, eventRecord }] : undefined;
       }),
     );
 
     const addrBalances = new Map() as Map<Bech32Address, Coin[]>;
-    await makeWorkPool(addrsWithActivity, undefined, async addr => {
+    await makeWorkPool(addrsWithActivity, undefined, async eventRecord => {
+      const { address: addr } = eventRecord;
+      // TODO: Switch to an API that exposes block height, so we can detect stale
+      // data and push to `deferrals`.
+      // cf. https://github.com/Agoric/agoric-sdk/pull/11630
       const balancesResp = await cosmosRest.getAccountBalances('agoric', addr);
       addrBalances.set(addr, balancesResp.balances);
     }).done;
@@ -662,7 +821,7 @@ export const startEngine = async (
     // Respond to deposits.
     const portfolioOps = await Promise.all(
       [...depositAddrsWithActivity.entries()].map(
-        async ([addr, portfolioKey]) => {
+        async ([addr, { portfolioKey, eventRecord: _eventRecord }]) => {
           const amount = pickBalance(addrBalances.get(addr), depositAsset);
           if (!amount) {
             console.warn(`No ${q(depositAsset.issuerName)} at ${addr}`);
@@ -674,6 +833,8 @@ export const startEngine = async (
             `${PORTFOLIOS_PATH_PREFIX}.${portfolioKey}`,
           );
 
+          // TODO: Switch to an API that exposes block height, so we can detect stale
+          // data and push to `deferrals`.
           const steps = await handleDeposit(
             amount,
             unprefixedPortfolioPath as any,

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -75,6 +75,8 @@ export const stripPrefix = (prefix: string, str: string) => {
  */
 const tryJsonParse = (json: string, replaceErr?: (err?: Error) => unknown) => {
   try {
+    const type = typeof json;
+    if (type !== 'string') throw Error(`input must be a string, not ${type}`);
     return JSON.parse(json);
   } catch (err) {
     if (!replaceErr) throw err;

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -346,6 +346,11 @@ const processPortfolioEvents = async (
             if (!depositAddress) continue;
             portfolioKeyForDepositAddr.set(depositAddress, key);
             console.warn('Added new portfolio', key, depositAddress);
+            deferrals.push({
+              blockHeight: eventRecord.blockHeight,
+              type: 'transfer' as const,
+              address: depositAddress,
+            });
           } catch (err) {
             if (err.code !== STALE) throw err;
             console.error(


### PR DESCRIPTION
Extends #11806

## Description
Acknowledge the possibility of vstorage reads getting data for a block height lower than that of the event that triggers the request by performing a small number of retries, and then if that fails pushing onto a deferrals queue for later blocks. And then use that pattern to push an initial "deferral" for reading deposit address balances upon detecting a new portfolio.

### Security Considerations
Deferrals could in principle stack up indefinitely, which we mitigate by logging their age.

### Scaling Considerations
This will increase the number of RPC node requests, particularly when a node falls behind. Hence the low retry count before deferral.

### Documentation Considerations
n/a

### Testing Considerations
We don't yet have a setup for adequately mocking blockchain state against which the planner operates, but it's on the list for me or @mhofman: #11874

### Upgrade Considerations
None.