### PR TITLE
feat(client-utils): sendBridgeAction supports fee param

### DIFF
--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -50,7 +50,7 @@ export const makeSigningSmartWalletKit = async (
     ) => walletUtils.pollOffer(address, ...args),
   };
 
-  const sendBridgeAction = (action: BridgeAction) => {
+  const sendBridgeAction = (action: BridgeAction, fee: StdFee = defaultFee) => {
     const msgSpend = MsgWalletSpendAction.fromPartial({
       owner: toAccAddress(address),
       spendAction: JSON.stringify(walletUtils.marshaller.toCapData(action)),
@@ -59,7 +59,7 @@ export const makeSigningSmartWalletKit = async (
     return client.signAndBroadcast(
       address,
       [{ typeUrl: MsgWalletSpendAction.typeUrl, value: msgSpend }],
-      defaultFee,
+      fee,
     );
   };
 

--- a/packages/client-utils/test/signing-smart-wallet-kit.test.ts
+++ b/packages/client-utils/test/signing-smart-wallet-kit.test.ts
@@ -74,3 +74,31 @@ test('sendBridgeAction handles simple action', async t => {
     fee: { amount: [{ denom: 'ubld', amount: '30000' }], gas: '197000' },
   });
 });
+
+test('sendBridgeAction supports fee param', async t => {
+  const { calls, connectWithSigner } = mockSigner();
+
+  const walletUtils = await makeSmartWalletKit(
+    { fetch: notImplemented, delay: notImplemented, names: false },
+    LOCAL_CONFIG,
+  );
+
+  const signing = await makeSigningSmartWalletKit(
+    { connectWithSigner, walletUtils },
+    mnemonic,
+  );
+
+  const moar: StdFee = {
+    gas: '1234567',
+    amount: [{ denom: 'ubld', amount: '123' }],
+  };
+  const actual = await signing.sendBridgeAction(
+    harden({ method: 'tryExitOffer', offerId: 'bid-1' }),
+    moar,
+  );
+  t.deepEqual(actual, { code: 42 });
+  t.is(calls.length, 1);
+  t.like(calls[0], {
+    fee: { amount: [{ denom: 'ubld', amount: '123' }], gas: '1234567' },
+  });
+});

--- a/packages/client-utils/test/signing-smart-wallet-kit.test.ts
+++ b/packages/client-utils/test/signing-smart-wallet-kit.test.ts
@@ -1,0 +1,76 @@
+import test from 'ava';
+
+import { decodeHex } from '@agoric/internal/src/hex.js';
+import type { EncodeObject } from '@cosmjs/proto-signing';
+import type {
+  DeliverTxResponse,
+  SigningStargateClient,
+  StdFee,
+} from '@cosmjs/stargate';
+import { makeSigningSmartWalletKit } from '../dist/signing-smart-wallet-kit.js';
+import { LOCAL_CONFIG } from '../src/network-config.js';
+import { makeSmartWalletKit } from '../src/smart-wallet-kit.js';
+
+const mockSigner = () => {
+  const calls: any[] = [];
+  const connectWithSigner: typeof SigningStargateClient.connectWithSigner =
+    async () => {
+      return {
+        async signAndBroadcast(
+          signerAddress: string,
+          messages: readonly EncodeObject[],
+          fee: StdFee | 'auto' | number,
+          memo?: string,
+          timeoutHeight?: bigint,
+        ) {
+          calls.push({ signerAddress, messages, fee, memo, timeoutHeight });
+          const resp = { code: 42 } as DeliverTxResponse;
+          return resp;
+        },
+      } as SigningStargateClient;
+    };
+  return { calls, connectWithSigner };
+};
+
+const notImplemented = () => {
+  throw Error('not implemented');
+};
+
+const mnemonic =
+  'cause eight cattle slot course mail more aware vapor slab hobby match';
+
+test('sendBridgeAction handles simple action', async t => {
+  const { calls, connectWithSigner } = mockSigner();
+
+  const walletUtils = await makeSmartWalletKit(
+    { fetch: notImplemented, delay: notImplemented, names: false },
+    LOCAL_CONFIG,
+  );
+
+  const signing = await makeSigningSmartWalletKit(
+    { connectWithSigner, walletUtils },
+    mnemonic,
+  );
+
+  const actual = await signing.sendBridgeAction(
+    harden({ method: 'tryExitOffer', offerId: 'bid-1' }),
+  );
+  t.deepEqual(actual, { code: 42 });
+  t.is(calls.length, 1);
+  t.like(calls[0], {
+    signerAddress: 'agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl',
+    messages: [
+      {
+        typeUrl: '/agoric.swingset.MsgWalletSpendAction',
+        value: {
+          owner: decodeHex(
+            '2703d823 35a28e14 5a024159 151cd54f 4cbb7db0'.replace(/ /g, ''),
+          ),
+          spendAction:
+            '{"body":"#{\\"method\\":\\"tryExitOffer\\",\\"offerId\\":\\"bid-1\\"}","slots":[]}',
+        },
+      },
+    ],
+    fee: { amount: [{ denom: 'ubld', amount: '30000' }], gas: '197000' },
+  });
+});


### PR DESCRIPTION
refs:
 - #5912

## Description

The default fee isn't sufficient for ymaxControl privateArgs; making it much bigger worked in that case (6eaab6c37f1  / #11825) but letting the caller specify is The Right Thing.

### Security /  Scaling / Documentation / Upgrade Considerations

unremarkable

### Testing Considerations

The test imports from `../dist/...` and needs a build step; I don't see a way around it.
