### PR TITLE
fix(ymax-resolver): retry getInvitationMakers call for transient rpc failures

### DIFF
--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -1,8 +1,10 @@
 import { type SigningSmartWalletKit } from '@agoric/client-utils';
+import type { CurrentWalletRecord } from '@agoric/smart-wallet/src/smartWallet.js';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.js';
 import type { StdFee } from '@cosmjs/stargate';
+import { readStreamCellValue } from './vstorage-utils.ts';
 
 type ResolveTxParams = {
   signingSmartWalletKit: SigningSmartWalletKit;
@@ -23,9 +25,17 @@ const smartWalletFee: StdFee = {
   amount: [{ denom: 'ubld', amount: '10000' }],
 };
 
+const WALLET_RECORD_RETRIES = 4;
+
 const getInvitationMakers = async (wallet: SigningSmartWalletKit) => {
-  const getCurrentWalletRecord = await wallet.query.getCurrentWalletRecord();
-  const invitation = getCurrentWalletRecord.offerToUsedInvitation
+  const walletPath = `published.wallet.${wallet.address}.current`;
+  const capData = await readStreamCellValue(wallet.query.vstorage, walletPath, {
+    retries: WALLET_RECORD_RETRIES,
+  });
+  const currentRecord: CurrentWalletRecord =
+    wallet.marshaller.fromCapData(capData);
+
+  const invitation = currentRecord.offerToUsedInvitation
     .filter(inv => inv[1].value[0].description === 'resolver')
     .toSorted()
     .at(-1);

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -427,31 +427,56 @@ export const mockEvmCtx = {
   } as unknown as YdsNotifier,
 };
 
+const mockWalletRecord = {
+  offerToUsedInvitation: [
+    [
+      'resolver-offer-1',
+      {
+        value: [
+          {
+            description: 'resolver',
+            instance: 'mock-instance',
+            installation: 'mock-installation',
+          },
+        ],
+      },
+    ],
+  ],
+  liveOffers: [],
+  purses: [],
+};
+
+/** CapData encoding of the mock wallet record (no slots needed). */
+const mockWalletCapData = JSON.stringify({
+  body: JSON.stringify(mockWalletRecord),
+  slots: [],
+});
+
+/** StreamCell wrapping the CapData-encoded wallet record. */
+const mockStreamCell = JSON.stringify({
+  blockHeight: '100',
+  values: [mockWalletCapData],
+});
+
 export const createMockSigningSmartWalletKit = (): SigningSmartWalletKit => {
   const executedOffers: OfferSpec[] = [];
 
   return {
     address: 'agoric1mockplanner123456789abcdefghijklmnopqrstuvwxyz',
 
+    marshaller: {
+      fromCapData: (capData: { body: string; slots: string[] }) =>
+        JSON.parse(capData.body),
+    },
+
     query: {
-      getCurrentWalletRecord: async () => ({
-        offerToUsedInvitation: [
-          [
-            'resolver-offer-1',
-            {
-              value: [
-                {
-                  description: 'resolver',
-                  instance: 'mock-instance',
-                  installation: 'mock-installation',
-                },
-              ],
-            },
-          ],
-        ],
-        liveOffers: [],
-        purses: [],
-      }),
+      getCurrentWalletRecord: async () => mockWalletRecord,
+      vstorage: {
+        readStorageMeta: async () => ({
+          result: { value: mockStreamCell },
+          blockHeight: 100n,
+        }),
+      },
     },
 
     executeOffer: async (offerSpec: OfferSpec) => {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

ref: https://linear.app/agoric/issue/PAK-168/resolver-found-tx-status-but-failed-while-settling-the-tx

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

- Replaced `wallet.query.getCurrentWalletRecord()` in `getInvitationMakers` with `readStreamCellValue()` which has built-in retry support (4 retries with exponential backoff)
- This fixes transient RPC failures that caused the resolver to silently fail during tx post-processing, leaving on-chain transactions unresolved.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- Performed manual testing by settling a previously pending transaction on devnet.
```
scripts/tx-tool.ts settle tx81 fail 'tx timeout'
```
Reference transaction state:
https://vstorage.agoric.net/?path=published.ymax0.pendingTxs.tx81&endpoint=https%3A%2F%2Fdevnet.rpc.agoric.net%3A443&height=undefined

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`.