### PR TITLE
fix(cosmic-proto): solidify `CodecHelper` for proto backward compatibility

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -5,6 +5,14 @@ name: Protobuf
 # - check protobuf definitions are up-to-date
 on:
   pull_request:
+    types:
+      # These are the default pull request types...
+      - opened
+      - reopened
+      - synchronize
+      # ... and these respond to label changes.
+      - labeled
+      - unlabeled
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/golang/cosmos/x/vlocalchain/keeper/keeper_test.go
+++ b/golang/cosmos/x/vlocalchain/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Agoric/agoric-sdk/golang/cosmos/app/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 )
 
 func TestKeeper_ParseRequestTypeURL(t *testing.T) {
@@ -40,11 +41,17 @@ func TestKeeper_ParseRequestTypeURL(t *testing.T) {
 	}
 }
 
+type MsgTransfer struct {
+	transfertypes.MsgTransfer
+	Encoding2 string
+}
+
 func TestKeeper_DeserializeTxMessages(t *testing.T) {
 	encodingConfig := params.MakeEncodingConfig()
 	cdc := encodingConfig.Codec
 
 	banktypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	transfertypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 
 	keeper := NewKeeper(cdc, nil, nil, nil, nil)
 
@@ -56,29 +63,51 @@ func TestKeeper_DeserializeTxMessages(t *testing.T) {
 		},
 	}
 
+	expectedMsgTransfer := []sdk.Msg{
+		&transfertypes.MsgTransfer{
+			Sender:   "cosmos1abc",
+			Receiver: "cosmos1xyz",
+			Token:    sdk.NewCoin("stake", sdkmath.NewInt(100)),
+			SourcePort: "transfer",
+			SourceChannel: "channel-0",
+		},
+	}
+
 	testCases := []struct {
 		name     string
 		json     string
 		expected []sdk.Msg
-		wantErr  bool
+		expectedError  string
 	}{
 		{
 			name:     "camelCase keys",
 			json:     `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","fromAddress":"cosmos1abc","toAddress":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
 			expected: expectedMsgSend,
-			wantErr:  false,
 		},
 		{
 			name:     "snake_case keys",
 			json:     `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_address":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
 			expected: expectedMsgSend,
-			wantErr:  false,
 		},
 		{
 			name:     "misspelled key",
 			json:     `{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_addresss":"cosmos1abc","to_address":"cosmos1xyz","amount":[{"denom":"stake","amount":"100"}]}]}`,
-			expected: expectedMsgSend,
-			wantErr:  true,
+			expectedError:  `can't unmarshal Any nested proto *types.MsgSend: unknown field "from_addresss" in types.MsgSend`,
+		},
+		{
+			name:    "base transfer",
+			json:     `{"messages":[{"@type":"/ibc.applications.transfer.v1.MsgTransfer","source_port":"transfer","source_channel":"channel-0","token":{"denom":"stake","amount":"100"},"sender":"cosmos1abc","receiver":"cosmos1xyz","timeout_height":{}}]}]`,
+			expected: expectedMsgTransfer,
+		},
+		{
+			name:     "transfer with empty encoding2",
+			json:     `{"messages":[{"@type":"/ibc.applications.transfer.v1.MsgTransfer","source_port":"transfer","source_channel":"channel-0","token":{"denom":"stake","amount":"100"},"sender":"cosmos1abc","receiver":"cosmos1xyz","timeout_height":{},"encoding2":""}]}]`,
+			expectedError:  `can't unmarshal Any nested proto *types.MsgTransfer: unknown field "encoding2" in types.MsgTransfer`,
+		},
+		{
+			name:     "transfer with filled encoding2",
+			json:     `{"messages":[{"@type":"/ibc.applications.transfer.v1.MsgTransfer","source_port":"transfer","source_channel":"channel-0","token":{"denom":"stake","amount":"100"},"sender":"cosmos1abc","receiver":"cosmos1xyz","timeout_height":{},"encoding2":"some encoding2"}]}]`,
+			expectedError:  `can't unmarshal Any nested proto *types.MsgTransfer: unknown field "encoding2" in types.MsgTransfer`,
 		},
 	}
 
@@ -86,11 +115,12 @@ func TestKeeper_DeserializeTxMessages(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			msgs, err := keeper.DeserializeTxMessages([]byte(tc.json))
 
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
+			if tc.expectedError == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, msgs)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedError, err.Error())
 			}
 		})
 	}

--- a/packages/cosmic-proto/src/codec-helpers.ts
+++ b/packages/cosmic-proto/src/codec-helpers.ts
@@ -1,129 +1,279 @@
+import type { DeepPartial } from './codegen/helpers.ts';
 import type { BinaryReader, BinaryWriter, JsonSafe } from './codegen/index.js';
 import type { MessageBody, TypedJson } from './helpers.js';
+import {
+  type FieldAnnotations,
+  type ProtoFieldName,
+  type TypeUrl,
+  defaultAnnotationsFromTypeUrl,
+  scalarMakersFromType,
+} from './type-url-annotations.js';
 
 const { freeze } = Object;
 
-/** Name of a field to its boolean annotation. */
-type BooleanAnnotations = Record<string, boolean>;
+type ChildFieldProcessor = (
+  child: Record<string, unknown>,
+  field: string,
+  typeUrlToAnnotations: Map<TypeUrl, FieldAnnotations>,
+  valueTypeUrl: string | undefined,
+) => void;
 
-/** Name of a field to its alias. */
-type EmbedAnnotations = Record<string, string>;
-interface ManualAnnotations {
-  'gogoproto.nullable'?: BooleanAnnotations;
-  'gogoproto.embed'?: EmbedAnnotations;
-}
+const processChildFields = (
+  process: ChildFieldProcessor,
+  typeUrl: string | undefined,
+  input: unknown,
+  annotationsFromTypeUrl: Map<TypeUrl, FieldAnnotations>,
+) => {
+  if (typeUrl == null || !typeUrl.startsWith('/')) {
+    // Default to no elision when we don't recognize the typeUrl.
+    return input;
+  }
 
-// This is a mapping from typeUrl to maps of annotation metadata.
-// TODO: codegen
-const manualAnnotationsFromTypeUrl: Record<string, ManualAnnotations> = {
-  '/ibc.applications.transfer.v1.MsgTransfer': {
-    'gogoproto.nullable': {
-      timeout_height: false,
-      timeoutHeight: false,
-      token: false,
-    },
-  },
-  '/cosmos.auth.v1beta1.ModuleAccount': {
-    'gogoproto.embed': {
-      base_account: 'baseAccount',
-    },
-  },
-  '/cosmos.tx.v1beta1.TxBody': {
-    'gogoproto.nullable': {
-      timeout_timestamp: true,
-      timeoutTimestamp: true,
-    },
-  },
+  // Shallow copy to avoid mutating the input, but we will mutate the child as
+  // we process it.
+  const child = { ...(typeof input === 'object' && input) };
+
+  const typeUrlFromField = annotationsFromTypeUrl
+    .get(typeUrl)
+    ?.get('typeUrlFromField');
+
+  for (const [field, originalValue] of Object.entries(child)) {
+    let value = originalValue;
+    const fieldTypeUrl = typeUrlFromField?.get(field);
+    if (value) {
+      value = processChildFields(
+        process,
+        fieldTypeUrl,
+        value,
+        annotationsFromTypeUrl,
+      );
+    }
+
+    child[field] = value;
+    process(child, field, annotationsFromTypeUrl, fieldTypeUrl);
+  }
+
+  freeze(child);
+  return child;
 };
 
-const makeFromPartial = <TU = string, MT = MessageBody<TU>, IM = MT>(
-  codec: Proto3Codec<TU, MT, IM>,
-  annotations: ManualAnnotations,
+const addNonNullablePlaceholders = (
+  typeUrl: string | undefined,
+  input: unknown,
+  annotationsFromTypeUrl: Map<TypeUrl, FieldAnnotations>,
 ) => {
-  const embedPropMap = {
-    ...manualAnnotationsFromTypeUrl[codec.typeUrl as string]?.[
-      'gogoproto.embed'
-    ],
-    ...annotations?.['gogoproto.embed'],
-  };
-
-  const nullableAnnotations = {
-    ...manualAnnotationsFromTypeUrl[codec.typeUrl as string]?.[
-      'gogoproto.nullable'
-    ],
-    ...annotations?.['gogoproto.nullable'],
-  };
-
-  const nullableFields = [] as string[];
-  const nonNullableFields = [] as string[];
-  for (const [fieldName, isNullable] of Object.entries(nullableAnnotations)) {
-    if (isNullable) {
-      nullableFields.push(fieldName);
+  if (typeUrl == null) {
+    return input;
+  } else if (!typeUrl.startsWith('/')) {
+    const scalarMaker = scalarMakersFromType.get(typeUrl);
+    if (scalarMaker) {
+      return scalarMaker(input);
     } else {
-      nonNullableFields.push(fieldName);
+      // Default to no transformation when we don't recognize the typeUrl.
+      return input;
     }
   }
 
-  const fromPartial = (message: Partial<MT>): MT => {
-    const input = { ...message };
+  // Shallow copy to avoid mutating the input, but we will mutate the child as
+  // we process it.
+  const child = { ...(typeof input === 'object' && input) };
+
+  const fieldAnnotations = annotationsFromTypeUrl.get(typeUrl);
+  const typeUrlFromField = fieldAnnotations?.get('typeUrlFromField');
+  const nullableAnnotationFromField =
+    fieldAnnotations?.get('gogoproto.nullable');
+  const remainingNonNullableFields = new Set<string>(
+    [...(nullableAnnotationFromField?.entries() ?? [])].flatMap(
+      ([fieldName, isNullable]) => (!isNullable ? [fieldName] : []),
+    ),
+  );
+
+  for (const [field, value] of Object.entries(child)) {
+    if (nullableAnnotationFromField?.get(field) !== false) {
+      continue;
+    }
+    remainingNonNullableFields.delete(field);
+    const message = addNonNullablePlaceholders(
+      typeUrlFromField?.get(field),
+      value,
+      annotationsFromTypeUrl,
+    );
+    if (message != null) {
+      child[field] = message;
+    }
+  }
+  for (const field of remainingNonNullableFields.keys()) {
+    const message = addNonNullablePlaceholders(
+      typeUrlFromField?.get(field),
+      child[field],
+      annotationsFromTypeUrl,
+    );
+    if (message != null) {
+      child[field] = message;
+    }
+  }
+  freeze(child);
+  return child;
+};
+
+const processGogo3PackedChildField = (
+  child: Record<string, unknown>,
+  field: string,
+  typeUrlToAnnotations: Map<TypeUrl, FieldAnnotations>,
+  fieldTypeUrl: string | undefined,
+) => {
+  const nullableAnnotationFromField = fieldTypeUrl
+    ? typeUrlToAnnotations.get(fieldTypeUrl)?.get('gogoproto.nullable')
+    : undefined;
+
+  if (
+    child[field] == null &&
+    nullableAnnotationFromField?.get(field) === false
+  ) {
+    // Add an empty message for the fromPartial to fill in.
+    child[field] = {};
+  } else if (!child[field]) {
+    delete child[field];
+  }
+};
+
+const processGogo3UndefinedChildField = (
+  child: Record<string, unknown>,
+  field: string,
+  _typeUrlToAnnotations: Map<TypeUrl, FieldAnnotations>,
+  _fieldTypeUrl: string | undefined,
+) => {
+  // Undefined values should be omitted.
+  const maybeEmpty = child[field];
+  if (maybeEmpty === undefined) {
+    delete child[field];
+  }
+};
+
+/**
+ * The underlying Proto3Codecs are ignorant of Gogoproto annotations. Our
+ * decoder/encoder transformations implement them, and the new Codec applies
+ * the transformations as if the Proto3Codec handled them natively.
+ *
+ * So, we have two types of Proto3Json, which are indistinguishable at
+ * runtime:
+ * - Proto3Jsonable: what Telescope generates and consumes, ignorant of
+ *   Gogoproto annotations.
+ * - GogoProto3Jsonable: the Proto3Json type honoring Gogoproto annotations.
+ *
+ * XXX Ideally, Telescope would implement Gogoproto annotations directly, and
+ * we wouldn't need to do this.
+ */
+const makeGogo3Transformations = <TU extends string = string>(
+  codec: Pick<Proto3Codec<TU>, 'typeUrl' | 'fromPartial'>,
+  annotationsFromTypeUrl: Map<TypeUrl, FieldAnnotations>,
+) => {
+  type FullMessage = MessageBody<TU>;
+  type InputMessage = DeepPartial<FullMessage>;
+
+  const fieldAnnotations = annotationsFromTypeUrl.get(codec.typeUrl);
+  const embedPropMap = fieldAnnotations?.get('gogoproto.embed');
+  const childNullableAnnotations = fieldAnnotations?.get('gogoproto.nullable');
+
+  const nonNullableFields: ProtoFieldName[] = [
+    ...(childNullableAnnotations?.entries() ?? []),
+  ].flatMap(([fieldName, isNullable]) => (isNullable ? [] : [fieldName]));
+  freeze(nonNullableFields);
+
+  const encoderInputFromGogo3 = (object: InputMessage): FullMessage => {
+    const input = { ...(typeof object === 'object' && Object(object)) };
 
     // For each embedded field, if the message is missing the message property
     // but has the value property, copy the value to the message property. This
     // allows users to provide either the embedded object or its fields
     // directly.
-    for (const [valueProp, messageProp] of Object.entries(embedPropMap)) {
+    for (const [valueProp, messageProp] of embedPropMap?.entries() ?? []) {
       if (input[messageProp] == null) {
         input[messageProp] = input[valueProp] ?? input;
       }
     }
 
-    for (const prop of nonNullableFields) {
-      if (input[prop] == null) {
-        input[prop] = {};
-      }
-    }
+    const newInput = addNonNullablePlaceholders(
+      codec.typeUrl,
+      input,
+      annotationsFromTypeUrl,
+    ) as InputMessage;
 
-    freeze(input);
-    const filled = { ...codec.fromPartial(input) };
-
-    // Spread the object embeddeds into the filled object.
-    for (const messageProp of Object.values(embedPropMap)) {
-      const embedded = filled[messageProp] ?? filled;
-      if (Object(embedded) !== embedded) continue;
-      for (const [key, val] of Object.entries(embedded)) {
-        if (filled[key] == null) {
-          filled[key] = val;
-        }
-      }
-    }
-
-    // Delete the empty nullable fields from the impartial object.
-    for (const prop of nullableFields) {
-      if (message[prop] == null) {
-        // impartial[prop] = undefined;
-        delete filled[prop];
-      }
-    }
-
-    return freeze(filled);
+    const filled = codec.fromPartial(newInput ?? input);
+    freeze(filled);
+    return filled;
   };
 
-  return fromPartial;
+  const packedFromGogo3 = (object: InputMessage): FullMessage => {
+    const input = encoderInputFromGogo3(object);
+
+    const packed = processChildFields(
+      processGogo3PackedChildField,
+      codec.typeUrl,
+      input,
+      annotationsFromTypeUrl,
+    );
+    freeze(packed);
+    return (packed ?? input) as FullMessage;
+  };
+
+  const strippedFromDecoderOutput = (object: InputMessage): FullMessage => {
+    const output = gogo3FromDecoderOutput(object as FullMessage);
+
+    const newOutput = processChildFields(
+      processGogo3UndefinedChildField,
+      codec.typeUrl,
+      output,
+      annotationsFromTypeUrl,
+    );
+    return freeze(newOutput) as FullMessage;
+  };
+
+  const gogo3FromDecoderOutput = (message: FullMessage): FullMessage => {
+    const output = { ...message };
+
+    // Spread the object embeddeds into the filled object.
+    for (const messageProp of embedPropMap?.keys() ?? []) {
+      const embedded = output[messageProp] ?? output;
+      if (Object(embedded) !== embedded) continue;
+      for (const [key, val] of Object.entries(embedded)) {
+        if (output[key] == null) {
+          output[key] = val;
+        }
+      }
+      delete output[messageProp];
+    }
+
+    const newOutput = addNonNullablePlaceholders(
+      codec.typeUrl,
+      output,
+      annotationsFromTypeUrl,
+    );
+
+    return freeze(newOutput) as FullMessage;
+  };
+
+  return freeze({
+    encoderInputFromGogo3,
+    gogo3FromDecoderOutput,
+    packedFromGogo3,
+    strippedFromDecoderOutput,
+  });
 };
 
-export type ProtoMsg<TU = string> = {
+export type ProtoMsg<TU extends string = string> = {
   readonly typeUrl: TU;
   readonly value: Uint8Array;
 };
 
-export interface EncodeObject<TU = string> {
+export interface EncodeObject<TU extends string = string> {
   readonly typeUrl: TU;
   readonly value: MessageBody<TU>;
 }
 
-export interface TypedAmino<TU = string, MT = MessageBody<TU>> {
+export interface TypedAmino<TU extends string = string> {
   readonly type: TU;
-  readonly value: MT;
+  readonly value: MessageBody<TU>;
 }
 
 const extractTypeUrlAndValue = (input: any) => {
@@ -132,6 +282,8 @@ const extractTypeUrlAndValue = (input: any) => {
     const { '@type': typeUrl, ...value } = input;
     return { typeUrl, value };
   } else if ('$typeUrl' in input) {
+    // Any (with the special $typeUrl field to avoid conflicts with the actual
+    // typeUrl field in ProtoMsg and EncodeObject)
     const { $typeUrl: typeUrl, ...value } = input;
     return { typeUrl, value };
   } else if ('typeUrl' in input) {
@@ -142,7 +294,6 @@ const extractTypeUrlAndValue = (input: any) => {
       value: value instanceof Uint8Array ? value : { ...value },
     };
   } else if ('type' in input) {
-    // TypedAmino
     const { type: typeUrl, value } = input;
     // We assert later that typeUrl matches the Codec's, so we can know
     // that the value is Proto3Json.
@@ -151,108 +302,121 @@ const extractTypeUrlAndValue = (input: any) => {
   throw TypeError(`Unrecognized input: ${input}`);
 };
 
-export interface Proto3Codec<TU = string, MT = MessageBody<TU>, IM = MT> {
+/**
+ * The TU parameter is the TypeUrl of the "naive" Telescope message, which for
+ * all intents and purposes, is good enough to use as the GogoProto3Jsonable
+ * type.
+ *
+ * The rest of these methods are highly dependent on our specific Telescope
+ * codegen configuration.
+ */
+export interface Proto3Codec<
+  TU extends string = string,
+  DP extends boolean = false,
+> {
   readonly typeUrl: TU;
-  encode(message: IM, writer?: BinaryWriter): BinaryWriter;
-  decode(input: BinaryReader | Uint8Array, length?: number): MT;
-  fromJSON(object: any): MT;
-  toJSON(message: IM): JsonSafe<MT>;
-  fromPartial(object: Partial<MT>): MT;
-  fromProtoMsg(message: ProtoMsg<TU>): MT;
-  toProto(message: IM): Uint8Array;
-  toProtoMsg(message: IM): ProtoMsg<TU>;
+  encode(message: DeepMessage<TU, DP>, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): MessageBody<TU>;
+  fromJSON(object: any): MessageBody<TU>;
+  toJSON(message: DeepMessage<TU, DP>): JsonSafe<MessageBody<TU>>;
+  fromPartial(object: DeepMessage<TU, true>): MessageBody<TU>;
+  fromProtoMsg(message: ProtoMsg<TU>): MessageBody<TU>;
+  toProto(message: DeepMessage<TU, DP>): Uint8Array;
+  toProtoMsg(message: DeepMessage<TU, DP>): ProtoMsg<TU>;
 }
+
+type DeepMessage<
+  TU extends string = string,
+  DP extends boolean = true,
+> = DP extends true ? DeepPartial<MessageBody<TU>> : MessageBody<TU>;
 
 /**
  * Wraps a codec, adding built-in partial message support.
  *
- * @template [TU=string]
- * @template [MT=MessageBody<TU>]
- * @param {Proto3Codec<TU, MT>} codec The original codec.
- * @param {ManualAnnotations} [annotations] The value for `(gogoproto.nullable)`-annotated fields.
- * @returns {Proto3Codec<TU, MT, Partial<MT>>} A new codec that can handle partial input messages.
+ * @template TU TypeUrl
+ * @param codec The original codec.
+ * @param annotationsFromTypeUrl The field annotations by TypeUrl.
+ * @returns A new codec that can handle partial input messages.
  */
-export const Codec = <TU = string, MT = MessageBody<TU>>(
-  codec: Proto3Codec<TU, MT>,
-  annotations: ManualAnnotations = {},
-): Proto3Codec<TU, MT, Partial<MT>> => {
-  const fromPartial = makeFromPartial(codec, annotations);
+export const Codec = <TU extends string = string>(
+  codec: Proto3Codec<TU>,
+  annotationsFromTypeUrl: Map<
+    TypeUrl,
+    FieldAnnotations
+  > = defaultAnnotationsFromTypeUrl,
+): Proto3Codec<TU, true> => {
+  const { gogo3FromDecoderOutput, encoderInputFromGogo3 } =
+    makeGogo3Transformations(codec, annotationsFromTypeUrl);
 
-  const cdc = freeze({
+  const cdc: Proto3Codec<TU, true> = {
     typeUrl: codec.typeUrl,
     encode(message, writer) {
-      return codec.encode(fromPartial(message), writer);
+      return codec.encode(encoderInputFromGogo3(message), writer);
     },
     decode(reader, length) {
-      return fromPartial(codec.decode(reader, length));
+      return gogo3FromDecoderOutput(codec.decode(reader, length));
     },
     fromJSON(object) {
-      return fromPartial(codec.fromJSON(object));
+      return gogo3FromDecoderOutput(codec.fromJSON(object));
     },
     toJSON(message) {
-      return codec.toJSON(fromPartial(message));
+      return codec.toJSON(encoderInputFromGogo3(message));
     },
     fromPartial(object) {
-      return fromPartial(object);
+      return encoderInputFromGogo3(object);
     },
     fromProtoMsg(message) {
-      return fromPartial(codec.fromProtoMsg(message));
+      return gogo3FromDecoderOutput(codec.fromProtoMsg(message));
     },
     toProto(message) {
-      return codec.toProto(fromPartial(message));
+      return codec.toProto(encoderInputFromGogo3(message));
     },
     toProtoMsg(message) {
-      return codec.toProtoMsg(fromPartial(message));
+      return codec.toProtoMsg(encoderInputFromGogo3(message));
     },
-  });
+  };
+  freeze(cdc);
   return cdc;
 };
 
 export interface Proto3CodecHelper<
-  TU = string,
-  MT = MessageBody<TU>,
-> extends Proto3Codec<TU, MT, Partial<MT>> {
-  typedJson(message: Partial<MT>): TypedJson<TU>;
-  typedAmino(message: Partial<MT>): TypedAmino<TU, MT>;
-  typedEncode(message: Partial<MT>): EncodeObject<TU>;
-  fromTyped(
-    object: unknown,
-    embeddedFields?: { [valueProp: string]: string },
-  ): MT;
+  TU extends string = string,
+> extends Proto3Codec<TU, true> {
+  typedJson(message: DeepMessage<TU>): TypedJson<TU>;
+  fromTyped(object: TypedJson): MessageBody<TU>;
+  fromTyped(object: TypedAmino): MessageBody<TU>;
+  fromTyped(object: EncodeObject): MessageBody<TU>;
+  fromTyped(object: DeepMessage): MessageBody<TU>;
+  fromTyped(object: unknown): MessageBody<TU>;
 }
 
 /**
  * Wraps a codec, adding built-in partial message support and helpers for common
  * manipulations.
  *
- * @template [TU=string]
- * @template [MT=MessageBody<TU>]
- * @param {Proto3Codec<TU, MT>} codec The original codec.
- * @param {ManualAnnotations} [annotations] The fields that are marked with `gogoproto.nullable`.
- * @returns {Proto3CodecHelper<TU, MT>} Codec and helpers that can handle partial input messages.
+ * @template TU TypeUrl
+ * @param codec The original codec.
+ * @param annotationsFromTypeUrl The fields that are marked with `gogoproto.nullable`.
+ * @returns Codec extended by helpers that can handle partial input messages.
  */
-export const CodecHelper = <TU = string, MT = MessageBody<TU>>(
-  codec: Proto3Codec<TU, MT>,
-  annotations: ManualAnnotations = {},
-): Proto3CodecHelper<TU, MT> => {
-  const cdc = Codec(codec, annotations);
-  const fromPartial = makeFromPartial(cdc, annotations);
+export const CodecHelper = <TU extends string = string>(
+  codec: Proto3Codec<TU>,
+  annotationsFromTypeUrl: Map<
+    TypeUrl,
+    FieldAnnotations
+  > = defaultAnnotationsFromTypeUrl,
+): Proto3CodecHelper<TU> => {
+  const cdc = Codec(codec, annotationsFromTypeUrl);
+  const { strippedFromDecoderOutput, packedFromGogo3 } =
+    makeGogo3Transformations(cdc, annotationsFromTypeUrl);
 
-  const help: Proto3CodecHelper<TU, MT> = freeze({
+  const help: Proto3CodecHelper<TU> = {
     ...cdc,
-    typedAmino(message) {
-      return { type: codec.typeUrl, value: fromPartial(message) };
-    },
-    typedEncode(message) {
-      return {
-        typeUrl: codec.typeUrl,
-        value: fromPartial(message),
-      } as EncodeObject<TU>;
-    },
     typedJson(message) {
+      const value = packedFromGogo3(message);
       return {
         '@type': codec.typeUrl,
-        ...fromPartial(message),
+        ...(typeof value === 'object' && value),
       } as TypedJson<TU>;
     },
     fromTyped(object) {
@@ -268,8 +432,9 @@ export const CodecHelper = <TU = string, MT = MessageBody<TU>>(
         return cdc.fromProtoMsg({ typeUrl, value });
       }
 
-      return fromPartial(value);
+      return strippedFromDecoderOutput(value);
     },
-  });
+  };
+  freeze(help);
   return help;
 };

--- a/packages/cosmic-proto/src/type-url-annotations.ts
+++ b/packages/cosmic-proto/src/type-url-annotations.ts
@@ -1,0 +1,81 @@
+export type TypeUrl = string;
+export type ProtoFieldName = string;
+
+/** Record for select annotations of the fields for a protobuf message. */
+export interface FieldAnnotationsRecord {
+  typeUrlFromField?: Record<ProtoFieldName, TypeUrl>;
+  'gogoproto.nullable'?: Record<ProtoFieldName, boolean>;
+  'gogoproto.embed'?: Record<ProtoFieldName, string>;
+  'amino.dont_omitempty'?: Record<ProtoFieldName, boolean>;
+}
+
+/** Map for select annotations of the fields for a protobuf message */
+export type FieldAnnotations = Map<
+  keyof FieldAnnotationsRecord,
+  Map<ProtoFieldName, any>
+>;
+
+const annotationsFromRecord = (
+  record: FieldAnnotationsRecord,
+): FieldAnnotations =>
+  new Map(
+    Object.entries(record).map(([name, valueRecord]) => [
+      name as keyof FieldAnnotationsRecord,
+      new Map(Object.entries(valueRecord)),
+    ]),
+  );
+
+const typeUrlMapFromRecord = (
+  record: Record<TypeUrl, FieldAnnotationsRecord>,
+): Map<TypeUrl, FieldAnnotations> =>
+  new Map(
+    Object.entries(record).map(([typeUrl, annotationsRecord]) => [
+      typeUrl as TypeUrl,
+      annotationsFromRecord(annotationsRecord),
+    ]),
+  );
+
+/**
+ * A map from typeUrl to Map<annotationId, Map<fieldName, annotationValue>> data.
+ * XXX we should codegen this data rather than manually updating it.
+ */
+export const defaultAnnotationsFromTypeUrl = typeUrlMapFromRecord({
+  '/ibc.applications.transfer.v1.MsgTransfer': {
+    typeUrlFromField: {
+      timeoutHeight: '/ibc.core.client.v1.Height',
+      token: '/cosmos.base.v1beta1.Coin',
+    },
+    'gogoproto.nullable': {
+      timeoutHeight: false,
+      token: false,
+    },
+  },
+  '/cosmos.auth.v1beta1.ModuleAccount': {
+    'gogoproto.embed': {
+      base_account: 'baseAccount',
+    },
+  },
+  '/cosmos.base.v1beta1.Coin': {
+    typeUrlFromField: {
+      amount: 'cosmos.Int',
+    },
+    'gogoproto.nullable': {
+      amount: false,
+    },
+    'amino.dont_omitempty': {
+      amount: true,
+    },
+  },
+  '/cosmos.tx.v1beta1.TxBody': {
+    'gogoproto.nullable': {
+      timeoutTimestamp: true,
+    },
+  },
+} as const satisfies Record<TypeUrl, FieldAnnotationsRecord>);
+
+const scalarMakersRecord = {
+  'cosmos.Int': (input: any) => `${BigInt(input || 0)}`,
+};
+export const scalarMakersFromType = new Map<string, (input: any) => unknown>(
+  Object.entries(scalarMakersRecord),
+);

--- a/packages/cosmic-proto/test/helpers.test.js
+++ b/packages/cosmic-proto/test/helpers.test.js
@@ -13,8 +13,14 @@ import {
 } from '../dist/helpers.js';
 import { QueryAllBalancesRequest } from '../dist/codegen/cosmos/bank/v1beta1/query.js';
 import { MsgSend } from '../dist/codegen/cosmos/bank/v1beta1/tx.js';
+import { MsgTransfer as MsgTransferOrig } from '../dist/codegen/ibc/applications/transfer/v1/tx.js';
+
+/**
+ * @import {ExecutionContext, Macro} from 'ava';
+ */
 
 const ModuleAccount = CodecHelper(ModuleAccountType);
+const MsgTransfer = CodecHelper(MsgTransferOrig);
 
 const mockMsgSend = {
   fromAddress: 'agoric1from',
@@ -26,6 +32,134 @@ test('MsgSend', t => {
   t.like(cosmos.bank.v1beta1.MsgSend.toProtoMsg(mockMsgSend), {
     typeUrl: '/cosmos.bank.v1beta1.MsgSend',
   });
+});
+
+test('MsgTransfer basic', t => {
+  const msgTransfer = MsgTransfer.typedJson({
+    sender: 'agoric1from',
+    receiver: 'agoric1to',
+    token: { denom: 'ucosm', amount: '1' },
+    sourcePort: 'transfer',
+    sourceChannel: 'channel-0',
+  });
+  const expected = {
+    '@type': '/ibc.applications.transfer.v1.MsgTransfer',
+    sender: 'agoric1from',
+    receiver: 'agoric1to',
+    timeoutHeight: {},
+    token: { denom: 'ucosm', amount: '1' },
+    sourcePort: 'transfer',
+    sourceChannel: 'channel-0',
+  };
+  t.deepEqual(msgTransfer, expected);
+});
+
+test('MsgTransfer typedJson empty', t => {
+  const msgTransfer = MsgTransfer.typedJson({});
+  t.deepEqual(msgTransfer, {
+    '@type': '/ibc.applications.transfer.v1.MsgTransfer',
+    timeoutHeight: {},
+    token: { amount: '0' },
+  });
+});
+
+/**
+ * @template {any[]} [Args=any[]]
+ * @typedef {object} ParityTestCase
+ * @property {(...args: Args) => unknown} callA - method to test (e.g. 'typedJson')
+ * @property {Args} args - arguments to the method
+ * @property {any} expectedA - expected result of the method call
+ * @property {(...args: Args) => unknown} callB - method to test (e.g. 'typedJson')
+ * @property {any} [failureB] - expected failure result for objectB (optional)
+ */
+
+/** @type {Macro<[ParityTestCase]>} */
+const codecParity = test.macro((t, tc) => {
+  const { callA, args, expectedA, callB, failureB } = tc;
+  const resultA = callA(...args);
+  t.deepEqual(resultA, expectedA, `resultA should match expected`);
+
+  const resultB = callB(...args);
+  if (failureB) {
+    t.deepEqual(resultB, failureB, `resultB should match expected failure`);
+    return;
+  }
+  t.deepEqual(resultB, expectedA, `resultB should match expected`);
+});
+
+/** @type {Omit<ParityTestCase, 'args'>} */
+const emptyMsgTransferTestCase = {
+  callA: message => MsgTransfer.toJSON(message),
+  expectedA: {
+    encoding: '',
+    memo: '',
+    receiver: '',
+    sender: '',
+    sourceChannel: '',
+    sourcePort: '',
+    timeoutHeight: {
+      revisionHeight: '0',
+      revisionNumber: '0',
+    },
+    timeoutTimestamp: '0',
+    token: {
+      amount: '0',
+      denom: '',
+    },
+  },
+  callB: message =>
+    MsgTransferOrig.toJSON(MsgTransferOrig.fromPartial(message)),
+};
+
+const {
+  timeoutHeight: _1,
+  token: _2,
+  ...emptyMsgTransferFailureB
+} = emptyMsgTransferTestCase.expectedA;
+
+const failedEmptyMsgTransferTestCase = {
+  ...emptyMsgTransferTestCase,
+  failureB: emptyMsgTransferFailureB,
+};
+
+test('MsgTransfer toJSON empty', codecParity, {
+  ...failedEmptyMsgTransferTestCase,
+  args: [{}],
+});
+
+test('MsgTransfer toJSON with nonsense', codecParity, {
+  ...failedEmptyMsgTransferTestCase,
+  args: [{ nonsense: 'ignored' }],
+});
+
+const {
+  token: { amount: _3, ...tokenRest },
+  ...expectedMsgTransferWithoutToken
+} = emptyMsgTransferTestCase.expectedA;
+const failedEmptySubmessagesMsgTransferTestCase = {
+  ...emptyMsgTransferTestCase,
+  failureB: {
+    ...expectedMsgTransferWithoutToken,
+    token: {
+      amount: '',
+      ...tokenRest,
+    },
+  },
+};
+
+test('MsgTransfer toJSON with empty submessages', codecParity, {
+  ...failedEmptySubmessagesMsgTransferTestCase,
+  args: [
+    {
+      timeoutHeight: {},
+      token: {},
+    },
+  ],
+});
+
+test('MsgTransfer toJSON with zero token amount', codecParity, {
+  ...emptyMsgTransferTestCase,
+  args: [{ timeoutHeight: {}, token: { amount: '0' } }],
 });
 
 test('typedJson', t => {
@@ -65,27 +199,37 @@ test('CodecHelper', t => {
     // @ts-expect-error invalid field
     other: 3,
   });
-  const body = { address, pagination: undefined, resolveDenom: false };
   t.deepEqual(qabr, {
     '@type': help.typeUrl,
-    ...body,
+    address,
   });
 
-  t.deepEqual(help.fromTyped(qabr), body);
+  t.deepEqual(
+    help.fromPartial({
+      address,
+      // @ts-expect-error invalid field
+      bad: 'nono',
+    }),
+    {
+      address,
+      resolveDenom: false,
+      pagination: undefined,
+    },
+  );
 
-  const aminoMessage = help.typedAmino({ address });
-  t.deepEqual(aminoMessage, {
+  t.deepEqual(help.fromTyped(qabr), { address });
+
+  const aminoMessage = {
     type: help.typeUrl,
-    value: body,
-  });
-  t.deepEqual(help.fromTyped(aminoMessage), body);
+    value: { address, resolveDenom: false },
+  };
+  t.deepEqual(help.fromTyped(aminoMessage), { address, resolveDenom: false });
 
-  const jsonMessage = help.typedEncode({ address });
-  t.deepEqual(jsonMessage, {
+  const jsonMessage = {
     typeUrl: '/cosmos.bank.v1beta1.QueryAllBalancesRequest',
-    value: body,
-  });
-  t.deepEqual(help.fromTyped(jsonMessage), body);
+    value: { address, resolveDenom: false, pagination: undefined },
+  };
+  t.deepEqual(help.fromTyped(jsonMessage), { address, resolveDenom: false });
 
   const msgSend = CodecHelper(MsgSend).typedJson({
     fromAddress: address,
@@ -103,34 +247,36 @@ test('CodecHelper', t => {
 });
 
 test('CodecHelper agd q auth module-account', t => {
-  const agd47 = {
-    account: {
-      '@type': '/cosmos.auth.v1beta1.ModuleAccount',
-      base_account: {
-        address: 'agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl',
-        pub_key: null,
-        account_number: '110',
-        sequence: '0',
-      },
-      name: 'vbank/reserve',
-      permissions: [],
-    },
-  };
-  const agd50 = {
-    account: {
-      type: '/cosmos.auth.v1beta1.ModuleAccount',
-      value: {
-        account_number: 110,
-        address: 'agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl',
+  const samples = {
+    agd47: {
+      account: {
+        '@type': '/cosmos.auth.v1beta1.ModuleAccount',
+        base_account: {
+          address: 'agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl',
+          pub_key: null,
+          account_number: '110',
+          sequence: '0',
+        },
         name: 'vbank/reserve',
-        permissions: null,
-        public_key: '',
-        sequence: 0,
+        permissions: [],
+      },
+    },
+    agd50: {
+      account: {
+        type: '/cosmos.auth.v1beta1.ModuleAccount',
+        value: {
+          account_number: 110,
+          address: 'agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl',
+          name: 'vbank/reserve',
+          permissions: null,
+          public_key: '',
+          sequence: 0,
+        },
       },
     },
   };
 
-  for (const [key, value] of Object.entries({ agd47, agd50 })) {
+  for (const [key, value] of Object.entries(samples)) {
     const { account } = value;
     const decoded = ModuleAccount.fromTyped(account);
     t.like(

--- a/packages/orchestration/src/utils/codecs.js
+++ b/packages/orchestration/src/utils/codecs.js
@@ -166,17 +166,17 @@ export { MsgTransferType, MsgTransferResponseType };
 const AnyRawHelper = CodecHelper(AnyType);
 const AnyToJSON = {
   /**
-   * TypeScript 6 note: constrain TU to string keys for AnyType.typeUrl compatibility.
-   * @template {string} [TU=Extract<keyof TypeFromUrl, string>]
-   * @param {Partial<Omit<AnyType, 'typeUrl'> & { typeUrl: TU }>} msg
+   * `Any.toJSON` has a template parameter matching the passed-through typeUrl
+   * property.  This is different than other codecs which produce a fixed shape.
+   * @template {string} [TU=string]
+   * @param {{ typeUrl: TU } & Omit<AnyType, 'typeUrl'>} msg
    */
   toJSON: msg => {
     const ne = AnyRawHelper.toJSON(msg);
-    return /** @type {Omit<typeof ne, 'typeUrl'> & { typeUrl: TU }} */ (ne);
+    return /** @type {{ typeUrl: TU } & Omit<typeof ne, 'typeUrl'>} */ (ne);
   },
 };
 
-/** @type {Omit<typeof AnyRawHelper, 'toJSON'> & typeof AnyToJSON} */
 export const Any = Object.freeze({
   ...AnyRawHelper,
   ...AnyToJSON,

--- a/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
+++ b/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
@@ -173,6 +173,10 @@ test('through issuing chain', async t => {
     // callers of `.makeTransferRoute` will provide these fields themselves:
     sender: 'agoric123',
   });
+  t.not(
+    'encoding' in transferMsg,
+    'encoding should not be present on MsgTransfer',
+  );
   t.like(transferMsg, {
     memo: '{"forward":{"receiver":"osmo1234","port":"transfer","channel":"channel-1","retries":3,"timeout":"10m"}}',
     receiver: 'pfm',

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -393,7 +393,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
   >(account.executeEncodedTx);
 
   expectType<
-    <TUS extends readonly (keyof TypeFromUrl | unknown)[]>(
+    <TUS extends readonly string[]>(
       msgs: Readonly<{ [K in keyof TUS]: AnyJson<TUS[K]> }>,
       opts?: CosmosActionOptions,
     ) => Promise<{ [K in keyof TUS]: MessageBody<ResponseTypeUrl<TUS[K]>> }>

--- a/packages/orchestration/tools/ibc-mocks.ts
+++ b/packages/orchestration/tools/ibc-mocks.ts
@@ -37,7 +37,8 @@ const FungibleTokenPacketData = CodecHelper(FungibleTokenPacketDataType);
 const CosmosResponse = CodecHelper(CosmosResponseType);
 const ResponseQuery = CodecHelper(ResponseQueryType);
 
-type EncoderCommon<T> = Proto3Codec<string, T>;
+type EncoderCommon<T> =
+  T extends Proto3Codec<infer TU> ? Proto3Codec<TU> : Proto3Codec<string>;
 
 const toPacket = (obj: Record<string, any>): string =>
   btoa(JSON.stringify(obj));

--- a/scripts/forks/go-mod-replace.js
+++ b/scripts/forks/go-mod-replace.js
@@ -39,7 +39,8 @@ const goStdout = async (args, options = {}) => {
     stdio: stdio ?? ['inherit', 'pipe', 'inherit'],
     ...restOpts,
   });
-  const stdout = `${result.stdout ?? ''}`.trim();
+  const stdout =
+    `${typeof result === 'string' ? result : result.stdout}`.trim();
   return stdout;
 };
 


### PR DESCRIPTION
## Description
This PR makes `packages/cosmic-proto`'s `CodecHelper` more robust so partially specified or older proto message shapes round-trip cleanly across generated codecs and downstream orchestration code. Most review attention should go to `packages/cosmic-proto/src/codec-helpers.ts`, `packages/cosmic-proto/src/type-url-annotations.ts`, and `packages/cosmic-proto/test/helpers.test.js`.

- move proto annotation handling into `type-url-annotations.ts`, including nested field type metadata and scalar makers for special cases like `cosmos.Int`
- rework `Codec` and `CodecHelper` transforms so partial input, embedded fields, non-nullable placeholders, and decode output are normalized consistently for gogoproto-annotated messages such as `MsgTransfer`
- expand regression coverage around `MsgTransfer`, `ModuleAccount`, and typed wrappers, with small follow-on updates in `packages/orchestration` and `.github/workflows/proto.yml`

### Security Considerations
This PR does not add new authorities, dependencies, or trust boundaries; it only changes how existing generated codec helpers normalize message data. The main risk is incorrect field normalization, and the added regression coverage is meant to catch that.

### Scaling Considerations
This should not materially change CPU, memory, storage, or network usage beyond small in-memory object shaping during existing encode/decode paths. The extra work is bounded to message normalization that these helpers were already doing.

### Documentation Considerations
Downstream users should know that `CodecHelper` now preserves gogoproto semantics more faithfully for partial JSON inputs, especially around `MsgTransfer`, embedded fields, and non-nullable placeholders. No saved-data migration or deployment upgrade step is expected from this change.

### Testing Considerations
This adds direct unit coverage for empty and partial `MsgTransfer` cases, `fromTyped` and `fromPartial` behavior, and module-account compatibility, plus orchestration assertions that newly-introduced fields like `encoding` stay absent. The proto workflow trigger was also widened so label changes rerun the relevant CI expectations.

### Upgrade Considerations
This is compatibility robustness in generated and client-side codec behavior, not a state migration or protocol upgrade. Release verification should exercise `MsgTransfer` and account-query JSON round-trips against the upgraded chain to confirm previously problematic partial or extra-field inputs no longer break callers.
