### PR TITLE
Make deposit/withdraw helpers use NatValue for target allocations

### DIFF
--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -9,7 +9,7 @@ import { makePortfolioQuery } from '@aglocal/portfolio-contract/tools/portfolio-
 import type { VstorageKit } from '@agoric/client-utils';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import type { Brand, NatAmount, NatValue } from '@agoric/ertp/src/types.js';
-import { Fail, q, X } from '@endo/errors';
+import { Fail, q } from '@endo/errors';
 // import { TEST_NETWORK } from '@aglocal/portfolio-contract/test/network/test-network.js';
 import type {
   AssetPlaceRef,
@@ -123,9 +123,9 @@ const computeWeightedTargets = (
     AmountMath.makeEmpty(brand),
   );
   const total = totalCurrentAmt.value + delta;
-  assert(total >= 0n, X`total after delta must not be negative`);
+  total >= 0n || Fail`total after delta must not be negative`;
   const weights = Object.entries(allocation) as Array<[PoolKey, NatValue]>;
-  assert(weights.length > 0, X`empty allocation`);
+  weights.length > 0 || Fail`empty allocation`;
   for (const entry of weights) {
     const w = entry[1];
     (typeof w === 'bigint' && w > 0n) ||


### PR DESCRIPTION
## Description
This pull request refactors the allocation handling logic in `plan-deposit.ts` to use a more precise and type-safe approach for representing allocation weights. Specifically, it replaces the use of generic `Record<PoolKey, number>` with a stricter `TargetAllocation` type that uses `NatValue` (bigint) for allocation weights. This change ensures that allocation weights are always non-negative integers, improving type safety and reducing potential runtime errors.

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
N/A

### Upgrade Considerations
N/A