### PR TITLE
doc: fix broken link in env.md

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -137,7 +137,7 @@ When the program is run under a debugger, it will breakpoint when the JS
 `debugger;` statement will have no effect. The `debugger;` statement
 is executed *before* the method is entered.
 
-See https://github.com/endojs/endo/blob/master/packages/pass-style/test/prepare-breakpoints.js for an example.
+See https://github.com/endojs/endo/blob/master/packages/pass-style/test/_prepare-breakpoints.js for an example.
 
 ## ENDO_SEND_BREAKPOINTS
 


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md#endo_delivery_breakpoints https://github.com/endojs/endo/blob/master/packages/pass-style/test/_prepare-breakpoints.js

## Description

At some point in the distant past we renamed a bunch of `test/prepare-*.js` files to `test/_prepare-*.js`. (Also other local test helper files.) However https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md#endo_delivery_breakpoints still linked to https://github.com/endojs/endo/blob/master/packages/pass-style/test/prepare-breakpoints.js which 404ed. However, there are so many files following the old convention that it would be harder for this PR to do anything more comprehensive.

So this PR just corrects that one link to
https://github.com/endojs/endo/blob/master/packages/pass-style/test/_prepare-breakpoints.js

(Why are we still finding 404s one at a time? Aren't there well established tools that will do that in bulk?)

### Security Considerations
no
### Scaling Considerations
no
### Documentation Considerations
the point. Fixes a broken link in documentation.
### Testing Considerations
none
### Upgrade Considerations
none