### PR TITLE
feat(ymax-tool): REPL

### DIFF
--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -225,18 +225,25 @@ $(DEPLOY)/dist/portfolio.contract.bundle.js:
 PUBLISHER=gov2.devnet
 publish-ymax0: ,ymax0-installed
 
+AGORIC_NET ?= devnet
+YMAX_TOOL=./scripts/ymax-tool.ts
+
 ,ymax0-installed: $(DEPLOY)/dist/bundle-ymax0.json
 	agd keys --keyring-backend=test show $(PUBLISHER)
 	AGORIC_NET=devnet ./scripts/install-bundle.ts $< >$@ || (rm $@; false)
+
+,privateArgsOverrides.json:
+	@echo "Using AGORIC_NET=$(AGORIC_NET)"
+	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --buildEthOverrides >$@ || (rm $@; false)
 
 yctrl-redeploy: ,ymax0-deployed
 
 REASON=
 NETCONFIG=https://devnet.agoric.net/network-config
-,ymax0-deployed: $(DEPLOY)/dist/bundle-ymax0.json ,ymax0-bundle-id ,ymax0-installed
+,ymax0-deployed: $(DEPLOY)/dist/bundle-ymax0.json ,ymax0-bundle-id ,ymax0-installed ,privateArgsOverrides.json
 	@[ -n "$$MNEMONIC" ] || (echo "ymaxControl MNEMONIC not set; see gov keys sheet"; false)
 	if [ -n "$$REASON" ]; then AGORIC_NET=devnet ./scripts/ymax-tool.ts --terminate "$(REASON)"; else true; fi
-	AGORIC_NET=devnet ./scripts/ymax-tool.ts --installAndStart $$(cat ,ymax0-bundle-id)
+	AGORIC_NET=devnet ./scripts/ymax-tool.ts --installAndStart $$(cat ,ymax0-bundle-id) <,privateArgsOverrides.json
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 
 ,creatorFacet: ,ymax0-deployed

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -250,12 +250,28 @@ NETCONFIG=https://devnet.agoric.net/network-config
 	AGORIC_NET=devnet ./scripts/ymax-tool.ts --getCreatorFacet
 	touch $@
 
+introduce-parties: ,invitePlanner ,inviteResolver
+
 # see gov keys sheet
-PLANNER=agoric140yw0u2qrvmrgp33ejpddgnrwpm74vpfpx5v7n
+PLANNER ?= agoric140yw0u2qrvmrgp33ejpddgnrwpm74vpfpx5v7n
 ,invitePlanner: ,creatorFacet
-	AGORIC_NET=devnet ./scripts/ymax-tool.ts --pruneStorage --invitePlanner $(PLANNER)
+	AGORIC_NET=devnet ./scripts/ymax-tool.ts --invitePlanner $(PLANNER)
 	touch $@
-	@echo now use planner MNEMONIC: ymax-tool.ts --redeem
+	@echo now use planner MNEMONIC: ymax-tool.ts --redeem --description planner
+
+RESOLVER ?= $(PLANNER)
+,inviteResolver: ,creatorFacet
+	AGORIC_NET=$(AGORIC_NET) \
+		$(YMAX_TOOL) --inviteResolver $(RESOLVER)
+	touch $@
+	@echo now use resolver MNEMONIC: ymax-tool.ts --redeem --description resolver
+
+check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
+
+,vstorage-outdated-$(AGORIC_NET).json:
+	@echo "Using AGORIC_NET=$(AGORIC_NET)"
+	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --checkStorage >$@ || \
+		(rm $@; false)
 
 # TODO: get from vstorage
 FEE_ACCT=agoric1rqqy9r0s4ahl8agr89f200gch78hnef3jckf4vntqe4p67rsxegs9qpzjw

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -49,7 +49,10 @@ import type { OfferStatus } from '@agoric/smart-wallet/src/offers.js';
 import type { NameHub } from '@agoric/vats';
 import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils';
 import { SigningStargateClient } from '@cosmjs/stargate';
+import { E } from '@endo/far';
 import { M } from '@endo/patterns';
+import { once } from 'node:events';
+import repl from 'node:repl';
 import { parseArgs } from 'node:util';
 import {
   reflectWalletStore,
@@ -70,6 +73,7 @@ Options:
   --contract=[ymax0]  agoricNames.instance name of contract that issued invitation
   --description=[planner]
   --submit-for <id>   submit (empty) plan for portfolio <id>
+  --repl              start a repl with walletStore and ymaxControl bound
   -h, --help          Show this help message`;
 
 const parseToolArgs = (argv: string[]) =>
@@ -83,6 +87,7 @@ const parseToolArgs = (argv: string[]) =>
       redeem: { type: 'boolean', default: false },
       contract: { type: 'string', default: 'ymax0' },
       description: { type: 'string', default: 'planner' },
+      repl: { type: 'boolean', default: false },
       getCreatorFacet: { type: 'boolean', default: false },
       terminate: { type: 'string' },
       buildEthOverrides: { type: 'boolean' },
@@ -443,6 +448,23 @@ const main = async (
   }
 
   const yc = walletStore.get<ContractControl<YMaxStartFn>>('ymaxControl');
+
+  if (values.repl) {
+    const tools = {
+      E,
+      harden,
+      networkConfig,
+      walletKit,
+      signing: sig,
+      walletStore,
+      ymaxControl: yc,
+    };
+    console.error('bindings:', Object.keys(tools).join(', '));
+    const session = repl.start({ prompt: 'ymax> ', useGlobal: true });
+    Object.assign(session.context, tools);
+    await once(session, 'exit');
+    return;
+  }
 
   if (values.getCreatorFacet) {
     await walletStore.savingResult('creatorFacet', () => yc.getCreatorFacet());

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -501,8 +501,15 @@ const main = async (
 
   if (values.pruneStorage) {
     const txt = await readText(stdin);
-    const toPrune = JSON.parse(txt);
-    await yc.pruneChainStorage(toPrune);
+    const toPrune: Record<string, string[]> = JSON.parse(txt);
+    // avoid: Must not have more than 80 properties: (an object)
+    const batchSize = 50;
+
+    const es = Object.entries(toPrune);
+    for (let i = 0; i < es.length; i += batchSize) {
+      const batch = es.slice(i, i + batchSize);
+      await yc.pruneChainStorage(fromEntries(batch));
+    }
     return;
   }
 

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -61,14 +61,14 @@ NETCONFIG=https://main.agoric.net/network-config
 		$(YMAX_TOOL) --getCreatorFacet
 	touch $@
 
-PLANNER=agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
+PLANNER ?= agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
 ,invitePlanner: ,creatorFacet
 	AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --invitePlanner $(PLANNER)
 	touch $@
 	@echo now use planner MNEMONIC: ymax-tool.ts --redeem
 
-RESOLVER=agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
+RESOLVER ?= agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
 ,inviteResolver: ,creatorFacet
 	AGORIC_NET=$(AGORIC_NET) \
 		$(YMAX_TOOL) --inviteResolver $(RESOLVER)


### PR DESCRIPTION
## Description

misc ymax Makefile update, plus...

`ymax-tool.ts` lacked support for `.upgrade()` and `.revoke()`. Rather than adding yet more code to map CLI args to js method calls, let's just add a REPL.

Example usage:

```console
$ AGORIC_NET=devnet ./scripts/ymax-tool.ts --repl
----- YMXTool,24  address agoric1c0eq3m8sze9cj8lxr7h66fu3jgqtevqxv8svcm
bindings: E, harden, networkConfig, walletKit, signing, walletStore, ymaxControl
ymax> try { await ymaxControl.revoke() } catch(err) { console.log('???', err); }
----- YMXTool,24  invoke {
  id: 'revoke.2025-10-04T23:10:28.335Z',
  targetName: 'ymaxControl',
  method: 'revoke',
  args: []
}
...
----- YMXTool,24  RESULT {
  id: 'revoke.2025-10-04T23:10:28.335Z',
  result: { passStyle: 'undefined' },
  updated: 'invocation'
}
undefined
```

### Security / Scaling Considerations

YOLO!

That is: the user can execute arbitrary code. But they could do that by writing scripts and modules anyway. So in the end, it's no more power than whatever MNEMONIC they're using.

### Documentation Considerations

self-explanatory?

### Testing Considerations

Did I mention YOLO?

### Upgrade Considerations

n/a
