### PR TITLE
fix(ymax-planner): Ignore policy rebalanceCount increments

### DIFF
--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -50,7 +50,6 @@ import type { NameHub } from '@agoric/vats';
 import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils';
 import { SigningStargateClient } from '@cosmjs/stargate';
 import { M } from '@endo/patterns';
-import fsp from 'node:fs/promises';
 import { parseArgs } from 'node:util';
 import {
   reflectWalletStore,
@@ -377,7 +376,6 @@ const main = async (
     now = Date.now,
     stdin = process.stdin,
     stdout = process.stdout,
-    readFile = fsp.readFile,
   } = {},
 ) => {
   const { values } = parseToolArgs(argv);

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -171,11 +171,12 @@ const processPortfolioEvents = async (
       const { depositAddress } = status;
       if (!depositAddress) return;
       setPortfolioKeyForDepositAddr(depositAddress, portfolioKey);
-      // TODO: Detect and address unhandled `status.policyVersion`.
-      // https://github.com/Agoric/agoric-sdk/issues/11805
-      // https://github.com/Agoric/agoric-sdk/pull/11917
-      const needsAction = true;
-      if (needsAction) {
+      // If rebalanceCount is 0, then no plan has been submitted for this
+      // policyVersion so we synthesize an activity record for its deposit
+      // address to trigger a rebalance.
+      // Otherwise, we assume that the update was a response to such a
+      // submission and take no further action here.
+      if (status.rebalanceCount === 0) {
         deferrals.push({
           blockHeight: eventRecord.blockHeight,
           type: 'transfer' as const,


### PR DESCRIPTION
Ref #11805
Ref #11973

## Description
The planner was responding to `rebalanceCount` increments by submitting new plans, causing a high-cardinality loop that would only terminate when the deposit address was finally drained.
This prevents such loops by triggering such submissions only when `rebalanceCount` is 0, corresponding with a `policyVersion` increment.

### Testing Considerations
We still lack a framework for properly testing the planner against these vstorage scenarios. But it's Coming Soon™.

### Upgrade Considerations
Safe to deploy immediately.