### PR TITLE
refactor(ymax-resolver): consolidate operation-watcher to single Alchemy subscription

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -160,12 +160,14 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
         kvStore: ctx.kvStore,
         txId,
       });
-      void liveResultP.then(result => {
-        if (result.settled) {
-          log(`${logPrefix} Live mode completed`);
-          abortController.abort();
-        }
-      });
+      void liveResultP
+        .then(result => {
+          if (result.settled) {
+            log(`${logPrefix} Live mode completed`);
+            abortController.abort();
+          }
+        })
+        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
@@ -281,13 +283,15 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
       // Attach handler to abort lookback if live mode completes first with
       // a definitive result. This handler does NOT resolve the transaction -
       // resolution happens once at the end to prevent duplicate resolutions.
-      void liveResultP.then(result => {
-        if (result.settled) {
-          const reason = `${logPrefix} Live mode completed`;
-          log(reason);
-          abortController.abort(reason);
-        }
-      });
+      void liveResultP
+        .then(result => {
+          if (result.settled) {
+            const reason = `${logPrefix} Live mode completed`;
+            log(reason);
+            abortController.abort(reason);
+          }
+        })
+        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
@@ -416,12 +420,14 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
         signal: abortController.signal,
         txId,
       });
-      void liveResultP.then(result => {
-        if (result.settled) {
-          log(`${logPrefix} Live mode completed`);
-          abortController.abort();
-        }
-      });
+      void liveResultP
+        .then(result => {
+          if (result.settled) {
+            log(`${logPrefix} Live mode completed`);
+            abortController.abort();
+          }
+        })
+        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
 
       await null;
 
@@ -530,13 +536,15 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
         signal: abortController.signal,
       });
 
-      void liveResultP.then(result => {
-        if (result.settled) {
-          const reason = `${logPrefix} Live mode completed`;
-          log(reason);
-          abortController.abort(reason);
-        }
-      });
+      void liveResultP
+        .then(result => {
+          if (result.settled) {
+            const reason = `${logPrefix} Live mode completed`;
+            log(reason);
+            abortController.abort(reason);
+          }
+        })
+        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -168,7 +168,7 @@ export const watchOperationResult = ({
   WatcherTimeoutOptions & {
     retryOptions?: RetryOptions;
   }): Promise<WatcherResult> => {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       resolve({ settled: false });
       return;
@@ -177,10 +177,6 @@ export const watchOperationResult = ({
     // The txId must be padded to match sourceAddress length
     const paddedTxId = padTxId(txId, sourceAddress);
     const expectedIdHash = id(paddedTxId);
-    const filter: Filter = {
-      address: routerAddress,
-      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
-    };
 
     log(
       `Watching for OperationResult on router ${routerAddress} with id: ${txId}`,
@@ -208,163 +204,187 @@ export const watchOperationResult = ({
       for (const cleanup of cleanups) cleanup();
     };
 
+    /**
+     * Cleanup and reject with error.
+     * Used for fatal errors where we cannot continue watching (e.g., WebSocket failure,
+     * subscription failure). This indicates the WATCHING failed, not that the transaction
+     * failed.
+     */
+    const fail = (err: unknown) => {
+      if (done) return;
+      done = true;
+
+      if (timeoutId) clearTimeout(timeoutId);
+
+      reject(err);
+      if (subId) {
+        void provider
+          .send('eth_unsubscribe', [subId])
+          .catch(error =>
+            log('Failed to unsubscribe during error cleanup:', error),
+          );
+      }
+      for (const cleanup of cleanups) cleanup();
+    };
+
+    const onWsError = (e: any) => {
+      const errorMsg = e?.message || String(e);
+      log(
+        `WebSocket error during OperationResult watch for txId=${txId}: ${errorMsg}`,
+      );
+      fail(new Error(`WebSocket connection error: ${errorMsg}`));
+    };
+
+    const onWsClose = (code?: number, reason?: any) => {
+      if (!done) {
+        log(
+          `WebSocket closed during OperationResult watch for txId=${txId} (code=${code}, reason=${reason})`,
+        );
+        fail(
+          new Error(`WebSocket closed unexpectedly: ${reason} (code=${code})`),
+        );
+      }
+    };
+
+    ws.on('error', onWsError);
+    cleanups.unshift(() => ws.off('error', onWsError));
+
+    ws.on('close', onWsClose);
+    cleanups.unshift(() => ws.off('close', onWsClose));
+
     if (signal) {
       const onAbort = () => finish({ settled: false });
       signal.addEventListener('abort', onAbort);
       cleanups.unshift(() => signal.removeEventListener('abort', onAbort));
     }
 
-    // Primary path: OperationResult event listener
-    const listenForOperationResult = async (eventLog: Log) => {
+    const messageHandler = async (data: any) => {
       await null;
       if (done) return;
-      try {
-        const { success } = parseOperationResultLog(eventLog);
 
-        if (success) {
-          const txHash = eventLog.transactionHash;
-          log(`✅ SUCCESS: expectedId=${txId} txHash=${txHash}`);
-          return finish({ settled: true, txHash, success: true });
+      try {
+        const msg = tryJsonParse(
+          data.toString(),
+          'alchemy_minedTransactions subscription response',
+        ) as AlchemySubscriptionMessage;
+
+        if (msg.method !== 'eth_subscription') return;
+
+        const tx = msg.params?.result?.transaction;
+        const removed = msg.params?.result?.removed;
+        if (!tx) return;
+
+        if (removed === true) {
+          log(
+            `⚠️  REORG: txId=${txId} txHash=${tx.hash} was removed from chain - ignoring`,
+          );
+          return;
         }
 
-        // Failure case: wait for confirmations before declaring failure
-        const result = await handleOperationFailure(
-          eventLog,
-          filter,
-          parseOperationResultLog,
-          `expectedId=${txId}`,
-          chainId,
+        const txHash = tx.hash;
+        const txData = tx.input;
+        if (!txHash || !txData) return;
+
+        if (
+          !matchesTxPayload(txData, paddedTxId, payloadHash, log, txHash, txId)
+        )
+          return;
+
+        const receipt = await fetchReceiptWithRetry(
           provider,
+          txHash,
           log,
+          retryOptions,
+          setTimeout,
+        );
+        if (!receipt) {
+          log(`Transaction ${txHash} not confirmed after waiting`);
+          return;
+        }
+
+        // Check for OperationResult event in receipt
+        const operationResultLog = receipt.logs.find(
+          (l: any) =>
+            l.topics?.[0] === OPERATION_RESULT_SIGNATURE &&
+            l.topics?.[1] === expectedIdHash,
         );
 
-        if (result) {
-          return finish(result);
-        }
-      } catch (error: any) {
-        log(`Error:`, error);
-      }
-    };
+        if (operationResultLog) {
+          const { success } = parseOperationResultLog(operationResultLog);
 
-    void provider.on(filter, listenForOperationResult);
-    cleanups.unshift(() => {
-      void provider.off(filter, listenForOperationResult);
-    });
-
-    // Secondary path: Alchemy mined-tx subscription for revert detection
-    {
-      const messageHandler = async (data: any) => {
-        await null;
-        if (done) return;
-
-        try {
-          const msg = tryJsonParse(
-            data.toString(),
-            'alchemy_minedTransactions subscription response',
-          ) as AlchemySubscriptionMessage;
-
-          if (msg.method !== 'eth_subscription') return;
-
-          const tx = msg.params?.result?.transaction;
-          const removed = msg.params?.result?.removed;
-          if (!tx) return;
-
-          if (removed === true) {
-            log(
-              `⚠️  REORG: txId=${txId} txHash=${tx.hash} was removed from chain - ignoring`,
-            );
-            return;
+          if (success) {
+            log(`✅ SUCCESS: expectedId=${txId} txHash=${txHash}`);
+            return finish({ settled: true, txHash, success: true });
           }
 
-          const txHash = tx.hash;
-          const txData = tx.input;
-          if (!txHash || !txData) return;
-
-          if (
-            !matchesTxPayload(
-              txData,
-              paddedTxId,
-              payloadHash,
-              log,
-              txHash,
-              txId,
-            )
-          )
-            return;
-
-          const receipt = await fetchReceiptWithRetry(
-            provider,
-            txHash,
-            log,
-            retryOptions,
-            setTimeout,
-          );
-          if (!receipt) {
-            log(`Transaction ${txHash} not confirmed after waiting`);
-            return;
-          }
-
-          // If receipt has an OperationResult event, let the event listener handle it
-          const hasOperationResultEvent = receipt.logs.some(
-            l =>
-              l.topics?.[0] === OPERATION_RESULT_SIGNATURE &&
-              l.topics?.[1] === expectedIdHash,
-          );
-          if (hasOperationResultEvent) return;
-
-          // Transaction reverted (status=0) without emitting OperationResult
-          const result = await handleTxRevert(
-            receipt,
-            txHash,
-            `txId=${txId}`,
+          // Event-level failure: wait for confirmations before declaring failure
+          const filter: Filter = {
+            address: routerAddress,
+            topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+          };
+          const result = await handleOperationFailure(
+            operationResultLog,
+            filter,
+            parseOperationResultLog,
+            `expectedId=${txId}`,
             chainId,
             provider,
             log,
           );
+
           if (result) {
             return finish(result);
           }
-        } catch (e) {
-          log(
-            `Error processing WebSocket message for txId=${txId}:`,
-            e instanceof Error ? e.message : String(e),
-          );
+          return;
         }
-      };
 
-      const subscribe = async () => {
-        await provider.getNetwork();
-
-        ws.on('message', messageHandler);
-        cleanups.unshift(() => ws.off('message', messageHandler));
-
-        subId = await provider.send('eth_subscribe', [
-          'alchemy_minedTransactions',
-          {
-            addresses: [{ to: routerAddress }],
-            includeRemoved: true,
-            hashesOnly: false,
-          },
-        ]);
-      };
-
-      if (ws.readyState === 1) {
-        subscribe().catch(e => {
-          log(`Alchemy subscription failed (non-fatal):`, e);
-        });
-      } else {
-        ws.once('open', () =>
-          subscribe().catch(e => {
-            log(`Alchemy subscription failed (non-fatal):`, e);
-          }),
+        // No OperationResult event — check for transaction revert
+        const result = await handleTxRevert(
+          receipt,
+          txHash,
+          `txId=${txId}`,
+          chainId,
+          provider,
+          log,
+        );
+        if (result) {
+          return finish(result);
+        }
+      } catch (e) {
+        log(
+          `Error processing WebSocket message for txId=${txId}:`,
+          e instanceof Error ? e.message : String(e),
         );
       }
+    };
+
+    const subscribe = async () => {
+      await provider.getNetwork();
+
+      ws.on('message', messageHandler);
+      cleanups.unshift(() => ws.off('message', messageHandler));
+
+      subId = await provider.send('eth_subscribe', [
+        'alchemy_minedTransactions',
+        {
+          addresses: [{ to: routerAddress }],
+          includeRemoved: true,
+          hashesOnly: false,
+        },
+      ]);
+      log(`Subscribed with subId=${subId} for router=${routerAddress}`);
+    };
+
+    if (ws.readyState === 1) {
+      subscribe().catch(fail);
+    } else {
+      ws.once('open', () => subscribe().catch(fail));
     }
 
     timeoutId = setTimeout(() => {
       if (!done) {
         log(
-          `✗ No matching OperationResult found within ${timeoutMs / 60000} minutes`,
+          `[${PendingTxCode.ROUTED_GMP_TX_NOT_FOUND}] ✗ No matching OperationResult found within ${timeoutMs / 60000} minutes`,
         );
       }
     }, timeoutMs);
@@ -422,8 +442,6 @@ export const lookBackOperationResult = async ({
       topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
     };
 
-    const abiCoder = new AbiCoder();
-
     const updateFailedTxLowerBound = (_from: number, to: number) =>
       setTxBlockLowerBound(kvStore, txId, to, FAILED_TX_SCOPE);
 
@@ -447,7 +465,7 @@ export const lookBackOperationResult = async ({
       onRejectedChunk: (_from, to) => setTxBlockLowerBound(kvStore, txId, to),
       predicate: ev => {
         try {
-          const parsed = parseOperationResultLog(ev, abiCoder);
+          const parsed = parseOperationResultLog(ev);
           log(`Check: idHash=${parsed.idHash} success=${parsed.success}`);
           return parsed.idHash === expectedIdHash;
         } catch (e) {
@@ -458,7 +476,7 @@ export const lookBackOperationResult = async ({
     });
 
     if (matchingEvent) {
-      const parsed = parseOperationResultLog(matchingEvent, abiCoder);
+      const parsed = parseOperationResultLog(matchingEvent);
       const txHash = matchingEvent.transactionHash;
 
       if (parsed.success) {
@@ -472,7 +490,7 @@ export const lookBackOperationResult = async ({
       const result = await handleOperationFailure(
         matchingEvent,
         baseFilter,
-        logEntry => parseOperationResultLog(logEntry, abiCoder),
+        parseOperationResultLog,
         `txId=${txId}`,
         chainId,
         provider,

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -371,7 +371,7 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   const finalBlock = confirmedReceipt.blockNumber;
 
-  // Re-fetch logs to verify the failure is still present
+  // Fetch logs to verify the failure is still present
   const logsInBlock = await provider.getLogs({
     ...filter,
     fromBlock: finalBlock,
@@ -382,7 +382,7 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   if (!confirmedLog) {
     log(
-      `Event not found after ${confirmations} confirmations (possibly reorged): ${identifier} txHash=${txHash}`,
+      `Event not found after ${confirmations} confirmations (possibly reorged or tx reverted): ${identifier} txHash=${txHash}`,
     );
     return null;
   }

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -44,14 +44,17 @@ const buildRouterPayload = (paddedTxId: string) => {
  * Encode Axelar execute() calldata with a given payload, returning the
  * calldata and the expected payloadHash (keccak256 of the raw payload bytes).
  */
-const encodeExecuteCalldata = (payload: string) => {
+const encodeExecuteCalldata = (
+  payload: string,
+  sourceAddress: string = 'agoric1test',
+) => {
   const axelarExecuteIface = new Interface([
     'function execute(bytes32 commandId, string sourceChain, string sourceAddress, bytes payload) external',
   ]);
   const calldata = axelarExecuteIface.encodeFunctionData('execute', [
     hexlify(randomBytes(32)),
     'agoric',
-    'agoric1test',
+    sourceAddress,
     payload,
   ]);
   return { calldata, payloadHash: keccak256(payload) };
@@ -125,24 +128,61 @@ test('watchOperationResult detects successful OperationResult event (live mode)'
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
 
-  // Emit success event after a short delay
+  const txHash = '0x123abc';
+  const blockNumber = 18500000;
+
+  const mockLog = createMockOperationResultLog(
+    routerAddress,
+    paddedId,
+    true, // success
+    '',
+    blockNumber,
+    txHash,
+  );
+
+  // Build calldata for the Alchemy subscription message
+  const payload = buildRouterPayload(paddedId);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    MOCK_SOURCE_ADDRESS,
+  );
+
+  // Mock receipt with OperationResult event
+  (provider as any).getTransactionReceipt = async (hash: string) => {
+    if (hash === txHash) {
+      return {
+        status: 1,
+        blockNumber,
+        blockHash: '0xblockhash',
+        transactionHash: txHash,
+        logs: [mockLog],
+      };
+    }
+    return null;
+  };
+
+  // Emit Alchemy mined-tx message after a short delay
   setTimeout(() => {
-    const mockLog = createMockOperationResultLog(
-      routerAddress,
-      paddedId,
-      true, // success
-      '',
-      18500000,
-      '0x123abc',
-    );
+    const wsMessage = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        result: {
+          removed: false,
+          transaction: {
+            hash: txHash,
+            input: calldata,
+            to: routerAddress,
+            from: '0x0000000000000000000000000000000000000001',
+            value: '0x0',
+            blockNumber: `0x${blockNumber.toString(16)}`,
+          },
+        },
+        subscription: 'mock-sub-id',
+      },
+    });
 
-    const expectedIdHash = id(paddedId);
-    const filter = {
-      address: routerAddress,
-      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
-    };
-
-    (provider as any).emit(filter, mockLog);
+    (provider as any).websocket.emit('message', wsMessage);
   }, 50);
 
   const result = await watchOperationResult({
@@ -152,14 +192,14 @@ test('watchOperationResult detects successful OperationResult event (live mode)'
     kvStore,
     txId,
     sourceAddress: MOCK_SOURCE_ADDRESS,
-    payloadHash: MOCK_PAYLOAD_HASH,
+    payloadHash,
     timeoutMs: 3000,
     log: logger,
   });
 
   t.true(result.settled, 'Should be settled');
   t.true(result.success, 'Should be successful');
-  t.is(result.txHash, '0x123abc', 'Should have correct txHash');
+  t.is(result.txHash, txHash, 'Should have correct txHash');
 
   t.true(
     logMessages.some(msg => msg.includes('✅ SUCCESS')),
@@ -189,9 +229,32 @@ test('watchOperationResult detects failed OperationResult event with finality pr
     blockNumber,
     txHash,
   );
+
+  // Build calldata for the Alchemy subscription message
+  const payload = buildRouterPayload(paddedId);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    MOCK_SOURCE_ADDRESS,
+  );
+
+  // Mock receipt with failed OperationResult event
+  (provider as any).getTransactionReceipt = async (hash: string) => {
+    if (hash === txHash) {
+      return {
+        status: 1,
+        blockNumber,
+        blockHash: '0xblockhash',
+        transactionHash: txHash,
+        logs: [mockLog],
+      };
+    }
+    return null;
+  };
+
+  // Re-fetch logs for finality check (handleOperationFailure)
   (provider as any).getLogs = async () => [mockLog];
 
-  // Override waitForTransaction to return a receipt (needed for finality check)
+  // Override waitForTransaction for finality check
   (provider as any).waitForTransaction = async () => ({
     status: 1,
     blockNumber,
@@ -199,15 +262,28 @@ test('watchOperationResult detects failed OperationResult event with finality pr
     transactionHash: txHash,
   });
 
-  // Emit failure event after a short delay
+  // Emit Alchemy mined-tx message after a short delay
   setTimeout(() => {
-    const expectedIdHash = id(paddedId);
-    const filter = {
-      address: routerAddress,
-      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
-    };
+    const wsMessage = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        result: {
+          removed: false,
+          transaction: {
+            hash: txHash,
+            input: calldata,
+            to: routerAddress,
+            from: '0x0000000000000000000000000000000000000001',
+            value: '0x0',
+            blockNumber: `0x${blockNumber.toString(16)}`,
+          },
+        },
+        subscription: 'mock-sub-id',
+      },
+    });
 
-    (provider as any).emit(filter, mockLog);
+    (provider as any).websocket.emit('message', wsMessage);
   }, 50);
 
   const result = await watchOperationResult({
@@ -217,7 +293,7 @@ test('watchOperationResult detects failed OperationResult event with finality pr
     kvStore,
     txId,
     sourceAddress: MOCK_SOURCE_ADDRESS,
-    payloadHash: MOCK_PAYLOAD_HASH,
+    payloadHash,
     timeoutMs: 3000,
     log: logger,
   });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

ref: https://linear.app/agoric/issue/PAK-179/consolidate-routed-gmp-dual-websocket-subscriptions-into-single

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Consolidates the operation-watcher from a dual-subscription approach (ethers log filter + Alchemy mined-tx) into a single Alchemy `alchemy_minedTransactions` subscription, matching the GMP watcher pattern. Also adds proper WebSocket error/close handling and unhandled rejection protection to the live watchers, which previously would silently hang forever on WS failures.


### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- Currently, the change is unit tested only.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`.
