### PR TITLE
feat(ymax-planner): Replace tx-based deposit response with flow-based deposit/withdraw submission

### DIFF
--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -262,7 +262,10 @@ export const planWithdrawFromAllocations = async (
   return flowDetail.steps;
 };
 
-// Back-compat utility used by CLI or handlers
+/**
+ * Back-compat utility used by CLI or handlers
+ * @deprecated in favor of planDepositToAllocations
+ */
 export const handleDeposit = async (
   portfolioKey: `${string}.portfolios.portfolio${number}`,
   amount: NatAmount,


### PR DESCRIPTION
Ref #12016

## Description
Drive everything from `flowsRunning`, ignoring cosmos-level transaction activity.

### Security Considerations
None known.

### Scaling Considerations
Dramatically reduces the stream of RPC data consumed by ymax-planner and slightly reduces its outbound requests (no more `cosmosRest.getAccountBalances('agoric', addr)` because deposit FlowDetail includes `amount`).

### Documentation Considerations
n/a

### Testing Considerations
Uses functions that are covered by unit tests, but an integration harness is still forthcoming (#11874). Manual testing is advised.

### Upgrade Considerations
Because this removes tx-based deposit response, it requires coördinated deployment of #12030. If that is deemed unacceptable, I can instead revert the second commit and add in conditional use of tx-based deposit response only for portfolios that lack a running flow of type "deposit".