### PR TITLE
express schemas in Zod

### DIFF
--- a/packages/agoric-cli/src/sdk-package-names.js
+++ b/packages/agoric-cli/src/sdk-package-names.js
@@ -36,6 +36,7 @@ export default [
   "@agoric/pegasus",
   "@agoric/pola-io",
   "@agoric/portfolio-api",
+  "@agoric/schemas",
   "@agoric/smart-wallet",
   "@agoric/solo",
   "@agoric/sparse-ints",

--- a/packages/schemas/bin/compile-schemas.js
+++ b/packages/schemas/bin/compile-schemas.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/* eslint-disable prefer-template, @jessie.js/safe-await-separator */
+import '@endo/init/unsafe-fast.js';
+import { readdir, readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import process from 'node:process';
+import { compileSchemasModule } from '../src/compile.js';
+
+const usage = () => {
+  console.error('Usage: agoric-schemas <schemas directory>');
+};
+
+const [inputDirArg] = process.argv.slice(2);
+if (!inputDirArg) {
+  usage();
+  process.exitCode = 1;
+  process.exit();
+}
+
+const inputDir = resolve(process.cwd(), inputDirArg);
+
+const ensureSpecifier = (fromDir, toFile) => {
+  let rel = relative(fromDir, toFile).replace(/\\/g, '/');
+  if (!rel.startsWith('.')) {
+    rel = `./${rel}`;
+  }
+  return rel;
+};
+
+const deriveOutputPaths = (codegenDir, schemaFile) => {
+  const base = schemaFile.replace(/\.schemas\.[mc]?js$/, '');
+  if (base === schemaFile) {
+    throw new Error(`Unsupported schema filename: ${schemaFile}`);
+  }
+  const outputJs = join(codegenDir, `${base}.patterns.js`);
+  const outputDts = join(codegenDir, `${base}.patterns.d.ts`);
+  return { outputJs, outputDts };
+};
+
+try {
+  const stats = await stat(inputDir);
+  if (!stats.isDirectory()) {
+    throw new Error(`Not a directory: ${inputDirArg}`);
+  }
+
+  const dirEntries = await readdir(inputDir, { withFileTypes: true });
+  const schemaFiles = dirEntries
+    .filter(
+      entry =>
+        entry.isFile() &&
+        !entry.name.startsWith('.') &&
+        /\.[mc]?js$/.test(entry.name),
+    )
+    .map(entry => entry.name)
+    .sort();
+
+  if (schemaFiles.length === 0) {
+    throw new Error('No schema files (*.schemas.js) found in directory');
+  }
+
+  const codegenDir = join(inputDir, 'codegen');
+  await mkdir(codegenDir, { recursive: true });
+
+  for (const schemaFile of schemaFiles) {
+    const schemaPath = join(inputDir, schemaFile);
+    const { outputJs, outputDts } = deriveOutputPaths(codegenDir, schemaFile);
+
+    const source = await readFile(schemaPath, 'utf8');
+    const sourceSpecifier = ensureSpecifier(dirname(outputJs), schemaPath);
+    const moduleComment = `Generated from ${sourceSpecifier} by @agoric/schemas`;
+    try {
+      const compiled = await compileSchemasModule(source, {
+        sourceModuleSpecifier: sourceSpecifier,
+        moduleComment,
+        evaluateModuleSpecifier: pathToFileURL(schemaPath).href,
+        virtualModuleFilename: schemaFile,
+      });
+
+      await writeFile(outputJs, compiled.js, 'utf8');
+      await writeFile(outputDts, compiled.dts, 'utf8');
+    } catch (err) {
+      if (err instanceof Error && /No Zod schemas were exported/.test(err.message)) {
+        continue;
+      }
+      throw err;
+    }
+  }
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+}

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@agoric/schemas",
+  "version": "0.1.0",
+  "description": "Compile Zod schema modules to Endo pattern modules",
+  "type": "module",
+  "main": "src/index.js",
+  "bin": {
+    "agoric-schemas": "bin/compile-schemas.js"
+  },
+  "engines": {
+    "node": "^20.9 || ^22.11"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "test": "ava",
+    "lint": "yarn run -T eslint .",
+    "lint-fix": "yarn run -T eslint . --fix"
+  },
+  "dependencies": {
+    "@endo/init": "^1.1.12",
+    "@endo/patterns": "^1.7.0",
+    "zod": "^4.1.11"
+  },
+  "devDependencies": {
+    "@endo/far": "^1.1.14",
+    "@endo/ses-ava": "^1.3.2",
+    "ava": "^5.3.0"
+  },
+  "ava": {
+    "require": [
+      "@endo/init/debug.js"
+    ],
+    "files": [
+      "test/**/*.test.*"
+    ]
+  },
+  "files": [
+    "src",
+    "bin"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/schemas/src/compile.js
+++ b/packages/schemas/src/compile.js
@@ -1,0 +1,459 @@
+/* eslint-disable no-underscore-dangle */
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { z } from 'zod';
+import { MZ_META_KEY } from './mz.js';
+
+const isZodType = value => value instanceof z.ZodType;
+
+const VALID_IDENTIFIER = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+
+const indent = (text, spaces = 2) =>
+  text
+    .split('\n')
+    .map(line => (line ? `${' '.repeat(spaces)}${line}` : line))
+    .join('\n');
+
+const formatKey = key =>
+  VALID_IDENTIFIER.test(key) ? key : JSON.stringify(key);
+
+const formatPlainArray = arr => {
+  if (arr.length === 0) {
+    return '[]';
+  }
+  const items = arr.map(item => formatLiteral(item));
+  if (items.some(item => item.includes('\n'))) {
+    return `[\n${indent(items.join(',\n'))}\n]`;
+  }
+  return `[${items.join(', ')}]`;
+};
+
+const formatPlainObject = obj => {
+  const entries = Object.entries(obj);
+  if (entries.length === 0) {
+    return '{}';
+  }
+  const lines = entries.map(
+    ([key, value]) => `${formatKey(key)}: ${formatLiteral(value)}`,
+  );
+  return `{\n${indent(lines.join(',\n'))}\n}`;
+};
+
+const formatLiteral = value => {
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('Non-finite numbers are not supported in literals');
+    }
+    if (Object.is(value, -0)) {
+      return '-0';
+    }
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'bigint') {
+    return `${value}n`;
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return formatPlainArray(value);
+  }
+  if (typeof value === 'object') {
+    return formatPlainObject(value);
+  }
+  throw new Error(`Unsupported literal value: ${String(value)}`);
+};
+
+const getTypeName = schema => {
+  if (!schema || typeof schema !== 'object') {
+    return undefined;
+  }
+  const def = schema._def || schema.def;
+  return def?.typeName ?? def?.type;
+};
+
+const unwrapSchema = (schema, { dropOptional = false } = {}) => {
+  /** @type {Array<{ kind: string, value?: unknown }>} */
+  const wrappers = [];
+  let current = schema;
+  let optional = false;
+  for (;;) {
+    const typeName = getTypeName(current);
+    if (typeName === 'optional') {
+      optional = true;
+      if (!dropOptional) {
+        wrappers.push({ kind: 'optional' });
+      }
+      current = current._def.innerType;
+      continue;
+    }
+    if (typeName === 'nullable') {
+      wrappers.push({ kind: 'nullable' });
+      current = current._def.innerType;
+      continue;
+    }
+    if (typeName === 'default') {
+      optional = true;
+      current = current._def.innerType;
+      continue;
+    }
+    if (typeName === 'branded') {
+      current = current._def.type;
+      continue;
+    }
+    if (typeName === 'pipeline') {
+      throw new Error('Zod pipelines are not supported');
+    }
+    if (typeName === 'effects') {
+      throw new Error('Zod effects are not supported');
+    }
+    break;
+  }
+  return { schema: current, wrappers, optional };
+};
+
+const applyWrappers = (wrappers, code) => {
+  let result = code;
+  for (let i = wrappers.length - 1; i >= 0; i -= 1) {
+    const wrapper = wrappers[i];
+    if (wrapper.kind === 'optional') {
+      result = `M.or(M.undefined(), ${result})`;
+    } else if (wrapper.kind === 'nullable') {
+      result = `M.or(M.null(), ${result})`;
+    } else {
+      throw new Error(`Unsupported wrapper kind: ${wrapper.kind}`);
+    }
+  }
+  return result;
+};
+
+const renderCopyRecord = entries => {
+  if (entries.length === 0) {
+    return '{}';
+  }
+  const chunks = entries.map(({ key, code, description }) => {
+    const parts = [];
+    if (description) {
+      parts.push(jsDocComment(description));
+    }
+    parts.push(`${formatKey(key)}: ${code}`);
+    return parts.join('\n');
+  });
+  return `{\n${indent(chunks.join(',\n'))}\n}`;
+};
+
+const renderCopyArray = elements => {
+  if (elements.length === 0) {
+    return '[]';
+  }
+  const multiline = elements.some(el => el.includes('\n'));
+  if (multiline) {
+    return `[\n${indent(elements.join(',\n'))}\n]`;
+  }
+  return `[${elements.join(', ')}]`;
+};
+
+const getMzMeta = schema => {
+  if (!schema || typeof schema !== 'object') {
+    return undefined;
+  }
+  const metadata =
+    typeof schema.meta === 'function' ? schema.meta() : schema._def.metadata;
+  return metadata && metadata[MZ_META_KEY];
+};
+
+const TEMP_ROOT = join(process.cwd(), '.agoric-schemas-tmp');
+
+const writeTempModuleAndImport = async (source, filenameBase) => {
+  await mkdir(TEMP_ROOT, { recursive: true });
+  const dir = await mkdtemp(join(TEMP_ROOT, 'module-'));
+  const filename = join(dir, filenameBase);
+  await writeFile(filename, source, 'utf8');
+  try {
+    const url = pathToFileURL(filename).href;
+    return await import(`${url}?${Date.now()}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+const loadSchemaNamespace = async (
+  source,
+  evaluateModuleSpecifier,
+  virtualModuleFilename,
+) => {
+  if (evaluateModuleSpecifier) {
+    let spec = evaluateModuleSpecifier;
+    try {
+      const url = new URL(spec);
+      url.searchParams.set('__ts', `${Date.now()}`);
+      spec = url.href;
+    } catch (_err) {
+      const joiner = spec.includes('?') ? '&' : '?';
+      spec = `${spec}${joiner}${Date.now()}`;
+    }
+    return import(spec);
+  }
+  const filename = basename(virtualModuleFilename || 'module.mjs');
+  const normalized =
+    filename.endsWith('.js') || filename.endsWith('.mjs')
+      ? filename
+      : `${filename}.mjs`;
+  return writeTempModuleAndImport(source, normalized);
+};
+
+const buildEntry = (key, code, description) => ({ key, code, description });
+
+const emitObjectMatcher = schema => {
+  const rawShape = schema._def.shape;
+  const shape = typeof rawShape === 'function' ? rawShape() : rawShape;
+  const entries = Object.entries(shape);
+  const requiredEntries = [];
+  const optionalEntries = [];
+  for (const [key, propertySchema] of entries) {
+    const {
+      schema: inner,
+      wrappers,
+      optional,
+    } = unwrapSchema(propertySchema, {
+      dropOptional: true,
+    });
+    const pattern = applyWrappers(wrappers, emitMatcher(inner));
+    const description = propertySchema.description || undefined;
+    const entry = buildEntry(key, pattern, description);
+    const target = optional ? optionalEntries : requiredEntries;
+    target.push(entry);
+  }
+  const catchall = schema._def.catchall;
+  const hasRest = catchall && getTypeName(catchall) !== 'never';
+
+  const requiredArg = renderCopyRecord(requiredEntries);
+  const optionalArg = renderCopyRecord(optionalEntries);
+  const restArg = hasRest ? emitMatcher(catchall) : '{}';
+
+  const args = [
+    requiredArg,
+    optionalEntries.length > 0 || hasRest ? optionalArg : '{}',
+    restArg,
+  ];
+
+  return `M.splitRecord(${args.join(', ')})`;
+};
+
+const emitTupleMatcher = schema => {
+  const requiredItems = [];
+  const optionalItems = [];
+
+  for (const itemSchema of schema._def.items) {
+    const {
+      schema: inner,
+      wrappers,
+      optional,
+    } = unwrapSchema(itemSchema, {
+      dropOptional: true,
+    });
+    const matcher = applyWrappers(wrappers, emitMatcher(inner));
+    if (optional) {
+      optionalItems.push(matcher);
+    } else {
+      if (optionalItems.length > 0) {
+        throw new Error('Tuple optional items must follow required items');
+      }
+      requiredItems.push(matcher);
+    }
+  }
+
+  const args = [];
+  args.push(renderCopyArray(requiredItems));
+  if (optionalItems.length > 0) {
+    args.push(renderCopyArray(optionalItems));
+  } else if (schema._def.rest) {
+    args.push('[]');
+  }
+  if (schema._def.rest) {
+    args.push(emitMatcher(schema._def.rest));
+  }
+
+  return `M.splitArray(${args.join(', ')})`;
+};
+
+const emitUnionMatcher = schema => {
+  const options = schema._def.options.map(option => emitMatcher(option));
+  return `M.or(${options.join(', ')})`;
+};
+
+const emitEnumMatcher = schema => {
+  const raw = schema._def.values ?? schema._def.entries;
+  const values = Array.isArray(raw) ? raw : Object.values(raw ?? {});
+  const formatted = values.map(value => formatLiteral(value));
+  return `M.or(${formatted.join(', ')})`;
+};
+
+const emitRecordMatcher = schema => {
+  const keyPattern = emitMatcher(schema._def.keyType);
+  const valuePattern = emitMatcher(schema._def.valueType);
+  return `M.recordOf(${keyPattern}, ${valuePattern})`;
+};
+
+const emitMatcherBase = schema => {
+  const meta = getMzMeta(schema);
+  if (meta) {
+    switch (meta.kind) {
+      case 'remotable':
+        return meta.label
+          ? `M.remotable(${formatLiteral(meta.label)})`
+          : 'M.remotable()';
+      case 'nat':
+        if (meta.limits === undefined) {
+          return 'M.nat()';
+        }
+        return `M.nat(${formatLiteral(meta.limits)})`;
+      case 'gte':
+        return `M.gte(${formatLiteral(meta.bound)})`;
+      case 'raw':
+        return meta.expression;
+      default:
+        throw new Error(`Unknown Mz metadata kind: ${meta.kind}`);
+    }
+  }
+
+  const typeName = getTypeName(schema);
+  switch (typeName) {
+    case 'string':
+      return 'M.string()';
+    case 'number':
+      return 'M.number()';
+    case 'boolean':
+      return 'M.boolean()';
+    case 'bigint':
+      return 'M.bigint()';
+    case 'any':
+    case 'unknown':
+      return 'M.any()';
+    case 'null':
+      return 'M.null()';
+    case 'undefined':
+      return 'M.undefined()';
+    case 'literal': {
+      const value = schema._def.value ?? schema._def.values?.[0];
+      return formatLiteral(value);
+    }
+    case 'object':
+      return emitObjectMatcher(schema);
+    case 'array':
+      return `M.arrayOf(${emitMatcher(schema._def.element)})`;
+    case 'tuple':
+      return emitTupleMatcher(schema);
+    case 'union':
+      return emitUnionMatcher(schema);
+    case 'enum':
+      return emitEnumMatcher(schema);
+    case 'record':
+      return emitRecordMatcher(schema);
+    default:
+      throw new Error(`Unsupported Zod type: ${typeName}`);
+  }
+};
+
+const emitMatcher = schema => {
+  const { schema: base, wrappers } = unwrapSchema(schema);
+  const code = emitMatcherBase(base);
+  return applyWrappers(wrappers, code);
+};
+
+const jsDocComment = description => {
+  if (!description) {
+    return '';
+  }
+  const lines = description.split(/\r?\n/);
+  const body = lines.map(line => ` * ${line}`).join('\n');
+  return `/**\n${body}\n */`;
+};
+
+const deriveExportName = schemaName =>
+  schemaName.endsWith('Schema')
+    ? schemaName.slice(0, -6)
+    : `${schemaName}Pattern`;
+
+export const compileSchemasModule = async (source, options = {}) => {
+  const {
+    sourceModuleSpecifier = './source.js',
+    moduleComment = 'Generated by @agoric/schemas',
+    evaluateModuleSpecifier = undefined,
+    virtualModuleFilename = 'source.schemas.mjs',
+  } = options;
+
+  const namespace = await loadSchemaNamespace(
+    source,
+    evaluateModuleSpecifier,
+    virtualModuleFilename,
+  );
+
+  const schemaEntries = Object.entries(namespace).filter(([, value]) =>
+    isZodType(value),
+  );
+  if (schemaEntries.length === 0) {
+    throw new Error('No Zod schemas were exported from the provided source');
+  }
+
+  schemaEntries.sort(([a], [b]) => a.localeCompare(b));
+
+  const exports = schemaEntries.map(([schemaName, schema]) => {
+    const exportName = deriveExportName(schemaName);
+    const description = schema.description || undefined;
+    const patternExpression = emitMatcher(schema);
+    const lines = [];
+    if (description) {
+      lines.push(jsDocComment(description));
+    }
+    lines.push(`export const ${exportName} = ${patternExpression};`);
+    lines.push(`harden(${exportName});`);
+    return { schemaName, exportName, description, js: lines.join('\n') };
+  });
+
+  const jsParts = [
+    `// ${moduleComment}`,
+    "import { M } from '@endo/patterns';",
+    '',
+  ];
+  for (const entry of exports) {
+    jsParts.push(entry.js);
+    jsParts.push('');
+  }
+  const jsSource = `${jsParts.join('\n').trim()}\n`;
+
+  const dtsParts = [
+    `// ${moduleComment}`,
+    "import type { Pattern } from '@endo/patterns';",
+    "import type { z } from 'zod';",
+    `import type * as source from '${sourceModuleSpecifier}';`,
+    '',
+  ];
+  for (const entry of exports) {
+    if (entry.description) {
+      dtsParts.push(jsDocComment(entry.description));
+    }
+    dtsParts.push(
+      `export type ${entry.exportName} = z.infer<typeof source.${entry.schemaName}>;`,
+    );
+    dtsParts.push(
+      `export declare const ${entry.exportName}: TypedPattern<${entry.exportName}>;`,
+    );
+    dtsParts.push('');
+  }
+  const dtsSource = `${dtsParts.join('\n').trim()}\n`;
+
+  return harden({ js: jsSource, dts: dtsSource, exports });
+};
+
+export default compileSchemasModule;

--- a/packages/schemas/src/index.js
+++ b/packages/schemas/src/index.js
@@ -1,0 +1,2 @@
+export { compileSchemasModule } from './compile.js';
+export { Mz, MZ_META_KEY } from './mz.js';

--- a/packages/schemas/src/mz.js
+++ b/packages/schemas/src/mz.js
@@ -1,0 +1,96 @@
+/* eslint-disable no-underscore-dangle */
+import { z } from 'zod';
+
+export const MZ_META_KEY = '@agoric/schemas/endo';
+
+const withMzMeta = (schema, payload) => {
+  const prior = schema._def.metadata || {};
+  return schema.meta({ ...prior, [MZ_META_KEY]: payload });
+};
+
+const natRefinement = (value, ctx) => {
+  if (typeof value !== 'bigint' || value < 0n) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Expected a natural number',
+    });
+  }
+};
+
+const refineForGte = (schema, bound) => {
+  if (typeof bound === 'bigint') {
+    return schema.superRefine((value, ctx) => {
+      if (typeof value !== 'bigint' || value < bound) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Expected bigint >= ${bound}n`,
+        });
+      }
+    });
+  }
+  if (typeof bound === 'number') {
+    return schema.superRefine((value, ctx) => {
+      if (typeof value !== 'number' || value < bound) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Expected number >= ${bound}`,
+        });
+      }
+    });
+  }
+  return schema;
+};
+
+export const Mz = harden({
+  /**
+   * Describe an Endo remotable pattern.
+   *
+   * @param {string} [label]
+   */
+  remotable(label) {
+    return withMzMeta(z.any(), harden({ kind: 'remotable', label }));
+  },
+
+  /**
+   * Matches natural numbers. Maps to `M.nat()` during compilation.
+   *
+   * @param {import('@endo/patterns').Limits} [limits]
+   */
+  nat(limits = undefined) {
+    const schema = z.bigint().superRefine(natRefinement);
+    return withMzMeta(schema, harden({ kind: 'nat', limits }));
+  },
+
+  /**
+   * Match values greater than or equal to the given bound using `M.gte()`.
+   *
+   * @param {unknown} bound
+   * @param {import('zod').ZodTypeAny} [base]
+   */
+  gte(bound, base = undefined) {
+    let root = base;
+    if (!root) {
+      if (typeof bound === 'bigint') {
+        root = z.bigint();
+      } else if (typeof bound === 'number') {
+        root = z.number();
+      } else {
+        root = z.any();
+      }
+    }
+    const refined = refineForGte(root, bound);
+    return withMzMeta(refined, harden({ kind: 'gte', bound }));
+  },
+
+  /**
+   * Attach an arbitrary pattern expression so the compiler lowers it verbatim.
+   *
+   * @param {string} expression
+   */
+  raw(expression) {
+    if (typeof expression !== 'string') {
+      throw new TypeError('Mz.raw() expects a string expression');
+    }
+    return withMzMeta(z.any(), harden({ kind: 'raw', expression }));
+  },
+});

--- a/packages/schemas/test/compile.test.js
+++ b/packages/schemas/test/compile.test.js
@@ -1,0 +1,234 @@
+import test from 'ava';
+import { execFile } from 'node:child_process';
+import { readFile, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { Far } from '@endo/far';
+import { M, matches } from '@endo/patterns';
+import { compileSchemasModule } from '../src/compile.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const execFileAsync = promisify(execFile);
+
+const TEST_TEMP_ROOT = join(process.cwd(), '.agoric-schemas-test');
+
+const importFromSource = async source => {
+  await mkdir(TEST_TEMP_ROOT, { recursive: true });
+  const dir = await mkdtemp(join(TEST_TEMP_ROOT, 'module-'));
+  const file = join(dir, 'module.mjs');
+  await writeFile(file, source, 'utf8');
+  try {
+    return await import(`${pathToFileURL(file).href}?${Date.now()}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+test('compiles simple described schema', async t => {
+  const source = `import { z } from 'zod';\nexport const FooSchema = z.string().describe('Greeting text');\n`;
+  const compiled = await compileSchemasModule(source, {
+    sourceModuleSpecifier: './foo.js',
+  });
+
+  t.true(compiled.js.includes('/**\n * Greeting text\n */'));
+  t.true(compiled.js.includes('export const Foo = M.string();'));
+  t.true(compiled.js.includes('harden(Foo);'));
+  t.true(
+    compiled.dts.includes(
+      'export type Foo = z.infer<typeof source.FooSchema>;',
+    ),
+  );
+  t.true(compiled.dts.includes('export declare const Foo: TypedPattern<Foo>;'));
+
+  const mod = await importFromSource(compiled.js);
+  t.deepEqual(mod.Foo, M.string());
+});
+
+test('transforms smart-wallet fixture schemas', async t => {
+  const fixturePath = resolve(here, 'fixtures', 'smart-wallet.schemas.js');
+  const source = await readFile(fixturePath, 'utf8');
+  const compiled = await compileSchemasModule(source, {
+    sourceModuleSpecifier: './smart-wallet.schemas.js',
+    evaluateModuleSpecifier: pathToFileURL(fixturePath).href,
+  });
+
+  t.true(compiled.js.includes('M.remotable("InstanceHandle")'));
+  t.true(
+    compiled.js.includes('M.splitArray([M.string()], [M.arrayOf(M.any())])'),
+  );
+  t.true(
+    compiled.js.includes(
+      '  /**\n   * If present, save the result of this invocation with this key.\n   */\n  saveResult: M.splitRecord({',
+    ),
+  );
+
+  const mod = await importFromSource(compiled.js);
+  const {
+    ResultPlan,
+    AgoricContractInvitationSpec,
+    ContractInvitationSpec,
+    WalletBridgeMsg,
+  } = mod;
+
+  t.true(matches(harden({ name: 'plan' }), ResultPlan));
+  t.false(matches(harden({ name: 3n }), ResultPlan));
+
+  const callPipeSample = harden([
+    harden(['method']),
+    harden(['other', harden([1, 2])]),
+  ]);
+  t.true(
+    matches(
+      harden({
+        source: 'agoricContract',
+        instancePath: harden(['instance', 'invitation']),
+        callPipe: callPipeSample,
+      }),
+      AgoricContractInvitationSpec,
+    ),
+  );
+  t.false(
+    matches(
+      harden({
+        source: 'agoricContract',
+        instancePath: harden(['instance']),
+        callPipe: harden([harden([1, 2])]),
+      }),
+      AgoricContractInvitationSpec,
+    ),
+  );
+
+  const expectedContractPattern = M.splitRecord(
+    {
+      source: 'contract',
+      instance: M.remotable('InstanceHandle'),
+      publicInvitationMaker: M.string(),
+    },
+    { invitationArgs: M.arrayOf(M.any()) },
+    {},
+  );
+  t.deepEqual(ContractInvitationSpec, expectedContractPattern);
+
+  const walletAction = harden({
+    type: 'WALLET_ACTION',
+    action: 'provision',
+    blockHeight: 99,
+    blockTime: 1234,
+    owner: 'addr1',
+  });
+  const walletSpend = harden({
+    type: 'WALLET_SPEND_ACTION',
+    spendAction: 'pay',
+    blockHeight: 99,
+    blockTime: 1234,
+    owner: 'addr1',
+  });
+  t.true(matches(walletAction, WalletBridgeMsg));
+  t.true(matches(walletSpend, WalletBridgeMsg));
+  t.false(
+    matches(
+      harden({
+        type: 'WALLET_SPEND_ACTION',
+        spendAction: 42,
+        blockHeight: 99,
+        blockTime: 1234,
+        owner: 'addr1',
+      }),
+      WalletBridgeMsg,
+    ),
+  );
+});
+
+test('transforms portfolio fixture schemas', async t => {
+  const fixturePath = resolve(here, 'fixtures', 'portfolio.schemas.js');
+  const source = await readFile(fixturePath, 'utf8');
+  const compiled = await compileSchemasModule(source, {
+    sourceModuleSpecifier: './portfolio.schemas.js',
+    evaluateModuleSpecifier: pathToFileURL(fixturePath).href,
+  });
+
+  t.true(
+    compiled.js.includes(
+      'M.recordOf(M.or("USDN", "Aave_Avalanche", "Compound_Base"), M.nat())',
+    ),
+  );
+  t.true(compiled.js.includes('M.gte(0n)') || compiled.js.includes('M.nat()'));
+
+  const mod = await importFromSource(compiled.js);
+  const {
+    TargetAllocation,
+    FlowDetail,
+    FlowStatus,
+    PortfolioStatus,
+    PositionStatus,
+  } = mod;
+
+  const allocation = harden({ USDN: 100n, Aave_Avalanche: 0n });
+  t.true(matches(allocation, TargetAllocation));
+  t.false(matches(harden({ Unknown: 1n }), TargetAllocation));
+
+  const withdrawDetail = harden({
+    type: 'withdraw',
+    amount: harden({ brand: Far('Brand', {}), value: 5n }),
+  });
+  t.true(matches(withdrawDetail, FlowDetail));
+
+  t.true(
+    matches(
+      harden({ state: 'fail', step: 2, how: 'transfer', error: 'boom' }),
+      FlowStatus,
+    ),
+  );
+  t.false(matches(harden({ state: 'run', step: 'bad', how: 'x' }), FlowStatus));
+
+  const portfolio = harden({
+    positionKeys: harden(['USDN']),
+    flowCount: 1,
+    accountIdByChain: harden({ cosmoshub: 'addr1' }),
+    policyVersion: 1,
+    rebalanceCount: 0,
+    flowsRunning: harden({ flow1: withdrawDetail }),
+  });
+  t.true(matches(portfolio, PortfolioStatus));
+
+  const position = harden({
+    protocol: 'Aave',
+    accountId: 'acc',
+    netTransfers: withdrawDetail.amount,
+    totalIn: withdrawDetail.amount,
+    totalOut: withdrawDetail.amount,
+  });
+  t.true(matches(position, PositionStatus));
+});
+
+test('cli emits compiled module and declaration', async t => {
+  await mkdir(TEST_TEMP_ROOT, { recursive: true });
+  const tmp = await mkdtemp(join(TEST_TEMP_ROOT, 'cli-'));
+  const schemasDir = resolve(tmp, 'schemas');
+  await mkdir(schemasDir, { recursive: true });
+  const inputPath = resolve(schemasDir, 'input.schemas.js');
+  await writeFile(
+    inputPath,
+    `import { z } from 'zod';\nexport const FooSchema = z.number().describe('Number foo');\n`,
+    'utf8',
+  );
+
+  const cliPath = resolve(here, '..', 'bin', 'compile-schemas.js');
+  await execFileAsync(process.execPath, [cliPath, schemasDir]);
+
+  const codegenDir = resolve(schemasDir, 'codegen');
+  const jsPath = resolve(codegenDir, 'input.patterns.js');
+  const dtsPath = resolve(codegenDir, 'input.patterns.d.ts');
+  const js = await readFile(jsPath, 'utf8');
+  const dts = await readFile(dtsPath, 'utf8');
+
+  t.true(js.includes('Generated from ../input.schemas.js by @agoric/schemas'));
+  t.true(js.includes('export const Foo = M.number();'));
+  t.true(js.includes('harden(Foo);'));
+  t.true(js.includes('/**\n * Number foo\n */'));
+  t.true(dts.includes('export type Foo = z.infer<typeof source.FooSchema>;'));
+  t.true(dts.includes('export declare const Foo: TypedPattern<Foo>;'));
+
+  await rm(tmp, { recursive: true, force: true });
+});

--- a/packages/schemas/test/fixtures/portfolio.schemas.js
+++ b/packages/schemas/test/fixtures/portfolio.schemas.js
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { Mz } from '../../src/index.js';
+
+export const NatAmountSchema = z
+  .object({
+    brand: Mz.remotable('Brand'),
+    value: Mz.gte(0n),
+  })
+  .strict();
+
+const PoolKeySchema = z.enum([
+  'USDN',
+  'Aave_Avalanche',
+  'Compound_Base',
+]);
+
+export const TargetAllocationSchema = z
+  .record(PoolKeySchema, Mz.nat())
+  .describe('PoolKey to target portions.');
+
+export const TargetAllocationExtSchema = z.record(z.string(), Mz.nat());
+
+export const FlowDetailSchema = z.union([
+  z
+    .object({
+      type: z.literal('withdraw'),
+      amount: NatAmountSchema,
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('other'),
+    })
+    .strict(),
+]);
+
+export const FlowStatusSchema = z.union([
+  z.object({ state: z.literal('run'), step: z.number(), how: z.string() }).strict(),
+  z.object({ state: z.literal('undo'), step: z.number(), how: z.string() }).strict(),
+  z.object({ state: z.literal('done') }).strict(),
+  z
+    .object({
+      state: z.literal('fail'),
+      step: z.number(),
+      how: z.string(),
+      error: z.string(),
+      where: z.string().optional(),
+    })
+    .strict(),
+]);
+
+export const FlowStepsSchema = z.array(
+  z
+    .object({
+      how: z.string(),
+      amount: NatAmountSchema,
+      src: z.object({ address: z.string() }).strict(),
+      dest: z.object({ address: z.string() }).strict(),
+    })
+    .strict(),
+);
+
+export const PortfolioStatusSchema = z
+  .object({
+    positionKeys: z.array(z.string()),
+    flowCount: z.number(),
+    accountIdByChain: z.record(z.string(), z.string()),
+    policyVersion: z.number(),
+    rebalanceCount: z.number(),
+    depositAddress: z.string().optional(),
+    targetAllocation: TargetAllocationExtSchema.optional(),
+    accountsPending: z.array(z.string()).optional(),
+    flowsRunning: z.record(z.string(), FlowDetailSchema).optional(),
+  })
+  .strict();
+
+export const PositionStatusSchema = z
+  .object({
+    protocol: z.enum(['Aave', 'USDN', 'Beefy']),
+    accountId: z.string(),
+    netTransfers: NatAmountSchema,
+    totalIn: NatAmountSchema,
+    totalOut: NatAmountSchema,
+  })
+  .strict();

--- a/packages/schemas/test/fixtures/smart-wallet.schemas.js
+++ b/packages/schemas/test/fixtures/smart-wallet.schemas.js
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import { Mz } from '../../src/index.js';
+
+const IdSchema = z.union([z.string(), z.number()]);
+
+export const ResultPlanSchema = z
+  .object({
+    name: z.string(),
+    overwrite: z.boolean().optional(),
+  })
+  .strict()
+  .describe('Planner result persistence directive.');
+
+export const InvokeEntryMessageSchema = z
+  .object({
+    targetName: z.string(),
+    method: z.string(),
+    args: z.array(z.any()),
+    saveResult: ResultPlanSchema.optional().describe(
+      'If present, save the result of this invocation with this key.',
+    ),
+    id: IdSchema.optional(),
+  })
+  .strict();
+
+export const StringCapDataSchema = z
+  .object({
+    body: z.string(),
+    slots: z.array(z.string()),
+  })
+  .strict();
+
+const ContractInvitationArgsSchema = z.object({
+  source: z.literal('contract'),
+  instance: Mz.remotable('InstanceHandle'),
+  publicInvitationMaker: z.string(),
+  invitationArgs: z.array(z.any()).optional(),
+});
+
+export const ContractInvitationSpecSchema = ContractInvitationArgsSchema.strict();
+
+const ContinuingInvitationArgsSchema = z.object({
+  source: z.literal('continuing'),
+  previousOffer: IdSchema,
+  invitationMakerName: z.string(),
+  invitationArgs: z.array(z.any()).optional(),
+});
+
+export const ContinuingInvitationSpecSchema = ContinuingInvitationArgsSchema.strict();
+
+export const AgoricContractInvitationSpecSchema = z
+  .object({
+    source: z.literal('agoricContract'),
+    instancePath: z.array(z.string()),
+    callPipe: z.array(
+      z
+        .tuple([z.string(), z.array(z.any()).optional()])
+        .describe('Pipe entry'),
+    ),
+  })
+  .strict();
+
+export const OfferSpecSchema = z
+  .object({
+    id: IdSchema,
+    invitationSpec: z.any(),
+    proposal: z.any(),
+    offerArgs: z.any().optional(),
+    saveResult: ResultPlanSchema.optional(),
+  })
+  .strict();
+
+const WalletActionFields = {
+  blockHeight: z.number(),
+  blockTime: z.number(),
+  owner: z.string(),
+};
+
+export const WalletActionMsgSchema = z
+  .object({
+    type: z.literal('WALLET_ACTION'),
+    action: z.string(),
+    ...WalletActionFields,
+  })
+  .strict();
+
+export const WalletSpendActionMsgSchema = z
+  .object({
+    type: z.literal('WALLET_SPEND_ACTION'),
+    spendAction: z.string(),
+    ...WalletActionFields,
+  })
+  .strict();
+
+export const WalletBridgeMsgSchema = z.union([
+  WalletActionMsgSchema,
+  WalletSpendActionMsgSchema,
+]);
+
+export const ShapeSchema = z.object({
+  StringCapData: StringCapDataSchema,
+  AgoricContractInvitationSpec: AgoricContractInvitationSpecSchema,
+  ContractInvitationSpec: ContractInvitationSpecSchema,
+  ContinuingInvitationSpec: ContinuingInvitationSpecSchema,
+  PurseInvitationSpec: z
+    .object({
+      source: z.literal('purse'),
+      instance: Mz.remotable('InstanceHandle'),
+      description: z.string(),
+    })
+    .strict(),
+  OfferSpec: OfferSpecSchema,
+  ResultPlan: ResultPlanSchema,
+  InvokeEntryMessage: InvokeEntryMessageSchema,
+  WalletActionMsg: WalletActionMsgSchema,
+  WalletSpendActionMsg: WalletSpendActionMsgSchema,
+  WalletBridgeMsg: WalletBridgeMsgSchema,
+}).strict();

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": [
+    "bin",
+    "src",
+    "test",
+    "tools"
+  ]
+}

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
-    "build": "yarn build:bundles",
+    "build": "yarn run -T run-p schemas:compile build:bundles",
     "build:bundles": "node ./scripts/build-bundles.js",
+    "schemas:compile": "node ../schemas/bin/compile-schemas.js ./src/schemas",
     "prepack": "yarn run -T tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.*ts*' '*.tsbuildinfo'",
     "test": "ava",
@@ -44,6 +45,10 @@
     "@endo/nat": "^5.1.3",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13"
+  },
+  "peerDependencies": {
+    "@agoric/schemas": "workspace:*",
+    "zod": "^4.1.11"
   },
   "files": [
     "src/"

--- a/packages/smart-wallet/src/schemas/codegen/type-guards.patterns.d.ts
+++ b/packages/smart-wallet/src/schemas/codegen/type-guards.patterns.d.ts
@@ -1,0 +1,47 @@
+// Generated from ../type-guards.schemas.js by @agoric/schemas
+import type { Pattern } from '@endo/patterns';
+import type { z } from 'zod';
+import type * as source from '../type-guards.schemas.js';
+
+export type AgoricContractInvitationSpec = z.infer<typeof source.AgoricContractInvitationSpecSchema>;
+export declare const AgoricContractInvitationSpec: TypedPattern<AgoricContractInvitationSpec>;
+
+export type ContinuingInvitationSpec = z.infer<typeof source.ContinuingInvitationSpecSchema>;
+export declare const ContinuingInvitationSpec: TypedPattern<ContinuingInvitationSpec>;
+
+export type ContractInvitationSpec = z.infer<typeof source.ContractInvitationSpecSchema>;
+export declare const ContractInvitationSpec: TypedPattern<ContractInvitationSpec>;
+
+export type InvokeEntryMessage = z.infer<typeof source.InvokeEntryMessageSchema>;
+export declare const InvokeEntryMessage: TypedPattern<InvokeEntryMessage>;
+
+export type PurseInvitationSpec = z.infer<typeof source.PurseInvitationSpecSchema>;
+export declare const PurseInvitationSpec: TypedPattern<PurseInvitationSpec>;
+
+/**
+ * Planner result persistence directive.
+ */
+export type ResultPlan = z.infer<typeof source.ResultPlanSchema>;
+export declare const ResultPlan: TypedPattern<ResultPlan>;
+
+export type StringCapData = z.infer<typeof source.StringCapDataSchema>;
+export declare const StringCapData: TypedPattern<StringCapData>;
+
+/**
+ * Defined by walletAction struct in msg_server.go
+ * 
+ * @see {agoric.swingset.MsgWalletAction} and walletSpendAction in msg_server.go
+ */
+export type WalletActionMsg = z.infer<typeof source.WalletActionMsgSchema>;
+export declare const WalletActionMsg: TypedPattern<WalletActionMsg>;
+
+/**
+ * Messages transmitted over Cosmos chain, cryptographically verifying that the message came from the 'owner'.
+ * 
+ * The two wallet actions are distinguished by whether the user had to confirm the sending of the message (as is the case for WALLET_SPEND_ACTION).
+ */
+export type WalletBridgeMsg = z.infer<typeof source.WalletBridgeMsgSchema>;
+export declare const WalletBridgeMsg: TypedPattern<WalletBridgeMsg>;
+
+export type WalletSpendActionMsg = z.infer<typeof source.WalletSpendActionMsgSchema>;
+export declare const WalletSpendActionMsg: TypedPattern<WalletSpendActionMsg>;

--- a/packages/smart-wallet/src/schemas/codegen/type-guards.patterns.js
+++ b/packages/smart-wallet/src/schemas/codegen/type-guards.patterns.js
@@ -1,0 +1,134 @@
+// Generated from ../type-guards.schemas.js by @agoric/schemas
+import { M } from '@endo/patterns';
+
+export const AgoricContractInvitationSpec = M.splitRecord({
+  source: "agoricContract",
+  instancePath: M.arrayOf(M.string()),
+  callPipe: M.arrayOf(M.splitArray([M.string()], [M.arrayOf(M.any())]))
+}, {}, {});
+harden(AgoricContractInvitationSpec);
+
+export const ContinuingInvitationSpec = M.splitRecord({
+  source: "continuing",
+  previousOffer: M.or(M.string(), M.number()),
+  invitationMakerName: M.string()
+}, {
+  invitationArgs: M.arrayOf(M.any())
+}, {});
+harden(ContinuingInvitationSpec);
+
+export const ContractInvitationSpec = M.splitRecord({
+  source: "contract",
+  instance: M.remotable("InstanceHandle"),
+  publicInvitationMaker: M.string()
+}, {
+  invitationArgs: M.arrayOf(M.any())
+}, {});
+harden(ContractInvitationSpec);
+
+export const InvokeEntryMessage = M.splitRecord({
+  targetName: M.string(),
+  method: M.string(),
+  args: M.arrayOf(M.any())
+}, {
+  /**
+   * If present, save the result of this invocation with this key.
+   */
+  saveResult: M.splitRecord({
+    name: M.string()
+  }, {
+    overwrite: M.boolean()
+  }, {}),
+  id: M.or(M.string(), M.number())
+}, {});
+harden(InvokeEntryMessage);
+
+export const PurseInvitationSpec = M.splitRecord({
+  source: "purse",
+  instance: M.remotable("InstanceHandle"),
+  description: M.string()
+}, {}, {});
+harden(PurseInvitationSpec);
+
+/**
+ * Planner result persistence directive.
+ */
+export const ResultPlan = M.splitRecord({
+  name: M.string()
+}, {
+  overwrite: M.boolean()
+}, {});
+harden(ResultPlan);
+
+export const StringCapData = M.splitRecord({
+  body: M.string(),
+  slots: M.arrayOf(M.string())
+}, {}, {});
+harden(StringCapData);
+
+/**
+ * Defined by walletAction struct in msg_server.go
+ * 
+ * @see {agoric.swingset.MsgWalletAction} and walletSpendAction in msg_server.go
+ */
+export const WalletActionMsg = M.splitRecord({
+  type: "WALLET_ACTION",
+  /**
+   * JSON of marshalled BridgeAction
+   */
+  action: M.string(),
+  blockHeight: M.bigint(),
+  blockTime: M.bigint(),
+  /**
+   * base64 of Uint8Array of bech32 data
+   */
+  owner: M.string()
+}, {}, {});
+harden(WalletActionMsg);
+
+/**
+ * Messages transmitted over Cosmos chain, cryptographically verifying that the message came from the 'owner'.
+ * 
+ * The two wallet actions are distinguished by whether the user had to confirm the sending of the message (as is the case for WALLET_SPEND_ACTION).
+ */
+export const WalletBridgeMsg = M.or(M.splitRecord({
+  type: "WALLET_ACTION",
+  /**
+   * JSON of marshalled BridgeAction
+   */
+  action: M.string(),
+  blockHeight: M.bigint(),
+  blockTime: M.bigint(),
+  /**
+   * base64 of Uint8Array of bech32 data
+   */
+  owner: M.string()
+}, {}, {}), M.splitRecord({
+  type: "WALLET_SPEND_ACTION",
+  /**
+   * JSON of BridgeActionCapData
+   */
+  spendAction: M.string(),
+  blockHeight: M.bigint(),
+  blockTime: M.bigint(),
+  /**
+   * base64 of Uint8Array of bech32 data
+   */
+  owner: M.string()
+}, {}, {}));
+harden(WalletBridgeMsg);
+
+export const WalletSpendActionMsg = M.splitRecord({
+  type: "WALLET_SPEND_ACTION",
+  /**
+   * JSON of BridgeActionCapData
+   */
+  spendAction: M.string(),
+  blockHeight: M.bigint(),
+  blockTime: M.bigint(),
+  /**
+   * base64 of Uint8Array of bech32 data
+   */
+  owner: M.string()
+}, {}, {});
+harden(WalletSpendActionMsg);

--- a/packages/smart-wallet/src/schemas/type-guards.schemas.js
+++ b/packages/smart-wallet/src/schemas/type-guards.schemas.js
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { Mz } from '@agoric/schemas';
+
+const IdSchema = z.union([z.string(), z.number()]);
+
+export const ResultPlanSchema = z
+  .object({
+    name: z.string(),
+    overwrite: z.boolean().optional(),
+  })
+  .strict()
+  .describe('Planner result persistence directive.');
+
+export const InvokeEntryMessageSchema = z
+  .object({
+    targetName: z.string(),
+    method: z.string(),
+    args: z.array(z.any()),
+    saveResult: ResultPlanSchema.optional().describe(
+      'If present, save the result of this invocation with this key.',
+    ),
+    id: IdSchema.optional(),
+  })
+  .strict();
+
+export const StringCapDataSchema = z
+  .object({
+    body: z.string(),
+    slots: z.array(z.string()),
+  })
+  .strict();
+
+export const AgoricContractInvitationSpecSchema = z
+  .object({
+    source: z.literal('agoricContract'),
+    instancePath: z.array(z.string()),
+    callPipe: z.array(
+      z.tuple([z.string(), z.array(z.any()).optional()]).describe('Pipe entry'),
+    ),
+  })
+  .strict();
+
+export const ContractInvitationSpecSchema = z
+  .object({
+    source: z.literal('contract'),
+    instance: Mz.remotable('InstanceHandle'),
+    publicInvitationMaker: z.string(),
+    invitationArgs: z.array(z.any()).optional(),
+  })
+  .strict();
+
+export const ContinuingInvitationSpecSchema = z
+  .object({
+    source: z.literal('continuing'),
+    previousOffer: IdSchema,
+    invitationMakerName: z.string(),
+    invitationArgs: z.array(z.any()).optional(),
+  })
+  .strict();
+
+export const PurseInvitationSpecSchema = z
+  .object({
+    source: z.literal('purse'),
+    instance: Mz.remotable('InstanceHandle'),
+    description: z.string(),
+  })
+  .strict();
+
+const WalletActionFields = {
+  blockHeight: z.bigint(),
+  blockTime: z.bigint(),
+  owner: z.string().describe('base64 of Uint8Array of bech32 data'),
+};
+
+export const WalletActionMsgSchema = z
+  .object({
+    type: z.literal('WALLET_ACTION'),
+    action: z.string().describe('JSON of marshalled BridgeAction'),
+    ...WalletActionFields,
+  })
+  .strict().describe(`Defined by walletAction struct in msg_server.go
+
+@see {agoric.swingset.MsgWalletAction} and walletSpendAction in msg_server.go`);
+
+export const WalletSpendActionMsgSchema = z
+  .object({
+    type: z.literal('WALLET_SPEND_ACTION'),
+    spendAction: z.string().describe('JSON of BridgeActionCapData'),
+    ...WalletActionFields,
+  })
+  .strict();
+
+export const WalletBridgeMsgSchema = z
+  .union([WalletActionMsgSchema, WalletSpendActionMsgSchema])
+  .describe(
+    `Messages transmitted over Cosmos chain, cryptographically verifying that the message came from the 'owner'.
+
+The two wallet actions are distinguished by whether the user had to confirm the sending of the message (as is the case for WALLET_SPEND_ACTION).`,
+  );

--- a/packages/smart-wallet/src/typeGuards.js
+++ b/packages/smart-wallet/src/typeGuards.js
@@ -1,69 +1,27 @@
 import { M } from '@agoric/store';
+import { ProposalShape } from '@agoric/zoe/src/typeGuards.js';
 import {
-  InstanceHandleShape,
-  ProposalShape,
-} from '@agoric/zoe/src/typeGuards.js';
-
-/**
- * @import {TypedPattern} from '@agoric/internal';
- * @import {InvokeEntryMessage, ResultPlan} from './offers';
- */
-
-/** @type {TypedPattern<ResultPlan>} */
-const ResultPlanShape = M.splitRecord(
-  { name: M.string() },
-  { overwrite: M.boolean() },
-  {},
-);
-/** @type {TypedPattern<InvokeEntryMessage>} */
-const InvokeEntryMessageShape = M.splitRecord(
-  {
-    targetName: M.string(),
-    method: M.string(),
-    args: M.array(),
-  },
-  { saveResult: ResultPlanShape, id: M.or(M.number(), M.string()) },
-  {},
-);
+  AgoricContractInvitationSpec as AgoricContractInvitationSpecPattern,
+  ContractInvitationSpec as ContractInvitationSpecPattern,
+  ContinuingInvitationSpec as ContinuingInvitationSpecPattern,
+  InvokeEntryMessage,
+  PurseInvitationSpec as PurseInvitationSpecPattern,
+  ResultPlan,
+  StringCapData as StringCapDataPattern,
+  WalletActionMsg as WalletActionMsgPattern,
+  WalletBridgeMsg as WalletBridgeMsgPattern,
+  WalletSpendActionMsg as WalletSpendActionMsgPattern,
+} from './schemas/codegen/type-guards.patterns.js';
 
 export const shape = {
   // smartWallet
-  StringCapData: {
-    body: M.string(),
-    slots: M.arrayOf(M.string()),
-  },
+  StringCapData: StringCapDataPattern,
 
   // invitations
-  AgoricContractInvitationSpec: {
-    source: 'agoricContract',
-    instancePath: M.arrayOf(M.string()),
-    callPipe: M.arrayOf(M.splitArray([M.string()], [M.arrayOf(M.any())])),
-  },
-  ContractInvitationSpec: M.splitRecord(
-    {
-      source: 'contract',
-      instance: InstanceHandleShape,
-      publicInvitationMaker: M.string(),
-    },
-    {
-      invitationArgs: M.array(),
-    },
-  ),
-  ContinuingInvitationSpec: M.splitRecord(
-    {
-      source: 'continuing',
-      previousOffer: M.or(M.number(), M.string()),
-      invitationMakerName: M.string(),
-    },
-    {
-      invitationArgs: M.array(),
-    },
-  ),
-  PurseInvitationSpec: {
-    source: 'purse',
-    instance: InstanceHandleShape,
-    description: M.string(),
-  },
+  AgoricContractInvitationSpec: AgoricContractInvitationSpecPattern,
+  ContractInvitationSpec: ContractInvitationSpecPattern,
+  ContinuingInvitationSpec: ContinuingInvitationSpecPattern,
+  PurseInvitationSpec: PurseInvitationSpecPattern,
 
   // offers
   OfferSpec: M.splitRecord(
@@ -75,12 +33,12 @@ export const shape = {
     },
     {
       offerArgs: M.any(),
-      saveResult: ResultPlanShape,
+      saveResult: ResultPlan,
     },
     {},
   ),
-  ResultPlan: ResultPlanShape,
-  InvokeEntryMessage: InvokeEntryMessageShape,
+  ResultPlan,
+  InvokeEntryMessage,
 
   // walletFactory
   /**
@@ -88,28 +46,14 @@ export const shape = {
    *
    * @see walletAction in msg_server.go
    */
-  WalletActionMsg: M.splitRecord({
-    type: 'WALLET_ACTION',
-    action: M.string(),
-
-    blockHeight: M.number(),
-    blockTime: M.number(),
-    owner: M.string(),
-  }),
+  WalletActionMsg: WalletActionMsgPattern,
 
   /**
    * Defined by walletAction struct in msg_server.go
    *
    * @see walletSpendAction in msg_server.go
    */
-  WalletSpendActionMsg: M.splitRecord({
-    type: 'WALLET_SPEND_ACTION',
-    spendAction: M.string(),
-
-    blockHeight: M.number(),
-    blockTime: M.number(),
-    owner: M.string(),
-  }),
+  WalletSpendActionMsg: WalletSpendActionMsgPattern,
+  WalletBridgeMsg: WalletBridgeMsgPattern,
 };
-shape.WalletBridgeMsg = M.or(shape.WalletActionMsg, shape.WalletSpendActionMsg);
 harden(shape);

--- a/packages/smart-wallet/src/types.ts
+++ b/packages/smart-wallet/src/types.ts
@@ -42,44 +42,11 @@ export type Cell<T> = {
   set(val: T): void;
 };
 
-/**
- * Defined by walletAction struct in msg_server.go
- *
- * @see {agoric.swingset.MsgWalletAction} and walletSpendAction in msg_server.go
- */
-export type WalletActionMsg = {
-  type: 'WALLET_ACTION';
-  /** base64 of Uint8Array of bech32 data  */
-  owner: string;
-  /** JSON of marshalled BridgeAction */
-  action: string;
-  blockHeight: unknown; // int64
-  blockTime: unknown; // int64
-};
-
-/**
- * Defined by walletSpendAction struct in msg_server.go
- *
- * @see {agoric.swingset.MsgWalletSpendAction} and walletSpendAction in msg_server.go
- */
-export type WalletSpendActionMsg = {
-  type: 'WALLET_SPEND_ACTION';
-  /** base64 of Uint8Array of bech32 data  */
-  owner: string;
-  /** JSON of BridgeActionCapData */
-  spendAction: string;
-  blockHeight: unknown; // int64
-  blockTime: unknown; // int64
-};
-
-/**
- * Messages transmitted over Cosmos chain, cryptographically verifying that the
- * message came from the 'owner'.
- *
- * The two wallet actions are distinguished by whether the user had to confirm
- * the sending of the message (as is the case for WALLET_SPEND_ACTION).
- */
-export type WalletBridgeMsg = WalletActionMsg | WalletSpendActionMsg;
+export type {
+  WalletBridgeMsg,
+  WalletActionMsg,
+  WalletSpendActionMsg,
+} from './schemas/codegen/type-guards.patterns.js';
 
 /**
  * Used for clientSupport helpers

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,6 +1047,9 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.13"
     ava: "npm:^5.3.0"
     import-meta-resolve: "npm:^4.1.0"
+  peerDependencies:
+    "@agoric/schemas": "workspace:*"
+    zod: ^4.1.11
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,6 +959,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@agoric/schemas@workspace:packages/schemas":
+  version: 0.0.0-use.local
+  resolution: "@agoric/schemas@workspace:packages/schemas"
+  dependencies:
+    "@endo/far": "npm:^1.1.14"
+    "@endo/init": "npm:^1.1.12"
+    "@endo/patterns": "npm:^1.7.0"
+    "@endo/ses-ava": "npm:^1.3.2"
+    ava: "npm:^5.3.0"
+    zod: "npm:^4.1.11"
+  bin:
+    agoric-schemas: bin/compile-schemas.js
+  languageName: unknown
+  linkType: soft
+
 "@agoric/sdk@workspace:.":
   version: 0.0.0-use.local
   resolution: "@agoric/sdk@workspace:."
@@ -17975,5 +17990,12 @@ __metadata:
   dependencies:
     grammex: "npm:^3.1.10"
   checksum: 10c0/a40e4159aac8e5afa1977591ec71803265a28a436010e0cc046a0fb893c06aaeb4f51c40cd8eba7ab6cad4c499af98eccc16d7e12171b228ca936f6ef2eb1529
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "zod@npm:4.1.11"
+  checksum: 10c0/ce6a4c4acfbf51d7dd0f2669c82f207d62a1f00264eef608994b94eb99d86a74c99f59b0dd3e61ef82909ee136631378b709e0908f0a02a2d5c21d0c497de5db
   languageName: node
   linkType: hard


### PR DESCRIPTION
refs: #6160

## Description
Zod is a well-supported and widely used library for expressing and validating JS schemas. Agoric is using it in web services and browser apps that don't support remotables.

This is an experiment to use Zod schemas as the source of truth for type schemas so they can be exported and re-use in those environments. It uses a new codegen script to generate matching Endo Patterns.

One of the upshots is that we get autogenerated docs and TS typedefs!

One regression is that the conversion process is losing the composition expression. For example, a union gets expanded into the full structural description instead of maintaining the concise `UnionType = TypeAlias1 | TypeAlias2`. To address that we'd need the transformation to read the AST rather than just the Zod object exports. Very doable tho.

There is some DX cost to having this build step.

One other upside of this is is opens up autogenerating the types for what comes out of vstorage which changes remotables to `null | boardId`. 



### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
