### PR TITLE
chore(portfolio-deploy): eth had wrong axelarid

### DIFF
--- a/packages/portfolio-deploy/src/axelar-configs.js
+++ b/packages/portfolio-deploy/src/axelar-configs.js
@@ -30,8 +30,8 @@ const AxelarChainIdMap = harden({
     mainnet: 'Avalanche',
   },
   Ethereum: {
-    testnet: 'Ethereum',
-    mainnet: 'ethereum-sepolia',
+    testnet: 'ethereum-sepolia',
+    mainnet: 'Ethereum',
   },
   Arbitrum: {
     testnet: 'arbitrum-sepolia',


### PR DESCRIPTION
refs:
 - #11825

### Testing Considerations

turned up in integration testing

### Upgrade Considerations

This change can be deployed using `privateArgsOverride` in `ymaxControl`.