### PR TITLE
chore(ymax-resolver): handle 429 rate-limit errors in resolver

### DIFF
--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -28,9 +28,13 @@ import { loadConfig } from '../src/config.ts';
 import { CosmosRestClient } from '../src/cosmos-rest-client.ts';
 import { CosmosRPCClient } from '../src/cosmos-rpc.ts';
 import { createEVMContext, prepareAbortController } from '../src/support.ts';
+import { makeEvmRpc } from '../src/evm-scanner.ts';
 import type { SimplePowers } from '../src/main.ts';
 import { makeSQLiteKeyValueStore } from '../src/kv-store.ts';
-import type { HandlePendingTxOpts } from '../src/pending-tx-manager.ts';
+import type {
+  EvmRpcProviders,
+  HandlePendingTxOpts,
+} from '../src/pending-tx-manager.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
 import {
   parseStreamCell,
@@ -128,6 +132,13 @@ export const processTx = async (
   failedEvmChains.length === 0 ||
     Fail`Could not connect to EVM chains: ${q(failedEvmChains)}`;
 
+  const retryProviders = Object.fromEntries(
+    Object.entries(evmCtx.evmProviders).map(([caip, provider]) => [
+      caip,
+      makeEvmRpc(provider, setTimeout),
+    ]),
+  ) as EvmRpcProviders;
+
   const { db, kvStore } = makeSQLiteKeyValueStore(config.sqlite.dbPath, {
     trace: () => {},
   });
@@ -179,6 +190,7 @@ export const processTx = async (
       // Prepare powers for handling the transaction
       const txPowers: HandlePendingTxOpts = Object.freeze({
         ...evmCtx,
+        retryProviders,
         cosmosRest,
         cosmosRpc: rpc,
         fetch,

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -53,6 +53,26 @@ type BinarySearch = {
 };
 
 /**
+ * A thin provider facade whose methods automatically retry on Alchemy 429
+ * rate-limit errors using exponential backoff with jitter.
+ */
+const makeRetryProvider = (
+  provider: WebSocketProvider,
+  setTimeout: typeof globalThis.setTimeout,
+) => ({
+  getBlock: (n: number) =>
+    withRateLimitRetry(() => provider.getBlock(n), setTimeout),
+  getBlockNumber: () =>
+    withRateLimitRetry(() => provider.getBlockNumber(), setTimeout),
+  getLogs: (filter: Filter) =>
+    withRateLimitRetry(() => provider.getLogs(filter), setTimeout),
+  send: (...args: Parameters<WebSocketProvider['send']>) =>
+    withRateLimitRetry(() => provider.send(...args), setTimeout),
+});
+
+type RetryProvider = ReturnType<typeof makeRetryProvider>;
+
+/**
  * Generic binary search helper for finding the greatest value that satisfies a predicate.
  * Assumes a transition from acceptance to rejection somewhere in [start, end].
  *
@@ -99,24 +119,27 @@ export const getBlockNumberBeforeRealTime = async (
   {
     fudgeFactorMs = 5 * 60 * 1000, // 5 minutes to account for cross-chain clock differences
     meanBlockDurationMs,
+    setTimeout = globalThis.setTimeout,
   }: {
     fudgeFactorMs?: number;
     meanBlockDurationMs?: number;
+    setTimeout?: typeof globalThis.setTimeout;
   } = {},
 ) => {
   const posixSeconds = Math.floor((targetMs - fudgeFactorMs) / 1000);
+  const rpc = makeRetryProvider(provider, setTimeout);
 
   // Try to find a good starting point.
   let startNumber = 0;
-  const latestNumber = await provider.getBlockNumber();
-  const latestBlock = await provider.getBlock(latestNumber);
+  const latestNumber = await rpc.getBlockNumber();
+  const latestBlock = await rpc.getBlock(latestNumber);
   const deltaSec = latestBlock!.timestamp - posixSeconds;
   if (deltaSec <= 0) return latestNumber;
   if (deltaSec > 0 && meanBlockDurationMs) {
     const deltaBlocks = Math.ceil(deltaSec / (meanBlockDurationMs / 1000));
     const pastNumber = latestNumber - deltaBlocks * 2;
     if (startNumber < pastNumber) {
-      const pastBlock = await provider.getBlock(pastNumber);
+      const pastBlock = await rpc.getBlock(pastNumber);
       if (pastBlock?.timestamp && pastBlock.timestamp <= posixSeconds) {
         startNumber = pastNumber;
       }
@@ -124,7 +147,7 @@ export const getBlockNumberBeforeRealTime = async (
   }
 
   const blockNumber = await binarySearch(startNumber, latestNumber, async n => {
-    const block = await provider.getBlock(n);
+    const block = await rpc.getBlock(n);
     return block?.timestamp ? block.timestamp <= posixSeconds : false;
   });
   return blockNumber;
@@ -140,8 +163,48 @@ const isRateLimitError = (err: unknown): boolean =>
   isError(err, 'UNKNOWN_ERROR') &&
   (err as { error?: { code?: number } }).error?.code === 429;
 
-const RATE_LIMIT_BACKOFF_MS = 1_000;
-const MAX_RATE_LIMIT_RETRIES = 3;
+/**
+ * Alchemy-recommended retry parameters for 429 rate-limit errors.
+ * Uses exponential backoff with jitter:
+ *   delay = min(2^attempt * minTimeout + random(0..1000), maxTimeout)
+ *
+ * @see https://www.alchemy.com/docs/how-to-implement-retries
+ */
+const RATE_LIMIT_RETRIES = 5;
+const RATE_LIMIT_MIN_TIMEOUT_MS = 1_000;
+const RATE_LIMIT_MAX_TIMEOUT_MS = 60_000;
+const RATE_LIMIT_FACTOR = 2;
+
+/** Compute exponential backoff delay with jitter for a given attempt. */
+const rateLimitBackoffMs = (attempt: number): number => {
+  const jitter = Math.random() * 1000;
+  return Math.min(
+    RATE_LIMIT_FACTOR ** attempt * RATE_LIMIT_MIN_TIMEOUT_MS + jitter,
+    RATE_LIMIT_MAX_TIMEOUT_MS,
+  );
+};
+
+/**
+ * Retry a provider call on Alchemy 429 rate-limit errors using exponential
+ * backoff with jitter, per Alchemy's recommended strategy.
+ *
+ * @see https://www.alchemy.com/docs/how-to-implement-retries
+ */
+export const withRateLimitRetry = async <T>(
+  fn: () => Promise<T>,
+  setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
+): Promise<T> => {
+  await null;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!isRateLimitError(err) || attempt >= RATE_LIMIT_RETRIES) throw err;
+      const delay = rateLimitBackoffMs(attempt);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+};
 
 /** Common configuration for all chunk-based EVM chain scanning. */
 type ScanOptsBase = {
@@ -225,9 +288,9 @@ const getTraces = async (
   fromBlock: string,
   toBlock: string,
   toAddress: string,
-  provider: WebSocketProvider,
+  rpc: RetryProvider,
 ): Promise<CallTraceResult[]> => {
-  const result: CallTraceResult[] | null = await provider.send('trace_filter', [
+  const result: CallTraceResult[] | null = await rpc.send('trace_filter', [
     { fromBlock, toBlock, toAddress: [toAddress] },
   ]);
   return result ?? [];
@@ -265,6 +328,7 @@ const scanEvmBlocksInChunks = async <T>(
   } = opts;
 
   const blockTimeMs = getBlockTimeMs(chainId);
+  const rpc = makeRetryProvider(provider, setTimeout);
   await null;
   let rateLimitRetries = 0;
   for (let currentBlock = -Infinity, start = fromBlock; start <= toBlock; ) {
@@ -276,7 +340,7 @@ const scanEvmBlocksInChunks = async <T>(
 
     try {
       // Wait for the chain to catch up if end block doesn't exist yet
-      if (end > currentBlock) currentBlock = await provider.getBlockNumber();
+      if (end > currentBlock) currentBlock = await rpc.getBlockNumber();
       if (end > currentBlock) {
         const blocksToWait = Math.max(50, chunkSize);
         const waitTimeMs = blocksToWait * blockTimeMs;
@@ -294,11 +358,11 @@ const scanEvmBlocksInChunks = async <T>(
       await opts.onRejectedChunk?.(start, end);
       rateLimitRetries = 0;
     } catch (err) {
-      if (isRateLimitError(err) && rateLimitRetries < MAX_RATE_LIMIT_RETRIES) {
+      if (isRateLimitError(err) && rateLimitRetries < RATE_LIMIT_RETRIES) {
         rateLimitRetries += 1;
-        const backoffMs = RATE_LIMIT_BACKOFF_MS * rateLimitRetries;
+        const backoffMs = rateLimitBackoffMs(rateLimitRetries - 1);
         log(
-          `[${label}] Rate limited on chunk ${start}–${end}, retry ${rateLimitRetries}/${MAX_RATE_LIMIT_RETRIES} after ${backoffMs}ms`,
+          `[${label}] Rate limited on chunk ${start}–${end}, retry ${rateLimitRetries}/${RATE_LIMIT_RETRIES} after ${Math.round(backoffMs)}ms`,
         );
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         continue; // Retry same chunk
@@ -328,6 +392,8 @@ export const scanEvmLogsInChunks = async (
     ...rest
   } = opts;
 
+  const rpc = makeRetryProvider(provider, rest.setTimeout);
+
   return scanEvmBlocksInChunks<Log>({
     ...rest,
     provider,
@@ -340,7 +406,7 @@ export const scanEvmLogsInChunks = async (
         fromBlock: start,
         toBlock: end,
       };
-      const logs = await provider.getLogs(chunkFilter);
+      const logs = await rpc.getLogs(chunkFilter);
       for (const evt of logs) {
         if (await predicate(evt)) {
           log(`[LogScan] Match in tx=${evt.transactionHash}`);
@@ -368,13 +434,14 @@ const scanChunkTracesForFailedTx = async (
   end: number,
   opts: FailedTxScanOpts,
 ): Promise<TransactionResponse | undefined> => {
-  const { provider, toAddress, verifyFailedTx } = opts;
+  const { provider, toAddress, verifyFailedTx, setTimeout } = opts;
+  const rpc = makeRetryProvider(provider, setTimeout);
 
   const traces = await getTraces(
     toQuantity(start),
     toQuantity(end),
     toAddress,
-    provider,
+    rpc,
   );
 
   const failedTopLevel = traces.filter(

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -53,24 +53,41 @@ type BinarySearch = {
 };
 
 /**
- * A thin provider facade whose methods automatically retry on Alchemy 429
+ * A provider facade whose methods automatically retry on Alchemy 429
  * rate-limit errors using exponential backoff with jitter.
  */
-const makeRetryProvider = (
+export const makeEvmRpc = (
   provider: WebSocketProvider,
   setTimeout: typeof globalThis.setTimeout,
 ) => ({
+  // RPC calls with retry
   getBlock: (n: number) =>
     withRateLimitRetry(() => provider.getBlock(n), setTimeout),
   getBlockNumber: () =>
     withRateLimitRetry(() => provider.getBlockNumber(), setTimeout),
   getLogs: (filter: Filter) =>
     withRateLimitRetry(() => provider.getLogs(filter), setTimeout),
+  getNetwork: () => withRateLimitRetry(() => provider.getNetwork(), setTimeout),
+  getTransactionReceipt: (txHash: string) =>
+    withRateLimitRetry(
+      () => provider.getTransactionReceipt(txHash),
+      setTimeout,
+    ),
+  waitForTransaction: (
+    ...args: Parameters<WebSocketProvider['waitForTransaction']>
+  ) =>
+    withRateLimitRetry(() => provider.waitForTransaction(...args), setTimeout),
   send: (...args: Parameters<WebSocketProvider['send']>) =>
     withRateLimitRetry(() => provider.send(...args), setTimeout),
+  // Subscription pass-throughs (no retry needed)
+  on: provider.on.bind(provider) as WebSocketProvider['on'],
+  off: provider.off.bind(provider) as WebSocketProvider['off'],
+  get websocket() {
+    return (provider as any).websocket;
+  },
 });
 
-type RetryProvider = ReturnType<typeof makeRetryProvider>;
+export type EvmRpc = ReturnType<typeof makeEvmRpc>;
 
 /**
  * Generic binary search helper for finding the greatest value that satisfies a predicate.
@@ -114,20 +131,17 @@ export const binarySearch = (async <Index extends number | bigint>(
  * equal to targetMs.
  */
 export const getBlockNumberBeforeRealTime = async (
-  provider: WebSocketProvider,
+  rpc: EvmRpc,
   targetMs: number,
   {
     fudgeFactorMs = 5 * 60 * 1000, // 5 minutes to account for cross-chain clock differences
     meanBlockDurationMs,
-    setTimeout = globalThis.setTimeout,
   }: {
     fudgeFactorMs?: number;
     meanBlockDurationMs?: number;
-    setTimeout?: typeof globalThis.setTimeout;
   } = {},
 ) => {
   const posixSeconds = Math.floor((targetMs - fudgeFactorMs) / 1000);
-  const rpc = makeRetryProvider(provider, setTimeout);
 
   // Try to find a good starting point.
   let startNumber = 0;
@@ -208,7 +222,7 @@ export const withRateLimitRetry = async <T>(
 
 /** Common configuration for all chunk-based EVM chain scanning. */
 type ScanOptsBase = {
-  provider: WebSocketProvider;
+  provider: EvmRpc;
   fromBlock: number;
   toBlock: number;
   chainId: CaipChainId;
@@ -288,7 +302,7 @@ const getTraces = async (
   fromBlock: string,
   toBlock: string,
   toAddress: string,
-  rpc: RetryProvider,
+  rpc: EvmRpc,
 ): Promise<CallTraceResult[]> => {
   const result: CallTraceResult[] | null = await rpc.send('trace_filter', [
     { fromBlock, toBlock, toAddress: [toAddress] },
@@ -328,9 +342,7 @@ const scanEvmBlocksInChunks = async <T>(
   } = opts;
 
   const blockTimeMs = getBlockTimeMs(chainId);
-  const rpc = makeRetryProvider(provider, setTimeout);
   await null;
-  let rateLimitRetries = 0;
   for (let currentBlock = -Infinity, start = fromBlock; start <= toBlock; ) {
     if (signal?.aborted) {
       log(`[${label}] Aborted`);
@@ -340,7 +352,7 @@ const scanEvmBlocksInChunks = async <T>(
 
     try {
       // Wait for the chain to catch up if end block doesn't exist yet
-      if (end > currentBlock) currentBlock = await rpc.getBlockNumber();
+      if (end > currentBlock) currentBlock = await provider.getBlockNumber();
       if (end > currentBlock) {
         const blocksToWait = Math.max(50, chunkSize);
         const waitTimeMs = blocksToWait * blockTimeMs;
@@ -356,19 +368,9 @@ const scanEvmBlocksInChunks = async <T>(
       const result = await scanChunk(start, end);
       if (result) return result;
       await opts.onRejectedChunk?.(start, end);
-      rateLimitRetries = 0;
     } catch (err) {
-      if (isRateLimitError(err) && rateLimitRetries < RATE_LIMIT_RETRIES) {
-        rateLimitRetries += 1;
-        const backoffMs = rateLimitBackoffMs(rateLimitRetries - 1);
-        log(
-          `[${label}] Rate limited on chunk ${start}–${end}, retry ${rateLimitRetries}/${RATE_LIMIT_RETRIES} after ${Math.round(backoffMs)}ms`,
-        );
-        await new Promise(resolve => setTimeout(resolve, backoffMs));
-        continue; // Retry same chunk
-      }
+      // Rate-limit retries are handled by EvmRpc; only log here.
       log(`[${label}] Error in chunk ${start}–${end}:`, err);
-      rateLimitRetries = 0;
     }
 
     start += chunkSize;
@@ -392,8 +394,6 @@ export const scanEvmLogsInChunks = async (
     ...rest
   } = opts;
 
-  const rpc = makeRetryProvider(provider, rest.setTimeout);
-
   return scanEvmBlocksInChunks<Log>({
     ...rest,
     provider,
@@ -406,7 +406,7 @@ export const scanEvmLogsInChunks = async (
         fromBlock: start,
         toBlock: end,
       };
-      const logs = await rpc.getLogs(chunkFilter);
+      const logs = await provider.getLogs(chunkFilter);
       for (const evt of logs) {
         if (await predicate(evt)) {
           log(`[LogScan] Match in tx=${evt.transactionHash}`);
@@ -434,14 +434,13 @@ const scanChunkTracesForFailedTx = async (
   end: number,
   opts: FailedTxScanOpts,
 ): Promise<TransactionResponse | undefined> => {
-  const { provider, toAddress, verifyFailedTx, setTimeout } = opts;
-  const rpc = makeRetryProvider(provider, setTimeout);
+  const { provider, toAddress, verifyFailedTx } = opts;
 
   const traces = await getTraces(
     toQuantity(start),
     toQuantity(end),
     toAddress,
-    rpc,
+    provider,
   );
 
   const failedTopLevel = traces.filter(
@@ -538,10 +537,7 @@ export const scanFailedTxsInChunks = async (
   });
 };
 
-export const waitForBlock = async (
-  provider: WebSocketProvider,
-  targetBlock: number,
-) => {
+export const waitForBlock = async (provider: EvmRpc, targetBlock: number) => {
   return new Promise(resolve => {
     const listener = blockNumber => {
       if (blockNumber >= targetBlock) {

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -56,9 +56,13 @@ import {
   spectrumPoolIdsByCluster,
 } from './support.ts';
 import type { MakeAbortController } from './support.ts';
+import { makeEvmRpc } from './evm-scanner.ts';
 import { makeGasEstimator } from './gas-estimation.ts';
 import { makeSQLiteKeyValueStore } from './kv-store.ts';
 import { YdsNotifier } from './yds-notifier.ts';
+import type { EvmRpcProviders } from './pending-tx-manager.ts';
+
+const { fromEntries, entries } = Object;
 
 const assertChainId = async (
   rpc: CosmosRPCClient,
@@ -295,6 +299,13 @@ export const main = async (
       )
     : undefined;
 
+  const retryProviders = fromEntries(
+    entries(evmCtx.evmProviders).map(([caip, provider]) => [
+      caip,
+      makeEvmRpc(provider, setTimeout),
+    ]),
+  ) as EvmRpcProviders;
+
   const powers = {
     evmCtx: {
       kvStore,
@@ -302,6 +313,7 @@ export const main = async (
       setTimeout,
       axelarApiUrl: config.axelar.apiUrl,
       ydsNotifier,
+      retryProviders,
       ...evmCtx,
     },
     rpc,

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -1,5 +1,3 @@
-import type { WebSocketProvider } from 'ethers';
-
 import { Fail } from '@endo/errors';
 
 import type { CaipChainId } from '@agoric/orchestration';
@@ -21,7 +19,7 @@ import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import type { CosmosRestClient } from './cosmos-rest-client.ts';
 import type { CosmosRPCClient } from './cosmos-rpc.ts';
 import { resolvePendingTx } from './resolver.ts';
-import { waitForBlock } from './evm-scanner.ts';
+import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
 import type {
   EvmProviders,
   MakeAbortController,
@@ -47,10 +45,15 @@ export type GmpWatcherResult = WatcherResult & {
   rejectionReason?: string;
 };
 
+export type EvmRpcProviders = Record<CaipChainId, EvmRpc>;
+
 export type EvmContext = {
   cosmosRest: CosmosRestClient;
   usdcAddresses: UsdcAddresses['mainnet' | 'testnet'];
+  // XXX eliminate evmProviders from EvmContext and use retryProviders for the
+  // balance-checking path too.
   evmProviders: EvmProviders;
+  retryProviders: EvmRpcProviders;
   signingSmartWalletKit: SigningSmartWalletKit;
   fetch: typeof fetch;
   setTimeout: typeof globalThis.setTimeout;
@@ -112,15 +115,15 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
     const usdcAddress =
       ctx.usdcAddresses[caipId] ||
       Fail`${logPrefix} No USDC address for chain: ${caipId}`;
-    const provider =
-      ctx.evmProviders[caipId] ||
-      Fail`${logPrefix} No EVM provider for chain: ${caipId}`;
+    const rpc =
+      ctx.retryProviders[caipId] ||
+      Fail`${logPrefix} No retry provider for chain: ${caipId}`;
 
     const watchArgs = {
       usdcAddress,
       toAddress: accountAddress as `0x${string}`,
       expectedAmount: amount,
-      provider,
+      provider: rpc,
       log: (msg, ...args) => log(logPrefix, msg, ...args),
     };
 
@@ -158,8 +161,8 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
-      const currentBlock = await provider.getBlockNumber();
-      await waitForBlock(provider, currentBlock + 1);
+      const currentBlock = await rpc.getBlockNumber();
+      await waitForBlock(rpc, currentBlock + 1);
 
       // Scan historical blocks
       transferResult = await lookBackCctp({
@@ -225,16 +228,15 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
     const { namespace, reference, accountAddress } =
       parseAccountId(destinationAddress);
     const caipId: CaipChainId = `${namespace}:${reference}`;
-    caipId in ctx.evmProviders ||
-      Fail`${logPrefix} No EVM provider for chain: ${caipId}`;
-
-    const provider = ctx.evmProviders[caipId] as WebSocketProvider;
+    const rpc =
+      ctx.retryProviders[caipId] ||
+      Fail`${logPrefix} No retry provider for chain: ${caipId}`;
 
     // Extract the address portion from sourceAddress (format: 'cosmos:agoric-3:agoric1...')
     const lcaAddress = parseAccountId(sourceAddress).accountAddress;
 
     const watchArgs = {
-      provider,
+      provider: rpc,
       contractAddress: accountAddress as `0x${string}`,
       txId,
       expectedSourceAddress: lcaAddress,
@@ -281,8 +283,8 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
-      const currentBlock = await provider.getBlockNumber();
-      await waitForBlock(provider, currentBlock + 1);
+      const currentBlock = await rpc.getBlockNumber();
+      await waitForBlock(rpc, currentBlock + 1);
 
       // Scan historical blocks
       const lookBackResult = await lookBackGmp({
@@ -361,9 +363,9 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
       parseAccountId(destinationAddress);
     const caipId: CaipChainId = `${namespace}:${reference}`;
 
-    const provider =
-      ctx.evmProviders[caipId] ||
-      Fail`${logPrefix} No EVM provider for chain: ${caipId}`;
+    const rpc =
+      ctx.retryProviders[caipId] ||
+      Fail`${logPrefix} No retry provider for chain: ${caipId}`;
 
     const lcaAddress = parseAccountId(sourceAddress).accountAddress;
 
@@ -378,7 +380,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
     const watchArgs = {
       factoryAddr: factoryAddr || (accountAddress as `0x${string}`),
       subscribeToAddr,
-      provider,
+      provider: rpc,
       expectedAddr: expectedAddr as `0x${string}`,
       expectedSourceAddress: lcaAddress,
       chainId: caipId,
@@ -415,8 +417,8 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
 
       await null;
 
-      const currentBlock = await provider.getBlockNumber();
-      await waitForBlock(provider, currentBlock + 1);
+      const currentBlock = await rpc.getBlockNumber();
+      await waitForBlock(rpc, currentBlock + 1);
 
       walletResult = await lookBackSmartWalletTx({
         ...watchArgs,

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -1,4 +1,4 @@
-import type { Filter, WebSocketProvider, Log } from 'ethers';
+import type { Filter, Log } from 'ethers';
 import { id, zeroPadValue, getAddress, ethers } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
@@ -6,6 +6,7 @@ import { PendingTxCode, TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
+  type EvmRpc,
   type WatcherTimeoutOptions,
 } from '../evm-scanner.ts';
 import {
@@ -39,7 +40,7 @@ const TRANSFER_SIGNATURE = id('Transfer(address,address,uint256)');
 
 type CctpWatch = {
   usdcAddress: `0x${string}`;
-  provider: WebSocketProvider;
+  provider: EvmRpc;
   toAddress: `0x${string}`;
   expectedAmount: bigint;
   log?: (...args: unknown[]) => void;

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import type { Filter, WebSocketProvider } from 'ethers';
+import type { Filter } from 'ethers';
 import type { WebSocket } from 'ws';
 import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.js';
 import type { CaipChainId } from '@agoric/orchestration';
@@ -10,6 +10,7 @@ import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
   scanFailedTxsInChunks,
+  type EvmRpc,
   type WatcherTimeoutOptions,
 } from '../evm-scanner.ts';
 import type { MakeAbortController } from '../support.ts';
@@ -34,7 +35,7 @@ const MULTICALL_STATUS_SIGNATURE = ethers.id(
 );
 
 type WatchGmp = {
-  provider: WebSocketProvider;
+  provider: EvmRpc;
   contractAddress: `0x${string}`;
   txId: TxId;
   expectedSourceAddress: string;

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -1,4 +1,4 @@
-import type { Filter, WebSocketProvider } from 'ethers';
+import type { Filter } from 'ethers';
 import { id, zeroPadValue, getAddress, AbiCoder } from 'ethers';
 import type { WebSocket } from 'ws';
 import type { CaipChainId } from '@agoric/orchestration';
@@ -9,6 +9,7 @@ import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
   scanFailedTxsInChunks,
+  type EvmRpc,
   type WatcherTimeoutOptions,
 } from '../evm-scanner.ts';
 import { PendingTxCode, TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
@@ -78,7 +79,7 @@ export const parseSmartWalletCreatedLog = (log: any) => {
 type SmartWalletWatchBase = {
   factoryAddr: `0x${string}`;
   subscribeToAddr: `0x${string}`;
-  provider: WebSocketProvider;
+  provider: EvmRpc;
   expectedAddr: `0x${string}`;
   expectedSourceAddress: string;
   chainId: CaipChainId;

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -1,7 +1,8 @@
-import type { TransactionReceipt, WebSocketProvider } from 'ethers';
+import type { TransactionReceipt } from 'ethers';
 import { Interface, AbiCoder, getAddress } from 'ethers';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
 import { decodeAbiParameters } from 'viem';
+import type { EvmRpc } from '../evm-scanner.ts';
 import { getConfirmationsRequired } from '../support.ts';
 
 /** Scope tag for failed-transaction lookback searches. */
@@ -169,7 +170,7 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 
 /**
  * Fetch transaction receipt with retry logic for freshly mined transactions.
- * @param provider - The WebSocket provider
+ * @param provider - The EVM RPC provider
  * @param txHash - Transaction hash
  * @param log - Logging function
  * @param retryOptions - Retry configuration (limit and backoffLimit)
@@ -177,7 +178,7 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
  * @returns Transaction receipt or null if not available after retries
  */
 export const fetchReceiptWithRetry = async (
-  provider: WebSocketProvider,
+  provider: EvmRpc,
   txHash: string,
   log: (...args: unknown[]) => void,
   retryOptions: RetryOptions = DEFAULT_RETRY_OPTIONS,
@@ -212,7 +213,7 @@ export const fetchReceiptWithRetry = async (
  * @param txHash - Transaction hash for logging
  * @param identifier - A string identifier for logging (e.g., "txId=tx1" or "expectedAddr=0x123")
  * @param chainId - Chain ID to determine confirmation requirements
- * @param provider - WebSocket provider for waiting for confirmations
+ * @param provider - EVM RPC provider for waiting for confirmations
  * @param log - Logging function
  * @returns Object with settled flag, success status, and transaction hash
  */
@@ -221,7 +222,7 @@ export const handleTxRevert = async (
   txHash: string,
   identifier: string,
   chainId: `${string}:${string}`,
-  provider: WebSocketProvider,
+  provider: EvmRpc,
   log: (...args: unknown[]) => void,
 ): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
   await null;

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -21,11 +21,15 @@ import type { CosmosRestClient } from '../src/cosmos-rest-client.ts';
 import type { CosmosRPCClient } from '../src/cosmos-rpc.ts';
 import type { Powers as EnginePowers } from '../src/engine.ts';
 import { makeGasEstimator } from '../src/gas-estimation.ts';
-import type { HandlePendingTxOpts } from '../src/pending-tx-manager.ts';
+import type {
+  HandlePendingTxOpts,
+  EvmRpcProviders,
+} from '../src/pending-tx-manager.ts';
 import { prepareAbortController } from '../src/support.ts';
 import type { YdsNotifier } from '../src/yds-notifier.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import type { Sdk as SpectrumPoolsSdk } from '../src/graphql/api-spectrum-pools/__generated/sdk.ts';
+import type { makeEvmRpc } from '../src/evm-scanner.ts';
 
 const PENDING_TX_PATH_PREFIX = 'published.ymax1';
 
@@ -380,19 +384,40 @@ export const createMockProvider = (
   return mockProvider as unknown as WebSocketProvider;
 };
 
-const createMockEvmProviders = (
+/**
+ * Create mock EVM providers and matching retry providers that share the same
+ * underlying instances (so websocket events emitted on evmProviders are
+ * visible to retryProviders).
+ */
+const createMockProviderSets = (
   latestBlock = 1000,
   events?: Pick<Log, 'blockNumber' | 'data' | 'topics' | 'transactionHash'>[],
-): Record<CaipChainId, WebSocketProvider> => ({
-  'eip155:1': createMockProvider(latestBlock, events),
-  'eip155:42161': createMockProvider(latestBlock, events),
-  'eip155:8453': createMockProvider(latestBlock, events),
-  'eip155:11155111': createMockProvider(latestBlock, events),
-});
+) => {
+  const chainIds: CaipChainId[] = [
+    'eip155:1',
+    'eip155:42161',
+    'eip155:8453',
+    'eip155:11155111',
+  ];
+  const evmProviders = {} as Record<CaipChainId, WebSocketProvider>;
+  const retryProviders = {} as EvmRpcProviders;
+  for (const chainId of chainIds) {
+    const provider = createMockProvider(latestBlock, events);
+    evmProviders[chainId] = provider;
+    // Mock providers already satisfy the EvmRpc shape.
+    retryProviders[chainId] = provider as unknown as ReturnType<
+      typeof makeEvmRpc
+    >;
+  }
+  return { evmProviders, retryProviders };
+};
+
+const defaultMockProviders = createMockProviderSets();
 
 export const mockEvmCtx = {
   usdcAddresses: {},
-  evmProviders: createMockEvmProviders(),
+  evmProviders: defaultMockProviders.evmProviders,
+  retryProviders: defaultMockProviders.retryProviders,
   kvStore: makeKVStoreFromMap(new Map()),
   setTimeout: globalThis.setTimeout,
   makeAbortController,
@@ -503,30 +528,37 @@ export const createMockCosmosRestClient = (
 export const createMockPendingTxOpts = (
   latestBlock = 1000,
   events?: Pick<Log, 'blockNumber' | 'data' | 'topics' | 'transactionHash'>[],
-): HandlePendingTxOpts => ({
-  cosmosRest: {} as unknown as CosmosRestClient,
-  cosmosRpc: {} as unknown as CosmosRPCClient,
-  evmProviders: createMockEvmProviders(latestBlock, events),
-  fetch: async () => ({ ok: true, json: async () => ({}) }) as Response,
-  setTimeout: globalThis.setTimeout,
-  marshaller: boardSlottingMarshaller(),
-  signingSmartWalletKit: createMockSigningSmartWalletKit(),
-  ydsNotifier: {
-    notifySettlement: async () => true,
-  } as unknown as YdsNotifier,
-  usdcAddresses: {
-    'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // Ethereum
-    'eip155:42161': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // Arbitrum
-  },
-  vstoragePathPrefixes: {
-    portfoliosPathPrefix: 'IGNORED',
-    pendingTxPathPrefix: PENDING_TX_PATH_PREFIX,
-  },
-  kvStore: makeKVStoreFromMap(new Map()),
-  makeAbortController,
-  axelarApiUrl: mockAxelarApiAddress,
-  pendingTxAbortControllers: new Map(),
-});
+): HandlePendingTxOpts => {
+  const { evmProviders, retryProviders } = createMockProviderSets(
+    latestBlock,
+    events,
+  );
+  return {
+    cosmosRest: {} as unknown as CosmosRestClient,
+    cosmosRpc: {} as unknown as CosmosRPCClient,
+    evmProviders,
+    retryProviders,
+    fetch: async () => ({ ok: true, json: async () => ({}) }) as Response,
+    setTimeout: globalThis.setTimeout,
+    marshaller: boardSlottingMarshaller(),
+    signingSmartWalletKit: createMockSigningSmartWalletKit(),
+    ydsNotifier: {
+      notifySettlement: async () => true,
+    } as unknown as YdsNotifier,
+    usdcAddresses: {
+      'eip155:1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // Ethereum
+      'eip155:42161': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // Arbitrum
+    },
+    vstoragePathPrefixes: {
+      portfoliosPathPrefix: 'IGNORED',
+      pendingTxPathPrefix: PENDING_TX_PATH_PREFIX,
+    },
+    kvStore: makeKVStoreFromMap(new Map()),
+    makeAbortController,
+    axelarApiUrl: mockAxelarApiAddress,
+    pendingTxAbortControllers: new Map(),
+  };
+};
 
 export const createMockPendingTxEvent = (
   txId: string,

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -9,7 +9,10 @@ import type {
   TxId,
 } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import { createMockPendingTxData } from '@aglocal/portfolio-contract/tools/mocks.ts';
-import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import {
+  handlePendingTx,
+  type EvmRpcProviders,
+} from '../src/pending-tx-manager.ts';
 import {
   processPendingTxEvents,
   processInitialPendingTransactions,
@@ -885,6 +888,7 @@ const makeFailedTxTestContext = ({
   const ctxWithFetch = harden({
     ...opts,
     evmProviders: newEvmProviders,
+    retryProviders: newEvmProviders as unknown as EvmRpcProviders,
     fetch: makeFetchMock({ failedTxHash }),
   });
 

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -3,7 +3,10 @@ import { zeroPadValue, AbiCoder, Interface, ethers } from 'ethers';
 import { objectMap } from '@endo/patterns';
 import type { WebSocketProvider } from 'ethers';
 import { createMockPendingTxOpts } from './mocks.ts';
-import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import {
+  handlePendingTx,
+  type EvmRpcProviders,
+} from '../src/pending-tx-manager.ts';
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import {
@@ -356,6 +359,7 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
   const ctxWithFetch = harden({
     ...opts,
     evmProviders: newEvmProviders,
+    retryProviders: newEvmProviders as EvmRpcProviders,
     fetch: async () => ({}) as Response,
   });
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs:
- https://linear.app/agoric/issue/PAK-141/add-retry-mechanism-for-429-errors-in-resolver

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Introduce `makeEvmRpc` - a provider facade that wraps every RPC call with Alchemy-recommended exponential backoff + jitter (5 retries, 1s–60s) for 429 rate-limit errors.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- E2E testing in progress.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`. 