### PR TITLE
chore(release): publish `upgrade-22-rc1`

### DIFF
--- a/golang/cosmos/CHANGELOG.md
+++ b/golang/cosmos/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.35.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmos@0.35.0-u22.0...@agoric/cosmos@0.35.0-u22.1) (2025-09-09)
+
+### Bug Fixes
+
+* **cosmos:** snapshot init error is not fatal ([#11903](https://github.com/Agoric/agoric-sdk/issues/11903)) ([99e9a22](https://github.com/Agoric/agoric-sdk/commit/99e9a22bfee864f23c032819ea59ea9c1e1267e0))
+
 ## [0.35.0-u22.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmos@0.34.1...@agoric/cosmos@0.35.0-u22.0) (2025-09-09)
 
 ### ⚠ BREAKING CHANGES

--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cosmos",
-  "version": "0.35.0-u22.0",
+  "version": "0.35.0-u22.1",
   "description": "Connect JS to the Cosmos blockchain SDK",
   "parsers": {
     "js": "mjs"

--- a/packages/ERTP/CHANGELOG.md
+++ b/packages/ERTP/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.17.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/ertp@0.17.0-u22.1...@agoric/ertp@0.17.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/ertp
+
 ## [0.17.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/ertp@0.17.0-u22.0...@agoric/ertp@0.17.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/ertp

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/ertp",
-  "version": "0.17.0-u22.1",
+  "version": "0.17.0-u22.2",
   "description": "Electronic Rights Transfer Protocol (ERTP). A smart contract framework for exchanging electronic rights",
   "type": "module",
   "main": "src/index.js",

--- a/packages/SwingSet/CHANGELOG.md
+++ b/packages/SwingSet/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/swingset-vat@0.33.0-u22.1...@agoric/swingset-vat@0.33.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/swingset-vat
+
 ## [0.33.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/swingset-vat@0.33.0-u22.0...@agoric/swingset-vat@0.33.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/swingset-vat

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/swingset-vat",
-  "version": "0.33.0-u22.1",
+  "version": "0.33.0-u22.2",
   "description": "Vat/Container Launcher",
   "type": "module",
   "main": "src/index.js",

--- a/packages/access-token/CHANGELOG.md
+++ b/packages/access-token/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.22-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/access-token@0.4.22-u22.1...@agoric/access-token@0.4.22-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/access-token
+
 ## [0.4.22-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/access-token@0.4.22-u22.0...@agoric/access-token@0.4.22-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/access-token

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/access-token",
-  "version": "0.4.22-u22.1",
+  "version": "0.4.22-u22.2",
   "description": "Persistent credentials for Agoric users, backed by a simple JSON file",
   "type": "module",
   "main": "src/access-token.js",

--- a/packages/agoric-cli/CHANGELOG.md
+++ b/packages/agoric-cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/agoric@0.22.0-u22.1...agoric@0.22.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package agoric
+
 ## [0.22.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/agoric@0.22.0-u22.0...agoric@0.22.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package agoric

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agoric",
-  "version": "0.22.0-u22.1",
+  "version": "0.22.0-u22.2",
   "description": "Manage the Agoric Javascript smart contract platform",
   "type": "module",
   "main": "src/main.js",

--- a/packages/async-flow/CHANGELOG.md
+++ b/packages/async-flow/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/async-flow@0.2.0-u22.1...@agoric/async-flow@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/async-flow
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/async-flow@0.2.0-u22.0...@agoric/async-flow@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/async-flow

--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/async-flow",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Upgrade async functions at await points by replay",
   "type": "module",
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/packages/benchmark/CHANGELOG.md
+++ b/packages/benchmark/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/benchmark@0.2.0-u22.1...@aglocal/benchmark@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/benchmark
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/benchmark@0.2.0-u22.0...@aglocal/benchmark@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/benchmark

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aglocal/benchmark",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "private": true,
   "description": "Benchmark support",
   "type": "module",

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/boot@0.2.0-u22.1...@aglocal/boot@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/boot
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/boot@0.2.0-u22.0...@aglocal/boot@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/boot

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aglocal/boot",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "private": true,
   "description": "Config and utilities to bootstrap an Agoric chain",
   "type": "module",
@@ -59,7 +59,7 @@
     "viem": "^2.31.0"
   },
   "devDependencies": {
-    "@aglocal/fast-usdc-deploy": "^0.2.0-u22.1",
+    "@aglocal/fast-usdc-deploy": "^0.2.0-u22.2",
     "@agoric/deploy-script-support": "workspace:*",
     "@agoric/governance": "workspace:*",
     "@agoric/store": "workspace:*",

--- a/packages/builders/CHANGELOG.md
+++ b/packages/builders/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/builders@0.2.0-u22.1...@agoric/builders@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/builders
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/builders@0.2.0-u22.0...@agoric/builders@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/builders

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/builders",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Build scripts for proposals to an Agoric chain",
   "type": "module",
   "main": "./index.js",

--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/cache@0.4.0-u22.1...@agoric/cache@0.4.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/cache
+
 ## [0.4.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/cache@0.4.0-u22.0...@agoric/cache@0.4.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/cache

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cache",
-  "version": "0.4.0-u22.1",
+  "version": "0.4.0-u22.2",
   "description": "Agoric's simple cache interface",
   "type": "module",
   "main": "src/main.js",

--- a/packages/casting/CHANGELOG.md
+++ b/packages/casting/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/casting@0.5.0-u22.1...@agoric/casting@0.5.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/casting
+
 ## [0.5.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/casting@0.5.0-u22.0...@agoric/casting@0.5.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/casting

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/casting",
-  "version": "0.5.0-u22.1",
+  "version": "0.5.0-u22.2",
   "description": "Agoric's OCap broadcasting system",
   "type": "module",
   "main": "src/main.js",

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/client-utils@0.2.0-u22.1...@agoric/client-utils@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/client-utils
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/client-utils@0.2.0-u22.0...@agoric/client-utils@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/client-utils

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/client-utils",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Utilities for building Agoric clients",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cosmic-proto/CHANGELOG.md
+++ b/packages/cosmic-proto/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmic-proto@0.5.0-u22.1...@agoric/cosmic-proto@0.5.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/cosmic-proto
+
 ## [0.5.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmic-proto@0.5.0-u22.0...@agoric/cosmic-proto@0.5.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/cosmic-proto

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cosmic-proto",
-  "version": "0.5.0-u22.1",
+  "version": "0.5.0-u22.2",
   "description": "Protobuf stubs for the Agoric cosmos-sdk module",
   "keywords": [],
   "author": "Agoric",

--- a/packages/cosmic-swingset/CHANGELOG.md
+++ b/packages/cosmic-swingset/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.42.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmic-swingset@0.42.0-u22.1...@agoric/cosmic-swingset@0.42.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/cosmic-swingset
+
 ## [0.42.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmic-swingset@0.42.0-u22.0...@agoric/cosmic-swingset@0.42.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/cosmic-swingset

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cosmic-swingset",
-  "version": "0.42.0-u22.1",
+  "version": "0.42.0-u22.2",
   "description": "Agoric's Cosmos blockchain integration",
   "type": "module",
   "bin": {

--- a/packages/create-dapp/CHANGELOG.md
+++ b/packages/create-dapp/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/create-dapp@0.2.0-u22.1...@agoric/create-dapp@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/create-dapp
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/create-dapp@0.2.0-u22.0...@agoric/create-dapp@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/create-dapp

--- a/packages/create-dapp/package.json
+++ b/packages/create-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/create-dapp",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Create an Agoric Javascript smart contract application",
   "type": "module",
   "bin": "src/create-dapp.js",

--- a/packages/deploy-script-support/CHANGELOG.md
+++ b/packages/deploy-script-support/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/deploy-script-support@0.11.0-u22.1...@agoric/deploy-script-support@0.11.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/deploy-script-support
+
 ## [0.11.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/deploy-script-support@0.11.0-u22.0...@agoric/deploy-script-support@0.11.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/deploy-script-support

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/deploy-script-support",
-  "version": "0.11.0-u22.1",
+  "version": "0.11.0-u22.2",
   "description": "Helpers and other support for writing deploy scripts",
   "type": "module",
   "main": "src/helpers.js",

--- a/packages/fast-usdc-contract/CHANGELOG.md
+++ b/packages/fast-usdc-contract/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/fast-usdc-contract@0.2.0-u22.1...@aglocal/fast-usdc-contract@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/fast-usdc-contract
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/fast-usdc-contract@0.2.0-u22.0...@aglocal/fast-usdc-contract@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/fast-usdc-contract

--- a/packages/fast-usdc-contract/package.json
+++ b/packages/fast-usdc-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aglocal/fast-usdc-contract",
   "private": true,
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Smart contract component of the Fast USDC product",
   "type": "module",
   "files": [

--- a/packages/fast-usdc-deploy/CHANGELOG.md
+++ b/packages/fast-usdc-deploy/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/fast-usdc-deploy@0.2.0-u22.1...@aglocal/fast-usdc-deploy@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/fast-usdc-deploy
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/fast-usdc-deploy@0.2.0-u22.0...@aglocal/fast-usdc-deploy@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/fast-usdc-deploy

--- a/packages/fast-usdc-deploy/package.json
+++ b/packages/fast-usdc-deploy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aglocal/fast-usdc-deploy",
   "private": true,
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Deployment facilities of the Fast USDC product",
   "type": "module",
   "files": [

--- a/packages/fast-usdc/CHANGELOG.md
+++ b/packages/fast-usdc/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/fast-usdc@0.2.0-u22.1...@agoric/fast-usdc@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/fast-usdc
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/fast-usdc@0.2.0-u22.0...@agoric/fast-usdc@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/fast-usdc

--- a/packages/fast-usdc/package.json
+++ b/packages/fast-usdc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/fast-usdc",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "CLI and library for Fast USDC product",
   "type": "module",
   "files": [

--- a/packages/governance/CHANGELOG.md
+++ b/packages/governance/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/governance@0.11.0-u22.1...@agoric/governance@0.11.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/governance
+
 ## [0.11.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/governance@0.11.0-u22.0...@agoric/governance@0.11.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/governance

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/governance",
-  "version": "0.11.0-u22.1",
+  "version": "0.11.0-u22.2",
   "description": "Core governance support",
   "type": "module",
   "main": "src/index.js",

--- a/packages/import-manager/CHANGELOG.md
+++ b/packages/import-manager/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.12-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-manager@0.3.12-u22.1...@agoric/import-manager@0.3.12-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/import-manager
+
 ## [0.3.12-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-manager@0.3.12-u22.0...@agoric/import-manager@0.3.12-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/import-manager

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/import-manager",
-  "version": "0.3.12-u22.1",
+  "version": "0.3.12-u22.2",
   "description": "Share code across vat boundaries",
   "type": "module",
   "main": "./src/importManager.js",

--- a/packages/inter-protocol/CHANGELOG.md
+++ b/packages/inter-protocol/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.17.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/inter-protocol@0.17.0-u22.1...@agoric/inter-protocol@0.17.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/inter-protocol
+
 ## [0.17.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/inter-protocol@0.17.0-u22.0...@agoric/inter-protocol@0.17.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/inter-protocol

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/inter-protocol",
-  "version": "0.17.0-u22.1",
+  "version": "0.17.0-u22.2",
   "description": "Core cryptoeconomy contracts",
   "type": "module",
   "main": "src/index.js",

--- a/packages/internal/CHANGELOG.md
+++ b/packages/internal/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/internal@0.4.0-u22.1...@agoric/internal@0.4.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/internal
+
 ## [0.4.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/internal@0.4.0-u22.0...@agoric/internal@0.4.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/internal

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/internal",
-  "version": "0.4.0-u22.1",
+  "version": "0.4.0-u22.2",
   "description": "Externally unsupported utilities internal to agoric-sdk",
   "type": "module",
   "main": "src/index.js",

--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/network@0.2.0-u22.1...@agoric/network@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/network
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/network@0.2.0-u22.0...@agoric/network@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/network

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/network",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Agoric's network protocol API",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/notifier/CHANGELOG.md
+++ b/packages/notifier/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/notifier@0.7.0-u22.1...@agoric/notifier@0.7.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/notifier
+
 ## [0.7.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/notifier@0.7.0-u22.0...@agoric/notifier@0.7.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/notifier

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/notifier",
-  "version": "0.7.0-u22.1",
+  "version": "0.7.0-u22.2",
   "description": "Notifier allows services to update clients about state changes using a stream of promises",
   "type": "module",
   "main": "src/index.js",

--- a/packages/orchestration/CHANGELOG.md
+++ b/packages/orchestration/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/orchestration@0.2.0-u22.1...@agoric/orchestration@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/orchestration
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/orchestration@0.2.0-u22.0...@agoric/orchestration@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/orchestration

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/orchestration",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Chain abstraction for Agoric's orchestration clients",
   "type": "module",
   "main": "index.js",

--- a/packages/pegasus/CHANGELOG.md
+++ b/packages/pegasus/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/pegasus@0.8.0-u22.1...@agoric/pegasus@0.8.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/pegasus
+
 ## [0.8.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/pegasus@0.8.0-u22.0...@agoric/pegasus@0.8.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/pegasus

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/pegasus",
-  "version": "0.8.0-u22.1",
+  "version": "0.8.0-u22.2",
   "description": "Peg-as-us contract",
   "type": "module",
   "main": "./src/pegasus.js",

--- a/packages/pola-io/CHANGELOG.md
+++ b/packages/pola-io/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/pola-io@0.2.0-u22.1...@agoric/pola-io@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/pola-io
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/pola-io@0.2.0-u22.0...@agoric/pola-io@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/pola-io

--- a/packages/pola-io/package.json
+++ b/packages/pola-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/pola-io",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Least Authority I/O utilities",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/portfolio-api/CHANGELOG.md
+++ b/packages/portfolio-api/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/portfolio-api@0.2.0-u22.1...@agoric/portfolio-api@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/portfolio-api
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/portfolio-api@0.2.0-u22.0...@agoric/portfolio-api@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/portfolio-api

--- a/packages/portfolio-api/package.json
+++ b/packages/portfolio-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/portfolio-api",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "API for Portfolio management",
   "type": "module",
   "files": [

--- a/packages/portfolio-contract/CHANGELOG.md
+++ b/packages/portfolio-contract/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/portfolio-contract@0.2.0-u22.1...@aglocal/portfolio-contract@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/portfolio-contract
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/portfolio-contract@0.2.0-u22.0...@aglocal/portfolio-contract@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/portfolio-contract

--- a/packages/portfolio-contract/package.json
+++ b/packages/portfolio-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aglocal/portfolio-contract",
   "private": true,
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "portfolio-contract aka ymax0 or YMax Proof of Concept (PoC)",
   "type": "module",
   "files": [

--- a/packages/portfolio-deploy/CHANGELOG.md
+++ b/packages/portfolio-deploy/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/portfolio-deploy@0.2.0-u22.1...@aglocal/portfolio-deploy@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/portfolio-deploy
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/portfolio-deploy@0.2.0-u22.0...@aglocal/portfolio-deploy@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/portfolio-deploy

--- a/packages/portfolio-deploy/package.json
+++ b/packages/portfolio-deploy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aglocal/portfolio-deploy",
   "private": true,
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Deployment facilities for the Portfolio contract",
   "type": "module",
   "files": [

--- a/packages/smart-wallet/CHANGELOG.md
+++ b/packages/smart-wallet/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.0-u22.2](https://github.com/Agoric/agoric/compare/@agoric/smart-wallet@0.6.0-u22.1...@agoric/smart-wallet@0.6.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/smart-wallet
+
 ## [0.6.0-u22.1](https://github.com/Agoric/agoric/compare/@agoric/smart-wallet@0.6.0-u22.0...@agoric/smart-wallet@0.6.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/smart-wallet

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/smart-wallet",
-  "version": "0.6.0-u22.1",
+  "version": "0.6.0-u22.2",
   "description": "Wallet contract",
   "type": "module",
   "main": "src/index.js",

--- a/packages/solo/CHANGELOG.md
+++ b/packages/solo/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/solo@0.11.0-u22.1...@agoric/solo@0.11.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/solo
+
 ## [0.11.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/solo@0.11.0-u22.0...@agoric/solo@0.11.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/solo

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/solo",
-  "version": "0.11.0-u22.1",
+  "version": "0.11.0-u22.2",
   "description": "Agoric's Solo vat runner",
   "type": "module",
   "bin": {

--- a/packages/spawner/CHANGELOG.md
+++ b/packages/spawner/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/spawner@0.6.9-u22.1...@agoric/spawner@0.6.9-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/spawner
+
 ## [0.6.9-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/spawner@0.6.9-u22.0...@agoric/spawner@0.6.9-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/spawner

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/spawner",
-  "version": "0.6.9-u22.1",
+  "version": "0.6.9-u22.2",
   "description": "Wrapper for JavaScript map",
   "type": "module",
   "main": "./src/contractHost.js",

--- a/packages/swing-store/CHANGELOG.md
+++ b/packages/swing-store/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.10.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/swing-store@0.10.0-u22.1...@agoric/swing-store@0.10.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/swing-store
+
 ## [0.10.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/swing-store@0.10.0-u22.0...@agoric/swing-store@0.10.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/swing-store

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/swing-store",
-  "version": "0.10.0-u22.1",
+  "version": "0.10.0-u22.2",
   "description": "Persistent storage for SwingSet",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/swingset-liveslots/CHANGELOG.md
+++ b/packages/swingset-liveslots/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/swingset-liveslots@0.11.0-u22.1...@agoric/swingset-liveslots@0.11.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/swingset-liveslots
+
 ## [0.11.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/swingset-liveslots@0.11.0-u22.0...@agoric/swingset-liveslots@0.11.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/swingset-liveslots

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/swingset-liveslots",
-  "version": "0.11.0-u22.1",
+  "version": "0.11.0-u22.2",
   "description": "SwingSet ocap support layer",
   "type": "module",
   "main": "src/index.js",

--- a/packages/swingset-runner/CHANGELOG.md
+++ b/packages/swingset-runner/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.23.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@aglocal/swingset-runner@0.23.0-u22.1...@aglocal/swingset-runner@0.23.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/swingset-runner
+
 ## [0.23.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/swingset-runner@0.23.0-u22.0...@aglocal/swingset-runner@0.23.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/swingset-runner

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aglocal/swingset-runner",
-  "version": "0.23.0-u22.1",
+  "version": "0.23.0-u22.2",
   "private": true,
   "description": "Application to launch SwingSet instances for development and testing",
   "type": "module",

--- a/packages/swingset-xsnap-supervisor/CHANGELOG.md
+++ b/packages/swingset-xsnap-supervisor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/swingset-xsnap-supervisor@0.11.0-u22.1...@agoric/swingset-xsnap-supervisor@0.11.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/swingset-xsnap-supervisor
+
 ## [0.11.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/swingset-xsnap-supervisor@0.11.0-u22.0...@agoric/swingset-xsnap-supervisor@0.11.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/swingset-xsnap-supervisor

--- a/packages/swingset-xsnap-supervisor/package.json
+++ b/packages/swingset-xsnap-supervisor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/swingset-xsnap-supervisor",
-  "version": "0.11.0-u22.1",
+  "version": "0.11.0-u22.2",
   "description": "Supervisor/Liveslots bundle for swingset xsnap workers",
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/telemetry@0.7.0-u22.1...@agoric/telemetry@0.7.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/telemetry
+
 ## [0.7.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/telemetry@0.7.0-u22.0...@agoric/telemetry@0.7.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/telemetry

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/telemetry",
-  "version": "0.7.0-u22.1",
+  "version": "0.7.0-u22.2",
   "description": "Agoric's telemetry implementation",
   "type": "module",
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/packages/vat-data/CHANGELOG.md
+++ b/packages/vat-data/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/vat-data@0.6.0-u22.1...@agoric/vat-data@0.6.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/vat-data
+
 ## [0.6.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/vat-data@0.6.0-u22.0...@agoric/vat-data@0.6.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/vat-data

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/vat-data",
-  "version": "0.6.0-u22.1",
+  "version": "0.6.0-u22.2",
   "description": "Safe access to VatData global",
   "type": "module",
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/packages/vats/CHANGELOG.md
+++ b/packages/vats/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.16.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/vats@0.16.0-u22.1...@agoric/vats@0.16.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/vats
+
 ## [0.16.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/vats@0.16.0-u22.0...@agoric/vats@0.16.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/vats

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/vats",
-  "version": "0.16.0-u22.1",
+  "version": "0.16.0-u22.2",
   "description": "Agoric's Vat library",
   "type": "module",
   "main": "./index.js",

--- a/packages/vow/CHANGELOG.md
+++ b/packages/vow/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/vow@0.2.0-u22.1...@agoric/vow@0.2.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/vow
+
 ## [0.2.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/vow@0.2.0-u22.0...@agoric/vow@0.2.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/vow

--- a/packages/vow/package.json
+++ b/packages/vow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/vow",
-  "version": "0.2.0-u22.1",
+  "version": "0.2.0-u22.2",
   "description": "Remote (shortening and disconnection-tolerant) Promise-likes",
   "type": "module",
   "main": "src/index.js",

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.19.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/wallet@0.19.0-u22.1...@agoric/wallet@0.19.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/wallet
+
 ## [0.19.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/wallet@0.19.0-u22.0...@agoric/wallet@0.19.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/wallet

--- a/packages/wallet/api/CHANGELOG.md
+++ b/packages/wallet/api/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.15.0-u22.1](https://github.com/Agoric/agoric/compare/@agoric/wallet-backend@0.15.0-u22.0...@agoric/wallet-backend@0.15.0-u22.1) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/wallet-backend
+
 ## [0.15.0-u22.0](https://github.com/Agoric/agoric/compare/@agoric/wallet-backend@0.14.3...@agoric/wallet-backend@0.15.0-u22.0) (2025-09-09)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/wallet-backend",
-  "version": "0.15.0-u22.0",
+  "version": "0.15.0-u22.1",
   "description": "Wallet backend",
   "type": "module",
   "scripts": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/wallet",
-  "version": "0.19.0-u22.1",
+  "version": "0.19.0-u22.2",
   "type": "module",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/xsnap/CHANGELOG.md
+++ b/packages/xsnap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.15.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/xsnap@0.15.0-u22.1...@agoric/xsnap@0.15.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/xsnap
+
 ## [0.15.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/xsnap@0.15.0-u22.0...@agoric/xsnap@0.15.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/xsnap

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/xsnap",
-  "version": "0.15.0-u22.1",
+  "version": "0.15.0-u22.2",
   "description": "Snapshotting VM worker based on Moddable's XS Javascript engine",
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/zoe/CHANGELOG.md
+++ b/packages/zoe/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.27.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/zoe@0.27.0-u22.1...@agoric/zoe@0.27.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/zoe
+
 ## [0.27.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/zoe@0.27.0-u22.0...@agoric/zoe@0.27.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/zoe

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/zoe",
-  "version": "0.27.0-u22.1",
+  "version": "0.27.0-u22.2",
   "description": "Zoe: the Smart Contract Framework for Offer Enforcement",
   "type": "module",
   "main": "./src/zoeService/zoe.js",

--- a/packages/zone/CHANGELOG.md
+++ b/packages/zone/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.0-u22.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/zone@0.3.0-u22.1...@agoric/zone@0.3.0-u22.2) (2025-09-09)
+
+**Note:** Version bump only for package @agoric/zone
+
 ## [0.3.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/zone@0.3.0-u22.0...@agoric/zone@0.3.0-u22.1) (2025-09-09)
 
 **Note:** Version bump only for package @agoric/zone

--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/zone",
-  "version": "0.3.0-u22.1",
+  "version": "0.3.0-u22.2",
   "description": "Allocation zone abstraction for objects on the heap, persistent stores, etc.",
   "type": "module",
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/services/ymax-planner/CHANGELOG.md
+++ b/services/ymax-planner/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-u22.1](https://github.com/Agoric/agoric-sdk/compare/@aglocal/ymax-planner@1.0.1-u22.0...@aglocal/ymax-planner@1.0.1-u22.1) (2025-09-09)
+
+**Note:** Version bump only for package @aglocal/ymax-planner
+
 ## 1.0.1-u22.0 (2025-09-09)
 
 **Note:** Version bump only for package @aglocal/ymax-planner

--- a/services/ymax-planner/package.json
+++ b/services/ymax-planner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aglocal/ymax-planner",
   "private": true,
-  "version": "1.0.1-u22.0",
+  "version": "1.0.1-u22.1",
   "description": "Portfolio contract off-chain engine",
   "main": "dist/entrypoint.js",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,7 +38,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aglocal/boot@workspace:packages/boot"
   dependencies:
-    "@aglocal/fast-usdc-deploy": "npm:^0.2.0-u22.1"
+    "@aglocal/fast-usdc-deploy": "npm:^0.2.0-u22.2"
     "@agoric/builders": "workspace:*"
     "@agoric/client-utils": "workspace:*"
     "@agoric/cosmic-proto": "workspace:*"
@@ -148,7 +148,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aglocal/fast-usdc-deploy@npm:^0.2.0-u22.1, @aglocal/fast-usdc-deploy@workspace:packages/fast-usdc-deploy":
+"@aglocal/fast-usdc-deploy@npm:^0.2.0-u22.2, @aglocal/fast-usdc-deploy@workspace:packages/fast-usdc-deploy":
   version: 0.0.0-use.local
   resolution: "@aglocal/fast-usdc-deploy@workspace:packages/fast-usdc-deploy"
   dependencies:


### PR DESCRIPTION
## Packages that have NEWS.md updates

```diff
--- a/golang/cosmos/CHANGELOG.md
+++ b/golang/cosmos/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.35.0-u22.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmos@0.35.0-u22.0...@agoric/cosmos@0.35.0-u22.1) (2025-09-09)
+
+### Bug Fixes
+
+* **cosmos:** snapshot init error is not fatal ([#11903](https://github.com/Agoric/agoric-sdk/issues/11903)) ([99e9a22](https://github.com/Agoric/agoric-sdk/commit/99e9a22bfee864f23c032819ea59ea9c1e1267e0))
+
 ## [0.35.0-u22.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/cosmos@0.34.1...@agoric/cosmos@0.35.0-u22.0) (2025-09-09)
 
 ### ⚠ BREAKING CHANGES
```


## Changed Packages
 - @agoric/cosmos@0.35.0-u22.1
 - @agoric/ertp@0.17.0-u22.2
 - @agoric/swingset-vat@0.33.0-u22.2
 - @agoric/access-token@0.4.22-u22.2
 - agoric@0.22.0-u22.2
 - @agoric/async-flow@0.2.0-u22.2
 - @aglocal/benchmark@0.2.0-u22.2
 - @aglocal/boot@0.2.0-u22.2
 - @agoric/builders@0.2.0-u22.2
 - @agoric/cache@0.4.0-u22.2
 - @agoric/casting@0.5.0-u22.2
 - @agoric/client-utils@0.2.0-u22.2
 - @agoric/cosmic-proto@0.5.0-u22.2
 - @agoric/cosmic-swingset@0.42.0-u22.2
 - @agoric/create-dapp@0.2.0-u22.2
 - @agoric/deploy-script-support@0.11.0-u22.2
 - @aglocal/fast-usdc-contract@0.2.0-u22.2
 - @aglocal/fast-usdc-deploy@0.2.0-u22.2
 - @agoric/fast-usdc@0.2.0-u22.2
 - @agoric/governance@0.11.0-u22.2
 - @agoric/import-manager@0.3.12-u22.2
 - @agoric/inter-protocol@0.17.0-u22.2
 - @agoric/internal@0.4.0-u22.2
 - @agoric/network@0.2.0-u22.2
 - @agoric/notifier@0.7.0-u22.2
 - @agoric/orchestration@0.2.0-u22.2
 - @agoric/pegasus@0.8.0-u22.2
 - @agoric/pola-io@0.2.0-u22.2
 - @agoric/portfolio-api@0.2.0-u22.2
 - @aglocal/portfolio-contract@0.2.0-u22.2
 - @aglocal/portfolio-deploy@0.2.0-u22.2
 - @agoric/smart-wallet@0.6.0-u22.2
 - @agoric/solo@0.11.0-u22.2
 - @agoric/spawner@0.6.9-u22.2
 - @agoric/swing-store@0.10.0-u22.2
 - @agoric/swingset-liveslots@0.11.0-u22.2
 - @aglocal/swingset-runner@0.23.0-u22.2
 - @agoric/swingset-xsnap-supervisor@0.11.0-u22.2
 - @agoric/telemetry@0.7.0-u22.2
 - @agoric/vat-data@0.6.0-u22.2
 - @agoric/vats@0.16.0-u22.2
 - @agoric/vow@0.2.0-u22.2
 - @agoric/wallet@0.19.0-u22.2
 - @agoric/xsnap@0.15.0-u22.2
 - @agoric/zoe@0.27.0-u22.2
 - @agoric/zone@0.3.0-u22.2
 - @agoric/wallet-backend@0.15.0-u22.1
 - @aglocal/ymax-planner@1.0.1-u22.1

