### PR TITLE
u22 cherrypicks round 1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -285,19 +285,19 @@ jobs:
         run: make --directory packages/cosmic-swingset install
         working-directory: agoric-sdk
 
-      - name: verify SDK image didn't change
-        # In the future when we can rebuild the SDK image with resolved endo packages, it would
-        # be expected that the SDK image previously built has changed
-        if: steps.restore-node.outputs.endo-branch == 'NOPE'
-        run: |
-          original=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
-          yarn build:sdk
-          new=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
-          if [ "$original" != "$new" ]; then
-            echo "New SDK docker image ($new) changed after restore-node (original $original)" 1>&2
-            exit 1
-          fi
-        working-directory: agoric-sdk/a3p-integration
+      # - name: verify SDK image didn't change
+      #   # In the future when we can rebuild the SDK image with resolved endo packages, it would
+      #   # be expected that the SDK image previously built has changed
+      #   if: steps.restore-node.outputs.endo-branch == 'NOPE'
+      #   run: |
+      #     original=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
+      #     yarn build:sdk
+      #     new=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
+      #     if [ "$original" != "$new" ]; then
+      #       echo "New SDK docker image ($new) changed after restore-node (original $original)" 1>&2
+      #       exit 1
+      #     fi
+      #   working-directory: agoric-sdk/a3p-integration
 
       - id: get-loadgen-branch
         name: Get the appropriate loadgen branch

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@yarnpkg/types": "^4.0.1",
     "ava": "^5.3.0",
     "c8": "^10.1.3",
-    "conventional-changelog-conventionalcommits": "^4.6.0",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^9.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-jessie": "^0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -965,7 +965,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.1"
     ava: "npm:^5.3.0"
     c8: "npm:^10.1.3"
-    conventional-changelog-conventionalcommits: "npm:^4.6.0"
+    conventional-changelog-conventionalcommits: "npm:^9.1.0"
     eslint: "npm:^9.32.0"
     eslint-config-airbnb-base: "npm:^15.0.0"
     eslint-config-jessie: "npm:^0.0.6"
@@ -8575,14 +8575,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "conventional-changelog-conventionalcommits@npm:4.6.0"
+"conventional-changelog-conventionalcommits@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "conventional-changelog-conventionalcommits@npm:9.1.0"
   dependencies:
     compare-func: "npm:^2.0.0"
-    lodash: "npm:^4.17.15"
-    q: "npm:^1.5.1"
-  checksum: 10c0/87d4868288d0a03d3f94796bf5245888d326eca75cd3bcef188ed6aa8315150015087cf854a2d6f5ab678ff5294dd81916c40e4f36be4d59113af1b13e845e2d
+  checksum: 10c0/b1dfbb8ce5983bb80837c35f089fb0f9603a1b067f34be680f88fde20871792e461e29d119d468bc293f38a1ca916c1c40a841f8c049a0a1efaa40582f4fecc9
   languageName: node
   linkType: hard
 
@@ -15453,13 +15451,6 @@ __metadata:
   version: 5.0.1
   resolution: "pure-rand@npm:5.0.1"
   checksum: 10c0/56fb43edf336ac939564d60535597a4182a6310627c4c7c54ef22499223a3d967bfa6d05a9c95c45ed5324bb7167de57a25e3fac5495dd4409672c08166d7973
-  languageName: node
-  linkType: hard
-
-"q@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "q@npm:1.5.1"
-  checksum: 10c0/7855fbdba126cb7e92ef3a16b47ba998c0786ec7fface236e3eb0135b65df36429d91a86b1fff3ab0927b4ac4ee88a2c44527c7c3b8e2a37efbec9fe34803df4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cherry-picks the following commits from master.

[chore: bump conventional-changelog-conventionalcommits to 9.1.0](https://github.com/Agoric/agoric-sdk/commit/bef990a5d8bdd33cc7223e92095d33d8666764bf)
[ci: temporarily disable sdk image hash comparison check](https://github.com/Agoric/agoric-sdk/commit/094edf13acdbeec81de102d35b05e088b613cf5d)