### PR TITLE
fix(ymax-planner): Allow target weight of zero

### DIFF
--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -127,12 +127,12 @@ const computeWeightedTargets = (
     : typedEntries(current as Required<typeof current>).map(
         ([key, amount]) => [key, amount.value] as [PoolKey, NatValue],
       );
-  for (const entry of weights) {
+  const sumW = weights.reduce<bigint>((acc, entry) => {
     const w = entry[1];
     (typeof w === 'bigint' && w >= 0n) ||
       Fail`allocation weight in ${entry} must be a Nat`;
-  }
-  const sumW = weights.reduce<bigint>((acc, [, w]) => acc + w, 0n);
+    return acc + w;
+  }, 0n);
   sumW > 0n || Fail`allocation weights must sum > 0`;
   const draft: Partial<Record<AssetPlaceRef, NatAmount>> = {};
   let remainder = total;

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -129,7 +129,7 @@ const computeWeightedTargets = (
       );
   for (const entry of weights) {
     const w = entry[1];
-    (typeof w === 'bigint' && w > 0n) ||
+    (typeof w === 'bigint' && w >= 0n) ||
       Fail`allocation weight in ${entry} must be a Nat`;
   }
   const sumW = weights.reduce<bigint>((acc, [, w]) => acc + w, 0n);

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -317,6 +317,7 @@ test('planRebalanceToAllocations emits an empty plan when already balanced', asy
 test('planRebalanceToAllocations moves funds when needed', async t => {
   const targetAllocation = {
     USDN: 40n,
+    USDNVault: 0n,
     Aave_Arbitrum: 40n,
     Compound_Arbitrum: 20n,
   };


### PR DESCRIPTION
## Description
`0n` is a valid Nat, and more importantly a valid targetAllocation value that is already allowed by the contract and UI.

### Testing Considerations
Covered.

### Upgrade Considerations
Safe to deploy immediately.