### PR TITLE
chore(ymax-resolver): rename sourceAddress to txIdPlaintext in OperationResult parser

### DIFF
--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -119,7 +119,7 @@ const parseOperationResultLog = (
   abiCoder: AbiCoder = new AbiCoder(),
 ): {
   idHash: string;
-  sourceAddress: string;
+  txIdPlaintext: string;
   allegedRemoteAccount: string;
   instructionSelector: string;
   success: boolean;
@@ -131,14 +131,14 @@ const parseOperationResultLog = (
 
   const idHash = log.topics[1];
   const allegedRemoteAccount = log.topics[3];
-  const [sourceAddress, instructionSelector, success, reason] = abiCoder.decode(
+  const [txIdPlaintext, instructionSelector, success, reason] = abiCoder.decode(
     ['string', 'bytes4', 'bool', 'bytes'],
     log.data,
   );
 
   return {
     idHash,
-    sourceAddress,
+    txIdPlaintext,
     allegedRemoteAccount,
     instructionSelector,
     success,

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -119,7 +119,7 @@ const parseOperationResultLog = (
   abiCoder: AbiCoder = new AbiCoder(),
 ): {
   idHash: string;
-  txIdPlaintext: string;
+  txId: string;
   allegedRemoteAccount: string;
   instructionSelector: string;
   success: boolean;
@@ -131,14 +131,14 @@ const parseOperationResultLog = (
 
   const idHash = log.topics[1];
   const allegedRemoteAccount = log.topics[3];
-  const [txIdPlaintext, instructionSelector, success, reason] = abiCoder.decode(
+  const [txIdPadded, instructionSelector, success, reason] = abiCoder.decode(
     ['string', 'bytes4', 'bool', 'bytes'],
     log.data,
   );
 
   return {
     idHash,
-    txIdPlaintext,
+    txId: txIdPadded.replace(/\0+$/, ''),
     allegedRemoteAccount,
     instructionSelector,
     success,


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

Rename `sourceAddress` -> `txIdPlaintext` in `parseOperationResultLog` to align with upstream `OperationResult` event change from [agoric-labs/agoric-to-axelar-local#72](https://github.com/agoric-labs/agoric-to-axelar-local/pull/72), where the third non-indexed field now carries the txId instead of the sourceAddress.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`.