### PR TITLE
chore(ymax-planner) local tweaks

### DIFF
--- a/packages/ymax-planner/src/cosmos-rest-client.ts
+++ b/packages/ymax-planner/src/cosmos-rest-client.ts
@@ -40,7 +40,7 @@ const CHAIN_CONFIGS: Record<string, Record<string, ChainConfig>> = {
       name: agoricMain.prettyName!,
     },
   },
-  testnet: {
+  devnet: {
     noble: {
       chainId: nobleTest.chainId!,
       restEndpoint: nobleTest.apis!.rest![0].address,

--- a/packages/ymax-planner/src/entrypoint.js
+++ b/packages/ymax-planner/src/entrypoint.js
@@ -3,9 +3,11 @@
 /* eslint-env node */
 
 // We need some pre-lockdown shimming.
-import '@endo/init/pre-remoting.js';
-import './shims.cjs';
-import '@endo/lockdown/commit.js';
+// import '@endo/init/pre-remoting.js';
+// import './shims.cjs';
+// import '@endo/lockdown/commit-debug.js';
+
+import '@endo/init/unsafe-fast.js';
 
 // ...but the WebSocket shim must be loaded *after* lockdown, seemingly because
 // of a dependency upon EventEmitter that is otherwise broken:


### PR DESCRIPTION
## Description

These tweaks from the `lp-ymax-aave-e2e` branch were sufficient to get the planner to work on my workstation while working with @gibson042 on Aug 23. I hope this is subsumed by other work and `yarn dev` Just Works now, but it seems best to confirm.

### Security Considerations

I don't know whether `@endo/init/unsafe-fast.js` is consistent with the threat-model of the planner deployment.

### Documentation Considerations

Is it `testnet` or `devnet`?

### Testing Considerations

These changes were only tested manually.

The endo change was in response to:

```
~/projects/agoric-sdk/packages/ymax-planner$ ./src/entrypoint.js 
Error in main: (TypeError#1)
TypeError#1: Cannot assign to read only property 'constructor' of object ''
  at TracingChannel.traceSync (node:diagnostics_channel:322:14)
  at TracingChannel.traceSync (node:diagnostics_channel:322:14)
  at TracingChannel.traceSync (node:diagnostics_channel:322:14)
```

### Upgrade Considerations

n/a
