### PR TITLE
fix(ymax-planner): process pending tx events concurrently with portfolio events

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -900,14 +900,18 @@ export const startEngine = async (
         compareBigints(a.eventRecord.blockHeight, b.eventRecord.blockHeight) ||
         naturalCompare(a.path, b.path),
     );
-    await processPortfolioEvents(
-      portfolioEvents,
-      respHeight,
-      portfoliosMemory,
-      processPortfolioPowers,
-    );
-
-    await processPendingTxEvents(pendingTxEvents, handlePendingTx, txPowers);
+    // Process concurrently: pending tx watchers must subscribe to EVM events
+    // ASAP to avoid missing transactions that settle while portfolio
+    // processing (balance queries, planning, tx submission) is in progress.
+    await Promise.all([
+      processPortfolioEvents(
+        portfolioEvents,
+        respHeight,
+        portfoliosMemory,
+        processPortfolioPowers,
+      ),
+      processPendingTxEvents(pendingTxEvents, handlePendingTx, txPowers),
+    ]);
 
     console.log(
       inspectForStdout({


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


ref: https://linear.app/agoric/issue/PAK-181/resolver-startup-delay-can-miss-wallet-tx-pickup
ref: https://linear.app/agoric/issue/PAK-180/tx3727-not-resolved-by-the-ymax1-resolver-in-live-mode

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Portfolio event processing (balance queries, planning, tx submission) was blocking pending tx pickup for ~2 minutes per block. This created a window where EVM transactions settled before the resolver's `eth_subscribe` was established, causing watchers to miss already-settled txs and time out after 30 minutes.

The two processing paths have no shared mutable state, so they can safely run concurrently via `Promise.all`.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`