### PR TITLE
chore: update resolver service to resolve gmp transactions

### DIFF
--- a/services/ymax-planner/package.json
+++ b/services/ymax-planner/package.json
@@ -26,7 +26,6 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@axelarjs/api": "^0.4.4",
     "@types/node": "^22.10.2",
     "@types/ws": "^8",
     "ava": "^6.3.0",

--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -3,6 +3,7 @@ import { Fail } from '@endo/errors';
 
 export interface YmaxPlannerConfig {
   readonly mnemonic: string;
+  readonly alchemy: string;
   readonly spectrum: {
     readonly apiUrl?: string;
     readonly timeout: number;
@@ -60,6 +61,7 @@ export const loadConfig = (
   try {
     const config: YmaxPlannerConfig = harden({
       mnemonic: validateRequired(env.MNEMONIC, 'MNEMONIC'),
+      alchemy: validateRequired(env.ALCHEMY_API_KEY, 'ALCHEMY_API_KEY'),
       spectrum: {
         apiUrl: validateOptionalUrl(env.SPECTRUM_API_URL, 'SPECTRUM_API_URL'),
         timeout: parsePositiveInteger(

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -308,7 +308,10 @@ const parseSubscription = (
 };
 
 const createSubscriptionContext = (
-  evmCtx: Pick<EvmContext, 'axelarQueryApi' | 'evmProviders'>,
+  evmCtx: Pick<
+    EvmContext,
+    'axelarQueryApi' | 'evmProviders' | 'usdcAddresses' | 'axelarChainIds'
+  >,
   signingSmartWalletKit: SigningSmartWalletKit,
 ): EvmContext => ({
   ...evmCtx,
@@ -317,7 +320,10 @@ const createSubscriptionContext = (
 });
 
 const processPendingSubscription = async (
-  evmCtx: Pick<EvmContext, 'axelarQueryApi' | 'evmProviders'>,
+  evmCtx: Pick<
+    EvmContext,
+    'axelarQueryApi' | 'evmProviders' | 'usdcAddresses' | 'axelarChainIds'
+  >,
   signingSmartWalletKit: SigningSmartWalletKit,
   subscription: Subscription,
   log: (...args: unknown[]) => void,
@@ -334,7 +340,10 @@ const processPendingSubscription = async (
 };
 
 type IO = {
-  evmCtx: Pick<EvmContext, 'axelarQueryApi' | 'evmProviders'>;
+  evmCtx: Pick<
+    EvmContext,
+    'axelarQueryApi' | 'evmProviders' | 'usdcAddresses' | 'axelarChainIds'
+  >;
   rpc: CosmosRPCClient;
   spectrum: SpectrumClient;
   cosmosRest: CosmosRestClient;
@@ -387,7 +396,10 @@ const processPortfolioEvents = async (
 const processSubscriptionEvents = async (
   subscriptionEvents: Array<{ path: string; value: string }>,
   marshaller: SigningSmartWalletKit['marshaller'],
-  evmCtx: Pick<EvmContext, 'axelarQueryApi' | 'evmProviders'>,
+  evmCtx: Pick<
+    EvmContext,
+    'axelarQueryApi' | 'evmProviders' | 'usdcAddresses' | 'axelarChainIds'
+  >,
   signingSmartWalletKit: SigningSmartWalletKit,
 ) => {
   for (const { path, value: vstorageValue } of subscriptionEvents) {

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -389,7 +389,7 @@ export const processPendingTxEvents = async (
         console.error(`⚠️ Failed to process pendingTx: ${txId}`, error);
       };
 
-      void handlePendingTxFn(evmCtx, tx, logFn).catch(errorHandler);
+      void handlePendingTxFn(evmCtx, tx, { log: logFn }).catch(errorHandler);
     }
   }
 };
@@ -515,11 +515,9 @@ export const startEngine = async ({
     });
 
     // Process existing pending transactions on startup
-    void handlePendingTx(
-      { ...evmCtx, signingSmartWalletKit, fetch },
-      tx,
+    void handlePendingTx({ ...evmCtx, signingSmartWalletKit, fetch }, tx, {
       log,
-    ).catch(logIgnoredError);
+    }).catch(logIgnoredError);
   }).done;
 
   // console.warn('consuming events');

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -336,7 +336,6 @@ export const parsePendingTx = (
   marshaller?: SigningSmartWalletKit['marshaller'],
 ): PendingTx | null => {
   const data = marshaller ? marshaller.fromCapData(txData) : txData;
-
   if (!matches(data, PendingTxShape)) {
     const err = assert.error(
       X`expected data ${data} to match ${q(PendingTxShape)}`,

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -83,6 +83,7 @@ export const main = async (
   const evmCtx = await createEVMContext({
     // Any non-mainnet Agoric chain would be connected to Axelar testnet.
     net: env.AGORIC_NET === 'mainnet' ? 'mainnet' : 'testnet',
+    alchemy: config.alchemy,
   });
 
   await startEngine({

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -39,6 +39,9 @@ export type GmpTransfer = {
  * pending -> failed (when operation fails or times out)
  *
  * Terminal states: success and timeout never transition to other states.
+ *
+ * A PendingTx is a PublishedTx (published by ymax contract) with an additional
+ * txId property used by the resolver to track and manage pending transactions.
  */
 export type PendingTx = {
   txId: TxId;

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -1,10 +1,11 @@
 import { type SigningSmartWalletKit } from '@agoric/client-utils';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
+import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
 
-type ResolveSubscriptionParams = {
+type ResolveTxParams = {
   signingSmartWalletKit: SigningSmartWalletKit;
-  subscriptionId: string;
+  txId: TxId;
   status: Omit<TxStatus, 'pending'>;
   proposal?: object;
 };
@@ -22,10 +23,10 @@ const getInvitationMakers = async (wallet: SigningSmartWalletKit) => {
 
 export const resolvePendingTx = async ({
   signingSmartWalletKit,
-  subscriptionId,
+  txId,
   status,
   proposal = {},
-}: ResolveSubscriptionParams) => {
+}: ResolveTxParams) => {
   const invitationMakersOffer = await getInvitationMakers(
     signingSmartWalletKit,
   );
@@ -39,7 +40,7 @@ export const resolvePendingTx = async ({
     },
     offerArgs: {
       status,
-      txId: subscriptionId,
+      txId,
     },
     proposal,
   });

--- a/services/ymax-planner/src/subscription-manager.ts
+++ b/services/ymax-planner/src/subscription-manager.ts
@@ -1,7 +1,6 @@
 import type { AxelarId } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
 import type { SigningSmartWalletKit } from '@agoric/client-utils';
 import type { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
-import { JsonRpcProvider } from 'ethers';
 import { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import { watchGmp } from './watchers/gmp-watcher.ts';
 import { resolvePendingTx } from './resolver.ts';
@@ -10,12 +9,15 @@ import type {
   PublishedTx,
   TxId,
 } from '@aglocal/portfolio-contract/src/resolver/types.ts';
+import type { EvmProviders, UsdcAddresses } from './support.ts';
+import type { CaipChainId } from '@agoric/orchestration';
 
 export type EvmChain = keyof typeof AxelarChain;
 
 export type EvmContext = {
   axelarQueryApi: string;
-  evmProviders: Partial<Record<EvmChain, JsonRpcProvider>>;
+  usdcAddresses: UsdcAddresses['mainnet' | 'testnet'];
+  evmProviders: EvmProviders;
   signingSmartWalletKit: SigningSmartWalletKit;
   fetch: typeof fetch;
 };
@@ -53,202 +55,6 @@ type MonitorRegistry = {
   gmp: SubscriptionMonitor<GmpSubscription>;
 };
 
-export type CctpChainConfig = {
-  name: string;
-  domain: number;
-  contracts: {
-    tokenMessengerV2: string;
-    messageTransmitterV2: string;
-    tokenMinterV2: string;
-    messageV2: string;
-    usdc: string;
-  };
-};
-
-// Type of the full config object
-type CctpConfig = {
-  [chainId: string]: CctpChainConfig;
-};
-
-// XXX: move to support.ts?
-/**
- * Sourced from:
- * - https://chainlist.org/
- * - https://docs.simplehash.com/reference/supported-chains-testnets
- *   (accessed on 27th August 2025)
- * - https://developers.circle.com/cctp/evm-smart-contracts
- * - https://developers.circle.com/stablecoins/usdc-contract-addresses
- *
- * Notes:
- * - This list should conceptually come from an orchestration type
- *   for supported EVM networks.
- * - Currently this config mirrors the EVM chains defined in
- *   packages/orchestration/src/cctp-chain-info.js
- */
-const cctpConfig: CctpConfig = {
-  // 1 — Ethereum
-  '1': {
-    name: 'Ethereum',
-    domain: 0,
-    // NOTE: Currently only USDC address is used for filtering.
-    // In future, other contract addresses can be used to narrow tx filters further.
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-    },
-  },
-
-  // 42161 — Arbitrum
-  '42161': {
-    name: 'Arbitrum',
-    domain: 3,
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-    },
-  },
-
-  // 43114 — Avalanche
-  '43114': {
-    name: 'Avalanche',
-    domain: 1,
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-    },
-  },
-
-  // 137 — Polygon PoS
-  '137': {
-    name: 'Polygon',
-    domain: 7,
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
-    },
-  },
-
-  // 10 — Optimism
-  '10': {
-    name: 'Optimism',
-    domain: 2,
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-    },
-  },
-
-  // 8453 — Base
-  '8453': {
-    name: 'Base',
-    domain: 6,
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-    },
-  },
-
-  // 11155111 — Ethereum Sepolia
-  '11155111': {
-    name: 'Ethereum',
-    domain: 0,
-    contracts: {
-      tokenMessengerV2: '0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA',
-      messageTransmitterV2: '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275',
-      tokenMinterV2: '0xb43db544E2c27092c107639Ad201b3dEfAbcF192',
-      messageV2: '0xbaC0179bB358A8936169a63408C8481D582390C4',
-      usdc: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
-    },
-  },
-
-  // 421614 — Arbitrum Sepolia
-  '421614': {
-    name: 'Arbitrum',
-    domain: 3,
-    contracts: {
-      tokenMessengerV2: '0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA',
-      messageTransmitterV2: '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275',
-      tokenMinterV2: '0xb43db544E2c27092c107639Ad201b3dEfAbcF192',
-      messageV2: '0xbaC0179bB358A8936169a63408C8481D582390C4',
-      usdc: '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d',
-    },
-  },
-
-  // 43113 — Avalanche Fuji
-  '43113': {
-    name: 'Avalanche',
-    domain: 1,
-    contracts: {
-      tokenMessengerV2: '0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA',
-      messageTransmitterV2: '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275',
-      tokenMinterV2: '0xb43db544E2c27092c107639Ad201b3dEfAbcF192',
-      messageV2: '0xbaC0179bB358A8936169a63408C8481D582390C4',
-      usdc: '0x5425890298aed601595a70AB815c96711a31Bc65',
-    },
-  },
-
-  // 80002 — Polygon Amoy
-  '80002': {
-    name: 'Polygon',
-    domain: 7,
-    contracts: {
-      tokenMessengerV2: '0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA',
-      messageTransmitterV2: '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275',
-      tokenMinterV2: '0xb43db544E2c27092c107639Ad201b3dEfAbcF192',
-      messageV2: '0xbaC0179bB358A8936169a63408C8481D582390C4',
-      usdc: '0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582',
-    },
-  },
-
-  // 11155420 — OP Sepolia
-  '11155420': {
-    name: 'Optimism',
-    domain: 2,
-    contracts: {
-      tokenMessengerV2: '0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA',
-      messageTransmitterV2: '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275',
-      tokenMinterV2: '0xb43db544E2c27092c107639Ad201b3dEfAbcF192',
-      messageV2: '0xbaC0179bB358A8936169a63408C8481D582390C4',
-      usdc: '0x5fd84259d66Cd46123540766Be93DFE6D43130D7',
-    },
-  },
-
-  // 84532 — Base Sepolia
-  '84532': {
-    name: 'Base',
-    domain: 6,
-    contracts: {
-      tokenMessengerV2: '0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA',
-      messageTransmitterV2: '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275',
-      tokenMinterV2: '0xb43db544E2c27092c107639Ad201b3dEfAbcF192',
-      messageV2: '0xbaC0179bB358A8936169a63408C8481D582390C4',
-      usdc: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-    },
-  },
-};
-
-export function getCctpConfig(chainId: string) {
-  return cctpConfig[chainId];
-}
-
 const cctpMonitor: SubscriptionMonitor<CctpSubscription> = {
   watch: async (ctx, subscription, log) => {
     const { txId, destinationAddress, amount } = subscription;
@@ -257,18 +63,18 @@ const cctpMonitor: SubscriptionMonitor<CctpSubscription> = {
     log(`${logPrefix} handling cctp subscription`);
 
     // Parse destinationAddress format: 'eip155:42161:0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092'
-    const [, chainId, receiver] = destinationAddress.split(':');
-    const config = cctpConfig[chainId];
-    const provider = ctx.evmProviders[config.name];
-
+    const [namespace, chainId, receiver] = destinationAddress.split(':');
+    const caipId: CaipChainId = `${namespace}:${chainId}`;
+    const usdcAddress = ctx.usdcAddresses[caipId];
+    const provider = ctx.evmProviders[caipId];
     if (!provider) {
       throw Error(
-        `${logPrefix} No EVM provider configured for chain: ${cctpConfig.name}`,
+        `${logPrefix} No EVM provider configured for chain: ${caipId}`,
       );
     }
 
     const transferStatus = await watchCctpTransfer({
-      config,
+      usdcAddress,
       watchAddress: receiver,
       expectedAmount: amount,
       provider,

--- a/services/ymax-planner/src/subscription-manager.ts
+++ b/services/ymax-planner/src/subscription-manager.ts
@@ -9,7 +9,11 @@ import type {
   PublishedTx,
   TxId,
 } from '@aglocal/portfolio-contract/src/resolver/types.ts';
-import type { EvmProviders, UsdcAddresses } from './support.ts';
+import type {
+  AxelarChainIdMap,
+  EvmProviders,
+  UsdcAddresses,
+} from './support.ts';
 import type { CaipChainId } from '@agoric/orchestration';
 
 export type EvmChain = keyof typeof AxelarChain;
@@ -17,6 +21,7 @@ export type EvmChain = keyof typeof AxelarChain;
 export type EvmContext = {
   axelarQueryApi: string;
   usdcAddresses: UsdcAddresses['mainnet' | 'testnet'];
+  axelarChainIds: AxelarChainIdMap[keyof AxelarChainIdMap];
   evmProviders: EvmProviders;
   signingSmartWalletKit: SigningSmartWalletKit;
   fetch: typeof fetch;
@@ -97,7 +102,9 @@ const gmpMonitor: SubscriptionMonitor<GmpSubscription> = {
     const logPrefix = `[${txId}]`;
 
     // Parse destinationAddress format: 'eip155:42161:0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092'
-    const [, chainId, addr] = destinationAddress.split(':');
+    const [namespace, chainId, addr] = destinationAddress.split(':');
+    const caipId: CaipChainId = `${namespace}:${chainId}`;
+    const axelarChainId = ctx.axelarChainIds[caipId];
 
     log(`${logPrefix} handling gmp subscription`);
 
@@ -106,7 +113,7 @@ const gmpMonitor: SubscriptionMonitor<GmpSubscription> = {
       fetch: ctx.fetch,
       params: {
         sourceChain: 'agoric',
-        destinationChain: chainId as unknown as string,
+        destinationChain: axelarChainId as unknown as string,
         contractAddress: addr as `0x${string}`,
       },
       txId,

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -10,6 +10,25 @@ export const axelarQueryAPI = {
 const { ALCHEMY_API_KEY } = process.env;
 if (!ALCHEMY_API_KEY) throw Error(`ALCHEMY_API_KEY not set`);
 
+const axelarChainIdMap = {
+  mainnet: {
+    'eip155:1': 'ethereum-sepolia',
+    'eip155:43114': 'Avalanche',
+    'eip155:42161': 'arbitrum',
+    'eip155:10': 'optimism',
+    'eip155:137': 'Polygon',
+  },
+  testnet: {
+    'eip155:11155111': 'Ethereum',
+    'eip155:43113': 'Avalanche',
+    'eip155:421614': 'arbitrum-sepolia',
+    'eip155:11155420': 'optimism-sepolia',
+    'eip155:80002': 'polygon-sepolia',
+  },
+};
+
+export type AxelarChainIdMap = typeof axelarChainIdMap;
+
 type HexAddress = `0x${string}`;
 
 export type UsdcAddresses = {
@@ -85,7 +104,10 @@ export type EvmProviders = Partial<Record<CaipChainId, JsonRpcProvider>>;
 export const createEVMContext = async ({
   net = 'testnet',
 }: CreateContextParams): Promise<
-  Pick<EvmContext, 'axelarQueryApi' | 'evmProviders' | 'usdcAddresses'>
+  Pick<
+    EvmContext,
+    'axelarQueryApi' | 'evmProviders' | 'usdcAddresses' | 'axelarChainIds'
+  >
 > => {
   const axelarQueryApi = axelarQueryAPI[net];
 
@@ -97,11 +119,10 @@ export const createEVMContext = async ({
     ]),
   ) as EvmProviders;
 
-  const usdc = usdcAddresses[net];
-
   return {
     axelarQueryApi,
     evmProviders,
-    usdcAddresses: usdc,
+    usdcAddresses: usdcAddresses[net],
+    axelarChainIds: axelarChainIdMap[net],
   };
 };

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -1,5 +1,6 @@
 import { JsonRpcProvider } from 'ethers';
-import type { EvmContext, EvmChain } from './subscription-manager';
+import type { EvmContext } from './subscription-manager';
+import type { CaipChainId } from '@agoric/orchestration';
 
 export const axelarQueryAPI = {
   mainnet: 'https://api.axelarscan.io/gmp/searchGMP',
@@ -9,24 +10,69 @@ export const axelarQueryAPI = {
 const { ALCHEMY_API_KEY } = process.env;
 if (!ALCHEMY_API_KEY) throw Error(`ALCHEMY_API_KEY not set`);
 
-export const evmRpcUrls = {
+type HexAddress = `0x${string}`;
+
+export type UsdcAddresses = {
+  mainnet: Record<CaipChainId, HexAddress>;
+  testnet: Record<CaipChainId, HexAddress>;
+};
+
+/**
+ * Sourced from:
+ * - https://chainlist.org/
+ * - https://docs.simplehash.com/reference/supported-chains-testnets
+ *   (accessed on 27th August 2025)
+ * - https://developers.circle.com/cctp/evm-smart-contracts
+ * - https://developers.circle.com/stablecoins/usdc-contract-addresses
+ *
+ * Notes:
+ * - This list should conceptually come from an orchestration type
+ *   for supported EVM networks.
+ * - Currently this config mirrors the EVM chains defined in
+ *   packages/orchestration/src/cctp-chain-info.js
+ */
+export const usdcAddresses: UsdcAddresses = {
   mainnet: {
-    Ethereum: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
-    // Source: https://build.avax.network/docs/tooling/rpc-providers#http
-    Avalanche: 'https://api.avax.network/ext/bc/C/rpc',
-    // Source: https://docs.arbitrum.io/build-decentralized-apps/reference/node-providers
-    Arbitrum: 'https://arb1.arbitrum.io/rpc',
-    // Source: https://docs.optimism.io/superchain/networks
-    Optimism: 'https://mainnet.optimism.io',
-    // Source: https://docs.polygon.technology/pos/reference/rpc-endpoints/#amoy
-    Polygon: 'https://polygon-rpc.com/',
+    'eip155:8453': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // Base
+    'eip155:43114': '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E', // Avalanche
+    'eip155:42161': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // Arbitrum
+    'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // Ethereum
+    'eip155:10': '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85', // Optimism
+    'eip155:137': '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359', // Polygon
   },
   testnet: {
-    Ethereum: `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
-    Avalanche: 'https://api.avax-test.network/ext/bc/C/rpc',
-    Arbitrum: 'https://arbitrum-sepolia-rpc.publicnode.com',
-    Optimism: 'https://optimism-sepolia-rpc.publicnode.com',
-    Polygon: 'https://polygon-amoy-bor-rpc.publicnode.com',
+    'eip155:84532': '0x036CbD53842c5426634e7929541eC2318f3dCF7e', // Base Sepolia
+    'eip155:43113': '0x5425890298aed601595a70AB815c96711a31Bc65', // Avalanche Fuji
+    'eip155:421614': '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', // Arbitrum Sepolia
+    'eip155:11155111': '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238', // Ethereum Sepolia
+    'eip155:11155420': '0x5fd84259d66Cd46123540766Be93DFE6D43130D7', // Optimism Sepolia
+    'eip155:80002': '0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582', // Polygon Amoy
+  },
+};
+
+export type EvmRpc = {
+  mainnet: Record<CaipChainId, string>;
+  testnet: Record<CaipChainId, string>;
+};
+
+export const evmRpcUrls: EvmRpc = {
+  mainnet: {
+    'eip155:1': `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    // Source: https://build.avax.network/docs/tooling/rpc-providers#http
+    'eip155:43114': 'https://api.avax.network/ext/bc/C/rpc',
+    // Source: https://docs.arbitrum.io/build-decentralized-apps/reference/node-providers
+    'eip155:42161': 'https://arb1.arbitrum.io/rpc',
+    // Source: https://docs.optimism.io/superchain/networks
+    'eip155:10': 'https://mainnet.optimism.io',
+    // Source: https://docs.polygon.technology/pos/reference/rpc-endpoints/#amoy
+    'eip155:137': 'https://polygon-rpc.com/',
+  },
+  testnet: {
+    'eip155:11155111': `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    'eip155:43113': 'https://api.avax-test.network/ext/bc/C/rpc',
+    'eip155:421614': 'https://arbitrum-sepolia-rpc.publicnode.com',
+    'eip155:11155420': 'https://optimism-sepolia-rpc.publicnode.com',
+    'eip155:80002': 'https://polygon-amoy-bor-rpc.publicnode.com',
   },
 };
 
@@ -34,22 +80,28 @@ type CreateContextParams = {
   net?: 'mainnet' | 'testnet';
 };
 
+export type EvmProviders = Partial<Record<CaipChainId, JsonRpcProvider>>;
+
 export const createEVMContext = async ({
   net = 'testnet',
 }: CreateContextParams): Promise<
-  Pick<EvmContext, 'axelarQueryApi' | 'evmProviders'>
+  Pick<EvmContext, 'axelarQueryApi' | 'evmProviders' | 'usdcAddresses'>
 > => {
   const axelarQueryApi = axelarQueryAPI[net];
 
-  const rpcUrls = evmRpcUrls[net];
+  const urls = evmRpcUrls[net];
   const evmProviders = Object.fromEntries(
-    Object.entries(rpcUrls).map(([chain, rpcUrl]) => {
-      return [chain as EvmChain, new JsonRpcProvider(rpcUrl)];
-    }),
-  );
+    Object.entries(urls).map(([caip, rpcUrl]) => [
+      caip,
+      new JsonRpcProvider(rpcUrl),
+    ]),
+  ) as EvmProviders;
+
+  const usdc = usdcAddresses[net];
 
   return {
     axelarQueryApi,
     evmProviders,
+    usdcAddresses: usdc,
   };
 };

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -12,14 +12,14 @@ if (!ALCHEMY_API_KEY) throw Error(`ALCHEMY_API_KEY not set`);
 
 const axelarChainIdMap = {
   mainnet: {
-    'eip155:1': 'ethereum-sepolia',
+    'eip155:1': 'Ethereum',
     'eip155:43114': 'Avalanche',
     'eip155:42161': 'arbitrum',
     'eip155:10': 'optimism',
     'eip155:137': 'Polygon',
   },
   testnet: {
-    'eip155:11155111': 'Ethereum',
+    'eip155:11155111': 'ethereum-sepolia',
     'eip155:43113': 'Avalanche',
     'eip155:421614': 'arbitrum-sepolia',
     'eip155:11155420': 'optimism-sepolia',

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -2,32 +2,8 @@ import { JsonRpcProvider } from 'ethers';
 import type { EvmContext } from './pending-tx-manager';
 import type { CaipChainId } from '@agoric/orchestration';
 
-export const axelarQueryAPI = {
-  mainnet: 'https://api.axelarscan.io/gmp/searchGMP',
-  testnet: 'https://testnet.api.axelarscan.io/gmp/searchGMP',
-};
-
 const { ALCHEMY_API_KEY } = process.env;
 if (!ALCHEMY_API_KEY) throw Error(`ALCHEMY_API_KEY not set`);
-
-const axelarChainIdMap = {
-  mainnet: {
-    'eip155:1': 'Ethereum',
-    'eip155:43114': 'Avalanche',
-    'eip155:42161': 'arbitrum',
-    'eip155:10': 'optimism',
-    'eip155:137': 'Polygon',
-  },
-  testnet: {
-    'eip155:11155111': 'ethereum-sepolia',
-    'eip155:43113': 'Avalanche',
-    'eip155:421614': 'arbitrum-sepolia',
-    'eip155:11155420': 'optimism-sepolia',
-    'eip155:80002': 'polygon-sepolia',
-  },
-};
-
-export type AxelarChainIdMap = typeof axelarChainIdMap;
 
 type HexAddress = `0x${string}`;
 
@@ -104,13 +80,8 @@ export type EvmProviders = Partial<Record<CaipChainId, JsonRpcProvider>>;
 export const createEVMContext = async ({
   net = 'mainnet',
 }: CreateContextParams): Promise<
-  Pick<
-    EvmContext,
-    'axelarQueryApi' | 'evmProviders' | 'usdcAddresses' | 'axelarChainIds'
-  >
+  Pick<EvmContext, 'evmProviders' | 'usdcAddresses'>
 > => {
-  const axelarQueryApi = axelarQueryAPI[net];
-
   const urls = evmRpcUrls[net];
   const evmProviders = Object.fromEntries(
     Object.entries(urls).map(([caip, rpcUrl]) => [
@@ -120,9 +91,7 @@ export const createEVMContext = async ({
   ) as EvmProviders;
 
   return {
-    axelarQueryApi,
     evmProviders,
     usdcAddresses: usdcAddresses[net],
-    axelarChainIds: axelarChainIdMap[net],
   };
 };

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from 'ethers';
-import type { EvmContext } from './subscription-manager';
+import type { EvmContext } from './pending-tx-manager';
 import type { CaipChainId } from '@agoric/orchestration';
 
 export const axelarQueryAPI = {

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -102,7 +102,7 @@ type CreateContextParams = {
 export type EvmProviders = Partial<Record<CaipChainId, JsonRpcProvider>>;
 
 export const createEVMContext = async ({
-  net = 'testnet',
+  net = 'mainnet',
 }: CreateContextParams): Promise<
   Pick<
     EvmContext,

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -1,13 +1,13 @@
+import type { JsonRpcProvider } from 'ethers';
 import type { Log } from 'ethers';
 import { id, zeroPadValue, getAddress, type Provider } from 'ethers';
-import type { CctpChainConfig } from '../subscription-manager';
 
 const TRANSFER = id('Transfer(address,address,uint256)');
 const MILLIS_PER_MINUTE = 60 * 1000;
 
 type WatchTransferOptions = {
-  config: CctpChainConfig;
-  provider: Provider;
+  usdcAddress: `0x${string}`;
+  provider: JsonRpcProvider;
   watchAddress: string;
   expectedAmount: bigint;
   timeoutMinutes?: number;
@@ -38,7 +38,7 @@ const parseAmount = data => {
 };
 
 export const watchCctpTransfer = ({
-  config,
+  usdcAddress,
   provider,
   watchAddress,
   expectedAmount,
@@ -84,7 +84,7 @@ export const watchCctpTransfer = ({
         `Transfer detected: token=${tokenAddr} from=${from} to=${to} amount=${amount} tx=${eventLog.transactionHash}`,
       );
 
-      if (amount === expectedAmount && config.contracts.usdc === tokenAddr) {
+      if (amount === expectedAmount && usdcAddress === tokenAddr) {
         log(
           `✓ Amount matches! Expected: ${expectedAmount}, Received: ${amount}`,
         );

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -1,6 +1,6 @@
 import type { JsonRpcProvider } from 'ethers';
 import type { Log } from 'ethers';
-import { id, zeroPadValue, getAddress, type Provider } from 'ethers';
+import { id, zeroPadValue, getAddress } from 'ethers';
 
 const TRANSFER = id('Transfer(address,address,uint256)');
 const MILLIS_PER_MINUTE = 60 * 1000;
@@ -8,7 +8,7 @@ const MILLIS_PER_MINUTE = 60 * 1000;
 type WatchTransferOptions = {
   usdcAddress: `0x${string}`;
   provider: JsonRpcProvider;
-  watchAddress: string;
+  watchAddress: `0x${string}`;
   expectedAmount: bigint;
   timeoutMinutes?: number;
   log: (...args: unknown[]) => void;

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line -- Types in this file match external Axelar API schema
 import { ethers } from 'ethers';
 import type { SearchGMPParams, SearchGMPResponse } from '@axelarjs/api';
+import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
 
 const wait = async (seconds: number) => {
   return new Promise(resolve => setTimeout(resolve, seconds * 1000));
@@ -19,7 +20,7 @@ export const watchGmp = async ({
   url,
   fetch = globalThis.fetch,
   params,
-  subscriptionId,
+  txId,
   log = () => {},
   timeoutMinutes = 5,
   retryDelaySeconds = 20,
@@ -28,7 +29,7 @@ export const watchGmp = async ({
   url: string;
   fetch: typeof globalThis.fetch;
   params: SearchGMPParams;
-  subscriptionId: string;
+  txId: TxId;
   logPrefix?: string;
   log: (...args: unknown[]) => void;
   timeoutMinutes?: number;
@@ -89,11 +90,11 @@ export const watchGmp = async ({
         );
 
         log(`decodedSubscriptionId:`, decodedSubscriptionId);
-        if (decodedSubscriptionId === subscriptionId) {
+        if (decodedSubscriptionId === txId) {
           return { logs: execution, success: true };
         }
       }
-      log(`no log for subscriptionId ${subscriptionId}, retrying...`);
+      log(`no log for txId ${txId}, retrying...`);
     } else {
       log(`no data, retrying...`);
     }

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -59,8 +59,7 @@ export const watchGmp = async ({
     if (Array.isArray(data) && data?.[0]?.executed) {
       const execution = data[0].executed;
 
-      log(`✅ contract call executed`, execution);
-      log(`txHash on EVM:`, execution.transactionHash);
+      log(`✅ contract call executed, txHash: ${execution.transactionHash}`);
 
       const multicallTopic = ethers.id(
         'MulticallExecuted(string,(bool,bytes)[])',

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -1,100 +1,80 @@
 // eslint-disable-next-line -- Types in this file match external Axelar API schema
-import { ethers } from 'ethers';
-import type { SearchGMPParams, SearchGMPResponse } from '@axelarjs/api';
+import { ethers, type JsonRpcProvider, type Log } from 'ethers';
 import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
-
-const wait = async (seconds: number) => {
-  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
-};
 
 const MILLIS_PER_MINUTE = 60 * 1000;
 
-const fetchRequestHeaders = {
-  accept: '*/*',
-  'content-type': 'application/json',
+const MULTICALL_EXECUTED = ethers.id(
+  'MulticallExecuted(string,(bool,bytes)[])',
+);
+
+type WatchGmpOptions = {
+  provider: JsonRpcProvider;
+  contractAddress: `0x${string}`;
+  txId: TxId;
+  timeoutMinutes?: number;
+  log: (...args: unknown[]) => void;
+  setTimeout?: typeof globalThis.setTimeout;
 };
 
-// Helpful for experimenting with different parameters:
-// Visit https://docs.axelarscan.io/axelarscan
-export const watchGmp = async ({
-  url,
-  fetch = globalThis.fetch,
-  params,
+export const watchGmp = ({
+  provider,
+  contractAddress,
   txId,
-  log = () => {},
   timeoutMinutes = 5,
-  retryDelaySeconds = 20,
-  now = () => performance.now(),
-}: {
-  url: string;
-  fetch: typeof globalThis.fetch;
-  params: SearchGMPParams;
-  txId: TxId;
-  logPrefix?: string;
-  log: (...args: unknown[]) => void;
-  timeoutMinutes?: number;
-  retryDelaySeconds?: number;
-  now?: () => number;
-}) => {
-  await null;
-  const body = JSON.stringify(params);
-  log(`params: ${body}`);
+  log = () => {},
+  setTimeout = globalThis.setTimeout,
+}: WatchGmpOptions): Promise<boolean> => {
+  return new Promise(resolve => {
+    const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
+    const filter = {
+      address: contractAddress,
+      topics: [MULTICALL_EXECUTED, expectedIdTopic],
+    };
 
-  const startTime = now();
-  const pollingDurationMs = timeoutMinutes * MILLIS_PER_MINUTE;
+    log(
+      `Watching for MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    );
 
-  while (now() - startTime < pollingDurationMs) {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: fetchRequestHeaders,
-      body,
-    });
+    let executionFound = false;
+    let timeoutId: NodeJS.Timeout;
+    let listeners: Array<{ event: any; listener: any }> = [];
 
-    if (!res.ok) {
-      throw new Error(`axelar api error: ${res.status} ${res.statusText}`);
-    }
+    const cleanup = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      listeners.forEach(({ event, listener }) => {
+        provider.off(event, listener);
+      });
+      listeners = [];
+    };
 
-    const { data } = (await res.json()) as SearchGMPResponse;
-
-    if (Array.isArray(data) && data?.[0]?.executed) {
-      const execution = data[0].executed;
-
-      log(`✅ contract call executed, txHash: ${execution.transactionHash}`);
-
-      const multicallTopic = ethers.id(
-        'MulticallExecuted(string,(bool,bytes)[])',
-      );
-      const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
-
-      /**
-       * - For **EVM events** (executed / approved / callback), the Axelar API returns
-       *   receipts with a `logs[]` array. However, the SDK type `SearchGMPReceipt`
-       *   does not declare `logs`, so TypeScript will show an error.
-       *
-       * - You can experiment with a real transaction hash in the AxelarScan GMP docs:
-       *   https://docs.axelarscan.io/gmp
-       *   Example txHash:
-       *   0x06bbd15ea188edb9098e02e0c0a2f6bf7dbaaf0ab35ec317dd37255bdbf607a4
-       *
-       * This inconsistency comes from @axelarjs/api types lagging behind the actual API schema.
-       */
-      // @ts-expect-error -- logs exist at runtime but are not in the SDK types
-      const logs = execution.receipt.logs;
-      const match = logs.find(
-        l =>
-          l.topics?.[0] === multicallTopic && l.topics?.[1] === expectedIdTopic,
+    const listenForExecution = (eventLog: Log) => {
+      log(
+        `MulticallExecuted detected: txId=${txId} contract=${contractAddress} tx=${eventLog.transactionHash}`,
       );
 
-      if (match) {
-        log('✅ MulticallExecuted for txId found');
-        return { logs: execution, success: true };
+      // Check if this log matches our expected txId
+      if (eventLog.topics[1] === expectedIdTopic) {
+        log(`✓ MulticallExecuted matches txId: ${txId}`);
+        executionFound = true;
+        cleanup();
+        resolve(true);
+      } else {
+        log(`MulticallExecuted txId mismatch for ${txId}`);
       }
-      log(`no log for txId ${txId}, retrying...`);
-    } else {
-      log(`no data, retrying...`);
-    }
+    };
 
-    await wait(retryDelaySeconds);
-  }
-  return { logs: null, success: false };
+    provider.on(filter, listenForExecution);
+    listeners.push({ event: filter, listener: listenForExecution });
+
+    timeoutId = setTimeout(() => {
+      if (!executionFound) {
+        log(
+          `✗ No MulticallExecuted found for txId ${txId} within ${timeoutMinutes} minutes`,
+        );
+        cleanup();
+        resolve(false);
+      }
+    }, timeoutMinutes * MILLIS_PER_MINUTE);
+  });
 };

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -1,43 +1,13 @@
 import test from 'ava';
-import { type JsonRpcProvider, id, toBeHex, zeroPadValue } from 'ethers';
+import { id, toBeHex, zeroPadValue } from 'ethers';
 import { watchCctpTransfer } from '../src/watchers/cctp-watcher.ts';
+import { createMockProvider } from './mocks.ts';
 
 const watchAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
 const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 
 const encodeAmount = (amount: bigint): string => {
   return zeroPadValue(toBeHex(amount), 32);
-};
-
-const createMockProvider = () => {
-  const eventListeners = new Map<string, Function[]>();
-
-  return {
-    on: (eventOrFilter: any, listener: Function) => {
-      const key = JSON.stringify(eventOrFilter);
-      if (!eventListeners.has(key)) {
-        eventListeners.set(key, []);
-      }
-      eventListeners.get(key)!.push(listener);
-    },
-    off: (eventOrFilter: any, listener: Function) => {
-      const key = JSON.stringify(eventOrFilter);
-      const listeners = eventListeners.get(key);
-      if (listeners) {
-        const index = listeners.indexOf(listener);
-        if (index > -1) {
-          listeners.splice(index, 1);
-        }
-      }
-    },
-    emit: (eventOrFilter: any, log: any) => {
-      const key = JSON.stringify(eventOrFilter);
-      const listeners = eventListeners.get(key);
-      if (listeners) {
-        listeners.forEach(listener => listener(log));
-      }
-    },
-  } as JsonRpcProvider;
 };
 
 test('watchCCTPTransfer detects exact amount match', async t => {

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -7,6 +7,7 @@ import {
   mockFetch,
 } from './mocks.ts';
 import { handlePendingTx, type PendingTx } from '../src/pending-tx-manager.ts';
+import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 
 const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const watchAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
@@ -23,7 +24,7 @@ test('handlePendingTx processes CCTP transaction successfully', async t => {
   const amount = 1_000_000n; // 1 USDC
   const receiver = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
   const provider = mockEvmCtx.evmProviders[chain];
-  const type = 'cctp';
+  const type = TxType.CCTP;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
@@ -85,7 +86,7 @@ test('handlePendingTx keeps tx pending on amount mismatch until timeout', async 
   const notExpectedAmt = 1_00_000n;
   const receiver = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
   const provider = mockEvmCtx.evmProviders[chain];
-  const type = 'cctp';
+  const type = TxType.CCTP;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -1,26 +1,12 @@
 import test from 'ava';
-import { type Provider, id, toBeHex, zeroPadValue } from 'ethers';
+import { type JsonRpcProvider, id, toBeHex, zeroPadValue } from 'ethers';
 import { watchCctpTransfer } from '../src/watchers/cctp-watcher.ts';
 
 const watchAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
+const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 
 const encodeAmount = (amount: bigint): string => {
   return zeroPadValue(toBeHex(amount), 32);
-};
-
-const mockCctpConfig = {
-  // 1 — Ethereum
-  '1': {
-    name: 'Ethereum',
-    domain: 0,
-    contracts: {
-      tokenMessengerV2: '0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d',
-      messageTransmitterV2: '0x81D40F21F12A8F0E3252Bccb954D722d4c464B64',
-      tokenMinterV2: '0xfd78EE919681417d192449715b2594ab58f5D002',
-      messageV2: '0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78',
-      usdc: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-    },
-  },
 };
 
 const createMockProvider = () => {
@@ -51,7 +37,7 @@ const createMockProvider = () => {
         listeners.forEach(listener => listener(log));
       }
     },
-  } as Provider;
+  } as JsonRpcProvider;
 };
 
 test('watchCCTPTransfer detects exact amount match', async t => {
@@ -59,7 +45,7 @@ test('watchCCTPTransfer detects exact amount match', async t => {
   const expectedAmount = 1_000_000n; // 1 USDC
 
   const watchPromise = watchCctpTransfer({
-    config: mockCctpConfig['1'],
+    usdcAddress,
     provider: provider,
     watchAddress,
     expectedAmount,
@@ -70,7 +56,7 @@ test('watchCCTPTransfer detects exact amount match', async t => {
   // Simulate a matching transfer event after short delay
   setTimeout(() => {
     const mockLog = {
-      address: mockCctpConfig[1].contracts.usdc, // USDC contract
+      address: usdcAddress, // USDC contract
       topics: [
         id('Transfer(address,address,uint256)'), // Transfer event signature
         '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266', // from
@@ -101,7 +87,7 @@ test('watchCCTPTransfer ignores amount mismatch', async t => {
   const expectedAmount = 1_000_000n;
 
   const watchPromise = watchCctpTransfer({
-    config: mockCctpConfig['1'],
+    usdcAddress,
     provider,
     watchAddress,
     expectedAmount,
@@ -111,7 +97,7 @@ test('watchCCTPTransfer ignores amount mismatch', async t => {
 
   setTimeout(() => {
     const mockLog = {
-      address: mockCctpConfig[1].contracts.usdc,
+      address: usdcAddress,
       topics: [
         id('Transfer(address,address,uint256)'),
         '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
@@ -142,7 +128,7 @@ test('watchCCTPTransfer detects multiple transfers but only matches exact amount
   const expectedAmount = 5_000_000n; // 5 USDC
 
   const watchPromise = watchCctpTransfer({
-    config: mockCctpConfig['1'],
+    usdcAddress,
     provider,
     watchAddress,
     expectedAmount,
@@ -160,7 +146,7 @@ test('watchCCTPTransfer detects multiple transfers but only matches exact amount
   transfers.forEach(({ amount, delay }) => {
     setTimeout(() => {
       const mockLog = {
-        address: mockCctpConfig[1].contracts.usdc,
+        address: usdcAddress,
         topics: [
           id('Transfer(address,address,uint256)'),
           '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -1,38 +1,50 @@
 import test from 'ava';
 import { id, toBeHex, zeroPadValue } from 'ethers';
 import { watchCctpTransfer } from '../src/watchers/cctp-watcher.ts';
-import { createMockProvider } from './mocks.ts';
+import {
+  createMockEvmContext,
+  createMockProvider,
+  mockFetch,
+} from './mocks.ts';
+import { handlePendingTx, type PendingTx } from '../src/pending-tx-manager.ts';
 
-const watchAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
 const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const watchAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
 
 const encodeAmount = (amount: bigint): string => {
   return zeroPadValue(toBeHex(amount), 32);
 };
 
-test('watchCCTPTransfer detects exact amount match', async t => {
-  const provider = createMockProvider();
-  const expectedAmount = 1_000_000n; // 1 USDC
+test('handlePendingTx processes CCTP transaction successfully', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const txId = 'tx1';
+  mockEvmCtx.fetch = mockFetch({ txId });
+  const chain = 'eip155:1'; // Ethereum
+  const amount = 1_000_000n; // 1 USDC
+  const receiver = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const provider = mockEvmCtx.evmProviders[chain];
+  const type = 'cctp';
 
-  const watchPromise = watchCctpTransfer({
-    usdcAddress,
-    provider: provider,
-    watchAddress,
-    expectedAmount,
-    timeoutMinutes: 0.05, // 3 seconds for test
-    log: console.log,
-  });
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
 
-  // Simulate a matching transfer event after short delay
+  const cctpTx: PendingTx = {
+    txId,
+    type,
+    status: 'pending',
+    amount,
+    destinationAddress: `${chain}:${receiver}`,
+  };
+
   setTimeout(() => {
     const mockLog = {
       address: usdcAddress, // USDC contract
       topics: [
         id('Transfer(address,address,uint256)'), // Transfer event signature
         '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266', // from
-        zeroPadValue(watchAddress.toLowerCase(), 32), // to (our watch address)
+        zeroPadValue(receiver.toLowerCase(), 32), // to (our watch address)
       ],
-      data: encodeAmount(expectedAmount),
+      data: encodeAmount(amount),
       transactionHash: '0x123abc',
       blockNumber: 18500000,
     };
@@ -41,39 +53,60 @@ test('watchCCTPTransfer detects exact amount match', async t => {
       topics: [
         id('Transfer(address,address,uint256)'),
         null,
-        zeroPadValue(watchAddress.toLowerCase(), 32),
+        zeroPadValue(receiver.toLowerCase(), 32),
       ],
     };
 
     (provider as any).emit(filter, mockLog);
   }, 50);
 
-  const result = await watchPromise;
-  t.true(result, 'Should detect matching transfer');
+  await t.notThrowsAsync(async () => {
+    await handlePendingTx(mockEvmCtx, cctpTx, {
+      log: logger,
+      timeoutMinutes: 0.05, // 3 sec
+    });
+  });
+
+  t.deepEqual(logMessages, [
+    `[${txId}] handling ${type} tx`,
+    `[${txId}] Watching for ERC-20 transfers to: ${receiver} with amount: ${amount}`,
+    `[${txId}] Transfer detected: token=${usdcAddress} from=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to=${receiver} amount=${amount} tx=0x123abc`,
+    `[${txId}] ✓ Amount matches! Expected: ${amount}, Received: ${amount}`,
+    `[${txId}] CCTP tx resolved`,
+  ]);
 });
 
-test('watchCCTPTransfer ignores amount mismatch', async t => {
-  const provider = createMockProvider();
-  const expectedAmount = 1_000_000n;
+test('handlePendingTx keeps tx pending on amount mismatch until timeout', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const txId = 'tx2';
+  mockEvmCtx.fetch = mockFetch({ txId });
+  const chain = 'eip155:1'; // Ethereum
+  const expectedAmount = 1_000_000n; // 1 USDC
+  const notExpectedAmt = 1_00_000n;
+  const receiver = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const provider = mockEvmCtx.evmProviders[chain];
+  const type = 'cctp';
 
-  const watchPromise = watchCctpTransfer({
-    usdcAddress,
-    provider,
-    watchAddress,
-    expectedAmount,
-    timeoutMinutes: 0.05,
-    log: console.log,
-  });
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const cctpTx: PendingTx = {
+    txId,
+    type,
+    status: 'pending',
+    amount: expectedAmount,
+    destinationAddress: `${chain}:${receiver}`,
+  };
 
   setTimeout(() => {
     const mockLog = {
-      address: usdcAddress,
+      address: usdcAddress, // USDC contract
       topics: [
-        id('Transfer(address,address,uint256)'),
-        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-        zeroPadValue(watchAddress.toLowerCase(), 32),
+        id('Transfer(address,address,uint256)'), // Transfer event signature
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266', // from
+        zeroPadValue(receiver.toLowerCase(), 32), // to (our watch address)
       ],
-      data: encodeAmount(1_000_00n), // 0.1 USDC in hex (wrong amount)
+      data: encodeAmount(notExpectedAmt),
       transactionHash: '0x123abc',
       blockNumber: 18500000,
     };
@@ -82,15 +115,28 @@ test('watchCCTPTransfer ignores amount mismatch', async t => {
       topics: [
         id('Transfer(address,address,uint256)'),
         null,
-        zeroPadValue(watchAddress.toLowerCase(), 32),
+        zeroPadValue(receiver.toLowerCase(), 32),
       ],
     };
 
     (provider as any).emit(filter, mockLog);
   }, 50);
 
-  const result = await watchPromise;
-  t.false(result, 'Should timeout on amount mismatch');
+  await t.notThrowsAsync(async () => {
+    await handlePendingTx(mockEvmCtx, cctpTx, {
+      log: logger,
+      timeoutMinutes: 0.05,
+    });
+  });
+
+  t.deepEqual(logMessages, [
+    `[${txId}] handling ${type} tx`,
+    `[${txId}] Watching for ERC-20 transfers to: ${receiver} with amount: ${expectedAmount}`,
+    `[${txId}] Transfer detected: token=${usdcAddress} from=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to=${receiver} amount=${notExpectedAmt} tx=0x123abc`,
+    `[${txId}] Amount mismatch. Expected: ${expectedAmount}, Received: ${notExpectedAmt}`,
+    `[${txId}] ✗ No matching transfer found within 0.05 minutes`,
+    `[${txId}] CCTP tx resolved`,
+  ]);
 });
 
 test('watchCCTPTransfer detects multiple transfers but only matches exact amount', async t => {

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -14,11 +14,11 @@ test('loadConfig validates required MNEMONIC', t => {
 test('loadConfig accepts valid configuration', t => {
   const env = {
     MNEMONIC: 'test mnemonic phrase',
+    ALCHEMY_API_KEY: 'test1234',
     SPECTRUM_API_URL: 'https://api.spectrum.example.com',
     SPECTRUM_API_TIMEOUT: '5000',
     SPECTRUM_API_RETRIES: '2',
     AGORIC_NET: 'devnet',
-    ALCHEMY_API_KEY: 'xWradf',
     COSMOS_REST_TIMEOUT: '10000',
     COSMOS_REST_RETRIES: '5',
   };
@@ -26,6 +26,7 @@ test('loadConfig accepts valid configuration', t => {
   const config = loadConfig(env);
 
   t.is(config.mnemonic, 'test mnemonic phrase');
+  t.is(config.alchemy, 'test1234');
   t.is(config.spectrum.apiUrl, 'https://api.spectrum.example.com');
   t.is(config.spectrum.timeout, 5000);
   t.is(config.spectrum.retries, 2);
@@ -37,11 +38,13 @@ test('loadConfig accepts valid configuration', t => {
 test('loadConfig uses default values when optional fields are missing', t => {
   const env = {
     MNEMONIC: 'test mnemonic phrase',
+    ALCHEMY_API_KEY: 'test1234',
   };
 
   const config = loadConfig(env);
 
   t.is(config.mnemonic, 'test mnemonic phrase');
+  t.is(config.alchemy, 'test1234');
   t.is(config.spectrum.apiUrl, undefined);
   t.is(config.spectrum.timeout, 30000);
   t.is(config.spectrum.retries, 3);
@@ -53,6 +56,7 @@ test('loadConfig uses default values when optional fields are missing', t => {
 test('loadConfig validates positive integers', t => {
   const env = {
     MNEMONIC: 'test mnemonic phrase',
+    ALCHEMY_API_KEY: 'test1234',
     SPECTRUM_API_TIMEOUT: '0',
   };
 
@@ -64,6 +68,7 @@ test('loadConfig validates positive integers', t => {
 test('loadConfig validates URL format', t => {
   const env = {
     MNEMONIC: 'test mnemonic phrase',
+    ALCHEMY_API_KEY: 'test1234',
     SPECTRUM_API_URL: 'not-a-url',
   };
 
@@ -75,12 +80,14 @@ test('loadConfig validates URL format', t => {
 test('loadConfig trims whitespace from values', t => {
   const env = {
     MNEMONIC: '  test mnemonic phrase  ',
+    ALCHEMY_API_KEY: '  test1234  ',
     AGORIC_NET: '  devnet  ',
   };
 
   const config = loadConfig(env);
 
   t.is(config.mnemonic, 'test mnemonic phrase');
+  t.is(config.alchemy, 'test1234');
   t.is(config.cosmosRest.agoricNetwork, 'devnet');
 });
 
@@ -94,7 +101,10 @@ test('loadConfig rejects empty required values', t => {
 
 // --- Unit tests for createEVMContext ---
 test('createEVMContext generates valid testnet context', async t => {
-  const result = await createEVMContext({ net: 'testnet' });
+  const result = await createEVMContext({
+    net: 'testnet',
+    alchemy: 'test1234',
+  });
 
   t.truthy(result.evmProviders);
   t.truthy(result.usdcAddresses);

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -18,6 +18,7 @@ test('loadConfig accepts valid configuration', t => {
     SPECTRUM_API_TIMEOUT: '5000',
     SPECTRUM_API_RETRIES: '2',
     AGORIC_NET: 'devnet',
+    ALCHEMY_API_KEY: 'xWradf',
     COSMOS_REST_TIMEOUT: '10000',
     COSMOS_REST_RETRIES: '5',
   };

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -1,5 +1,9 @@
 import test from 'ava';
 import { loadConfig } from '../src/config.ts';
+import { createEVMContext } from '../src/support.ts';
+import { JsonRpcProvider } from 'ethers';
+
+const { entries, keys } = Object;
 
 test('loadConfig validates required MNEMONIC', t => {
   const env = {};
@@ -85,4 +89,75 @@ test('loadConfig rejects empty required values', t => {
   };
 
   t.throws(() => loadConfig(env), { message: /"MNEMONIC" is required/ });
+});
+
+// --- Unit tests for createEVMContext ---
+test('createEVMContext generates valid testnet context', async t => {
+  const result = await createEVMContext({ net: 'testnet' });
+
+  t.truthy(result.axelarQueryApi);
+  t.truthy(result.evmProviders);
+  t.truthy(result.usdcAddresses);
+  t.truthy(result.axelarChainIds);
+  t.is(
+    result.axelarQueryApi,
+    'https://testnet.api.axelarscan.io/gmp/searchGMP',
+  );
+
+  // Check that evmProviders contains JsonRpcProvider instances
+  const providerEntries = entries(result.evmProviders);
+  t.true(providerEntries.length > 0, 'should have at least one provider');
+
+  for (const [caipId, provider] of providerEntries) {
+    t.regex(
+      caipId,
+      /^eip155:\d+$/,
+      'CAIP ID should match eip155:chainId format',
+    );
+    t.true(
+      provider instanceof JsonRpcProvider,
+      'provider should be JsonRpcProvider instance',
+    );
+  }
+
+  // Check that collections have consistent CAIP IDs
+  const providerCaipIds = keys(result.evmProviders);
+  const usdcCaipIds = keys(result.usdcAddresses);
+  const chainCaipIds = keys(result.axelarChainIds);
+
+  // Each provider should have corresponding USDC address and chain mapping
+  for (const caipId of providerCaipIds) {
+    t.true(
+      usdcCaipIds.includes(caipId),
+      `USDC address should exist for ${caipId}`,
+    );
+    t.true(
+      chainCaipIds.includes(caipId),
+      `Chain mapping should exist for ${caipId}`,
+    );
+  }
+});
+
+test('createEVMContext defaults to mainnet', async t => {
+  const result = await createEVMContext({});
+  t.is(result.axelarQueryApi, 'https://api.axelarscan.io/gmp/searchGMP');
+});
+
+test('createEVMContext axelarChainIds contain expected values', async t => {
+  const mainnetResult = await createEVMContext({ net: 'mainnet' });
+  const testnetResult = await createEVMContext({ net: 'testnet' });
+
+  // Check mainnet axelarChainIds
+  t.is(mainnetResult.axelarChainIds['eip155:1'], 'Ethereum');
+  t.is(mainnetResult.axelarChainIds['eip155:42161'], 'arbitrum');
+  t.is(mainnetResult.axelarChainIds['eip155:43114'], 'Avalanche');
+  t.is(mainnetResult.axelarChainIds['eip155:10'], 'optimism');
+  t.is(mainnetResult.axelarChainIds['eip155:137'], 'Polygon');
+
+  // Check testnet axelarChainIds
+  t.is(testnetResult.axelarChainIds['eip155:11155111'], 'ethereum-sepolia');
+  t.is(testnetResult.axelarChainIds['eip155:43113'], 'Avalanche');
+  t.is(testnetResult.axelarChainIds['eip155:421614'], 'arbitrum-sepolia');
+  t.is(testnetResult.axelarChainIds['eip155:11155420'], 'optimism-sepolia');
+  t.is(testnetResult.axelarChainIds['eip155:80002'], 'polygon-sepolia');
 });

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -96,14 +96,8 @@ test('loadConfig rejects empty required values', t => {
 test('createEVMContext generates valid testnet context', async t => {
   const result = await createEVMContext({ net: 'testnet' });
 
-  t.truthy(result.axelarQueryApi);
   t.truthy(result.evmProviders);
   t.truthy(result.usdcAddresses);
-  t.truthy(result.axelarChainIds);
-  t.is(
-    result.axelarQueryApi,
-    'https://testnet.api.axelarscan.io/gmp/searchGMP',
-  );
 
   // Check that evmProviders contains JsonRpcProvider instances
   const providerEntries = entries(result.evmProviders);
@@ -124,7 +118,6 @@ test('createEVMContext generates valid testnet context', async t => {
   // Check that collections have consistent CAIP IDs
   const providerCaipIds = keys(result.evmProviders);
   const usdcCaipIds = keys(result.usdcAddresses);
-  const chainCaipIds = keys(result.axelarChainIds);
 
   // Each provider should have corresponding USDC address and chain mapping
   for (const caipId of providerCaipIds) {
@@ -132,33 +125,5 @@ test('createEVMContext generates valid testnet context', async t => {
       usdcCaipIds.includes(caipId),
       `USDC address should exist for ${caipId}`,
     );
-    t.true(
-      chainCaipIds.includes(caipId),
-      `Chain mapping should exist for ${caipId}`,
-    );
   }
-});
-
-test('createEVMContext defaults to mainnet', async t => {
-  const result = await createEVMContext({});
-  t.is(result.axelarQueryApi, 'https://api.axelarscan.io/gmp/searchGMP');
-});
-
-test('createEVMContext axelarChainIds contain expected values', async t => {
-  const mainnetResult = await createEVMContext({ net: 'mainnet' });
-  const testnetResult = await createEVMContext({ net: 'testnet' });
-
-  // Check mainnet axelarChainIds
-  t.is(mainnetResult.axelarChainIds['eip155:1'], 'Ethereum');
-  t.is(mainnetResult.axelarChainIds['eip155:42161'], 'arbitrum');
-  t.is(mainnetResult.axelarChainIds['eip155:43114'], 'Avalanche');
-  t.is(mainnetResult.axelarChainIds['eip155:10'], 'optimism');
-  t.is(mainnetResult.axelarChainIds['eip155:137'], 'Polygon');
-
-  // Check testnet axelarChainIds
-  t.is(testnetResult.axelarChainIds['eip155:11155111'], 'ethereum-sepolia');
-  t.is(testnetResult.axelarChainIds['eip155:43113'], 'Avalanche');
-  t.is(testnetResult.axelarChainIds['eip155:421614'], 'arbitrum-sepolia');
-  t.is(testnetResult.axelarChainIds['eip155:11155420'], 'optimism-sepolia');
-  t.is(testnetResult.axelarChainIds['eip155:80002'], 'polygon-sepolia');
 });

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -1,0 +1,220 @@
+import test from 'ava';
+import { boardSlottingMarshaller } from '@agoric/client-utils';
+import type { EvmContext, PendingTx } from '../src/pending-tx-manager.ts';
+import { processPendingTxEvents, parsePendingTx } from '../src/engine.ts';
+import {
+  createMockEvmContext,
+  createMockPendingTxData,
+  createMockPendingTxEvent,
+  createMockStreamCell,
+} from './mocks.ts';
+
+const marshaller = boardSlottingMarshaller();
+
+// --- Unit tests for parsePendingTx ---
+test('parsePendingTx creates valid PendingTx from data', t => {
+  const txId = 'tx1' as `tx${number}`;
+  const txData = createMockPendingTxData({ type: 'cctp' });
+  const capData = marshaller.toCapData(txData);
+
+  const result = parsePendingTx(txId, capData, marshaller);
+
+  t.truthy(result);
+  t.is(result?.txId, txId);
+  t.is(result?.type, 'cctp');
+  t.is(result?.status, 'pending');
+  t.is(result?.amount, 1000_00n);
+  t.is(
+    result?.destinationAddress,
+    'eip155:42161:0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
+  );
+});
+
+test('parsePendingTx returns null for invalid data shape', t => {
+  const txId = 'tx3' as `tx${number}`;
+  const invalidTxData = harden({
+    someOtherField: 'value',
+  });
+
+  const result = parsePendingTx(txId, invalidTxData);
+
+  t.is(result, null);
+});
+
+// --- Unit tests for processPendingTxEvents ---
+test('processPendingTxEvents handles valid single transaction event', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const handledTxs: PendingTx[] = [];
+  const logMessages: any[][] = [];
+
+  // Mock handlePendingTx to track calls
+  const mockHandlePendingTx = async (
+    ctx: EvmContext,
+    tx: PendingTx,
+    log: any,
+  ) => {
+    handledTxs.push(tx);
+  };
+
+  const mockLog = (...args: any[]) => {
+    logMessages.push(args);
+  };
+
+  const txData = createMockPendingTxData({ type: 'cctp' });
+  const capData = marshaller.toCapData(txData);
+  const streamCell = createMockStreamCell([JSON.stringify(capData)]);
+  const events = [createMockPendingTxEvent('tx1', JSON.stringify(streamCell))];
+
+  await processPendingTxEvents(
+    mockEvmCtx,
+    events,
+    marshaller,
+    mockHandlePendingTx,
+    mockLog,
+  );
+
+  t.is(handledTxs.length, 1);
+  t.is(handledTxs[0].txId, 'tx1');
+  t.is(handledTxs[0].type, 'cctp');
+  t.is(handledTxs[0].status, 'pending');
+});
+
+test('processPendingTxEvents handles multiple transaction events', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const handledTxs: PendingTx[] = [];
+
+  const mockHandlePendingTx = async (
+    ctx: EvmContext,
+    tx: PendingTx,
+    log: any,
+  ) => {
+    handledTxs.push(tx);
+  };
+
+  const originalCctpData = createMockPendingTxData({ type: 'cctp' });
+  const originalGmpData = createMockPendingTxData({ type: 'gmp' });
+
+  const cctpCapData = marshaller.toCapData(originalCctpData);
+  const gmpCapData = marshaller.toCapData(originalGmpData);
+
+  const events = [
+    createMockPendingTxEvent(
+      'tx1',
+      JSON.stringify(createMockStreamCell([JSON.stringify(cctpCapData)])),
+    ),
+    createMockPendingTxEvent(
+      'tx2',
+      JSON.stringify(createMockStreamCell([JSON.stringify(gmpCapData)])),
+    ),
+  ];
+
+  await processPendingTxEvents(
+    mockEvmCtx,
+    events,
+    marshaller,
+    mockHandlePendingTx,
+  );
+
+  t.is(handledTxs.length, 2);
+  t.is(handledTxs[0].txId, 'tx1');
+  t.is(handledTxs[0].type, 'cctp');
+  t.is(handledTxs[1].txId, 'tx2');
+  t.is(handledTxs[1].type, 'gmp');
+});
+
+test('processPendingTxEvents processes valid transactions before throwing on invalid stream cell', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const handledTxs: PendingTx[] = [];
+
+  const mockHandlePendingTx = async (
+    ctx: EvmContext,
+    tx: PendingTx,
+    log: any,
+  ) => {
+    handledTxs.push(tx);
+  };
+
+  const validTx1 = createMockPendingTxData({ type: 'cctp' });
+  const validTx2 = createMockPendingTxData({ type: 'gmp' });
+  const invalidTxData = harden({
+    status: 'pending',
+    // Missing: type, amount, destinationAddress
+    someOtherField: 'invalid',
+  });
+
+  const validCapData1 = marshaller.toCapData(validTx1);
+  const validCapData2 = marshaller.toCapData(validTx2);
+  const invalidCapData = marshaller.toCapData(invalidTxData);
+
+  const events = [
+    createMockPendingTxEvent(
+      'tx1',
+      JSON.stringify(createMockStreamCell([JSON.stringify(validCapData1)])),
+    ),
+    createMockPendingTxEvent(
+      'tx2',
+      JSON.stringify(createMockStreamCell([JSON.stringify(invalidCapData)])),
+    ),
+    createMockPendingTxEvent(
+      'tx3',
+      JSON.stringify({ values: [JSON.stringify(validCapData2)] }),
+    ),
+  ];
+
+  await t.throwsAsync(
+    () =>
+      processPendingTxEvents(
+        mockEvmCtx,
+        events,
+        marshaller,
+        mockHandlePendingTx,
+      ),
+    { message: /Must have missing properties.*blockHeight/ },
+  );
+
+  t.is(
+    handledTxs.length,
+    1,
+    'No transactions should be handled due to invalid tx causing early return',
+  );
+});
+
+test('processPendingTxEvents handles only pending transactions', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const handledTxs: PendingTx[] = [];
+
+  const mockHandlePendingTx = async (
+    ctx: EvmContext,
+    tx: PendingTx,
+    log: any,
+  ) => {
+    handledTxs.push(tx);
+  };
+
+  const tx1 = createMockPendingTxData({ type: 'cctp' });
+  const tx2 = createMockPendingTxData({ type: 'gmp', status: 'success' });
+
+  const data1 = marshaller.toCapData(tx1);
+  const data2 = marshaller.toCapData(tx2);
+
+  const events = [
+    createMockPendingTxEvent(
+      'tx1',
+      JSON.stringify(createMockStreamCell([JSON.stringify(data2)])),
+    ),
+    createMockPendingTxEvent(
+      'tx2',
+      JSON.stringify(createMockStreamCell([JSON.stringify(data1)])),
+    ),
+  ];
+
+  await processPendingTxEvents(
+    mockEvmCtx,
+    events,
+    marshaller,
+    mockHandlePendingTx,
+  );
+
+  t.is(handledTxs.length, 1);
+  t.is(handledTxs[0].status, 'pending');
+});

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import { id, keccak256, toUtf8Bytes } from 'ethers';
 import { createMockEvmContext } from './mocks.ts';
 import { type PendingTx, handlePendingTx } from '../src/pending-tx-manager.ts';
+import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 
 test('handlePendingTx processes GMP transaction successfully', async t => {
   const mockEvmCtx = createMockEvmContext();
@@ -10,7 +11,7 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
   const amount = 1_000_000n; // 1 USDC
   const contractAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
   const provider = mockEvmCtx.evmProviders[chain];
-  const type = 'gmp';
+  const type = TxType.GMP;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
@@ -66,7 +67,7 @@ test('handlePendingTx times out GMP transaction with no matching event', async t
   const chain = 'eip155:1'; // Ethereum
   const amount = 1_000_000n; // 1 USDC
   const contractAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
-  const type = 'gmp';
+  const type = TxType.GMP;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -140,7 +140,7 @@ const createMockAxelarResponse = (
 test('getTxStatus detects successful execution with matching txId', async t => {
   const txId = 'tx0';
 
-  // Mock fetch that returns executed status with matching subscription ID
+  // Mock fetch that returns executed status with matching txId
   const mockFetch = async (url: string, options: any) => {
     const response = createMockAxelarResponse('executed', txId);
     return {
@@ -165,7 +165,7 @@ test('getTxStatus detects successful execution with matching txId', async t => {
   t.truthy(result.logs, 'Should return execution logs');
 });
 
-test('getTxStatus rejects execution with mismatched subscription ID', async t => {
+test('getTxStatus rejects execution with mismatched txId', async t => {
   const expectedTxId = 'tx1';
   const actualTxId = 'tx-2';
 
@@ -192,9 +192,6 @@ test('getTxStatus rejects execution with mismatched subscription ID', async t =>
     log: console.log,
   });
 
-  t.false(
-    result.success,
-    'Should return failure for mismatched subscription ID',
-  );
-  t.is(result.logs, null, 'Should not return logs for mismatched subscription');
+  t.false(result.success, 'Should return failure for mismatched txId');
+  t.is(result.logs, null, 'Should not return logs for mismatched pendingTx');
 });

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -1,157 +1,13 @@
 import test from 'ava';
-import { ethers } from 'ethers';
 import { watchGmp } from '../src/watchers/gmp-watcher.ts';
-
-const createMockAxelarResponse = (
-  status: 'executed' | 'pending' | 'error',
-  txId: string,
-) => {
-  const baseEvent = {
-    call: {
-      chain: 'agoric',
-      blockNumber: 15234567,
-      transactionHash:
-        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-      returnValues: {
-        destinationContractAddress:
-          '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
-        destinationChain: 'ethereum',
-        messageId: 'msg_12345',
-        payload: '0x',
-        sender: 'agoric1sender123',
-        sourceChain: 'agoric',
-      },
-    },
-    gas_paid: {
-      transactionHash: '0xgaspaid123',
-      returnValues: {
-        amount: '1000000',
-        messageId: 'msg_12345',
-      },
-    },
-    confirm: {
-      sourceChain: 'agoric',
-      messageId: 'msg_12345',
-      transactionHash: '0xconfirm123',
-    },
-    approved: {
-      returnValues: {
-        sourceChain: 'agoric',
-        commandId: 'cmd_12345',
-        payloadHash: '0xhash123',
-      },
-    },
-    message_id: 'msg_12345',
-    status: status === 'executed' ? 'executed' : 'confirming',
-    simplified_status: status,
-    is_invalid_call: false,
-    is_not_enough_gas: false,
-  };
-
-  if (status === 'executed') {
-    const multicallTopic = ethers.id(
-      'MulticallExecuted(string,(bool,bytes)[])',
-    );
-    const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
-
-    const executed = {
-      chain: 'ethereum',
-      sourceChain: 'agoric',
-      chain_type: 'evm',
-      messageId: 'msg_12345',
-      created_at: {
-        ms: Date.now(),
-        hour: 0,
-        day: 0,
-        week: 0,
-        month: 0,
-        quarter: 0,
-        year: 2024,
-      },
-      sourceTransactionLogIndex: 0,
-      transactionIndex: 42,
-      contract_address: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
-      relayerAddress: '0xrelayer123',
-      transactionHash: '0xexecuted123',
-      blockNumber: 18500000,
-      block_timestamp: Math.floor(Date.now() / 1000),
-      from: '0xrelayer123',
-      receipt: {
-        gasUsed: '150000',
-        blockNumber: 18500000,
-        from: '0xrelayer123',
-        transactionIndex: 42,
-        status: 1,
-        transactionHash: '0xexecuted123',
-        cumulativeGasUsed: '2000000',
-        effectiveGasPrice: '20000000000',
-        confirmations: 12,
-        logs: [
-          {
-            logIndex: 0,
-            data: '0x',
-            topics: [multicallTopic, expectedIdTopic],
-            blockNumber: 18500000,
-            transactionIndex: 42,
-          },
-          {
-            logIndex: 1,
-            data: '0xotherdata',
-            topics: ['0xotherevent'],
-            blockNumber: 18500000,
-            transactionIndex: 42,
-          },
-        ],
-      },
-      sourceTransactionHash:
-        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-      _id: 'event_123',
-      id: 'event_123',
-      event: 'ContractCallExecuted',
-      transaction: {
-        blockNumber: 18500000,
-        gas: '200000',
-        from: '0xrelayer123',
-        transactionIndex: 42,
-        to: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
-        hash: '0xexecuted123',
-        gasPrice: '20000000000',
-        chainId: 1,
-        maxPriorityFeePerGas: '2000000000',
-        maxFeePerGas: '25000000000',
-        nonce: 100,
-      },
-    };
-
-    return {
-      data: [{ ...baseEvent, executed }],
-      total: 1,
-      time_spent: 123,
-    };
-  }
-
-  return {
-    data: [baseEvent],
-    total: 1,
-    time_spent: 100,
-  };
-};
+import { mockFetch } from './mocks.ts';
 
 test('getTxStatus detects successful execution with matching txId', async t => {
   const txId = 'tx0';
 
-  // Mock fetch that returns executed status with matching txId
-  const mockFetch = async (url: string, options: any) => {
-    const response = createMockAxelarResponse('executed', txId);
-    return {
-      ok: true,
-      json: async () => response,
-    } as Response;
-  };
-
   const result = await watchGmp({
     url: 'https://testnet.api.axelarscan.io/gmp/searchGMP',
-    fetch: mockFetch,
+    fetch: mockFetch({ txId }),
     params: {
       sourceChain: 'agoric',
       destinationChain: 'Avalanche',
@@ -167,19 +23,11 @@ test('getTxStatus detects successful execution with matching txId', async t => {
 
 test('getTxStatus rejects execution with mismatched txId', async t => {
   const expectedTxId = 'tx1';
-  const actualTxId = 'tx-2';
-
-  const mockFetch = async (url: string, options: any) => {
-    const response = createMockAxelarResponse('executed', actualTxId);
-    return {
-      ok: true,
-      json: async () => response,
-    } as Response;
-  };
+  const actualTxId = 'tx2';
 
   const result = await watchGmp({
     url: 'https://testnet.api.axelarscan.io/gmp/searchGMP',
-    fetch: mockFetch,
+    fetch: mockFetch({ txId: actualTxId }),
     params: {
       sourceChain: 'agoric',
       destinationChain: 'arbitrum',

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -1,16 +1,15 @@
 import test from 'ava';
-import { watchGmp } from '../src/watchers/gmp-watcher.ts';
-import { createMockEvmContext, mockFetch } from './mocks.ts';
+import { id, keccak256, toUtf8Bytes } from 'ethers';
+import { createMockEvmContext } from './mocks.ts';
 import { type PendingTx, handlePendingTx } from '../src/pending-tx-manager.ts';
 
 test('handlePendingTx processes GMP transaction successfully', async t => {
   const mockEvmCtx = createMockEvmContext();
   const txId = 'tx1';
-  mockEvmCtx.fetch = mockFetch({ txId });
   const chain = 'eip155:1'; // Ethereum
   const amount = 1_000_000n; // 1 USDC
   const contractAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
-  const destinationChain = mockEvmCtx.axelarChainIds[chain];
+  const provider = mockEvmCtx.evmProviders[chain];
   const type = 'gmp';
 
   const logMessages: string[] = [];
@@ -24,6 +23,27 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
     destinationAddress: `${chain}:${contractAddress}`,
   };
 
+  setTimeout(() => {
+    const expectedIdTopic = keccak256(toUtf8Bytes(txId));
+    const mockLog = {
+      address: contractAddress,
+      topics: [
+        id('MulticallExecuted(string,(bool,bytes)[])'), // MulticallExecuted event signature
+        expectedIdTopic, // txId as topic
+      ],
+      data: '0x', // No additional data needed for this event
+      transactionHash: '0x123abc',
+      blockNumber: 18500000,
+    };
+
+    const filter = {
+      address: contractAddress,
+      topics: [id('MulticallExecuted(string,(bool,bytes)[])'), expectedIdTopic],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 50);
+
   await t.notThrowsAsync(async () => {
     await handlePendingTx(mockEvmCtx, gmpTx, {
       log: logger,
@@ -33,51 +53,45 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
 
   t.deepEqual(logMessages, [
     `[${txId}] handling gmp tx`,
-    `[${txId}] params: {"sourceChain":"agoric","destinationChain":"${destinationChain}","contractAddress":"${contractAddress}"}`,
-    `[${txId}] ✅ contract call executed, txHash: 0xexecuted123`,
-    `[${txId}] ✅ MulticallExecuted for txId found`,
+    `[${txId}] Watching for MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] MulticallExecuted detected: txId=${txId} contract=${contractAddress} tx=0x123abc`,
+    `[${txId}] ✓ MulticallExecuted matches txId: ${txId}`,
     `[${txId}] GMP tx resolved`,
   ]);
 });
 
-test('watchGmp detects successful execution with matching txId', async t => {
-  const txId = 'tx0';
+test('handlePendingTx times out GMP transaction with no matching event', async t => {
+  const mockEvmCtx = createMockEvmContext();
+  const txId = 'tx2';
+  const chain = 'eip155:1'; // Ethereum
+  const amount = 1_000_000n; // 1 USDC
+  const contractAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const type = 'gmp';
 
-  const result = await watchGmp({
-    url: 'https://testnet.api.axelarscan.io/gmp/searchGMP',
-    fetch: mockFetch({ txId }),
-    params: {
-      sourceChain: 'agoric',
-      destinationChain: 'Avalanche',
-      contractAddress: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
-    },
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const gmpTx: PendingTx = {
     txId,
-    log: console.log,
+    type,
+    status: 'pending',
+    amount,
+    destinationAddress: `${chain}:${contractAddress}`,
+  };
+
+  // Don't emit any matching events - let it timeout
+
+  await t.notThrowsAsync(async () => {
+    await handlePendingTx(mockEvmCtx, gmpTx, {
+      log: logger,
+      timeoutMinutes: 0.05, // 3 sec
+    });
   });
 
-  t.true(result.success, 'Should return success for executed transaction');
-  t.truthy(result.logs, 'Should return execution logs');
-});
-
-test('watchGmp rejects execution with mismatched txId', async t => {
-  const expectedTxId = 'tx1';
-  const actualTxId = 'tx2';
-
-  const result = await watchGmp({
-    url: 'https://testnet.api.axelarscan.io/gmp/searchGMP',
-    fetch: mockFetch({ txId: actualTxId }),
-    params: {
-      sourceChain: 'agoric',
-      destinationChain: 'arbitrum',
-      contractAddress: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
-    },
-    txId: expectedTxId,
-    logPrefix: '[TEST]',
-    timeoutMinutes: 0.05, // 3 seconds timeout for test
-    retryDelaySeconds: 0.05,
-    log: console.log,
-  });
-
-  t.false(result.success, 'Should return failure for mismatched txId');
-  t.is(result.logs, null, 'Should not return logs for mismatched pendingTx');
+  t.deepEqual(logMessages, [
+    `[${txId}] handling gmp tx`,
+    `[${txId}] Watching for MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] ✗ No MulticallExecuted found for txId ${txId} within 0.05 minutes`,
+    `[${txId}] GMP tx resolved`,
+  ]);
 });

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -137,11 +137,11 @@ const createMockAxelarResponse = (
 };
 
 test('getTxStatus detects successful execution with matching subscription ID', async t => {
-  const subscriptionId = 'test-subscription-12345';
+  const txId = 'tx0';
 
   // Mock fetch that returns executed status with matching subscription ID
   const mockFetch = async (url: string, options: any) => {
-    const response = createMockAxelarResponse('executed', subscriptionId);
+    const response = createMockAxelarResponse('executed', txId);
     return {
       ok: true,
       json: async () => response,
@@ -156,7 +156,7 @@ test('getTxStatus detects successful execution with matching subscription ID', a
       destinationChain: 'Avalanche',
       contractAddress: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
     },
-    subscriptionId,
+    txId,
     log: console.log,
   });
 
@@ -165,11 +165,11 @@ test('getTxStatus detects successful execution with matching subscription ID', a
 });
 
 test('getTxStatus rejects execution with mismatched subscription ID', async t => {
-  const expectedSubscriptionId = 'test-subscription-12345';
-  const actualSubscriptionId = 'different-subscription-67890';
+  const expectedTxId = 'tx1';
+  const actualTxId = 'tx-2';
 
   const mockFetch = async (url: string, options: any) => {
-    const response = createMockAxelarResponse('executed', actualSubscriptionId);
+    const response = createMockAxelarResponse('executed', actualTxId);
     return {
       ok: true,
       json: async () => response,
@@ -184,7 +184,7 @@ test('getTxStatus rejects execution with mismatched subscription ID', async t =>
       destinationChain: 'arbitrum',
       contractAddress: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
     },
-    subscriptionId: expectedSubscriptionId,
+    txId: expectedTxId,
     logPrefix: '[TEST]',
     timeoutMinutes: 0.05, // 3 seconds timeout for test
     retryDelaySeconds: 0.05,

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -4,7 +4,7 @@ import { watchGmp } from '../src/watchers/gmp-watcher.ts';
 
 const createMockAxelarResponse = (
   status: 'executed' | 'pending' | 'error',
-  subscriptionId: string,
+  txId: string,
 ) => {
   const baseEvent = {
     call: {
@@ -49,9 +49,10 @@ const createMockAxelarResponse = (
   };
 
   if (status === 'executed') {
-    const subscriptionTopic = ethers.id('SubscriptionResolved(string)');
-    const abiCoder = ethers.AbiCoder.defaultAbiCoder();
-    const encodedSubscriptionId = abiCoder.encode(['string'], [subscriptionId]);
+    const multicallTopic = ethers.id(
+      'MulticallExecuted(string,(bool,bytes)[])',
+    );
+    const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
 
     const executed = {
       chain: 'ethereum',
@@ -88,8 +89,8 @@ const createMockAxelarResponse = (
         logs: [
           {
             logIndex: 0,
-            data: encodedSubscriptionId,
-            topics: [subscriptionTopic],
+            data: '0x',
+            topics: [multicallTopic, expectedIdTopic],
             blockNumber: 18500000,
             transactionIndex: 42,
           },
@@ -136,7 +137,7 @@ const createMockAxelarResponse = (
   };
 };
 
-test('getTxStatus detects successful execution with matching subscription ID', async t => {
+test('getTxStatus detects successful execution with matching txId', async t => {
   const txId = 'tx0';
 
   // Mock fetch that returns executed status with matching subscription ID

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -1,6 +1,5 @@
 import type { SigningSmartWalletKit } from '@agoric/client-utils';
 import type { EvmContext } from '../src/pending-tx-manager';
-import type { AxelarChainIdMap } from '../src/support.ts';
 import type { AccountId } from '@agoric/orchestration';
 import { PENDING_TX_PATH_PREFIX } from '../src/engine.ts';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
@@ -80,15 +79,10 @@ export const createMockSigningSmartWalletKit = (): SigningSmartWalletKit => {
 };
 
 export const createMockEvmContext = (): EvmContext => ({
-  axelarQueryApi: 'https://testnet.api.axelarscan.io',
   usdcAddresses: {
     'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // Ethereum
     'eip155:42161': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // Arbitrum
   },
-  axelarChainIds: {
-    'eip155:42161': 'arbitrum',
-    'eip155:1': 'Ethereum',
-  } as AxelarChainIdMap[keyof AxelarChainIdMap],
   evmProviders: {
     'eip155:42161': createMockProvider(),
     'eip155:1': createMockProvider(),

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -4,6 +4,8 @@ import type { AxelarChainIdMap } from '../src/support.ts';
 import type { AccountId } from '@agoric/orchestration';
 import { PENDING_TX_PATH_PREFIX } from '../src/engine.ts';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
+import { ethers, type JsonRpcProvider } from 'ethers';
+import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 
 export const createMockEvmContext = (): EvmContext => ({
   axelarQueryApi: 'https://testnet.api.axelarscan.io',
@@ -50,3 +52,176 @@ export const createMockStreamCell = (values: unknown[]) => ({
   values,
   blockHeight: '1000',
 });
+
+export const createMockProvider = () => {
+  const eventListeners = new Map<string, Function[]>();
+
+  return {
+    on: (eventOrFilter: any, listener: Function) => {
+      const key = JSON.stringify(eventOrFilter);
+      if (!eventListeners.has(key)) {
+        eventListeners.set(key, []);
+      }
+      eventListeners.get(key)!.push(listener);
+    },
+    off: (eventOrFilter: any, listener: Function) => {
+      const key = JSON.stringify(eventOrFilter);
+      const listeners = eventListeners.get(key);
+      if (listeners) {
+        const index = listeners.indexOf(listener);
+        if (index > -1) {
+          listeners.splice(index, 1);
+        }
+      }
+    },
+    emit: (eventOrFilter: any, log: any) => {
+      const key = JSON.stringify(eventOrFilter);
+      const listeners = eventListeners.get(key);
+      if (listeners) {
+        listeners.forEach(listener => listener(log));
+      }
+    },
+  } as JsonRpcProvider;
+};
+
+const createMockAxelarScanResponse = (txId: string, status = 'executed') => {
+  const baseEvent = {
+    call: {
+      chain: 'agoric',
+      blockNumber: 15234567,
+      transactionHash:
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      returnValues: {
+        destinationContractAddress:
+          '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
+        destinationChain: 'ethereum',
+        messageId: 'msg_12345',
+        payload: '0x',
+        sender: 'agoric1sender123',
+        sourceChain: 'agoric',
+      },
+    },
+    gas_paid: {
+      transactionHash: '0xgaspaid123',
+      returnValues: {
+        amount: '1000000',
+        messageId: 'msg_12345',
+      },
+    },
+    confirm: {
+      sourceChain: 'agoric',
+      messageId: 'msg_12345',
+      transactionHash: '0xconfirm123',
+    },
+    approved: {
+      returnValues: {
+        sourceChain: 'agoric',
+        commandId: 'cmd_12345',
+        payloadHash: '0xhash123',
+      },
+    },
+    message_id: 'msg_12345',
+    status: status === 'executed' ? 'executed' : 'confirming',
+    simplified_status: status,
+    is_invalid_call: false,
+    is_not_enough_gas: false,
+  };
+
+  if (status === 'executed') {
+    const multicallTopic = ethers.id(
+      'MulticallExecuted(string,(bool,bytes)[])',
+    );
+    const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
+
+    const executed = {
+      chain: 'ethereum',
+      sourceChain: 'agoric',
+      chain_type: 'evm',
+      messageId: 'msg_12345',
+      created_at: {
+        ms: Date.now(),
+        hour: 0,
+        day: 0,
+        week: 0,
+        month: 0,
+        quarter: 0,
+        year: 2024,
+      },
+      sourceTransactionLogIndex: 0,
+      transactionIndex: 42,
+      contract_address: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
+      relayerAddress: '0xrelayer123',
+      transactionHash: '0xexecuted123',
+      blockNumber: 18500000,
+      block_timestamp: Math.floor(Date.now() / 1000),
+      from: '0xrelayer123',
+      receipt: {
+        gasUsed: '150000',
+        blockNumber: 18500000,
+        from: '0xrelayer123',
+        transactionIndex: 42,
+        status: 1,
+        transactionHash: '0xexecuted123',
+        cumulativeGasUsed: '2000000',
+        effectiveGasPrice: '20000000000',
+        confirmations: 12,
+        logs: [
+          {
+            logIndex: 0,
+            data: '0x',
+            topics: [multicallTopic, expectedIdTopic],
+            blockNumber: 18500000,
+            transactionIndex: 42,
+          },
+          {
+            logIndex: 1,
+            data: '0xotherdata',
+            topics: ['0xotherevent'],
+            blockNumber: 18500000,
+            transactionIndex: 42,
+          },
+        ],
+      },
+      sourceTransactionHash:
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      _id: 'event_123',
+      id: 'event_123',
+      event: 'ContractCallExecuted',
+      transaction: {
+        blockNumber: 18500000,
+        gas: '200000',
+        from: '0xrelayer123',
+        transactionIndex: 42,
+        to: '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
+        hash: '0xexecuted123',
+        gasPrice: '20000000000',
+        chainId: 1,
+        maxPriorityFeePerGas: '2000000000',
+        maxFeePerGas: '25000000000',
+        nonce: 100,
+      },
+    };
+
+    return {
+      data: [{ ...baseEvent, executed }],
+      total: 1,
+      time_spent: 123,
+    };
+  }
+
+  return {
+    data: [baseEvent],
+    total: 1,
+    time_spent: 100,
+  };
+};
+
+export const mockFetch = ({ txId }: { txId: TxId }) => {
+  return async () => {
+    const response = createMockAxelarScanResponse(txId);
+    return {
+      ok: true,
+      json: async () => response,
+    } as Response;
+  };
+};

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -1,0 +1,52 @@
+import type { SigningSmartWalletKit } from '@agoric/client-utils';
+import type { EvmContext } from '../src/pending-tx-manager';
+import type { AxelarChainIdMap } from '../src/support.ts';
+import type { AccountId } from '@agoric/orchestration';
+import { PENDING_TX_PATH_PREFIX } from '../src/engine.ts';
+import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
+
+export const createMockEvmContext = (): EvmContext => ({
+  axelarQueryApi: 'https://testnet.api.axelarscan.io',
+  usdcAddresses: {
+    'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // Ethereum
+    'eip155:42161': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // Arbitrum
+  },
+  axelarChainIds: {
+    'eip155:42161': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  } as AxelarChainIdMap[keyof AxelarChainIdMap],
+  evmProviders: {},
+  signingSmartWalletKit: {} as SigningSmartWalletKit,
+  fetch: global.fetch,
+});
+
+export const createMockPendingTxData = ({
+  type = 'cctp',
+  status = 'pending',
+  amount = 100_000n,
+  destinationAddress = 'eip155:42161:0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64',
+}: {
+  type?: 'cctp' | 'gmp';
+  status?: TxStatus;
+  amount?: bigint;
+  destinationAddress?: AccountId;
+} = {}) =>
+  harden({
+    type,
+    status,
+    amount,
+    destinationAddress,
+  });
+
+export const createMockPendingTxEvent = (
+  txId: string,
+  vstorageValue: string,
+) => ({
+  path: `${PENDING_TX_PATH_PREFIX}.${txId}`,
+  value: vstorageValue,
+});
+
+export const createMockStreamCell = (values: unknown[]) => ({
+  values,
+  blockHeight: '1000',
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adraffy/ens-normalize@npm:^1.10.1, @adraffy/ens-normalize@npm:^1.11.0":
+"@adraffy/ens-normalize@npm:^1.10.1":
   version: 1.11.0
   resolution: "@adraffy/ens-normalize@npm:1.11.0"
   checksum: 10c0/5111d0f1a273468cb5661ed3cf46ee58de8f32f84e2ebc2365652e66c1ead82649df94c736804e2b9cfa831d30ef24e1cc3575d970dbda583416d3a98d8870a6
@@ -294,7 +294,6 @@ __metadata:
     "@agoric/client-utils": "workspace:*"
     "@agoric/ertp": "workspace:*"
     "@agoric/internal": "workspace:*"
-    "@axelarjs/api": "npm:^0.4.4"
     "@cosmjs/crypto": "npm:^0.36.0"
     "@cosmjs/encoding": "npm:^0.36.0"
     "@cosmjs/proto-signing": "npm:^0.36.0"
@@ -1525,76 +1524,6 @@ __metadata:
     escape-string-regexp: "npm:^5.0.0"
     execa: "npm:^8.0.1"
   checksum: 10c0/4f0f9fbcf34f632a95d5565d2c0f7b397873cdc9b55288c54bc7d1dde58fbf600beaa470639e5367aceb99841efa3d4b8c0b5b4bf4778fe8fe5f7e926e4a3fad
-  languageName: node
-  linkType: hard
-
-"@axelarjs/api@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "@axelarjs/api@npm:0.4.4"
-  dependencies:
-    "@axelarjs/core": "npm:0.2.11"
-    "@axelarjs/cosmos": "npm:0.2.13"
-    "@axelarjs/utils": "npm:0.1.12"
-    isomorphic-unfetch: "npm:^4.0.2"
-    rambda: "npm:^9.1.1"
-    viem: "npm:^2.8.18"
-  peerDependencies:
-    unfetch: <=4.2
-  checksum: 10c0/003a95039fc11060be9cd722cdb3797b8166aba955576f4a81dde081670f3ce295e2e6e73a60155f8066c8ac61d70fe769c300ee919832ded8230eab8b8610e9
-  languageName: node
-  linkType: hard
-
-"@axelarjs/config@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@axelarjs/config@npm:0.1.8"
-  checksum: 10c0/ff698f94f8a63686246a2631d952b458364b70335b7f7e6243474f287e3e95826d42d9db8f811a935be415bfeb74d05ac76b2fbc4488f4fac4c85c810449cbcf
-  languageName: node
-  linkType: hard
-
-"@axelarjs/core@npm:0.2.11":
-  version: 0.2.11
-  resolution: "@axelarjs/core@npm:0.2.11"
-  checksum: 10c0/63c3a0acccaeb5f64ae43aef9cdb96eb44d2c4d0f676194b38b50441e25d1d57ca6436b4e6a9f171820267be271c2a6ff22724ea5d9d427d0dabd5e7e22fa79a
-  languageName: node
-  linkType: hard
-
-"@axelarjs/cosmos@npm:0.2.13":
-  version: 0.2.13
-  resolution: "@axelarjs/cosmos@npm:0.2.13"
-  dependencies:
-    "@axelarjs/config": "npm:0.1.8"
-    "@axelarjs/proto": "npm:0.35.5"
-    "@axelarjs/utils": "npm:0.1.12"
-    "@cosmjs/proto-signing": "npm:^0.31.3"
-    "@cosmjs/stargate": "npm:^0.31.3"
-    "@cosmjs/tendermint-rpc": "npm:^0.31.3"
-    inflection: "npm:^2.0.1"
-    long: "npm:^5.2.3"
-  checksum: 10c0/06364deb17ade8df5b1b2c23c43f69f55fb246384e92f457b4a98940f4aece0d42c77e04bc196a61b535ff3ba5a3bc7ab197361b44e591d7711d7d05586bc7d6
-  languageName: node
-  linkType: hard
-
-"@axelarjs/proto@npm:0.35.5":
-  version: 0.35.5
-  resolution: "@axelarjs/proto@npm:0.35.5"
-  dependencies:
-    long: "npm:^5.2.3"
-    protobufjs: "npm:^7.2.6"
-  checksum: 10c0/b0147cc58959bcde065047aadd7cdebb275290d4fa8ffaf9e98a579a0805eb230fcc414fee0c3959cb8f65d7fca8b5c7097f739d3ceb9fc06beb2b584f3fb7b0
-  languageName: node
-  linkType: hard
-
-"@axelarjs/utils@npm:0.1.12":
-  version: 0.1.12
-  resolution: "@axelarjs/utils@npm:0.1.12"
-  dependencies:
-    immer: "npm:^10.0.3"
-    isomorphic-unfetch: "npm:^4.0.2"
-    lodash.debounce: "npm:^4.0.8"
-    lodash.throttle: "npm:^4.1.1"
-    ramda: "npm:^0.29.1"
-    tiny-invariant: "npm:^1.3.1"
-  checksum: 10c0/b34e151d6a302bfc6c2baa945eec782c6b638be8d8ff212450537d0f129ac78968fff43ef8e48b4e8827c631c497b21a0325663ecbdd144a91eeafd5fa421879
   languageName: node
   linkType: hard
 
@@ -3125,16 +3054,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@confio/ics23@npm:^0.6.8":
-  version: 0.6.8
-  resolution: "@confio/ics23@npm:0.6.8"
-  dependencies:
-    "@noble/hashes": "npm:^1.0.0"
-    protobufjs: "npm:^6.8.8"
-  checksum: 10c0/2f3f5032cd6a34c9b2fbd64bbf7e1cdec75ca71f348a770f7b5474b5027b12202bfbcd404eca931efddb5901f769af035a87cb8bddbf3f23d7e5d93c9d3d7f6f
-  languageName: node
-  linkType: hard
-
 "@conventional-changelog/git-client@npm:^2.5.1":
   version: 2.5.1
   resolution: "@conventional-changelog/git-client@npm:2.5.1"
@@ -3154,18 +3073,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/amino@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/amino@npm:0.31.3"
-  dependencies:
-    "@cosmjs/crypto": "npm:^0.31.3"
-    "@cosmjs/encoding": "npm:^0.31.3"
-    "@cosmjs/math": "npm:^0.31.3"
-    "@cosmjs/utils": "npm:^0.31.3"
-  checksum: 10c0/2f5f866df043bef072ef8802844beacd282027dcc32f69428fe98e256d5fec0dd4a45a4c7d6c45c8a7d7f4387893ef02c8b471a32d6450215f56157d6eaa467e
-  languageName: node
-  linkType: hard
-
 "@cosmjs/amino@npm:^0.36.0":
   version: 0.36.0
   resolution: "@cosmjs/amino@npm:0.36.0"
@@ -3175,21 +3082,6 @@ __metadata:
     "@cosmjs/math": "npm:^0.36.0"
     "@cosmjs/utils": "npm:^0.36.0"
   checksum: 10c0/7f755eb59dba493b088303b6bea68a05443517de3abf20a05d2db64b5b6b9a63bd203097fc7e32ced3d48b4902bf82ae6da6233a3b4100930a0048a5bd219268
-  languageName: node
-  linkType: hard
-
-"@cosmjs/crypto@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/crypto@npm:0.31.3"
-  dependencies:
-    "@cosmjs/encoding": "npm:^0.31.3"
-    "@cosmjs/math": "npm:^0.31.3"
-    "@cosmjs/utils": "npm:^0.31.3"
-    "@noble/hashes": "npm:^1"
-    bn.js: "npm:^5.2.0"
-    elliptic: "npm:^6.5.4"
-    libsodium-wrappers-sumo: "npm:^0.7.11"
-  checksum: 10c0/595de61be8832c0f012e80343427efc5f7dec6157f31410908edefcae710f31bed723b50d0979b66d961765854e76d89e6942b5430a727f458b8d7e67fc7b174
   languageName: node
   linkType: hard
 
@@ -3208,17 +3100,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/encoding@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/encoding@npm:0.31.3"
-  dependencies:
-    base64-js: "npm:^1.3.0"
-    bech32: "npm:^1.1.4"
-    readonly-date: "npm:^1.0.0"
-  checksum: 10c0/48eb9f9259bdfd88db280b6b5ea970fd1b3b0f81a8f4253f315ff2c736b27dbe0fdf74405c52ad35fcd4b16f1fde4250c4de936997b9d92e79cb97d98cc538c7
-  languageName: node
-  linkType: hard
-
 "@cosmjs/encoding@npm:^0.36.0":
   version: 0.36.0
   resolution: "@cosmjs/encoding@npm:0.36.0"
@@ -3227,16 +3108,6 @@ __metadata:
     bech32: "npm:^1.1.4"
     readonly-date: "npm:^1.0.0"
   checksum: 10c0/3e8038b8856d080acf7e233bfdde9ce1a90e5146e4a2104da30aeba7922a0a3bc2d732589a07554e0f5d201802a85cf63771e44841873846b2364b1fed594254
-  languageName: node
-  linkType: hard
-
-"@cosmjs/json-rpc@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/json-rpc@npm:0.31.3"
-  dependencies:
-    "@cosmjs/stream": "npm:^0.31.3"
-    xstream: "npm:^11.14.0"
-  checksum: 10c0/8cc8fa9490e512a2865e888b162e2cc38477a6a5b6261fce885579712c880087c8bb2733717eb5fe03c131f31064e1f9060f87ae2a4d1d01d6c465761ab1a32d
   languageName: node
   linkType: hard
 
@@ -3250,34 +3121,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/math@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/math@npm:0.31.3"
-  dependencies:
-    bn.js: "npm:^5.2.0"
-  checksum: 10c0/7dd742ee6ff52bc322d3cd43b9ab0e15d70b41b74a487f64c23609ffe5abce9a02cbec46a729155608a1abb3bc0067ac97361f0af23453fb0b4c438b17e37a99
-  languageName: node
-  linkType: hard
-
 "@cosmjs/math@npm:^0.36.0":
   version: 0.36.0
   resolution: "@cosmjs/math@npm:0.36.0"
   checksum: 10c0/72fbbd8beeef9919775c213e8b2ce568b957c9f73a4a634a275f5bac7cb7a0b614dcc81d3d3593b4634ded1b36fea1fe1bc9aa689a706fd51e94320a919b06b5
-  languageName: node
-  linkType: hard
-
-"@cosmjs/proto-signing@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/proto-signing@npm:0.31.3"
-  dependencies:
-    "@cosmjs/amino": "npm:^0.31.3"
-    "@cosmjs/crypto": "npm:^0.31.3"
-    "@cosmjs/encoding": "npm:^0.31.3"
-    "@cosmjs/math": "npm:^0.31.3"
-    "@cosmjs/utils": "npm:^0.31.3"
-    cosmjs-types: "npm:^0.8.0"
-    long: "npm:^4.0.0"
-  checksum: 10c0/91bc6c0d03462b16e85fd6acfd3d28ab56a8de9a199f97601aac30aace75b64250bf0efcdda0aa5e3ea9e6defa46844b5f8e4358aabaeeb16d439480f55bbff7
   languageName: node
   linkType: hard
 
@@ -3295,18 +3142,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/socket@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/socket@npm:0.31.3"
-  dependencies:
-    "@cosmjs/stream": "npm:^0.31.3"
-    isomorphic-ws: "npm:^4.0.1"
-    ws: "npm:^7"
-    xstream: "npm:^11.14.0"
-  checksum: 10c0/35ce93726f1c5c7d4cdf49c68d754b5587ac94fa65fd66f3db625c4794413359e225ddcaa55ee0bb17806a0b9cc13f884a7ec780503267addc6d03aacee1770c
-  languageName: node
-  linkType: hard
-
 "@cosmjs/socket@npm:^0.36.0":
   version: 0.36.0
   resolution: "@cosmjs/socket@npm:0.36.0"
@@ -3316,26 +3151,6 @@ __metadata:
     ws: "npm:^7"
     xstream: "npm:^11.14.0"
   checksum: 10c0/17722b99a5e32db510a62ef19413c9788c7e4d17fe7f21ad8717d48e22228ba25207a616c437aaf432dc73d24827d82765fcb88ea096de8d6ca1461600e71803
-  languageName: node
-  linkType: hard
-
-"@cosmjs/stargate@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/stargate@npm:0.31.3"
-  dependencies:
-    "@confio/ics23": "npm:^0.6.8"
-    "@cosmjs/amino": "npm:^0.31.3"
-    "@cosmjs/encoding": "npm:^0.31.3"
-    "@cosmjs/math": "npm:^0.31.3"
-    "@cosmjs/proto-signing": "npm:^0.31.3"
-    "@cosmjs/stream": "npm:^0.31.3"
-    "@cosmjs/tendermint-rpc": "npm:^0.31.3"
-    "@cosmjs/utils": "npm:^0.31.3"
-    cosmjs-types: "npm:^0.8.0"
-    long: "npm:^4.0.0"
-    protobufjs: "npm:~6.11.3"
-    xstream: "npm:^11.14.0"
-  checksum: 10c0/85ce69ac6314f5194206c01f6ef346dd3e1fbfbe4489adf5926badfabcc61913ef97e5f6d155bd2370e4e5cdedfcfb951248321b37fdfaf8e866fa0711c5cfbd
   languageName: node
   linkType: hard
 
@@ -3355,39 +3170,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/stream@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/stream@npm:0.31.3"
-  dependencies:
-    xstream: "npm:^11.14.0"
-  checksum: 10c0/e0279b925c4f02535ba9b1f6f9563a1db4fb53ed1396e4e3958fcad887e047a78b431a227dd7c159aadb6e0e054db9dfb34b7a9128f2082ff3114bcfd74516c3
-  languageName: node
-  linkType: hard
-
 "@cosmjs/stream@npm:^0.36.0":
   version: 0.36.0
   resolution: "@cosmjs/stream@npm:0.36.0"
   dependencies:
     xstream: "npm:^11.14.0"
   checksum: 10c0/3595430d4880d3488d0d15743cf5967a60ef8a4126cb81d54581ae9e0368787b28b8454a46436d9b75cecfa860aaec6c67d29f1b3f0026f98309f2486f4d0f7f
-  languageName: node
-  linkType: hard
-
-"@cosmjs/tendermint-rpc@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/tendermint-rpc@npm:0.31.3"
-  dependencies:
-    "@cosmjs/crypto": "npm:^0.31.3"
-    "@cosmjs/encoding": "npm:^0.31.3"
-    "@cosmjs/json-rpc": "npm:^0.31.3"
-    "@cosmjs/math": "npm:^0.31.3"
-    "@cosmjs/socket": "npm:^0.31.3"
-    "@cosmjs/stream": "npm:^0.31.3"
-    "@cosmjs/utils": "npm:^0.31.3"
-    axios: "npm:^0.21.2"
-    readonly-date: "npm:^1.0.0"
-    xstream: "npm:^11.14.0"
-  checksum: 10c0/1d8d8a78cc1dc54884c0916e709c98d533215f2235ce48f2079cbd8b3a9edf7aa14f216b815d727cacabfead54c0b15ca622fd43243260d8d311bc408edd0f11
   languageName: node
   linkType: hard
 
@@ -3405,13 +3193,6 @@ __metadata:
     readonly-date: "npm:^1.0.0"
     xstream: "npm:^11.14.0"
   checksum: 10c0/48e290ead946ed6df7f7665b256c435da6c2c5831a58b0859b6c602db9c93701a211330694385127fa5392a87825385a7aebfd876caae7a1c0185e8a02c96bd6
-  languageName: node
-  linkType: hard
-
-"@cosmjs/utils@npm:^0.31.3":
-  version: 0.31.3
-  resolution: "@cosmjs/utils@npm:0.31.3"
-  checksum: 10c0/26266e1206ed8c7c4e744db1e97fc7a341ffee383ca9f43e6c9e8ff596039a90068c39aadc4f6524b6f2b5b6d581318657f3eb272f98b9e430f2d0df79382b6a
   languageName: node
   linkType: hard
 
@@ -5143,30 +4924,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.9.6":
-  version: 1.9.6
-  resolution: "@noble/curves@npm:1.9.6"
-  dependencies:
-    "@noble/hashes": "npm:1.8.0"
-  checksum: 10c0/e462875ad752d2cdffc3c7b27b6de3adcff5fae0731e94138bd9e452c5f9b7aaf4c01ea6c62d3c0544b4e7419662535bb2ef1103311de48d51885c053206e118
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:^1.6.0, @noble/curves@npm:^1.9.2, @noble/curves@npm:~1.9.0":
   version: 1.9.2
   resolution: "@noble/curves@npm:1.9.2"
   dependencies:
     "@noble/hashes": "npm:1.8.0"
   checksum: 10c0/21d049ae4558beedbf5da0004407b72db84360fa29d64822d82dc9e80251e1ecb46023590cc4b20e70eed697d1b87279b4911dc39f8694c51c874289cfc8e9a7
-  languageName: node
-  linkType: hard
-
-"@noble/curves@npm:^1.9.1":
-  version: 1.9.7
-  resolution: "@noble/curves@npm:1.9.7"
-  dependencies:
-    "@noble/hashes": "npm:1.8.0"
-  checksum: 10c0/150014751ebe8ca06a8654ca2525108452ea9ee0be23430332769f06808cddabfe84f248b6dbf836916bc869c27c2092957eec62c7506d68a1ed0a624017c2a3
   languageName: node
   linkType: hard
 
@@ -5177,7 +4940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:~1.8.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
@@ -6013,7 +5776,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/bip32@npm:1.7.0, @scure/bip32@npm:^1.5.0, @scure/bip32@npm:^1.7.0":
+"@scure/bip32@npm:1.7.0, @scure/bip32@npm:^1.5.0":
   version: 1.7.0
   resolution: "@scure/bip32@npm:1.7.0"
   dependencies:
@@ -6024,7 +5787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/bip39@npm:1.6.0, @scure/bip39@npm:^1.4.0, @scure/bip39@npm:^1.6.0":
+"@scure/bip39@npm:1.6.0, @scure/bip39@npm:^1.4.0":
   version: 1.6.0
   resolution: "@scure/bip39@npm:1.6.0"
   dependencies:
@@ -6371,7 +6134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/long@npm:^4.0.0, @types/long@npm:^4.0.1":
+"@types/long@npm:^4.0.0":
   version: 4.0.2
   resolution: "@types/long@npm:4.0.2"
   checksum: 10c0/42ec66ade1f72ff9d143c5a519a65efc7c1c77be7b1ac5455c530ae9acd87baba065542f8847522af2e3ace2cc999f3ad464ef86e6b7352eece34daf88f8c924
@@ -6804,21 +6567,6 @@ __metadata:
     zod:
       optional: true
   checksum: 10c0/d3393f32898c1f0f6da4eed2561da6830dcd0d5129a160fae9517214236ee6a6c8e5a0380b8b960c5bc1b949320bcbd015ec7f38b5d7444f8f2b854a1b5dd754
-  languageName: node
-  linkType: hard
-
-"abitype@npm:^1.0.8":
-  version: 1.0.9
-  resolution: "abitype@npm:1.0.9"
-  peerDependencies:
-    typescript: ">=5.0.4"
-    zod: ^3 >=3.22.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-    zod:
-      optional: true
-  checksum: 10c0/8707fcc80d3edaea14717b0c9ebe15cef1f11825a9c5ffcdbd3ac8e53ae34aaa4c5eb9fb4c352d598d0013fcf71370eeda8eac2fc575f04fa0699a43477ae52b
   languageName: node
   linkType: hard
 
@@ -7499,15 +7247,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.2":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
-  dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10c0/fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
-  languageName: node
-  linkType: hard
-
 "axobject-query@npm:^4.1.0":
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
@@ -7694,20 +7433,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.11.9":
-  version: 4.12.2
-  resolution: "bn.js@npm:4.12.2"
-  checksum: 10c0/09a249faa416a9a1ce68b5f5ec8bbca87fe54e5dd4ef8b1cc8a4969147b80035592bddcb1e9cc814c3ba79e573503d5c5178664b722b509fb36d93620dba9b57
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:^5.2.0":
-  version: 5.2.2
-  resolution: "bn.js@npm:5.2.2"
-  checksum: 10c0/cb97827d476aab1a0194df33cd84624952480d92da46e6b4a19c32964aa01553a4a613502396712704da2ec8f831cf98d02e74ca03398404bd78a037ba93f2ab
-  languageName: node
-  linkType: hard
-
 "body-parser@npm:^2.0.1":
   version: 2.0.1
   resolution: "body-parser@npm:2.0.1"
@@ -7752,13 +7477,6 @@ __metadata:
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10c0/7c6dfd30c338d2997ba77500539227b9d1f85e388a5f43220865201e407e076783d0881f2d297b9f80951b4c957fcf0b51c1d2d24227631643c3f7c284b0aa04
-  languageName: node
-  linkType: hard
-
-"brorand@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "brorand@npm:1.1.0"
-  checksum: 10c0/6f366d7c4990f82c366e3878492ba9a372a73163c09871e80d82fb4ae0d23f9f8924cb8a662330308206e6b3b76ba1d528b4601c9ef73c2166b440b2ea3b7571
   languageName: node
   linkType: hard
 
@@ -8709,16 +8427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmjs-types@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "cosmjs-types@npm:0.8.0"
-  dependencies:
-    long: "npm:^4.0.0"
-    protobufjs: "npm:~6.11.2"
-  checksum: 10c0/910a84d04d17c3a32120bda52063a582325b900e9bb2f5ddffee621c1d053bc562bedc0d39d20e12736445b66d897bdae085247f51c6ffd1ca0154f99b938214
-  languageName: node
-  linkType: hard
-
 "cross-fetch@npm:^3.1.5":
   version: 3.1.8
   resolution: "cross-fetch@npm:3.1.8"
@@ -9186,21 +8894,6 @@ __metadata:
   version: 1.5.70
   resolution: "electron-to-chromium@npm:1.5.70"
   checksum: 10c0/135dfe5b764eb54afcd70ec6084430ea562706570a7104eda8b69e694c3ec900f8d0a2f2e90f0fc86f7dbc6435dad427ec1732bb88f4e62cc5c86c55265ebcf4
-  languageName: node
-  linkType: hard
-
-"elliptic@npm:^6.5.4":
-  version: 6.6.1
-  resolution: "elliptic@npm:6.6.1"
-  dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10c0/8b24ef782eec8b472053793ea1e91ae6bee41afffdfcb78a81c0a53b191e715cbe1292aa07165958a9bbe675bd0955142560b1a007ffce7d6c765bcaf951a867
   languageName: node
   linkType: hard
 
@@ -10624,16 +10317,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
-  languageName: node
-  linkType: hard
-
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -11274,33 +10957,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
-  version: 1.1.7
-  resolution: "hash.js@npm:1.1.7"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    minimalistic-assert: "npm:^1.0.1"
-  checksum: 10c0/41ada59494eac5332cfc1ce6b7ebdd7b88a3864a6d6b08a3ea8ef261332ed60f37f10877e0c825aaa4bddebf164fbffa618286aeeec5296675e2671cbfa746c4
-  languageName: node
-  linkType: hard
-
 "hasown@npm:^2.0.0, hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-  languageName: node
-  linkType: hard
-
-"hmac-drbg@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "hmac-drbg@npm:1.0.1"
-  dependencies:
-    hash.js: "npm:^1.0.3"
-    minimalistic-assert: "npm:^1.0.0"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10c0/f3d9ba31b40257a573f162176ac5930109816036c59a09f901eb2ffd7e5e705c6832bedfff507957125f2086a0ab8f853c0df225642a88bf1fcaea945f20600d
   languageName: node
   linkType: hard
 
@@ -11527,13 +11189,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^10.0.3":
-  version: 10.1.1
-  resolution: "immer@npm:10.1.1"
-  checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
-  languageName: node
-  linkType: hard
-
 "import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -11595,13 +11250,6 @@ __metadata:
   version: 1.1.0
   resolution: "index-to-position@npm:1.1.0"
   checksum: 10c0/77ef140f0218df0486a08cff204de4d382e8c43892039aaa441ac5b87f0c8d8a72af633c8a1c49f1b1ec4177bd809e4e045958a9aebe65545f203342b95886b3
-  languageName: node
-  linkType: hard
-
-"inflection@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "inflection@npm:2.0.1"
-  checksum: 10c0/1aee299618b24ae4f36eed41b2e9d3390f2a015b854bad558d7dc42c13e5c9638c403b9540736670a38647c33d99089a44f26e9c6e474bb68ebecab23de3f55b
   languageName: node
   linkType: hard
 
@@ -12190,16 +11838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-unfetch@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "isomorphic-unfetch@npm:4.0.2"
-  dependencies:
-    node-fetch: "npm:^3.2.0"
-    unfetch: "npm:^5.0.0"
-  checksum: 10c0/1727d85344818eaf798b569904f70313e8eafbc192d84400a3e646bb0b893a2e405727ee45ccac0fc3d41ee48561eaa5cdd55813131613d7f8a55031ed49103d
-  languageName: node
-  linkType: hard
-
 "isomorphic-ws@npm:^4.0.1":
   version: 4.0.1
   resolution: "isomorphic-ws@npm:4.0.1"
@@ -12704,22 +12342,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libsodium-sumo@npm:^0.7.15":
-  version: 0.7.15
-  resolution: "libsodium-sumo@npm:0.7.15"
-  checksum: 10c0/5a1437ccff03c72669e7b49da702034e171df9ff6a4e65698297ab63ad0bf8f889d3dd51494e29418c643143526d8d7f08cbba3929d220334cddbe3e74a1560e
-  languageName: node
-  linkType: hard
-
-"libsodium-wrappers-sumo@npm:^0.7.11":
-  version: 0.7.15
-  resolution: "libsodium-wrappers-sumo@npm:0.7.15"
-  dependencies:
-    libsodium-sumo: "npm:^0.7.15"
-  checksum: 10c0/6da919a13395346d54f2ce4841adda8feb3fbb8a8c378ec5c93b7e6dc6353b379289349e659f3e017a9f1995ef396bf43f89c7ab4aab4e3b5ed85df62407d810
-  languageName: node
-  linkType: hard
-
 "lilconfig@npm:^3.1.1, lilconfig@npm:^3.1.3":
   version: 3.1.3
   resolution: "lilconfig@npm:3.1.3"
@@ -12845,13 +12467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.throttle@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "lodash.throttle@npm:4.1.1"
-  checksum: 10c0/14628013e9e7f65ac904fc82fd8ecb0e55a9c4c2416434b1dd9cf64ae70a8937f0b15376a39a68248530adc64887ed0fe2b75204b2c9ec3eea1cb2d66ddd125d
-  languageName: node
-  linkType: hard
-
 "lodash.upperfirst@npm:4.3.1":
   version: 4.3.1
   resolution: "lodash.upperfirst@npm:4.3.1"
@@ -12880,20 +12495,6 @@ __metadata:
   version: 5.2.3
   resolution: "long@npm:5.2.3"
   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
-  languageName: node
-  linkType: hard
-
-"long@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "long@npm:4.0.0"
-  checksum: 10c0/50a6417d15b06104dbe4e3d4a667c39b137f130a9108ea8752b352a4cfae047531a3ac351c181792f3f8768fe17cca6b0f406674a541a86fb638aaac560d83ed
-  languageName: node
-  linkType: hard
-
-"long@npm:^5.2.3":
-  version: 5.3.2
-  resolution: "long@npm:5.3.2"
-  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
   languageName: node
   linkType: hard
 
@@ -13560,20 +13161,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "minimalistic-assert@npm:1.0.1"
-  checksum: 10c0/96730e5601cd31457f81a296f521eb56036e6f69133c0b18c13fe941109d53ad23a4204d946a0d638d7f3099482a0cec8c9bb6d642604612ce43ee536be3dddd
-  languageName: node
-  linkType: hard
-
-"minimalistic-crypto-utils@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "minimalistic-crypto-utils@npm:1.0.1"
-  checksum: 10c0/790ecec8c5c73973a4fbf2c663d911033e8494d5fb0960a4500634766ab05d6107d20af896ca2132e7031741f19888154d44b2408ada0852446705441383e9f8
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:5.1.0":
   version: 5.1.0
   resolution: "minimatch@npm:5.1.0"
@@ -14016,7 +13603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:3.3.2, node-fetch@npm:^3.2.0":
+"node-fetch@npm:3.3.2":
   version: 3.3.2
   resolution: "node-fetch@npm:3.3.2"
   dependencies:
@@ -14554,27 +14141,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/15370d76f7e5fe1b06c5b9986bc709a8c433e4242660900b3d1adb2a56c8f762a2010a9166bdb95bdf531806cde7891911456c7ec8ba135fc232a5d5037ac673
-  languageName: node
-  linkType: hard
-
-"ox@npm:0.9.1":
-  version: 0.9.1
-  resolution: "ox@npm:0.9.1"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:^1.11.0"
-    "@noble/ciphers": "npm:^1.3.0"
-    "@noble/curves": "npm:^1.9.1"
-    "@noble/hashes": "npm:^1.8.0"
-    "@scure/bip32": "npm:^1.7.0"
-    "@scure/bip39": "npm:^1.6.0"
-    abitype: "npm:^1.0.8"
-    eventemitter3: "npm:5.0.1"
-  peerDependencies:
-    typescript: ">=5.4.0"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10c0/1678b0cb3e0f1b0986e8a944f64789ca00eb9e3d02fcb4a613f43fa9d75d9fb782f15a18133779fe6095f190fec2fd8be7a3c9df7ecf9c038fb0037ef542256d
   languageName: node
   linkType: hard
 
@@ -15337,30 +14903,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^6.8.8, protobufjs@npm:~6.11.2, protobufjs@npm:~6.11.3":
-  version: 6.11.4
-  resolution: "protobufjs@npm:6.11.4"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/long": "npm:^4.0.1"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^4.0.0"
-  bin:
-    pbjs: bin/pbjs
-    pbts: bin/pbts
-  checksum: 10c0/c244d7b9b6d3258193da5c0d1e558dfb47f208ae345e209f90ec45c9dca911b90fa17e937892a9a39a4136ab9886981aae9efdf6039f7baff4f7225f5eeb9812
-  languageName: node
-  linkType: hard
-
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0, protobufjs@npm:^7.3.2":
   version: 7.4.0
   resolution: "protobufjs@npm:7.4.0"
@@ -15378,26 +14920,6 @@ __metadata:
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
   checksum: 10c0/a5460a63fe596523b9a067cbce39a6b310d1a71750fda261f076535662aada97c24450e18c5bc98a27784f70500615904ff1227e1742183509f0db4fdede669b
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^7.2.6":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
   languageName: node
   linkType: hard
 
@@ -15494,20 +15016,6 @@ __metadata:
   version: 4.0.1
   resolution: "quick-lru@npm:4.0.1"
   checksum: 10c0/f9b1596fa7595a35c2f9d913ac312fede13d37dc8a747a51557ab36e11ce113bbe88ef4c0154968845559a7709cb6a7e7cbe75f7972182451cd45e7f057a334d
-  languageName: node
-  linkType: hard
-
-"rambda@npm:^9.1.1":
-  version: 9.4.2
-  resolution: "rambda@npm:9.4.2"
-  checksum: 10c0/ee32773c7ef7a281782cf2e09cd0f2dbb67facf59924042e861ef42f166eb081c92e55ed6bd1a7c5c1a937831227bea16b9c11680bc9d57b4b8cb29ca78241ac
-  languageName: node
-  linkType: hard
-
-"ramda@npm:^0.29.1":
-  version: 0.29.1
-  resolution: "ramda@npm:0.29.1"
-  checksum: 10c0/5de53a07400959c1a704c366ec52b1b8cd9a444dc1f9cdf17d607e0b9eeaa38cbaea309d43e59dbd7f36731ba977a64d40092555c0e7c2d4a41e8e922239c0ba
   languageName: node
   linkType: hard
 
@@ -17151,13 +16659,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.3.1":
-  version: 1.3.3
-  resolution: "tiny-invariant@npm:1.3.3"
-  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
-  languageName: node
-  linkType: hard
-
 "tinyexec@npm:^0.3.2":
   version: 0.3.2
   resolution: "tinyexec@npm:0.3.2"
@@ -17781,13 +17282,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unfetch@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "unfetch@npm:5.0.0"
-  checksum: 10c0/ccbbf648a384d57aeaf3bd4972761327a6cf60c84a3edb8e2f9d18aed0df6214576fc8fcd444ea87672e8e32f4a74590bc5c07756f053f57f492c6d8363045c9
-  languageName: node
-  linkType: hard
-
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.0
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
@@ -18023,27 +17517,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/4f327af609d41720f94664546eae1b8a892ae787630c0259a95ca145f7b07ef82387975b6ab8c223decd34ead69650119226af360d02ac7c17dbc4b60cfdf523
-  languageName: node
-  linkType: hard
-
-"viem@npm:^2.8.18":
-  version: 2.36.0
-  resolution: "viem@npm:2.36.0"
-  dependencies:
-    "@noble/curves": "npm:1.9.6"
-    "@noble/hashes": "npm:1.8.0"
-    "@scure/bip32": "npm:1.7.0"
-    "@scure/bip39": "npm:1.6.0"
-    abitype: "npm:1.0.8"
-    isows: "npm:1.0.7"
-    ox: "npm:0.9.1"
-    ws: "npm:8.18.3"
-  peerDependencies:
-    typescript: ">=5.0.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10c0/b46e19ffaf85b0e80d168a707d7b295cf58ebefde27cfb8626510dfdf845bcd25c0154a02b488fc545b07397fd880d87543622d2be6973b35ab94012092b512c
   languageName: node
   linkType: hard
 
@@ -18398,21 +17871,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.18.3, ws@npm:^8.18.3":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
-  languageName: node
-  linkType: hard
-
 "ws@npm:^7, ws@npm:^7.2.0":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
@@ -18425,6 +17883,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/aec4ef4eb65821a7dde7b44790f8699cfafb7978c9b080f6d7a98a7f8fc0ce674c027073a78574c94786ba7112cc90fa2cc94fc224ceba4d4b1030cff9662494
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs:
- https://github.com/Agoric/agoric-sdk/issues/11853

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

  - Updated type definitions to match resolver exo.
  - Added functionality to resolve GMP transactions through the resolver service.
  - Moved CCTP configuration to `support.ts` with CAIP ID integration.
  - Updated GMP watcher to monitor `MulticallExecuted(string,(bool,bytes)[])` events instead of `SubscriptionResolved(string)`(prev placeholder) events for more reliable transaction tracking.
  - Aligned CCTP and GMP watcher tests with new function signatures. And fixed the test mocks.
 - Added new unit tests to increase the coverage. 
 - Eliminates the use of AxelarScan for checking transaction status of GMP transactions. Instead listen for `MulticallExecuted` events on the EVM remote account.
 

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None. 

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
See https://github.com/Agoric/agoric-sdk/issues/11860

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None. 

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Additional test cases have been added to increase the coverage.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
These changes in this PR require:
- A fresh deployment of the main version Factory contract from [agoric-labs/agoric-to-axelar-local](https://github.com/agoric-labs/agoric-to-axelar-local?utm_source=chatgpt.com)
- Deployment of the ymax contract, which publishes GMP transaction data to vstorage.