### PR TITLE
chore: clean up lint uncovered in ymax contract

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,7 @@ export default [
       '**/ava*.config.js',
       '**/.ava*.config.js',
       '**/tsup.config.ts',
+      '*/vendor/**',
       'yarn.config.cjs',
       'packages/client-utils/scripts/',
       'packages/cosmic-proto/proto/',

--- a/packages/portfolio-contract/eslint.config.js
+++ b/packages/portfolio-contract/eslint.config.js
@@ -1,9 +1,0 @@
-// packages/portfolio-contract/eslint.config.js
-export default [
-  {
-    ignores: [
-      'src/vendor/viem/viem-abi.bundle.js', // ignore this specific file
-    ],
-  },
-  // You may already have additional config objects here
-];

--- a/packages/portfolio-contract/package.json
+++ b/packages/portfolio-contract/package.json
@@ -19,12 +19,12 @@
     "lint:types": "yarn run -T tsc"
   },
   "devDependencies": {
+    "@aglocal/boot": "workspace:*",
+    "@agoric/async-flow": "workspace:*",
     "@agoric/client-utils": "workspace:*",
-    "@agoric/ertp": "workspace:*",
     "@agoric/fast-usdc": "workspace:*",
-    "@agoric/portfolio-api": "workspace:*",
+    "@agoric/smart-wallet": "workspace:*",
     "@agoric/swingset-liveslots": "workspace:*",
-    "@agoric/zoe": "workspace:*",
     "@agoric/zone": "workspace:*",
     "@endo/init": "^1.1.12",
     "@endo/nat": "^5.1.3",
@@ -36,16 +36,22 @@
   },
   "dependencies": {
     "@agoric/cosmic-proto": "workspace:*",
+    "@agoric/ertp": "workspace:*",
     "@agoric/internal": "workspace:*",
     "@agoric/orchestration": "workspace:*",
+    "@agoric/portfolio-api": "workspace:*",
     "@agoric/time": "workspace:*",
     "@agoric/vats": "workspace:*",
     "@agoric/vow": "workspace:*",
+    "@agoric/zoe": "workspace:*",
+    "@cosmjs/encoding": "^0.36.0",
     "@endo/base64": "^1.0.12",
     "@endo/errors": "^1.2.13",
     "@endo/far": "^1.1.14",
+    "@endo/marshal": "^1.8.0",
     "@endo/pass-style": "^1.6.3",
-    "@endo/patterns": "^1.7.0"
+    "@endo/patterns": "^1.7.0",
+    "viem": "^2.31.0"
   },
   "ava": {
     "extensions": {

--- a/packages/portfolio-contract/src/planner.exo.ts
+++ b/packages/portfolio-contract/src/planner.exo.ts
@@ -19,10 +19,6 @@ const trace = makeTracer('PPLN');
  * Planning is currently done off-chain
  * because it requires access to real-time APYs, balances, and market data that
  * are not readily available to the on-chain contract.
- *
- * @param zone - Durable storage zone
- * @param deps - Dependencies including rebalance flow and portfolio access
- * @returns Planner exo maker function
  */
 export const preparePlanner = (
   zone: Zone,
@@ -56,7 +52,7 @@ export const preparePlanner = (
      *
      * @param portfolioId - Target portfolio identifier
      * @param plan - Array of asset movements to execute
-     * @returns Vow that resolves when all movements complete
+     * @returns {Vow<void>} that resolves when all movements complete
      * @throws If portfolio not found. Rejects if plan validation or execution fails
      */
     submit(portfolioId: number, plan: MovementDesc[]): Vow<void> {

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -116,7 +116,7 @@ export type AxelarId = {
   [chain in AxelarChain]: string;
 };
 
-const EVMContractAddressesMap: TypedPattern<EVMContractAddressesMap> =
+const EVMContractAddressesMapShape: TypedPattern<EVMContractAddressesMap> =
   M.splitRecord(
     fromEntries(
       keys(AxelarChain).map(chain => [chain, EVMContractAddressesShape]),
@@ -160,7 +160,7 @@ const privateArgsShape: TypedPattern<PortfolioPrivateArgs> = {
   ),
   assetInfo: M.arrayOf([M.string(), DenomDetailShape]),
   axelarIds: AxelarIdShape,
-  contracts: EVMContractAddressesMap,
+  contracts: EVMContractAddressesMapShape,
   gmpAddresses: GmpAddressesShape,
 };
 
@@ -294,14 +294,13 @@ export const contract = async (
   };
 
   // Create rebalance flow first - needed by preparePortfolioKit
-  const { rebalance, parseInboundTransfer } =
-    orchestrateAll(
-      {
-        rebalance: flows.rebalance,
-        parseInboundTransfer: flows.parseInboundTransfer,
-      },
-      ctx1,
-    );
+  const { rebalance, parseInboundTransfer } = orchestrateAll(
+    {
+      rebalance: flows.rebalance,
+      parseInboundTransfer: flows.parseInboundTransfer,
+    },
+    ctx1,
+  );
 
   const makePortfolioKit = preparePortfolioKit(zone, {
     zcf,
@@ -456,6 +455,7 @@ export const contract = async (
 };
 harden(contract);
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const keepDocsTypesImported:
   | undefined
   | YieldProtocol

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -294,7 +294,7 @@ export const contract = async (
   };
 
   // Create rebalance flow first - needed by preparePortfolioKit
-  const { rebalance, parseInboundTransfer: parseInboundTransfer } =
+  const { rebalance, parseInboundTransfer } =
     orchestrateAll(
       {
         rebalance: flows.rebalance,
@@ -309,7 +309,7 @@ export const contract = async (
     axelarIds,
     gmpAddresses,
     rebalance,
-    parseInboundTransfer: parseInboundTransfer,
+    parseInboundTransfer,
     proposalShapes,
     offerArgsShapes,
     timer: timerService,

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -119,6 +119,8 @@ const accountIdByChain = (
           case 'noble':
             byChain[n] = coerceAccountId(info.ica.getAddress());
             break;
+          default:
+            trace('skipping: unexpected chainName', info);
         }
         break;
       case 'eip155':

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -330,7 +330,7 @@ export const preparePortfolioKit = (
 
             this.facets.manager.resolveAccount({
               namespace: 'eip155',
-              chainName: chainName,
+              chainName,
               chainId: caipId,
               remoteAddress: address,
             });

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -348,8 +348,6 @@ export const preparePortfolioKit = (
          *
          * We rely on the portfolio creator internally adding the Agoric
          * account before making the PortfolioKit available to any clients.
-         *
-         * @returns the LocalAccount for the current chain.
          */
         getLocalAccount(): LocalAccount {
           const { accounts } = this.state;

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -49,7 +49,6 @@ import {
 } from './type-guards.js';
 
 const trace = makeTracer('PortExo');
-const { values } = Object;
 
 export const DECODE_CONTRACT_CALL_RESULT_ABI = [
   {

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -312,12 +312,12 @@ export const preparePortfolioKit = (
             console.warn('TODO: Handle the result of the contract call', data);
           } else {
             const [message] = data;
-            const { success, result } = message;
+            const { success, result: result2 } = message;
             if (!success) return;
 
             const [address] = decodeAbiParameters(
               [{ type: 'address' }],
-              result,
+              result2,
             );
 
             // chainInfo is safe to await: registerChain(...) ensure it's already resolved,

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -342,7 +342,7 @@ export const wayFromSrcToDesc = (moveDesc: MovementDesc): Way => {
       switch (destKind) {
         case 'seat':
           return { how: 'withdrawToSeat' }; // XXX check that src is agoric
-        case 'accountId':
+        case 'accountId': {
           const destName = getChainNameOfPlaceRef(dest);
           assert(destName);
           if (keys(AxelarChain).includes(destName)) {
@@ -360,6 +360,7 @@ export const wayFromSrcToDesc = (moveDesc: MovementDesc): Way => {
           } else {
             throw Fail`no route between chains: ${q(moveDesc)}`;
           }
+        }
         case 'pos': {
           const poolKey = dest as PoolKey;
           const { protocol } = PoolPlaces[poolKey];

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -582,8 +582,7 @@ const stepFlow = async (
 
       case 'CCTP': {
         todo.push(async () => {
-          const { how, apply, recover } = CCTP;
-          const [{ lca }, nInfo, axelar] = await Promise.all([
+          const [_ag, nInfo, _axelar] = await Promise.all([
             provideCosmosAccount(orch, 'agoric', kit, traceMove),
             provideCosmosAccount(orch, 'noble', kit, traceMove),
             orch.getChain('axelar'),

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -163,6 +163,7 @@ const trackFlow = async (
   todo: (() => Promise<AssetMovement>)[],
   tracePortfolio: TraceLogger,
 ) => {
+  await null; // cf. wiki:NoNestedAwait
   const flowId = reporter.allocateFlowId();
   const traceFlow = tracePortfolio.sub(`flow${flowId}`);
   let step = 1;
@@ -702,6 +703,7 @@ export const rebalance = (async (
   offerArgs: OfferArgsFor['rebalance'],
   kit: GuestInterface<PortfolioKit>,
 ) => {
+  await null; // cf. wiki:NoNestedAwait
   const trace = makeTracer('rebalance');
   const proposal = seat.getProposal() as ProposalType['rebalance'];
   trace('proposal', proposal.give, proposal.want, offerArgs);

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -224,7 +224,7 @@ const provideCosmosAccount = async <C extends 'agoric' | 'noble'>(
 ): Promise<AccountInfoFor[C]> => {
   await null;
   const traceChain = tracePortfolio.sub(chainName);
-  let promiseMaybe = kit.manager.reserveAccount(chainName);
+  const promiseMaybe = kit.manager.reserveAccount(chainName);
   if (promiseMaybe) {
     return promiseMaybe as unknown as Promise<AccountInfoFor[C]>;
   }

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -693,8 +693,11 @@ const stepFlow = async (
  *
  * **Input Validation**: ASSUME caller validates args
  *
+ * @param orch
+ * @param ctx
  * @param seat - proposal guarded as per {@link makeProposalShapes}
  * @param offerArgs - guarded as per {@link makeOfferArgsShapes}
+ * @param kit
  */
 export const rebalance = (async (
   orch: Orchestrator,
@@ -747,9 +750,11 @@ export const parseInboundTransfer = (async (
  *
  * **Input Validation**: ASSUME caller validates args
  *
+ * @param orch
+ * @param ctx
  * @param seat - proposal guarded as per {@link makeProposalShapes}
  * @param offerArgs - guarded as per {@link makeOfferArgsShapes}
- * @returns {*} following continuing invitation pattern,
+ * returns following continuing invitation pattern,
  * with a topic for the portfolio.
  */
 export const openPortfolio = (async (

--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -32,7 +32,7 @@ import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.j
 import { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
 import { fromBech32 } from '@cosmjs/encoding';
 import { q, X } from '@endo/errors';
-import type { GuestInterface } from "@agoric/async-flow/src/types.ts";
+import type { GuestInterface } from '@agoric/async-flow';
 import { ERC20, makeEVMSession, type EVMT } from './evm-facade.ts';
 import type {
   AxelarId,

--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -178,7 +178,7 @@ export const CCTP = {
     await result;
     trace(`CCTP transaction completed after confirmation`);
   },
-  recover: async (_ctx, amount, src, dest) => {
+  recover: async (_ctx, _amount, _src, _dest) => {
     // XXX evmCtx needs a GMP fee
     // return CCTPfromEVM.apply(evmCtx, amount, dest, src);
     throw Error('TODO(Luqi): how to recover from CCTP transfer?');

--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -32,7 +32,7 @@ import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.j
 import { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
 import { fromBech32 } from '@cosmjs/encoding';
 import { q, X } from '@endo/errors';
-import type { GuestInterface } from '../../async-flow/src/types.ts';
+import type { GuestInterface } from "@agoric/async-flow/src/types.ts";
 import { ERC20, makeEVMSession, type EVMT } from './evm-facade.ts';
 import type {
   AxelarId,

--- a/packages/portfolio-contract/src/pos-usdn.flows.ts
+++ b/packages/portfolio-contract/src/pos-usdn.flows.ts
@@ -15,7 +15,7 @@ import {
   MsgUnlock as MsgUnlockType,
 } from '@agoric/cosmic-proto/noble/dollar/vaults/v1/tx.js';
 import { MsgSwap as MsgSwapType } from '@agoric/cosmic-proto/noble/swap/v1/tx.js';
-import { AmountMath, type NatValue } from '@agoric/ertp';
+import { type NatValue } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 import type { CosmosChainAddress, Denom } from '@agoric/orchestration';
 import {
@@ -29,7 +29,6 @@ const MsgLock = CodecHelper(MsgLockType);
 const MsgUnlock = CodecHelper(MsgUnlockType);
 const MsgSwap = CodecHelper(MsgSwapType);
 
-const { add } = AmountMath;
 const trace = makeTracer('USDNF');
 
 export const makeSwapLockMessages = (

--- a/packages/portfolio-contract/src/resolver/resolver.exo.ts
+++ b/packages/portfolio-contract/src/resolver/resolver.exo.ts
@@ -85,11 +85,6 @@ const proposalShape = M.splitRecord(
  *
  * This prepares a resolver maker with generic transaction functionality
  * that supports multiple transaction types through key-based identification.
- *
- * @param resolverZone - Durable storage zone
- * @param zcf - Zoe Contract Facet for creating invitations
- * @param vowTools - Vow tools for creating promises
- * @returns Resolver kit maker function
  */
 export const prepareResolverKit = (
   resolverZone: Zone,

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -76,6 +76,8 @@ export type PortfolioContinuingInvitationMaker =
   keyof PortfolioKit['invitationMakers'];
 
 // #region Proposal Shapes
+type Empty = Record<never, Amount>;
+
 /**
  * Proposal shapes for portfolio operations.
  *
@@ -91,8 +93,8 @@ export type ProposalType = {
     };
   };
   rebalance:
-    | { give: { Deposit?: NatAmount }; want: {} }
-    | { want: { Cash: NatAmount }; give: {} };
+    | { give: { Deposit?: NatAmount }; want: Empty }
+    | { want: { Cash: NatAmount }; give: Empty };
 };
 
 export const makeProposalShapes = (

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -357,3 +357,10 @@ export const FlowStatusShape: TypedPattern<StatusFor['flow']> = M.splitRecord(
 export type EVMContractAddressesMap = {
   [chain in AxelarChain]: EVMContractAddresses;
 };
+
+// keep these types imported for IDE navigation
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const keepDocsTypesImported:
+  | undefined
+  | ContinuingInvitationSpec
+  | ContractInvitationSpec = undefined;

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -43,6 +43,8 @@ import type { PortfolioKit } from './portfolio.exo.js';
 
 export type { OfferArgsFor } from './type-guards-steps.js';
 
+/* eslint jsdoc/require-returns-type: 0 */
+
 // #region preliminaries
 const { keys } = Object;
 

--- a/packages/portfolio-contract/test/cctp-resolver.test.ts
+++ b/packages/portfolio-contract/test/cctp-resolver.test.ts
@@ -8,11 +8,8 @@ import { ResolverOfferArgsShapes } from '../src/resolver/types.ts';
 import { deploy } from './contract-setup.ts';
 
 test('CCTP settlement invitation - no pending transaction found', async t => {
-  const { started, zoe, common } = await deploy(t);
+  const { started, zoe } = await deploy(t);
   const { creatorFacet } = started;
-  const { usdc } = common.brands;
-
-  const amount = usdc.units(1000);
 
   const resolverInvitation = await E(creatorFacet).makeResolverInvitation();
   const resolverSeat = await E(zoe).offer(resolverInvitation);
@@ -35,10 +32,8 @@ test('CCTP settlement invitation - no pending transaction found', async t => {
 });
 
 test('CCTP confirmation invitation - invalid status throws', async t => {
-  const { common } = await deploy(t);
-  const { usdc } = common.brands;
+  await deploy(t);
 
-  const amount = usdc.units(1000);
   const invalidOfferArgs: TransactionSettlementOfferArgs = harden({
     status: 'invalid' as any,
     txId: 'tx0',
@@ -49,11 +44,8 @@ test('CCTP confirmation invitation - invalid status throws', async t => {
 });
 
 test('CCTP confirmation invitation exits seat properly', async t => {
-  const { started, zoe, common } = await deploy(t);
+  const { started, zoe } = await deploy(t);
   const { creatorFacet } = started;
-  const { usdc } = common.brands;
-
-  const amount = usdc.units(1000);
 
   const resolverInvitation = await E(creatorFacet).makeResolverInvitation();
   const resolverSeat = await E(zoe).offer(resolverInvitation);

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -172,6 +172,5 @@ export const simulateAckTransferToAxelar = async utils => {
     .transmitVTransferEvent('acknowledgementPacket', -1)
     .finally(() => {
       // console.debug('ack Axelar done');
-      return;
     });
 };

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -14,14 +14,12 @@ import {
 const usdc = withAmountUtils(makeIssuerKit('USDC'));
 const { brand: USDC } = usdc;
 const bld = withAmountUtils(makeIssuerKit('BLD'));
-const { brand: BLD } = bld;
 
 test('ProposalShapes', t => {
   const { brand: Poc26 } = makeIssuerKit('Poc26');
   const shapes = makeProposalShapes(USDC, Poc26);
 
   const usdc = (value: bigint) => AmountMath.make(USDC, value);
-  const fee = (value: bigint) => AmountMath.make(BLD, value);
   const poc26 = (value: bigint) => AmountMath.make(Poc26, value);
   const cases = harden({
     openPortfolio: {

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -11,15 +11,15 @@ import {
   PortfolioStatusShapeExt,
 } from '../src/type-guards.ts';
 
-const usdc = withAmountUtils(makeIssuerKit('USDC'));
-const { brand: USDC } = usdc;
+const usdcKit = withAmountUtils(makeIssuerKit('USDC'));
+const usdc = usdcKit.make;
+const { brand: USDC } = usdcKit;
 const bld = withAmountUtils(makeIssuerKit('BLD'));
 
 test('ProposalShapes', t => {
   const { brand: Poc26 } = makeIssuerKit('Poc26');
   const shapes = makeProposalShapes(USDC, Poc26);
 
-  const usdc = (value: bigint) => AmountMath.make(USDC, value);
   const poc26 = (value: bigint) => AmountMath.make(Poc26, value);
   const cases = harden({
     openPortfolio: {
@@ -92,7 +92,7 @@ test('ProposalShapes', t => {
 
 test('offerArgs can carry fee', t => {
   const shapes = makeOfferArgsShapes(USDC);
-  const [amount, fee] = [usdc.make(200n), bld.make(100n)];
+  const [amount, fee] = [usdc(200n), bld.make(100n)];
   const specimen = harden({
     flow: [{ src: '@noble', dest: '@Arbitrum', amount, fee }],
   });
@@ -101,7 +101,7 @@ test('offerArgs can carry fee', t => {
 
 test('offerArgs can carry usdnOut', t => {
   const shapes = makeOfferArgsShapes(USDC);
-  const [amount, detail] = [usdc.make(200n), { usdnOut: 198n }];
+  const [amount, detail] = [usdc(200n), { usdnOut: 198n }];
   const specimen = harden({
     flow: [{ src: '@noble', dest: 'USDN', amount, detail }],
   });
@@ -131,7 +131,7 @@ test('PoolKeyExt shapes accept future pool keys', t => {
 
 test('numeric position references are rejected', t => {
   const shapes = makeOfferArgsShapes(USDC);
-  const amount = usdc.make(200n);
+  const amount = usdc(200n);
 
   // Numeric position references from old design should be rejected
   const specimenWithNumber = harden({

--- a/packages/portfolio-contract/test/planner.exo.test.ts
+++ b/packages/portfolio-contract/test/planner.exo.test.ts
@@ -28,7 +28,7 @@ test('planner exo submit method', async t => {
     }),
   } as ZCF;
 
-  const mockGetPortfolio = id => null as any;
+  const mockGetPortfolio = _id => null as any;
 
   const shapes = makeOfferArgsShapes(USDC);
   // Create planner exo

--- a/packages/portfolio-contract/test/planner.exo.test.ts
+++ b/packages/portfolio-contract/test/planner.exo.test.ts
@@ -1,14 +1,14 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeHeapZone } from '@agoric/zone';
-import { preparePlanner } from '../src/planner.exo.ts';
 import { makeIssuerKit } from '@agoric/ertp';
+import { prepareVowTools } from '@agoric/vow';
+import type { ZCF } from '@agoric/zoe';
 import {
   makeOfferArgsShapes,
   type MovementDesc,
 } from '../src/type-guards-steps.ts';
-import { prepareVowTools } from '@agoric/vow';
-import type { ZCF } from '@agoric/zoe';
+import { preparePlanner } from '../src/planner.exo.ts';
 
 const { brand: USDC } = makeIssuerKit('USDC');
 

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -101,7 +101,7 @@ test('open portfolio with USDN position', async t => {
   t.is(keys(result.publicSubscribers).length, 1);
   const { storagePath } = result.publicSubscribers.portfolio;
   t.log(storagePath);
-  const { contents, positionPaths, flowPaths } = getPortfolioInfo(
+  const { contents, positionPaths } = getPortfolioInfo(
     storagePath,
     common.bootstrap.storage,
   );
@@ -892,7 +892,7 @@ const getCapDataStructure = cell => {
 
 test('start deposit more to same', async t => {
   const { trader1, common } = await setupTrader(t);
-  const { usdc, bld, poc26 } = common.brands;
+  const { usdc, poc26 } = common.brands;
 
   const targetAllocation = {
     USDN: 60n,
@@ -905,16 +905,13 @@ test('start deposit more to same', async t => {
   );
 
   const amount = usdc.units(3_333.33);
-  const actualP = trader1.rebalance(
+  await trader1.rebalance(
     t,
     { give: { Deposit: amount }, want: {} },
     {
       flow: [{ src: '<Deposit>', dest: '+agoric', amount }],
     },
   );
-
-  const actual = await actualP;
-  const result = actual.result as any;
 
   const info = await trader1.getPortfolioStatus();
   t.deepEqual(

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -112,7 +112,7 @@ test('open portfolio with USDN position', async t => {
   );
   t.is(contents[positionPaths[0]].accountId, `cosmos:noble-1:cosmos1test`);
   t.is(
-    contents[storagePath].accountIdByChain['agoric'],
+    contents[storagePath].accountIdByChain.agoric,
     `cosmos:agoric-3:${portfolio0lcaOrch}`,
     'LCA',
   );
@@ -294,7 +294,7 @@ test('open portfolio with USDN, Aave positions', async t => {
   t.snapshot(done.payouts, 'refund payouts');
 
   const tree = inspectMapStore(contractBaggage);
-  delete tree['chainHub']; // 'initial baggage' test captures this
+  delete tree.chainHub; // 'initial baggage' test captures this
   // XXX portfolio exo state not included UNTIL https://github.com/Agoric/agoric-sdk/issues/10950
   t.snapshot(tree, 'baggage after open with positions');
 });
@@ -350,7 +350,7 @@ test('open portfolio with target allocations', async t => {
   t.snapshot(done.payouts, 'refund payouts');
 
   const tree = inspectMapStore(contractBaggage);
-  delete tree['chainHub']; // 'initial baggage' test captures this
+  delete tree.chainHub; // 'initial baggage' test captures this
   // XXX portfolio exo state not included UNTIL https://github.com/Agoric/agoric-sdk/issues/10950
   t.snapshot(tree, 'baggage after open with target allocations');
 });
@@ -477,7 +477,7 @@ test('USDN claim fails currently', async t => {
   );
   t.is(contents[positionPaths[0]].accountId, `cosmos:noble-1:cosmos1test`);
   t.is(
-    contents[storagePath].accountIdByChain['agoric'],
+    contents[storagePath].accountIdByChain.agoric,
     `cosmos:agoric-3:${portfolio0lcaOrch}`,
     'LCA',
   );
@@ -643,18 +643,18 @@ test('Withdraw from a Beefy position', async t => {
         {
           src: 'Beefy_re7_Avalanche',
           dest: '@Arbitrum',
-          amount: amount,
+          amount,
           fee: feeCall,
         },
         {
           src: '@Arbitrum',
           dest: '@noble',
-          amount: amount,
+          amount,
         },
         {
           src: '@noble',
           dest: '@agoric',
-          amount: amount,
+          amount,
         },
         {
           src: '@agoric',

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -722,7 +722,7 @@ test.serial(
     const { usdc, bld, poc26 } = common.brands;
 
     const amount = usdc.units(6_666.66);
-    const amount_half = usdc.units(3_333.33);
+    const amountHalf = usdc.units(3_333.33);
     const feeAcct = bld.make(100n);
     const feeCall = bld.make(100n);
 
@@ -736,13 +736,13 @@ test.serial(
           {
             src: '@noble',
             dest: '@Arbitrum',
-            amount: amount_half,
+            amount: amountHalf,
             fee: feeAcct,
           },
           {
             src: '@noble',
             dest: '@Arbitrum',
-            amount: amount_half,
+            amount: amountHalf,
             fee: feeAcct,
           },
           { src: '@Arbitrum', dest: 'Aave_Arbitrum', amount, fee: feeCall },

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -1,11 +1,11 @@
 /** @file tests for PortfolioKit exo */
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import { preparePortfolioKit } from '../src/portfolio.exo.ts';
 import { makeHeapZone } from '@agoric/zone';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { preparePortfolioKit } from '../src/portfolio.exo.ts';
 import { gmpAddresses } from './mocks.ts';
 
 const { brand: USDC } = makeIssuerKit('USDC');

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -762,7 +762,7 @@ test(
 );
 
 test('rebalance handles stepFlow failure correctly', async t => {
-  const { orch, ctx, offer, storage } = mocks(
+  const { orch, ctx, offer } = mocks(
     {
       // Mock a failure in IBC transfer
       transfer: Error('IBC transfer failed'),
@@ -848,7 +848,6 @@ test('claim rewards on Aave position', async t => {
 });
 
 test('open portfolio with Beefy position', async t => {
-  const { add } = AmountMath;
   const amount = AmountMath.make(USDC, 300n);
   const feeAcct = AmountMath.make(BLD, 50n);
   const detail = { evmGas: 50n };
@@ -909,7 +908,7 @@ test('wayFromSrcToDesc handles +agoric -> @agoric', t => {
 
 test('Engine can move deposits +agoric -> @agoric', async t => {
   const { orch, ctx, offer, storage } = mocks({}, {});
-  const { log, seat } = offer;
+  const { log } = offer;
 
   const amount = AmountMath.make(USDC, 300n);
   const kit = await ctx.makePortfolioKit();
@@ -937,7 +936,7 @@ test('Engine can move deposits +agoric -> @agoric', async t => {
 
 test('client can move to deposit LCA', async t => {
   const { orch, ctx, offer, storage } = mocks({}, {});
-  const { log, seat } = offer;
+  const { log } = offer;
 
   const amount = AmountMath.make(USDC, 300n);
   const kit = await ctx.makePortfolioKit();

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -963,7 +963,7 @@ test('receiveUpcall returns false if sender is not AXELAR_GMP', async t => {
 
   // The portfolio flow will hang waiting for valid GMP, so we don't await it
   // This is expected behavior - the test just needs to verify receiveUpcall validation
-  openPortfolio(orch, { ...ctx }, offer.seat, {
+  void openPortfolio(orch, { ...ctx }, offer.seat, {
     flow: steps,
   });
 

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -211,7 +211,7 @@ const mocks = (
                   denomOrTrace = `${packet.destination_port}/${packet.destination_channel}/${transferDenom}`;
                 }
 
-                const localDenom = denomOrTrace.match(/^([^/]+)(\/[^\/]+)?$/)
+                const localDenom = denomOrTrace.match(/^([^/]+)(\/[^/]+)?$/)
                   ? denomOrTrace
                   : `ibc/${denomHash(denomOrTrace.match(/^(?<path>[^/]+\/[^/]+)\/(?<denom>.*)$/)?.groups)}`;
 

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -39,6 +39,7 @@ import buildZoeManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeHeapZone } from '@agoric/zone';
 import { Far, passStyleOf } from '@endo/pass-style';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
 import {
   preparePortfolioKit,
   type PortfolioKit,
@@ -74,7 +75,6 @@ import {
   makeIncomingEVMEvent,
   makeIncomingVTransferEvent,
 } from './supports.ts';
-import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
 
 // Use an EVM chain whose axelar ID differs from its chain name
 const { sourceChain } = evmNamingDistinction;

--- a/packages/portfolio-contract/test/rebalance-grok.test.ts
+++ b/packages/portfolio-contract/test/rebalance-grok.test.ts
@@ -106,7 +106,7 @@ test('withBrand adds fees for Compound', async t => {
   assert('flow' in offerArgs);
 
   const step =
-    offerArgs?.flow?.find(step => step.dest.startsWith('Compound')) ||
+    offerArgs?.flow?.find(({ dest }) => dest.startsWith('Compound')) ||
     assert.fail();
   t.truthy(step.fee);
 });

--- a/packages/portfolio-contract/test/resolver-helpers.ts
+++ b/packages/portfolio-contract/test/resolver-helpers.ts
@@ -13,7 +13,7 @@ import type { TxStatus } from '../src/resolver/constants.js';
  *
  * @param zoe - Zoe service instance
  * @param creatorFacet - The creator facet that has makeResolverInvitation
- * @returns Promise<ResolverInvitationMakers>
+ * @returns {Promise<ResolverInvitationMakers>}
  */
 export const getResolverMakers = async (
   zoe: ZoeService,
@@ -33,8 +33,8 @@ export const getResolverMakers = async (
  *
  * @param zoe - Zoe service instance
  * @param resolverMakers - ResolverInvitationMakers instance
- * @param status - Transaction status
  * @param txNumber - Transaction number for txId
+ * @param status - Transaction status
  * @param log - Optional logging function (defaults to console.log, pass () => {} to disable)
  */
 export const settleTransaction = async (

--- a/packages/portfolio-contract/test/resolver.exo.test.ts
+++ b/packages/portfolio-contract/test/resolver.exo.test.ts
@@ -8,10 +8,10 @@ import { prepareVowTools } from '@agoric/vow/vat.js';
 import type { ZCF } from '@agoric/zoe';
 import { makeHeapZone } from '@agoric/zone';
 import type { TestFn } from 'ava';
+import { defaultMarshaller } from '@agoric/internal/src/storage-test-utils.js';
 import { TxStatus, TxType } from '../src/resolver/constants.js';
 import { prepareResolverKit } from '../src/resolver/resolver.exo.ts';
 import type { PublishedTx } from '../src/resolver/types.ts';
-import { defaultMarshaller } from '@agoric/internal/src/storage-test-utils.js';
 
 const test = anyTest as TestFn<{
   nodeUpdates: Record<string, PublishedTx>;

--- a/packages/portfolio-contract/test/resolver.exo.test.ts
+++ b/packages/portfolio-contract/test/resolver.exo.test.ts
@@ -104,7 +104,7 @@ test('resolver updates nodes in chain storage on settleTransaction', async t => 
     marshaller,
   });
 
-  const { client, service, reporter } = makeResolverKit();
+  const { client, service } = makeResolverKit();
 
   // Register transaction
   const tx = client.registerTransaction(
@@ -149,7 +149,7 @@ test('resolver updates nodes in chain storage on settleTransaction', async t => 
 });
 
 test('resolver creates ids in sequence on registerTransaction', async t => {
-  const { nodeUpdates, makeMockNode } = t.context;
+  const { makeMockNode } = t.context;
 
   const zone = makeHeapZone();
   const board = makeFakeBoard();

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -79,7 +79,7 @@ export const makeIncomingVTransferEvent = ({
     amount,
     denom,
     sender,
-    target: target,
+    target,
     receiver,
     sourceChannel,
     destinationChannel,

--- a/packages/portfolio-contract/test/ymax-scenario.test.ts
+++ b/packages/portfolio-contract/test/ymax-scenario.test.ts
@@ -124,7 +124,7 @@ const rebalanceScenarioMacro = test.macro({
       ? openPortfolioAndAck(sceneB.proposal.give, sceneB.offerArgs)
       : openPortfolioAndAck(sceneBP!.proposal.give, sceneBP!.offerArgs));
 
-    const { result, payouts } = await (async () => {
+    const { payouts } = await (async () => {
       if (openOnly) return openResult;
 
       const rebalanceP = trader1.rebalance(

--- a/packages/portfolio-contract/tools/agents-mock.ts
+++ b/packages/portfolio-contract/tools/agents-mock.ts
@@ -7,7 +7,7 @@ import type { MovementDesc } from '../src/type-guards-steps.js';
 export const plannerClientMock = (
   wallet: SmartWallet,
   instance: Instance<typeof startYMax>,
-  readAt: VStorage['readAt'],
+  _readAt: VStorage['readAt'],
 ) => {
   const offersP = E(wallet).getOffersFacet();
   const redeem = async () => {

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -88,7 +88,7 @@ export const makePortfolioQuery = (
  * @param wallet - WalletTool for executing offers (analogous to wallet connection in web UIs)
  * @param instance - Portfolio contract instance (obtained via chainStorageWatcher in web UIs)
  * @param readPublished - Function to read vstorage data (analogous to chainStorageWatcher)
- * @returns Trader object with methods for portfolio operations
+ * returns Trader object with methods for portfolio operations
  *
  * @example
  * // In a web client, similar patterns would use:

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -353,11 +353,12 @@ export const planTransfer = (
   const steps: MovementDesc[] = [];
 
   switch (p) {
-    case 'USDN':
+    case 'USDN': {
       const detail = { usdnOut: ((amount.value || 0n) * 99n) / 100n };
       console.warn('TODO: client should query exchange rate');
       steps.push({ src: '@noble', dest: 'USDNVault', amount, detail });
       break;
+    }
     case 'Aave':
     case 'Compound':
       // XXX optimize: combine noble->evm steps

--- a/packages/portfolio-contract/tools/rebalance-grok.ts
+++ b/packages/portfolio-contract/tools/rebalance-grok.ts
@@ -172,11 +172,13 @@ export const grokRebalanceScenarios = (data: Array<string[]>) => {
         assert(amount && amount.startsWith('$'), `bad amount in row ${rownum}`);
 
         flow.push({ src, dest, amount });
+        break;
       }
       case 'After':
         // console.debug('After row', row);
         currentScenario.after = parseProtocolAmounts(row);
         currentScenario.positionsNet = T2B as Dollars;
+        break;
       case 'Payouts':
         currentScenario.payouts = {
           ...parseCell('Deposit', Deposit),
@@ -184,12 +186,15 @@ export const grokRebalanceScenarios = (data: Array<string[]>) => {
         };
         currentScenario.offerNet = T2B as Dollars;
         currentScenario.operationNet = T2C as Dollars;
-      // console.debug(
-      //   'Payouts row',
-      //   row,
-      //   currentScenario.description,
-      //   currentScenario.payouts,
-      // );
+        // console.debug(
+        //   'Payouts row',
+        //   row,
+        //   currentScenario.description,
+        //   currentScenario.payouts,
+        // );
+        break;
+      default:
+      // pass
     }
   }
 

--- a/packages/portfolio-contract/tools/rebalance-grok.ts
+++ b/packages/portfolio-contract/tools/rebalance-grok.ts
@@ -26,14 +26,16 @@ export const importCSV = (specifier: string, base: string) =>
 export type Dollars = `$${string}` | `-$${string}`;
 export const numeral = (amt: Dollars) => amt.replace(/[$,]/g, '');
 
+type Empty = Record<never, never>;
+
 export type RebalanceScenario = {
   description: string;
   before: Partial<Record<YieldProtocol, Dollars>>;
   previous: string;
   proposal:
-    | { give: {}; want: {} }
-    | { give: { Deposit: Dollars }; want: {} }
-    | { want: { Cash: Dollars }; give: {} };
+    | { give: Empty; want: Empty }
+    | { give: { Deposit: Dollars }; want: Empty }
+    | { want: { Cash: Dollars }; give: Empty };
   offerArgs?: { flow: (Omit<MovementDesc, 'amount'> & { amount: Dollars })[] };
   after: Partial<Record<YieldProtocol, Dollars>>;
   payouts: { Deposit?: Dollars; Cash?: Dollars };

--- a/packages/portfolio-contract/tools/rebalance-grok.ts
+++ b/packages/portfolio-contract/tools/rebalance-grok.ts
@@ -113,8 +113,8 @@ export const grokRebalanceScenarios = (data: Array<string[]>) => {
       continue;
     }
 
-    const [label, aave, compound, usdn] = [row[0], ...row.slice(6)];
-    const [_l, Deposit, Cash, agoricLCA, nobleICA, acctEVM] = row;
+    const [label, aave, compound, _usdn] = [row[0], ...row.slice(6)];
+    const [_l, Deposit, Cash, _agoricLCA, _nobleICA, _acctEVM] = row;
     const [T2A, T2B, T2C] = row.slice(emptyHdCol);
 
     // Skip header row
@@ -148,7 +148,7 @@ export const grokRebalanceScenarios = (data: Array<string[]>) => {
           if (pDef.match(/^LCA/)) return `@agoric`;
           if (pDef.match(/^ICA/)) return `@noble`;
           if (pDef.match(/^GMP/)) return `@Arbitrum`;
-          const { entries, keys } = Object;
+          const { entries } = Object;
           const [poolKey] =
             entries(PoolPlaces).find(
               ([_k, p]) =>
@@ -168,7 +168,6 @@ export const grokRebalanceScenarios = (data: Array<string[]>) => {
         const src = asPlaceRef(hd[srcCol]) as AssetPlaceRef;
         const dest = asPlaceRef(hd[destCol]);
 
-        const { give = {} } = currentScenario.proposal || {};
         const amount = T2B as Dollars;
         assert(amount && amount.startsWith('$'), `bad amount in row ${rownum}`);
 

--- a/packages/portfolio-contract/tools/rebalance-grok.ts
+++ b/packages/portfolio-contract/tools/rebalance-grok.ts
@@ -49,7 +49,7 @@ const parseCSVRow = (row: string): string[] => {
   let current = '';
   let inQuotes = false;
 
-  for (let i = 0; i < row.length; i++) {
+  for (let i = 0; i < row.length; i += 1) {
     const char = row[i];
 
     if (char === '"') {

--- a/packages/portfolio-contract/tools/wallet-offer-tools.ts
+++ b/packages/portfolio-contract/tools/wallet-offer-tools.ts
@@ -121,7 +121,7 @@ export const makeWallet = (
         providePurse,
       );
       const refund: AmountKeywordRecord = await deeplyFulfilledObject(
-        objectMap(payouts, async pmt => wallet.deposit(await pmt)),
+        objectMap(payouts, async pmt => E.when(pmt, wallet.deposit)),
       );
 
       if (typeof result === 'object' && 'invitationMakers' in result) {
@@ -155,7 +155,7 @@ export const makeWallet = (
       const result = await when(E(seat).getOfferResult());
       const payouts = await E(seat).getPayouts();
       const refund: AmountKeywordRecord = await deeplyFulfilledObject(
-        objectMap(payouts, async pmt => wallet.deposit(await pmt)),
+        objectMap(payouts, async pmt => E.when(pmt, wallet.deposit)),
       );
       return harden({ result, payouts: refund });
     },

--- a/packages/portfolio-contract/tools/wallet-offer-tools.ts
+++ b/packages/portfolio-contract/tools/wallet-offer-tools.ts
@@ -16,7 +16,6 @@ import type {
 import type { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { Fail } from '@endo/errors';
 import { E } from '@endo/far';
-import type { CopyRecord } from '@endo/pass-style';
 
 const { keys } = Object;
 

--- a/packages/portfolio-contract/tsconfig.json
+++ b/packages/portfolio-contract/tsconfig.json
@@ -6,8 +6,5 @@
     "test",
     "testing",
     "tools"
-  ],
-  "exclude": [
-    "src/vendor/viem/viem-abi.bundle.js",
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,6 +189,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aglocal/portfolio-contract@workspace:packages/portfolio-contract"
   dependencies:
+    "@aglocal/boot": "workspace:*"
+    "@agoric/async-flow": "workspace:*"
     "@agoric/client-utils": "workspace:*"
     "@agoric/cosmic-proto": "workspace:*"
     "@agoric/ertp": "workspace:*"
@@ -196,16 +198,19 @@ __metadata:
     "@agoric/internal": "workspace:*"
     "@agoric/orchestration": "workspace:*"
     "@agoric/portfolio-api": "workspace:*"
+    "@agoric/smart-wallet": "workspace:*"
     "@agoric/swingset-liveslots": "workspace:*"
     "@agoric/time": "workspace:*"
     "@agoric/vats": "workspace:*"
     "@agoric/vow": "workspace:*"
     "@agoric/zoe": "workspace:*"
     "@agoric/zone": "workspace:*"
+    "@cosmjs/encoding": "npm:^0.36.0"
     "@endo/base64": "npm:^1.0.12"
     "@endo/errors": "npm:^1.2.13"
     "@endo/far": "npm:^1.1.14"
     "@endo/init": "npm:^1.1.12"
+    "@endo/marshal": "npm:^1.8.0"
     "@endo/nat": "npm:^5.1.3"
     "@endo/pass-style": "npm:^1.6.3"
     "@endo/patterns": "npm:^1.7.0"
@@ -214,6 +219,7 @@ __metadata:
     ava: "npm:^5.3.0"
     c8: "npm:^10.1.3"
     ts-blank-space: "npm:^0.6.2"
+    viem: "npm:^2.31.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

A stray `eslint.config.js` file was masking the normal shop rules. This cleans up the problems uncovered when moving it out of the way.

### Security / Documentation / Testing Considerations

none, by design. but careful review is requested. Toward that end, commits that should have no possible runtime impact are marked `style`. Things like missing `break` statements are in `chore:` commits; I think that was only in a test tool. Adding `await null` can have runtime impact.

Some type refinements were necessary; fortunately they don't seem to have knock-on effects.

### Scaling / Upgrade Considerations

n/a