### PR TITLE
chore: Minor cleanup in ymax-planner and core package comments

### DIFF
--- a/packages/client-utils/src/vstorage.js
+++ b/packages/client-utils/src/vstorage.js
@@ -97,7 +97,7 @@ export const makeVStorage = ({ fetch }, config) => {
   /**
    * Make a vstorage Children or Data query, returning the decoded result along
    * with response metadata derived from fields documented at
-   * https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#query (for
+   * https://docs.cometbft.com/v0.38/spec/abci/abci++_methods#query (for
    * successful responses, `log` and `height` [as `blockHeight`], and for error
    * responses, `codespace` and `code`).
    *

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -1133,7 +1133,7 @@ export async function launchAndShareInternals({
   };
 
   // Handle actions related to ABCI block methods: BeginBlock, EndBlock, Commit
-  // https://docs.cometbft.com/v0.34/spec/abci/abci#block-execution
+  // https://docs.cometbft.com/v0.37/spec/abci/abci++_app_requirements#beginblock---delivertx---endblock
   // We also have a once-per-process-lifetime AG_COSMOS_INIT message, and split
   // Commit into two phases (see `Commit` at
   // {@link ../../../golang/cosmos/app/app.go}).

--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/* global process */
 
 import timersPromises from 'node:timers/promises';
 import { inspect } from 'node:util';

--- a/services/ymax-planner/scripts/resolve-tx-lib.ts
+++ b/services/ymax-planner/scripts/resolve-tx-lib.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S node --import ts-blank-space/register
-/* eslint-env node */
+/* global process */
 
 import { SigningStargateClient } from '@cosmjs/stargate';
 

--- a/services/ymax-planner/scripts/tx-tool.ts
+++ b/services/ymax-planner/scripts/tx-tool.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S node --import ts-blank-space/register
-/* eslint-env node */
+/* global process */
 
 import '@endo/init/pre-remoting.js';
 import '../src/shims.cjs';

--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -35,7 +35,6 @@ export interface YmaxPlannerConfig {
   readonly spectrumPoolsEndpoints: string[];
   readonly cosmosRest: {
     readonly agoricNetworkSpec: string;
-    readonly agoricNetSubdomain?: string;
     readonly timeout: number;
     readonly retries: number;
   };
@@ -187,7 +186,6 @@ export const loadConfig = async (
     spectrumPoolsEndpoints,
     cosmosRest: {
       agoricNetworkSpec,
-      agoricNetSubdomain,
       timeout: parsePositiveInteger(env, 'COSMOS_REST_TIMEOUT', timeout),
       retries: parsePositiveInteger(env, 'COSMOS_REST_RETRIES', maxRetries),
     },

--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -6,7 +6,7 @@ const MAX_SUBSCRIPTIONS = 5;
 const hasOwnProperties = (obj: unknown) =>
   typeof obj === 'object' && obj !== null && Reflect.ownKeys(obj).length > 0;
 
-/** cf. https://docs.cometbft.com/v1.0/explanation/core/subscription */
+/** cf. https://docs.cometbft.com/v0.38/core/subscription */
 export type SubscriptionResponse = {
   type: string;
   value: Record<string, unknown>;
@@ -152,7 +152,7 @@ export class CosmosRPCClient extends JSONRPCClient {
   }
 
   /**
-   * Websocket documentation: https://docs.cometbft.com/v1.0/explanation/core/subscription
+   * Websocket documentation: https://docs.cometbft.com/v0.38/core/subscription
    * Query syntax: https://pkg.go.dev/github.com/cometbft/cometbft@v1.0.1/libs/pubsub/query/syntax
    * List of events: https://pkg.go.dev/github.com/cometbft/cometbft/types#pkg-constants
    */

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -1,5 +1,5 @@
 /// <reference types="ses" />
-/* eslint-env node */
+/* global process */
 
 import type { InspectOptions } from 'node:util';
 import { inspect } from 'node:util';

--- a/services/ymax-planner/src/entrypoint.ts
+++ b/services/ymax-planner/src/entrypoint.ts
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/* global process */
 
 // We need some pre-lockdown shimming.
 import '@endo/init/pre-remoting.js';

--- a/services/ymax-planner/src/graphql/codegen-config.base.ts
+++ b/services/ymax-planner/src/graphql/codegen-config.base.ts
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/* global process */
 
 import fs from 'node:fs';
 import pathlib from 'node:path';

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/* global process */
 
 import timersPromises from 'node:timers/promises';
 import { inspect } from 'node:util';

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -26,8 +26,8 @@ harden(UserInputError);
 type ROPartial<K extends string, V> = Readonly<Partial<Record<K, V>>>;
 
 /**
- * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
- *   or @agoric/orchestration
+ * @deprecated should come from e.g. \@agoric/portfolio-api/src/constants.js
+ *   or \@agoric/orchestration
  */
 export type UsdcAddresses = {
   mainnet: Record<CaipChainId, EvmAddress>;
@@ -131,8 +131,8 @@ export const spectrumProtocols: Readonly<
  * - https://developers.circle.com/cctp/evm-smart-contracts
  * - https://developers.circle.com/stablecoins/usdc-contract-addresses
  *
- * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
- *   or @agoric/orchestration
+ * @deprecated should come from e.g. \@agoric/portfolio-api/src/constants.js
+ *   or \@agoric/orchestration
  * @see {@link ../../../packages/orchestration/src/cctp-chain-info.js}
  */
 export const usdcAddresses: UsdcAddresses = {
@@ -185,8 +185,8 @@ export const walletOperationFallbackGasLimit = 276_809n;
  * Testnet data: https://eth.blockscout.com/ (except Avalanche),
  *   https://subnets-test.avax.network/c-chain
  *
- * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
- *   or @agoric/orchestration
+ * @deprecated should come from e.g. \@agoric/portfolio-api/src/constants.js
+ *   or \@agoric/orchestration
  */
 const chainBlockTimesMs: Record<CaipChainId, number> = harden({
   // ========= Mainnet =========
@@ -280,8 +280,8 @@ export const getRevertConfirmationsRequired = (
 };
 
 /**
- * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
- *   or @agoric/orchestration
+ * @deprecated should come from e.g. \@agoric/portfolio-api/src/constants.js
+ *   or \@agoric/orchestration
  */
 export const getEvmRpcMap = (
   clusterName: ClusterName,
@@ -345,7 +345,7 @@ export const createEVMContext = async ({
 
   return {
     evmProviders,
-    // XXX Remove now that @agoric/portfolio-api/src/constants.js
+    // XXX Remove now that \@agoric/portfolio-api/src/constants.js
     // defines UsdcTokenIds.
     usdcAddresses: usdcAddresses[clusterName],
   };

--- a/services/ymax-planner/src/vstorage-utils.ts
+++ b/services/ymax-planner/src/vstorage-utils.ts
@@ -133,7 +133,7 @@ export type ReadStorageMetaOptions<
 /**
  * Make a vstorage Children or Data query, returning the decoded result along
  * with response metadata derived from fields documented at
- * https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#query (for
+ * https://docs.cometbft.com/v0.38/spec/abci/abci++_methods#query (for
  * successful responses, `log` and `height` [as `blockHeight`], and for error
  * responses, `codespace` and `code`) or a transformation thereof.
  * UNTIL https://github.com/Agoric/agoric-sdk/pull/11630

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -73,7 +73,6 @@ test('loadConfig accepts valid configuration', async t => {
   t.is(config.mnemonic, 'test mnemonic phrase');
   t.is(config.alchemyApiKey, 'test1234');
   t.is(config.cosmosRest.agoricNetworkSpec, 'devnet,myChainId');
-  t.is(config.cosmosRest.agoricNetSubdomain, 'devnet');
   t.is(config.cosmosRest.timeout, 10000);
   t.is(config.cosmosRest.retries, 5);
 });
@@ -86,7 +85,6 @@ test('loadConfig uses default values when optional fields are missing', async t 
   t.is(config.mnemonic, 'test mnemonic phrase');
   t.is(config.alchemyApiKey, 'test1234');
   t.is(config.cosmosRest.agoricNetworkSpec, 'local');
-  t.is(config.cosmosRest.agoricNetSubdomain, 'local');
   t.is(config.cosmosRest.timeout, 10000);
   t.is(config.cosmosRest.retries, 3);
 });
@@ -133,11 +131,6 @@ test('loadConfig defaults CLUSTER from AGORIC_NET', async t => {
         t.is(
           config.cosmosRest.agoricNetworkSpec,
           agoricNetworkSpec,
-          `AGORIC_NET=${agoricNetworkSpec}`,
-        );
-        t.is(
-          config.cosmosRest.agoricNetSubdomain,
-          agoricNetSubdomain,
           `AGORIC_NET=${agoricNetworkSpec}`,
         );
         t.is(


### PR DESCRIPTION
## Description
* Replace URLs broken by CometBFT mismanagement
* Fix "Unexpected inline JSDoc tag" warnings caused by unprefixed `@`s
* Replace `/* eslint-env node */` comments, since their presence will soon be an error
* Remove unused configuration field `YmaxPlannerConfig.cosmosRest.agoricNetSubdomain`