### PR TITLE
fix: allow unhardened arg to sendBridgeAction

### DIFF
--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -65,6 +65,11 @@ export const makeSigningSmartWalletKit = async (
     memo: string = '',
     signerData?: SignerData,
   ): Promise<DeliverTxResponse> => {
+    // The caller should do this but it's more ergonomic to allow an object
+    // literal, and in that case this hardening does not create an external
+    // side-effect.
+    harden(action);
+
     const msgSpend = MsgWalletSpendAction.fromPartial({
       owner: toAccAddress(address),
       spendAction: JSON.stringify(swk.marshaller.toCapData(action)),

--- a/packages/client-utils/test/signing-smart-wallet-kit.test.ts
+++ b/packages/client-utils/test/signing-smart-wallet-kit.test.ts
@@ -76,9 +76,10 @@ test('sendBridgeAction handles simple action', async t => {
     mnemonic,
   );
 
-  const actual = await signing.sendBridgeAction(
-    harden({ method: 'tryExitOffer', offerId: 'bid-1' }),
-  );
+  const actual = await signing.sendBridgeAction({
+    method: 'tryExitOffer',
+    offerId: 'bid-1',
+  });
   t.deepEqual(actual, { code: 42 });
   t.is(calls.length, 1);
   t.like(calls[0], {
@@ -117,7 +118,7 @@ test('sendBridgeAction supports fee param', async t => {
     amount: [{ denom: 'ubld', amount: '123' }],
   };
   const actual = await signing.sendBridgeAction(
-    harden({ method: 'tryExitOffer', offerId: 'bid-1' }),
+    { method: 'tryExitOffer', offerId: 'bid-1' },
     moar,
   );
   t.deepEqual(actual, { code: 42 });
@@ -147,7 +148,7 @@ test('sendBridgeAction uses explicit signing when signerData provided', async t 
   };
 
   const actual = await signing.sendBridgeAction(
-    harden({ method: 'tryExitOffer', offerId: 'bid-1' }),
+    { method: 'tryExitOffer', offerId: 'bid-1' },
     undefined, // use default fee
     'test memo',
     signerData,


### PR DESCRIPTION
_incidental_

## Description
ymax-planner hit an error,
```
Error in main: (Error#2)
Error#2: Cannot pass non-frozen objects like {
  method: 'invokeEntry',
  message: {
    targetName: 'planner',
    method: 'submit',
    args: [ 0, [Array], 1, 0 ]
  }
} . Use harden()
  at Object.sendBridgeAction (packages/client-utils/dist/signing-smart-wallet-kit.js:32:56)
  at startEngine (file:///Users/luqi/github/Agoric/agoric-sdk/services/ymax-planner/src/engine.ts:675:50)
  at async main (file:///Users/luqi/github/Agoric/agoric-sdk/services/ymax-planner/src/main.ts:99:3)
```

I thought it was caused by https://github.com/Agoric/agoric-sdk/pull/11986 but that `toCapData` call in `sendBridgeAction` wasn't changed. The function always required a hardened `action` param.

However I think that's unnecessary and worse ergonomically. The argument is almost always a literal, so the `harden()` is just clutter. This makes the function harden the arg itself. It could copy the arg to a new hardened one to pass to `toCapData` but I think it's reasonable to expect that the caller is okay with the hardening, and in most cases it won't matter at all because it's a literal.

### Security Considerations
If the caller doesn't trust `sendBridgeAction` they can opt into hardening before the call.

### Scaling Considerations
n/a

### Documentation Considerations
none

### Testing Considerations
updated tests

### Upgrade Considerations
none
