### PR TITLE
chore: allow failed state without address in PortfolioGenericRemoteAccountState

### DIFF
--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -204,7 +204,7 @@ export type PortfolioGenericRemoteAccountState =
       state: PortfolioRemoteAccountCommonStates;
     }
   | {
-      state: 'provisioning' | 'unknown';
+      state: 'provisioning' | 'failed' | 'unknown';
     };
 
 export type PortfolioEVMRemoteAccountState = {


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


refs: https://github.com/Agoric/ymax-web/pull/533#discussion_r3037970667

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Updated `PortfolioGenericRemoteAccountState` to allow `failed` state without `chainId`/`address`, covering cases where provisioning fails before account details are known.
