### PR TITLE
chore(multichain-testing): Fix lint issues

### DIFF
--- a/multichain-testing/tools/wallet-store-reflect.ts
+++ b/multichain-testing/tools/wallet-store-reflect.ts
@@ -6,7 +6,7 @@ import type { EMethods } from '@agoric/vow/src/E.js';
 export const walletUpdates = (
   getLastUpdate: () => Promise<UpdateRecord>,
   retryOpts: RetryOptions & {
-    log: (...args: any[]) => void;
+    log: (...args: unknown[]) => void;
     setTimeout: typeof globalThis.setTimeout;
   },
 ) => {
@@ -49,7 +49,7 @@ export const walletUpdates = (
 export const reflectWalletStore = (
   sig: SigningSmartWalletKit,
   retryOpts: RetryOptions & {
-    log: (...args: any[]) => void;
+    log: (...args: unknown[]) => void;
     setTimeout: typeof globalThis.setTimeout;
     fresh: () => number | string;
   },
@@ -76,7 +76,7 @@ export const reflectWalletStore = (
         if (method === 'then') return undefined;
         const boundMethod = async (...args) => {
           const id = `${method}.${retryOpts.fresh()}`;
-          let tx = await sig.invokeEntry(
+          const tx = await sig.invokeEntry(
             logged('invoke', {
               id,
               targetName,
@@ -85,8 +85,9 @@ export const reflectWalletStore = (
               ...(saveResult ? { saveResult } : {}),
             }),
           );
-          if (tx.result.transaction.code !== 0)
+          if (tx.result.transaction.code !== 0) {
             throw Error(tx.result.transaction.rawLog);
+          }
           lastTx = tx.result.transaction;
           await up.invocation(id);
           return saveResult ? makeEntryProxy(saveResult.name) : undefined;


### PR DESCRIPTION
Ref #11825

cf. https://github.com/Agoric/agoric-sdk/actions/runs/17619187085/job/50060261381?pr=11881
> ```
> Run yarn lint && yarn ava test/imports.test.ts
>   yarn lint && yarn ava test/imports.test.ts
>   shell: /usr/bin/bash -e {0}
>   env:
>     LOG_DIR: /home/runner/work/agoric-sdk/agoric-sdk/agoric-sdk/multichain-testing/logs/17619187085/multichain-e2e
>     NAMESPACE: agoric-multichain-testing-fusdc
>     VALIDATOR_PODS: agoriclocal-genesis-0 noblelocal-genesis-0 osmosislocal-genesis-0 
>     RELAYER_PODS: hermes-osmosis-noble-0 hermes-agoric-osmosis-0 hermes-agoric-noble-0 
> 
> /home/runner/work/agoric-sdk/agoric-sdk/agoric-sdk/multichain-testing/tools/wallet-store-reflect.ts
> Error:    9:20  error  Unexpected any. Specify a different type       @typescript-eslint/no-explicit-any
> Error:   52:20  error  Unexpected any. Specify a different type       @typescript-eslint/no-explicit-any
> Error:   79:15  error  'tx' is never reassigned. Use 'const' instead  prefer-const
> 
> ✖ 3 problems (3 errors, 0 warnings)
>   1 error and 0 warnings potentially fixable with the `--fix` option.
> 
> Error: Process completed with exit code 1.
> ```