### PR TITLE
feat(internal): `trace.sub(prefixStep, subEnable = enable)` for logging prefix paths

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -40,6 +40,7 @@
     "@agoric/cosmic-proto": "workspace:*",
     "@endo/exo": "^1.5.12",
     "@endo/init": "^1.1.12",
+    "@endo/ses-ava": "^1.3.2",
     "@fast-check/ava": "^2.0.1",
     "ava": "^5.3.0",
     "tsd": "^0.33.0"

--- a/packages/internal/src/debug.js
+++ b/packages/internal/src/debug.js
@@ -1,41 +1,108 @@
 // @jessie-check
 
+/**
+ * @import {OptPrefixPath} from './types-internal.js';
+ */
+
+// TODO This is top level static mutable state. Why did it pass at-jessie-check?
 let debugInstance = 1;
 
+const logDisabled = (..._args) => {};
+logDisabled.sub = _ => logDisabled;
+harden(logDisabled);
+
 /**
- * @param {string} name
- * @param {boolean | 'verbose'} enable
+ * @typedef {typeof logDisabled} TraceLogger
  */
-export const makeTracer = (name, enable = true) => {
-  debugInstance += 1;
+
+/**
+ * @param {OptPrefixPath} optPrefixPath
+ * @param {number} rootInstanceNum
+ * @param {boolean | 'verbose'} enable
+ * @returns {TraceLogger}
+ */
+const makeSubTracer = (optPrefixPath, rootInstanceNum, enable) => {
+  // DO NOT ASSIGN to the parameter variables above, since they are captured
+  // by closures below.
+  const makeKey = () => {
+    // As much as possible, postpone anything expensive to here, since this is
+    // only called when a tracer or sub-tracer function is called. Not when it
+    // is made.
+    let prefix;
+    // instead, make a local assignable copy
+    let optPath = optPrefixPath;
+    while (optPath !== undefined) {
+      const [step, optRestSteps] = optPath;
+      if (prefix === undefined) {
+        prefix = step;
+      } else {
+        prefix = `${step}.${prefix}`;
+      }
+      optPath = optRestSteps;
+    }
+    return `----- ${prefix}.${rootInstanceNum} `;
+  };
+  const sub = prefixStep =>
+    makeSubTracer([prefixStep, optPrefixPath], rootInstanceNum, enable);
+
+  // Because `debugCount` is pre-incremented before output, starting it at
+  // `1` means the output counts start at `2`.
   let debugCount = 1;
-  const key = `----- ${name}.${debugInstance} `;
   // the cases below define a named variable to provide better debug info
   switch (enable) {
     case false: {
-      const logDisabled = (..._args) => {};
       return logDisabled;
     }
     case 'verbose': {
       const infoTick = (optLog, ...args) => {
-        if (optLog.log) {
+        const key = makeKey();
+        if (typeof optLog.log === 'function') {
           console.info(key, (debugCount += 1), ...args);
         } else {
           console.info(key, (debugCount += 1), optLog, ...args);
         }
       };
-      return infoTick;
+      infoTick.sub = sub;
+      return harden(infoTick);
     }
     default: {
       const debugTick = (optLog, ...args) => {
-        if (optLog.log) {
+        const key = makeKey();
+        if (typeof optLog.log === 'function') {
           optLog.log(key, (debugCount += 1), ...args);
         } else {
           console.info(key, (debugCount += 1), optLog, ...args);
         }
       };
-      return debugTick;
+      debugTick.sub = sub;
+      return harden(debugTick);
     }
   }
+};
+harden(makeSubTracer);
+
+/**
+ * Makes and returns a tracer function (typically `trace`), that first outputs a
+ * structured header one can search on, and then outputs its arguments to
+ * `console.info`.
+ *
+ * The returned tracer function is intended to support passing the Ava test
+ * object (typically `t`) as an optional first argument, in which case the
+ * remainder of the output is sent there rather than `console.info`. The trace
+ * function doesn't test for this specifically, but rather tests if the first
+ * argument is something with a `.log` method.
+ *
+ * When the `enable` argument to `makeTracer` is 'verbose', output is forced to
+ * `console.log` even in a successful test, whereas `t.log` _might_ be
+ * suppressed in the success case. (TODO is that currently a possible config of
+ * `t.log`?)
+ *
+ * @param {string} name
+ * @param {boolean | 'verbose'} [enable]
+ * @returns {TraceLogger}
+ */
+export const makeTracer = (name, enable = true) => {
+  debugInstance += 1;
+  return makeSubTracer([name, undefined], debugInstance, enable);
 };
 harden(makeTracer);

--- a/packages/internal/src/types-internal.d.ts
+++ b/packages/internal/src/types-internal.d.ts
@@ -1,0 +1,5 @@
+/**
+ * For use by debug.js but defined here because .js files cannot define
+ * circular TS types.
+ */
+export type OptPrefixPath = undefined | [string, OptPrefixPath];

--- a/packages/internal/test/debug-demo.test.js
+++ b/packages/internal/test/debug-demo.test.js
@@ -1,0 +1,94 @@
+import { makeError, X } from '@endo/errors';
+import test from '@endo/ses-ava/prepare-endo.js';
+import { makeTracer } from '../src/debug.js';
+
+// As a *-demo.test.js, the purpose of this test file is not so much to be an
+// automated regression test as to be something whose console output
+// should be visually and manually inspected.
+//
+// TODO 'makeTracer should somehow be migrated to the endo repo, perhaps as
+// an extension of the causalConsole from the `'ses'` package. Once there,
+// it should get a genuine automated test by using the `_throws-and-logs.js`
+// module that supports testing what's sent to the console. Note that
+// the functionality of `_throws-and-logs.js` is not exported from `'ses'`,
+// so writing such tests before migration would be awkward.
+test('test makeTracer top level', t => {
+  const e = makeError(X`pretending`, URIError);
+
+  const defaultTracer = makeTracer('defaultTracer');
+  // Should noop
+  const falseTracer = makeTracer('falseTracer', false);
+  // Should be same as default
+  const trueTracer = makeTracer('trueTracer', true);
+  // Should be same as default, except when the first argument to
+  // `verboseTracer` is an object with a `.log` method.
+  const verboseTracer = makeTracer('verboseTracer', 'verbose');
+
+  defaultTracer('foo1', 'bar1', e);
+  falseTracer('foo2', 'bar2', e);
+  trueTracer('foo3', 'bar3', e);
+  verboseTracer('foo4', 'bar4', e);
+
+  defaultTracer(t, 'foo5', 'bar5', e);
+  falseTracer(t, 'foo6', 'bar6', e);
+  trueTracer(t, 'foo7', 'bar7', e);
+  // ignores `t` and uses `console.log`
+  verboseTracer(t, 'foo8', 'bar8', e);
+  t.pass();
+});
+
+// For example,
+// $ LOCKDOWN_STACK_FILTERING=concise yarn test test/debug-demo.test.js
+// should produce output that looks like
+/*
+
+----- defaultTracer.2  2 foo1 bar1 (URIError#1)
+  ✔ test makeTracer top level
+    ℹ ----- defaultTracer.2  3 foo5 bar5 (URIError#1)
+    ℹ URIError#1: pretending
+    ℹ   at packages/internal/test/debug-demo.test.js:16:13
+        at async Promise.all (index 0)
+
+    ℹ ----- trueTracer.4  3 foo7 bar7 (URIError#1)
+  ✔ test makeTracer sub-tracers
+    ℹ ----- PortC.portflio23:flow3.6  2 hello from flow3
+URIError#1: pretending
+  at packages/internal/test/debug-demo.test.js:16:13
+  at async Promise.all (index 0)
+
+----- trueTracer.4  2 foo3 bar3 (URIError#1)
+----- verboseTracer.5  2 foo4 bar4 (URIError#1)
+----- verboseTracer.5  3 foo8 bar8 (URIError#1)
+
+*/
+// The lines above prefixed with "ℹ" are the ones sent to `t.log`.
+// Nothing sent to `falseTracer` appears anywhere.
+// All trace calls without the `t` argument were sent to `console.info`.
+// The `foo5 bar5` and `foo7 bar7` output was sent to `t.log`
+// The `foo8 bar8` output was sent to `console.log` despite the
+// first `t` argument, which was only skipped.
+//
+// The contents of any error, such as URIError#1 above, are only printed
+// to the console once, whether via `t.log` or the `console` object. All
+// other occurences just mention the name as a backreference to that one
+// logging of its contents.
+
+// The lines
+/*
+
+✔ test makeTracer sub-tracers
+    ℹ ----- PortC.portflio23:flow3.6  2 hello from flow3
+
+*/
+// above are from the next test.
+
+test('test makeTracer sub-tracers', t => {
+  // Example from the original slack conversation.
+
+  const trace = makeTracer('PortC');
+  const trace2 = trace.sub('portfolio23');
+  const trace3 = trace2.sub('flow3');
+
+  trace3(t, 'hello from flow3');
+  t.pass();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,6 +768,7 @@ __metadata:
     "@endo/pass-style": "npm:^1.6.3"
     "@endo/patterns": "npm:^1.7.0"
     "@endo/promise-kit": "npm:^1.1.13"
+    "@endo/ses-ava": "npm:^1.3.2"
     "@endo/stream": "npm:^1.2.13"
     "@fast-check/ava": "npm:^2.0.1"
     anylogger: "npm:^0.21.0"


### PR DESCRIPTION
closes: https://github.com/Agoric/agoric-sdk/issues/11849 
closes: https://github.com/Agoric/agoric-sdk/issues/11846  
closes: https://github.com/Agoric/agoric-sdk/issues/11847  
closes: https://github.com/Agoric/agoric-sdk/issues/11848  
closes: https://github.com/Agoric/agoric-sdk/issues/11851

refs: https://github.com/Agoric/agoric-sdk/issues/5615 , https://github.com/Agoric/agoric-sdk/issues/5222 , https://github.com/Agoric/agoric-sdk/issues/3711 , https://github.com/Agoric/agoric-sdk/issues/2479 , https://github.com/Agoric/agoric-sdk/issues/1864 , https://github.com/Agoric/agoric-sdk/pull/10821 , https://github.com/Agoric/agoric-sdk/issues/10820 , and especially https://github.com/Agoric/agoric-sdk/issues/1318 

refs: https://github.com/Agoric/agoric-sdk/issues/11844 , https://github.com/Agoric/agoric-sdk/issues/11845 , https://github.com/Agoric/agoric-sdk/issues/11850

## Description

***Obsolete***. About to be closed in favor of https://github.com/Agoric/agoric-sdk/pull/11857

The existing `makeTracer` makes tracer functions (typically `trace`) are for outputting console logs preceded with a text designed to ease searching. They first output a structured header one can search on, and then output the rest as normal console output. 

It has a subtle interplay of some options, like the optional second `enable` argument of `makeTracer` and the optional logger first argument of the resulting `trace` function. (See https://github.com/Agoric/agoric-sdk/issues/11850 )

This PR first of all is not intended to break any existing behavior. But these cases are not exercised by the code on master because some of these cases exist to support debugging prior to merging. So this PR first tests those cases. Those tests were written and behavior recorded before this PR changed `makeTrace`, to gain confidence that we're not breaking that behavior. IOW, that we are only changing it in minor ways likely acceptable to all existing users. (See https://github.com/Agoric/agoric-sdk/issues/11848 , https://github.com/Agoric/agoric-sdk/issues/11846)

This PR also introduces a new feature suggested by @dckc in an internal slack discussion: Add a `.sub(prefixStep)` method to a tracer function for producing a new tracer function with an enhanced prefix. (See https://github.com/Agoric/agoric-sdk/issues/11849)


### Security Considerations

Prior to this PR, the returned tracer functions were not hardened, which is a security/integrity hazard. ***Omit needless mutability!*** This PR fixes that oversight. (See https://github.com/Agoric/agoric-sdk/issues/11851)

The implementation of `makeTracer` properly relies on top-level mutable state, only in order to produce console log output that only privileged parties can see. ***HOWEVER***, by passing in one's own alleged logger object (object with a `.log` method), one can read the `debugInstance` top level mutable state, enabling subsystems that should be isolated from each other to communicate without using any special privilege, such as reading console output. (See https://github.com/Agoric/agoric-sdk/issues/11845)

If the only intended use case is the `t` object from Ava or ses-ava, then a proper fix to this integrity hazard would check that it is specifically such an object -- one that only discloses the contents of its arguments (eventually) to the console. But that change is independent of this PR and hard to fix, so this PR leaves that security hazard in place.

Another security hazard discovered by this PR is that `@jessie-check` did not flag this top level mutable state, even though it had no "ignore me" annotation. Until we have a reliable static check for that, we have no good idea how much top level mutable state has accidentally accumulated in our system. (See https://github.com/Agoric/agoric-sdk/issues/11844)

### Scaling Considerations

The previous implementation did a string concat on every trace function creation. Because it was a trivial concat, I'd guess the cost was negligible. With the addition of extended prefix, the costs would accumulate. To encourage lightweight patterns of creating and passing around of labeled tracers, this PR moves as much expense as possible to the time that one of these tracers is called.

Further, because of the link-list path bookkeeping, all bookkeeping info needed only for a sub-tracer deep in the prefix tree is gc'ed when all relevant sub-tracers are gc'ed. Tracers that share a common ancestor also share to booking of their common prefix.

***Update***: The linked list representation was more review trouble than it was worth, since the strings are small. Will revert that and just work with strings. (See https://github.com/Agoric/agoric-sdk/pull/11827#discussion_r2308235246)

### Documentation Considerations

Are there any existing docs on `makeTracer` or the resulting tracers? We should add an explanation of `.sub` to those.

### Testing Considerations

This PR both tests the old (untested) functionality and the new `.sub` functionality. However, as with many tests of behavior that is only about console outputs, these are so-called "demo" tests, to manually run and visually inspect the output. The endo `'ses'` package internally has the `_throws-and-logs.js` test helpers for writing automated regression tests of console output. IMO, the correct eventual home for the `makeLogger` functionality is somewhere in endo. Once migrated to endo, we could figure out how to make these tests automated. Before then it is too awkward.

### Upgrade Considerations

Neither `makeTracer` nor the resulting `trace` functions are `Passable`, so AFAICT they cannot appear in a place where they could cause upgrade concerns. But please let me know if I'm missing something.