### PR TITLE
test(ymax-planner): ignore additional balances

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -446,6 +446,21 @@ const processSubscriptionEvents = async (
   }
 };
 
+export const pickBalance = (
+  balances: Coin[] | undefined,
+  depositAsset: AssetInfo,
+) => {
+  const deposited = balances?.find(({ denom }) => denom === depositAsset.denom);
+  if (!deposited) {
+    return undefined;
+  }
+
+  return AmountMath.make(
+    depositAsset.brand as Brand<'nat'>,
+    Nat(BigInt(deposited.amount)),
+  );
+};
+
 export const startEngine = async (
   { evmCtx, rpc, spectrum, cosmosRest, signingSmartWalletKit }: Powers,
   { depositIbcDenom }: { depositIbcDenom: string },
@@ -699,19 +714,11 @@ export const startEngine = async (
     const portfolioOps = await Promise.all(
       [...depositAddrsWithActivity.entries()].map(
         async ([addr, portfolioKey]) => {
-          const balances = addrBalances.get(addr);
-          const deposited = balances?.find(
-            ({ denom }) => denom === depositAsset.denom,
-          );
-          if (!deposited) {
+          const amount = pickBalance(addrBalances.get(addr), depositAsset);
+          if (!amount) {
             console.warn(`No ${q(depositAsset.issuerName)} at ${addr}`);
             return;
           }
-
-          const amount = AmountMath.make(
-            depositAsset.brand as Brand<'nat'>,
-            Nat(BigInt(deposited.amount)),
-          );
 
           const unprefixedPortfolioPath = stripPrefix(
             'published.',

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+
+import type { Brand, DisplayInfo, Issuer } from '@agoric/ertp';
+import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
+import { Far } from '@endo/pass-style';
+import { pickBalance } from '../src/engine.ts';
+
+const mockDepositAsset = (name: string, assetKind: 'nat') => {
+  // avoid VatData
+  const brand = Far(`${name} brand`) as Brand<'nat'>;
+  const issuer = Far(`${name} issuer`) as Issuer<'nat'>;
+  const displayInfo: DisplayInfo = harden({ assetKind, decimalPlaces: 6 });
+  const denom = 'ibc/123';
+  const depositAsset: AssetInfo = harden({
+    brand,
+    denom,
+    issuer,
+    displayInfo,
+    issuerName: name,
+    proposedName: name,
+  });
+  return depositAsset;
+};
+
+test('ignore additional balances', t => {
+  const usdc = mockDepositAsset('USDC', 'nat');
+  const { denom, brand } = usdc;
+
+  const balances = [
+    { amount: '50', denom },
+    { amount: '123', denom: 'ubld' },
+  ];
+
+  const actual = pickBalance(balances, usdc);
+  t.deepEqual(actual, { brand, value: 50n });
+});


### PR DESCRIPTION
refs:
  - #11806

## Description / Testing Considerations

add "ignore additional balances" test after factoring out a function

In an alternate history, we might have
 1. factored out `pickBalance`, taking `vbankAssets` as the 2nd arg
 2. written a failing test
 3. added `depositAsset` stuff
 4. updated this test