### PR TITLE
chore: increase resolver timeout and document CCTP_TO_NOBLE denom

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -231,7 +231,6 @@ const processPortfolioEvents = async (
   }
 };
 
-// TODO: replace it with processInitialPendingTransactions
 export const processPendingTxEvents = async (
   events: Array<{ path: string; value: string }>,
   handlePendingTxFn,

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -193,13 +193,13 @@ export type HandlePendingTxOpts = {
   timeoutMs?: number;
 } & EvmContext;
 
-export const TX_TIMEOUT_MS = 20 * 60 * 1000; // 20 min
+export const TX_TIMEOUT_MS = 30 * 60 * 1000; // 30 min
 export const handlePendingTx = async (
   tx: PendingTx,
   {
     log = () => {},
     registry = createMonitorRegistry(),
-    timeoutMs = TX_TIMEOUT_MS, // 10 min
+    timeoutMs = TX_TIMEOUT_MS,
     ...evmCtx
   }: HandlePendingTxOpts,
   txTimestampMs?: number,

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -150,7 +150,17 @@ const nobleWithdrawMonitor: PendingTxMonitor<NobleWithdrawTx, EvmContext> = {
     const { accountAddress } = parseAccountId(destinationAddress);
 
     const nobleAddress = accountAddress as Bech32Address;
-    const expectedDenom = 'uusdc'; // TODO: find the exact denom while e2e testing
+
+    /**
+     * - depositForBurn initiated from Ethereum:
+     *   https://sepolia.etherscan.io/tx/0x68c2c427e43e089db94ae105c30645e5fe00bf6124fcac9eab9df9f8a8f7fb83
+     *
+     * - Corresponding message received on Noble:
+     *   https://www.mintscan.io/noble-testnet/tx/6D165B5B8F1BF6004AA9A61FE00CC8B841C09120BDB433A11063C2A7F71C7028?height=39572351
+     *
+     * This confirms the expected denom is `uusdc`.
+     */
+    const expectedDenom = 'uusdc';
 
     log(
       `${logPrefix} Watching Noble withdrawal to ${nobleAddress} for ${amount} ${expectedDenom}`,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
- Increases resolver timeout period for a pending tx to be 30 minutes.
- Document the denom for `CCTP_TO_NOBLE` transaction.
