### PR TITLE
chore(portfolio-contract): use cache to avoid calls to board

### DIFF
--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -8,11 +8,11 @@ import * as cb from './callback.js';
 
 /**
  * @import {ERef} from '@endo/far';
- * @import {PassableCap} from '@endo/marshal';
+ * @import {PassableCap, Marshal} from '@endo/marshal';
  * @import {TypedPattern} from './types.js';
  */
 
-/** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
+/** @typedef {Marshal<unknown>} Marshaller */
 /** @typedef {Pick<Marshaller, 'fromCapData'>} Unserializer */
 
 /**

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -64,6 +64,19 @@ export const boardSlottingMarshaller = (slotToVal = undefined) => {
   );
 };
 
+const ifaceAllegedPrefix = 'Alleged: ';
+const ifaceInaccessiblePrefix = 'SEVERED: ';
+/**
+ * @param {string | undefined} iface
+ * @returns {any}
+ */
+export const makeInaccessibleVal = iface => {
+  if (typeof iface === 'string' && iface.startsWith(ifaceAllegedPrefix)) {
+    iface = iface.slice(ifaceAllegedPrefix.length);
+  }
+  return Far(`${ifaceInaccessiblePrefix}${iface}`, {});
+};
+
 // TODO move CapDataShape to Endo
 /**
  * @type {TypedPattern<CapData<any>>}

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -20,7 +20,7 @@ const trace = makeTracer('StorTU', false);
  * A convertSlotToVal function that produces basic Remotables. Assumes that all
  * slots are Remotables (i.e. none are Promises).
  *
- * @param {string} _slotId
+ * @param {string | null} _slotId
  * @param {string} iface
  */
 export const slotToRemotable = (_slotId, iface = 'Remotable') =>

--- a/packages/internal/test/marshal.test.js
+++ b/packages/internal/test/marshal.test.js
@@ -1,0 +1,171 @@
+// @ts-check
+import test from 'ava';
+
+import { Far, makeMarshal, passStyleOf } from '@endo/marshal';
+import { Fail } from '@endo/errors';
+import { wrapRemoteMarshaller, makeInaccessibleVal } from '../src/marshal.js';
+
+/**
+ * @import {Marshal} from '@endo/marshal';
+ * @import {Farable} from '@endo/exo';
+ */
+
+/**
+ * @param {object} [options]
+ * @param {Map<string, object>} [options.slotToVal]
+ * @param {WeakMap<object, string>} [options.valToSlot]
+ * @param {(val: any, direction: 'from' | 'to') => void} [options.valueHook]
+ * @param {boolean} [options.readOnly]
+ * @returns {Farable<
+ *   Pick<Marshal<string | null>, 'fromCapData' | 'toCapData'>
+ * >}
+ */
+const makeMockMarshaller = ({
+  slotToVal = new Map(),
+  valToSlot = new WeakMap(),
+  valueHook,
+  readOnly = false,
+} = {}) => {
+  let nextId = 1;
+  const marshaller = makeMarshal(
+    val => {
+      if (!valToSlot.has(val) && !readOnly) {
+        const nextSlot = `mock${nextId}`;
+        nextId += 1;
+        valToSlot.set(val, nextSlot);
+        slotToVal.set(nextSlot, val);
+      }
+      return valToSlot.get(val) || null;
+    },
+    (slot, iface) => {
+      if (slot === null) {
+        return makeInaccessibleVal(iface);
+      }
+      return slotToVal.get(slot) || Fail`Unknown mock slot ${slot}`;
+    },
+    {
+      serializeBodyFormat: 'smallcaps',
+    },
+  );
+
+  return Far('mock marshaller', {
+    toCapData(val) {
+      valueHook?.(val, 'to');
+      return marshaller.toCapData(val);
+    },
+    fromCapData(data) {
+      const val = marshaller.fromCapData(data);
+      valueHook?.(val, 'from');
+      return val;
+    },
+  });
+};
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {any} val
+ */
+const checkRemoteMarshallerValueInvariants = (t, val) => {
+  t.true(Array.isArray(val));
+  t.true(val.length > 0);
+  let hasCap = false;
+  for (const elem of val) {
+    const passStyle = passStyleOf(elem);
+    if (passStyle !== 'null') {
+      t.is(passStyle, 'remotable');
+      hasCap = true;
+    }
+  }
+  t.true(hasCap);
+};
+
+const unexpectedMarshallerInvocation = (t, val) => {
+  t.log('Unexpected marshalled value', val);
+  t.fail('Remote marshaller should not have been invoked');
+};
+
+test('wrapRemoteMarshaller - empty slots', async t => {
+  const marshaller = makeMockMarshaller({
+    valueHook: val => {
+      unexpectedMarshallerInvocation(t, val);
+    },
+  });
+
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  const specimen = harden({ foo: 42, err: Error('bar') });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, specimen);
+});
+
+test('wrapRemoteMarshaller - with slots', async t => {
+  const marshaller = makeMockMarshaller({
+    valueHook: val => {
+      checkRemoteMarshallerValueInvariants(t, val);
+    },
+  });
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  const specimen = harden({ foo: 42, bar: Far('bar', { sentinel() {} }) });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, specimen);
+});
+
+test('wrapRemoteMarshaller - read-only marshaller', async t => {
+  const marshaller = makeMockMarshaller({
+    valueHook: (val, direction) => {
+      if (direction === 'from') {
+        unexpectedMarshallerInvocation(t, val);
+      } else {
+        checkRemoteMarshallerValueInvariants(t, val);
+      }
+    },
+    readOnly: true,
+  });
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  const specimen = harden({ foo: 42, bar: Far('bar', { sentinel() {} }) });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
+});
+
+test('wrapRemoteMarshaller - null and non-null slots', async t => {
+  const sharedCap = Far('shared', { sentinel() {} });
+
+  const slotToVal = new Map();
+  const valToSlot = new WeakMap();
+
+  const writeMarshaller = makeMockMarshaller({ slotToVal, valToSlot });
+  const marshaller = makeMockMarshaller({
+    slotToVal,
+    valToSlot,
+    valueHook: val => {
+      checkRemoteMarshallerValueInvariants(t, val);
+    },
+    readOnly: true,
+  });
+
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  writeMarshaller.toCapData(sharedCap);
+
+  const specimen = harden({
+    foo: 42,
+    bar: Far('bar', { sentinel() {} }),
+    shared: sharedCap,
+  });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
+});

--- a/packages/internal/test/marshal.test.js
+++ b/packages/internal/test/marshal.test.js
@@ -1,9 +1,10 @@
 // @ts-check
 import test from 'ava';
 
-import { Far, makeMarshal, passStyleOf } from '@endo/marshal';
 import { Fail } from '@endo/errors';
-import { wrapRemoteMarshaller, makeInaccessibleVal } from '../src/marshal.js';
+import { E } from '@endo/far';
+import { Far, makeMarshal, passStyleOf } from '@endo/marshal';
+import { makeInaccessibleVal, wrapRemoteMarshaller } from '../src/marshal.js';
 
 /**
  * @import {Marshal} from '@endo/marshal';
@@ -168,4 +169,16 @@ test('wrapRemoteMarshaller - null and non-null slots', async t => {
   const clone = await wrappedMarshaller.fromCapData(capData);
 
   t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
+});
+
+test('wrapRemoteMarshaller preserves identity in fromCapData', async t => {
+  const src = makeMockMarshaller();
+  const wrappedMarshaller = wrapRemoteMarshaller(src);
+
+  const specimen = Far('BLD Brand');
+  const capData = await E(src).toCapData(specimen);
+
+  const presence1 = await wrappedMarshaller.fromCapData(capData);
+  const presence2 = await wrappedMarshaller.fromCapData(capData);
+  t.is(presence1, presence2);
 });

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -3,11 +3,8 @@
  */
 import type { AgoricResponse } from '@aglocal/boot/tools/axelar-supports.js';
 import { AmountMath, type Brand } from '@agoric/ertp';
-import { makeTracer, mustMatch } from '@agoric/internal';
-import type {
-  Marshaller,
-  StorageNode,
-} from '@agoric/internal/src/lib-chainStorage.js';
+import { makeTracer, mustMatch, type Remote } from '@agoric/internal';
+import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
 import {
   type AccountId,
   type CaipChainId,
@@ -31,6 +28,7 @@ import { decodeBase64 } from '@endo/base64';
 import { Fail, X } from '@endo/errors';
 import type { ERef } from '@endo/far';
 import { E } from '@endo/far';
+import type { Marshal } from '@endo/marshal';
 import { M } from '@endo/patterns';
 import type { AxelarId, GmpAddresses } from './portfolio.contract.js';
 import type { LocalAccount, NobleAccount } from './portfolio.flows.js';
@@ -178,7 +176,7 @@ export const preparePortfolioKit = (
     vowTools: VowTools;
     zcf: ZCF;
     portfoliosNode: ERef<StorageNode>;
-    marshaller: Marshaller;
+    marshaller: Remote<Marshal<string | null>>;
     usdcBrand: Brand<'nat'>;
   },
 ) => {

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -10,10 +10,13 @@ import {
   defineRecorderKit,
   prepareRecorder,
 } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { E, Far } from '@endo/far';
+import { E } from '@endo/far';
 import { isRemotable, makeMarshal } from '@endo/marshal';
 
-import { CapDataShape } from '@agoric/internal/src/marshal.js';
+import {
+  CapDataShape,
+  makeInaccessibleVal,
+} from '@agoric/internal/src/marshal.js';
 import { crc6 } from './crc.js';
 
 /**
@@ -181,9 +184,6 @@ const getValue = (id, { prefix, crcDigits, idToVal }) => {
 
 /** @param {BoardState} state */
 const makeSlotToVal = state => {
-  const ifaceAllegedPrefix = 'Alleged: ';
-  const ifaceInaccessiblePrefix = 'SEVERED: ';
-
   /**
    * @param {BoardId} slot
    * @param {string} iface
@@ -195,10 +195,7 @@ const makeSlotToVal = state => {
     }
 
     // Private object.
-    if (typeof iface === 'string' && iface.startsWith(ifaceAllegedPrefix)) {
-      iface = iface.slice(ifaceAllegedPrefix.length);
-    }
-    return Far(`${ifaceInaccessiblePrefix}${iface}`, {});
+    return makeInaccessibleVal(iface);
   };
   return slotToVal;
 };


### PR DESCRIPTION
closes: #11692

## Description

 - feat(internal): wrapRemoteMarshaller
 - use it in the ymax contract

There's some type friction; I used `@ts-expect-error`.

### Security Considerations

unremarkable

### Scaling Considerations

Should reduce round trips to board vat from O(vstorage-writes) to O(1), since we only need to look up a handful of things such as the USDC brand.

### Documentation Considerations

invisible, externally

### Testing Considerations

`wrapRemoteMarshaller` comes with unit tests

### Upgrade Considerations

inconsequential for ymax

Note: this has a refactor in the board vat that we don't intend to deploy.