### PR TITLE
feat(ymax-planner): use alchemy to fetch evm account balances

### DIFF
--- a/packages/portfolio-api/src/type-guards.ts
+++ b/packages/portfolio-api/src/type-guards.ts
@@ -1,7 +1,7 @@
 import type {
   BeefyInstrumentId,
   ERC4626InstrumentId,
-} from '@aglocal/portfolio-contract/src/type-guards.ts';
+} from '@aglocal/portfolio-contract/src/type-guards.js';
 import type { InstrumentId } from './instruments.js';
 import type {
   DepositFromChainRef,

--- a/packages/portfolio-contract/src/interfaces/orch-router.ts
+++ b/packages/portfolio-contract/src/interfaces/orch-router.ts
@@ -5,7 +5,7 @@
 import {
   PermitTransferFromComponents,
   PermitTransferFromInternalTypeName,
-} from '@agoric/orchestration/src/utils/permit2.ts';
+} from '@agoric/orchestration/src/utils/permit2.js';
 import type { Abi, AbiParameter, AbiParameterToPrimitiveType } from 'viem';
 
 /**

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -46,7 +46,7 @@ import {
   YieldProtocol,
   FlowConfigShape,
 } from '@agoric/portfolio-api/src/constants.js';
-import type { YmaxFullDomain } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.ts';
+import type { YmaxFullDomain } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
 import type {
   PermitDetails,
   YmaxOperationDetails,

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -57,6 +57,7 @@ import type {
   SupportedChain,
 } from '@agoric/portfolio-api';
 
+import type { EvmAddress } from '@agoric/fast-usdc';
 import type { CosmosRestClient } from './cosmos-rest-client.ts';
 import type { CosmosRPCClient, SubscriptionResponse } from './cosmos-rpc.ts';
 import type { Sdk as SpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
@@ -175,7 +176,7 @@ export type Powers = {
   rpc: CosmosRPCClient;
   spectrumBlockchain: SpectrumBlockchainSdk;
   spectrumChainIds: Partial<Record<SupportedChain, string>>;
-  positionTokenAddresses: Partial<Record<InstrumentId, string>>;
+  evmTokenAddresses: Partial<Record<InstrumentId, EvmAddress>>;
   cosmosRest: CosmosRestClient;
   network: NetworkSpec;
   signingSmartWalletKit: SigningSmartWalletKit;
@@ -196,7 +197,7 @@ export type ProcessPortfolioPowers = Pick<
   | 'network'
   | 'spectrumBlockchain'
   | 'spectrumChainIds'
-  | 'positionTokenAddresses'
+  | 'evmTokenAddresses'
   | 'signingSmartWalletKit'
   | 'walletStore'
   | 'getWalletInvocationUpdate'
@@ -253,7 +254,7 @@ export const processPortfolioEvents = async (
     getWalletInvocationUpdate,
     spectrumBlockchain,
     spectrumChainIds,
-    positionTokenAddresses,
+    evmTokenAddresses,
     usdcTokensByChain,
     vstoragePathPrefixes,
     evmProviders,
@@ -281,7 +282,7 @@ export const processPortfolioEvents = async (
     cosmosRest,
     spectrumBlockchain,
     spectrumChainIds,
-    positionTokenAddresses,
+    evmTokenAddresses,
     usdcTokensByChain,
     evmProviders,
     chainNameToChainIdMap,

--- a/services/ymax-planner/src/evm-utils.ts
+++ b/services/ymax-planner/src/evm-utils.ts
@@ -36,7 +36,7 @@ export const getPoolTokenAddresses = (
    * XXX This should take `axelarCfg` as an argument and be promoted up out of
    * getPoolTokenAddresses.
    */
-  const pickContracts = <K extends PoolKey>(
+  const pickContracts = <K extends PoolKey | `@${EvmChain}`>(
     keyFromContractLabel: (
       name: keyof EVMContractAddresses,
       chainName: EvmChain,
@@ -61,11 +61,17 @@ export const getPoolTokenAddresses = (
     (label, chainName) =>
       label === 'compound' && (`Compound_${chainName}` as PoolKey),
   );
+  const usdcAddresses = pickContracts(
+    (label, chainName) =>
+      label === 'usdc' && (`@${chainName}` as `@${EvmChain}`),
+  );
+
   const positionTokenAddresses = {
     ...erc4626VaultAddresses,
     ...beefyVaultAddresses,
     ...aavePoolAddresses,
     ...compoundPoolAddresses,
+    ...usdcAddresses,
   } as Partial<Record<PoolKey, EvmAddress>>;
 
   return positionTokenAddresses;
@@ -179,20 +185,20 @@ const getERC4626VaultBalance = async (
 };
 
 type PositionBalanceResult = {
-  place: PoolKey;
+  place: PoolKey | `@${EvmChain}`;
   balance: bigint | undefined;
   error?: string;
 };
 
 export type EVMPositionQuery = {
-  place: PoolKey;
+  place: PoolKey | `@${EvmChain}`;
   chainName: SupportedChain;
   address: string;
 };
 
 export type EVMPositionBalancePowers = {
-  /** Map from instrument ID (e.g. 'Aave_Ethereum') to its receipt token address */
-  positionTokenAddresses: Partial<Record<PoolKey, string>>;
+  /** Map from place (e.g. 'Aave_Ethereum', '@Ethereum') to its token address */
+  positionTokenAddresses: Partial<Record<PoolKey | `@${EvmChain}`, string>>;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
   evmProviders: EvmProviders;
 };

--- a/services/ymax-planner/src/evm-utils.ts
+++ b/services/ymax-planner/src/evm-utils.ts
@@ -27,7 +27,7 @@ import type { EvmProviders } from './support.ts';
  * - Compound pools
  * - USDC tokens (for USDC-based positions without a receipt token)
  *
- * These addresses are used by {@link getErc20PositionBalances} to query on-chain
+ * These addresses are used by {@link getErc20Balances} to query on-chain
  * balances via Alchemy
  */
 export const getPoolTokenAddresses = (
@@ -69,7 +69,7 @@ export const getPoolTokenAddresses = (
       label === 'usdc' && (`@${chainName}` as `@${EvmChain}`),
   );
 
-  const positionTokenAddresses = {
+  const evmTokenAddresses = {
     ...erc4626VaultAddresses,
     ...beefyVaultAddresses,
     ...aavePoolAddresses,
@@ -77,7 +77,7 @@ export const getPoolTokenAddresses = (
     ...usdcAddresses,
   } as Partial<Record<PoolKey, EvmAddress>>;
 
-  return positionTokenAddresses;
+  return evmTokenAddresses;
 };
 
 /**
@@ -124,7 +124,7 @@ const BEEFY_VAULT_DECIMALS = 10n ** 18n;
 /**
  * Fetch the ERC-20 token balance for an address using an ethers WebSocketProvider.
  */
-export const getErc20PositionBalance = async (
+export const getErc20Balance = async (
   tokenAddress: string,
   userAddress: string,
   provider: WebSocketProvider,
@@ -135,7 +135,7 @@ export const getErc20PositionBalance = async (
     const balance: bigint = await token.balanceOf(userAddress);
     return balance;
   } catch (cause) {
-    throw Error(`Failed to fetch EVM position balance`, { cause });
+    throw Error(`Failed to fetch EVM balance`, { cause });
   }
 };
 
@@ -187,48 +187,47 @@ const getERC4626VaultBalance = async (
   }
 };
 
-type PositionBalanceResult = {
+type EvmBalanceResult = {
   place: InterChainAccountRef | PoolKey;
   balance: bigint | undefined;
   error?: string;
 };
 
-export type EVMPositionQuery = {
+export type EvmBalanceQuery = {
   place: InterChainAccountRef | PoolKey;
   chainName: SupportedChain;
   address: string;
 };
 
-export type EVMPositionBalancePowers = {
+export type EvmBalancePowers = {
   /** Map from place (e.g. 'Aave_Ethereum', '@Ethereum') to its token address */
-  positionTokenAddresses: Partial<
-    Record<InterChainAccountRef | PoolKey, string>
+  evmTokenAddresses: Partial<
+    Record<InterChainAccountRef | PoolKey, EvmAddress>
   >;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
   evmProviders: EvmProviders;
 };
 
 /**
- * Fetch EVM position balances by querying receipt token contracts directly.
+ * Fetch EVM balances by querying receipt token contracts directly.
  *
  * Dispatches to protocol-specific functions:
  * - Beefy: `balanceOf` + `getPricePerFullShare()` scaling
  * - ERC4626 (Morpho, etc.): `balanceOf` + `convertToAssets()`
- * - Default (Aave, Compound): simple `balanceOf` (already underlying)
+ * - Default (Aave, Compound, EVM accounts): simple `balanceOf` (already underlying)
  */
-export const getErc20PositionBalances = async (
-  queries: EVMPositionQuery[],
-  powers: EVMPositionBalancePowers,
-): Promise<{ balances: PositionBalanceResult[] }> => {
-  const { positionTokenAddresses, chainNameToChainIdMap, evmProviders } =
-    powers;
+export const getErc20Balances = async (
+  queries: EvmBalanceQuery[],
+  powers: EvmBalancePowers,
+): Promise<{ balances: EvmBalanceResult[] }> => {
+  const { evmTokenAddresses, chainNameToChainIdMap, evmProviders } = powers;
 
   const balances = await Promise.all(
     queries.map(async ({ place, chainName, address }) => {
       await null;
       try {
         const tokenAddress =
-          positionTokenAddresses[place] ||
+          evmTokenAddresses[place] ||
           Fail`No token address configured for instrument ${q(place)}`;
 
         const chainId: CaipChainId = chainNameToChainIdMap[chainName];
@@ -247,21 +246,17 @@ export const getErc20PositionBalances = async (
             provider,
           );
         } else {
-          balance = await getErc20PositionBalance(
-            tokenAddress,
-            address,
-            provider,
-          );
+          balance = await getErc20Balance(tokenAddress, address, provider);
         }
 
-        return { place, balance } as PositionBalanceResult;
+        return { place, balance } as EvmBalanceResult;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return {
           place,
           balance: undefined,
-          error: `Could not get EVM position balance: ${message}`,
-        } as PositionBalanceResult;
+          error: `Could not get EVM balance: ${message}`,
+        } as EvmBalanceResult;
       }
     }),
   );

--- a/services/ymax-planner/src/evm-utils.ts
+++ b/services/ymax-planner/src/evm-utils.ts
@@ -2,7 +2,10 @@ import { Contract } from 'ethers';
 import type { WebSocketProvider } from 'ethers';
 import type { PoolKey } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import type { CaipChainId } from '@agoric/orchestration';
-import type { SupportedChain } from '@agoric/portfolio-api';
+import type {
+  InterChainAccountRef,
+  SupportedChain,
+} from '@agoric/portfolio-api';
 import {
   isBeefyInstrumentId,
   isERC4626InstrumentId,
@@ -29,14 +32,14 @@ import type { EvmProviders } from './support.ts';
  */
 export const getPoolTokenAddresses = (
   axelarCfg: typeof axelarConfig,
-): Partial<Record<PoolKey | `@${EvmChain}`, EvmAddress>> => {
+): Partial<Record<InterChainAccountRef | PoolKey, EvmAddress>> => {
   /**
    * Select contracts from `axelarCfg` using a function that ensures uniqueness
    * of the corresponding name (e.g., by embedding the chain name).
    * XXX This should take `axelarCfg` as an argument and be promoted up out of
    * getPoolTokenAddresses.
    */
-  const pickContracts = <K extends PoolKey | `@${EvmChain}`>(
+  const pickContracts = <K extends InterChainAccountRef | PoolKey>(
     keyFromContractLabel: (
       name: keyof EVMContractAddresses,
       chainName: EvmChain,
@@ -185,20 +188,22 @@ const getERC4626VaultBalance = async (
 };
 
 type PositionBalanceResult = {
-  place: PoolKey | `@${EvmChain}`;
+  place: InterChainAccountRef | PoolKey;
   balance: bigint | undefined;
   error?: string;
 };
 
 export type EVMPositionQuery = {
-  place: PoolKey | `@${EvmChain}`;
+  place: InterChainAccountRef | PoolKey;
   chainName: SupportedChain;
   address: string;
 };
 
 export type EVMPositionBalancePowers = {
   /** Map from place (e.g. 'Aave_Ethereum', '@Ethereum') to its token address */
-  positionTokenAddresses: Partial<Record<PoolKey | `@${EvmChain}`, string>>;
+  positionTokenAddresses: Partial<
+    Record<InterChainAccountRef | PoolKey, string>
+  >;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
   evmProviders: EvmProviders;
 };

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -121,7 +121,7 @@ export const main = async (
     clusterName === 'mainnet' ? axelarConfig : axelarConfigTestnet
   ) as typeof axelarConfig;
 
-  const positionTokenAddresses = getPoolTokenAddresses(axelarCfg);
+  const evmTokenAddresses = getPoolTokenAddresses(axelarCfg);
   const networkConfig = await fetchEnvNetworkConfig({
     env: { AGORIC_NET: config.cosmosRest.agoricNetworkSpec },
     fetch,
@@ -298,7 +298,7 @@ export const main = async (
     },
     rpc,
     spectrumChainIds,
-    positionTokenAddresses,
+    evmTokenAddresses,
     spectrumBlockchain,
     cosmosRest,
     network: PROD_NETWORK,

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -59,7 +59,7 @@ export type BalanceQueryPowers = {
   cosmosRest: CosmosRestClient;
   spectrumBlockchain: SpectrumBlockchainSdk;
   spectrumChainIds: Partial<Record<SupportedChain, string>>;
-  positionTokenAddresses: Partial<Record<PoolKey, string>>;
+  positionTokenAddresses: Partial<Record<PoolKey | `@${EvmChain}`, string>>;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
   evmProviders: EvmProviders;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
@@ -73,9 +73,9 @@ type AccountQueryDescriptor = {
 };
 
 type PositionQueryDescriptor = {
-  place: PoolKey;
+  place: PoolKey | `@${EvmChain}`;
   chainName: SupportedChain;
-  protocol: PoolPlaceInfo['protocol'];
+  protocol: PoolPlaceInfo['protocol'] | 'USDC';
   address: string;
 };
 
@@ -113,9 +113,20 @@ export const getCurrentBalances = async (
     try {
       const addressParts = parseAccountId(accountId);
       addressInfo.set(chainName, addressParts);
-      const { accountAddress: address } = addressParts;
-      accountQueries.push({ place, chainName, address, asset: 'USDC' });
-    } catch {
+      const { namespace, accountAddress: address } = addressParts;
+      if (namespace === 'eip155') {
+        // EVM chain USDC balances are fetched directly via Alchemy.
+        positionQueries.push({
+          place: place as `@${EvmChain}`,
+          chainName,
+          protocol: 'USDC',
+          address,
+        });
+      } else {
+        accountQueries.push({ place, chainName, address, asset: 'USDC' });
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_err) {
       errors.push(Error(`Invalid CAIP-10 address for chain: ${chainName}`));
     }
   }
@@ -196,9 +207,12 @@ export const getCurrentBalances = async (
       errors.push(Error(result.error));
     }
     if (result.balance === undefined) {
-      balances.set(result.place, undefined);
+      balances.set(result.place as AssetPlaceRef, undefined);
     } else {
-      balances.set(result.place, AmountMath.make(brand, result.balance));
+      balances.set(
+        result.place as AssetPlaceRef,
+        AmountMath.make(brand, result.balance),
+      );
     }
   }
 

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -16,7 +16,11 @@ import type { Brand, NatAmount, NatValue } from '@agoric/ertp/src/types.js';
 import { objectMap, objectMetaMap, typedEntries } from '@agoric/internal';
 import type { Caip10Record, CaipChainId } from '@agoric/orchestration';
 import { parseAccountId } from '@agoric/orchestration/src/utils/address.js';
-import type { FundsFlowPlan, SupportedChain } from '@agoric/portfolio-api';
+import type {
+  FundsFlowPlan,
+  InterChainAccountRef,
+  SupportedChain,
+} from '@agoric/portfolio-api';
 import { ACCOUNT_DUST_EPSILON, isInstrumentId } from '@agoric/portfolio-api';
 
 import type { CosmosRestClient } from './cosmos-rest-client.js';
@@ -59,7 +63,9 @@ export type BalanceQueryPowers = {
   cosmosRest: CosmosRestClient;
   spectrumBlockchain: SpectrumBlockchainSdk;
   spectrumChainIds: Partial<Record<SupportedChain, string>>;
-  positionTokenAddresses: Partial<Record<PoolKey | `@${EvmChain}`, string>>;
+  positionTokenAddresses: Partial<
+    Record<InterChainAccountRef | PoolKey, string>
+  >;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
   evmProviders: EvmProviders;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
@@ -73,7 +79,7 @@ type AccountQueryDescriptor = {
 };
 
 type PositionQueryDescriptor = {
-  place: PoolKey | `@${EvmChain}`;
+  place: InterChainAccountRef | PoolKey;
   chainName: SupportedChain;
   protocol: PoolPlaceInfo['protocol'] | 'USDC';
   address: string;

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -101,8 +101,8 @@ export const getCurrentBalances = async (
   const { positionKeys, accountIdByChain } = status;
   const { spectrumBlockchain } = powers;
   const addressInfo = new Map<SupportedChain, Caip10Record>();
-  const accountQueries = [] as AccountQueryDescriptor[];
-  const positionQueries = [] as PositionQueryDescriptor[];
+  const spectrumQueries = [] as AccountQueryDescriptor[];
+  const alchemyQueries = [] as PositionQueryDescriptor[];
   const balances = new Map<AssetPlaceRef, NatAmount | undefined>();
   const errors = [] as Error[];
   for (const [chainName, accountId] of typedEntries(
@@ -116,14 +116,14 @@ export const getCurrentBalances = async (
       const { namespace, accountAddress: address } = addressParts;
       if (namespace === 'eip155') {
         // EVM chain USDC balances are fetched directly via Alchemy.
-        positionQueries.push({
+        alchemyQueries.push({
           place: place as `@${EvmChain}`,
           chainName,
           protocol: 'USDC',
           address,
         });
       } else {
-        accountQueries.push({ place, chainName, address, asset: 'USDC' });
+        spectrumQueries.push({ place, chainName, address, asset: 'USDC' });
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_err) {
@@ -143,51 +143,51 @@ export const getCurrentBalances = async (
         Fail`No ${chainName} address for instrument ${instrument}`;
       if (namespace !== 'eip155') {
         // A USDN Vault is queried as an "account" rather than a "position".
-        accountQueries.push({ place, chainName, address, asset: protocol });
+        spectrumQueries.push({ place, chainName, address, asset: protocol });
       } else {
         // EVM position queries (Aave, Beefy, Compound, ERC4626) are issued directly.
-        positionQueries.push({ place, chainName, protocol, address });
+        alchemyQueries.push({ place, chainName, protocol, address });
       }
     } catch (err) {
       errors.push(err);
     }
   }
 
-  const spectrumAccountQueries = accountQueries.map(desc =>
+  const spectrumAccountQueries = spectrumQueries.map(desc =>
     makeSpectrumAccountQuery(desc, powers),
   );
 
-  const [accountResult, positionResult] = await Promise.allSettled([
+  const [spectrumResult, alchemyResult] = await Promise.allSettled([
     spectrumAccountQueries.length
       ? spectrumBlockchain.getBalances({ accounts: spectrumAccountQueries })
       : { balances: [] },
-    positionQueries.length
-      ? getErc20PositionBalances(positionQueries, powers)
+    alchemyQueries.length
+      ? getErc20PositionBalances(alchemyQueries, powers)
       : { balances: [] },
   ]);
 
   if (
-    accountResult.status !== 'fulfilled' ||
-    positionResult.status !== 'fulfilled'
+    spectrumResult.status !== 'fulfilled' ||
+    alchemyResult.status !== 'fulfilled'
   ) {
-    const rejections = [accountResult, positionResult].flatMap(settlement =>
+    const rejections = [spectrumResult, alchemyResult].flatMap(settlement =>
       settlement.status === 'fulfilled' ? [] : [settlement.reason],
     );
     errors.push(...rejections);
     throw AggregateError(errors, 'Could not get balances');
   }
-  const accountBalances = accountResult.value.balances;
-  const positionBalances = positionResult.value.balances;
+  const spectrumBalances = spectrumResult.value.balances;
+  const alchemyBalances = alchemyResult.value.balances;
   if (
-    accountBalances.length !== accountQueries.length ||
-    positionBalances.length !== positionQueries.length
+    spectrumBalances.length !== spectrumQueries.length ||
+    alchemyBalances.length !== alchemyQueries.length
   ) {
-    const msg = `Bad balance query response(s), expected [${[accountBalances.length, positionBalances.length]}] results but got [${[accountQueries.length, positionQueries.length]}]`;
+    const msg = `Bad balance query response(s), expected [${[spectrumBalances.length, alchemyBalances.length]}] results but got [${[spectrumQueries.length, alchemyQueries.length]}]`;
     throw AggregateError(errors, msg);
   }
-  for (let i = 0; i < accountQueries.length; i += 1) {
-    const { place, asset } = accountQueries[i];
-    const result = accountBalances[i];
+  for (let i = 0; i < spectrumQueries.length; i += 1) {
+    const { place, asset } = spectrumQueries[i];
+    const result = spectrumBalances[i];
     if (result.error) errors.push(Error(result.error));
     const balanceAmount = amountFromAccountBalance(brand, result.balance);
     balances.set(place, balanceAmount);
@@ -201,8 +201,8 @@ export const getCurrentBalances = async (
       balances.set(place, AmountMath.make(brand, BigInt(result.balance)));
     }
   }
-  for (let i = 0; i < positionBalances.length; i += 1) {
-    const result = positionBalances[i];
+  for (let i = 0; i < alchemyBalances.length; i += 1) {
+    const result = alchemyBalances[i];
     if (result.error) {
       errors.push(Error(result.error));
     }

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -23,8 +23,9 @@ import type {
 } from '@agoric/portfolio-api';
 import { ACCOUNT_DUST_EPSILON, isInstrumentId } from '@agoric/portfolio-api';
 
+import type { EvmAddress } from '@agoric/fast-usdc';
 import type { CosmosRestClient } from './cosmos-rest-client.js';
-import { getErc20PositionBalances } from './evm-utils.ts';
+import { getErc20Balances } from './evm-utils.ts';
 import type { ChainAddressTokenBalance } from './graphql/api-spectrum-blockchain/__generated/graphql.ts';
 import type { Sdk as SpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import type { EvmChain } from './pending-tx-manager.ts';
@@ -63,8 +64,8 @@ export type BalanceQueryPowers = {
   cosmosRest: CosmosRestClient;
   spectrumBlockchain: SpectrumBlockchainSdk;
   spectrumChainIds: Partial<Record<SupportedChain, string>>;
-  positionTokenAddresses: Partial<
-    Record<InterChainAccountRef | PoolKey, string>
+  evmTokenAddresses: Partial<
+    Record<InterChainAccountRef | PoolKey, EvmAddress>
   >;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
   evmProviders: EvmProviders;
@@ -78,25 +79,31 @@ type AccountQueryDescriptor = {
   asset: string;
 };
 
-type PositionQueryDescriptor = {
+type BalanceQueryDescriptor = {
   place: InterChainAccountRef | PoolKey;
   chainName: SupportedChain;
-  protocol: PoolPlaceInfo['protocol'] | 'USDC';
+  token: PoolPlaceInfo['protocol'] | 'USDC';
   address: string;
+};
+
+type SpectrumAccountQuery = AccountQueryDescriptor & {
+  chain: string;
+  address: string;
+  token: string;
 };
 
 const makeSpectrumAccountQuery = (
   desc: AccountQueryDescriptor,
   powers: BalanceQueryPowers,
-) => {
+): SpectrumAccountQuery => {
   const { chainName, address, asset } = desc;
   const chainId = lookupValueForKey(powers.spectrumChainIds, chainName);
   if (asset !== 'USDC') {
     // "USDN" -> "usdn"
-    return { chain: chainId, address, token: asset.toLowerCase() };
+    return { ...desc, chain: chainId, address, token: asset.toLowerCase() };
   }
   const token = lookupValueForKey(powers.usdcTokensByChain, chainName);
-  return { chain: chainId, address, token };
+  return { ...desc, chain: chainId, address, token };
 };
 
 export const getCurrentBalances = async (
@@ -107,10 +114,11 @@ export const getCurrentBalances = async (
   const { positionKeys, accountIdByChain } = status;
   const { spectrumBlockchain } = powers;
   const addressInfo = new Map<SupportedChain, Caip10Record>();
-  const spectrumQueries = [] as AccountQueryDescriptor[];
-  const alchemyQueries = [] as PositionQueryDescriptor[];
+  const spectrumAccountQueries: Array<SpectrumAccountQuery> = [];
+  const alchemyQueries = [] as BalanceQueryDescriptor[];
   const balances = new Map<AssetPlaceRef, NatAmount | undefined>();
   const errors = [] as Error[];
+  // Define account queries (EVM chains via Alchemy, others via Spectrum).
   for (const [chainName, accountId] of typedEntries(
     accountIdByChain as Required<typeof accountIdByChain>,
   )) {
@@ -125,17 +133,22 @@ export const getCurrentBalances = async (
         alchemyQueries.push({
           place: place as `@${EvmChain}`,
           chainName,
-          protocol: 'USDC',
+          token: 'USDC',
           address,
         });
       } else {
-        spectrumQueries.push({ place, chainName, address, asset: 'USDC' });
+        const query = makeSpectrumAccountQuery(
+          { place, chainName, address, asset: 'USDC' },
+          powers,
+        );
+        spectrumAccountQueries.push(query);
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_err) {
       errors.push(Error(`Invalid CAIP-10 address for chain: ${chainName}`));
     }
   }
+  // Define position queries (EVM chains via Alchemy, others via Spectrum).
   for (const instrument of positionKeys) {
     const place = instrument;
     balances.set(place, undefined);
@@ -147,53 +160,54 @@ export const getCurrentBalances = async (
       const { namespace, accountAddress: address } =
         addressInfo.get(chainName) ||
         Fail`No ${chainName} address for instrument ${instrument}`;
-      if (namespace !== 'eip155') {
-        // A USDN Vault is queried as an "account" rather than a "position".
-        spectrumQueries.push({ place, chainName, address, asset: protocol });
-      } else {
+      if (namespace === 'eip155') {
         // EVM position queries (Aave, Beefy, Compound, ERC4626) are issued directly.
-        alchemyQueries.push({ place, chainName, protocol, address });
+        alchemyQueries.push({ place, chainName, token: protocol, address });
+      } else {
+        // A USDN Vault is queried as an "account" rather than a "position".
+        const query = makeSpectrumAccountQuery(
+          { place, chainName, address, asset: protocol },
+          powers,
+        );
+        spectrumAccountQueries.push(query);
       }
     } catch (err) {
       errors.push(err);
     }
   }
 
-  const spectrumAccountQueries = spectrumQueries.map(desc =>
-    makeSpectrumAccountQuery(desc, powers),
-  );
-
-  const [spectrumResult, alchemyResult] = await Promise.allSettled([
+  const [spectrumAccountResult, alchemyResult] = await Promise.allSettled([
     spectrumAccountQueries.length
       ? spectrumBlockchain.getBalances({ accounts: spectrumAccountQueries })
       : { balances: [] },
     alchemyQueries.length
-      ? getErc20PositionBalances(alchemyQueries, powers)
+      ? getErc20Balances(alchemyQueries, powers)
       : { balances: [] },
   ]);
 
   if (
-    spectrumResult.status !== 'fulfilled' ||
+    spectrumAccountResult.status !== 'fulfilled' ||
     alchemyResult.status !== 'fulfilled'
   ) {
-    const rejections = [spectrumResult, alchemyResult].flatMap(settlement =>
-      settlement.status === 'fulfilled' ? [] : [settlement.reason],
+    const rejections = [spectrumAccountResult, alchemyResult].flatMap(
+      settlement =>
+        settlement.status === 'fulfilled' ? [] : [settlement.reason],
     );
     errors.push(...rejections);
     throw AggregateError(errors, 'Could not get balances');
   }
-  const spectrumBalances = spectrumResult.value.balances;
+  const spectrumAccountBalances = spectrumAccountResult.value.balances;
   const alchemyBalances = alchemyResult.value.balances;
   if (
-    spectrumBalances.length !== spectrumQueries.length ||
+    spectrumAccountBalances.length !== spectrumAccountQueries.length ||
     alchemyBalances.length !== alchemyQueries.length
   ) {
-    const msg = `Bad balance query response(s), expected [${[spectrumBalances.length, alchemyBalances.length]}] results but got [${[spectrumQueries.length, alchemyQueries.length]}]`;
+    const msg = `Bad balance query response(s), expected [${[spectrumAccountBalances.length, alchemyBalances.length]}] results but got [${[spectrumAccountQueries.length, alchemyQueries.length]}]`;
     throw AggregateError(errors, msg);
   }
-  for (let i = 0; i < spectrumQueries.length; i += 1) {
-    const { place, asset } = spectrumQueries[i];
-    const result = spectrumBalances[i];
+  for (let i = 0; i < spectrumAccountQueries.length; i += 1) {
+    const { place, asset } = spectrumAccountQueries[i];
+    const result = spectrumAccountBalances[i];
     if (result.error) errors.push(Error(result.error));
     const balanceAmount = amountFromAccountBalance(brand, result.balance);
     balances.set(place, balanceAmount);

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -80,8 +80,8 @@ const handleDeposit = async (
     gasEstimator: GasEstimator;
     spectrumBlockchain?: SpectrumBlockchainSdk;
     spectrumChainIds?: Partial<Record<SupportedChain, string>>;
-    positionTokenAddresses?: Partial<
-      Record<InterChainAccountRef | PoolKey, string>
+    evmTokenAddresses?: Partial<
+      Record<InterChainAccountRef | PoolKey, EvmAddress>
     >;
     usdcTokensByChain?: Partial<Record<SupportedChain, string>>;
     addressToBalanceMap?: Partial<Record<EvmAddress, bigint>>;
@@ -97,7 +97,7 @@ const handleDeposit = async (
   const currentBalances = await getCurrentBalances(status, amount.brand, {
     spectrumChainIds: powers.spectrumChainIds || {},
     usdcTokensByChain: powers.usdcTokensByChain || {},
-    positionTokenAddresses: powers.positionTokenAddresses || {},
+    evmTokenAddresses: powers.evmTokenAddresses || {},
     spectrumBlockchain: createMockSpectrumBlockchain({}),
     chainNameToChainIdMap: CaipChainIds.testnet,
     evmProviders: createMockProviderSets({
@@ -145,11 +145,11 @@ test('getNonDustBalances filters balances at or below the dust epsilon', async t
     spectrumBlockchain: createMockSpectrumBlockchain({}),
     spectrumChainIds: {},
     usdcTokensByChain: {},
-    positionTokenAddresses: {
-      Aave_Arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    evmTokenAddresses: {
+      Aave_Arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as EvmAddress,
       Compound_Base: compoundBaseAddress,
-      '@Arbitrum': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-      '@Base': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '@Arbitrum': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as EvmAddress,
+      '@Base': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as EvmAddress,
     },
     chainNameToChainIdMap: CaipChainIds.mainnet,
     evmProviders: createMockProviderSets({
@@ -186,7 +186,7 @@ test('getNonDustBalances retains noble balances above the dust epsilon', async t
     spectrumBlockchain: createMockSpectrumBlockchain({ usdn: 101 }),
     spectrumChainIds: { noble: 'noble-1' },
     usdcTokensByChain: { noble: 'uusdc' },
-    positionTokenAddresses: {},
+    evmTokenAddresses: {},
     chainNameToChainIdMap: CaipChainIds.testnet,
     evmProviders: mockEvmCtx.evmProviders,
   });
@@ -247,10 +247,10 @@ test('handleDeposit works with mocked dependencies', async t => {
     spectrumChainIds: {
       noble: 'noble-1',
     },
-    positionTokenAddresses: {
+    evmTokenAddresses: {
       Aave_Arbitrum: aaveArbitrumAddress,
       Compound_Arbitrum: compoundArbitrumAddress,
-      '@Arbitrum': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      '@Arbitrum': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as EvmAddress,
     },
     usdcTokensByChain: {
       noble: 'uusdc',
@@ -381,11 +381,12 @@ test('handleDeposit handles different position types correctly', async t => {
       spectrumChainIds: {
         noble: 'noble-1',
       },
-      positionTokenAddresses: {
+      evmTokenAddresses: {
         Aave_Avalanche: aaveAvalancheAddress,
         Compound_Ethereum: compoundEthereumAddress,
-        '@Avalanche': '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-        '@Ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        '@Avalanche':
+          '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E' as EvmAddress,
+        '@Ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as EvmAddress,
       },
       usdcTokensByChain: {
         noble: 'uusdc',
@@ -657,9 +658,9 @@ test('getNonDustBalances works for erc4626 vaults', async t => {
       agoric: 'agoricdev-25',
       noble: 'grand-1',
     },
-    positionTokenAddresses: {
+    evmTokenAddresses: {
       ERC4626_vaultU2_Ethereum: erc4626Address,
-      '@Ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      '@Ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as EvmAddress,
     },
     spectrumBlockchain: createMockSpectrumBlockchain({}),
     usdcTokensByChain: {

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -5,6 +5,7 @@ import {
   ACCOUNT_DUST_EPSILON,
   CaipChainIds,
   SupportedChain,
+  type InterChainAccountRef,
   type StatusFor,
 } from '@agoric/portfolio-api';
 import { planUSDNDeposit } from '@aglocal/portfolio-contract/test/mocks.js';
@@ -79,7 +80,9 @@ const handleDeposit = async (
     gasEstimator: GasEstimator;
     spectrumBlockchain?: SpectrumBlockchainSdk;
     spectrumChainIds?: Partial<Record<SupportedChain, string>>;
-    positionTokenAddresses?: Partial<Record<PoolKey | `@${EvmChain}`, string>>;
+    positionTokenAddresses?: Partial<
+      Record<InterChainAccountRef | PoolKey, string>
+    >;
     usdcTokensByChain?: Partial<Record<SupportedChain, string>>;
     addressToBalanceMap?: Partial<Record<EvmAddress, bigint>>;
   },

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -27,6 +27,7 @@ import { objectMap } from '@agoric/internal';
 import { arrayIsLike } from '@agoric/internal/tools/ava-assertions.js';
 import { Far } from '@endo/pass-style';
 import PROD_NETWORK from '@aglocal/portfolio-contract/tools/network/prod-network.ts';
+import type { EvmAddress } from '@agoric/fast-usdc';
 import { CosmosRestClient, USDN } from '../src/cosmos-rest-client.ts';
 import {
   getCurrentBalances,
@@ -43,7 +44,6 @@ import {
   createMockProviderSets,
 } from './mocks.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
-import type { EvmAddress } from '@agoric/fast-usdc';
 
 const depositBrand = Far('mock brand') as Brand<'nat'>;
 const makeDeposit = value => AmountMath.make(depositBrand, value);
@@ -79,7 +79,7 @@ const handleDeposit = async (
     gasEstimator: GasEstimator;
     spectrumBlockchain?: SpectrumBlockchainSdk;
     spectrumChainIds?: Partial<Record<SupportedChain, string>>;
-    positionTokenAddresses?: Partial<Record<PoolKey, string>>;
+    positionTokenAddresses?: Partial<Record<PoolKey | `@${EvmChain}`, string>>;
     usdcTokensByChain?: Partial<Record<SupportedChain, string>>;
     addressToBalanceMap?: Partial<Record<EvmAddress, bigint>>;
   },
@@ -140,14 +140,13 @@ test('getNonDustBalances filters balances at or below the dust epsilon', async t
   const balances = await getNonDustBalances(status, depositBrand, {
     cosmosRest: mockCosmosRestClient,
     spectrumBlockchain: createMockSpectrumBlockchain({}),
-    spectrumChainIds: { Arbitrum: '0xa4b1', Base: '0x2105' },
-    usdcTokensByChain: {
-      Arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-      Base: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-    },
+    spectrumChainIds: {},
+    usdcTokensByChain: {},
     positionTokenAddresses: {
       Aave_Arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
       Compound_Base: compoundBaseAddress,
+      '@Arbitrum': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      '@Base': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     },
     chainNameToChainIdMap: CaipChainIds.mainnet,
     evmProviders: createMockProviderSets({
@@ -244,15 +243,14 @@ test('handleDeposit works with mocked dependencies', async t => {
     spectrumBlockchain: createMockSpectrumBlockchain({ usdn: 0.2 }),
     spectrumChainIds: {
       noble: 'noble-1',
-      Arbitrum: '0xa4b1',
     },
     positionTokenAddresses: {
       Aave_Arbitrum: aaveArbitrumAddress,
       Compound_Arbitrum: compoundArbitrumAddress,
+      '@Arbitrum': '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
     },
     usdcTokensByChain: {
       noble: 'uusdc',
-      Arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
     },
     cosmosRest: {} as unknown as CosmosRestClient,
     gasEstimator: mockGasEstimator,
@@ -379,17 +377,15 @@ test('handleDeposit handles different position types correctly', async t => {
       spectrumBlockchain: createMockSpectrumBlockchain({ usdn: 0.3 }),
       spectrumChainIds: {
         noble: 'noble-1',
-        Avalanche: '0xa86a',
-        Ethereum: '0x1',
       },
       positionTokenAddresses: {
         Aave_Avalanche: aaveAvalancheAddress,
         Compound_Ethereum: compoundEthereumAddress,
+        '@Avalanche': '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+        '@Ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       },
       usdcTokensByChain: {
         noble: 'uusdc',
-        Avalanche: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-        Ethereum: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       },
       cosmosRest: {} as unknown as CosmosRestClient,
       gasEstimator: mockGasEstimator,
@@ -655,16 +651,15 @@ test('getNonDustBalances works for erc4626 vaults', async t => {
   const balances = await getNonDustBalances(status, depositBrand, {
     cosmosRest: {} as unknown as CosmosRestClient,
     spectrumChainIds: {
-      Ethereum: '0xaaa',
       agoric: 'agoricdev-25',
       noble: 'grand-1',
     },
     positionTokenAddresses: {
       ERC4626_vaultU2_Ethereum: erc4626Address,
+      '@Ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
     },
     spectrumBlockchain: createMockSpectrumBlockchain({}),
     usdcTokensByChain: {
-      Ethereum: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       agoric: 'uusdc',
       noble: 'uusdc',
     },

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -56,7 +56,6 @@ import { setLogTarget } from '../src/logger.ts';
 import {
   createMockEnginePowers,
   makeNotImplemented,
-  makeNotImplementedAsync,
   mockEvmCtx,
 } from './mocks.ts';
 

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -143,7 +143,6 @@ export const mockGasEstimator = makeGasEstimator({
 export const createMockProvider = (
   latestBlock = 1000,
   events?: Pick<Log, 'blockNumber' | 'data' | 'topics' | 'transactionHash'>[],
-  // maps address to an amount to retrun for it e.g '0x111...' => 100n
   // Allows each test to specify custom balances for certain addresses
   addressToBalanceMap = {},
 ): WebSocketProvider => {

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -104,7 +104,7 @@ export const createMockEnginePowers = (): EnginePowers => ({
   rpc: {} as any,
   spectrumBlockchain: createMockSpectrumBlockchain({}),
   spectrumChainIds: {},
-  positionTokenAddresses: {},
+  evmTokenAddresses: {},
   cosmosRest: {} as any,
   network: TEST_NETWORK,
   signingSmartWalletKit: {} as any,

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -143,6 +143,7 @@ export const mockGasEstimator = makeGasEstimator({
 export const createMockProvider = (
   latestBlock = 1000,
   events?: Pick<Log, 'blockNumber' | 'data' | 'topics' | 'transactionHash'>[],
+  // maps address to an amount to retrun for it e.g '0x111...' => 100n
   // Allows each test to specify custom balances for certain addresses
   addressToBalanceMap = {},
 ): WebSocketProvider => {


### PR DESCRIPTION
closes: https://linear.app/agoric/issue/PAK-111/ymax-planner-get-account-balances-using-alchemy

## Description
This PR:
- Modifies `getCurrentBalances` to use the alchemy API in order to fetch account balances
- Renames `accountQueries` to `spectrumQueries` and `poolQueries` to `alchemyQueries`, which is more accurate after the refactor
- Updates mocks to account for these changes. mocks for the evmProvider have also been modified to get different balances for different addresses

### Scaling Considerations
Similar to https://github.com/Agoric/agoric-sdk/pull/12518, this will increase usage of alchemy API but not by a large amount


### Testing Considerations
Tested `getCurrentBalances` by calling it directly and using mock arguments:
mock portfolio provided:
```    
{
      accountIdByChain: {
        Avalanche: 'eip155:43114:0x8E9B13a6e0CC3447d5E54c366a1499B9BD48f5dA',
        agoric:
          'cosmos:agoric-3:agoric1x4p246h2chy3a9upevs92ge8juatmwnync6q3zrlntlyk7utywhq6dyfvt',
        noble:
          'cosmos:noble-1:noble1mgwvc6tezu5r6njr7c9eywmj7qs77wcjfcyk70mjn0hnmkewr22qtjmxv2',

        Optimism: 'eip155:10:0xa9a29cc29394cec52e87b9aecf51b67312fa944c',
        Arbitrum: 'eip155:42161:0xa9a29cc29394cec52e87b9aecf51b67312fa944c',
        Ethereum: 'eip155:1:0x54880f4ea9b6adb4976e3b717ca352dd02f41b36',
      },
      accountsPending: [],
      depositAddress:
        'agoric19ugpxq3qld3lx6y6ha3tr9ema7370x7g8qks0xyr5qmry6k0my8qh2h4t9',
      flowCount: 4,
      flowsRunning: {},
      nobleForwardingAddress: 'noble17pp8yf6953373nycmv740flnunh36g86s2rzt8',
      policyVersion: 1,
      positionKeys: [
        'Beefy_re7_Avalanche',
        'Compound_Optimism',
        'Aave_Arbitrum',
        'ERC4626_morphoAlphaUsdcCore_Ethereum',
      ],
      rebalanceCount: 17722,
      targetAllocation: {
        Beefy_re7_Avalanche: 100n,
        Compound_Optimism: 100n,
        Aave_Arbitrum: 100n,
        USDN: 70n,
        ERC4626_morphoAlphaUsdcCore_Ethereum: 100n,
      },
    },

```

Balances Received:
```
{
  '@Avalanche': {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 48201n
  },
  '@agoric': {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 0n
  },
  '@noble': {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 0n
  },
  '@Optimism': {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 0n
  },
  '@Arbitrum': {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 0n
  },
  '@Ethereum': {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 0n
  },
  Beefy_re7_Avalanche: {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 2464211n
  },
  Compound_Optimism: {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 55304874n
  },
  Aave_Arbitrum: {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 55288968n
  },
  ERC4626_morphoAlphaUsdcCore_Ethereum: {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 51037383n
  }
```

E2E testing still needs to be done...