### PR TITLE
fix(ymax-planner): get USDN balance using uusdn denom

### DIFF
--- a/services/ymax-planner/src/cosmos-rest-client.ts
+++ b/services/ymax-planner/src/cosmos-rest-client.ts
@@ -3,10 +3,14 @@ import type { QueryAllBalancesResponse } from '@agoric/cosmic-proto/cosmos/bank/
 import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import ky, { HTTPError, type KyInstance } from 'ky';
 
-import { chain as nobleMain } from 'chain-registry/mainnet/noble/index.js';
+import {
+  chain as nobleMain,
+  assetList as nobleAssetList,
+} from 'chain-registry/mainnet/noble/index.js';
 import { chain as agoricMain } from 'chain-registry/mainnet/agoric/index.js';
 import { chain as nobleTest } from 'chain-registry/testnet/nobletestnet/index.js';
 import { chain as agoricTest } from 'chain-registry/testnet/agoricdevnet/index.js'; // agoricdev was named before testnets were a thing
+import { Fail } from '@endo/errors';
 
 import type { ClusterName } from './config.ts';
 
@@ -58,6 +62,9 @@ const CHAIN_CONFIGS: Record<
     },
   },
 };
+
+export const USDN =
+  nobleAssetList.assets.find(a => a.symbol === 'USDN') || Fail`no USDN`;
 
 export class CosmosRestClient {
   private readonly fetch: typeof fetch;

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -20,7 +20,7 @@ import type { NetworkSpec } from '@aglocal/portfolio-contract/tools/network/netw
 import { PROD_NETWORK } from '@aglocal/portfolio-contract/tools/network/network.prod.js';
 import { planRebalanceFlow } from '@aglocal/portfolio-contract/tools/plan-solve.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
-import type { CosmosRestClient } from './cosmos-rest-client.js';
+import { USDN, type CosmosRestClient } from './cosmos-rest-client.js';
 import type { Chain, Pool, SpectrumClient } from './spectrum-client.js';
 
 const getOwn = <O, K extends PropertyKey>(
@@ -46,7 +46,11 @@ export const getCurrentBalance = async (
     case 'USDN': {
       const addr = addressOfAccountId(accountIdByChain[chainName]);
       // XXX add denom to PoolPlaceInfo?
-      const resp = await cosmosRest.getAccountBalance(chainName, addr, 'usdn');
+      const resp = await cosmosRest.getAccountBalance(
+        chainName,
+        addr,
+        USDN.base,
+      );
       return BigInt(resp.amount);
     }
     case 'Aave':

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -9,7 +9,7 @@ import type { VstorageKit } from '@agoric/client-utils';
 import { AmountMath, type Brand } from '@agoric/ertp';
 import { objectMap } from '@agoric/internal';
 import { Far } from '@endo/pass-style';
-import { CosmosRestClient } from '../src/cosmos-rest-client.ts';
+import { CosmosRestClient, USDN } from '../src/cosmos-rest-client.ts';
 import {
   handleDeposit,
   planDepositToAllocations,
@@ -110,7 +110,7 @@ test('handleDeposit works with mocked dependencies', async t => {
     }
 
     async getAccountBalance(chainName: string, addr: string, denom: string) {
-      if (chainName === 'noble' && denom === 'usdn') {
+      if (chainName === 'noble' && denom === 'uusdn') {
         return { denom, amount: '200' };
       }
       return { denom, amount: '0' };
@@ -269,7 +269,7 @@ test('handleDeposit handles different position types correctly', async t => {
     }
 
     async getAccountBalance(chainName: string, addr: string, denom: string) {
-      if (chainName === 'noble' && denom === 'usdn') {
+      if (chainName === 'noble' && denom === 'uusdn') {
         return { denom, amount: '300' };
       }
       return { denom, amount: '0' };
@@ -391,4 +391,8 @@ test('planDepositToAllocations produces steps expected by contract', async t => 
 
   const expected = planUSDNDeposit(amount);
   t.deepEqual(actual, expected);
+});
+
+test('USDN denom', t => {
+  t.is(USDN.base, 'uusdn');
 });


### PR DESCRIPTION
refs:
 - https://github.com/Agoric/agoric-private/issues/426

## Description

fix typo: `usdn` -> `uusdn`

### Security Considerations

Using the wrong denom interfered with withdrawals.

### Scaling Considerations

n/a

### Documentation / Testing Considerations

Uses `@chain-registry` to get denom. Checks it against a constant in a test.

### Upgrade Considerations

SOP
