### PR TITLE
fix(ymax-resolver): add watcher diagnostics and prevent duplicate subscriptions

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -564,6 +564,13 @@ export const processPendingTxEvents = async (
 
       mustMatch(data, PublishedTxShape, `${path} index -1`);
       const tx = { txId, ...data } as PendingTx;
+
+      // Skip if a watcher is already running for this txId.
+      if (pendingTxAbortControllers.has(txId)) {
+        log(`Watcher already active for ${txId}, skipping`);
+        continue;
+      }
+
       log('New pending tx', tx);
 
       const abortController = provideLazyMap(

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -157,7 +157,13 @@ export const watchGmp = ({
 
         const tx = msg.params?.result?.transaction;
         const removed = msg.params?.result?.removed;
-        if (!tx) return;
+        if (!tx) {
+          log(
+            `Subscription message missing transaction data`,
+            msg.params?.result,
+          );
+          return;
+        }
 
         // Ignore transactions that have been removed from canonical chain (reorged)
         if (removed === true) {
@@ -169,10 +175,22 @@ export const watchGmp = ({
 
         const txHash = tx.hash;
         const txData = tx.input;
-        if (!txHash || !txData) return;
+        if (!txHash || !txData) {
+          log(`Subscription message missing txHash or input data`);
+          return;
+        }
 
         const executeData = extractGmpExecuteData(txData);
-        if (!executeData || executeData.txId !== txId) return;
+        if (!executeData) {
+          log(`Calldata did not match Axelar execute ABI for txHash=${txHash}`);
+          return;
+        }
+        if (executeData.txId !== txId) {
+          log(
+            `Matched different txId: expected=${txId} got=${executeData.txId} txHash=${txHash}`,
+          );
+          return;
+        }
 
         if (executeData.sourceAddress !== expectedSourceAddress) {
           log(
@@ -250,6 +268,7 @@ export const watchGmp = ({
           hashesOnly: false,
         },
       ]);
+      log(`Subscribed with subId=${subId} for contract=${contractAddress}`);
     };
 
     if (ws.readyState === 1) {

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -203,7 +203,13 @@ export const watchSmartWalletTx = ({
 
         const tx = msg.params?.result?.transaction;
         const removed = msg.params?.result?.removed;
-        if (!tx) return;
+        if (!tx) {
+          log(
+            `Subscription message missing transaction data`,
+            msg.params?.result,
+          );
+          return;
+        }
 
         // Ignore transactions that have been removed from canonical chain (reorged)
         if (removed === true) {
@@ -216,7 +222,10 @@ export const watchSmartWalletTx = ({
         const txHash = tx.hash;
         const txData = tx.input;
         const txTo = tx.to;
-        if (!txHash || !txData || !txTo) return;
+        if (!txHash || !txData || !txTo) {
+          log(`Subscription message missing txHash, input, or to field`);
+          return;
+        }
 
         // Determine which contract is being called and use appropriate parser
         const isFactoryPath = getAddress(txTo) === getAddress(factoryAddr);
@@ -224,7 +233,12 @@ export const watchSmartWalletTx = ({
           ? extractFactoryExecuteData(txData)
           : extractDepositFactoryExecuteData(txData);
 
-        if (!executeData) return;
+        if (!executeData) {
+          log(
+            `Calldata did not match factory execute ABI for txHash=${txHash} to=${txTo}`,
+          );
+          return;
+        }
 
         const { sourceAddress, expectedWalletAddress } = executeData;
 
@@ -233,6 +247,9 @@ export const watchSmartWalletTx = ({
           sourceAddress !== expectedSourceAddress ||
           getAddress(expectedWalletAddress) !== getAddress(expectedAddr)
         ) {
+          log(
+            `Address mismatch for txHash=${txHash}: sourceAddress=${sourceAddress} expectedWallet=${expectedWalletAddress}`,
+          );
           return;
         }
 

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -131,6 +131,7 @@ test('handlePendingTx aborts GMP watcher in live mode when signal is aborted', a
   t.deepEqual(logs, [
     `[${txId}] handling ${TxType.GMP} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] Subscribed with subId=mock-subscription-id for contract=${contractAddress}`,
     '[TEST] Aborting signal',
   ]);
 

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -67,6 +67,7 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] Subscribed with subId=mock-subscription-id for contract=${contractAddress}`,
     `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
@@ -129,6 +130,7 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] Subscribed with subId=mock-subscription-id for contract=${contractAddress}`,
     `[${txId}] [GMP_TX_NOT_FOUND] ✗ No transaction status found for txId ${txId} within 0.01 minutes`,
     `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -254,6 +254,7 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
     `[${txId}] Watching for wallet creation: subscribing to ${factoryAddress}, expecting event from ${factoryAddress}, expectedAddr ${expectedWalletAddr}`,
     `[${txId}] Attempting to subscribe to ${factoryAddress}...`,
     `[${txId}] ✓ Subscribed to ${factoryAddress} (subscription ID: mock-subscription-id)`,
+    `[${txId}] Address mismatch for txHash=0x123abc: sourceAddress=agoric1test expectedWallet=${wrongWalletAddrChecksummed}`,
     `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=${correctTxHash} block=18500000`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: 
- https://linear.app/agoric/issue/PAK-145/ymax1-resolver-subscription-failure-causes-delayed-tx-resolution
## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

- Add diagnostic logging at every silent bail-out point in the GMP and wallet watcher message handlers, so we can determine whether Alchemy subscription messages are received but filtered out, or never delivered at all.
- Prevent duplicate watchers from being spawned for the same `txId` when a pending transaction appears in multiple block events.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`