### PR TITLE
docs: update resolver docs

### DIFF
--- a/packages/portfolio-contract/resolver-service.md
+++ b/packages/portfolio-contract/resolver-service.md
@@ -81,6 +81,7 @@ The resolver:
 **Finality protection:**
 - Before confirming a failure, the resolver waits for additional block confirmations to guard against blockchain reorgs
 - **For reverted transactions (status=0):** Waits for a higher confirmation threshold computed from a 10-minute window (`REVERT_WAIT_TIME_MS / blockTime`). This gives Axelar relayers time to retry the transaction. After the wait, re-checks the receipt — if the transaction is now successful (reorg flipped it), reports success instead
+- **Resubmission during confirmation wait:** If Axelar resubmits the transaction while the resolver is waiting for revert confirmations, the subscription remains active and catches the new transaction. Each incoming message is handled by an independent async invocation, so a successful resubmission resolves immediately via a `done` flag. When the original revert confirmation completes, its resolution attempt is a no-op because `done` is already true. This prevents double resolution.
 
 **Detection modes:**
 - **Live mode:** Subscribes to `alchemy_minedTransactions` for the contract address
@@ -124,6 +125,7 @@ The resolver:
 - Before confirming a failure, the resolver waits for additional block confirmations to guard against blockchain reorgs
 - **For failed events (`success=false`):** Waits for the standard confirmation threshold (e.g. 25 blocks), then re-checks that the event still exists in the finalized block. If the event was removed by a reorg, the resolver continues watching
 - **For reverted transactions (status=0):** Waits for a higher confirmation threshold computed from a 10-minute window (`REVERT_WAIT_TIME_MS / blockTime`). This gives Axelar relayers time to retry the transaction. After the wait, re-checks the receipt — if the transaction is now successful (reorg flipped it), reports success instead
+- **Resubmission during confirmation wait:** If Axelar resubmits the transaction while the resolver is waiting for revert confirmations, the subscription remains active and catches the new transaction. Each incoming message is handled by an independent async invocation, so a successful resubmission resolves immediately via a `done` flag. When the original revert confirmation completes, its resolution attempt is a no-op because `done` is already true. This prevents double resolution.
 
 **Detection modes:**
 - **Live mode:** Subscribes to real-time events via WebSocket and also monitors `alchemy_minedTransactions` for early revert detection

--- a/packages/portfolio-contract/resolver-service.md
+++ b/packages/portfolio-contract/resolver-service.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-The resolver service monitors and resolves transactions between Agoric and remote EVM chains."Resolving" implies determining and reporting the transaction status (SUCCESS or FAILED) back to the ymax contract. It uses WebSocket connections to listen for specific events on EVM chains and automatically marks transactions as resolved when the expected events are detected.
+The resolver service monitors and resolves transactions between Agoric and remote EVM chains. "Resolving" implies determining and reporting the transaction status (SUCCESS or FAILED) back to the ymax contract. It uses WebSocket connections to listen for specific events on EVM chains and automatically marks transactions as resolved when the expected events are detected.
 
 ## How It Works
 
 The resolver:
-- Maintains active WebSocket connections to EVM chains
+- Maintains active WebSocket connections to EVM chains via Alchemy
 - Listens for specific contract events based on transaction type
 - Automatically resolves transactions when expected events are detected
-- Sends alerts when transactions cannot be resolved automatically
-- Never gives up on a transaction unless manually resolved
+- Supports two operating modes: **live** (real-time WebSocket subscriptions) and **lookback** (historical block scanning)
+- Persists scan progress in a SQLite KV store so block scanning can resume after planner restarts
 
 ## Supported Transaction Types
 
@@ -20,13 +20,25 @@ The resolver:
 **Purpose:** Creates a remote EVM wallet for a user.
 
 **How it resolves:**
-- Listens for `SmartWalletCreated` events from the [Factory contract](https://github.com/agoric-labs/agoric-to-axelar-local/blob/c5b5b2892fe4fe3f822ba460dc9b35239a3fdc2e/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol#L155)
-- Automatically resolves when event matches:
-  - **Wallet address:** The created wallet address matches the expected address
+- Subscribes to `alchemy_minedTransactions` for the Factory or DepositFactory contract address
+- Supports two transaction paths:
+  - **makeAccount mode:** Transaction sent directly to the Factory contract
+  - **createAndDeposit mode:** Transaction sent to the DepositFactory contract (the Factory still emits the `SmartWalletCreated` event)
+- Parses the Axelar `execute(bytes32, string, string, bytes)` calldata to extract the `expectedWalletAddress` and `sourceAddress`
+- Validates that both `sourceAddress` (the LCA address) and `expectedWalletAddress` match the pending transaction
+- Checks the receipt for a `SmartWalletCreated` event matching the expected wallet address
 
-**Limitations:**
-- Cannot detect failures automatically
-- Failures require manual resolution
+
+**Failure detection:**
+
+- **Via revert:** If the transaction reverts (receipt `status=0`), waits for confirmations (~10 minutes / block time) via `handleTxRevert()` before confirming the failure
+- **Via lookback:** Scans historical blocks for failed transactions using `trace_filter` on supported chains (Ethereum, Base, Optimism)
+
+**Detection modes:**
+- **Live mode:** Subscribes to `alchemy_minedTransactions` for the factory address
+- **Lookback mode:** Scans historical blocks in two phases:
+  1. **Phase 1 (cheap):** Scans `eth_getLogs` for `SmartWalletCreated` events (both v1 and v2 signatures concurrently)
+  2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `trace_filter` (on supported chains)
 
 ---
 
@@ -35,11 +47,15 @@ The resolver:
 **Purpose:** Transfers USDC from Agoric to a remote EVM wallet via CCTP (Cross-Chain Transfer Protocol).
 
 **How it resolves:**
-- Listens for ERC20 `Transfer` events from the USDC token contract
+- Listens for ERC-20 `Transfer` events from the USDC token contract
 - Automatically resolves when a transfer matches all conditions:
   - **Recipient address:** Transfer TO the expected remote EVM wallet address
-  - **Token contract:** Transfer FROM the USDC token contract (exact match)
+  - **Token contract:** Event emitted by the correct USDC token contract address
   - **Amount:** Exact match of the expected USDC amount
+
+**Detection modes:**
+- **Live mode:** Uses `provider.on(filter)` with ethers event filtering by `Transfer` topic and recipient address
+- **Lookback mode:** Scans historical blocks using `scanEvmLogsInChunks()` with `eth_getLogs`
 
 **Limitations:**
 - Cannot detect CCTP failures automatically
@@ -52,14 +68,25 @@ The resolver:
 **Purpose:** Deploys or withdraws funds from the remote EVM wallet to/from an EVM protocol.
 
 **How it resolves:**
-- Listens for `MulticallStatus` events from the [remote EVM wallet](https://github.com/agoric-labs/agoric-to-axelar-local/blob/c5b5b2892fe4fe3f822ba460dc9b35239a3fdc2e/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol#L82)
-- Automatically resolves when event matches:
-  - **Transaction ID:** The event's txId hash matches the expected transaction ID
+- Subscribes to `alchemy_minedTransactions` for the destination contract (remote EVM wallet) address
+- Parses the Axelar `execute(bytes32, string, string, bytes)` calldata to extract the `txId` and `sourceAddress` via `extractGmpExecuteData()`
+- The payload is decoded as `CallMessage { string id; ContractCalls[] calls; }` — the `id` field is the transaction ID
+- Validates that both `txId` and `sourceAddress` (the LCA address) match the pending transaction
+- Checks the receipt for a `MulticallStatus(string,bool,uint256)` event where `topics[1]` matches `keccak256(txId)`
 
 **Failure detection:**
-- After 30 minutes without resolution, checks [AxelarScan](https://axelarscan.io/) for transaction status
-- If AxelarScan confirms failure, automatically marks transaction as "failed"
-- If AxelarScan has no record, proceeds to alerting (see below)
+- **Via revert:** If the transaction reverts (receipt status=0) and the `sourceAddress` matches the expected LCA address, waits for confirmations (~10 minutes / block time) via `handleTxRevert()` before confirming the failure
+- **Via lookback:** Scans historical blocks for failed transactions using `trace_filter` on supported chains (Ethereum, Base, Optimism)
+
+**Finality protection:**
+- Before confirming a failure, the resolver waits for additional block confirmations to guard against blockchain reorgs
+- **For reverted transactions (status=0):** Waits for a higher confirmation threshold computed from a 10-minute window (`REVERT_WAIT_TIME_MS / blockTime`). This gives Axelar relayers time to retry the transaction. After the wait, re-checks the receipt — if the transaction is now successful (reorg flipped it), reports success instead
+
+**Detection modes:**
+- **Live mode:** Subscribes to `alchemy_minedTransactions` for the contract address
+- **Lookback mode:** Scans historical blocks in two phases:
+  1. **Phase 1 (cheap):** Scans `eth_getLogs` for `MulticallStatus` events
+  2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `trace_filter` (on supported chains)
 
 ---
 
@@ -102,87 +129,113 @@ The resolver:
 - **Live mode:** Subscribes to real-time events via WebSocket and also monitors `alchemy_minedTransactions` for early revert detection
 - **Lookback mode:** Scans historical blocks in two phases:
   1. **Phase 1 (cheap):** Scans `eth_getLogs` for `OperationResult` events
-  2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `eth_getBlockReceipts` or `trace_filter`
+  2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `trace_filter`
 - Both modes run concurrently when a transaction timestamp is available, ensuring no gap in coverage
 
 ---
 
-## Alert System
+## Timeout Behavior
 
-### When Alerts Are Triggered
+When a transaction is not resolved within 30 minutes (`TX_TIMEOUT_MS`):
 
-Alerts are sent when:
-- **MAKE_ACCOUNT / CCTP_TO_EVM:** No expected event after 30 minutes
-- **GMP:** No expected event after 30 minutes AND no status found on AxelarScan
-- **ROUTED_GMP:** No `OperationResult` event and no failed transaction detected after 30 minutes
+- A single log message is emitted with a stable error code prefix (e.g., `GMP_TX_NOT_FOUND`, `WALLET_TX_NOT_FOUND`, `CCTP_TX_NOT_FOUND`, `ROUTED_GMP_TX_NOT_FOUND`)
+- Ops alerting in `#ops-ymax-resolver` matches on these stable codes
+- The timeout **does not** resolve or reject the watcher — it only logs. The watcher continues running indefinitely until either:
+  - The expected event is detected
+  - The on-chain pending tx status changes (triggering an abort via `AbortController`)
+  - The resolver service is restarted
 
-### Alert Behavior
+---
 
-- Alerts are sent every 30 minutes until the transaction is resolved
-- The resolver **continues processing** the transaction even after alerting
-- WebSocket listeners remain active
-- For GMP transactions, AxelarScan checks continue periodically
-- The resolver never abandons a transaction
+## Settlement Notification
+
+When a transaction is settled (success or failure), two actions occur:
+1. **On-chain resolution:** `resolvePendingTx()` submits a `SettleTransaction` offer to the Agoric smart wallet
+2. **YDS notification (optional):** If configured, `YdsNotifier.notifySettlement()` sends a POST to the YDS `/flow-step-tx-hashes` endpoint with the txId and EVM transaction hash
 
 ---
 
 ## Summary Matrix
 
-| Transaction Type | Listens For | Contract Monitored | Auto-Resolve Success | Auto-Detect Failure |
-|-----------------|-------------|-------------------|---------------------|---------------------|
-| MAKE_ACCOUNT | `SmartWalletCreated` | Factory | ✅ | ❌ |
-| CCTP_TO_EVM | ERC20 `Transfer` | USDC Token | ✅ | ❌ |
-| GMP | `MulticallStatus` | Remote EVM Wallet | ✅ | ✅ (via AxelarScan) |
-| ROUTED_GMP | `OperationResult` | PortfolioRouter | ✅ | ✅ (via event + revert detection) |
+| Transaction Type | Listens For | Contract Monitored | Live Mechanism | Auto-Resolve Success | Auto-Detect Failure |
+|-----------------|-------------|-------------------|----------------|---------------------|---------------------|
+| MAKE_ACCOUNT | `SmartWalletCreated` | Factory / DepositFactory | `alchemy_minedTransactions` | ✅ | ✅ (via revert + trace_filter) |
+| CCTP_TO_EVM | ERC-20 `Transfer` | USDC Token | `provider.on(filter)` | ✅ | ❌ |
+| GMP | `MulticallStatus` | Remote EVM Wallet | `alchemy_minedTransactions` | ✅ | ✅ (via revert + trace_filter) |
+| ROUTED_GMP | `OperationResult` | PortfolioRouter | `provider.on(filter)` + `alchemy_minedTransactions` | ✅ | ✅ (via event + revert + trace_filter) |
 
 ---
 
+## Transaction Resolution Flows
 
----
-
-## Transaction Resolution Flow
-
-### MAKE_ACCOUNT / CCTP_TO_EVM / GMP
+### CCTP_TO_EVM
 ```mermaid
 flowchart LR
-  Start([New Transaction]) --> TxType{Transaction<br/>Type?}
+  Start([New CCTP_TO_EVM<br/>Transaction]) --> Mode{Has<br/>timestamp?}
 
-  TxType -->|MAKE_ACCOUNT| ListenMA[Listen: SmartWalletCreated Events<br/>Contract: Factory]
-  TxType -->|CCTP_TO_EVM| ListenCCTP[Listen: ERC20 Transfer Events<br/>Contract: USDC Token]
-  TxType -->|GMP| ListenGMP[Listen: MulticallStatus Events<br/>Contract: Remote Wallet]
+  Mode -->|No| LiveOnly[Live Mode]
+  Mode -->|Yes| Both[Start Live + Lookback]
 
-  ListenMA --> Wait{Event Found in<br/>30 min?}
-  ListenCCTP --> Wait
-  ListenGMP --> Wait
+  LiveOnly --> LiveSub[Subscribe to<br/>Transfer events via<br/>provider.on]
+  Both -->|Live mode| LiveSub
+  Both -->|Lookback| Scan[Scan eth_getLogs<br/>for Transfer events]
 
-  Wait -->|Yes| Success[✅ SUCCESS]
-  Wait -->|No| NoEvent{Tx Type<br/>is GMP?}
+  Scan -->|Match found| Success[✅ SUCCESS]
+  Scan -->|Not found| LiveSub
 
-  NoEvent -->|No| Alert[🔔 Alert Sent]
-  NoEvent -->|Yes| Check{Check<br/>AxelarScan}
+  LiveSub -->|Transfer matches| Success
+  LiveSub -->|Timeout 30min| Log[Log CCTP_TX_NOT_FOUND<br/>Keep listening]
+  Log --> Manual[🧑‍💻 Manual Intervention]
 
-  Check -->|Error| Failed[❌ FAILED]
-  Check -->|Unknown| Alert
+  Success --> Done([Transaction Settled])
+  Manual --> Done
 
-  Alert --> Loop[Keep Listening<br/>Alert Every 30min]
-  Loop -->|Event Found| Success
+  style Success fill:#90EE90
+  style LiveSub fill:#E3F2FD
+  style Scan fill:#E3F2FD
+  style Log fill:#FFE4B5
+  style Manual fill:#E6E6FA,stroke:#6A5ACD,stroke-width:2px
+```
 
-  %% 👇 Explicit manual step (very visible)
-  Loop --> Manual[🧑‍💻 Manual Intervention]
-  Manual --> Decide{Operator<br/>Decision}
-  Decide -->|Success| Success
-  Decide -->|Failed| Failed
+### MAKE_ACCOUNT / GMP
+```mermaid
+flowchart LR
+  Start([New Transaction]) --> Mode{Has<br/>timestamp?}
+
+  Mode -->|No| LiveOnly[Live Mode]
+  Mode -->|Yes| Both[Start Live + Lookback]
+
+  LiveOnly --> LiveSub
+  Both -->|Live mode| LiveSub[Subscribe to<br/>alchemy_minedTransactions]
+  Both -->|Lookback| Phase1[Phase 1: eth_getLogs<br/>for success events]
+
+  Phase1 -->|Event found| Success[✅ SUCCESS]
+  Phase1 -->|Not found| Phase2[Phase 2: trace_filter<br/>for failed txs]
+
+  Phase2 -->|Revert found| Finality[Wait for revert<br/>confirmations ~10 min]
+  Phase2 -->|Not found| LiveSub
+
+  LiveSub -->|Success event in receipt| Success
+  LiveSub -->|TX reverted| Finality
+  LiveSub -->|Timeout 30min| Log[Log timeout warning<br/>Keep listening]
+
+  Finality --> Recheck{Re-verify receipt<br/>after finality}
+  Recheck -->|Still reverted| Failed[❌ FAILED]
+  Recheck -->|Now successful| Success
+
+  Log --> Manual[🧑‍💻 Manual Intervention]
+  Manual --> Done
 
   Success --> Done([Transaction Settled])
   Failed --> Done
 
   style Success fill:#90EE90
   style Failed fill:#FFB6C6
-  style ListenMA fill:#E3F2FD
-  style ListenCCTP fill:#E3F2FD
-  style ListenGMP fill:#E3F2FD
-  style Alert fill:#FFE4B5
-  style Loop fill:#FFF4E0
+  style Phase1 fill:#E3F2FD
+  style Phase2 fill:#E3F2FD
+  style LiveSub fill:#E3F2FD
+  style Finality fill:#FFF4E0
+  style Log fill:#FFE4B5
   style Manual fill:#E6E6FA,stroke:#6A5ACD,stroke-width:2px
 
 ```
@@ -203,10 +256,10 @@ flowchart LR
   Both -->|Lookback| Phase1[Phase 1: eth_getLogs<br/>for OperationResult]
 
   Phase1 -->|Event found| EventCheck{success?}
-  Phase1 -->|Not found| Phase2[Phase 2: Scan for<br/>failed transactions]
+  Phase1 -->|Not found| Phase2[Phase 2: trace_filter<br/>for failed transactions]
 
   Phase2 -->|Revert found| Finality2[Wait for revert<br/>confirmations ~10 min]
-  Phase2 -->|Wait for Live mode| LiveSub
+  Phase2 -->|Not found| LiveSub
 
   %% Live watcher detection paths
   LiveSub -->|OperationResult event| EventCheck
@@ -225,14 +278,10 @@ flowchart LR
   Recheck2 -->|Still reverted| Failed
   Recheck2 -->|Now successful| Success
 
-  %% Timeout / alerting
-  LiveSub -->|Timeout 30min| Alert[🔔 Alert Sent]
-  Alert --> Loop[Keep Listening<br/>Alert Every 30min]
-  Loop -->|Event Found| EventCheck
-  Loop --> Manual[🧑‍💻 Manual Intervention]
-  Manual --> Decide{Operator<br/>Decision}
-  Decide -->|Success| Success
-  Decide -->|Failed| Failed
+  %% Timeout
+  LiveSub -->|Timeout 30min| Log[Log ROUTED_GMP_TX_NOT_FOUND<br/>Keep listening]
+  Log --> Manual[🧑‍💻 Manual Intervention]
+  Manual --> Done
 
   Success --> Done([Transaction Settled])
   Failed --> Done
@@ -244,8 +293,7 @@ flowchart LR
   style LiveSub fill:#E3F2FD
   style Finality1 fill:#FFF4E0
   style Finality2 fill:#FFF4E0
-  style Alert fill:#FFE4B5
-  style Loop fill:#FFF4E0
+  style Log fill:#FFE4B5
   style Manual fill:#E6E6FA,stroke:#6A5ACD,stroke-width:2px
 
 ```

--- a/packages/portfolio-contract/resolver-service.md
+++ b/packages/portfolio-contract/resolver-service.md
@@ -10,8 +10,10 @@ The resolver:
 - Maintains active WebSocket connections to EVM chains via Alchemy
 - Listens for specific contract events based on transaction type
 - Automatically resolves transactions when expected events are detected
-- Supports two operating modes: **live** (real-time WebSocket subscriptions) and **lookback** (historical block scanning)
-- Persists scan progress in a SQLite KV store so block scanning can resume after planner restarts
+- Supports two operating modes:
+  - **Live mode:** Verifies transactions in real time via WebSocket subscriptions as new blocks are mined
+  - **Lookback mode:** Scans historical blocks as a fallback to cover cases where the live subscription missed a transaction — for example, if the resolver was restarted or if the live subscription dropped
+- Persists scan progress for lookback mode in a SQLite KV store so block scanning can resume after planner restarts
 
 ## Supported Transaction Types
 
@@ -19,26 +21,27 @@ The resolver:
 
 **Purpose:** Creates a remote EVM wallet for a user.
 
-**How it resolves:**
-- Subscribes to `alchemy_minedTransactions` for the Factory or DepositFactory contract address
-- Supports two transaction paths:
-  - **makeAccount mode:** Transaction sent directly to the Factory contract
-  - **createAndDeposit mode:** Transaction sent to the DepositFactory contract (the Factory still emits the `SmartWalletCreated` event)
-- Parses the Axelar `execute(bytes32, string, string, bytes)` calldata to extract the `expectedWalletAddress` and `sourceAddress`
-- Validates that both `sourceAddress` (the LCA address) and `expectedWalletAddress` match the pending transaction
-- Checks the receipt for a `SmartWalletCreated` event matching the expected wallet address
-
-
-**Failure detection:**
-
-- **Via revert:** If the transaction reverts (receipt `status=0`), waits for confirmations (~10 minutes / block time) via `handleTxRevert()` before confirming the failure
-- **Via lookback:** Scans historical blocks for failed transactions using `trace_filter` on supported chains (Ethereum, Base, Optimism)
-
 **Detection modes:**
 - **Live mode:** Subscribes to `alchemy_minedTransactions` for the factory address
 - **Lookback mode:** Scans historical blocks in two phases:
   1. **Phase 1 (cheap):** Scans `eth_getLogs` for `SmartWalletCreated` events (both v1 and v2 signatures concurrently)
   2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `trace_filter` (on supported chains)
+
+**How it resolves:**
+- Subscribes to `alchemy_minedTransactions` for the Factory or DepositFactory contract address
+- Supports two transaction types:
+  - **makeAccount txs:** Transaction sent directly to the Factory contract
+  - **createAndDeposit txs:** Transaction sent to the DepositFactory contract (the Factory still emits the `SmartWalletCreated` event)
+- Parses the calldata for the `execute(bytes32, string, string, bytes)` function to extract the `expectedWalletAddress` and `sourceAddress`
+- Validates that both `sourceAddress` (the LCA address) and `expectedWalletAddress` match the pending transaction
+- Checks the receipt for a `SmartWalletCreated` event matching the expected wallet address
+
+**Failure detection:**
+
+- **Via revert (in live mode):** If the transaction reverts (receipt `status=0`), waits for confirmations (~10 minutes / block time) via `handleTxRevert()` before confirming the failure
+- **Via lookback:** Scans historical blocks for failed transactions using `trace_filter` on supported chains (Ethereum, Base, Optimism)
+
+**Finality protection:** See [Common Finality Behavior](#common-finality-behavior).
 
 ---
 
@@ -56,6 +59,7 @@ The resolver:
 **Detection modes:**
 - **Live mode:** Uses `provider.on(filter)` with ethers event filtering by `Transfer` topic and recipient address
 - **Lookback mode:** Scans historical blocks using `scanEvmLogsInChunks()` with `eth_getLogs`
+  - There is no Phase 2 failure scan for CCTP because CCTP transfers have no on-chain failure signal to scan for
 
 **Limitations:**
 - Cannot detect CCTP failures automatically
@@ -67,27 +71,24 @@ The resolver:
 
 **Purpose:** Deploys or withdraws funds from the remote EVM wallet to/from an EVM protocol.
 
-**How it resolves:**
-- Subscribes to `alchemy_minedTransactions` for the destination contract (remote EVM wallet) address
-- Parses the Axelar `execute(bytes32, string, string, bytes)` calldata to extract the `txId` and `sourceAddress` via `extractGmpExecuteData()`
-- The payload is decoded as `CallMessage { string id; ContractCalls[] calls; }` — the `id` field is the transaction ID
-- Validates that both `txId` and `sourceAddress` (the LCA address) match the pending transaction
-- Checks the receipt for a `MulticallStatus(string,bool,uint256)` event where `topics[1]` matches `keccak256(txId)`
-
-**Failure detection:**
-- **Via revert:** If the transaction reverts (receipt status=0) and the `sourceAddress` matches the expected LCA address, waits for confirmations (~10 minutes / block time) via `handleTxRevert()` before confirming the failure
-- **Via lookback:** Scans historical blocks for failed transactions using `trace_filter` on supported chains (Ethereum, Base, Optimism)
-
-**Finality protection:**
-- Before confirming a failure, the resolver waits for additional block confirmations to guard against blockchain reorgs
-- **For reverted transactions (status=0):** Waits for a higher confirmation threshold computed from a 10-minute window (`REVERT_WAIT_TIME_MS / blockTime`). This gives Axelar relayers time to retry the transaction. After the wait, re-checks the receipt — if the transaction is now successful (reorg flipped it), reports success instead
-- **Resubmission during confirmation wait:** If Axelar resubmits the transaction while the resolver is waiting for revert confirmations, the subscription remains active and catches the new transaction. Each incoming message is handled by an independent async invocation, so a successful resubmission resolves immediately via a `done` flag. When the original revert confirmation completes, its resolution attempt is a no-op because `done` is already true. This prevents double resolution.
-
 **Detection modes:**
 - **Live mode:** Subscribes to `alchemy_minedTransactions` for the contract address
 - **Lookback mode:** Scans historical blocks in two phases:
   1. **Phase 1 (cheap):** Scans `eth_getLogs` for `MulticallStatus` events
   2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `trace_filter` (on supported chains)
+
+**How it resolves:**
+- Subscribes to `alchemy_minedTransactions` for the destination contract (remote EVM wallet) address
+- Parses the calldata for the `execute(bytes32, string, string, bytes)` function to extract the `txId` and `sourceAddress` via `extractGmpExecuteData()`
+- The payload is decoded as `CallMessage { string id; ContractCalls[] calls; }` — the `id` field is the transaction ID
+- Validates that both `txId` and `sourceAddress` (the LCA address) match the pending transaction
+- Checks the receipt for a `MulticallStatus(string,bool,uint256)` event where `topics[1]` matches `keccak256(txId)`
+
+**Failure detection:**
+- **Via revert (in live mode):** If the transaction reverts (receipt status=0) and the `sourceAddress` matches the expected LCA address, waits for confirmations (~10 minutes / block time) via `handleTxRevert()` before confirming the failure
+- **Via lookback:** Scans historical blocks for failed transactions using `trace_filter` on supported chains (Ethereum, Base, Optimism)
+
+**Finality protection:** See [Common Finality Behavior](#common-finality-behavior).
 
 ---
 
@@ -122,10 +123,9 @@ The resolver:
 - **Via revert:** If the transaction reverts (status=0) without emitting an `OperationResult` event, this is also detected and reported as a failure
 
 **Finality protection:**
-- Before confirming a failure, the resolver waits for additional block confirmations to guard against blockchain reorgs
+
+In addition to the [Common Finality Behavior](#common-finality-behavior), ROUTED_GMP has event-level finality:
 - **For failed events (`success=false`):** Waits for the standard confirmation threshold (e.g. 25 blocks), then re-checks that the event still exists in the finalized block. If the event was removed by a reorg, the resolver continues watching
-- **For reverted transactions (status=0):** Waits for a higher confirmation threshold computed from a 10-minute window (`REVERT_WAIT_TIME_MS / blockTime`). This gives Axelar relayers time to retry the transaction. After the wait, re-checks the receipt — if the transaction is now successful (reorg flipped it), reports success instead
-- **Resubmission during confirmation wait:** If Axelar resubmits the transaction while the resolver is waiting for revert confirmations, the subscription remains active and catches the new transaction. Each incoming message is handled by an independent async invocation, so a successful resubmission resolves immediately via a `done` flag. When the original revert confirmation completes, its resolution attempt is a no-op because `done` is already true. This prevents double resolution.
 
 **Detection modes:**
 - **Live mode:** Subscribes to real-time events via WebSocket and also monitors `alchemy_minedTransactions` for early revert detection
@@ -133,6 +133,16 @@ The resolver:
   1. **Phase 1 (cheap):** Scans `eth_getLogs` for `OperationResult` events
   2. **Phase 2 (if Phase 1 finds nothing):** Scans for failed transactions via `trace_filter`
 - Both modes run concurrently when a transaction timestamp is available, ensuring no gap in coverage
+
+---
+
+## Common Finality Behavior
+
+All transaction types that support automatic failure detection (MAKE_ACCOUNT, GMP, ROUTED_GMP) share the following finality protection logic:
+
+- Before confirming a failure, the resolver waits for additional block confirmations to guard against blockchain reorgs
+- **For reverted transactions (status=0):** Waits for a higher confirmation threshold computed from a 10-minute window (`REVERT_WAIT_TIME_MS / blockTime`). This gives Axelar relayers time to retry the transaction. After the wait, re-checks the receipt — if the transaction is now successful (reorg flipped it), reports success instead
+- **Resubmission during confirmation wait:** If Axelar resubmits the transaction while the resolver is waiting for revert confirmations, the subscription remains active and catches the new transaction. Each incoming message is handled by an independent async invocation, so a successful resubmission resolves immediately via a `done` flag. When the original revert confirmation completes, its resolution attempt is a no-op because `done` is already true. This prevents double resolution.
 
 ---
 
@@ -161,7 +171,7 @@ When a transaction is settled (success or failure), two actions occur:
 
 | Transaction Type | Listens For | Contract Monitored | Live Mechanism | Auto-Resolve Success | Auto-Detect Failure |
 |-----------------|-------------|-------------------|----------------|---------------------|---------------------|
-| MAKE_ACCOUNT | `SmartWalletCreated` | Factory / DepositFactory | `alchemy_minedTransactions` | ✅ | ✅ (via revert + trace_filter) |
+| MAKE_ACCOUNT | `SmartWalletCreated` | Factory / DepositFactory | `alchemy_minedTransactions` | ✅ | ✅ (via revert in live + trace_filter in lookback) |
 | CCTP_TO_EVM | ERC-20 `Transfer` | USDC Token | `provider.on(filter)` | ✅ | ❌ |
 | GMP | `MulticallStatus` | Remote EVM Wallet | `alchemy_minedTransactions` | ✅ | ✅ (via revert + trace_filter) |
 | ROUTED_GMP | `OperationResult` | PortfolioRouter | `provider.on(filter)` + `alchemy_minedTransactions` | ✅ | ✅ (via event + revert + trace_filter) |
@@ -183,7 +193,7 @@ flowchart LR
   Both -->|Lookback| Scan[Scan eth_getLogs<br/>for Transfer events]
 
   Scan -->|Match found| Success[✅ SUCCESS]
-  Scan -->|Not found| LiveSub
+  Scan -.->|Not found<br/>live already running| LiveSub
 
   LiveSub -->|Transfer matches| Success
   LiveSub -->|Timeout 30min| Log[Log CCTP_TX_NOT_FOUND<br/>Keep listening]
@@ -200,6 +210,9 @@ flowchart LR
 ```
 
 ### MAKE_ACCOUNT / GMP
+
+> Both types follow the same resolution flow. The difference is in event matching: MAKE_ACCOUNT matches `SmartWalletCreated` events using `expectedWalletAddress`, while GMP matches `MulticallStatus` events using `keccak256(txId)`. See each type's section above for details.
+
 ```mermaid
 flowchart LR
   Start([New Transaction]) --> Mode{Has<br/>timestamp?}
@@ -215,7 +228,7 @@ flowchart LR
   Phase1 -->|Not found| Phase2[Phase 2: trace_filter<br/>for failed txs]
 
   Phase2 -->|Revert found| Finality[Wait for revert<br/>confirmations ~10 min]
-  Phase2 -->|Not found| LiveSub
+  Phase2 -.->|Not found<br/>live already running| LiveSub
 
   LiveSub -->|Success event in receipt| Success
   LiveSub -->|TX reverted| Finality
@@ -261,7 +274,7 @@ flowchart LR
   Phase1 -->|Not found| Phase2[Phase 2: trace_filter<br/>for failed transactions]
 
   Phase2 -->|Revert found| Finality2[Wait for revert<br/>confirmations ~10 min]
-  Phase2 -->|Not found| LiveSub
+  Phase2 -.->|Not found<br/>live already running| LiveSub
 
   %% Live watcher detection paths
   LiveSub -->|OperationResult event| EventCheck
@@ -274,7 +287,6 @@ flowchart LR
   Finality1 --> Recheck1{Re-verify event<br/>after finality}
   Recheck1 -->|Still failed| Failed[❌ FAILED]
   Recheck1 -->|Now successful| Success
-  Recheck1 -->|Reorged away| LiveSub
 
   Finality2 --> Recheck2{Re-verify receipt<br/>after finality}
   Recheck2 -->|Still reverted| Failed


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

ref: https://linear.app/agoric/issue/PAK-175/update-resolver-docs-for-make-account-gmp-and-cctp-to-evm-watchers

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Rewrites `resolver-service.md` to accurately document the live/lookback dual-mode architecture, failure detection for `MAKE_ACCOUNT` and `GMP`, and the timeout/settlement behavior.

