### PR TITLE
ymaxControl mainnet tooling

### DIFF
--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -89,6 +89,7 @@ const parseToolArgs = (argv: string[]) =>
       buildEthOverrides: { type: 'boolean' },
       installAndStart: { type: 'string' },
       invitePlanner: { type: 'string' },
+      inviteResolver: { type: 'string' },
       checkStorage: { type: 'boolean' },
       pruneStorage: { type: 'boolean', default: false },
       'submit-for': { type: 'string' },
@@ -493,6 +494,17 @@ const main = async (
       await walletKit.readPublished('agoricNames.instance'),
     );
     await cf.deliverPlannerInvitation(planner, postalService);
+    return;
+  }
+
+  if (values.inviteResolver) {
+    const { inviteResolver: resolver } = values;
+    const cf =
+      walletStore.get<ZStarted<YMaxStartFn>['creatorFacet']>('creatorFacet');
+    const { postalService } = fromEntries(
+      await walletKit.readPublished('agoricNames.instance'),
+    );
+    await cf.deliverResolverInvitation(resolver, postalService);
     return;
   }
 

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -16,8 +16,8 @@ import {
 import { makePortfolioSteps } from '@aglocal/portfolio-contract/tools/plan-transfers.ts';
 import { makePortfolioQuery } from '@aglocal/portfolio-contract/tools/portfolio-actors.ts';
 import {
-  axelarConfigTestnet,
   axelarConfig as axelarConfigMainnet,
+  axelarConfigTestnet,
   gmpAddresses as gmpConfigs,
 } from '@aglocal/portfolio-deploy/src/axelar-configs.js';
 import type { ContractControl } from '@aglocal/portfolio-deploy/src/contract-control.js';

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -27,6 +27,7 @@ import {
   fetchEnvNetworkConfig,
   makeSigningSmartWalletKit,
   makeSmartWalletKit,
+  makeVStorage,
   type SigningSmartWalletKit,
   type VstorageKit,
 } from '@agoric/client-utils';
@@ -48,6 +49,7 @@ import type { NameHub } from '@agoric/vats';
 import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils';
 import { SigningStargateClient } from '@cosmjs/stargate';
 import { M } from '@endo/patterns';
+import fsp from 'node:fs/promises';
 import { parseArgs } from 'node:util';
 import {
   reflectWalletStore,
@@ -85,6 +87,7 @@ const parseToolArgs = (argv: string[]) =>
       terminate: { type: 'string' },
       installAndStart: { type: 'string' },
       invitePlanner: { type: 'string' },
+      checkStorage: { type: 'boolean' },
       pruneStorage: { type: 'boolean', default: false },
       'submit-for': { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
@@ -355,6 +358,12 @@ const overridesForEthChainInfo = async (
   return privateArgsOverrides;
 };
 
+async function readText(stream: typeof process.stdin) {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream as AsyncIterable<Buffer>) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
 const main = async (
   argv = process.argv,
   env = process.env,
@@ -363,6 +372,9 @@ const main = async (
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
     now = Date.now,
+    stdin = process.stdin,
+    stdout = process.stdout,
+    readFile = fsp.readFile,
   } = {},
 ) => {
   const { values } = parseToolArgs(argv);
@@ -372,12 +384,21 @@ const main = async (
     return;
   }
 
+  const networkConfig = await fetchEnvNetworkConfig({ env, fetch });
+  if (values.checkStorage) {
+    console.error('finding outdated vstorage...');
+    const vs = makeVStorage({ fetch }, networkConfig);
+    const toPrune = await findOutdated(vs);
+    stdout.write(JSON.stringify(toPrune, null, 2));
+    stdout.write('\n');
+    return;
+  }
+
   const { MNEMONIC } = env;
   if (!MNEMONIC) throw Error(`MNEMONIC not set`);
 
   const delay = ms =>
     new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
-  const networkConfig = await fetchEnvNetworkConfig({ env, fetch });
   const walletKit0 = await makeSmartWalletKit({ fetch, delay }, networkConfig);
   const walletKit = values['skip-poll'] ? noPoll(walletKit0) : walletKit0;
   const sig = await makeSigningSmartWalletKit(
@@ -445,10 +466,10 @@ const main = async (
   }
 
   if (values.pruneStorage) {
-    console.error('finding outdated vstorage...');
-    const toPrune = await findOutdated(walletKit.vstorage);
-    console.log('toPrune', toPrune);
+    const txt = await readText(stdin);
+    const toPrune = JSON.parse(txt);
     await yc.pruneChainStorage(toPrune);
+    return;
   }
 
   if (values.invitePlanner) {

--- a/multichain-testing/tools/wallet-store-reflect.ts
+++ b/multichain-testing/tools/wallet-store-reflect.ts
@@ -98,10 +98,12 @@ export const reflectWalletStore = (
             args,
             ...(saveResult ? { saveResult } : {}),
           });
-          const tx = await sig.sendBridgeAction({
-            method: 'invokeEntry',
-            message,
-          });
+          const tx = await sig.sendBridgeAction(
+            harden({
+              method: 'invokeEntry',
+              message,
+            }),
+          );
           if (tx.code !== 0) {
             throw Error(tx.rawLog);
           }

--- a/multichain-testing/ymax-ops/.gitignore
+++ b/multichain-testing/ymax-ops/.gitignore
@@ -1,0 +1,1 @@
+secrets.mk

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -1,0 +1,87 @@
+# ymaxControl mainnet operations automation
+
+# safe default with explicit prod usage: make AGORIC_NET=main ...
+AGORIC_NET ?= devnet
+
+-include secrets.mk
+YMAX_ITEM_ID ?=
+
+YMAX_TOOL=../scripts/ymax-tool.ts
+BW=bw
+
+# tested with 2025.8.0
+# XXX add as multichain-testing devtool, even though only dckc uses it?
+bw-install:
+	npm install -g @bitwarden/cli
+	$(BW) --version
+
+bw-login:
+	@test -n "$(BW_EMAIL)" || { echo "BW_EMAIL not set. Usage: make bw-login BW_EMAIL=you@example.com"; exit 1; }
+	@$(BW) login "$(BW_EMAIL)"
+
+# To see changes in vault since login...
+bw-sync:
+	$(BW) sync --session "$$BW_SESSION"
+
+list-items:
+	@$(BW) list items --search "ymax" --session "$$BW_SESSION" | jq '.[] | {id, name, type}'
+	@echo now pick one and update secrets.mk
+
+check-id:
+	@$(BW) get username $(YMAX_ITEM_ID)
+
+add-key:
+	$(BW) get password $(YMAX_ITEM_ID) | agd keys add ymaxControl
+
+provision-ymaxControl:
+	agd tx swingset provision-one yc $(YMAX_CONTROL_ADDR) SMART_WALLET --node $(NODE) --from $(YMAX_CONTROL_ADDR) $(SIG_OPTS)
+
+redeem-ymaxControl:
+	@echo "Using AGORIC_NET=$(AGORIC_NET)"
+	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" \
+		AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --redeem --contract 'postalService' --description 'deliver ymaxControl'
+
+REASON ?=
+ymax0-terminate:
+	@test -n "$(REASON)" || { echo "REASON not set."; exit 1; }
+	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --terminate "$(REASON)"
+
+,privateArgsOverrides.json:
+	@echo "Using AGORIC_NET=$(AGORIC_NET)"
+	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --buildEthOverrides >$@ || (rm $@; false)
+
+NETCONFIG=https://main.agoric.net/network-config
+,ymax0-deployed: ,ymax0-bundle-id ,privateArgsOverrides.json
+	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --installAndStart $$(cat ,ymax0-bundle-id) <,privateArgsOverrides.json
+	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
+
+,creatorFacet: ,ymax0-deployed
+	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --getCreatorFacet
+	touch $@
+
+PLANNER=agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
+,invitePlanner: ,creatorFacet
+	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --invitePlanner $(PLANNER)
+	touch $@
+	@echo now use planner MNEMONIC: ymax-tool.ts --redeem
+
+check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
+
+,vstorage-outdated-$(AGORIC_NET).json:
+	@echo "Using AGORIC_NET=$(AGORIC_NET)"
+	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --checkStorage >$@ || \
+		(rm $@; false)
+
+prune-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
+	@echo "Using AGORIC_NET=$(AGORIC_NET)"
+	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --pruneStorage < $<
+
+
+
+clean:
+	rm -rf build

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -14,6 +14,12 @@ DEPLOY=../../packages/portfolio-deploy
 # default make target: no chain interaction
 build: ,ymax0-bundle-id
 
+##
+# whole system update. see ymax0-terminate first, though.
+redeploy: ,ymax0-deployed introduce-parties prune-vstorage fund-fee-acct
+
+introduce-parties: ,invitePlanner ,inviteResolver
+
 ,ymax0-bundle-id: $(DEPLOY)/dist/bundle-ymax0.json
 	((cd $(DEPLOY); yarn build:bundle-id) ; cp $(DEPLOY)/dist/ymax0.bundleId $@; cat $@) \
 		|| (rm $@; false)
@@ -76,11 +82,24 @@ check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --checkStorage >$@ || \
 		(rm $@; false)
 
-prune-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
+prune-vstorage: ,vstorage-pruned
+
+,vstorage-pruned: ,vstorage-outdated-$(AGORIC_NET).json
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
 	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --pruneStorage < $<
+	touch $@
 
+NODE=https://main.rpc.agoric.net:443
+,ymax0-node.json:
+	$(AGD) --node $(NODE) query vstorage data published.ymax0 -o json >$@ \
+		|| (rm $@; false)
 
+SIG_OPTS=--chain-id=agoric-3 --gas-adjustment=1.5 --gas=auto
+WHALE=gov1
+fund-fee-acct: ,ymax0-node.json
+	$(AGD) tx bank send $(WHALE) \
+		$$($(JQ) -r '.value|fromjson|.values[0]|fromjson|.body|fromjson|.contractAccount' ,ymax0-node.json) \
+			120000000ubld -y -b block --node=$(NODE) $(SIG_OPTS)
 
 clean:
 	rm -rf ,* $(DEPLOY)/dist/

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -5,6 +5,19 @@ AGORIC_NET ?= devnet
 
 YMAX_TOOL=../scripts/ymax-tool.ts
 
+DEPLOY=../../packages/portfolio-deploy
+
+##
+# default make target: no chain interaction
+build: ,ymax0-bundle-id
+
+,ymax0-bundle-id: $(DEPLOY)/dist/bundle-ymax0.json
+	((cd $(DEPLOY); yarn build:bundle-id) ; cp $(DEPLOY)/dist/ymax0.bundleId $@; cat $@) \
+		|| (rm $@; false)
+
+$(DEPLOY)/dist/bundle-ymax0.json:
+	(cd $(DEPLOY); yarn build; yarn build:bundle)
+
 provision-ymaxControl:
 	agd tx swingset provision-one yc $(YMAX_CONTROL_ADDR) SMART_WALLET --node $(NODE) --from $(YMAX_CONTROL_ADDR) $(SIG_OPTS)
 
@@ -66,4 +79,4 @@ prune-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 
 
 clean:
-	rm -rf build
+	rm -rf ,* $(DEPLOY)/dist/

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -4,6 +4,9 @@
 AGORIC_NET ?= devnet
 
 YMAX_TOOL=../scripts/ymax-tool.ts
+AGD=agd
+AGORIC=agoric
+JQ=jq
 
 DEPLOY=../../packages/portfolio-deploy
 
@@ -19,7 +22,7 @@ $(DEPLOY)/dist/bundle-ymax0.json:
 	(cd $(DEPLOY); yarn build; yarn build:bundle)
 
 provision-ymaxControl:
-	agd tx swingset provision-one yc $(YMAX_CONTROL_ADDR) SMART_WALLET --node $(NODE) --from $(YMAX_CONTROL_ADDR) $(SIG_OPTS)
+	$(AGD) tx swingset provision-one yc $(YMAX_CONTROL_ADDR) SMART_WALLET --node $(NODE) --from $(YMAX_CONTROL_ADDR) $(SIG_OPTS)
 
 redeem-ymaxControl:
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
@@ -42,9 +45,10 @@ NETCONFIG=https://main.agoric.net/network-config
 		$(YMAX_TOOL) --installAndStart $$(cat ,ymax0-bundle-id) <,privateArgsOverrides.json
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 
-,ymax0-installed: $(DEPLOY)/dist/bundle-ymax0.json
-	agd keys --keyring-backend=test show $(PUBLISHER)
-	AGORIC_NET=devnet ./scripts/install-bundle.ts $< >$@ || (rm $@; false)
+,ymax0-installed: ,ymax0-bundle-id
+	grep $$($(AGORIC) follow -lF -B $(NETCONFIG) -o json :bundles \
+		| jq -r .endoZipBase64Sha512) ,ymax0-bundle-id >$@ \
+			|| (rm $@; false)
 
 ,creatorFacet: ,ymax0-deployed
 	AGORIC_NET=$(AGORIC_NET) \

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -3,42 +3,13 @@
 # safe default with explicit prod usage: make AGORIC_NET=main ...
 AGORIC_NET ?= devnet
 
--include secrets.mk
-YMAX_ITEM_ID ?=
-
 YMAX_TOOL=../scripts/ymax-tool.ts
-BW=bw
-
-# tested with 2025.8.0
-# XXX add as multichain-testing devtool, even though only dckc uses it?
-bw-install:
-	npm install -g @bitwarden/cli
-	$(BW) --version
-
-bw-login:
-	@test -n "$(BW_EMAIL)" || { echo "BW_EMAIL not set. Usage: make bw-login BW_EMAIL=you@example.com"; exit 1; }
-	@$(BW) login "$(BW_EMAIL)"
-
-# To see changes in vault since login...
-bw-sync:
-	$(BW) sync --session "$$BW_SESSION"
-
-list-items:
-	@$(BW) list items --search "ymax" --session "$$BW_SESSION" | jq '.[] | {id, name, type}'
-	@echo now pick one and update secrets.mk
-
-check-id:
-	@$(BW) get username $(YMAX_ITEM_ID)
-
-add-key:
-	$(BW) get password $(YMAX_ITEM_ID) | agd keys add ymaxControl
 
 provision-ymaxControl:
 	agd tx swingset provision-one yc $(YMAX_CONTROL_ADDR) SMART_WALLET --node $(NODE) --from $(YMAX_CONTROL_ADDR) $(SIG_OPTS)
 
 redeem-ymaxControl:
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" \
 		AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --redeem --contract 'postalService' --description 'deliver ymaxControl'
 

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -45,7 +45,7 @@ redeem-ymaxControl:
 REASON ?=
 ymax0-terminate:
 	@test -n "$(REASON)" || { echo "REASON not set."; exit 1; }
-	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+	AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --terminate "$(REASON)"
 
 ,privateArgsOverrides.json:
@@ -54,21 +54,32 @@ ymax0-terminate:
 
 NETCONFIG=https://main.agoric.net/network-config
 ,ymax0-deployed: ,ymax0-bundle-id ,privateArgsOverrides.json
-	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+	AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --installAndStart $$(cat ,ymax0-bundle-id) <,privateArgsOverrides.json
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 
+,ymax0-installed: $(DEPLOY)/dist/bundle-ymax0.json
+	agd keys --keyring-backend=test show $(PUBLISHER)
+	AGORIC_NET=devnet ./scripts/install-bundle.ts $< >$@ || (rm $@; false)
+
 ,creatorFacet: ,ymax0-deployed
-	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+	AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --getCreatorFacet
 	touch $@
 
 PLANNER=agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
 ,invitePlanner: ,creatorFacet
-	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) \
+	AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --invitePlanner $(PLANNER)
 	touch $@
 	@echo now use planner MNEMONIC: ymax-tool.ts --redeem
+
+RESOLVER=agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
+,inviteResolver: ,creatorFacet
+	AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --inviteResolver $(RESOLVER)
+	touch $@
+	@echo now use resolver MNEMONIC: ymax-tool.ts --redeem
 
 check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 
@@ -79,7 +90,7 @@ check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 
 prune-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	@MNEMONIC="$$($(BW) get password $(YMAX_ITEM_ID))" AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --pruneStorage < $<
+	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --pruneStorage < $<
 
 
 

--- a/packages/portfolio-deploy/package.json
+++ b/packages/portfolio-deploy/package.json
@@ -11,6 +11,8 @@
   ],
   "scripts": {
     "build": "esbuild ../portfolio-contract/src/portfolio.contract.ts --bundle --platform=neutral --main-fields=main --outfile=dist/portfolio.contract.bundle.js --metafile=dist/portfolio.contract.meta.json",
+    "build:bundle": "npx bundle-source --cache-json dist/ ./dist/portfolio.contract.bundle.js ymax0",
+    "build:bundle-id": "sh -c '(printf b1-; jq -r .endoZipBase64Sha512 ./dist/bundle-ymax0.json) >./dist/ymax0.bundleId'",
     "deploy:devnet": "yarn build && scripts/deploy-cli.ts src/portfolio.build.js --net=devnet",
     "test": "yarn build && ava",
     "test:c8": "c8 --all $C8_OPTIONS ava",

--- a/packages/portfolio-deploy/src/vstorage-outdated.js
+++ b/packages/portfolio-deploy/src/vstorage-outdated.js
@@ -50,8 +50,8 @@ export const findOutdated = async vs => {
   /** @type {PruneOpts['toPrune']} */
   const toPrune = {};
 
-  const noData = ['.portfolios', '.flows', '.positions'];
-  for await (const path of depthFirst(vs, 'published.ymax0.portfolios')) {
+  const noData = ['.portfolios', '.flows', '.positions', '.pendingTxs'];
+  for await (const path of depthFirst(vs, 'published.ymax0')) {
     if (noData.some(tail => path.endsWith(tail))) continue;
     const { blockHeight: age } = await getHeightLast(path);
     const ok = age >= t0;


### PR DESCRIPTION
refs:
 - #11825

## Description

 - fix(ymax-tool)!: separate checkStorage from pruneStorage
 - fix(ymax-tool)!: separate buildEthOverrides from installAndStart
 - feat(ymax-ops): ymaxControl usage with strict key management

### Security Considerations

key management: uses bitwarden API to put the MNEMONIC in env only for the duration of usage

### Scaling Considerations

n/a

### Documentation Considerations

some BREAKING CHANGES in ymax-tool

### Testing Considerations

no automated tests

### Upgrade Considerations

no on-chain code