### PR TITLE
feat(ymax planner): Support "ymax1" contract

### DIFF
--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -71,6 +71,7 @@ Options:
   --target-allocation JSON string of target allocation (e.g. '{"USDN":6000,"Aave_Arbitrum":4000}')
   --redeem            redeem invitation
   --contract=[ymax0]  agoricNames.instance name of contract that issued invitation
+                      ('ymax0' or 'ymax1')
   --description=[planner]
   --submit-for <id>   submit (empty) plan for portfolio <id>
   --repl              start a repl with walletStore and ymaxControl bound
@@ -145,11 +146,13 @@ const openPositions = async (
   {
     sig,
     when,
+    contract,
     targetAllocation,
     id = `open-${new Date(when).toISOString()}`,
   }: {
     sig: SigningSmartWalletKit;
     when: number;
+    contract: string;
     targetAllocation?: TargetAllocation;
     id?: string;
   },
@@ -196,7 +199,7 @@ const openPositions = async (
         id,
         invitationSpec: {
           source: 'agoricContract',
-          instancePath: ['ymax0'],
+          instancePath: [contract],
           callPipe: [['makeOpenPortfolioInvitation']],
         },
         proposal,
@@ -558,6 +561,7 @@ const main = async (
     const opened = await openPositions(positionData, {
       sig,
       when: now(),
+      contract: values.contract,
       targetAllocation,
     });
     trace('opened', opened);

--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -83,7 +83,7 @@ Environment variables:
   "$subdomain,$chainId" or "$fqdn,$chainId" for sending cosmos-sdk RPC requests
   to $subdomain.rpc.agoric.net or $fqdn (respectively) and assuming the chain ID
   (default derived from `CLUSTER`, falling back to "local")
-- `CONTRACT_INSTANCE`: Contract instance identifier, either "ymax0" (dev) or "ymax1" (prod) (default "ymax0")
+- `CONTRACT_INSTANCE`: Contract instance identifier, either "ymax0" (dev) or "ymax1" (prod) (required)
 - `ALCHEMY_API_KEY`: API key for accessing Alchemy's RPC endpoint (required, but not verified at startup)
   - **Important**: For all EVM chains in `AxelarChain` (see `packages/portfolio-api/src/constants.js`), ensure they are enabled in your Alchemy dashboard.
 - `GCP_PROJECT_ID`: For fetching an unset `MNEMONIC` from the Google Cloud Secret Manager (default "simulationlab")

--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -83,6 +83,7 @@ Environment variables:
   "$subdomain,$chainId" or "$fqdn,$chainId" for sending cosmos-sdk RPC requests
   to $subdomain.rpc.agoric.net or $fqdn (respectively) and assuming the chain ID
   (default derived from `CLUSTER`, falling back to "local")
+- `CONTRACT_INSTANCE`: Contract instance identifier, either "ymax0" (dev) or "ymax1" (prod) (default "ymax0")
 - `ALCHEMY_API_KEY`: API key for accessing Alchemy's RPC endpoint (required, but not verified at startup)
   - **Important**: For all EVM chains in `AxelarChain` (see `packages/portfolio-api/src/constants.js`), ensure they are enabled in your Alchemy dashboard.
 - `GCP_PROJECT_ID`: For fetching an unset `MNEMONIC` from the Google Cloud Secret Manager (default "simulationlab")

--- a/services/ymax-planner/package.json
+++ b/services/ymax-planner/package.json
@@ -77,7 +77,8 @@
     ],
     "require": [
       "@endo/init/debug.js"
-    ]
+    ],
+    "timeout": "30s"
   },
   "typeCoverage": {
     "atLeast": 93.19

--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -18,6 +18,7 @@ export const defaultAgoricNetworkSpecForCluster: Record<ClusterName, string> =
 
 export interface YmaxPlannerConfig {
   readonly clusterName: ClusterName;
+  readonly contractInstance: string;
   readonly mnemonic: string;
   readonly alchemyApiKey: string;
   readonly spectrum: {
@@ -138,8 +139,14 @@ export const loadConfig = async (
     isMainnet ? ids.mainnet : ids.testnet,
   );
 
+  const contractInstance = env.CONTRACT_INSTANCE?.trim() || 'ymax0';
+  if (contractInstance !== 'ymax0' && contractInstance !== 'ymax1') {
+    throw Fail`CONTRACT_INSTANCE must be 'ymax0' or 'ymax1', got: ${contractInstance}`;
+  }
+
   const config: YmaxPlannerConfig = harden({
     clusterName,
+    contractInstance,
     mnemonic,
     alchemyApiKey: validateRequired(env, 'ALCHEMY_API_KEY'),
     spectrum: {

--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -139,7 +139,7 @@ export const loadConfig = async (
     isMainnet ? ids.mainnet : ids.testnet,
   );
 
-  const contractInstance = env.CONTRACT_INSTANCE?.trim() || 'ymax0';
+  const contractInstance = validateRequired(env, 'CONTRACT_INSTANCE');
   if (contractInstance !== 'ymax0' && contractInstance !== 'ymax1') {
     throw Fail`CONTRACT_INSTANCE must be 'ymax0' or 'ymax1', got: ${contractInstance}`;
   }

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -122,6 +122,7 @@ export const main = async (
     gasEstimator,
   };
   await startEngine(powers, {
+    contractInstance: config.contractInstance,
     depositBrandName: env.DEPOSIT_BRAND_NAME || 'USDC',
     feeBrandName: env.FEE_BRAND_NAME || 'BLD',
   });

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -210,8 +210,8 @@ export type HandlePendingTxOpts = {
   registry?: MonitorRegistry;
   timeoutMs?: number;
   vstoragePathPrefixes: {
-    PORTFOLIOS_PATH_PREFIX: string;
-    PENDING_TX_PATH_PREFIX: string;
+    portfoliosPathPrefix: string;
+    pendingTxPathPrefix: string;
   };
 } & EvmContext;
 

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -209,6 +209,10 @@ export type HandlePendingTxOpts = {
   marshaller: SigningSmartWalletKit['marshaller'];
   registry?: MonitorRegistry;
   timeoutMs?: number;
+  vstoragePathPrefixes: {
+    PORTFOLIOS_PATH_PREFIX: string;
+    PENDING_TX_PATH_PREFIX: string;
+  };
 } & EvmContext;
 
 export const TX_TIMEOUT_MS = 30 * 60 * 1000; // 30 min

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -14,6 +14,7 @@ const { entries, keys } = Object;
 const minimalEnv = {
   MNEMONIC: 'test mnemonic phrase',
   ALCHEMY_API_KEY: 'test1234',
+  CONTRACT_INSTANCE: 'ymax1',
 };
 
 const makeFakeSecretManager = (mnemonic?: string) =>
@@ -45,6 +46,7 @@ test('loadConfig accepts valid configuration', async t => {
   const env = {
     CLUSTER: 'testnet',
     MNEMONIC: 'test mnemonic phrase',
+    CONTRACT_INSTANCE: 'ymax1',
     ALCHEMY_API_KEY: 'test1234',
     SPECTRUM_API_URL: 'https://api.spectrum.example.com',
     SPECTRUM_API_TIMEOUT: '5000',
@@ -73,7 +75,7 @@ test('loadConfig uses default values when optional fields are missing', async t 
   const config = await callLoadConfig();
 
   t.is(config.clusterName, 'local');
-  t.is(config.contractInstance, 'ymax0');
+  t.is(config.contractInstance, 'ymax1');
   t.is(config.mnemonic, 'test mnemonic phrase');
   t.is(config.alchemyApiKey, 'test1234');
   t.is(config.spectrum.apiUrl, undefined);

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -73,6 +73,7 @@ test('loadConfig uses default values when optional fields are missing', async t 
   const config = await callLoadConfig();
 
   t.is(config.clusterName, 'local');
+  t.is(config.contractInstance, 'ymax0');
   t.is(config.mnemonic, 'test mnemonic phrase');
   t.is(config.alchemyApiKey, 'test1234');
   t.is(config.spectrum.apiUrl, undefined);
@@ -166,6 +167,22 @@ test('loadConfig trims whitespace from values', async t => {
 test('loadConfig rejects empty required values', async t => {
   await t.throwsAsync(() => callLoadConfig({ ALCHEMY_API_KEY: '   ' }), {
     message: '"ALCHEMY_API_KEY" is required',
+  });
+});
+
+test('loadConfig accepts ymax0 contract instance', async t => {
+  const config = await callLoadConfig({ CONTRACT_INSTANCE: 'ymax0' });
+  t.is(config.contractInstance, 'ymax0');
+});
+
+test('loadConfig accepts ymax1 contract instance', async t => {
+  const config = await callLoadConfig({ CONTRACT_INSTANCE: 'ymax1' });
+  t.is(config.contractInstance, 'ymax1');
+});
+
+test('loadConfig rejects invalid contract instance', async t => {
+  await t.throwsAsync(() => callLoadConfig({ CONTRACT_INSTANCE: 'ymax2' }), {
+    message: /CONTRACT_INSTANCE must be 'ymax0' or 'ymax1'/,
   });
 });
 

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -9,9 +9,10 @@ import type { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers';
 import type { CosmosRestClient } from '../src/cosmos-rest-client.ts';
 import type { CosmosRPCClient } from '../src/cosmos-rpc.ts';
-import { PENDING_TX_PATH_PREFIX } from '../src/engine.ts';
 import { makeGasEstimator } from '../src/gas-estimation.ts';
 import type { HandlePendingTxOpts } from '../src/pending-tx-manager.ts';
+
+const PENDING_TX_PATH_PREFIX = 'published.ymax1';
 
 const mockFetchForGasEstimate = async (_, options?: any) => {
     return {
@@ -140,6 +141,10 @@ export const createMockPendingTxOpts = (): HandlePendingTxOpts => ({
   usdcAddresses: {
     'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // Ethereum
     'eip155:42161': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // Arbitrum
+  },
+  vstoragePathPrefixes: {
+    PORTFOLIOS_PATH_PREFIX: 'IGNORED',
+    PENDING_TX_PATH_PREFIX,
   },
 });
 

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -143,8 +143,8 @@ export const createMockPendingTxOpts = (): HandlePendingTxOpts => ({
     'eip155:42161': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // Arbitrum
   },
   vstoragePathPrefixes: {
-    PORTFOLIOS_PATH_PREFIX: 'IGNORED',
-    PENDING_TX_PATH_PREFIX,
+    portfoliosPathPrefix: 'IGNORED',
+    pendingTxPathPrefix: PENDING_TX_PATH_PREFIX,
   },
 });
 


### PR DESCRIPTION
Replaces #12060

## Description
Parameterizes ymax-planner on new required environment variable `CONTRACT_INSTANCE`, used to construct vstorage path prefixes like `published.${contractInstance}.portfolios`.

### Security Considerations
None.

### Scaling Considerations
None.

### Documentation Considerations
README updated.

### Testing Considerations
Preserved multichain-testing/ changes from #12060.

### Upgrade Considerations
Once deployed, ymax-planner will require the new environment variable (i.e., `CONTRACT_INSTANCE=ymax0` or `CONTRACT_INSTANCE=ymax1`).