### PR TITLE
ci(Mergify): don't label on queuing

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,6 +41,7 @@ shared:
 
 merge_queue:
   max_parallel_checks: 1
+  queued_label: null
 
 priority_rules:
   - name: high_priority

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,13 +27,13 @@ shared:
     - base=master
     - label=automerge:no-update
     - or:
-        - "#commits-behind=0"
+        - '#commits-behind=0'
         - label=bypass:linear-history
   pr_queue_rebase_conditions: &pr-queue-rebase-conditions
     - base=master
     - label=automerge:rebase
     - or:
-        - "#commits-behind>0"
+        - '#commits-behind>0'
         - linear-history
   pr_queue_squash_conditions: &pr-queue-squash-conditions
     - base=master
@@ -90,7 +90,7 @@ pull_request_rules:
     conditions:
       - base=master
       - label=automerge:rebase
-      - "#commits-behind=0"
+      - '#commits-behind=0'
       - or:
           - -linear-history
           - check-failure=no-fixup-commits

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,13 +27,13 @@ shared:
     - base=master
     - label=automerge:no-update
     - or:
-        - '#commits-behind=0'
+        - "#commits-behind=0"
         - label=bypass:linear-history
   pr_queue_rebase_conditions: &pr-queue-rebase-conditions
     - base=master
     - label=automerge:rebase
     - or:
-        - '#commits-behind>0'
+        - "#commits-behind>0"
         - linear-history
   pr_queue_squash_conditions: &pr-queue-squash-conditions
     - base=master
@@ -90,7 +90,7 @@ pull_request_rules:
     conditions:
       - base=master
       - label=automerge:rebase
-      - '#commits-behind=0'
+      - "#commits-behind=0"
       - or:
           - -linear-history
           - check-failure=no-fixup-commits


### PR DESCRIPTION
Disable the new `queued_label` as that negatively interacts with our "merge-strategy" check. When mergify embarks a PR, it would label the PR, which would temporarily invalidate the conditions that got the PR embarked in the first place, causing a race on whether the check finishes first, or whether mergify checks the conditions again first.

~Apparently the mergify editior changed the line ending...~